### PR TITLE
fix(servenv): enable unix socket for gRPC services

### DIFF
--- a/go/cmd/multigres/command/cluster/start.go
+++ b/go/cmd/multigres/command/cluster/start.go
@@ -109,7 +109,8 @@ func (s *ServiceSummary) PrintSummary() {
 		}
 	}
 	fmt.Println("- 🐘 Connect to PostgreSQL via Multigateway: TODO")
-	fmt.Println("- 🛑 Run \"multigres cluster stop\" to stop the cluster")
+	fmt.Println("- 🟢 Cluster started successfully. Enjoy!")
+	fmt.Println("- To stop the cluster: \"multigres cluster stop\"")
 	fmt.Println(strings.Repeat("=", 65))
 }
 

--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -73,15 +73,16 @@ type MultigatewayConfig struct {
 
 // MultipoolerConfig holds multipooler service configuration
 type MultipoolerConfig struct {
-	Path       string `yaml:"path"`
-	Database   string `yaml:"database"`
-	TableGroup string `yaml:"table-group"`
-	ServiceID  string `yaml:"service-id"`
-	PoolerDir  string `yaml:"pooler-dir"` // Directory path for PostgreSQL socket files
-	PgPort     int    `yaml:"pg-port"`    // PostgreSQL port number (same as pgctld)
-	HttpPort   int    `yaml:"http-port"`
-	GrpcPort   int    `yaml:"grpc-port"`
-	LogLevel   string `yaml:"log-level"`
+	Path           string `yaml:"path"`
+	Database       string `yaml:"database"`
+	TableGroup     string `yaml:"table-group"`
+	ServiceID      string `yaml:"service-id"`
+	PoolerDir      string `yaml:"pooler-dir"` // Directory path for PostgreSQL socket files
+	PgPort         int    `yaml:"pg-port"`    // PostgreSQL port number (same as pgctld)
+	HttpPort       int    `yaml:"http-port"`
+	GrpcPort       int    `yaml:"grpc-port"`
+	GRPCSocketFile string `yaml:"grpc-socket-file"` // Unix socket file path for gRPC
+	LogLevel       string `yaml:"log-level"`
 }
 
 // MultiorchConfig holds multiorch service configuration
@@ -102,15 +103,16 @@ type MultiadminConfig struct {
 
 // PgctldConfig holds pgctld service configuration
 type PgctldConfig struct {
-	Path       string `yaml:"path"`
-	PoolerDir  string `yaml:"pooler-dir"`  // Base directory for this pgctld instance
-	GrpcPort   int    `yaml:"grpc-port"`   // gRPC port for pgctld server
-	PgPort     int    `yaml:"pg-port"`     // PostgreSQL port
-	PgDatabase string `yaml:"pg-database"` // PostgreSQL database name
-	PgUser     string `yaml:"pg-user"`     // PostgreSQL username
-	PgPwfile   string `yaml:"pg-pwfile"`   // PostgreSQL password file path (optional)
-	Timeout    int    `yaml:"timeout"`     // Operation timeout in seconds
-	LogLevel   string `yaml:"log-level"`   // Log level
+	Path           string `yaml:"path"`
+	PoolerDir      string `yaml:"pooler-dir"`       // Base directory for this pgctld instance
+	GrpcPort       int    `yaml:"grpc-port"`        // gRPC port for pgctld server
+	GRPCSocketFile string `yaml:"grpc-socket-file"` // Unix socket file path for gRPC
+	PgPort         int    `yaml:"pg-port"`          // PostgreSQL port
+	PgDatabase     string `yaml:"pg-database"`      // PostgreSQL database name
+	PgUser         string `yaml:"pg-user"`          // PostgreSQL username
+	PgPwfile       string `yaml:"pg-pwfile"`        // PostgreSQL password file path (optional)
+	Timeout        int    `yaml:"timeout"`          // Operation timeout in seconds
+	LogLevel       string `yaml:"log-level"`        // Log level
 }
 
 // LoadConfig loads the provisioner-specific configuration from the given config paths
@@ -214,15 +216,16 @@ func (p *localProvisioner) DefaultConfig(configPaths []string) map[string]any {
 					LogLevel: "info",
 				},
 				Multipooler: MultipoolerConfig{
-					Path:       filepath.Join(binDir, "multipooler"),
-					Database:   dbName,
-					TableGroup: tableGroup,
-					ServiceID:  serviceIDZone1,
-					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone1),
-					PgPort:     5432, // Same as pgctld for this zone
-					HttpPort:   15100,
-					GrpcPort:   16001,
-					LogLevel:   "info",
+					Path:           filepath.Join(binDir, "multipooler"),
+					Database:       dbName,
+					TableGroup:     tableGroup,
+					ServiceID:      serviceIDZone1,
+					PoolerDir:      GeneratePoolerDir(baseDir, serviceIDZone1),
+					PgPort:         5432, // Same as pgctld for this zone
+					HttpPort:       15100,
+					GrpcPort:       16001,
+					GRPCSocketFile: filepath.Join(baseDir, "sockets", "multipooler-zone1.sock"),
+					LogLevel:       "info",
 				},
 				Multiorch: MultiorchConfig{
 					Path:     filepath.Join(binDir, "multiorch"),
@@ -231,15 +234,16 @@ func (p *localProvisioner) DefaultConfig(configPaths []string) map[string]any {
 					LogLevel: "info",
 				},
 				Pgctld: PgctldConfig{
-					Path:       filepath.Join(binDir, "pgctld"),
-					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone1),
-					GrpcPort:   17000,
-					PgPort:     5432,
-					PgDatabase: dbName,
-					PgUser:     "postgres",
-					PgPwfile:   filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone1), "pgpassword.txt"),
-					Timeout:    30,
-					LogLevel:   "info",
+					Path:           filepath.Join(binDir, "pgctld"),
+					PoolerDir:      GeneratePoolerDir(baseDir, serviceIDZone1),
+					GrpcPort:       17000,
+					GRPCSocketFile: filepath.Join(baseDir, "sockets", "pgctld-zone1.sock"),
+					PgPort:         5432,
+					PgDatabase:     dbName,
+					PgUser:         "postgres",
+					PgPwfile:       filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone1), "pgpassword.txt"),
+					Timeout:        30,
+					LogLevel:       "info",
 				},
 			},
 			"zone2": {
@@ -251,15 +255,16 @@ func (p *localProvisioner) DefaultConfig(configPaths []string) map[string]any {
 					LogLevel: "info",
 				},
 				Multipooler: MultipoolerConfig{
-					Path:       filepath.Join(binDir, "multipooler"),
-					Database:   dbName,
-					TableGroup: tableGroup,
-					ServiceID:  serviceIDZone2,
-					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone2),
-					PgPort:     5532,  // Same as pgctld for this zone (zone1 + 100)
-					HttpPort:   15200, // zone1 + 100
-					GrpcPort:   16101, // zone1 + 100
-					LogLevel:   "info",
+					Path:           filepath.Join(binDir, "multipooler"),
+					Database:       dbName,
+					TableGroup:     tableGroup,
+					ServiceID:      serviceIDZone2,
+					PoolerDir:      GeneratePoolerDir(baseDir, serviceIDZone2),
+					PgPort:         5532,  // Same as pgctld for this zone (zone1 + 100)
+					HttpPort:       15200, // zone1 + 100
+					GrpcPort:       16101, // zone1 + 100
+					GRPCSocketFile: filepath.Join(baseDir, "sockets", "multipooler-zone2.sock"),
+					LogLevel:       "info",
 				},
 				Multiorch: MultiorchConfig{
 					Path:     filepath.Join(binDir, "multiorch"),
@@ -268,15 +273,16 @@ func (p *localProvisioner) DefaultConfig(configPaths []string) map[string]any {
 					LogLevel: "info",
 				},
 				Pgctld: PgctldConfig{
-					Path:       filepath.Join(binDir, "pgctld"),
-					PoolerDir:  GeneratePoolerDir(baseDir, serviceIDZone2),
-					GrpcPort:   17100, // zone1 + 100
-					PgPort:     5532,  // zone1 + 100
-					PgDatabase: dbName,
-					PgUser:     "postgres",
-					PgPwfile:   filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone2), "pgpassword.txt"),
-					Timeout:    30,
-					LogLevel:   "info",
+					Path:           filepath.Join(binDir, "pgctld"),
+					PoolerDir:      GeneratePoolerDir(baseDir, serviceIDZone2),
+					GrpcPort:       17100, // zone1 + 100
+					GRPCSocketFile: filepath.Join(baseDir, "sockets", "pgctld-zone2.sock"),
+					PgPort:         5532, // zone1 + 100
+					PgDatabase:     dbName,
+					PgUser:         "postgres",
+					PgPwfile:       filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone2), "pgpassword.txt"),
+					Timeout:        30,
+					LogLevel:       "info",
 				},
 			},
 		},
