### PR TITLE
fixes vercel build

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- ./site/",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- site/",
   "redirects": [
     {
       "source": "/blog/2025/07/22/ha-postgres-full-sync",


### PR DESCRIPTION
# Desc

Take two at ignoring the vercel build. Now I tested this more throughly:
```
> git status
On branch fixes-vercel-config-take-2
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	site/test

# This exists 0, so it should ignore the build.
> git diff HEAD^ HEAD --quiet -- misc/
> echo $?
0

# This exists 1, so the build should be triggered.
> git diff HEAD^ HEAD --quiet -- site/
> echo $?
1
```

This matches Vercel’s documented behavior:
* exit 0 → build skipped
* exit 1 → build runs
