### PR TITLE
Refactor component

### DIFF
--- a/go/clustermetadata/topo/multipooler.go
+++ b/go/clustermetadata/topo/multipooler.go
@@ -27,13 +27,13 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
-// NewMultiPooler creates a new MultiPooler record with the given id, cell, and hostname.
-func NewMultiPooler(uid string, cell, host string) *clustermetadatapb.MultiPooler {
+// NewMultiPooler creates a new MultiPooler record with the given name, cell, and hostname.
+func NewMultiPooler(name string, cell, host string) *clustermetadatapb.MultiPooler {
 	return &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      cell,
-			Uid:       uid,
+			Name:      name,
 		},
 		Hostname: host,
 		PortMap:  make(map[string]int32),
@@ -78,7 +78,7 @@ func NewMultiPoolerInfo(multipooler *clustermetadatapb.MultiPooler, version Vers
 
 // MultiPoolerIDString returns the string representation of a MultiPooler ID
 func MultiPoolerIDString(id *clustermetadatapb.ID) string {
-	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Uid)
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Name)
 }
 
 // GetMultiPooler is a high level function to read multipooler data.

--- a/go/clustermetadata/topo/multipooler.go
+++ b/go/clustermetadata/topo/multipooler.go
@@ -28,11 +28,12 @@ import (
 )
 
 // NewMultiPooler creates a new MultiPooler record with the given id, cell, and hostname.
-func NewMultiPooler(uid uint32, cell, host string) *clustermetadatapb.MultiPooler {
+func NewMultiPooler(uid string, cell, host string) *clustermetadatapb.MultiPooler {
 	return &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
-			Cell: cell,
-			Uid:  uid,
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      cell,
+			Uid:       uid,
 		},
 		Hostname: host,
 		PortMap:  make(map[string]int32),
@@ -77,7 +78,7 @@ func NewMultiPoolerInfo(multipooler *clustermetadatapb.MultiPooler, version Vers
 
 // MultiPoolerIDString returns the string representation of a MultiPooler ID
 func MultiPoolerIDString(id *clustermetadatapb.ID) string {
-	return fmt.Sprintf("%s-%d", id.Cell, id.Uid)
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Uid)
 }
 
 // GetMultiPooler is a high level function to read multipooler data.

--- a/go/clustermetadata/topo/multipooler.go
+++ b/go/clustermetadata/topo/multipooler.go
@@ -28,7 +28,11 @@ import (
 )
 
 // NewMultiPooler creates a new MultiPooler record with the given name, cell, and hostname.
+// If name is empty, a random name will be generated.
 func NewMultiPooler(name string, cell, host string) *clustermetadatapb.MultiPooler {
+	if name == "" {
+		name = RandomString(8)
+	}
 	return &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,

--- a/go/clustermetadata/topo/multipooler_test.go
+++ b/go/clustermetadata/topo/multipooler_test.go
@@ -57,7 +57,7 @@ func getMultiPooler(database string, shard string, cell string, uid uint32) *clu
 		Id: &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      cell,
-			Uid:       fmt.Sprintf("%d", uid),
+			Name:      fmt.Sprintf("%d", uid),
 		},
 		Database: database,
 		Shard:    shard,
@@ -124,7 +124,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -149,7 +149,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -164,7 +164,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 2),
+						Name:      fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -179,7 +179,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 3),
+						Name:      fmt.Sprintf("%d", 3),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -194,7 +194,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 4),
+						Name:      fmt.Sprintf("%d", 4),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -219,7 +219,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -234,7 +234,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 2),
+						Name:      fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -265,7 +265,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -280,7 +280,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 2),
+						Name:      fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -295,7 +295,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 3),
+						Name:      fmt.Sprintf("%d", 3),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -310,7 +310,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 4),
+						Name:      fmt.Sprintf("%d", 4),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -349,7 +349,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Id: &clustermetadatapb.ID{
 							Component: clustermetadatapb.ID_MULTIPOOLER,
 							Cell:      cell,
-							Uid:       fmt.Sprintf("%d", uid),
+							Name:      fmt.Sprintf("%d", uid),
 						},
 						Hostname:      "host1",
 						PortMap:       map[string]int32{"grpc": int32(uid)},
@@ -368,10 +368,10 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 			require.Len(t, out, len(tt.expectedMultiPoolers))
 
 			slices.SortFunc(out, func(i, j *topo.MultiPoolerInfo) int {
-				return cmp.Compare(i.Id.Uid, j.Id.Uid)
+				return cmp.Compare(i.Id.Name, j.Id.Name)
 			})
 			slices.SortFunc(tt.expectedMultiPoolers, func(i, j *clustermetadatapb.MultiPooler) int {
-				return cmp.Compare(i.Id.Uid, j.Id.Uid)
+				return cmp.Compare(i.Id.Name, j.Id.Name)
 			})
 
 			for i, multipoolerInfo := range out {
@@ -390,18 +390,18 @@ func TestMultiPoolerIDString(t *testing.T) {
 	}{
 		{
 			name:     "simple case",
-			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Uid: "100"},
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "100"},
 			expected: "multipooler-zone1-100",
 		},
 		{
-			name:     "zero uid",
-			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "prod", Uid: "0"},
+			name:     "you can use name as numbers",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "prod", Name: "0"},
 			expected: "multipooler-prod-0",
 		},
 		{
-			name:     "large uid",
-			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test", Uid: "999999"},
-			expected: "multipooler-test-999999",
+			name:     "funny name",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "prod", Name: "sleepy"},
+			expected: "multipooler-prod-sleepy",
 		},
 	}
 
