### PR TITLE
Pgctld bootstrap local

### DIFF
--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/multigres/multigres/go/pb/pgctldservice"
+)
+
+// waitForServiceReady waits for a service to become ready by checking appropriate endpoints
+func (p *localProvisioner) waitForServiceReady(serviceName string, host string, servicePorts map[string]int, timeout time.Duration) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("%s did not become ready within %v", serviceName, timeout)
+		case <-ticker.C:
+			// First check TCP connectivity on all advertised ports
+			allPortsReady := true
+			for _, port := range servicePorts {
+				address := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+				conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+				if err != nil {
+					allPortsReady = false
+					break // This port not ready yet
+				}
+				conn.Close()
+			}
+			if !allPortsReady {
+				continue // Not all ports ready yet
+			}
+			// For services with HTTP endpoints, check debug/config endpoint
+			if err := p.checkMultigresServiceHealth(serviceName, host, servicePorts); err != nil {
+				continue // HTTP endpoint not ready yet
+			}
+			return nil // Service is ready
+		}
+	}
+}
+
+// checkMultigresServiceHealth checks health for all supported service port types
+func (p *localProvisioner) checkMultigresServiceHealth(serviceName string, host string, servicePorts map[string]int) error {
+	// Iterate over service ports and run health checks for supported types
+	for portType, port := range servicePorts {
+		switch portType {
+		case "http_port":
+			// Run HTTP health check
+			httpAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+			if err := p.checkDebugConfigEndpoint(httpAddress); err != nil {
+				return err
+			}
+		case "grpc_port":
+			// Run gRPC health check for pgctld
+			if serviceName == "pgctld" {
+				grpcAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+				if err := p.checkPgctldGrpcHealth(grpcAddress); err != nil {
+					return err
+				}
+			}
+			// Future: Add other gRPC services
+		default:
+			// No health check implemented for this port type, skip
+			continue
+		}
+	}
+	return nil
+}
+
+// checkDebugConfigEndpoint checks if the debug/config endpoint returns 200 OK
+func (p *localProvisioner) checkDebugConfigEndpoint(address string) error {
+	url := fmt.Sprintf("http://%s/live", address)
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to reach debug endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("debug endpoint returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// checkPgctldGrpcHealth checks if pgctld gRPC server is healthy by calling Status
+func (p *localProvisioner) checkPgctldGrpcHealth(address string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewPgCtldClient(conn)
+	_, err = client.Status(ctx, &pb.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("pgctld gRPC status call failed: %w", err)
+	}
+
+	return nil
+}

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -1133,7 +1133,9 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 	serviceID := ""
 	if id, ok := multipoolerConfig["service-id"].(string); ok && id != "" {
 		serviceID = id
-	} else {
+	}
+
+	if err != nil {
 		return nil, fmt.Errorf("service-id not found in multipooler config for cell %s", cell)
 	}
 

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +57,7 @@ type CellServicesConfig struct {
 	Multigateway MultigatewayConfig `yaml:"multigateway"`
 	Multipooler  MultipoolerConfig  `yaml:"multipooler"`
 	Multiorch    MultiorchConfig    `yaml:"multiorch"`
+	Pgctld       PgctldConfig       `yaml:"pgctld"`
 }
 
 // LocalProvisionerConfig represents the typed configuration for the local provisioner
@@ -91,6 +91,7 @@ type MultipoolerConfig struct {
 	Path       string `yaml:"path"`
 	Database   string `yaml:"database"`
 	TableGroup string `yaml:"table-group"`
+	ServiceID  string `yaml:"service-id"`
 	HttpPort   int    `yaml:"http-port"`
 	GrpcPort   int    `yaml:"grpc-port"`
 	LogLevel   string `yaml:"log-level"`
@@ -110,6 +111,19 @@ type MultiadminConfig struct {
 	HttpPort int    `yaml:"http-port"`
 	GrpcPort int    `yaml:"grpc-port"`
 	LogLevel string `yaml:"log-level"`
+}
+
+// PgctldConfig holds pgctld service configuration
+type PgctldConfig struct {
+	Path       string `yaml:"path"`
+	PoolerDir  string `yaml:"pooler-dir"`  // Base directory for this pgctld instance
+	GrpcPort   int    `yaml:"grpc-port"`   // gRPC port for pgctld server
+	PgPort     int    `yaml:"pg-port"`     // PostgreSQL port
+	PgDatabase string `yaml:"pg-database"` // PostgreSQL database name
+	PgUser     string `yaml:"pg-user"`     // PostgreSQL username
+	PgPwfile   string `yaml:"pg-pwfile"`   // PostgreSQL password file path (optional)
+	Timeout    int    `yaml:"timeout"`     // Operation timeout in seconds
+	LogLevel   string `yaml:"log-level"`   // Log level
 }
 
 // localProvisioner implements the Provisioner interface for local binary-based provisioning
@@ -207,10 +221,16 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 		fmt.Println("Warning: MTROOT environment variable is not set, using relative paths for default binary configuration in local provisioner.")
 	}
 
+	// Generate service IDs for each cell using the same method as topo components
+	serviceIDZone1 := stringutil.RandomString(8)
+	serviceIDZone2 := stringutil.RandomString(8)
+	tableGroup := "default"
+	dbName := "postgres"
+
 	// Create typed configuration with defaults
 	localConfig := LocalProvisionerConfig{
 		RootWorkingDir: baseDir,
-		DefaultDbName:  "postgres",
+		DefaultDbName:  dbName,
 		Etcd: EtcdConfig{
 			Version: "3.5.9",
 			DataDir: filepath.Join(baseDir, "data", "etcd-data"),
@@ -247,8 +267,9 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 				},
 				Multipooler: MultipoolerConfig{
 					Path:       filepath.Join(binDir, "multipooler"),
-					Database:   "postgres",
-					TableGroup: "default",
+					Database:   dbName,
+					TableGroup: tableGroup,
+					ServiceID:  serviceIDZone1,
 					HttpPort:   15100,
 					GrpcPort:   16001,
 					LogLevel:   "info",
@@ -258,6 +279,17 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 					HttpPort: 15300,
 					GrpcPort: 16000,
 					LogLevel: "info",
+				},
+				Pgctld: PgctldConfig{
+					Path:       filepath.Join(binDir, "pgctld"),
+					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone1),
+					GrpcPort:   17000,
+					PgPort:     5432,
+					PgDatabase: dbName,
+					PgUser:     "postgres",
+					PgPwfile:   filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone1), "pgpassword.txt"),
+					Timeout:    30,
+					LogLevel:   "info",
 				},
 			},
 			"zone2": {
@@ -270,8 +302,9 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 				},
 				Multipooler: MultipoolerConfig{
 					Path:       filepath.Join(binDir, "multipooler"),
-					Database:   "postgres",
-					TableGroup: "default",
+					Database:   dbName,
+					TableGroup: tableGroup,
+					ServiceID:  serviceIDZone2,
 					HttpPort:   15200, // zone1 + 100
 					GrpcPort:   16101, // zone1 + 100
 					LogLevel:   "info",
@@ -281,6 +314,17 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 					HttpPort: 15400, // zone1 + 100
 					GrpcPort: 16100, // zone1 + 100
 					LogLevel: "info",
+				},
+				Pgctld: PgctldConfig{
+					Path:       filepath.Join(binDir, "pgctld"),
+					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone2),
+					GrpcPort:   17100, // zone1 + 100
+					PgPort:     5532,  // zone1 + 100
+					PgDatabase: dbName,
+					PgUser:     "postgres",
+					PgPwfile:   filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone2), "pgpassword.txt"),
+					Timeout:    30,
+					LogLevel:   "info",
 				},
 			},
 		},
