### PR TITLE
build(provisioner): Prevent local provisioner from depending on non-topo logic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,23 @@ linters:
             - github.com/spf13/pflag
             - github.com/spf13/viper
             - github.com/stretchr/testify
+        provisioner:
+          files:
+            - "!$test"
+            - "**/go/provisioner/*.go"
+            - "**/go/provisioner/**/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "github.com/multigres/multigres/go"
+              desc: "provisioners should not depend on multigres logic aside from the topo"
+          allow:
+            - $gostd
+            - github.com/multigres/multigres/go/clustermetadata/topo
+            - github.com/multigres/multigres/go/tools
+            - github.com/multigres/multigres/go/pb
+            - github.com/multigres/multigres/go/provisioner
+            - github.com/multigres/multigres/go/provisioner/local
+            - github.com/multigres/multigres/go/grpccommon
         use_modern_packages:
           list-mode: lax
           deny:


### PR DESCRIPTION
The operator shouldn't depend on the multigres repo, so we don't want the local provisioner to pick up any unwanted dependencies either.