### PR TITLE
deps: enable monthly dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
This lets github automatically send PRs to gently encourage us to upgrade to the most recent versions of dependencies

Configured for now to once a month, but we can turn it off or adjust the frequency later