### PR TITLE
refactor(heartbeat): remove unnecessary leader_term column and fields

### DIFF
--- a/go/multipooler/heartbeat/reader.go
+++ b/go/multipooler/heartbeat/reader.go
@@ -186,7 +186,6 @@ func (r *Reader) ReadErrors() int64 {
 // LeadershipView contains the consensus state and replication lag information
 type LeadershipView struct {
 	LeaderID       string
-	LeaderTerm     int64
 	LastHeartbeat  time.Time
 	ReplicationLag time.Duration
 }
@@ -200,10 +199,10 @@ func (r *Reader) GetLeadershipView() (*LeadershipView, error) {
 	var tsNano int64
 
 	err := r.db.QueryRowContext(ctx, `
-		SELECT leader_id, ts, leader_term
+		SELECT leader_id, ts
 		FROM multigres.heartbeat
 		WHERE shard_id = $1
-	`, r.shardID).Scan(&view.LeaderID, &tsNano, &view.LeaderTerm)
+	`, r.shardID).Scan(&view.LeaderID, &tsNano)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to read leadership view")
 	}

--- a/go/multipooler/manager/db.go
+++ b/go/multipooler/manager/db.go
@@ -103,8 +103,7 @@ func CreateSidecarSchema(db *sql.DB) error {
 		CREATE TABLE IF NOT EXISTS multigres.heartbeat (
 			shard_id BYTEA PRIMARY KEY,
 			leader_id TEXT NOT NULL,
-			ts BIGINT NOT NULL,
-			leader_term BIGINT NOT NULL DEFAULT 0
+			ts BIGINT NOT NULL
 		)
 	`)
 	if err != nil {

--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -564,12 +564,6 @@ func (pm *MultiPoolerManager) validateAndUpdateTerm(ctx context.Context, request
 			return mterrors.Wrap(err, "failed to update consensus term")
 		}
 
-		// Synchronize term to heartbeat writer if it exists
-		if pm.replTracker != nil {
-			pm.replTracker.HeartbeatWriter().SetLeaderTerm(requestTerm)
-			pm.logger.InfoContext(ctx, "Synchronized term to heartbeat writer", "term", requestTerm)
-		}
-
 		pm.logger.InfoContext(ctx, "Consensus term updated successfully", "new_term", requestTerm)
 	}
 	// If requestTerm == currentCachedTerm, just continue (same term is OK)
@@ -646,12 +640,6 @@ func (pm *MultiPoolerManager) loadConsensusTermFromDisk() {
 		pm.mu.Unlock()
 
 		currentTerm := cs.GetCurrentTermNumber()
-
-		// Synchronize term to heartbeat writer if it exists
-		if pm.replTracker != nil && currentTerm > 0 {
-			pm.replTracker.HeartbeatWriter().SetLeaderTerm(currentTerm)
-			pm.logger.Info("Synchronized loaded term to heartbeat writer", "term", currentTerm)
-		}
 
 		pm.logger.Info("Loaded consensus term from disk", "current_term", currentTerm)
 		pm.checkAndSetReady()

--- a/go/multipooler/manager/rpc_consensus_test.go
+++ b/go/multipooler/manager/rpc_consensus_test.go
@@ -492,7 +492,6 @@ func TestConsensusStatus(t *testing.T) {
 		nilDB               bool
 		setupMocks          func(mock sqlmock.Sqlmock)
 		expectedCurrentTerm int64
-		expectedLeaderTerm  int64
 		expectedIsHealthy   bool
 		expectedRole        string
 		expectedWALLsn      string
@@ -509,8 +508,6 @@ func TestConsensusStatus(t *testing.T) {
 			},
 			termInMemory: true,
 			setupMocks: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("SELECT COALESCE\\(MAX\\(leader_term\\), 0\\)").
-					WillReturnRows(sqlmock.NewRows([]string{"leader_term"}).AddRow(5))
 				// Single pg_is_in_recovery check determines both role and which WAL position to query
 				mock.ExpectQuery("SELECT pg_is_in_recovery\\(\\)").
 					WillReturnRows(sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(false))
@@ -518,7 +515,6 @@ func TestConsensusStatus(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"pg_current_wal_lsn"}).AddRow("0/4000000"))
 			},
 			expectedCurrentTerm: 5,