@@ -431,7 +431,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -452,7 +452,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 		{
 			name: "Get nonexistent MultiPooler",
 			test: func(t *testing.T, ts topo.Store) {
-				id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: cell, Uid: "999"}
+				id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: cell, Name: "999"}
 				_, err := ts.GetMultiPooler(ctx, id)
 				require.Error(t, err)
 				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
@@ -465,7 +465,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -489,7 +489,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -527,7 +527,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -585,7 +585,7 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 						Id: &clustermetadatapb.ID{
 							Component: clustermetadatapb.ID_MULTIPOOLER,
 							Cell:      cell1,
-							Uid:       fmt.Sprintf("%d", 1),
+							Name:      fmt.Sprintf("%d", 1),
 						},
 						Database:      "db1",
 						Shard:         "shard1",
@@ -598,7 +598,7 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 						Id: &clustermetadatapb.ID{
 							Component: clustermetadatapb.ID_MULTIPOOLER,
 							Cell:      cell1,
-							Uid:       fmt.Sprintf("%d", 3),
+							Name:      fmt.Sprintf("%d", 3),
 						},
 						Database:      "db2",
 						Shard:         "shard2",
@@ -621,22 +621,22 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 					{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell1,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell1,
-						Uid:       fmt.Sprintf("%d", 3),
+						Name:      fmt.Sprintf("%d", 3),
 					},
 				}
 
 				slices.SortFunc(ids, func(a, b *clustermetadatapb.ID) int {
-					return cmp.Compare(a.Uid, b.Uid)
+					return cmp.Compare(a.Name, b.Name)
 				})
 
 				for i, id := range ids {
 					require.Equal(t, expectedIDs[i].Cell, id.Cell)
-					require.Equal(t, expectedIDs[i].Uid, id.Uid)
+					require.Equal(t, expectedIDs[i].Name, id.Name)
 				}
 
 				// Verify cell boundary: multipoolers are NOT accessible from cell2
@@ -679,7 +679,7 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				id := &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      cell,
-					Uid:       fmt.Sprintf("%d", 1),
+					Name:      fmt.Sprintf("%d", 1),
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
@@ -713,7 +713,7 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				id := &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      cell,
-					Uid:       fmt.Sprintf("%d", 1),
+					Name:      fmt.Sprintf("%d", 1),
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
@@ -744,7 +744,7 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				id := &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      cell,
-					Uid:       fmt.Sprintf("%d", 1),
+					Name:      fmt.Sprintf("%d", 1),
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
@@ -773,7 +773,7 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				id := &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      cell,
-					Uid:       fmt.Sprintf("%d", 1),
+					Name:      fmt.Sprintf("%d", 1),
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
@@ -832,7 +832,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -857,7 +857,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -872,7 +872,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -897,7 +897,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -912,7 +912,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -934,7 +934,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -949,7 +949,7 @@ func TestInitMultiPooler(t *testing.T) {
 					Id: &clustermetadatapb.ID{
 						Component: clustermetadatapb.ID_MULTIPOOLER,
 						Cell:      cell,
-						Uid:       fmt.Sprintf("%d", 1),
+						Name:      fmt.Sprintf("%d", 1),
 					},
 					Database:      "differentdb",
 					Shard:         "testshard",
@@ -978,21 +978,21 @@ func TestInitMultiPooler(t *testing.T) {
 // TestNewMultiPooler tests the factory function
 func TestNewMultiPooler(t *testing.T) {
 	tests := []struct {
+		testName string
 		name     string
-		uid      string
 		cell     string
 		host     string
 		expected *clustermetadatapb.MultiPooler
 	}{
 		{
-			name: "basic creation",
-			uid:  "100",
-			cell: "zone1",
-			host: "host.example.com",
+			testName: "basic creation",
+			name:     "100",
+			cell:     "zone1",
+			host:     "host.example.com",
 			expected: &clustermetadatapb.MultiPooler{
 				Id: &clustermetadatapb.ID{
 					Cell: "zone1",
-					Uid:  "100",
+					Name: "100",
 				},
 				Hostname: "host.example.com",
 				PortMap:  map[string]int32{},
@@ -1001,10 +1001,10 @@ func TestNewMultiPooler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := topo.NewMultiPooler(tt.uid, tt.cell, tt.host)
+		t.Run(tt.testName, func(t *testing.T) {
+			result := topo.NewMultiPooler(tt.name, tt.cell, tt.host)
 			require.Equal(t, tt.expected.Id.Cell, result.Id.Cell)
-			require.Equal(t, tt.expected.Id.Uid, result.Id.Uid)
+			require.Equal(t, tt.expected.Id.Name, result.Id.Name)
 			require.Equal(t, tt.expected.Hostname, result.Hostname)
 			require.NotNil(t, result.PortMap)
 		})
@@ -1017,7 +1017,7 @@ func TestMultiPoolerInfo(t *testing.T) {
 		Id: &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      "zone1",
-			Uid:       "100",
+			Name:      "100",
 		},
 		Hostname: "host.example.com",
 		PortMap: map[string]int32{
@@ -1051,7 +1051,7 @@ func TestMultiPoolerInfo(t *testing.T) {
 			Id: &clustermetadatapb.ID{
 				Component: clustermetadatapb.ID_MULTIPOOLER,
 				Cell:      "zone1",
-				Uid:       "100",
+				Name:      "100",
 			},
 			Hostname: "host.example.com",
 			PortMap: map[string]int32{
@@ -1083,7 +1083,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		// Setup: Create 4 multipoolers in zone1 (2 databases × 2 shards)
 		multipoolers := []*clustermetadatapb.MultiPooler{
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "1"},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "1"},
 				Database:      "db1",
 				Shard:         "-8",
 				Hostname:      "host1",
@@ -1092,7 +1092,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "2"},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "2"},
 				Database:      "db1",
 				Shard:         "8-",
 				Hostname:      "host2",
@@ -1101,7 +1101,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "3"},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "3"},
 				Database:      "db2",
 				Shard:         "-8",
 				Hostname:      "host3",
@@ -1110,7 +1110,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "4"},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "4"},
 				Database:      "db2",
 				Shard:         "8-",
 				Hostname:      "host4",
@@ -1156,7 +1156,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Id: &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      "zone1",
-					Uid:       "1",
+					Name:      "1",
 				},
 				Database:      "db1",
 				Shard:         "-8",
@@ -1169,7 +1169,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Id: &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      "zone1",
-					Uid:       "2",
+					Name:      "2",
 				},
 				Database:      "db1",
 				Shard:         "8-",
