### PR TITLE
build: simplify CI verification of postgres install

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -46,25 +46,16 @@ jobs:
 
       - name: Verify PostgreSQL Installation
         run: |
-          # Debug: Check what PostgreSQL packages are installed
-          dpkg -l | grep postgres
-          # Debug: Find PostgreSQL binaries
-          find /usr -name "initdb" 2>/dev/null || echo "initdb not found in /usr"
-          find /usr -name "postgres" 2>/dev/null | head -5
-          # Try to locate PostgreSQL binaries
-          ls -la /usr/lib/postgresql/*/bin/ || echo "No PostgreSQL bin directory found"
-          # Add PostgreSQL binaries to PATH if they exist
+          # Add PostgreSQL binaries to PATH
           # shellcheck disable=SC2012
           PATH="/usr/lib/postgresql/$(ls /usr/lib/postgresql/ | head -1)/bin:$PATH"
           export PATH
-          # Now try to verify the binaries
-          which initdb || echo "initdb still not found"
-          which postgres || echo "postgres still not found"
-          which pg_ctl || echo "pg_ctl still not found"
-          which pg_isready || echo "pg_isready still not found"
-          which psql || echo "psql still not found"
-          postgres --version || echo "postgres version failed"
-          initdb --version || echo "initdb version failed"
+          # Now verify the binaries
+          postgres --version
+          initdb --version
+          pg_ctl --version
+          pg_isready --version
+          psql --version
 
       - name: Install etcd binary
         run: |


### PR DESCRIPTION
The existing code is doing some debugging work that sometimes seems to make integration tests slow. Seems like we can always add debugging statements into PRs if/when something breaks, but maybe we don't need them for now?...