-			expectedLeaderTerm:  5,
 			expectedIsHealthy:   true,
 			expectedRole:        "primary",
 			expectedWALLsn:      "0/4000000",
@@ -532,8 +528,6 @@ func TestConsensusStatus(t *testing.T) {
 			},
 			termInMemory: true,
 			setupMocks: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("SELECT COALESCE\\(MAX\\(leader_term\\), 0\\)").
-					WillReturnRows(sqlmock.NewRows([]string{"leader_term"}).AddRow(5))
 				// Single pg_is_in_recovery check determines both role and which WAL position to query
 				mock.ExpectQuery("SELECT pg_is_in_recovery\\(\\)").
 					WillReturnRows(sqlmock.NewRows([]string{"pg_is_in_recovery"}).AddRow(true))
@@ -549,7 +543,6 @@ func TestConsensusStatus(t *testing.T) {
 					}).AddRow("0/4FFFFFF", "0/5000000", false, "not paused", nil, ""))
 			},
 			expectedCurrentTerm: 3,
-			expectedLeaderTerm:  5,
 			expectedIsHealthy:   true,
 			expectedRole:        "replica",
 			expectedWALLsn:      "0/5000000", // receive LSN
@@ -564,7 +557,6 @@ func TestConsensusStatus(t *testing.T) {
 			termInMemory:        true,
 			nilDB:               true,
 			expectedCurrentTerm: 7,
-			expectedLeaderTerm:  0,
 			expectedIsHealthy:   false,
 			expectedRole:        "replica",
 			description:         "Should handle missing database connection gracefully",
@@ -577,12 +569,10 @@ func TestConsensusStatus(t *testing.T) {
 			},
 			termInMemory: true,
 			setupMocks: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("SELECT COALESCE\\(MAX\\(leader_term\\), 0\\)").
-					WillReturnError(assert.AnError)
+				// No database queries expected - database connection exists but no queries made
 			},
 			expectedCurrentTerm: 4,
-			expectedLeaderTerm:  0,
-			expectedIsHealthy:   false,
+			expectedIsHealthy:   true,
 			expectedRole:        "replica",
 			description:         "Should handle database query failure gracefully",
 		},
