### PR TITLE
fix(test): resolve TestConsensus_GetLeadershipView flake due to shared state

### DIFF
--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -279,8 +279,8 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 		assert.NotEmpty(t, resp.LeaderId, "LeaderId should not be empty")
 		assert.Equal(t, "primary-multipooler", resp.LeaderId, "LeaderId should be primary-multipooler")
 
-		// Verify leader_term is set (should be 1 from test setup)
-		assert.Equal(t, int64(1), resp.LeaderTerm, "LeaderTerm should be 1")
+		// Verify leader_term is set (should be >= 1, may be higher if previous tests ran)
+		assert.GreaterOrEqual(t, resp.LeaderTerm, int64(1), "LeaderTerm should be at least 1")
 
 		// Verify last_heartbeat is set and recent
 		require.NotNil(t, resp.LastHeartbeat, "LastHeartbeat should not be nil")
@@ -315,7 +315,7 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 		// Standby should also see the same leader information
 		assert.NotEmpty(t, resp.LeaderId, "LeaderId should not be empty")
 		assert.Equal(t, "primary-multipooler", resp.LeaderId, "LeaderId should be primary-multipooler")
-		assert.Equal(t, int64(1), resp.LeaderTerm, "LeaderTerm should be 1")
+		assert.GreaterOrEqual(t, resp.LeaderTerm, int64(1), "LeaderTerm should be at least 1")
 
 		require.NotNil(t, resp.LastHeartbeat, "LastHeartbeat should not be nil")
 		assert.True(t, resp.LastHeartbeat.IsValid(), "LastHeartbeat should be a valid timestamp")


### PR DESCRIPTION
The test was failing intermittently because it expected consensus term to be exactly 1, but TestConsensus_BeginTerm (which runs first alphabetically) increments the term to 2.

Since tests use getSharedTestSetup() which creates a singleton cluster via sync.Once, the term mutation persists across tests.

Changed assertions from Equal(1) to GreaterOrEqual(1) since the actual term value doesn't matter for validating GetLeadershipView functionality.

Example failure: https://github.com/multigres/multigres/actions/runs/19256401238?pr=228