### PR TITLE
site: only trigger builds for vercel when there are changes in site

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoredBuildStep": "git diff HEAD^ HEAD --quiet -- ./site/",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- ./site/",
   "redirects": [
     {
       "source": "/blog/2025/07/22/ha-postgres-full-sync",


### PR DESCRIPTION
# Desc
* QoL improvement. This should only trigger builds in vercel when there are changes in the site directory.
* Following instructions from: https://vercel.com/guides/how-do-i-use-the-ignored-build-step-field-on-vercel