### PR TITLE
tools: install etcd

### DIFF
--- a/build.env
+++ b/build.env
@@ -12,3 +12,4 @@ export PROTOC_VER=25.1
 export ADDLICENSE_VER=v1.2.0
 export PROTOC_GEN_GO_VER=v1.36.7
 export PROTOC_GEN_GO_GRPC_VER=v1.3.0
+export ETCD_VER=v3.6.4

--- a/tools/setup_build_tools.sh
+++ b/tools/setup_build_tools.sh
@@ -25,6 +25,7 @@ PROTOC_VERSION="$PROTOC_VER"
 ADDLICENSE_VERSION="$ADDLICENSE_VER"
 PROTOC_GEN_GO_VERSION="$PROTOC_GEN_GO_VER"
 PROTOC_GEN_GO_GRPC_VERSION="$PROTOC_GEN_GO_GRPC_VER"
+ETCD_VERSION="$ETCD_VER"
 
 get_platform() {
     case $(uname) in
@@ -38,7 +39,7 @@ get_arch() {
     case $(uname -m) in
         x86_64) echo "x86_64";;
         aarch64) echo "aarch_64";;
-        arm64) 
+        arm64)
             case $(get_platform) in
                 osx) echo "aarch_64";;
                 *) echo "ERROR: unsupported architecture"; exit 1;;
@@ -51,30 +52,33 @@ install_dep() {
     local name="$1"
     local version="$2"
     local dist="$3"
-    
+
     local version_file="$dist/.installed_version"
-    
+
     # Check if already installed with correct version
     if [[ -f "$version_file" && "$(cat "$version_file")" == "$version" ]]; then
         return 0
     fi
-    
+
     echo "Installing $name $version..."
-    
+
     # Clean up any existing installation
     rm -rf "$dist"
     mkdir -p "$dist"
-    
+
     case "$name" in
         "protoc")
             install_protoc_impl "$version" "$dist"
+            ;;
+        "etcd")
+            install_etcd "$version" "$dist"
             ;;
         *)
             echo "ERROR: unknown dependency $name"
             exit 1
             ;;
     esac
-    
+
     # Mark as installed with this version
     echo "$version" > "$version_file"
     echo "$name installed successfully"
@@ -83,24 +87,65 @@ install_dep() {
 install_protoc_impl() {
     local version="$1"
     local dist="$2"
-    
+
     local platform=$(get_platform)
     local arch=$(get_arch)
     local filename="protoc-${version}-${platform}-${arch}.zip"
     local url="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/${filename}"
-    
+
     cd "$dist"
-    
+
     echo "Downloading ${url}..."
     curl -L -o "${filename}" "${url}"
-    
+
     echo "Extracting protoc..."
     unzip -q "${filename}"
-    
+
     # protoc is now available at $dist/bin/protoc
-    
+
     # Clean up
     rm "${filename}"
+    cd - > /dev/null
+}
+
+# Download and install etcd, link etcd binary into our root.
+install_etcd() {
+    local version="$1"
+    local dist="$2"
+
+    case $(uname) in
+        Linux)  local platform=linux; local ext=tar.gz;;
+        Darwin) local platform=darwin; local ext=zip;;
+        *)   echo "ERROR: unsupported platform for etcd"; exit 1;;
+    esac
+
+    case $(uname -m) in
+        aarch64)  local arch=arm64;;
+        x86_64)  local arch=amd64;;
+        arm64)  local arch=arm64;;
+        *)   echo "ERROR: unsupported architecture for etcd"; exit 1;;
+    esac
+
+    local filename="etcd-${version}-${platform}-${arch}.${ext}"
+
+    # This is how we'd download directly from source:
+    local url="https://github.com/etcd-io/etcd/releases/download/$version/$filename"
+
+    cd "$dist"
+    echo "Downloading ${url}..."
+    curl -L -o "${filename}" "${url}"
+
+    echo "Extracting etcd..."
+
+    if [ "$ext" = "tar.gz" ]; then
+        tar xzf "$filename"
+    else
+        unzip -q "$filename"
+    fi
+
+    rm "$filename"
+    ln -snf "$dist/etcd-${version}-${platform}-${arch}/etcd" "$MTROOT/bin/etcd"
+    ln -snf "$dist/etcd-${version}-${platform}-${arch}/etcdctl" "$MTROOT/bin/etcdctl"
     cd - > /dev/null
 }
 
@@ -128,10 +173,13 @@ install_go_tools() {
 install_all() {
     # Create dist directory
     mkdir -p "$MTROOT/dist"
-    
+
     # Install binary dependencies
     install_dep "protoc" "$PROTOC_VERSION" "$MTROOT/dist/protoc-$PROTOC_VERSION"
-    
+
+    # Install etcd
+    install_dep "etcd" "$ETCD_VERSION" "$MTROOT/dist/etcd"
+
     # Install Go dependencies
     install_go_plugins
     install_go_tools


### PR DESCRIPTION
`make tools` will now also install etcd so that there's no need to do it manually.
Cluster bootstrap expects etcd in the path. We symlink etcd into multigres/bin, so that it's available from the same place as all other binaries.
It is necessary to add ./bin from the multigres root directory for this version of etcd to be detected and used.