### PR TITLE
one more fix to the pre-commit

### DIFF
--- a/misc/hooks/golangci-lint
+++ b/misc/hooks/golangci-lint
@@ -48,7 +48,7 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$REQUIRED_VERSION
 else
   VERSION_OUTPUT=$(golangci-lint --version)
-  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -n 's/^golangci-lint has version v\([0-9.]*\).*/\1/p')
+  INSTALLED_VERSION=$(echo "$VERSION_OUTPUT" | sed -n 's/^golangci-lint has version \([0-9.]*\).*/\1/p')
   if ! version_greater_or_equal "$INSTALLED_VERSION" "${REQUIRED_VERSION#v}"; then
     echo "golangci-lint version $INSTALLED_VERSION found, but $REQUIRED_VERSION or newer is required."
     echo "Installing version $REQUIRED_VERSION..."


### PR DESCRIPTION
# Desc

Argh! One more fix here. I noticed that I was seeing this in all commits:
```
golangci-lint version  found, but v2.4.0 or newer is required.
Installing version v2.4.0...
```

 It turns out that after verssion 2.0.2, they stopped printing the version in the command. So instead of:
```
golangci-lint has version v2.0.2 built with go1.24.6 from (unknown, modified: ?, mod sum: "h1:dMCC8ikPiLDvHMFy3+XypSAuGDBOLzwWqqamer+bWsY=") on (unknown)
```

We start getting:

```
golangci-lint has version 2.4.0 built with go1.24.6 from (unknown, modified: ?, mod sum: "h1:qz6O6vr7kVzXJqyvHjHSz5fA3D+PM8v96QU5gxZCNWM=") on (unknown)
```

So we need to update the sed expression compared to what we had in Vitess. 