### PR TITLE
fixes: check license

### DIFF
--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -24,6 +24,6 @@ fi
 
 for hook in $GIT_DIR/../misc/hooks/*; do
  if [ -x "$hook" ]; then
-   $hook $@
+   $hook
  fi
 done

--- a/misc/hooks/check-license
+++ b/misc/hooks/check-license
@@ -29,7 +29,7 @@ for file in $staged_files; do
     fi
     
     # Check if file exists and has license header
-    if [[ -f "$file" ]] && ! head -20 "$file" | grep -q "Copyright.*The Multigres Authors"; then
+    if [[ -f "$file" ]] && ! head -20 "$file" | grep -q "Copyright.*The Multigres Authors\."; then
         files_without_license+=("$file")
     fi
 done


### PR DESCRIPTION
# Desc

* When I first added this hook, I did not have the integration for golang-ci and accidentally broke the expectations on how this is called from the [pre-commit](https://github.com/multigres/multigres/blob/main/misc/git/pre-commit#L0-L1) hook. These fixes that regression.
* It also makes sure addlicense is installed when running the hook. 