### PR TITLE
topo: small update to api to init multipooler

### DIFF
--- a/go/clustermetadata/topo/multipooler.go
+++ b/go/clustermetadata/topo/multipooler.go
@@ -275,12 +275,7 @@ func (ts *store) DeleteMultiPooler(ctx context.Context, id *clustermetadatapb.ID
 
 // InitMultiPooler creates or updates a multipooler. If allowUpdate is true,
 // and a multipooler with the same ID exists, just update it.
-// If a multipooler is created as primary, and there is already a different
-// primary in the shard, allowPrimaryOverride must be set.
-func (ts *store) InitMultiPooler(ctx context.Context, mtpooler *clustermetadatapb.MultiPooler, allowPrimaryOverride, allowUpdate bool) error {
-	// TODO (@rafa): How are we going to do this? Is the topo suppose to try to discover
-	// where is the primary? We no longer have the shard metadata in the topo.
-	// In this context how do we discover where the ShardMetadata is???
+func (ts *store) InitMultiPooler(ctx context.Context, mtpooler *clustermetadatapb.MultiPooler, allowUpdate bool) error {
 	err := ts.CreateMultiPooler(ctx, mtpooler)
 	if errors.Is(err, &TopoError{Code: NodeExists}) && allowUpdate {
 		// Try to update then

--- a/go/clustermetadata/topo/multipooler_test.go
+++ b/go/clustermetadata/topo/multipooler_test.go
@@ -839,7 +839,7 @@ func TestInitMultiPooler(t *testing.T) {
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				}
 
-				err := ts.InitMultiPooler(ctx, multipooler, false, false)
+				err := ts.InitMultiPooler(ctx, multipooler, false)
 				require.NoError(t, err)
 
 				retrieved, err := ts.GetMultiPooler(ctx, multipooler.Id)
@@ -879,7 +879,7 @@ func TestInitMultiPooler(t *testing.T) {
 					ServingStatus: clustermetadatapb.PoolerServingStatus_NOT_SERVING,
 				}
 
-				err := ts.InitMultiPooler(ctx, updated, false, true)
+				err := ts.InitMultiPooler(ctx, updated, true)
 				require.NoError(t, err)
 
 				retrieved, err := ts.GetMultiPooler(ctx, original.Id)
@@ -919,7 +919,7 @@ func TestInitMultiPooler(t *testing.T) {
 					ServingStatus: clustermetadatapb.PoolerServingStatus_NOT_SERVING,
 				}
 
-				err := ts.InitMultiPooler(ctx, updated, false, false)
+				err := ts.InitMultiPooler(ctx, updated, false)
 				require.Error(t, err)
 				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NodeExists}))
 			},
@@ -956,7 +956,7 @@ func TestInitMultiPooler(t *testing.T) {
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				}
 
-				err := ts.InitMultiPooler(ctx, updated, false, true)
+				err := ts.InitMultiPooler(ctx, updated, true)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "Cannot override with shard")
 			},

--- a/go/clustermetadata/topo/store.go
+++ b/go/clustermetadata/topo/store.go
@@ -162,7 +162,7 @@ type CellStore interface {
 	UpdateMultiPooler(ctx context.Context, mpi *MultiPoolerInfo) error
 	UpdateMultiPoolerFields(ctx context.Context, id *clustermetadatapb.ID, update func(*clustermetadatapb.MultiPooler) error) (*clustermetadatapb.MultiPooler, error)
 	DeleteMultiPooler(ctx context.Context, id *clustermetadatapb.ID) error
-	InitMultiPooler(ctx context.Context, multipooler *clustermetadatapb.MultiPooler, allowPrimaryOverride, allowUpdate bool) error
+	InitMultiPooler(ctx context.Context, multipooler *clustermetadatapb.MultiPooler, allowUpdate bool) error
 
 	// MultiGateway CRUD operations
 	GetMultiGateway(ctx context.Context, id *clustermetadatapb.ID) (*MultiGatewayInfo, error)


### PR DESCRIPTION
# Desc

We discussed this and aligned on this flag not being a concern that should be encoded in the topo. In any case it should be MultiOrch who enforces this invariant. 