@@ -340,15 +346,16 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 		}, nil
 	case "multipooler":
 		return map[string]any{
-			"path":        cellServices.Multipooler.Path,
-			"database":    cellServices.Multipooler.Database,
-			"table_group": cellServices.Multipooler.TableGroup,
-			"service-id":  cellServices.Multipooler.ServiceID,
-			"http_port":   cellServices.Multipooler.HttpPort,
-			"grpc_port":   cellServices.Multipooler.GrpcPort,
-			"log_level":   cellServices.Multipooler.LogLevel,
-			"pooler_dir":  cellServices.Multipooler.PoolerDir,
-			"pg_port":     cellServices.Multipooler.PgPort,
+			"path":             cellServices.Multipooler.Path,
+			"database":         cellServices.Multipooler.Database,
+			"table_group":      cellServices.Multipooler.TableGroup,
+			"service-id":       cellServices.Multipooler.ServiceID,
+			"http_port":        cellServices.Multipooler.HttpPort,
+			"grpc_port":        cellServices.Multipooler.GrpcPort,
+			"grpc_socket_file": cellServices.Multipooler.GRPCSocketFile,
+			"log_level":        cellServices.Multipooler.LogLevel,
+			"pooler_dir":       cellServices.Multipooler.PoolerDir,
+			"pg_port":          cellServices.Multipooler.PgPort,
 		}, nil
 	case "multiorch":
 		return map[string]any{
@@ -359,15 +366,16 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 		}, nil
 	case "pgctld":
 		return map[string]any{
-			"path":        cellServices.Pgctld.Path,
-			"pooler_dir":  cellServices.Pgctld.PoolerDir,
-			"grpc_port":   cellServices.Pgctld.GrpcPort,
-			"pg_port":     cellServices.Pgctld.PgPort,
-			"pg_database": cellServices.Pgctld.PgDatabase,
-			"pg_user":     cellServices.Pgctld.PgUser,
-			"pg_pwfile":   cellServices.Pgctld.PgPwfile,
-			"timeout":     cellServices.Pgctld.Timeout,
-			"log_level":   cellServices.Pgctld.LogLevel,
+			"path":             cellServices.Pgctld.Path,
+			"pooler_dir":       cellServices.Pgctld.PoolerDir,
+			"grpc_port":        cellServices.Pgctld.GrpcPort,
+			"grpc_socket_file": cellServices.Pgctld.GRPCSocketFile,
+			"pg_port":          cellServices.Pgctld.PgPort,
+			"pg_database":      cellServices.Pgctld.PgDatabase,
+			"pg_user":          cellServices.Pgctld.PgUser,
+			"pg_pwfile":        cellServices.Pgctld.PgPwfile,
+			"timeout":          cellServices.Pgctld.Timeout,
+			"log_level":        cellServices.Pgctld.LogLevel,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown service %s", service)

--- a/go/servenv/grpc_server.go
+++ b/go/servenv/grpc_server.go
@@ -144,6 +144,7 @@ func RegisterGRPCServerFlags() {
 		fs.StringVar(&gRPCServerCA, "grpc-server-ca", gRPCServerCA, "path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients")
 		fs.DurationVar(&gRPCKeepaliveTime, "grpc-server-keepalive-time", gRPCKeepaliveTime, "After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive.")
 		fs.DurationVar(&gRPCKeepaliveTimeout, "grpc-server-keepalive-timeout", gRPCKeepaliveTimeout, "After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed.")
+		fs.StringVar(&gRPCSocketFile, "grpc-socket-file", gRPCSocketFile, "Local unix socket file to listen on")
 	})
 }
 