@@ -302,6 +346,44 @@ func (p *localProvisioner) DefaultConfig() map[string]any {
 	}
 
 	return configMap
+}
+
+// createPasswordFileAndDirectories creates the pooler directory structure and password file
+func createPasswordFileAndDirectories(poolerDir, passwordFilePath string) error {
+	// Create the pooler directory structure
+	if err := os.MkdirAll(poolerDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create pooler directory %s: %w", poolerDir, err)
+	}
+
+	// Create the password file with "postgres" password
+	if err := os.WriteFile(passwordFilePath, []byte("postgres"), 0o600); err != nil {
+		return fmt.Errorf("failed to create password file %s: %w", passwordFilePath, err)
+	}
+
+	return nil
+}
+
+// initializePgctldDirectories initializes all pgctld directories and password files based on the config
+func (p *localProvisioner) initializePgctldDirectories() error {
+	// Get the typed configuration
+	config := p.config
+
+	// Initialize directories for each cell's pgctld configuration
+	for cellName, cellConfig := range config.Cells {
+		fmt.Printf("Setting up pgctld directory for cell %s...\n", cellName)
+
+		poolerDir := cellConfig.Pgctld.PoolerDir
+		passwordFile := cellConfig.Pgctld.PgPwfile
+
+		if err := createPasswordFileAndDirectories(poolerDir, passwordFile); err != nil {
+			return fmt.Errorf("failed to initialize pgctld directory for cell %s: %w", cellName, err)
+		}
+
+		fmt.Printf("✓ Created pooler directory: %s\n", poolerDir)
+		fmt.Printf("✓ Created password file: %s\n", passwordFile)
+	}
+
+	return nil
 }
 
 // provisionEtcd provisions etcd using local binary
@@ -403,7 +485,7 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 
 	// Wait for etcd to be ready
 	servicePorts := map[string]int{"etcd_port": port}
