### PR TITLE
feat(heartbeat): sync leader_term from database when starting writer

### DIFF
--- a/go/multipooler/heartbeat/repltracker.go
+++ b/go/multipooler/heartbeat/repltracker.go
@@ -50,13 +50,16 @@ func (rt *ReplTracker) HeartbeatReader() *Reader {
 }
 
 // MakePrimary must be called if the database becomes a primary.
-func (rt *ReplTracker) MakePrimary() {
+func (rt *ReplTracker) MakePrimary() error {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
 	rt.hr.Close()
-	rt.hw.Open()
+	if err := rt.hw.Open(); err != nil {
+		return err
+	}
 	rt.isPrimary = true
+	return nil
 }
 
 // MakeNonPrimary must be called if the database becomes a non-primary (standby).

--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -268,7 +268,9 @@ func (pm *MultiPoolerManager) startHeartbeat(ctx context.Context, shardID []byte
 
 	if isPrimary {
 		pm.logger.InfoContext(ctx, "Starting heartbeat writer - connected to primary database")
-		pm.replTracker.MakePrimary()
+		if err := pm.replTracker.MakePrimary(); err != nil {
+			return fmt.Errorf("failed to start heartbeat writer: %w", err)
+		}
 	} else {
 		pm.logger.InfoContext(ctx, "Not starting heartbeat writer - connected to standby database")
 		pm.replTracker.MakeNonPrimary()
@@ -1103,7 +1105,9 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 	// Update heartbeat tracker to primary mode
 	if pm.replTracker != nil {
 		pm.logger.InfoContext(ctx, "Updating heartbeat tracker to primary mode")
-		pm.replTracker.MakePrimary()
+		if err := pm.replTracker.MakePrimary(); err != nil {
+			return mterrors.Wrap(err, "failed to update heartbeat tracker to primary mode")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
While reviewing #188, we realized that the heartbeat writer needs to notified of a new `leader_term` (term number). However, that should only happen after a new leader appointment is complete.
This PR removes the code that implements that notification in the wrong place. We will reimplement it when we write the full leader appointment code.
In addition, we also need to initialize the `leader_term` from the underlying database when a multipooler restarts in place. That feature has been implemented in this PR with some guardrails.