@@ -1219,7 +1219,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Id: &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      "zone1",
-					Uid:       "1",
+					Name:      "1",
 				},
 				Database:      "db2",
 				Shard:         "-8",
@@ -1232,7 +1232,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Id: &clustermetadatapb.ID{
 					Component: clustermetadatapb.ID_MULTIPOOLER,
 					Cell:      "zone1",
-					Uid:       "2",
+					Name:      "2",
 				},
 				Database:      "db2",
 				Shard:         "8-",
@@ -1306,7 +1306,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 			Id: &clustermetadatapb.ID{
 				Component: clustermetadatapb.ID_MULTIPOOLER,
 				Cell:      "zone1",
-				Uid:       "1",
+				Name:      "1",
 			},
 			Database:      "db1",
 			Shard:         "-8",
@@ -1319,7 +1319,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 			Id: &clustermetadatapb.ID{
 				Component: clustermetadatapb.ID_MULTIPOOLER,
 				Cell:      "zone2",
-				Uid:       "1",
+				Name:      "1",
 			},
 			Database:      "db1",
 			Shard:         "-8",

--- a/go/clustermetadata/topo/multipooler_test.go
+++ b/go/clustermetadata/topo/multipooler_test.go
@@ -18,6 +18,8 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
+	"path"
 	"slices"
 	"testing"
 	"time"
@@ -53,8 +55,9 @@ func init() {
 func getMultiPooler(database string, shard string, cell string, uid uint32) *clustermetadatapb.MultiPooler {
 	return &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
-			Cell: cell,
-			Uid:  uid,
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      cell,
+			Uid:       fmt.Sprintf("%d", uid),
 		},
 		Database: database,
 		Shard:    shard,
@@ -119,8 +122,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 			expectedMultiPoolers: []*clustermetadatapb.MultiPooler{
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(1),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -143,8 +147,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 			expectedMultiPoolers: []*clustermetadatapb.MultiPooler{
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(1),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -157,8 +162,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(2),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -171,8 +177,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(3),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 3),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -185,8 +192,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(4),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 4),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -209,8 +217,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 			expectedMultiPoolers: []*clustermetadatapb.MultiPooler{
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(1),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -223,8 +232,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(2),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -253,8 +263,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 			expectedMultiPoolers: []*clustermetadatapb.MultiPooler{
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(1),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -267,8 +278,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(2),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 2),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -281,8 +293,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(3),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 3),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -295,8 +308,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				},
 				{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  uint32(4),
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 4),
 					},
 					Hostname: "host1",
 					PortMap: map[string]int32{
@@ -333,8 +347,9 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 				for i := 0; i < tt.createShardMultiPoolers; i++ {
 					multipooler := &clustermetadatapb.MultiPooler{
 						Id: &clustermetadatapb.ID{
-							Cell: cell,
-							Uid:  uid,
+							Component: clustermetadatapb.ID_MULTIPOOLER,
+							Cell:      cell,
+							Uid:       fmt.Sprintf("%d", uid),
 						},
 						Hostname:      "host1",
 						PortMap:       map[string]int32{"grpc": int32(uid)},
@@ -375,18 +390,18 @@ func TestMultiPoolerIDString(t *testing.T) {
 	}{
 		{
 			name:     "simple case",
-			id:       &clustermetadatapb.ID{Cell: "zone1", Uid: 100},
-			expected: "zone1-100",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Uid: "100"},
+			expected: "multipooler-zone1-100",
 		},
 		{
 			name:     "zero uid",
-			id:       &clustermetadatapb.ID{Cell: "prod", Uid: 0},
-			expected: "prod-0",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "prod", Uid: "0"},
+			expected: "multipooler-prod-0",
 		},
 		{
 			name:     "large uid",
-			id:       &clustermetadatapb.ID{Cell: "test", Uid: 999999},
-			expected: "test-999999",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "test", Uid: "999999"},
+			expected: "multipooler-test-999999",
 		},
 	}
 