-	if err := p.waitForServiceReady("etcd", "localhost", servicePorts); err != nil {
+	if err := p.waitForServiceReady("etcd", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("etcd readiness check failed: %w\n\nLast 20 lines from etcd logs:\n%s", err, logs)
 	}
@@ -509,85 +591,6 @@ func (p *localProvisioner) checkEtcdVersion(binaryPath, expectedVersion string) 
 	return nil
 }
 
-// waitForServiceReady waits for a service to become ready by checking appropriate endpoints
-func (p *localProvisioner) waitForServiceReady(serviceName string, host string, servicePorts map[string]int) error {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	deadline := time.After(10 * time.Second)
-
-	for {
-		select {
-		case <-deadline:
-			return fmt.Errorf("%s did not become ready within 10 seconds", serviceName)
-		case <-ticker.C:
-			// First check TCP connectivity on all advertised ports
-			allPortsReady := true
-			for _, port := range servicePorts {
-				address := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-				conn, err := net.DialTimeout("tcp", address, 2*time.Second)
-				if err != nil {
-					allPortsReady = false
-					break // This port not ready yet
-				}
-				conn.Close()
-			}
-			if !allPortsReady {
-				continue // Not all ports ready yet
-			}
-
-			// For services with HTTP endpoints, check debug/config endpoint
-			if err := p.checkMultigresServiceHealth(serviceName, host, servicePorts); err != nil {
-				continue // HTTP endpoint not ready yet
-			}
-
-			return nil // Service is ready
-		}
-	}
-}
-
-// checkMultigresServiceHealth checks health for all supported service port types
-func (p *localProvisioner) checkMultigresServiceHealth(serviceName string, host string, servicePorts map[string]int) error {
-	// Iterate over service ports and run health checks for supported types
-	for portType, port := range servicePorts {
-		switch portType {
-		case "http_port":
-			// Run HTTP health check
-			httpAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-			if err := p.checkDebugConfigEndpoint(httpAddress); err != nil {
-				return err
-			}
-		// Future: Add other port types like grpc_port, etc.
-		default:
-			// No health check implemented for this port type, skip
-			continue
-		}
-	}
-
-	return nil
-}
-
-// checkDebugConfigEndpoint checks if the debug/config endpoint returns 200 OK
-func (p *localProvisioner) checkDebugConfigEndpoint(address string) error {
-	url := fmt.Sprintf("http://%s/live", address)
-
-	client := &http.Client{
-		Timeout: 2 * time.Second,
-	}
-
-	resp, err := client.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed to reach debug endpoint: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("debug endpoint returned status %d", resp.StatusCode)
-	}
-
-	return nil
-}
-
 // readServiceLogs reads the last few lines from a service's log file for debugging
 func (p *localProvisioner) readServiceLogs(logFile string, lines int) string {
 	if logFile == "" {
@@ -649,6 +652,11 @@ func (p *localProvisioner) getRootWorkingDir() string {
 	}
 
 	return p.config.RootWorkingDir
+}
+
+// GeneratePoolerDir generates a pooler directory path for a given base directory and service ID
+func GeneratePoolerDir(baseDir, serviceID string) string {
+	return filepath.Join(baseDir, "data", fmt.Sprintf("pooler_%s", serviceID))
 }
 
 // getStateDir returns the path to the state directory
@@ -883,7 +891,7 @@ func (p *localProvisioner) provisionMultigateway(ctx context.Context, req *provi
 
 	// Wait for multigateway to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multigateway", "localhost", servicePorts); err != nil {
+	if err := p.waitForServiceReady("multigateway", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multigateway readiness check failed: %w\n\nLast 20 lines from multigateway logs:\n%s", err, logs)
 	}
@@ -1015,7 +1023,7 @@ func (p *localProvisioner) provisionMultiadmin(ctx context.Context, req *provisi
 
 	// Wait for multiadmin to be ready (check HTTP port)
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multiadmin", "localhost", servicePorts); err != nil {
+	if err := p.waitForServiceReady("multiadmin", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multiadmin readiness check failed: %w\n\nLast 20 lines from multiadmin logs:\n%s", err, logs)
 	}
@@ -1112,10 +1120,12 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 		return nil, fmt.Errorf("multipooler binary not found: %w", err)
 	}
 
-	// Get or generate unique ID for this service instance (needed for log file)
-	serviceID := stringutil.RandomString(8)
-	if id, ok := req.Params["service_id"].(string); ok && id != "" {
+	// Get service ID from multipooler config - this should always be set
+	serviceID := ""
+	if id, ok := multipoolerConfig["service-id"].(string); ok && id != "" {
 		serviceID = id
+	} else {
+		return nil, fmt.Errorf("service-id not found in multipooler config for cell %s", cell)
 	}
 
 	// Create log file path
@@ -1124,7 +1134,13 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 		return nil, fmt.Errorf("failed to create log file: %w", err)
 	}
 
-	// Build command arguments
+	// Provision pgctld for this multipooler
+	pgctldResult, err := p.provisionPgctld(ctx, database, tableGroup, serviceID, cell)
+	if err != nil {
+		return nil, fmt.Errorf("failed to provision pgctld for multipooler: %w", err)
+	}
+
+	// Build command arguments with pgctld-addr
 	args := []string{
 		"--http-port", fmt.Sprintf("%d", httpPort),
 		"--grpc-port", fmt.Sprintf("%d", grpcPort),
@@ -1135,6 +1151,7 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 		"--database", database,
 		"--table-group", tableGroup,
 		"--service-id", serviceID,
+		"--pgctld-addr", pgctldResult.Address,
 		"--log-level", logLevel,
 		"--log-output", logFile,
 	}
@@ -1155,7 +1172,7 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 
 	// Wait for multipooler to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multipooler", "localhost", servicePorts); err != nil {
+	if err := p.waitForServiceReady("multipooler", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multipooler readiness check failed: %w\n\nLast 20 lines from multipooler logs:\n%s", err, logs)
 	}
@@ -1191,6 +1208,13 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 			"log_file":   logFile,
 		},
 	}, nil