@@ -178,7 +179,7 @@ func isGRPCEnabled() bool {
 		return true
 	}
 
-	if socketFile != "" {
+	if gRPCSocketFile != "" {
 		return true
 	}
 

--- a/go/servenv/run.go
+++ b/go/servenv/run.go
@@ -43,8 +43,7 @@ func Run(bindAddress string, port int) {
 	createGRPCServer()
 	onRunHooks.Fire()
 	serveGRPC()
-	// Do we want this?
-	// serveSocketFile()
+	serveSocketFile()
 
 	l, err := net.Listen("tcp", net.JoinHostPort(bindAddress, strconv.Itoa(port)))
 	if err != nil {

--- a/go/servenv/unix_socket.go
+++ b/go/servenv/unix_socket.go
@@ -20,21 +20,19 @@ import (
 	"log/slog"
 	"net"
 	"os"
-
-	"github.com/spf13/pflag"
 )
 
-// socketFile has the flag used when calling
-// RegisterDefaultSocketFileFlags.
-var socketFile string
+// gRPCSocketFile has the flag used when calling
+// RegisterGRPCServerFlags.
+var gRPCSocketFile string
 
 // serveSocketFile listen to the named socket and serves RPCs on it.
 func serveSocketFile() {
-	if socketFile == "" {
+	if gRPCSocketFile == "" {
 		slog.Info("Not listening on socket file")
 		return
 	}
-	name := socketFile
+	name := gRPCSocketFile
 
 	// try to delete if file exists
 	if _, err := os.Stat(name); err == nil {
@@ -55,12 +53,4 @@ func serveSocketFile() {
 			slog.Error("grpc server failed", "err", err)
 		}
 	}()
-}
-
-// RegisterDefaultSocketFileFlags registers the default flags for listening
-// to a socket. This needs to be called before flags are parsed.
-func RegisterDefaultSocketFileFlags() {
-	OnParse(func(fs *pflag.FlagSet) {
-		fs.StringVar(&socketFile, "socket-file", socketFile, "Local unix socket file to listen on")
-	})
 }

--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -30,10 +30,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v3"
 
 	"github.com/multigres/multigres/go/clustermetadata/topo"
 	"github.com/multigres/multigres/go/cmd/multigres/command/cluster"
+	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/provisioner/local"
 	"github.com/multigres/multigres/go/test/utils"
 	"github.com/multigres/multigres/go/tools/appendpath"
@@ -218,15 +221,16 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					LogLevel: "info",
 				},
 				Multipooler: local.MultipoolerConfig{
-					Path:       filepath.Join(binPath, "multipooler"),
-					Database:   "postgres",
-					TableGroup: "default",
-					ServiceID:  serviceIDZone1,
-					PoolerDir:  local.GeneratePoolerDir(tempDir, serviceIDZone1),
-					PgPort:     portConfig.PgctldPGPort, // Same as pgctld for this zone
-					HttpPort:   portConfig.MultipoolerHTTPPort,
-					GrpcPort:   portConfig.MultipoolerGRPCPort,
-					LogLevel:   "info",
+					Path:           filepath.Join(binPath, "multipooler"),
+					Database:       "postgres",
+					TableGroup:     "default",
+					ServiceID:      serviceIDZone1,
+					PoolerDir:      local.GeneratePoolerDir(tempDir, serviceIDZone1),
+					PgPort:         portConfig.PgctldPGPort, // Same as pgctld for this zone
+					HttpPort:       portConfig.MultipoolerHTTPPort,
+					GrpcPort:       portConfig.MultipoolerGRPCPort,
+					GRPCSocketFile: filepath.Join(tempDir, "sockets", "multipooler-zone1.sock"),
+					LogLevel:       "info",
 				},
 				Multiorch: local.MultiorchConfig{
 					Path:     filepath.Join(binPath, "multiorch"),
@@ -235,15 +239,16 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					LogLevel: "info",
 				},
 				Pgctld: local.PgctldConfig{
-					Path:       filepath.Join(binPath, "pgctld"),
-					GrpcPort:   portConfig.PgctldGRPCPort,
-					PgPort:     portConfig.PgctldPGPort,
-					PgDatabase: "postgres",
-					PgUser:     "postgres",
-					Timeout:    30,
-					LogLevel:   "info",
-					PoolerDir:  local.GeneratePoolerDir(tempDir, serviceIDZone1),
-					PgPwfile:   filepath.Join(local.GeneratePoolerDir(tempDir, serviceIDZone1), "pgctld.pwfile"),
+					Path:           filepath.Join(binPath, "pgctld"),
+					GrpcPort:       portConfig.PgctldGRPCPort,
+					GRPCSocketFile: filepath.Join(tempDir, "sockets", "pgctld-zone1.sock"),
+					PgPort:         portConfig.PgctldPGPort,
+					PgDatabase:     "postgres",
+					PgUser:         "postgres",
+					Timeout:        30,
+					LogLevel:       "info",
+					PoolerDir:      local.GeneratePoolerDir(tempDir, serviceIDZone1),
+					PgPwfile:       filepath.Join(local.GeneratePoolerDir(tempDir, serviceIDZone1), "pgctld.pwfile"),
 				},
 			},
 			"zone2": {
@@ -255,15 +260,16 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					LogLevel: "info",
 				},
 				Multipooler: local.MultipoolerConfig{
-					Path:       filepath.Join(binPath, "multipooler"),
-					Database:   "postgres",
-					TableGroup: "default",
-					ServiceID:  serviceIDZone2,
-					PoolerDir:  local.GeneratePoolerDir(tempDir, serviceIDZone2),
-					PgPort:     portConfig.PgctldPGPort + 100, // Same as pgctld for this zone (offset for zone2)
-					HttpPort:   portConfig.MultipoolerHTTPPort + 100,
-					GrpcPort:   portConfig.MultipoolerGRPCPort + 100,
-					LogLevel:   "info",
+					Path:           filepath.Join(binPath, "multipooler"),
+					Database:       "postgres",
+					TableGroup:     "default",
+					ServiceID:      serviceIDZone2,
+					PoolerDir:      local.GeneratePoolerDir(tempDir, serviceIDZone2),
+					PgPort:         portConfig.PgctldPGPort + 100, // Same as pgctld for this zone (offset for zone2)
+					HttpPort:       portConfig.MultipoolerHTTPPort + 100,
+					GrpcPort:       portConfig.MultipoolerGRPCPort + 100,
+					GRPCSocketFile: filepath.Join(tempDir, "sockets", "multipooler-zone2.sock"),
+					LogLevel:       "info",
 				},
 				Multiorch: local.MultiorchConfig{
 					Path:     filepath.Join(binPath, "multiorch"),
@@ -272,15 +278,16 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 					LogLevel: "info",
 				},
 				Pgctld: local.PgctldConfig{
-					Path:       filepath.Join(binPath, "pgctld"),
-					GrpcPort:   portConfig.PgctldGRPCPort + 100, // offset for zone2
-					PgPort:     portConfig.PgctldPGPort + 100,   // offset for zone2
-					PgDatabase: "postgres",
-					PgUser:     "postgres",
-					Timeout:    30,
-					LogLevel:   "info",
-					PoolerDir:  local.GeneratePoolerDir(tempDir, serviceIDZone2),
-					PgPwfile:   filepath.Join(local.GeneratePoolerDir(tempDir, serviceIDZone2), "pgctld.pwfile"),
+					Path:           filepath.Join(binPath, "pgctld"),
+					GrpcPort:       portConfig.PgctldGRPCPort + 100, // offset for zone2
+					GRPCSocketFile: filepath.Join(tempDir, "sockets", "pgctld-zone2.sock"),
+					PgPort:         portConfig.PgctldPGPort + 100, // offset for zone2
+					PgDatabase:     "postgres",
+					PgUser:         "postgres",
+					Timeout:        30,
+					LogLevel:       "info",
+					PoolerDir:      local.GeneratePoolerDir(tempDir, serviceIDZone2),
+					PgPwfile:       filepath.Join(local.GeneratePoolerDir(tempDir, serviceIDZone2), "pgctld.pwfile"),
 				},
 			},
 		},