@@ -414,8 +429,9 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 			test: func(t *testing.T, ts topo.Store) {
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  1,
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -436,7 +452,7 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 		{
 			name: "Get nonexistent MultiPooler",
 			test: func(t *testing.T, ts topo.Store) {
-				id := &clustermetadatapb.ID{Cell: cell, Uid: 999}
+				id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: cell, Uid: "999"}
 				_, err := ts.GetMultiPooler(ctx, id)
 				require.Error(t, err)
 				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
@@ -447,8 +463,9 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 			test: func(t *testing.T, ts topo.Store) {
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  1,
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -470,8 +487,9 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 			test: func(t *testing.T, ts topo.Store) {
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  1,
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -507,8 +525,9 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 			test: func(t *testing.T, ts topo.Store) {
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id: &clustermetadatapb.ID{
-						Cell: cell,
-						Uid:  1,
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
 					},
 					Database:      "testdb",
 					Shard:         "testshard",
@@ -563,7 +582,11 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 			test: func(t *testing.T, ts topo.Store) {
 				multipoolers := []*clustermetadatapb.MultiPooler{
 					{
-						Id:            &clustermetadatapb.ID{Cell: cell1, Uid: 1},
+						Id: &clustermetadatapb.ID{
+							Component: clustermetadatapb.ID_MULTIPOOLER,
+							Cell:      cell1,
+							Uid:       fmt.Sprintf("%d", 1),
+						},
 						Database:      "db1",
 						Shard:         "shard1",
 						Hostname:      "host1",
@@ -572,7 +595,11 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 						ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 					},
 					{
-						Id:            &clustermetadatapb.ID{Cell: cell1, Uid: 3},
+						Id: &clustermetadatapb.ID{
+							Component: clustermetadatapb.ID_MULTIPOOLER,
+							Cell:      cell1,
+							Uid:       fmt.Sprintf("%d", 3),
+						},
 						Database:      "db2",
 						Shard:         "shard2",
 						Hostname:      "host3",
@@ -591,8 +618,16 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 				require.Len(t, ids, 2)
 
 				expectedIDs := []*clustermetadatapb.ID{
-					{Cell: cell1, Uid: 1},
-					{Cell: cell1, Uid: 3},
+					{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell1,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
+					{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell1,
+						Uid:       fmt.Sprintf("%d", 3),
+					},
 				}
 
 				slices.SortFunc(ids, func(a, b *clustermetadatapb.ID) int {
@@ -641,7 +676,11 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 		{
 			name: "Successful update",
 			test: func(t *testing.T, ts topo.Store) {
-				id := &clustermetadatapb.ID{Cell: cell, Uid: 1}
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      cell,
+					Uid:       fmt.Sprintf("%d", 1),
+				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
 					Database:      "testdb",
@@ -671,7 +710,11 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 		{
 			name: "Update function returns error",
 			test: func(t *testing.T, ts topo.Store) {
-				id := &clustermetadatapb.ID{Cell: cell, Uid: 1}
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      cell,
+					Uid:       fmt.Sprintf("%d", 1),
+				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
 					Database:      "testdb",
@@ -698,7 +741,11 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 		{
 			name: "NoUpdateNeeded returns nil",
 			test: func(t *testing.T, ts topo.Store) {
-				id := &clustermetadatapb.ID{Cell: cell, Uid: 1}
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      cell,
+					Uid:       fmt.Sprintf("%d", 1),
+				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
 					Database:      "testdb",
@@ -723,7 +770,11 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				tsWithFactory, factory := memorytopo.NewServerAndFactory(ctx, cell)
 				defer tsWithFactory.Close()
 
-				id := &clustermetadatapb.ID{Cell: cell, Uid: 1}
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      cell,
+					Uid:       fmt.Sprintf("%d", 1),
+				}
 				multipooler := &clustermetadatapb.MultiPooler{
 					Id:            id,
 					Database:      "testdb",
@@ -736,7 +787,8 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 				require.NoError(t, tsWithFactory.CreateMultiPooler(ctx, multipooler))
 
 				badVersionErr := &topo.TopoError{Code: topo.BadVersion}
-				factory.AddOneTimeOperationError(memorytopo.Update, "poolers/zone-1-1/Pooler", badVersionErr)
+				poolerPath := path.Join(topo.PoolersPath, topo.MultiPoolerIDString(id), topo.PoolerFile)
+				factory.AddOneTimeOperationError(memorytopo.Update, poolerPath, badVersionErr)
 
 				updateCallCount := 0
 				updated, err := tsWithFactory.UpdateMultiPoolerFields(ctx, id, func(mp *clustermetadatapb.MultiPooler) error {
@@ -777,7 +829,11 @@ func TestInitMultiPooler(t *testing.T) {
 			name: "Create new multipooler",
 			test: func(t *testing.T, ts topo.Store) {
 				multipooler := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "host1",
@@ -798,7 +854,11 @@ func TestInitMultiPooler(t *testing.T) {
 			name: "Update existing multipooler with allowUpdate=true",
 			test: func(t *testing.T, ts topo.Store) {
 				original := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "host1",
@@ -809,7 +869,11 @@ func TestInitMultiPooler(t *testing.T) {
 				require.NoError(t, ts.CreateMultiPooler(ctx, original))
 
 				updated := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "newhost",
@@ -830,7 +894,11 @@ func TestInitMultiPooler(t *testing.T) {
 			name: "Fail to update existing multipooler with allowUpdate=false",
 			test: func(t *testing.T, ts topo.Store) {
 				original := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "host1",
@@ -841,7 +909,11 @@ func TestInitMultiPooler(t *testing.T) {
 				require.NoError(t, ts.CreateMultiPooler(ctx, original))
 
 				updated := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "newhost",
@@ -859,7 +931,11 @@ func TestInitMultiPooler(t *testing.T) {
 			name: "Fail to update with different database/shard",
 			test: func(t *testing.T, ts topo.Store) {
 				original := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "testdb",
 					Shard:         "testshard",
 					Hostname:      "host1",
@@ -870,7 +946,11 @@ func TestInitMultiPooler(t *testing.T) {
 				require.NoError(t, ts.CreateMultiPooler(ctx, original))
 
 				updated := &clustermetadatapb.MultiPooler{
-					Id:            &clustermetadatapb.ID{Cell: cell, Uid: 1},
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIPOOLER,
+						Cell:      cell,
+						Uid:       fmt.Sprintf("%d", 1),
+					},
 					Database:      "differentdb",
 					Shard:         "testshard",
 					Hostname:      "host1",
@@ -899,20 +979,20 @@ func TestInitMultiPooler(t *testing.T) {
 func TestNewMultiPooler(t *testing.T) {
 	tests := []struct {
 		name     string
-		uid      uint32
+		uid      string
 		cell     string
 		host     string
 		expected *clustermetadatapb.MultiPooler
 	}{
 		{
 			name: "basic creation",
-			uid:  100,
+			uid:  "100",
 			cell: "zone1",
 			host: "host.example.com",
 			expected: &clustermetadatapb.MultiPooler{
 				Id: &clustermetadatapb.ID{
 					Cell: "zone1",
-					Uid:  100,
+					Uid:  "100",
 				},
 				Hostname: "host.example.com",
 				PortMap:  map[string]int32{},
@@ -935,8 +1015,9 @@ func TestNewMultiPooler(t *testing.T) {
 func TestMultiPoolerInfo(t *testing.T) {
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
-			Cell: "zone1",
-			Uid:  100,
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Uid:       "100",
 		},
 		Hostname: "host.example.com",
 		PortMap: map[string]int32{
@@ -949,13 +1030,13 @@ func TestMultiPoolerInfo(t *testing.T) {
 
 	t.Run("String method", func(t *testing.T) {
 		result := info.String()
-		expected := "MultiPooler{zone1-100}"
+		expected := "MultiPooler{multipooler-zone1-100}"
 		require.Equal(t, expected, result)
 	})
 
 	t.Run("IDString method", func(t *testing.T) {
 		result := info.IDString()
-		expected := "zone1-100"
+		expected := "multipooler-zone1-100"
 		require.Equal(t, expected, result)
 	})
 
@@ -968,8 +1049,9 @@ func TestMultiPoolerInfo(t *testing.T) {
 	t.Run("Addr method without grpc port", func(t *testing.T) {
 		multipoolerNoGrpc := &clustermetadatapb.MultiPooler{
 			Id: &clustermetadatapb.ID{
-				Cell: "zone1",
-				Uid:  100,
+				Component: clustermetadatapb.ID_MULTIPOOLER,
+				Cell:      "zone1",
+				Uid:       "100",
 			},
 			Hostname: "host.example.com",
 			PortMap: map[string]int32{
@@ -1001,7 +1083,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		// Setup: Create 4 multipoolers in zone1 (2 databases × 2 shards)
 		multipoolers := []*clustermetadatapb.MultiPooler{
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 1},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "1"},
 				Database:      "db1",
 				Shard:         "-8",
 				Hostname:      "host1",
@@ -1010,7 +1092,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 2},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "2"},
 				Database:      "db1",
 				Shard:         "8-",
 				Hostname:      "host2",
@@ -1019,7 +1101,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 3},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "3"},
 				Database:      "db2",
 				Shard:         "-8",
 				Hostname:      "host3",
@@ -1028,7 +1110,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 4},
+				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: "4"},
 				Database:      "db2",
 				Shard:         "8-",
 				Hostname:      "host4",
@@ -1071,7 +1153,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		// Setup: Create 2 multipoolers for db1 in zone1
 		multipoolers := []*clustermetadatapb.MultiPooler{
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 1},
+				Id: &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      "zone1",
+					Uid:       "1",
+				},
 				Database:      "db1",
 				Shard:         "-8",
 				Hostname:      "host1",
@@ -1080,7 +1166,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 2},
+				Id: &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      "zone1",
+					Uid:       "2",
+				},
 				Database:      "db1",
 				Shard:         "8-",
 				Hostname:      "host2",
@@ -1126,7 +1216,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		// Setup: Create 2 multipoolers for db2 in zone1
 		multipoolers := []*clustermetadatapb.MultiPooler{
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 1},
+				Id: &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      "zone1",
+					Uid:       "1",
+				},
 				Database:      "db2",
 				Shard:         "-8",
 				Hostname:      "host1",
@@ -1135,7 +1229,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 2},
+				Id: &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIPOOLER,
+					Cell:      "zone1",
+					Uid:       "2",
+				},
 				Database:      "db2",
 				Shard:         "8-",
 				Hostname:      "host2",
@@ -1205,7 +1303,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 
 		// Setup: Create multipoolers in both cells
 		zone1Multipooler := &clustermetadatapb.MultiPooler{
-			Id:            &clustermetadatapb.ID{Cell: "zone1", Uid: 1},
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIPOOLER,
+				Cell:      "zone1",
+				Uid:       "1",
+			},
 			Database:      "db1",
 			Shard:         "-8",
 			Hostname:      "host1",
@@ -1214,7 +1316,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 		}
 		zone2Multipooler := &clustermetadatapb.MultiPooler{
-			Id:            &clustermetadatapb.ID{Cell: "zone2", Uid: 1},
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIPOOLER,
+				Cell:      "zone2",
+				Uid:       "1",
+			},
 			Database:      "db1",
 			Shard:         "-8",
 			Hostname:      "host2",

--- a/go/clustermetadata/topo/multipooler_test.go
+++ b/go/clustermetadata/topo/multipooler_test.go
@@ -1009,6 +1009,30 @@ func TestNewMultiPooler(t *testing.T) {
 			require.NotNil(t, result.PortMap)
 		})
 	}
+
+	// Test random name generation when name is empty
+	t.Run("empty name generates random name", func(t *testing.T) {
+		result := topo.NewMultiPooler("", "zone2", "host2.example.com")
+
+		// Verify basic properties
+		require.Equal(t, "zone2", result.Id.Cell)
+		require.Equal(t, "host2.example.com", result.Hostname)
+		require.NotNil(t, result.PortMap)
+
+		// Verify random name was generated
+		require.NotEmpty(t, result.Id.Name, "expected random name to be generated for empty name")
+		require.Len(t, result.Id.Name, 8, "expected random name to be 8 characters long")
+
+		// Verify the generated name only contains valid characters
+		validChars := "bcdfghjklmnpqrstvwxz2456789"
+		for _, char := range result.Id.Name {
+			require.Contains(t, validChars, string(char), "generated name should only contain valid characters")
+		}
+
+		// Test that multiple calls generate different names
+		result2 := topo.NewMultiPooler("", "zone2", "host2.example.com")
+		require.NotEqual(t, result.Id.Name, result2.Id.Name, "multiple calls should generate different random names")
+	})
 }
 
 // TestMultiPoolerInfo tests the MultiPoolerInfo methods

--- a/go/clustermetadata/topo/utils.go
+++ b/go/clustermetadata/topo/utils.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Multigres Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topo
+
+import (
+	"strings"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// ComponentTypeToString converts a ComponentType enum to its string representation.
+// This function uses the generated name map to be resilient to refactors.
+// It's not specific to any single component type and can be used across the topology system.
+func ComponentTypeToString(component clustermetadatapb.ID_ComponentType) string {
+	// Use the generated name map for resilience - this automatically updates when the proto changes
+	if name, exists := clustermetadatapb.ID_ComponentType_name[int32(component)]; exists {
+		// Convert the generated name (e.g., "MULTIPOOLER") to lowercase for consistency
+		return strings.ToLower(name)
+	}
+	return "unknown"
+}

--- a/go/clustermetadata/topo/utils.go
+++ b/go/clustermetadata/topo/utils.go
@@ -15,7 +15,10 @@
 package topo
 
 import (
+	"math/rand/v2"
 	"strings"
+	"sync"
+	"time"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
@@ -30,4 +33,51 @@ func ComponentTypeToString(component clustermetadatapb.ID_ComponentType) string 
 		return strings.ToLower(name)
 	}
 	return "unknown"
+}
+
+// Random string generation utilities copied from Kubernetes codebase
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()))),
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// RandomString generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func RandomString(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt64 := rng.rand.Int64()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt64, remaining = rng.rand.Int64(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt64 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt64 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
 }

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -158,6 +158,62 @@ func (PoolerServingStatus) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{1}
 }
 
+type ID_ComponentType int32
+
+const (
+	// UNKNOWN represents an unknown or uninitialized component type
+	ID_UNKNOWN ID_ComponentType = 0
+	// MULTIPOOLER represents a multipooler component
+	ID_MULTIPOOLER ID_ComponentType = 1
+	// MULTIGATEWAY represents a multigateway component
+	ID_MULTIGATEWAY ID_ComponentType = 2
+	// MULTIORCH represents a multiorch component
+	ID_MULTIORCH ID_ComponentType = 3
+)
+
+// Enum value maps for ID_ComponentType.
+var (
+	ID_ComponentType_name = map[int32]string{
+		0: "UNKNOWN",
+		1: "MULTIPOOLER",
+		2: "MULTIGATEWAY",
+		3: "MULTIORCH",
+	}
+	ID_ComponentType_value = map[string]int32{
+		"UNKNOWN":      0,
+		"MULTIPOOLER":  1,
+		"MULTIGATEWAY": 2,
+		"MULTIORCH":    3,
+	}
+)
+
+func (x ID_ComponentType) Enum() *ID_ComponentType {
+	p := new(ID_ComponentType)
+	*p = x
+	return p
+}
+
+func (x ID_ComponentType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[2].Descriptor()
+}
+
+func (ID_ComponentType) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[2]
+}
+
+func (x ID_ComponentType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ID_ComponentType.Descriptor instead.
+func (ID_ComponentType) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{6, 0}
+}
+
 // TopoConfig defines the connection parameters for a topology service.
 // It specifies the type of topology backend, where it's hosted, and the
 // logical root path within that backend.
@@ -617,11 +673,13 @@ func (x *MultiOrch) GetPortMap() map[string]int32 {
 // ID is a globally unique pooler identifier.
 type ID struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// component identifies the type of Multigres component (multipooler, multigateway, or multiorch)
+	Component ID_ComponentType `protobuf:"varint,1,opt,name=component,proto3,enum=clustermetadata.ID_ComponentType" json:"component,omitempty"`
 	// cell is the Multigres cell where the component is located
 	Cell string `protobuf:"bytes,2,opt,name=cell,proto3" json:"cell,omitempty"`
 	// uid is a unique identifier for the component within the multigres
 	// cluster.
-	Uid           uint32 `protobuf:"varint,3,opt,name=uid,proto3" json:"uid,omitempty"`
+	Uid           string `protobuf:"bytes,3,opt,name=uid,proto3" json:"uid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -656,6 +714,13 @@ func (*ID) Descriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{6}
 }
 
+func (x *ID) GetComponent() ID_ComponentType {
+	if x != nil {
+		return x.Component
+	}
+	return ID_UNKNOWN
+}
+
 func (x *ID) GetCell() string {
 	if x != nil {
 		return x.Cell
@@ -663,11 +728,11 @@ func (x *ID) GetCell() string {
 	return ""
 }
 
-func (x *ID) GetUid() uint32 {
+func (x *ID) GetUid() string {
 	if x != nil {
 		return x.Uid
 	}
-	return 0
+	return ""
 }
 
 // KeyRange represents a range of keys for sharding
@@ -770,10 +835,16 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bport_map\x18\x03 \x03(\v2'.clustermetadata.MultiOrch.PortMapEntryR\aportMap\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"*\n" +
-	"\x02ID\x12\x12\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xbb\x01\n" +
+	"\x02ID\x12?\n" +
+	"\tcomponent\x18\x01 \x01(\x0e2!.clustermetadata.ID.ComponentTypeR\tcomponent\x12\x12\n" +
 	"\x04cell\x18\x02 \x01(\tR\x04cell\x12\x10\n" +
-	"\x03uid\x18\x03 \x01(\rR\x03uid\"2\n" +
+	"\x03uid\x18\x03 \x01(\tR\x03uid\"N\n" +
+	"\rComponentType\x12\v\n" +
+	"\aUNKNOWN\x10\x00\x12\x0f\n" +
+	"\vMULTIPOOLER\x10\x01\x12\x10\n" +
+	"\fMULTIGATEWAY\x10\x02\x12\r\n" +
+	"\tMULTIORCH\x10\x03\"2\n" +
 	"\bKeyRange\x12\x14\n" +
 	"\x05start\x18\x01 \x01(\fR\x05start\x12\x10\n" +
 	"\x03end\x18\x02 \x01(\fR\x03end*3\n" +
@@ -802,38 +873,40 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),          // 0: clustermetadata.PoolerType
 	(PoolerServingStatus)(0), // 1: clustermetadata.PoolerServingStatus
-	(*GlobalTopoConfig)(nil), // 2: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),             // 3: clustermetadata.Cell
-	(*Database)(nil),         // 4: clustermetadata.Database
-	(*MultiPooler)(nil),      // 5: clustermetadata.MultiPooler
-	(*MultiGateway)(nil),     // 6: clustermetadata.MultiGateway
-	(*MultiOrch)(nil),        // 7: clustermetadata.MultiOrch
-	(*ID)(nil),               // 8: clustermetadata.ID
-	(*KeyRange)(nil),         // 9: clustermetadata.KeyRange
-	nil,                      // 10: clustermetadata.MultiPooler.PortMapEntry
-	nil,                      // 11: clustermetadata.MultiGateway.PortMapEntry
-	nil,                      // 12: clustermetadata.MultiOrch.PortMapEntry
+	(ID_ComponentType)(0),    // 2: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil), // 3: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),             // 4: clustermetadata.Cell
+	(*Database)(nil),         // 5: clustermetadata.Database
+	(*MultiPooler)(nil),      // 6: clustermetadata.MultiPooler
+	(*MultiGateway)(nil),     // 7: clustermetadata.MultiGateway
+	(*MultiOrch)(nil),        // 8: clustermetadata.MultiOrch
+	(*ID)(nil),               // 9: clustermetadata.ID
+	(*KeyRange)(nil),         // 10: clustermetadata.KeyRange
+	nil,                      // 11: clustermetadata.MultiPooler.PortMapEntry
+	nil,                      // 12: clustermetadata.MultiGateway.PortMapEntry
+	nil,                      // 13: clustermetadata.MultiOrch.PortMapEntry
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	8,  // 0: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	9,  // 1: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	9,  // 0: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
+	10, // 1: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 2: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
 	1,  // 3: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	10, // 4: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	8,  // 5: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	11, // 6: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	8,  // 7: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	12, // 8: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	11, // 4: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	9,  // 5: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	12, // 6: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	9,  // 7: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	13, // 8: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	2,  // 9: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }
@@ -846,7 +919,7 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -158,6 +158,7 @@ func (PoolerServingStatus) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{1}
 }
 
+// ComponentType represents the type of Multigres component
 type ID_ComponentType int32
 
 const (
@@ -679,7 +680,7 @@ type ID struct {
 	Cell string `protobuf:"bytes,2,opt,name=cell,proto3" json:"cell,omitempty"`
 	// uid is a unique identifier for the component within the multigres
 	// cluster.
-	Uid           string `protobuf:"bytes,3,opt,name=uid,proto3" json:"uid,omitempty"`
+	Name          string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -728,9 +729,9 @@ func (x *ID) GetCell() string {
 	return ""
 }
 
-func (x *ID) GetUid() string {
+func (x *ID) GetName() string {
 	if x != nil {
-		return x.Uid
+		return x.Name
 	}
 	return ""
 }
@@ -835,11 +836,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bport_map\x18\x03 \x03(\v2'.clustermetadata.MultiOrch.PortMapEntryR\aportMap\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xbb\x01\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xbd\x01\n" +
 	"\x02ID\x12?\n" +
 	"\tcomponent\x18\x01 \x01(\x0e2!.clustermetadata.ID.ComponentTypeR\tcomponent\x12\x12\n" +
-	"\x04cell\x18\x02 \x01(\tR\x04cell\x12\x10\n" +
-	"\x03uid\x18\x03 \x01(\tR\x03uid\"N\n" +
+	"\x04cell\x18\x02 \x01(\tR\x04cell\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"N\n" +
 	"\rComponentType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x0f\n" +
 	"\vMULTIPOOLER\x10\x01\x12\x10\n" +

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -132,25 +132,6 @@ message MultiOrch {
   map<string, int32> port_map = 3;
 }
 
-// =============================================================================
-// Auxiliary Data Types
-// =============================================================================
-
-// ComponentType represents the type of Multigres component
-enum ComponentType {
-  // UNKNOWN represents an unknown or uninitialized component type
-  UNKNOWN = 0;
-  
-  // MULTIPOOLER represents a multipooler component
-  MULTIPOOLER = 1;
-  
-  // MULTIGATEWAY represents a multigateway component
-  MULTIGATEWAY = 2;
-  
-  // MULTIORCH represents a multiorch component
-  MULTIORCH = 3;
-}
-
 // ID is a globally unique pooler identifier.
 message ID {
   // component identifies the type of Multigres component (multipooler, multigateway, or multiorch)
@@ -161,7 +142,26 @@ message ID {
 
   // uid is a unique identifier for the component within the multigres
   // cluster. 
-  string uid = 3;
+  string name = 3;
+
+  // =============================================================================
+  // Auxiliary Data Types
+  // =============================================================================
+
+  // ComponentType represents the type of Multigres component
+  enum ComponentType {
+    // UNKNOWN represents an unknown or uninitialized component type
+    UNKNOWN = 0;
+
+    // MULTIPOOLER represents a multipooler component
+    MULTIPOOLER = 1;
+
+    // MULTIGATEWAY represents a multigateway component
+    MULTIGATEWAY = 2;
+
+    // MULTIORCH represents a multiorch component
+    MULTIORCH = 3;
+  }
 }
 
 // KeyRange represents a range of keys for sharding

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -136,14 +136,32 @@ message MultiOrch {
 // Auxiliary Data Types
 // =============================================================================
 
+// ComponentType represents the type of Multigres component
+enum ComponentType {
+  // UNKNOWN represents an unknown or uninitialized component type
+  UNKNOWN = 0;
+  
+  // MULTIPOOLER represents a multipooler component
+  MULTIPOOLER = 1;
+  
+  // MULTIGATEWAY represents a multigateway component
+  MULTIGATEWAY = 2;
+  
+  // MULTIORCH represents a multiorch component
+  MULTIORCH = 3;
+}
+
 // ID is a globally unique pooler identifier.
 message ID {
+  // component identifies the type of Multigres component (multipooler, multigateway, or multiorch)
+  ComponentType component = 1;
+  
   // cell is the Multigres cell where the component is located
   string cell = 2;
 
   // uid is a unique identifier for the component within the multigres
   // cluster. 
-  uint32 uid = 3;
+  string uid = 3;
 }
 
 // KeyRange represents a range of keys for sharding


### PR DESCRIPTION
# Desc
- Per our discussion, we are making the id not be an integer, but just a string. We think this will give better ergonomics. So ID's generated for components in the system will look something like this: `multigateway-cellname-q1t9v6bw`
- When creating a component, callers can decide to either provide the id themselves or let the system generate the names automatically. 
- The function to generate the names is the same kubernetes uses to generate pod names. 