### PR TITLE
feat(bootstrap): QoL validations when initializing and starting cluster

### DIFF
--- a/go/cmd/multigres/command/cluster/init.go
+++ b/go/cmd/multigres/command/cluster/init.go
@@ -78,6 +78,11 @@ func createConfigFile(cmd *cobra.Command, configPaths []string) (string, error) 
 		return "", err
 	}
 
+	// Validate the configuration before writing it
+	if err := validateConfig(config); err != nil {
+		return "", fmt.Errorf("configuration validation failed: %w", err)
+	}
+
 	// Marshal to YAML
 	yamlData, err := yaml.Marshal(config)
 	if err != nil {
@@ -152,6 +157,22 @@ func createDefaultConfig(provisionerName string, configPaths []string) (*Multigr
 		Provisioner:       provisionerName,
 		ProvisionerConfig: defaultConfig,
 	}, nil
+}
+
+// validateConfig validates the configuration using the appropriate provisioner
+func validateConfig(config *MultigresConfig) error {
+	// Get the provisioner instance
+	p, err := provisioner.GetProvisioner(config.Provisioner)
+	if err != nil {
+		return fmt.Errorf("failed to get provisioner '%s': %w", config.Provisioner, err)
+	}
+
+	// Validate the provisioner-specific configuration
+	if err := p.ValidateConfig(config.ProvisionerConfig); err != nil {
+		return fmt.Errorf("provisioner validation failed: %w", err)
+	}
+
+	return nil
 }
 
 var InitCommand = &cobra.Command{

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -1165,6 +1165,16 @@ func (p *localProvisioner) waitForProcessExit(process *os.Process, timeout time.
 
 // Bootstrap sets up etcd and creates the default database
 func (p *localProvisioner) Bootstrap(ctx context.Context) ([]*provisioner.ProvisionResult, error) {
+	// Validate binary paths before starting
+	if err := p.validateBinaryPaths(p.config); err != nil {
+		return nil, err
+	}
+
+	// Validate required system binaries before starting
+	if err := p.validateSystemBinaries(); err != nil {
+		return nil, err
+	}
+
 	fmt.Println("=== Bootstrapping Multigres cluster ===")
 	fmt.Println("")
 
@@ -1764,6 +1774,159 @@ func (p *localProvisioner) ValidateConfig(config map[string]any) error {
 		if cell.RootPath == "" {
 			return fmt.Errorf("cell %s root-path is required", cell.Name)
 		}
+	}
+
+	// Validate Unix socket path length limits
+	if err := p.validateUnixSocketPathLength(typedConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateUnixSocketPathLength validates that Unix socket paths won't exceed system limits
+func (p *localProvisioner) validateUnixSocketPathLength(config *LocalProvisionerConfig) error {
+	// Unix domain socket path length limit is typically 108 bytes on most systems
+	const maxSocketPathLength = 108
+
+	// Convert root working dir to absolute path for accurate length calculation
+	absRootWorkingDir, err := filepath.Abs(config.RootWorkingDir)
+	if err != nil {
+		return fmt.Errorf("failed to convert root working dir to absolute path: %w", err)
+	}
+
+	// Calculate the maximum possible path length for Unix sockets
+	// Path structure: <rootWorkingDir>/data/pooler_<serviceID>/pg_sockets/.s.PGSQL.5432
+	// We use a worst-case service ID length (8 chars) to be safe
+	maxServiceIDLength := 8
+	worstCasePoolerSocketPath := []string{
+		"data",
+		fmt.Sprintf("pooler_%s", strings.Repeat("x", maxServiceIDLength)),
+		"pg_sockets",
+		".s.PGSQL.5432",
+	}
+	worstCaseCurrentSocketPath := filepath.Join(append([]string{absRootWorkingDir}, worstCasePoolerSocketPath...)...)
+
+	worstCaseProposedSocketPath := filepath.Join(append([]string{"/tmp/mt"}, worstCasePoolerSocketPath...)...)
+
+	if len(worstCaseCurrentSocketPath) > maxSocketPathLength {
+		return fmt.Errorf("unix socket path would exceed system limit (%d bytes): %s\n\n"+
+			"To fix this issue:\n"+
+			"1. Initialize multigres from a directory with a shorter path\n"+
+			"2. Provide config-path to multigres (--config-path target_dir) that has a shorter length\n\n"+
+			"Example:\n"+
+			"  Current: multigres cluster init --config-path %s\n"+
+			"  Better:  multigres cluster init --config-path /tmp/mt/\n\n"+
+			"This will generate socket paths like:\n"+
+			"  %s (%d bytes)\n\n"+
+			"Current path length: %d bytes (limit: %d bytes)",
+			maxSocketPathLength, worstCaseCurrentSocketPath, config.RootWorkingDir, worstCaseProposedSocketPath, len(worstCaseProposedSocketPath), len(worstCaseCurrentSocketPath), maxSocketPathLength)
+	}
+
+	return nil
+}
+
+// validateBinaryPaths validates that all configured binary paths exist and are executable
+func (p *localProvisioner) validateBinaryPaths(config *LocalProvisionerConfig) error {
+	var errors []string
+
+	// Validate global service binaries
+	if config.Multiadmin.Path != "" {
+		if err := p.validateBinaryExists(config.Multiadmin.Path, "multiadmin"); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+
+	// Validate cell service binaries
+	for cellName, cellConfig := range config.Cells {
+		// Validate multigateway
+		if cellConfig.Multigateway.Path != "" {
+			if err := p.validateBinaryExists(cellConfig.Multigateway.Path, fmt.Sprintf("multigateway (cell %s)", cellName)); err != nil {
+				errors = append(errors, err.Error())
+			}
+		}
+
+		// Validate multipooler
+		if cellConfig.Multipooler.Path != "" {
+			if err := p.validateBinaryExists(cellConfig.Multipooler.Path, fmt.Sprintf("multipooler (cell %s)", cellName)); err != nil {
+				errors = append(errors, err.Error())
+			}
+		}
+
+		// Validate multiorch
+		if cellConfig.Multiorch.Path != "" {
+			if err := p.validateBinaryExists(cellConfig.Multiorch.Path, fmt.Sprintf("multiorch (cell %s)", cellName)); err != nil {
+				errors = append(errors, err.Error())
+			}
+		}
+
+		// Validate pgctld
+		if cellConfig.Pgctld.Path != "" {
+			if err := p.validateBinaryExists(cellConfig.Pgctld.Path, fmt.Sprintf("pgctld (cell %s)", cellName)); err != nil {
+				errors = append(errors, err.Error())
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("binary validation failed:\n%s", strings.Join(errors, "\n"))
+	}
+
+	return nil
+}
+
+// validateBinaryExists checks if a binary path exists and is executable
+func (p *localProvisioner) validateBinaryExists(binaryPath, serviceName string) error {
+	// Convert to absolute path if it's relative
+	var fullPath string
+	if filepath.IsAbs(binaryPath) {
+		fullPath = binaryPath
+	} else {
+		// Make it relative to current directory
+		fullPath = filepath.Join(".", binaryPath)
+	}
+
+	// Check if the binary exists and is executable
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return fmt.Errorf("  %s binary not found at %s: %w", serviceName, binaryPath, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("  %s path is a directory, not a binary: %s", serviceName, binaryPath)
+	}
+
+	// Check if it's executable (on Unix systems)
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("  %s binary is not executable: %s", serviceName, binaryPath)
+	}
+
+	return nil
+}
+
+// validateSystemBinaries validates that required system binaries are available in PATH
+func (p *localProvisioner) validateSystemBinaries() error {
+	requiredBinaries := []string{
+		"etcd",
+		"pg_ctl",
+		"postgres",
+		"pg_isready",
+	}
+
+	var missingBinaries []string
+
+	for _, binary := range requiredBinaries {
+		if _, err := exec.LookPath(binary); err != nil {
+			missingBinaries = append(missingBinaries, binary)
+		}
+	}
+
+	if len(missingBinaries) > 0 {
+		return fmt.Errorf("required system binaries not found in PATH: %s\n\n"+
+			"Please ensure PostgreSQL and etcd are installed and available in your PATH.\n"+
+			"For PostgreSQL: Install PostgreSQL client tools (pg_ctl, postgres, pg_isready)\n"+
+			"For etcd: Install etcd client binary",
+			strings.Join(missingBinaries, ", "))
 	}
 
 	return nil

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -1784,10 +1784,15 @@ func (p *localProvisioner) ValidateConfig(config map[string]any) error {
 	return nil
 }
 
+// UnixPathMax returns the maximum Unix socket path length for the current platform.
+func UnixPathMax() int {
+	var addr syscall.RawSockaddrUnix
+	return len(addr.Path)
+}
+
 // validateUnixSocketPathLength validates that Unix socket paths won't exceed system limits
 func (p *localProvisioner) validateUnixSocketPathLength(config *LocalProvisionerConfig) error {
-	// Unix domain socket path length limit is typically 108 bytes on most systems
-	const maxSocketPathLength = 108
+	maxSocketPathLength := UnixPathMax()
 
 	// Convert root working dir to absolute path for accurate length calculation
 	absRootWorkingDir, err := filepath.Abs(config.RootWorkingDir)

--- a/go/provisioner/local/local_test.go
+++ b/go/provisioner/local/local_test.go
@@ -45,7 +45,7 @@ func TestValidateUnixSocketPathLength(t *testing.T) {
 			name:        "very long path should fail",
 			rootDir:     "/Users/very/long/path/that/will/definitely/exceed/the/unix/socket/path/limit/for/postgresql/sockets",
 			expectError: true,
-			errorMsg:    "Unix socket path would exceed system limit",
+			errorMsg:    "unix socket path would exceed system limit",
 		},
 		{
 			name:        "relative path should be converted to absolute",

--- a/go/provisioner/local/local_test.go
+++ b/go/provisioner/local/local_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateUnixSocketPathLength(t *testing.T) {
+	provisioner := &localProvisioner{}
+
+	tests := []struct {
+		name        string
+		rootDir     string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "short path should pass",
+			rootDir:     "/tmp/mt",
+			expectError: false,
+		},
+		{
+			name:        "medium path should pass",
+			rootDir:     "/home/user/multigres",
+			expectError: false,
+		},
+		{
+			name:        "very long path should fail",
+			rootDir:     "/Users/very/long/path/that/will/definitely/exceed/the/unix/socket/path/limit/for/postgresql/sockets",
+			expectError: true,
+			errorMsg:    "Unix socket path would exceed system limit",
+		},
+		{
+			name:        "relative path should be converted to absolute",
+			rootDir:     "./short",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &LocalProvisionerConfig{
+				RootWorkingDir: tt.rootDir,
+			}
+
+			err := provisioner.validateUnixSocketPathLength(config)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+
+				// For path length errors, verify the error message contains helpful guidance
+				if strings.Contains(tt.errorMsg, "exceed system limit") {
+					assert.Contains(t, err.Error(), "To fix this issue:")
+					assert.Contains(t, err.Error(), "Initialize multigres from a directory with a shorter path")
+					assert.Contains(t, err.Error(), "Provide config-path to multigres")
+					assert.Contains(t, err.Error(), "Better:  multigres cluster init --config-path /tmp/mt/")
+					assert.Contains(t, err.Error(), "This will generate socket paths like:")
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/go/provisioner/local/local_test.go
+++ b/go/provisioner/local/local_test.go
@@ -81,7 +81,7 @@ func TestValidateUnixSocketPathLength(t *testing.T) {
 
 func TestValidateUnixSocketPathLengthWithWorkingDirectory(t *testing.T) {
 	// Setup test directory
-	tempDir, err := os.MkdirTemp("/tmp/", "socket_validation_test")
+	tempDir, err := os.MkdirTemp("/tmp/", "socket")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
# Desc

This part adds a few quality of life improvements when initializing and starting the cluster:

1) If the config path for multigres is too long, it will not allow to initialize as unix socket path can be an issue in postgres:
```
Initializing Multigres cluster configuration...
Error: configuration validation failed: provisioner validation failed: unix socket path would exceed system limit (108 bytes): /Users/rafael/sandboxes/multigres/multigres_local/long/path/test/rafael/data/pooler_xxxxxxxx/pg_sockets/.s.PGSQL.5432

To fix this issue:
1. Initialize multigres from a directory with a shorter path
2. Provide config-path to multigres (--config-path target_dir) that has a shorter length

Example:
  Current: multigres cluster init --config-path ./multigres_local/long/path/test/rafael/
  Better:  multigres cluster init --config-path /tmp/mt/

This will generate socket paths like:
  /tmp/mt/data/pooler_xxxxxxxx/pg_sockets/.s.PGSQL.5432 (53 bytes)

Current path length: 117 bytes (limit: 108 bytes)
```
2. Make sure that required binaries are available when starting the cluster, otherwise it fails to start. 

## Tests

* Adds relevant tests to cover the use case