### PR TITLE
fix: heartbeat PR follow-ups and improvements

### DIFF
--- a/go/mterrors/mterrors.go
+++ b/go/mterrors/mterrors.go
@@ -81,7 +81,7 @@
 //	      be printed in detail.
 //
 // Most but not all of the code in this file was originally copied from
-// Vittes, which also is mostly a copy from:
+// Vitess, which also is mostly a copy from:
 // https://github.com/pkg/errors/blob/v0.8.0/errors.go
 
 package mterrors

--- a/go/multipooler/heartbeat/repltracker.go
+++ b/go/multipooler/heartbeat/repltracker.go
@@ -32,9 +32,9 @@ type ReplTracker struct {
 }
 
 // NewReplTracker creates a new ReplTracker.
-func NewReplTracker(db *sql.DB, logger *slog.Logger, shardID []byte, poolerID string) *ReplTracker {
+func NewReplTracker(db *sql.DB, logger *slog.Logger, shardID []byte, poolerID string, intervalMs int) *ReplTracker {
 	return &ReplTracker{
-		hw: NewWriter(db, logger, shardID, poolerID),
+		hw: NewWriter(db, logger, shardID, poolerID, intervalMs),
 		hr: NewReader(db, logger, shardID),
 	}
 }

--- a/go/multipooler/heartbeat/writer_test.go
+++ b/go/multipooler/heartbeat/writer_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/fakepgdb"
-	"github.com/multigres/multigres/go/timer"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -250,10 +249,8 @@ func newTestWriter(t *testing.T, db *fakepgdb.DB, frozenTime *time.Time) *Writer
 	sqlDB := db.OpenDB()
 	t.Cleanup(func() { sqlDB.Close() })
 
-	tw := NewWriter(sqlDB, logger, shardID, poolerID)
 	// Use 250ms interval for tests to oversample our 1s test ticker
-	tw.interval = 250 * time.Millisecond
-	tw.ticks = timer.NewTimer(250 * time.Millisecond)
+	tw := NewWriter(sqlDB, logger, shardID, poolerID, 250)
 
 	if frozenTime != nil {
 		tw.now = func() time.Time {

--- a/go/multipooler/manager/config.go
+++ b/go/multipooler/manager/config.go
@@ -23,11 +23,12 @@ import (
 
 // Config holds configuration for the MultiPoolerManager
 type Config struct {
-	SocketFilePath string
-	PoolerDir      string
-	PgPort         int
-	Database       string
-	TopoClient     topo.Store
-	ServiceID      *clustermetadatapb.ID
-	PgctldAddr     string // Address of pgctld gRPC service
+	SocketFilePath      string
+	PoolerDir           string
+	PgPort              int
+	Database            string
+	TopoClient          topo.Store
+	ServiceID           *clustermetadatapb.ID
+	HeartbeatIntervalMs int
+	PgctldAddr          string // Address of pgctld gRPC service
 }

--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/multigres/multigres/go/clustermetadata/topo"
 	"github.com/multigres/multigres/go/mterrors"
+	"github.com/multigres/multigres/go/multipooler/heartbeat"
 	"github.com/multigres/multigres/go/servenv"
 	"github.com/multigres/multigres/go/tools/timertools"
 
@@ -47,11 +48,12 @@ const (
 
 // MultiPoolerManager manages the pooler lifecycle and PostgreSQL operations
 type MultiPoolerManager struct {
-	logger     *slog.Logger
-	config     *Config
-	db         *sql.DB
-	topoClient topo.Store
-	serviceID  *clustermetadatapb.ID
+	logger      *slog.Logger
+	config      *Config
+	db          *sql.DB
+	topoClient  topo.Store
+	serviceID   *clustermetadatapb.ID
+	replTracker *heartbeat.ReplTracker
 
 	// Multipooler record from topology and startup state
 	mu              sync.RWMutex
@@ -97,12 +99,96 @@ func (pm *MultiPoolerManager) connectDB() error {
 		return err
 	}
 	pm.db = db
+
+	// Test the connection
+	if err := pm.db.Ping(); err != nil {
+		pm.db.Close()
+		pm.db = nil
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	pm.logger.Info("MultiPoolerManager: Connected to PostgreSQL", "socket_path", pm.config.SocketFilePath, "database", pm.config.Database)
+
+	// Start heartbeat tracking if not already started
+	if pm.replTracker == nil {
+		pm.logger.Info("MultiPoolerManager: Starting database heartbeat")
+		ctx := context.Background()
+		// TODO: populate shard ID
+		shardID := []byte("0") // default shard ID
+
+		// Use the multipooler name from serviceID as the pooler ID
+		poolerID := pm.serviceID.Name
+
+		// Check if connected to a primary database
+		isPrimary, err := pm.isPrimary(ctx)
+		if err != nil {
+			pm.logger.Error("Failed to check if database is primary", "error", err)
+			// Don't fail the connection if primary check fails
+		} else if isPrimary {
+			// Only create the sidecar schema on primary databases
+			pm.logger.Info("MultiPoolerManager: Creating sidecar schema on primary database")
+			if err := CreateSidecarSchema(pm.db); err != nil {
+				return fmt.Errorf("failed to create sidecar schema: %w", err)
+			}
+		} else {
+			pm.logger.Info("MultiPoolerManager: Skipping sidecar schema creation on replica")
+		}
+
+		if err := pm.startHeartbeat(ctx, shardID, poolerID); err != nil {
+			pm.logger.Error("Failed to start heartbeat", "error", err)
+			// Don't fail the connection if heartbeat fails
+		}
+	}
+
+	return nil
+}
+
+// isPrimary checks if the connected database is a primary (not in recovery)
+//
+// TODO: replace with ReplicationStatus() when it's implemented
+func (pm *MultiPoolerManager) isPrimary(ctx context.Context) (bool, error) {
+	if pm.db == nil {
+		return false, fmt.Errorf("database connection not established")
+	}
+
+	var inRecovery bool
+	err := pm.db.QueryRowContext(ctx, "SELECT pg_is_in_recovery()").Scan(&inRecovery)
+	if err != nil {
+		return false, fmt.Errorf("failed to query pg_is_in_recovery: %w", err)
+	}
+
+	// pg_is_in_recovery() returns true if standby, false if primary
+	return !inRecovery, nil
+}
+
+// startHeartbeat starts the replication tracker and heartbeat writer if connected to a primary database
+func (pm *MultiPoolerManager) startHeartbeat(ctx context.Context, shardID []byte, poolerID string) error {
+	// Create the replication tracker
+	pm.replTracker = heartbeat.NewReplTracker(pm.db, pm.logger, shardID, poolerID, pm.config.HeartbeatIntervalMs)
+
+	// Check if we're connected to a primary
+	isPrimary, err := pm.isPrimary(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if database is primary: %w", err)
+	}
+
+	if isPrimary {
+		pm.logger.Info("Starting heartbeat writer - connected to primary database")
+		pm.replTracker.MakePrimary()
+	} else {
+		pm.logger.Info("Not starting heartbeat writer - connected to standby database")
+		pm.replTracker.MakeNonPrimary()
+	}
+
 	return nil
 }
 
 // Close closes the database connection and stops the async loader
 func (pm *MultiPoolerManager) Close() error {
 	pm.cancel()
+	if pm.replTracker != nil {
+		pm.replTracker.Close()
+	}
 	if pm.db != nil {
 		return pm.db.Close()
 	}
@@ -769,6 +855,19 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 	}, nil
 }
 
+// ReplicationLag returns the current replication lag from the heartbeat reader
+func (pm *MultiPoolerManager) ReplicationLag(ctx context.Context) (time.Duration, error) {
+	if err := pm.checkReady(); err != nil {
+		return 0, err
+	}
+
+	if pm.replTracker == nil {
+		return 0, mterrors.New(mtrpcpb.Code_UNAVAILABLE, "replication tracker not initialized")
+	}
+
+	return pm.replTracker.HeartbeatReader().Status()
+}
+
 // GetFollowers gets the list of follower servers
 func (pm *MultiPoolerManager) GetFollowers(ctx context.Context) ([]string, error) {
 	if err := pm.checkReady(); err != nil {
@@ -839,6 +938,12 @@ func (pm *MultiPoolerManager) Start(senv *servenv.ServEnv) {
 	senv.OnRun(func() {
 		pm.logger.Info("MultiPoolerManager started")
 		// Additional manager-specific initialization can happen here
+
+		// Connect to database and start heartbeats
+		if err := pm.connectDB(); err != nil {
+			pm.logger.Error("Failed to connect to database during startup", "error", err)
+			// Don't fail startup if DB connection fails - will retry on demand
+		}
 
 		// Register all gRPC services that have registered themselves
 		pm.registerGRPCServices()


### PR DESCRIPTION
Replaces #164, follow up to https://github.com/multigres/multigres/pull/161#pullrequestreview-3319293981

This commit consolidates several improvements and fixes:

1. Make heartbeat interval configurable via --heartbeat-interval-milliseconds flag
2. Fix sidecar schema creation to only run on primary databases
3. Fix possible race condition in heartbeat tracking
4. Add checkReplicaGuardrails helper function for replication operations
5. Improve error handling and logging throughout

Changes include:
- Add HeartbeatIntervalMs config field to manager.Config
- Add heartbeatIntervalMs field to MultiPooler struct
- Update CreateSidecarSchema to only run on primary instances
- Improve heartbeat initialization and cleanup
- Add primary/replica detection helpers