### PR TITLE
topo: add CRUD for multiorch

### DIFF
--- a/go/clustermetadata/topo/multiorch.go
+++ b/go/clustermetadata/topo/multiorch.go
@@ -1,0 +1,268 @@
+// Copyright 2025 The Multigres Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/multigres/multigres/go/mterrors"
+
+	"google.golang.org/protobuf/proto"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// NewMultiOrch creates a new MultiOrch record with the given name, cell, and hostname.
+// If name is empty, a random name will be generated.
+func NewMultiOrch(name string, cell, host string) *clustermetadatapb.MultiOrch {
+	if name == "" {
+		name = RandomString(8)
+	}
+	return &clustermetadatapb.MultiOrch{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIORCH,
+			Cell:      cell,
+			Name:      name,
+		},
+		Hostname: host,
+		PortMap:  make(map[string]int32),
+	}
+}
+
+// MultiOrchInfo is the container for a MultiOrch, read from the topology server.
+type MultiOrchInfo struct {
+	version Version // node version - used to prevent stomping concurrent writes
+	*clustermetadatapb.MultiOrch
+}
+
+// String returns a string describing the multiorch.
+func (moi *MultiOrchInfo) String() string {
+	return fmt.Sprintf("MultiOrch{%v}", MultiOrchIDString(moi.Id))
+}
+
+// IDString returns the string representation of the multiorch id
+func (moi *MultiOrchInfo) IDString() string {
+	return MultiOrchIDString(moi.Id)
+}
+
+// Addr returns hostname:grpc port.
+func (moi *MultiOrchInfo) Addr() string {
+	grpcPort, ok := moi.PortMap["grpc"]
+	if !ok {
+		return moi.Hostname
+	}
+	return fmt.Sprintf("%s:%d", moi.Hostname, grpcPort)
+}
+
+// Version returns the version of this multiorch from last time it was read or updated.
+func (moi *MultiOrchInfo) Version() Version {
+	return moi.version
+}
+
+// NewMultiOrchInfo returns a MultiOrchInfo based on multiorch with the
+// version set. This function should be only used by Server implementations.
+func NewMultiOrchInfo(multiorch *clustermetadatapb.MultiOrch, version Version) *MultiOrchInfo {
+	return &MultiOrchInfo{version: version, MultiOrch: multiorch}
+}
+
+// MultiOrchIDString returns the string representation of a MultiOrch ID
+func MultiOrchIDString(id *clustermetadatapb.ID) string {
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Name)
+}
+
+// GetMultiOrch is a high level function to read multiorch data.
+func (ts *store) GetMultiOrch(ctx context.Context, id *clustermetadatapb.ID) (*MultiOrchInfo, error) {
+	conn, err := ts.ConnForCell(ctx, id.Cell)
+	if err != nil {
+		return nil, mterrors.Wrap(err, fmt.Sprintf("unable to get connection for cell %q", id.Cell))
+	}
+
+	orchPath := path.Join(OrchsPath, MultiOrchIDString(id), OrchFile)
+	data, version, err := conn.Get(ctx, orchPath)
+	if err != nil {
+		return nil, mterrors.Wrap(err, fmt.Sprintf("unable to get multiorch %q", id))
+	}
+	multiorch := &clustermetadatapb.MultiOrch{}
+	if err := proto.Unmarshal(data, multiorch); err != nil {
+		return nil, mterrors.Wrap(err, "failed to unmarshal multiorch data")
+	}
+
+	return &MultiOrchInfo{
+		version:   version,
+		MultiOrch: multiorch,
+	}, nil
+}
+
+// GetMultiOrchIDsByCell returns all the multiorch IDs in a cell.
+// It returns ErrNoNode if the cell doesn't exist.
+// It returns (nil, nil) if the cell exists, but there are no multiorchs in it.
+func (ts *store) GetMultiOrchIDsByCell(ctx context.Context, cell string) ([]*clustermetadatapb.ID, error) {
+	// If the cell doesn't exist, this will return ErrNoNode.
+	conn, err := ts.ConnForCell(ctx, cell)
+	if err != nil {
+		return nil, err
+	}
+
+	// List the directory, and parse the IDs
+	children, err := conn.List(ctx, OrchsPath)
+	if err != nil {
+		if errors.Is(err, &TopoError{Code: NoNode}) {
+			// directory doesn't exist, empty list, no error.
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	result := make([]*clustermetadatapb.ID, len(children))
+	for i, child := range children {
+		multiorch := &clustermetadatapb.MultiOrch{}
+		if err := proto.Unmarshal(child.Value, multiorch); err != nil {
+			return nil, err
+		}
+		result[i] = multiorch.Id
+	}
+	return result, nil
+}
+
+// GetMultiOrchsByCell returns all the multiorchs in the cell.
+// It returns ErrNoNode if the cell doesn't exist.
+// It returns ErrPartialResult if some multiorchs couldn't be read. The results in the slice are incomplete.
+// It returns (nil, nil) if the cell exists, but there are no multiorchs in it.
+func (ts *store) GetMultiOrchsByCell(ctx context.Context, cellName string) ([]*MultiOrchInfo, error) {
+	// If the cell doesn't exist, this will return ErrNoNode.
+	cellConn, err := ts.ConnForCell(ctx, cellName)
+	if err != nil {
+		return nil, err
+	}
+	listResults, err := cellConn.List(ctx, OrchsPath)
+	if err != nil {
+		if errors.Is(err, &TopoError{Code: NoNode}) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	mtorchs := make([]*MultiOrchInfo, 0, len(listResults))
+	for n := range listResults {
+		multiorch := &clustermetadatapb.MultiOrch{}
+		if err := proto.Unmarshal(listResults[n].Value, multiorch); err != nil {
+			return nil, err
+		}
+		mtorchs = append(mtorchs, &MultiOrchInfo{MultiOrch: multiorch, version: listResults[n].Version})
+	}
+	return mtorchs, nil
+}
+
+// UpdateMultiOrch updates the multiorch data only - not associated replication paths.
+func (ts *store) UpdateMultiOrch(ctx context.Context, moi *MultiOrchInfo) error {
+	conn, err := ts.ConnForCell(ctx, moi.Id.Cell)
+	if err != nil {
+		return err
+	}
+
+	data, err := proto.Marshal(moi.MultiOrch)
+	if err != nil {
+		return err
+	}
+	orchPath := path.Join(OrchsPath, MultiOrchIDString(moi.Id), OrchFile)
+	newVersion, err := conn.Update(ctx, orchPath, data, moi.version)
+	if err != nil {
+		return err
+	}
+	moi.version = newVersion
+
+	return nil
+}
+
+// UpdateMultiOrchFields is a high level helper to read a multiorch record, call an
+// update function on it, and then write it back. If the write fails due to
+// a version mismatch, it will re-read the record and retry the update.
+// If the update succeeds, it returns the updated multiorch.
+// If the update method returns ErrNoUpdateNeeded, nothing is written,
+// and nil,nil is returned.
+func (ts *store) UpdateMultiOrchFields(ctx context.Context, id *clustermetadatapb.ID, update func(*clustermetadatapb.MultiOrch) error) (*clustermetadatapb.MultiOrch, error) {
+	for {
+		moi, err := ts.GetMultiOrch(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if err = update(moi.MultiOrch); err != nil {
+			if errors.Is(err, &TopoError{Code: NoUpdateNeeded}) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if err = ts.UpdateMultiOrch(ctx, moi); !errors.Is(err, &TopoError{Code: BadVersion}) {
+			return moi.MultiOrch, err
+		}
+	}
+}
+
+// CreateMultiOrch creates a new multiorch and all associated paths.
+func (ts *store) CreateMultiOrch(ctx context.Context, mtorch *clustermetadatapb.MultiOrch) error {
+	conn, err := ts.ConnForCell(ctx, mtorch.Id.Cell)
+	if err != nil {
+		return err
+	}
+
+	data, err := proto.Marshal(mtorch)
+	if err != nil {
+		return err
+	}
+	orchPath := path.Join(OrchsPath, MultiOrchIDString(mtorch.Id), OrchFile)
+	if _, err := conn.Create(ctx, orchPath, data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMultiOrch deletes the specified multiorch.
+func (ts *store) DeleteMultiOrch(ctx context.Context, id *clustermetadatapb.ID) error {
+	conn, err := ts.ConnForCell(ctx, id.Cell)
+	if err != nil {
+		return err
+	}
+
+	orchPath := path.Join(OrchsPath, MultiOrchIDString(id), OrchFile)
+	if err := conn.Delete(ctx, orchPath, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InitMultiOrch creates or updates a multiorch. If allowUpdate is true,
+// and a multiorch with the same ID exists, just update it.
+func (ts *store) InitMultiOrch(ctx context.Context, mtorch *clustermetadatapb.MultiOrch, allowUpdate bool) error {
+	err := ts.CreateMultiOrch(ctx, mtorch)
+	if errors.Is(err, &TopoError{Code: NodeExists}) && allowUpdate {
+		// Try to update then
+		oldMtOrch, err := ts.GetMultiOrch(ctx, mtorch.Id)
+		if err != nil {
+			return fmt.Errorf("failed reading existing mtorch %v: %v", MultiOrchIDString(mtorch.Id), err)
+		}
+
+		oldMtOrch.MultiOrch = proto.Clone(mtorch).(*clustermetadatapb.MultiOrch)
+		if err := ts.UpdateMultiOrch(ctx, oldMtOrch); err != nil {
+			return fmt.Errorf("failed updating mtorch %v: %v", MultiOrchIDString(mtorch.Id), err)
+		}
+		return nil
+	}
+	return err
+}

--- a/go/clustermetadata/topo/multiorch_test.go
+++ b/go/clustermetadata/topo/multiorch_test.go
@@ -1,0 +1,959 @@
+// Copyright 2025 The Multigres Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topo_test
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+
+	"github.com/multigres/multigres/go/clustermetadata/topo"
+	"github.com/multigres/multigres/go/clustermetadata/topo/memorytopo"
+)
+
+var (
+	multiorchs []*clustermetadatapb.MultiOrch
+)
+
+func init() {
+	uid := uint32(1)
+	for _, cell := range cells {
+		multiorch := getMultiOrch(cell, uid)
+		multiorchs = append(multiorchs, multiorch)
+		uid++
+	}
+}
+
+func getMultiOrch(cell string, uid uint32) *clustermetadatapb.MultiOrch {
+	return &clustermetadatapb.MultiOrch{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIORCH,
+			Cell:      cell,
+			Name:      fmt.Sprintf("%d", uid),
+		},
+		Hostname: "host1",
+		PortMap: map[string]int32{
+			"grpc": int32(uid),
+			"http": int32(uid + 8080),
+		},
+	}
+}
+
+func checkMultiOrchsEqual(t *testing.T, expected, actual *clustermetadatapb.MultiOrch) {
+	t.Helper()
+	require.Equal(t, expected.Id.String(), actual.Id.String())
+	require.Equal(t, expected.Hostname, actual.Hostname)
+	require.Equal(t, expected.PortMap, actual.PortMap)
+}
+
+func checkMultiOrchInfosEqual(t *testing.T, expected, actual []*topo.MultiOrchInfo) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for _, actualMO := range actual {
+		found := false
+		for _, expectedMO := range expected {
+			if topo.MultiOrchIDString(actualMO.Id) == topo.MultiOrchIDString(expectedMO.Id) {
+				checkMultiOrchsEqual(t, expectedMO.MultiOrch, actualMO.MultiOrch)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "unexpected multiorch %v", actualMO.IDString())
+	}
+}
+
+// Test various cases of calls to GetMultiOrchsByCell.
+func TestServerGetMultiOrchsByCell(t *testing.T) {
+	const cell = "zone1"
+
+	tests := []struct {
+		name                string
+		createCellMultiOrch int
+		expectedMultiOrch   []*clustermetadatapb.MultiOrch
+		listError           error
+	}{
+		{
+			name:                "single",
+			createCellMultiOrch: 1,
+			expectedMultiOrch: []*clustermetadatapb.MultiOrch{
+				{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "alpha",
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": 1,
+						"http": 8081,
+					},
+				},
+			},
+		},
+		{
+			name:                "multiple",
+			createCellMultiOrch: 4,
+			expectedMultiOrch: []*clustermetadatapb.MultiOrch{
+				{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "beta",
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": 1,
+						"http": 8081,
+					},
+				},
+				{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "echo",
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": 2,
+						"http": 8082,
+					},
+				},
+				{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "foxtrot",
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": 3,
+						"http": 8083,
+					},
+				},
+				{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "golf",
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": 4,
+						"http": 8084,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ts, factory := memorytopo.NewServerAndFactory(ctx, cell)
+			defer ts.Close()
+			if tt.listError != nil {
+				factory.AddOperationError(memorytopo.List, ".*", tt.listError)
+			}
+
+			// Create multiorchs with names from expected results
+			for i, expectedMO := range tt.expectedMultiOrch {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      expectedMO.Id.Name,
+					},
+					Hostname: "host1",
+					PortMap: map[string]int32{
+						"grpc": int32(i + 1),
+						"http": int32(i + 1 + 8080),
+					},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, multiorch))
+			}
+
+			out, err := ts.GetMultiOrchsByCell(ctx, cell)
+			require.NoError(t, err)
+			require.Len(t, out, len(tt.expectedMultiOrch))
+
+			slices.SortFunc(out, func(i, j *topo.MultiOrchInfo) int {
+				return cmp.Compare(i.Id.Name, j.Id.Name)
+			})
+			slices.SortFunc(tt.expectedMultiOrch, func(i, j *clustermetadatapb.MultiOrch) int {
+				return cmp.Compare(i.Id.Name, j.Id.Name)
+			})
+
+			for i, multiorchInfo := range out {
+				checkMultiOrchsEqual(t, tt.expectedMultiOrch[i], multiorchInfo.MultiOrch)
+			}
+		})
+	}
+}
+
+// TestMultiOrchIDString tests the ID string functionality
+func TestMultiOrchIDString(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       *clustermetadatapb.ID
+		expected string
+	}{
+		{
+			name:     "simple case",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "zone1", Name: "100"},
+			expected: "multiorch-zone1-100",
+		},
+		{
+			name:     "you can use name as numbers",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "prod", Name: "0"},
+			expected: "multiorch-prod-0",
+		},
+		{
+			name:     "funny name",
+			id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "prod", Name: "sleepy"},
+			expected: "multiorch-prod-sleepy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := topo.MultiOrchIDString(tt.id)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestMultiOrchCRUDOperations tests basic CRUD operations for multiorchs
+func TestMultiOrchCRUDOperations(t *testing.T) {
+	ctx := context.Background()
+	cell := "zone-1"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, ts topo.Store)
+	}{
+		{
+			name: "Create and Get MultiOrch",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "november",
+					},
+					Hostname: "host1.example.com",
+					PortMap:  map[string]int32{"grpc": 8080, "http": 9090},
+				}
+				err := ts.CreateMultiOrch(ctx, multiorch)
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetMultiOrch(ctx, multiorch.Id)
+				require.NoError(t, err)
+				checkMultiOrchsEqual(t, multiorch, retrieved.MultiOrch)
+				require.NotZero(t, retrieved.Version())
+			},
+		},
+		{
+			name: "Get nonexistent MultiOrch",
+			test: func(t *testing.T, ts topo.Store) {
+				id := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: cell, Name: "999"}
+				_, err := ts.GetMultiOrch(ctx, id)
+				require.Error(t, err)
+				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
+			},
+		},
+		{
+			name: "Create duplicate MultiOrch fails",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "oscar",
+					},
+					Hostname: "host1.example.com",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				err := ts.CreateMultiOrch(ctx, multiorch)
+				require.NoError(t, err)
+
+				err = ts.CreateMultiOrch(ctx, multiorch)
+				require.Error(t, err)
+				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NodeExists}))
+			},
+		},
+		{
+			name: "Update MultiOrch",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "papa",
+					},
+					Hostname: "host1.example.com",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				err := ts.CreateMultiOrch(ctx, multiorch)
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetMultiOrch(ctx, multiorch.Id)
+				require.NoError(t, err)
+				oldVersion := retrieved.Version()
+
+				retrieved.Hostname = "host2.example.com"
+				retrieved.PortMap["http"] = 9090
+
+				err = ts.UpdateMultiOrch(ctx, retrieved)
+				require.NoError(t, err)
+
+				updated, err := ts.GetMultiOrch(ctx, multiorch.Id)
+				require.NoError(t, err)
+				require.Equal(t, "host2.example.com", updated.Hostname)
+				require.Equal(t, int32(9090), updated.PortMap["http"])
+				require.NotEqual(t, oldVersion, updated.Version())
+			},
+		},
+		{
+			name: "Delete MultiOrch",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "quebec",
+					},
+					Hostname: "host1.example.com",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				err := ts.CreateMultiOrch(ctx, multiorch)
+				require.NoError(t, err)
+
+				err = ts.DeleteMultiOrch(ctx, multiorch.Id)
+				require.NoError(t, err)
+
+				_, err = ts.GetMultiOrch(ctx, multiorch.Id)
+				require.Error(t, err)
+
+				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := memorytopo.NewServerAndFactory(ctx, cell)
+			defer ts.Close()
+			tt.test(t, ts)
+		})
+	}
+}
+
+// TestGetMultiOrchIDsByCell tests getting multiorch IDs by cell
+func TestGetMultiOrchIDsByCell(t *testing.T) {
+	ctx := context.Background()
+	cell1 := "zone-1"
+	cell2 := "zone-2"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, ts topo.Store)
+	}{
+		{
+			name: "Empty cell returns empty list",
+			test: func(t *testing.T, ts topo.Store) {
+				ids, err := ts.GetMultiOrchIDsByCell(ctx, cell1)
+				require.NoError(t, err)
+				require.Empty(t, ids)
+			},
+		},
+		{
+			name: "Cell with multiorchs",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorchs := []*clustermetadatapb.MultiOrch{
+					{
+						Id: &clustermetadatapb.ID{
+							Component: clustermetadatapb.ID_MULTIORCH,
+							Cell:      cell1,
+							Name:      "bravo",
+						},
+						Hostname: "host1",
+						PortMap:  map[string]int32{"grpc": 8080},
+					},
+					{
+						Id: &clustermetadatapb.ID{
+							Component: clustermetadatapb.ID_MULTIORCH,
+							Cell:      cell1,
+							Name:      "charlie",
+						},
+						Hostname: "host3",
+						PortMap:  map[string]int32{"grpc": 8083},
+					},
+				}
+
+				for _, mo := range multiorchs {
+					require.NoError(t, ts.CreateMultiOrch(ctx, mo))
+				}
+
+				ids, err := ts.GetMultiOrchIDsByCell(ctx, cell1)
+				require.NoError(t, err)
+				require.Len(t, ids, 2)
+
+				expectedIDs := []*clustermetadatapb.ID{
+					{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell1,
+						Name:      "bravo",
+					},
+					{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell1,
+						Name:      "charlie",
+					},
+				}
+
+				slices.SortFunc(ids, func(a, b *clustermetadatapb.ID) int {
+					return cmp.Compare(a.Name, b.Name)
+				})
+
+				for i, id := range ids {
+					require.Equal(t, expectedIDs[i].Cell, id.Cell)
+					require.Equal(t, expectedIDs[i].Name, id.Name)
+				}
+
+				// Verify cell boundary: multiorchs are NOT accessible from cell2
+				cell2Ids, err := ts.GetMultiOrchIDsByCell(ctx, cell2)
+				require.NoError(t, err)
+				require.Empty(t, cell2Ids, "multiorchs should not be accessible from other cells")
+			},
+		},
+		{
+			name: "Nonexistent cell returns error",
+			test: func(t *testing.T, ts topo.Store) {
+				_, err := ts.GetMultiOrchIDsByCell(ctx, "nonexistent")
+				require.Error(t, err)
+				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := memorytopo.NewServerAndFactory(ctx, cell1, cell2)
+			defer ts.Close()
+			tt.test(t, ts)
+		})
+	}
+}
+
+// TestUpdateMultiOrchFields tests the update fields functionality with retry logic
+func TestUpdateMultiOrchFields(t *testing.T) {
+	ctx := context.Background()
+	cell := "zone-1"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, ts topo.Store)
+	}{
+		{
+			name: "Successful update",
+			test: func(t *testing.T, ts topo.Store) {
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIORCH,
+					Cell:      cell,
+					Name:      "tango",
+				}
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id:       id,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, multiorch))
+
+				updated, err := ts.UpdateMultiOrchFields(ctx, id, func(mo *clustermetadatapb.MultiOrch) error {
+					mo.Hostname = "newhost"
+					mo.PortMap["http"] = 9090
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, "newhost", updated.Hostname)
+				require.Equal(t, int32(9090), updated.PortMap["http"])
+
+				retrieved, err := ts.GetMultiOrch(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, "newhost", retrieved.Hostname)
+				require.Equal(t, int32(9090), retrieved.PortMap["http"])
+			},
+		},
+		{
+			name: "Update function returns error",
+			test: func(t *testing.T, ts topo.Store) {
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIORCH,
+					Cell:      cell,
+					Name:      "uniform",
+				}
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id:       id,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, multiorch))
+
+				updateErr := errors.New("update failed")
+				_, err := ts.UpdateMultiOrchFields(ctx, id, func(mo *clustermetadatapb.MultiOrch) error {
+					return updateErr
+				})
+				require.Error(t, err)
+				require.Equal(t, updateErr, err)
+
+				retrieved, err := ts.GetMultiOrch(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, "host1", retrieved.Hostname)
+			},
+		},
+		{
+			name: "NoUpdateNeeded returns nil",
+			test: func(t *testing.T, ts topo.Store) {
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIORCH,
+					Cell:      cell,
+					Name:      "victor",
+				}
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id:       id,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, multiorch))
+
+				result, err := ts.UpdateMultiOrchFields(ctx, id, func(mo *clustermetadatapb.MultiOrch) error {
+					return &topo.TopoError{Code: topo.NoUpdateNeeded}
+				})
+				require.NoError(t, err)
+				require.Nil(t, result)
+			},
+		},
+		{
+			name: "Retry on BadVersion error",
+			test: func(t *testing.T, ts topo.Store) {
+				tsWithFactory, factory := memorytopo.NewServerAndFactory(ctx, cell)
+				defer tsWithFactory.Close()
+
+				id := &clustermetadatapb.ID{
+					Component: clustermetadatapb.ID_MULTIORCH,
+					Cell:      cell,
+					Name:      "whiskey",
+				}
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id:       id,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, tsWithFactory.CreateMultiOrch(ctx, multiorch))
+
+				badVersionErr := &topo.TopoError{Code: topo.BadVersion}
+				orchPath := path.Join(topo.OrchsPath, topo.MultiOrchIDString(id), topo.OrchFile)
+				factory.AddOneTimeOperationError(memorytopo.Update, orchPath, badVersionErr)
+
+				updateCallCount := 0
+				updated, err := tsWithFactory.UpdateMultiOrchFields(ctx, id, func(mo *clustermetadatapb.MultiOrch) error {
+					updateCallCount++
+					mo.Hostname = "newhost"
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, 2, updateCallCount)
+				require.Equal(t, "newhost", updated.Hostname)
+
+				retrieved, err := tsWithFactory.GetMultiOrch(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, "newhost", retrieved.Hostname)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := memorytopo.NewServerAndFactory(ctx, cell)
+			defer ts.Close()
+			tt.test(t, ts)
+		})
+	}
+}
+
+// TestInitMultiOrch tests the init multiorch functionality
+func TestInitMultiOrch(t *testing.T) {
+	ctx := context.Background()
+	cell := "zone-1"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, ts topo.Store)
+	}{
+		{
+			name: "Create new multiorch",
+			test: func(t *testing.T, ts topo.Store) {
+				multiorch := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "zulu",
+					},
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+
+				err := ts.InitMultiOrch(ctx, multiorch, false)
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetMultiOrch(ctx, multiorch.Id)
+				require.NoError(t, err)
+				checkMultiOrchsEqual(t, multiorch, retrieved.MultiOrch)
+			},
+		},
+		{
+			name: "Update existing multiorch with allowUpdate=true",
+			test: func(t *testing.T, ts topo.Store) {
+				original := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "xray",
+					},
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, original))
+
+				updated := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "xray",
+					},
+					Hostname: "newhost",
+					PortMap:  map[string]int32{"grpc": 8081, "http": 9090},
+				}
+
+				err := ts.InitMultiOrch(ctx, updated, true)
+				require.NoError(t, err)
+
+				retrieved, err := ts.GetMultiOrch(ctx, original.Id)
+				require.NoError(t, err)
+				checkMultiOrchsEqual(t, updated, retrieved.MultiOrch)
+			},
+		},
+		{
+			name: "Fail to update existing multiorch with allowUpdate=false",
+			test: func(t *testing.T, ts topo.Store) {
+				original := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "whiskey",
+					},
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": 8080},
+				}
+				require.NoError(t, ts.CreateMultiOrch(ctx, original))
+
+				updated := &clustermetadatapb.MultiOrch{
+					Id: &clustermetadatapb.ID{
+						Component: clustermetadatapb.ID_MULTIORCH,
+						Cell:      cell,
+						Name:      "whiskey",
+					},
+					Hostname: "newhost",
+					PortMap:  map[string]int32{"grpc": 8081},
+				}
+
+				err := ts.InitMultiOrch(ctx, updated, false)
+				require.Error(t, err)
+				require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NodeExists}))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := memorytopo.NewServerAndFactory(ctx, cell)
+			defer ts.Close()
+			tt.test(t, ts)
+		})
+	}
+}
+
+// TestNewMultiOrch tests the factory function
+func TestNewMultiOrch(t *testing.T) {
+	tests := []struct {
+		testName string
+		name     string
+		cell     string
+		host     string
+		expected *clustermetadatapb.MultiOrch
+	}{
+		{
+			testName: "basic creation",
+			name:     "100",
+			cell:     "zone1",
+			host:     "host.example.com",
+			expected: &clustermetadatapb.MultiOrch{
+				Id: &clustermetadatapb.ID{
+					Cell: "zone1",
+					Name: "100",
+				},
+				Hostname: "host.example.com",
+				PortMap:  map[string]int32{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			result := topo.NewMultiOrch(tt.name, tt.cell, tt.host)
+			require.Equal(t, tt.expected.Id.Cell, result.Id.Cell)
+			require.Equal(t, tt.expected.Id.Name, result.Id.Name)
+			require.Equal(t, tt.expected.Hostname, result.Hostname)
+			require.NotNil(t, result.PortMap)
+		})
+	}
+
+	// Test random name generation when name is empty
+	t.Run("empty name generates random name", func(t *testing.T) {
+		result := topo.NewMultiOrch("", "zone2", "host2.example.com")
+
+		// Verify basic properties
+		require.Equal(t, "zone2", result.Id.Cell)
+		require.Equal(t, "host2.example.com", result.Hostname)
+		require.NotNil(t, result.PortMap)
+
+		// Verify random name was generated
+		require.NotEmpty(t, result.Id.Name, "expected random name to be generated for empty name")
+		require.Len(t, result.Id.Name, 8, "expected random name to be 8 characters long")
+
+		// Verify the generated name only contains valid characters
+		validChars := "bcdfghjklmnpqrstvwxz2456789"
+		for _, char := range result.Id.Name {
+			require.Contains(t, validChars, string(char), "generated name should only contain valid characters")
+		}
+
+		// Test that multiple calls generate different names
+		result2 := topo.NewMultiOrch("", "zone2", "host2.example.com")
+		require.NotEqual(t, result.Id.Name, result2.Id.Name, "multiple calls should generate different random names")
+	})
+}
+
+// TestMultiOrchInfo tests the MultiOrchInfo methods
+func TestMultiOrchInfo(t *testing.T) {
+	multiorch := &clustermetadatapb.MultiOrch{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIORCH,
+			Cell:      "zone1",
+			Name:      "100",
+		},
+		Hostname: "host.example.com",
+		PortMap: map[string]int32{
+			"grpc": 8080,
+			"http": 9090,
+		},
+	}
+	version := memorytopo.NodeVersion(123)
+	info := topo.NewMultiOrchInfo(multiorch, version)
+
+	t.Run("String method", func(t *testing.T) {
+		result := info.String()
+		expected := "MultiOrch{multiorch-zone1-100}"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("IDString method", func(t *testing.T) {
+		result := info.IDString()
+		expected := "multiorch-zone1-100"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("Addr method with grpc port", func(t *testing.T) {
+		result := info.Addr()
+		expected := "host.example.com:8080"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("Addr method without grpc port", func(t *testing.T) {
+		multiorchNoGrpc := &clustermetadatapb.MultiOrch{
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIORCH,
+				Cell:      "zone1",
+				Name:      "100",
+			},
+			Hostname: "host.example.com",
+			PortMap: map[string]int32{
+				"http": 9090,
+			},
+		}
+		infoNoGrpc := topo.NewMultiOrchInfo(multiorchNoGrpc, version)
+		result := infoNoGrpc.Addr()
+		expected := "host.example.com"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("Version method", func(t *testing.T) {
+		result := info.Version()
+		require.Equal(t, version, result)
+	})
+}
+
+// TestGetMultiOrchsByCell covers comprehensive scenarios for the GetMultiOrchsByCell method
+func TestGetMultiOrchsByCell_Comprehensive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Run("cell with multiple multiorchs", func(t *testing.T) {
+		// Create fresh topo for this test with multiple cells
+		ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1", "zone2")
+		defer ts.Close()
+
+		// Setup: Create 3 multiorchs in zone1
+		multiorchs := []*clustermetadatapb.MultiOrch{
+			{
+				Id:       &clustermetadatapb.ID{Cell: "zone1", Name: "1"},
+				Hostname: "host1",
+				PortMap:  map[string]int32{"grpc": 8080, "http": 9090},
+			},
+			{
+				Id:       &clustermetadatapb.ID{Cell: "zone1", Name: "2"},
+				Hostname: "host2",
+				PortMap:  map[string]int32{"grpc": 8081, "http": 9091},
+			},
+			{
+				Id:       &clustermetadatapb.ID{Cell: "zone1", Name: "3"},
+				Hostname: "host3",
+				PortMap:  map[string]int32{"grpc": 8082, "http": 9092},
+			},
+		}
+
+		// Create all multiorchs
+		for _, mo := range multiorchs {
+			require.NoError(t, ts.CreateMultiOrch(ctx, mo))
+		}
+
+		// Test: Get all multiorchs
+		multiorchInfos, err := ts.GetMultiOrchsByCell(ctx, "zone1")
+		require.NoError(t, err)
+		require.Len(t, multiorchInfos, 3)
+
+		// Verify all multiorchs are returned
+		expectedMOs := []*topo.MultiOrchInfo{
+			{MultiOrch: multiorchs[0]},
+			{MultiOrch: multiorchs[1]},
+			{MultiOrch: multiorchs[2]},
+		}
+		checkMultiOrchInfosEqual(t, expectedMOs, multiorchInfos)
+
+		// Verify cell boundary: multiorchs are NOT accessible from other cells
+		otherCellInfos, err := ts.GetMultiOrchsByCell(ctx, "zone2")
+		require.NoError(t, err)
+		require.Empty(t, otherCellInfos, "multiorchs should not be accessible from other cells")
+	})
+
+	t.Run("empty cell returns empty list", func(t *testing.T) {
+		// Create fresh topo for this test
+		ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+		defer ts.Close()
+
+		// Setup: No multiorchs created
+
+		// Test: Get multiorchs from empty cell
+		multiorchInfos, err := ts.GetMultiOrchsByCell(ctx, "zone1")
+		require.NoError(t, err)
+		require.Empty(t, multiorchInfos)
+	})
+
+	t.Run("nonexistent cell returns NoNode error", func(t *testing.T) {
+		// Create fresh topo for this test
+		ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+		defer ts.Close()
+
+		// Setup: No multiorchs created
+
+		// Test: Try to get multiorchs from nonexistent cell
+		_, err := ts.GetMultiOrchsByCell(ctx, "nonexistent")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, &topo.TopoError{Code: topo.NoNode}))
+	})
+
+	t.Run("multiorchs are isolated between cells", func(t *testing.T) {
+		// Create fresh topo for this test with multiple cells
+		ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1", "zone2")
+		defer ts.Close()
+
+		// Setup: Create multiorchs in both cells
+		zone1MultiOrch := &clustermetadatapb.MultiOrch{
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIORCH,
+				Cell:      "zone1",
+				Name:      "1",
+			},
+			Hostname: "host1",
+			PortMap:  map[string]int32{"grpc": 8080, "http": 9090},
+		}
+		zone2MultiOrch := &clustermetadatapb.MultiOrch{
+			Id: &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIORCH,
+				Cell:      "zone2",
+				Name:      "1",
+			},
+			Hostname: "host2",
+			PortMap:  map[string]int32{"grpc": 8081, "http": 9091},
+		}
+
+		// Create multiorchs in their respective cells
+		require.NoError(t, ts.CreateMultiOrch(ctx, zone1MultiOrch))
+		require.NoError(t, ts.CreateMultiOrch(ctx, zone2MultiOrch))
+
+		// Test: Verify zone1 can only see its own multiorch
+		zone1Infos, err := ts.GetMultiOrchsByCell(ctx, "zone1")
+		require.NoError(t, err)
+		require.Len(t, zone1Infos, 1)
+		require.Equal(t, "zone1", zone1Infos[0].Id.Cell)
+		require.Equal(t, "host1", zone1Infos[0].Hostname)
+
+		// Test: Verify zone2 can only see its own multiorch
+		zone2Infos, err := ts.GetMultiOrchsByCell(ctx, "zone2")
+		require.NoError(t, err)
+		require.Len(t, zone2Infos, 1)
+		require.Equal(t, "zone2", zone2Infos[0].Id.Cell)
+		require.Equal(t, "host2", zone2Infos[0].Hostname)
+
+		// Test: Verify cross-cell access is properly isolated
+		zone1FromZone2, err := ts.GetMultiOrch(ctx, zone1MultiOrch.Id)
+		require.NoError(t, err, "should be able to get multiorch by ID regardless of current cell context")
+		require.Equal(t, "zone1", zone1FromZone2.Id.Cell)
+
+		zone2FromZone1, err := ts.GetMultiOrch(ctx, zone2MultiOrch.Id)
+		require.NoError(t, err, "should be able to get multiorch by ID regardless of current cell context")
+		require.Equal(t, "zone2", zone2FromZone1.Id.Cell)
+	})
+}

--- a/go/clustermetadata/topo/store.go
+++ b/go/clustermetadata/topo/store.go
@@ -91,6 +91,7 @@ const (
 	DatabaseFile = "Database"
 	GatewayFile  = "Gateway"
 	PoolerFile   = "Pooler"
+	OrchFile     = "Orch"
 )
 
 // Paths for all object types in the topology hierarchy.
@@ -99,6 +100,7 @@ const (
 	CellsPath     = "cells"
 	GatewaysPath  = "gateways"
 	PoolersPath   = "poolers"
+	OrchsPath     = "orchs"
 )
 
 // Factory is a factory interface to create Conn objects.
@@ -173,6 +175,16 @@ type CellStore interface {
 	UpdateMultiGatewayFields(ctx context.Context, id *clustermetadatapb.ID, update func(*clustermetadatapb.MultiGateway) error) (*clustermetadatapb.MultiGateway, error)
 	DeleteMultiGateway(ctx context.Context, id *clustermetadatapb.ID) error
 	InitMultiGateway(ctx context.Context, multigateway *clustermetadatapb.MultiGateway, allowUpdate bool) error
+
+	// MultiOrch CRUD operations
+	GetMultiOrch(ctx context.Context, id *clustermetadatapb.ID) (*MultiOrchInfo, error)
+	GetMultiOrchIDsByCell(ctx context.Context, cell string) ([]*clustermetadatapb.ID, error)
+	GetMultiOrchsByCell(ctx context.Context, cellName string) ([]*MultiOrchInfo, error)
+	CreateMultiOrch(ctx context.Context, multiorch *clustermetadatapb.MultiOrch) error
+	UpdateMultiOrch(ctx context.Context, moi *MultiOrchInfo) error
+	UpdateMultiOrchFields(ctx context.Context, id *clustermetadatapb.ID, update func(*clustermetadatapb.MultiOrch) error) (*clustermetadatapb.MultiOrch, error)
+	DeleteMultiOrch(ctx context.Context, id *clustermetadatapb.ID) error
+	InitMultiOrch(ctx context.Context, multiorch *clustermetadatapb.MultiOrch, allowUpdate bool) error
 }
 
 // Store is the full topology API that combines both global and cell operations.


### PR DESCRIPTION
Added CRUD operations for MultiOrch in the topo with unit tests. This follows the same patterns as MultiPooler and MultiGateway.