+}
+
+// PgctldProvisionResult contains the result of provisioning pgctld
+type PgctldProvisionResult struct {
+	Address string
+	Port    int
+	LogFile string
 }
 
 // provisionMultiOrch provisions multi-orchestrator using local binary
@@ -1294,7 +1318,7 @@ func (p *localProvisioner) provisionMultiOrch(ctx context.Context, req *provisio
 
 	// Wait for multiorch to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multiorch", "localhost", servicePorts); err != nil {
+	if err := p.waitForServiceReady("multiorch", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multiorch readiness check failed: %w\n\nLast 20 lines from multiorch logs:\n%s", err, logs)
 	}
@@ -1743,6 +1767,16 @@ func (p *localProvisioner) stopService(ctx context.Context, req *provisioner.Dep
 		fallthrough
 	case "multiorch":
 		return p.deprovisionService(ctx, req)
+	case "pgctld":
+		// pgctld requires special handling to stop PostgreSQL first
+		service, err := p.loadServiceState(req)
+		if err != nil {
+			return err
+		}
+		if service == nil {
+			return fmt.Errorf("pgctld service not found")
+		}
+		return p.deprovisionPgctld(ctx, service)
 	default:
 		return fmt.Errorf("unknown service type: %s", req.Service)
 	}
@@ -1848,6 +1882,13 @@ func (p *localProvisioner) Bootstrap(ctx context.Context) ([]*provisioner.Provis
 	allResults = append(allResults, etcdResult)
 
 	etcdAddress := fmt.Sprintf("%s:%d", etcdResult.FQDN, tcpPort)
+
+	// Initialize pgctld directories and password files
+	fmt.Println("=== Setting up pgctld directories ===")
+	if err := p.initializePgctldDirectories(); err != nil {
+		return nil, fmt.Errorf("failed to initialize pgctld directories: %w", err)
+	}
+	fmt.Println("")
 
 	topoConfig, err := p.getTopologyConfig()
 	if err != nil {
@@ -2450,6 +2491,7 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 			"path":        cellServices.Multipooler.Path,
 			"database":    cellServices.Multipooler.Database,
 			"table_group": cellServices.Multipooler.TableGroup,
+			"service-id":  cellServices.Multipooler.ServiceID,
 			"http_port":   cellServices.Multipooler.HttpPort,
 			"grpc_port":   cellServices.Multipooler.GrpcPort,
 			"log_level":   cellServices.Multipooler.LogLevel,
@@ -2460,6 +2502,18 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 			"http_port": cellServices.Multiorch.HttpPort,
 			"grpc_port": cellServices.Multiorch.GrpcPort,
 			"log_level": cellServices.Multiorch.LogLevel,
+		}, nil
+	case "pgctld":
+		return map[string]any{
+			"path":        cellServices.Pgctld.Path,
+			"pooler_dir":  cellServices.Pgctld.PoolerDir,
+			"grpc_port":   cellServices.Pgctld.GrpcPort,
+			"pg_port":     cellServices.Pgctld.PgPort,
+			"pg_database": cellServices.Pgctld.PgDatabase,
+			"pg_user":     cellServices.Pgctld.PgUser,
+			"pg_pwfile":   cellServices.Pgctld.PgPwfile,
+			"timeout":     cellServices.Pgctld.Timeout,
+			"log_level":   cellServices.Pgctld.LogLevel,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown service %s", service)

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -373,7 +373,16 @@ func (p *localProvisioner) initializePgctldDirectories() error {
 		fmt.Printf("Setting up pgctld directory for cell %s...\n", cellName)
 
 		poolerDir := cellConfig.Pgctld.PoolerDir
+
+		if poolerDir == "" {
+			return fmt.Errorf("pooler-dir not found in config for pgtctld in cell %s", cellName)
+		}
+
 		passwordFile := cellConfig.Pgctld.PgPwfile
+
+		if passwordFile == "" {
+			return fmt.Errorf("pgctld password file not found in config for cell %s", cellName)
+		}
 
 		if err := createPasswordFileAndDirectories(poolerDir, passwordFile); err != nil {
 			return fmt.Errorf("failed to initialize pgctld directory for cell %s: %w", cellName, err)

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -1,0 +1,334 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/multigres/multigres/go/pb/pgctldservice"
+)
+
+// startPostgreSQLViaPgctld starts PostgreSQL via pgctld gRPC and verifies it's running
+func (p *localProvisioner) startPostgreSQLViaPgctld(address string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewPgCtldClient(conn)
+
+	// First, check if PostgreSQL is already running
+	statusResp, err := client.Status(ctx, &pb.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get pgctld status: %w", err)
+	}
+
+	// If already running, we're good
+	if statusResp.GetStatus() == pb.ServerStatus_RUNNING {
+		fmt.Printf(" PostgreSQL already running ✓")
+		return nil
+	}
+
+	// If not initialized, initialize first
+	if statusResp.GetStatus() == pb.ServerStatus_NOT_INITIALIZED {
+		fmt.Printf(" initializing...")
+		_, err = client.InitDataDir(ctx, &pb.InitDataDirRequest{})
+		if err != nil {
+			return fmt.Errorf("failed to initialize PostgreSQL data directory: %w", err)
+		}
+	}
+
+	// Start PostgreSQL
+	fmt.Printf(" starting PostgreSQL...")
+	startResp, err := client.Start(ctx, &pb.StartRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to start PostgreSQL: %w", err)
+	}
+
+	// Verify PostgreSQL is now running
+	statusResp, err = client.Status(ctx, &pb.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to verify PostgreSQL status after start: %w", err)
+	}
+
+	if statusResp.GetStatus() != pb.ServerStatus_RUNNING {
+		return fmt.Errorf("PostgreSQL failed to start - status: %s, message: %s",
+			statusResp.GetStatus().String(), statusResp.GetMessage())
+	}
+
+	fmt.Printf(" PostgreSQL started (PID: %d) ✓", statusResp.GetPid())
+	if startResp.GetMessage() != "" {
+		fmt.Printf(" - %s", startResp.GetMessage())
+	}
+
+	return nil
+}
+
+// stopPostgreSQLViaPgctld stops PostgreSQL via pgctld gRPC
+func (p *localProvisioner) stopPostgreSQLViaPgctld(address string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewPgCtldClient(conn)
+
+	// Check if PostgreSQL is running
+	statusResp, err := client.Status(ctx, &pb.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get pgctld status: %w", err)
+	}
+
+	// If not running, nothing to stop
+	if statusResp.GetStatus() != pb.ServerStatus_RUNNING {
+		fmt.Printf(" PostgreSQL already stopped")
+		return nil
+	}
+
+	// Stop PostgreSQL with fast mode
+	fmt.Printf(" stopping PostgreSQL...")
+	stopResp, err := client.Stop(ctx, &pb.StopRequest{Mode: "fast"})
+	if err != nil {
+		return fmt.Errorf("failed to stop PostgreSQL: %w", err)
+	}
+
+	// Verify PostgreSQL is now stopped
+	statusResp, err = client.Status(ctx, &pb.StatusRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to verify PostgreSQL status after stop: %w", err)
+	}
+
+	if statusResp.GetStatus() != pb.ServerStatus_STOPPED {
+		return fmt.Errorf("PostgreSQL failed to stop - status: %s, message: %s",
+			statusResp.GetStatus().String(), statusResp.GetMessage())
+	}
+
+	fmt.Printf(" PostgreSQL stopped ✓")
+	if stopResp.GetMessage() != "" {
+		fmt.Printf(" - %s", stopResp.GetMessage())
+	}
+
+	return nil
+}
+
+// provisionPgctld provisions a pgctld instance for a multipooler with the new directory structure
+func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGroup, serviceID, cell string) (*PgctldProvisionResult, error) {
+	// Create unique pgctld service ID using multipooler's service ID
+	pgctldServiceID := fmt.Sprintf("pgctld-%s", serviceID)
+
+	// Check if pgctld is already running for this service combination
+	existingService, err := p.findRunningDbService("pgctld", dbName, cell)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing pgctld service: %w", err)
+	}
+
+	// Check if the existing service matches our specific service ID
+	if existingService != nil && existingService.ID == pgctldServiceID {
+		fmt.Printf("pgctld is already running (PID %d)", existingService.PID)
+
+		// Verify PostgreSQL is running via gRPC health check
+		grpcAddress := fmt.Sprintf("localhost:%d", existingService.Ports["grpc_port"])
+		if err := p.checkPgctldGrpcHealth(grpcAddress); err != nil {
+			logs := p.readServiceLogs(existingService.LogFile, 20)
+			return nil, fmt.Errorf("pgctld health check failed: %w\n\nLast 20 lines from pgctld logs:\n%s", err, logs)
+		}
+
+		fmt.Printf(" ✓\n")
+		return &PgctldProvisionResult{
+			Address: fmt.Sprintf("localhost:%d", existingService.Ports["grpc_port"]),
+			Port:    existingService.Ports["grpc_port"],
+			LogFile: existingService.LogFile,
+		}, nil
+	}
+
+	// Get cell-specific pgctld config
+	pgctldConfig, err := p.getCellServiceConfig(cell, "pgctld")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pgctld config for cell %s: %w", cell, err)
+	}
+
+	// Find pgctld binary
+	pgctldBinary, err := p.findBinary("pgctld", pgctldConfig)
+	if err != nil {
+		return nil, fmt.Errorf("pgctld binary not found: %w", err)
+	}
+
+	// Get gRPC port from config or use default
+	grpcPort := 17000
+	if port, ok := pgctldConfig["grpc_port"].(int); ok {
+		grpcPort = port
+	}
+
+	// Get PostgreSQL port from config or use default
+	pgPort := 5432
+	if port, ok := pgctldConfig["pg_port"].(int); ok {
+		pgPort = port
+	}
+
+	// Get other pgctld configuration values with defaults
+	pgDatabase := "postgres"
+	if db, ok := pgctldConfig["pg_database"].(string); ok && db != "" {
+		pgDatabase = db
+	}
+
+	pgUser := "postgres"
+	if user, ok := pgctldConfig["pg_user"].(string); ok && user != "" {
+		pgUser = user
+	}
+
+	timeout := 30
+	if t, ok := pgctldConfig["timeout"].(int); ok {
+		timeout = t
+	}
+
+	logLevel := "info"
+	if level, ok := pgctldConfig["log_level"].(string); ok && level != "" {
+		logLevel = level
+	}
+
+	// Create pooler directory with shorter path: data/pooler_${service-id}/
+	poolerDir := GeneratePoolerDir(p.getRootWorkingDir(), serviceID)
+
+	// Create pgctld log file
+	pgctldLogFile, err := p.createLogFile("pgctld", serviceID, dbName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pgctld log file: %w", err)
+	}
+
+	// Initialize pgctld data directory
+	fmt.Printf("▶️  - Initializing pgctld for %s/%s/%s...", dbName, tableGroup, serviceID)
+
+	initArgs := []string{
+		"init",
+		"--pooler-dir", poolerDir,
+		"--pg-port", fmt.Sprintf("%d", pgPort),
+		"--pg-database", pgDatabase,
+		"--pg-user", pgUser,
+		"--timeout", fmt.Sprintf("%d", timeout),
+		"--log-level", logLevel,
+	}
+
+	// Add password file if available
+	if pgPwfile, ok := pgctldConfig["pg_pwfile"].(string); ok && pgPwfile != "" {
+		initArgs = append(initArgs, "--pg-pwfile", pgPwfile)
+	}
+
+	initCmd := exec.CommandContext(ctx, pgctldBinary, initArgs...)
+	if err := initCmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to initialize pgctld data directory: %w", err)
+	}
+	fmt.Printf(" initialized ✓\n")
+
+	// Start pgctld server
+	fmt.Printf("▶️  - Starting pgctld server (gRPC:%d)...", grpcPort)
+
+	serverArgs := []string{
+		"server",
+		"--pooler-dir", poolerDir,
+		"--grpc-port", fmt.Sprintf("%d", grpcPort),
+		"--pg-port", fmt.Sprintf("%d", pgPort),
+		"--pg-database", pgDatabase,
+		"--pg-user", pgUser,
+		"--timeout", fmt.Sprintf("%d", timeout),
+		"--log-level", logLevel,
+		"--log-output", pgctldLogFile,
+	}
+
+	pgctldCmd := exec.CommandContext(ctx, pgctldBinary, serverArgs...)
+	if err := pgctldCmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start pgctld server: %w", err)
+	}
+
+	// Validate process is running
+	if err := p.validateProcessRunning(pgctldCmd.Process.Pid); err != nil {
+		return nil, fmt.Errorf("pgctld process validation failed: %w", err)
+	}
+
+	// Wait for pgctld to be ready
+	servicePorts := map[string]int{"grpc_port": grpcPort}
+	if err := p.waitForServiceReady("pgctld", "localhost", servicePorts, 60*time.Second); err != nil {
+		logs := p.readServiceLogs(pgctldLogFile, 20)
+		return nil, fmt.Errorf("pgctld readiness check failed: %w\n\nLast 20 lines from pgctld logs:\n%s", err, logs)
+	}
+
+	// Now that pgctld is healthy, start PostgreSQL
+	grpcAddress := fmt.Sprintf("localhost:%d", grpcPort)
+	if err := p.startPostgreSQLViaPgctld(grpcAddress); err != nil {
+		logs := p.readServiceLogs(pgctldLogFile, 20)
+		return nil, fmt.Errorf("failed to start PostgreSQL: %w\n\nLast 20 lines from pgctld logs:\n%s", err, logs)
+	}
+
+	fmt.Printf(" ready ✓\n")
+
+	// Create provision state for pgctld
+	service := &LocalProvisionedService{
+		ID:         pgctldServiceID,
+		Service:    "pgctld",
+		PID:        pgctldCmd.Process.Pid,
+		BinaryPath: pgctldBinary,
+		Ports:      map[string]int{"grpc_port": grpcPort},
+		FQDN:       "localhost",
+		LogFile:    pgctldLogFile,
+		StartedAt:  time.Now(),
+		DataDir:    poolerDir,
+		Metadata:   map[string]any{"cell": cell, "database": dbName, "table_group": tableGroup, "service_id": serviceID, "multipooler_service_id": serviceID},
+	}
+
+	// Save pgctld service state to disk
+	if err := p.saveServiceState(service, dbName); err != nil {
+		fmt.Printf("Warning: failed to save pgctld service state: %v\n", err)
+	}
+
+	return &PgctldProvisionResult{
+		Address: fmt.Sprintf("localhost:%d", grpcPort),
+		Port:    grpcPort,
+		LogFile: pgctldLogFile,
+	}, nil
+}
+
+// deprovisionPgctld stops PostgreSQL via gRPC and then stops the pgctld process
+func (p *localProvisioner) deprovisionPgctld(ctx context.Context, service *LocalProvisionedService) error {
+	// First, try to gracefully stop PostgreSQL via pgctld gRPC
+	grpcPort := service.Ports["grpc_port"]
+	address := fmt.Sprintf("localhost:%d", grpcPort)
+
+	fmt.Printf("Stopping PostgreSQL via pgctld...")
+	if err := p.stopPostgreSQLViaPgctld(address); err != nil {
+		fmt.Printf("Warning: failed to stop PostgreSQL gracefully: %v\n", err)
+	}
+
+	// Then stop the pgctld process itself
+	fmt.Printf("Stopping pgctld process...")
+	if err := p.stopProcessByPID(service.PID); err != nil {
+		return fmt.Errorf("failed to stop pgctld process: %w", err)
+	}
+
+	fmt.Printf(" pgctld stopped ✓\n")
+	return nil
+}

