### PR TITLE
fix(local): gRPC client issue for macos

### DIFF
--- a/go/grpccommon/options.go
+++ b/go/grpccommon/options.go
@@ -50,3 +50,10 @@ func EnableGRPCPrometheus() bool {
 func MaxMessageSize() int {
 	return maxMessageSize
 }
+
+// ClientDialOptions returns a slice of grpc.DialOption to be used when creating a gRPC client.
+func ClientDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithDisableServiceConfig(),
+	}
+}

--- a/go/grpccommon/options.go
+++ b/go/grpccommon/options.go
@@ -19,6 +19,7 @@ package grpccommon
 import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -51,9 +52,15 @@ func MaxMessageSize() int {
 	return maxMessageSize
 }
 
-// ClientDialOptions returns a slice of grpc.DialOption to be used when creating a gRPC client.
-func ClientDialOptions() []grpc.DialOption {
+// LocalClientDialOptions returns a slice of grpc.DialOption to be used when creating a gRPC client.
+// These options are used for local clients connecting to the gRPC server.
+// They are not intended to be used for production environments.
+// The WithDisableServiceConfig is a workaround for a known issue
+// in MacOS where localhost host takes too long to resolve.
+// See the following PR for more details: https://github.com/multigres/multigres/pull/152
+func LocalClientDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDisableServiceConfig(),
 	}
 }

--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/grpccommon"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -141,8 +140,7 @@ func (p *localProvisioner) checkPgctldGrpcHealth(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(address, opts...)
+	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/grpccommon"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/tools/timertools"
 )
@@ -140,7 +141,8 @@ func (p *localProvisioner) checkPgctldGrpcHealth(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/grpccommon"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
 
@@ -32,7 +33,8 @@ func (p *localProvisioner) startPostgreSQLViaPgctld(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}
@@ -92,7 +94,8 @@ func (p *localProvisioner) stopPostgreSQLViaPgctld(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/grpccommon"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -33,8 +32,7 @@ func (p *localProvisioner) startPostgreSQLViaPgctld(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(address, opts...)
+	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}
@@ -94,8 +92,7 @@ func (p *localProvisioner) stopPostgreSQLViaPgctld(address string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(address, opts...)
+	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/test/endtoend/multipooler_client.go
+++ b/go/test/endtoend/multipooler_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/grpccommon"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -48,8 +47,7 @@ func NewMultiPoolerTestClient(addr string) (*MultiPoolerTestClient, error) {
 		return nil, fmt.Errorf("invalid address format: %s", addr)
 	}
 
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(addr, opts...)
+	conn, err := grpc.NewClient(addr, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client for multipooler at %s: %w", addr, err)
 	}

--- a/go/test/endtoend/multipooler_client.go
+++ b/go/test/endtoend/multipooler_client.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/grpccommon"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	querypb "github.com/multigres/multigres/go/pb/query"
@@ -47,8 +48,8 @@ func NewMultiPoolerTestClient(addr string) (*MultiPoolerTestClient, error) {
 		return nil, fmt.Errorf("invalid address format: %s", addr)
 	}
 
-	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(addr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client for multipooler at %s: %w", addr, err)
 	}

--- a/go/test/endtoend/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld_grpc_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/command"
+	"github.com/multigres/multigres/go/grpccommon"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -57,7 +58,8 @@ func TestGRPCServerIntegration(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -140,7 +142,8 @@ func TestGRPCErrorHandling(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -221,7 +224,8 @@ func TestGRPCConcurrentRequests(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -301,7 +305,8 @@ func TestGRPCWithDifferentConfigurations(t *testing.T) {
 		defer cleanupServer()
 
 		// Connect to the gRPC server
-		conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+		conn, err := grpc.NewClient(lis.Addr().String(), opts...)
 		require.NoError(t, err)
 		defer conn.Close()
 
@@ -355,7 +360,8 @@ func TestGRPCUninitializedDatabase(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
+	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/go/test/endtoend/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld_grpc_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/command"
 	"github.com/multigres/multigres/go/grpccommon"
@@ -58,8 +57,7 @@ func TestGRPCServerIntegration(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	conn, err := grpc.NewClient(lis.Addr().String(), grpccommon.LocalClientDialOptions()...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -142,8 +140,7 @@ func TestGRPCErrorHandling(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	conn, err := grpc.NewClient(lis.Addr().String(), grpccommon.LocalClientDialOptions()...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -224,8 +221,7 @@ func TestGRPCConcurrentRequests(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	conn, err := grpc.NewClient(lis.Addr().String(), grpccommon.LocalClientDialOptions()...)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -305,8 +301,7 @@ func TestGRPCWithDifferentConfigurations(t *testing.T) {
 		defer cleanupServer()
 
 		// Connect to the gRPC server
-		opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-		conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+		conn, err := grpc.NewClient(lis.Addr().String(), grpccommon.LocalClientDialOptions()...)
 		require.NoError(t, err)
 		defer conn.Close()
 
@@ -360,8 +355,7 @@ func TestGRPCUninitializedDatabase(t *testing.T) {
 	defer cleanupServer()
 
 	// Connect to the gRPC server
-	opts := append([]grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, grpccommon.ClientDialOptions()...)
-	conn, err := grpc.NewClient(lis.Addr().String(), opts...)
+	conn, err := grpc.NewClient(lis.Addr().String(), grpccommon.LocalClientDialOptions()...)
 	require.NoError(t, err)
 	defer conn.Close()
 


### PR DESCRIPTION
# Desc

* There is an issue in [gRPC](https://github.com/grpc/grpc-go/issues/8356) where localhost doesn't resolve correctly and it timeouts. 
* This happens if MacOS is for some reason `/etc/resolve.conf` gets an entry that is not working. In my case this happened when changing Wifi. There is a workaround documented [here](https://github.com/grpc/grpc-go/issues/7429), which this PR implements for local.
* I fixed my problem by cleaning up the entry in resolve.conf, but opening this PR in case we think this is a sensible change for local and people don't run into this in the future. It is a obscure failure that took a good chunk of a day to debug and get to understand. 