@@ -945,11 +952,23 @@ func TestClusterLifecycle(t *testing.T) {
 		testPostgreSQLConnection(t, testPorts.PgctldPGPort+100, "2")
 		t.Log("Both PostgreSQL instances are working correctly!")
 
-		// Test multipooler gRPC functionality
-		t.Log("Testing multipooler gRPC ExecuteQuery functionality...")
-		testMultipoolerGRPC(t, testPorts.MultipoolerGRPCPort)
-		testMultipoolerGRPC(t, testPorts.MultipoolerGRPCPort+100) // Zone 2
-		t.Log("Both multipooler gRPC instances are working correctly!")
+		// Test multipooler gRPC functionality via TCP
+		t.Log("Testing multipooler gRPC ExecuteQuery functionality via TCP...")
+		testMultipoolerGRPC(t, fmt.Sprintf("localhost:%d", testPorts.MultipoolerGRPCPort))
+		testMultipoolerGRPC(t, fmt.Sprintf("localhost:%d", testPorts.MultipoolerGRPCPort+100))
+		t.Log("Both multipooler gRPC instances are working correctly via TCP!")
+
+		// Test multipooler gRPC functionality via Unix socket
+		t.Log("Testing multipooler gRPC ExecuteQuery functionality via Unix socket...")
+		testMultipoolerGRPC(t, "unix://"+filepath.Join(tempDir, "sockets", "multipooler-zone1.sock"))
+		testMultipoolerGRPC(t, "unix://"+filepath.Join(tempDir, "sockets", "multipooler-zone2.sock"))
+		t.Log("Both multipooler gRPC instances are working correctly via Unix socket!")
+
+		// Test pgctld gRPC functionality via Unix socket
+		t.Log("Testing pgctld gRPC Status functionality via Unix socket...")
+		testPgctldGRPC(t, "unix://"+filepath.Join(tempDir, "sockets", "pgctld-zone1.sock"))
+		testPgctldGRPC(t, "unix://"+filepath.Join(tempDir, "sockets", "pgctld-zone2.sock"))
+		t.Log("Both pgctld gRPC instances are working correctly via Unix socket!")
 
 		// Start cluster is idempotent
 		t.Log("Attempting to start running cluster...")
@@ -1136,13 +1155,12 @@ func assertDirectoryTreeEmpty(rootPath string) error {
 }
 
 // testMultipoolerGRPC tests the multipooler gRPC ExecuteQuery functionality
-func testMultipoolerGRPC(t *testing.T, grpcPort int) {
+func testMultipoolerGRPC(t *testing.T, addr string) {
 	t.Helper()
 
 	// Connect to multipooler gRPC service
-	multipoolerAddr := fmt.Sprintf("localhost:%d", grpcPort)
-	client, err := NewMultiPoolerTestClient(multipoolerAddr)
-	require.NoError(t, err, "Failed to connect to multipooler gRPC at %s", multipoolerAddr)
+	client, err := NewMultiPoolerTestClient(addr)
+	require.NoError(t, err, "Failed to connect to multipooler gRPC at %s", addr)
 	defer client.Close()
 
 	// Test basic SELECT query
@@ -1152,7 +1170,8 @@ func testMultipoolerGRPC(t *testing.T, grpcPort int) {
 	TestDataTypes(t, client)
 
 	// Test a simple table lifecycle (without affecting other tests)
-	tableName := fmt.Sprintf("test_table_%d", grpcPort) // Unique table name per port
+	// Use a simple hash of the address to create unique table names
+	tableName := fmt.Sprintf("test_table_%d", stringHash(addr))
 	TestCreateTable(t, client, tableName)
 
 	// Insert some test data
@@ -1168,5 +1187,38 @@ func testMultipoolerGRPC(t *testing.T, grpcPort int) {
 	// Clean up
 	TestDropTable(t, client, tableName)
 
-	t.Logf("Multipooler gRPC test completed successfully for port %d", grpcPort)
+	t.Logf("Multipooler gRPC test completed successfully for %s", addr)
+}
+
+// testPgctldGRPC tests the pgctld gRPC Status functionality
+func testPgctldGRPC(t *testing.T, addr string) {
+	t.Helper()
+
+	// Connect to pgctld gRPC service
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "Failed to connect to pgctld gRPC at %s", addr)
+	defer conn.Close()
+
+	client := pb.NewPgCtldClient(conn)
+	ctx := context.Background()
+
+	// Test Status call to verify connectivity
+	statusResp, err := client.Status(ctx, &pb.StatusRequest{})
+	require.NoError(t, err, "Status call failed")
+	assert.Equal(t, pb.ServerStatus_RUNNING, statusResp.GetStatus(), "PostgreSQL should be running")
+	assert.NotZero(t, statusResp.GetPid(), "PID should be non-zero")
+
+	t.Logf("Pgctld gRPC test completed successfully for %s", addr)
+}
+
+// stringHash generates a simple hash from a string for creating unique identifiers
+func stringHash(s string) int {
+	h := 0
+	for _, c := range s {
+		h = 31*h + int(c)
+	}
+	if h < 0 {
+		h = -h
+	}
+	return h
 }


### PR DESCRIPTION
# Desc
* Easy PR, this closes a gap on the initial pass of servenv. We were not wiring the unix socket configuration for gRPC. This fixes that issue. For the cases where pgtctld is running in the same node as multipooler, we will want to use the socket. 
* This is mostly plumbing and adding tests as the functioanlity was already there, it was just not connected. 