### PR TITLE
fix: flaky test TestMultiGateway_PostgreSQLConnection

### DIFF
--- a/go/test/endtoend/multipooler_manager_test.go
+++ b/go/test/endtoend/multipooler_manager_test.go
@@ -552,13 +552,13 @@ func getSharedTestSetup(t *testing.T) *MultipoolerTestSetup {
 
 		t.Logf("Created topology cell '%s' at etcd %s", cellName, etcdClientAddr)
 
-		// Generate ports for shared instances
-		primaryGrpcPort := testutil.GenerateRandomPort()
-		primaryPgPort := testutil.GenerateRandomPort()
-		standbyGrpcPort := testutil.GenerateRandomPort()
-		standbyPgPort := testutil.GenerateRandomPort()
-		primaryMultipoolerPort := testutil.GenerateRandomPort()
-		standbyMultipoolerPort := testutil.GenerateRandomPort()
+		// Generate ports for shared instances using systematic allocation to avoid conflicts
+		primaryGrpcPort := utils.GetNextPort()
+		primaryPgPort := utils.GetNextPort()
+		standbyGrpcPort := utils.GetNextPort()
+		standbyPgPort := utils.GetNextPort()
+		primaryMultipoolerPort := utils.GetNextPort()
+		standbyMultipoolerPort := utils.GetNextPort()
 
 		t.Logf("Shared test setup - Primary pgctld gRPC: %d, Primary PG: %d, Standby pgctld gRPC: %d, Standby PG: %d, Primary multipooler: %d, Standby multipooler: %d",
 			primaryGrpcPort, primaryPgPort, standbyGrpcPort, standbyPgPort, primaryMultipoolerPort, standbyMultipoolerPort)
@@ -632,7 +632,7 @@ func waitForManagerReady(t *testing.T, setup *MultipoolerTestSetup, manager *Pro
 			t.Fatalf("Manager failed to initialize: %s", resp.ErrorMessage)
 		}
 		return resp.State == "ready"
-	}, 5*time.Second, 100*time.Millisecond, "Manager should become ready within 30 seconds")
+	}, 30*time.Second, 100*time.Millisecond, "Manager should become ready within 30 seconds")
 
 	t.Logf("Manager %s is ready", manager.Name)
 }


### PR DESCRIPTION
# Fix Port Conflicts in multipooler_manager_test.go

## Problem

The `multipooler_manager_test.go` test was experiencing flaky failures due to port conflicts, as reported in issue [#189](https://github.com/multigres/multigres/issues/189). The root cause was inconsistent port allocation mechanisms across the test suite:

- **`testutil.GenerateRandomPort()`**: Used in `multipooler_manager_test.go`, generates random ports between 10000-65535 without any coordination or conflict detection
- **`utils.GetNextPort()`**: Used in other tests like `cluster_test.go`, employs a systematic approach with process-based offsets to avoid port conflicts

This inconsistency led to race conditions where multiple tests could attempt to use the same randomly generated port, causing test failures.