@@ -621,7 +611,6 @@ func TestConsensusStatus(t *testing.T) {
 			require.NotNil(t, resp)
 			assert.Equal(t, "test-pooler", resp.PoolerId)
 			assert.Equal(t, tt.expectedCurrentTerm, resp.CurrentTerm)
-			assert.Equal(t, tt.expectedLeaderTerm, resp.LeaderTerm)
 			assert.Equal(t, tt.expectedIsHealthy, resp.IsHealthy, tt.description)
 			assert.True(t, resp.IsEligible)
 			assert.Equal(t, "zone1", resp.Cell)

--- a/go/multipooler/manager/rpc_manager.go
+++ b/go/multipooler/manager/rpc_manager.go
@@ -946,12 +946,6 @@ func (pm *MultiPoolerManager) SetTerm(ctx context.Context, term *multipoolermana
 		return mterrors.Wrap(err, "failed to set consensus term")
 	}
 
-	// Synchronize term to heartbeat writer if it exists
-	if pm.replTracker != nil {
-		pm.replTracker.HeartbeatWriter().SetLeaderTerm(term.GetTermNumber())
-		pm.logger.InfoContext(ctx, "Synchronized term to heartbeat writer", "term", term.GetTermNumber())
-	}
-
 	pm.logger.InfoContext(ctx, "SetTerm completed successfully", "current_term", term.GetTermNumber())
 	return nil
 }

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -310,8 +310,6 @@ type StatusResponse struct {
 	PoolerId string `protobuf:"bytes,1,opt,name=pooler_id,json=poolerId,proto3" json:"pooler_id,omitempty"`
 	// Current term from local file
 	CurrentTerm int64 `protobuf:"varint,2,opt,name=current_term,json=currentTerm,proto3" json:"current_term,omitempty"`
-	// Last successful leader term from Postgres
-	LeaderTerm int64 `protobuf:"varint,3,opt,name=leader_term,json=leaderTerm,proto3" json:"leader_term,omitempty"`
 	// Current WAL position
 	WalPosition *WALPosition `protobuf:"bytes,4,opt,name=wal_position,json=walPosition,proto3" json:"wal_position,omitempty"`
 	// Whether Postgres is healthy and reachable
@@ -366,13 +364,6 @@ func (x *StatusResponse) GetPoolerId() string {
 func (x *StatusResponse) GetCurrentTerm() int64 {
 	if x != nil {
 		return x.CurrentTerm
-	}
-	return 0
-}
-
-func (x *StatusResponse) GetLeaderTerm() int64 {
-	if x != nil {
-		return x.LeaderTerm
 	}
 	return 0
 }
@@ -462,8 +453,6 @@ type LeadershipViewResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// ID of the current leader
 	LeaderId string `protobuf:"bytes,1,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
-	// Leader's consensus term
-	LeaderTerm int64 `protobuf:"varint,2,opt,name=leader_term,json=leaderTerm,proto3" json:"leader_term,omitempty"`
 	// Last heartbeat timestamp
 	LastHeartbeat *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_heartbeat,json=lastHeartbeat,proto3" json:"last_heartbeat,omitempty"`
 	// Calculated replication lag in nanoseconds
@@ -507,13 +496,6 @@ func (x *LeadershipViewResponse) GetLeaderId() string {
 		return x.LeaderId
 	}
 	return ""
-}
-
-func (x *LeadershipViewResponse) GetLeaderTerm() int64 {
-	if x != nil {
-		return x.LeaderTerm
-	}
-	return 0
 }
 
 func (x *LeadershipViewResponse) GetLastHeartbeat() *timestamppb.Timestamp {
@@ -661,12 +643,10 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\tpooler_id\x18\x03 \x01(\tR\bpoolerId\">\n" +
 	"\rStatusRequest\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x03R\x04term\x12\x19\n" +
-	"\bshard_id\x18\x02 \x01(\tR\ashardId\"\x98\x02\n" +
+	"\bshard_id\x18\x02 \x01(\tR\ashardId\"\xf7\x01\n" +
 	"\x0eStatusResponse\x12\x1b\n" +
 	"\tpooler_id\x18\x01 \x01(\tR\bpoolerId\x12!\n" +
-	"\fcurrent_term\x18\x02 \x01(\x03R\vcurrentTerm\x12\x1f\n" +
-	"\vleader_term\x18\x03 \x01(\x03R\n" +
-	"leaderTerm\x12=\n" +
+	"\fcurrent_term\x18\x02 \x01(\x03R\vcurrentTerm\x12=\n" +
 	"\fwal_position\x18\x04 \x01(\v2\x1a.consensusdata.WALPositionR\vwalPosition\x12\x1d\n" +
 	"\n" +
 	"is_healthy\x18\x05 \x01(\bR\tisHealthy\x12\x1f\n" +
@@ -675,11 +655,9 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x04cell\x18\a \x01(\tR\x04cell\x12\x12\n" +
 	"\x04role\x18\t \x01(\tR\x04role\"2\n" +
 	"\x15LeadershipViewRequest\x12\x19\n" +
-	"\bshard_id\x18\x01 \x01(\tR\ashardId\"\xc7\x01\n" +
+	"\bshard_id\x18\x01 \x01(\tR\ashardId\"\xa6\x01\n" +
 	"\x16LeadershipViewResponse\x12\x1b\n" +
-	"\tleader_id\x18\x01 \x01(\tR\bleaderId\x12\x1f\n" +
-	"\vleader_term\x18\x02 \x01(\x03R\n" +
-	"leaderTerm\x12A\n" +
+	"\tleader_id\x18\x01 \x01(\tR\bleaderId\x12A\n" +
 	"\x0elast_heartbeat\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rlastHeartbeat\x12,\n" +
 	"\x12replication_lag_ns\x18\x05 \x01(\x03R\x10replicationLagNs\"^\n" +
 	"\x16CanReachPrimaryRequest\x12!\n" +

--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -279,9 +279,6 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 		assert.NotEmpty(t, resp.LeaderId, "LeaderId should not be empty")
 		assert.Equal(t, "primary-multipooler", resp.LeaderId, "LeaderId should be primary-multipooler")
 
-		// Verify leader_term is set (should be 1 from test setup)
-		assert.Equal(t, int64(1), resp.LeaderTerm, "LeaderTerm should be 1")
-
 		// Verify last_heartbeat is set and recent
 		require.NotNil(t, resp.LastHeartbeat, "LastHeartbeat should not be nil")
 		assert.True(t, resp.LastHeartbeat.IsValid(), "LastHeartbeat should be a valid timestamp")
@@ -296,8 +293,8 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 		assert.GreaterOrEqual(t, resp.ReplicationLagNs, int64(0),
 			"ReplicationLagNs should be non-negative")
 
-		t.Logf("Leadership view: leader_id=%s, term=%d, lag=%dns",
-			resp.LeaderId, resp.LeaderTerm, resp.ReplicationLagNs)
+		t.Logf("Leadership view: leader_id=%s, lag=%dns",
+			resp.LeaderId, resp.ReplicationLagNs)
 		t.Log("GetLeadershipView returns valid data from primary")
 	})
 
@@ -315,7 +312,7 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 		// Standby should also see the same leader information
 		assert.NotEmpty(t, resp.LeaderId, "LeaderId should not be empty")
 		assert.Equal(t, "primary-multipooler", resp.LeaderId, "LeaderId should be primary-multipooler")
-		assert.Equal(t, int64(1), resp.LeaderTerm, "LeaderTerm should be 1")
+		// LeaderTerm is deprecated and always 0 now (stored only in consensus state file)
 
 		require.NotNil(t, resp.LastHeartbeat, "LastHeartbeat should not be nil")
 		assert.True(t, resp.LastHeartbeat.IsValid(), "LastHeartbeat should be a valid timestamp")

--- a/go/test/endtoend/multipooler_client.go
+++ b/go/test/endtoend/multipooler_client.go
@@ -365,7 +365,7 @@ func TestHeartbeatTableExists(t *testing.T, client *MultiPoolerTestClient) {
 	result, err = client.ExecuteQuery(ctx, columnsQuery, 10)
 	require.NoError(t, err, "Columns check should succeed")
 	require.NotNil(t, result, "Result should not be nil")
-	assert.Len(t, result.Rows, 4, "heartbeat table should have 4 columns")
+	assert.Len(t, result.Rows, 3, "heartbeat table should have 3 columns")
 
 	// Verify column details - check that we have the expected columns
 	columnNames := make(map[string]bool)
@@ -374,7 +374,7 @@ func TestHeartbeatTableExists(t *testing.T, client *MultiPoolerTestClient) {
 		columnNames[columnName] = true
 	}
 
-	expectedColumns := []string{"shard_id", "leader_id", "ts", "leader_term"}
+	expectedColumns := []string{"shard_id", "leader_id", "ts"}
 	for _, expected := range expectedColumns {
 		assert.True(t, columnNames[expected], "Column %s should exist in heartbeat table", expected)
 	}

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -81,9 +81,6 @@ message StatusResponse {
   // Current term from local file
   int64 current_term = 2;
 
-  // Last successful leader term from Postgres
-  int64 leader_term = 3;
-
   // Current WAL position
   WALPosition wal_position = 4;
 
@@ -109,9 +106,6 @@ message LeadershipViewRequest {
 message LeadershipViewResponse {
   // ID of the current leader
   string leader_id = 1;
-
-  // Leader's consensus term
-  int64 leader_term = 2;
 
   // Last heartbeat timestamp
   google.protobuf.Timestamp last_heartbeat = 4;


### PR DESCRIPTION
One more follow up to #188. In that PR, we introduced a leader_term field into the heartbeat table, but given that we have a consensus state file on disk, we should not need this at all.
Ref: https://github.com/multigres/multigres/pull/225#issuecomment-3518383691