--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -453,7 +453,7 @@ func checkServiceConnectivity(service string, state local.LocalProvisionedServic
 // buildMultigresBinary builds the multigres binary and returns its path
 func buildMultigresBinary() (string, error) {
 	// Create a temporary directory for the multigres binary
-	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("/tmp", "mlt")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp directory for multigres binary: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with current directory",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+				tempDir, err := os.MkdirTemp("/tmp", "mlt")
 				require.NoError(t, err)
 				return []string{tempDir}, func() { os.RemoveAll(tempDir) }
 			},
@@ -603,7 +603,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with multiple valid paths",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir1, err := os.MkdirTemp("/tmp/", "mlt")
+				tempDir1, err := os.MkdirTemp("/tmp", "mlt")
 				require.NoError(t, err)
 				tempDir2, err := os.MkdirTemp("", "multigres_init_test2")
 				require.NoError(t, err)
@@ -742,7 +742,7 @@ func TestInitCommandConfigFileAlreadyExists(t *testing.T) {
 	ensureBinaryBuilt(t)
 
 	// Setup test directory
-	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("/tmp", "mlt")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
@@ -812,7 +812,7 @@ func TestClusterLifecycle(t *testing.T) {
 
 	t.Run("cluster init and basic connectivity test", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1013,7 +1013,7 @@ func TestClusterLifecycle(t *testing.T) {
 		// We'll test this by trying to run the provisioned multipooler directly
 		// without the --database flag and expecting it to fail
 
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1060,7 +1060,7 @@ func TestClusterLifecycle(t *testing.T) {
 	// cluster start fails with a helpful error mentioning the conflict.
 	t.Run("cluster start fails when a service port is already in use", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 

--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -209,6 +209,15 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					GrpcPort: portConfig.MultiorchGRPCPort,
 					LogLevel: "info",
 				},
+				Pgctld: local.PgctldConfig{
+					Path:       filepath.Join(binPath, "pgctld"),
+					GrpcPort:   17000,
+					PgPort:     5432,
+					PgDatabase: "postgres",
+					PgUser:     "postgres",
+					Timeout:    30,
+					LogLevel:   "info",
+				},
 			},
 			"zone2": {
 				Multigateway: local.MultigatewayConfig{
@@ -231,6 +240,15 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					HttpPort: portConfig.MultiorchHTTPPort + 100,
 					GrpcPort: portConfig.MultiorchGRPCPort + 100,
 					LogLevel: "info",
+				},
+				Pgctld: local.PgctldConfig{
+					Path:       filepath.Join(binPath, "pgctld"),
+					GrpcPort:   17100, // offset for zone2
+					PgPort:     5532,  // offset for zone2
+					PgDatabase: "postgres",
+					PgUser:     "postgres",
+					Timeout:    30,
+					LogLevel:   "info",
 				},
 			},
 		},

--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -453,7 +453,7 @@ func checkServiceConnectivity(service string, state local.LocalProvisionedServic
 // buildMultigresBinary builds the multigres binary and returns its path
 func buildMultigresBinary() (string, error) {
 	// Create a temporary directory for the multigres binary
-	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("tmp/", "mlt")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp directory for multigres binary: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with current directory",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+				tempDir, err := os.MkdirTemp("tmp/", "mlt")
 				require.NoError(t, err)
 				return []string{tempDir}, func() { os.RemoveAll(tempDir) }
 			},
@@ -603,7 +603,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with multiple valid paths",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir1, err := os.MkdirTemp("/tmp/", "mlt")
+				tempDir1, err := os.MkdirTemp("tmp/", "mlt")
 				require.NoError(t, err)
 				tempDir2, err := os.MkdirTemp("", "multigres_init_test2")
 				require.NoError(t, err)
@@ -742,7 +742,7 @@ func TestInitCommandConfigFileAlreadyExists(t *testing.T) {
 	ensureBinaryBuilt(t)
 
 	// Setup test directory
-	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("tmp/", "mlt")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
@@ -812,7 +812,7 @@ func TestClusterLifecycle(t *testing.T) {
 
 	t.Run("cluster init and basic connectivity test", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1013,7 +1013,7 @@ func TestClusterLifecycle(t *testing.T) {
 		// We'll test this by trying to run the provisioned multipooler directly
 		// without the --database flag and expecting it to fail
 
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1060,7 +1060,7 @@ func TestClusterLifecycle(t *testing.T) {
 	// cluster start fails with a helpful error mentioning the conflict.
 	t.Run("cluster start fails when a service port is already in use", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 

--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -453,7 +453,7 @@ func checkServiceConnectivity(service string, state local.LocalProvisionedServic
 // buildMultigresBinary builds the multigres binary and returns its path
 func buildMultigresBinary() (string, error) {
 	// Create a temporary directory for the multigres binary
-	tempDir, err := os.MkdirTemp("tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp directory for multigres binary: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with current directory",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir, err := os.MkdirTemp("tmp/", "mlt")
+				tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 				require.NoError(t, err)
 				return []string{tempDir}, func() { os.RemoveAll(tempDir) }
 			},
@@ -603,7 +603,7 @@ func TestInitCommand(t *testing.T) {
 		{
 			name: "successful init with multiple valid paths",
 			setupDirs: func(t *testing.T) ([]string, func()) {
-				tempDir1, err := os.MkdirTemp("tmp/", "mlt")
+				tempDir1, err := os.MkdirTemp("/tmp/", "mlt")
 				require.NoError(t, err)
 				tempDir2, err := os.MkdirTemp("", "multigres_init_test2")
 				require.NoError(t, err)
@@ -742,7 +742,7 @@ func TestInitCommandConfigFileAlreadyExists(t *testing.T) {
 	ensureBinaryBuilt(t)
 
 	// Setup test directory
-	tempDir, err := os.MkdirTemp("tmp/", "mlt")
+	tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 
@@ -812,7 +812,7 @@ func TestClusterLifecycle(t *testing.T) {
 
 	t.Run("cluster init and basic connectivity test", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1013,7 +1013,7 @@ func TestClusterLifecycle(t *testing.T) {
 		// We'll test this by trying to run the provisioned multipooler directly
 		// without the --database flag and expecting it to fail
 
-		tempDir, err := os.MkdirTemp("tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 
@@ -1060,7 +1060,7 @@ func TestClusterLifecycle(t *testing.T) {
 	// cluster start fails with a helpful error mentioning the conflict.
 	t.Run("cluster start fails when a service port is already in use", func(t *testing.T) {
 		// Setup test directory
-		tempDir, err := os.MkdirTemp("tmp/", "mlt")
+		tempDir, err := os.MkdirTemp("/tmp/", "mlt")
 		require.NoError(t, err)
 		defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
# Description
* This integrates into the local bootstrap pctctld. With this, we technically have all the core components starting and stopping locally. They don't anything, but hey, it boots. 
* This pgctld setup, integrates the postgres bootstrap. It starts two postgres instances in local (one for each pooler). They still don't have replication set up. Just two vanilla postgres. 
# Desc
* Integration test just works. Added few more assertions to make sure postgres is looking operational. Tested this in my local as well. 
