### PR TITLE
Fix typo and use slices.Contains for cell check

### DIFF
--- a/go/clustermetadata/topo/etcdtopo/store.go
+++ b/go/clustermetadata/topo/etcdtopo/store.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-Package etcd2topo implements topo.Server with etcd as the backend.
+Package etcd2topo implements topo.Conn with etcd as the backend.
 
 We expect the following behavior from the etcd client library:
 
@@ -65,7 +65,7 @@ func (f Factory) Create(cell, root string, serverAddrs []string) (topo.Conn, err
 	return NewServer(serverAddrs, root)
 }
 
-// Server is the implementation of topo.Server for etcd.
+// Server is the implementation of topo.Conn for etcd.
 type Server struct {
 	// cli is the v3 client.
 	cli *clientv3.Client
@@ -89,7 +89,7 @@ func registerEtcd2TopoFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&serverCaPath, "topo_etcd_tls_ca", serverCaPath, "path to the ca to use to validate the server cert when connecting to the etcd topo server")
 }
 
-// Close implements topo.Server.Close.
+// Close implements topo.Conn.Close.
 // It will nil out the global and cells fields, so any attempt to
 // re-use this server will panic.
 func (s *Server) Close() error {

--- a/go/clustermetadata/topo/store.go
+++ b/go/clustermetadata/topo/store.go
@@ -461,7 +461,7 @@ func (ts *store) Close() error {
 	}
 
 	// Clear the map to release references
-	ts.cellConns = nil
+	ts.cellConns = make(map[string]cellConn)
 
 	// Return combined error if any occurred during cleanup
 	if len(errs) > 0 {

--- a/go/clustermetadata/topo/store.go
+++ b/go/clustermetadata/topo/store.go
@@ -461,7 +461,7 @@ func (ts *store) Close() error {
 	}
 
 	// Clear the map to release references
-	ts.cellConns = make(map[string]cellConn)
+	ts.cellConns = nil
 
 	// Return combined error if any occurred during cleanup
 	if len(errs) > 0 {

--- a/go/cmd/multiorch/main.go
+++ b/go/cmd/multiorch/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -75,13 +76,7 @@ func CheckCellFlags(ts topo.Store, cell string) error {
 	}
 
 	// Check if the specified cell exists in topology
-	hasCell := false
-	for _, v := range cellsInTopo {
-		if v == cell {
-			hasCell = true
-			break
-		}
-	}
+	hasCell := slices.Contains(cellsInTopo, cell)
 	if !hasCell {
 		return fmt.Errorf("cell '%s' does not exist in topology. Available cells: [%s]",
 			cell, strings.Join(cellsInTopo, ", "))

--- a/go/cmd/multipooler/main.go
+++ b/go/cmd/multipooler/main.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -81,13 +82,7 @@ func CheckCellFlags(ts topo.Store, cell string) error {
 	}
 
 	// Check if the specified cell exists in topology
-	hasCell := false
-	for _, v := range cellsInTopo {
-		if v == cell {
-			hasCell = true
-			break
-		}
-	}
+	hasCell := slices.Contains(cellsInTopo, cell)
 	if !hasCell {
 		return fmt.Errorf("cell '%s' does not exist in topology. Available cells: [%s]",
 			cell, strings.Join(cellsInTopo, ", "))

--- a/go/netutil/conn.go
+++ b/go/netutil/conn.go
@@ -20,7 +20,7 @@ import (
 
 var _ net.Conn = (*ConnWithTimeouts)(nil)
 
-// A ConnWithTimeouts is a wrapper to net.Comm that allows to set a read and write timeouts.
+// A ConnWithTimeouts is a wrapper to net.Conn that allows to set a read and write timeouts.
 type ConnWithTimeouts struct {
 	net.Conn
 	readTimeout  time.Duration

--- a/go/servenv/grpc_server.go
+++ b/go/servenv/grpc_server.go
@@ -185,7 +185,7 @@ func isGRPCEnabled() bool {
 	return false
 }
 
-// createGRPCServer create the gRPC server we will be using.
+// createGRPCServer creates the gRPC server we will be using.
 // It has to be called after flags are parsed, but before
 // services register themselves.
 func createGRPCServer() {
@@ -289,7 +289,7 @@ func serveGRPC() {
 
 	// and serve on it
 	// NOTE: Before we call Serve(), all services must have registered themselves
-	//       with "GRPCServer". This is the case because go/vt/servenv/run.go
+	//       with "GRPCServer". This is the case because go/servenv/run.go
 	//       runs all OnRun() hooks after createGRPCServer() and before
 	//       serveGRPC(). If this was not the case, the binary would crash with
 	//       the error "grpc: Server.RegisterService after Server.Serve".


### PR DESCRIPTION
- Used slices.Contains for cell check in cellsInTopo.
- Fixed comment typos.

Multigres is a great project. I read the code tonight (except for the parser) and made minor changes. I checked the Discussion #6 , so if this PR isn't helpful, feel free to close it.