### PR TITLE
refactor: better traces for local cluster startup

### DIFF
--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -28,12 +28,21 @@ import (
 	"github.com/multigres/multigres/go/grpccommon"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/tools/retry"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // waitForServiceReady waits for a service to become ready by checking appropriate endpoints
-func (p *localProvisioner) waitForServiceReady(serviceName string, host string, servicePorts map[string]int, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+// The provided parentCtx should contain any active span for distributed tracing
+func (p *localProvisioner) waitForServiceReady(parentCtx context.Context, serviceName string, host string, servicePorts map[string]int, timeout time.Duration) error {
+	// Create span as child of parent context
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
+
+	ctx, span := tracer.Start(ctx, fmt.Sprintf("wait_for_service_ready/%s", serviceName))
+	defer span.End()
+
+	span.SetAttributes(attribute.String("service.name", serviceName))
 
 	r := retry.New(10*time.Millisecond, time.Second)
 	for attempt, err := range r.Attempts(ctx) {
@@ -57,7 +66,7 @@ func (p *localProvisioner) waitForServiceReady(serviceName string, host string, 
 		}
 
 		// For services with HTTP endpoints, check debug/config endpoint
-		if err := p.checkMultigresServiceHealth(serviceName, host, servicePorts); err != nil {
+		if err := p.checkMultigresServiceHealth(ctx, serviceName, host, servicePorts); err != nil {
 			continue // HTTP endpoint not ready yet, will backoff
 		}
 
@@ -67,21 +76,22 @@ func (p *localProvisioner) waitForServiceReady(serviceName string, host string, 
 }
 
 // checkMultigresServiceHealth checks health for all supported service port types
-func (p *localProvisioner) checkMultigresServiceHealth(serviceName string, host string, servicePorts map[string]int) error {
+// The context is propagated to all health check calls to maintain trace parent-child relationships
+func (p *localProvisioner) checkMultigresServiceHealth(ctx context.Context, serviceName string, host string, servicePorts map[string]int) error {
 	// Iterate over service ports and run health checks for supported types
 	for portType, port := range servicePorts {
 		switch portType {
 		case "http_port":
 			// Run HTTP health check
 			httpAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-			if err := p.checkDebugConfigEndpoint(httpAddress); err != nil {
+			if err := p.checkDebugConfigEndpoint(ctx, httpAddress); err != nil {
 				return err
 			}
 		case "grpc_port":
 			// Run gRPC health check for pgctld
 			if serviceName == "pgctld" {
 				grpcAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-				if err := p.checkPgctldGrpcHealth(grpcAddress); err != nil {
+				if err := p.checkPgctldGrpcHealth(ctx, grpcAddress); err != nil {
 					return err
 				}
 			}
@@ -89,7 +99,7 @@ func (p *localProvisioner) checkMultigresServiceHealth(serviceName string, host 
 			// Run etcd health check
 			if serviceName == "etcd" {
 				etcdAddress := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-				if err := p.checkEtcdHealth(etcdAddress); err != nil {
+				if err := p.checkEtcdHealth(ctx, etcdAddress); err != nil {
 					return err
 				}
 			}
@@ -103,16 +113,22 @@ func (p *localProvisioner) checkMultigresServiceHealth(serviceName string, host 
 }
 
 // checkEtcdHealth checks if etcd is ready by querying its health endpoint
-func (p *localProvisioner) checkEtcdHealth(address string) error {
+func (p *localProvisioner) checkEtcdHealth(ctx context.Context, address string) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	url := fmt.Sprintf("http://%s/health", address)
-	client := &http.Client{
-		Timeout: 5 * time.Second,
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
 	}
-	resp, err := client.Get(url)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to reach etcd health endpoint: %w", err)
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("etcd health endpoint returned status %d", resp.StatusCode)
 	}
@@ -120,16 +136,22 @@ func (p *localProvisioner) checkEtcdHealth(address string) error {
 }
 
 // checkDebugConfigEndpoint checks if the debug/config endpoint returns 200 OK
-func (p *localProvisioner) checkDebugConfigEndpoint(address string) error {
+func (p *localProvisioner) checkDebugConfigEndpoint(ctx context.Context, address string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
 	url := fmt.Sprintf("http://%s/live", address)
-	client := &http.Client{
-		Timeout: 2 * time.Second,
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
 	}
-	resp, err := client.Get(url)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to reach debug endpoint: %w", err)
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("debug endpoint returned status %d", resp.StatusCode)
 	}
@@ -137,8 +159,8 @@ func (p *localProvisioner) checkDebugConfigEndpoint(address string) error {
 }
 
 // checkPgctldGrpcHealth checks if pgctld gRPC server is healthy by calling Status
-func (p *localProvisioner) checkPgctldGrpcHealth(address string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+func (p *localProvisioner) checkPgctldGrpcHealth(ctx context.Context, address string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -43,6 +43,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 
 	"gopkg.in/yaml.v3"
 )
@@ -201,12 +202,9 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 	// Start etcd process
 	etcdCmd := exec.CommandContext(ctx, etcdBinary, args...)
 
-	// Inject trace context so etcd startup is part of the cluster_startup trace
-	telemetry.SetCmdEnvTraceContext(ctx, etcdCmd)
-
 	fmt.Printf("▶️  - Launching etcd on port %d...", port)
 
-	if err := etcdCmd.Start(); err != nil {
+	if err := telemetry.StartCmd(ctx, etcdCmd); err != nil {
 		return nil, fmt.Errorf("failed to start etcd: %w", err)
 	}
 
@@ -217,7 +215,7 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 
 	// Wait for etcd to be ready
 	servicePorts := map[string]int{"etcd_port": port}
-	if err := p.waitForServiceReady("etcd", "localhost", servicePorts, 10*time.Second); err != nil {
+	if err := p.waitForServiceReady(ctx, "etcd", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("etcd readiness check failed: %w\n\nLast 20 lines from etcd logs:\n%s", err, logs)
 	}
@@ -468,12 +466,9 @@ func (p *localProvisioner) provisionMultigateway(ctx context.Context, req *provi
 	// Start multigateway process
 	multigatewayCmd := exec.CommandContext(ctx, multigatewayBinary, args...)
 
-	// Inject trace context for distributed tracing
-	telemetry.SetCmdEnvTraceContext(ctx, multigatewayCmd)
-
 	fmt.Printf("▶️  - Launching multigateway (HTTP:%d, gRPC:%d, pg:%d)...", httpPort, grpcPort, pgPort)
 
-	if err := multigatewayCmd.Start(); err != nil {
+	if err := telemetry.StartCmd(ctx, multigatewayCmd); err != nil {
 		return nil, fmt.Errorf("failed to start multigateway: %w", err)
 	}
 
@@ -502,7 +497,7 @@ func (p *localProvisioner) provisionMultigateway(ctx context.Context, req *provi
 
 	// Wait for multigateway to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort, "pg_port": pgPort}
-	if err := p.waitForServiceReady("multigateway", "localhost", servicePorts, 10*time.Second); err != nil {
+	if err := p.waitForServiceReady(ctx, "multigateway", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multigateway readiness check failed: %w\n\nLast 20 lines from multigateway logs:\n%s", err, logs)
 	}
@@ -606,12 +601,9 @@ func (p *localProvisioner) provisionMultiadmin(ctx context.Context, req *provisi
 	// Start multiadmin process
 	multiadminCmd := exec.CommandContext(ctx, multiadminBinary, args...)
 
-	// Inject trace context for distributed tracing
-	telemetry.SetCmdEnvTraceContext(ctx, multiadminCmd)
-
 	fmt.Printf("▶️  - Launching multiadmin (HTTP:%d, gRPC:%d)...", httpPort, grpcPort)
 
-	if err := multiadminCmd.Start(); err != nil {
+	if err := telemetry.StartCmd(ctx, multiadminCmd); err != nil {
 		return nil, fmt.Errorf("failed to start multiadmin: %w", err)
 	}
 
@@ -639,7 +631,7 @@ func (p *localProvisioner) provisionMultiadmin(ctx context.Context, req *provisi
 
 	// Wait for multiadmin to be ready (check HTTP port)
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multiadmin", "localhost", servicePorts, 10*time.Second); err != nil {
+	if err := p.waitForServiceReady(ctx, "multiadmin", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multiadmin readiness check failed: %w\n\nLast 20 lines from multiadmin logs:\n%s", err, logs)
 	}
@@ -807,12 +799,9 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 	// Start multipooler process
 	multipoolerCmd := exec.CommandContext(ctx, multipoolerBinary, args...)
 
-	// Inject trace context for distributed tracing
-	telemetry.SetCmdEnvTraceContext(ctx, multipoolerCmd)
-
 	fmt.Printf("▶️  - Launching multipooler (HTTP:%d, gRPC:%d)...", httpPort, grpcPort)
 
-	if err := multipoolerCmd.Start(); err != nil {
+	if err := telemetry.StartCmd(ctx, multipoolerCmd); err != nil {
 		return nil, fmt.Errorf("failed to start multipooler: %w", err)
 	}
 
@@ -823,7 +812,7 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 
 	// Wait for multipooler to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multipooler", "localhost", servicePorts, 10*time.Second); err != nil {
+	if err := p.waitForServiceReady(ctx, "multipooler", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multipooler readiness check failed: %w\n\nLast 20 lines from multipooler logs:\n%s", err, logs)
 	}
@@ -957,12 +946,9 @@ func (p *localProvisioner) provisionMultiOrch(ctx context.Context, req *provisio
 	// Start multiorch process
 	multiorchCmd := exec.CommandContext(ctx, multiorchBinary, args...)
 
-	// Inject trace context for distributed tracing
-	telemetry.SetCmdEnvTraceContext(ctx, multiorchCmd)
-
 	fmt.Printf("▶️  - Launching multiorch (HTTP:%d, gRPC:%d)...", httpPort, grpcPort)
 
-	if err := multiorchCmd.Start(); err != nil {
+	if err := telemetry.StartCmd(ctx, multiorchCmd); err != nil {
 		return nil, fmt.Errorf("failed to start multiorch: %w", err)
 	}
 
@@ -973,7 +959,7 @@ func (p *localProvisioner) provisionMultiOrch(ctx context.Context, req *provisio
 
 	// Wait for multiorch to be ready
 	servicePorts := map[string]int{"http_port": httpPort, "grpc_port": grpcPort}
-	if err := p.waitForServiceReady("multiorch", "localhost", servicePorts, 10*time.Second); err != nil {
+	if err := p.waitForServiceReady(ctx, "multiorch", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("multiorch readiness check failed: %w\n\nLast 20 lines from multiorch logs:\n%s", err, logs)
 	}
@@ -1110,7 +1096,7 @@ func (p *localProvisioner) deprovisionService(ctx context.Context, req *provisio
 
 	// Stop the process if it's running
 	if service.PID > 0 {
-		if err := p.stopProcessByPID(service.PID); err != nil {
+		if err := p.stopProcessByPID(ctx, service.Service, service.PID); err != nil {
 			return fmt.Errorf("failed to stop process: %w", err)
 		}
 	}
@@ -1139,7 +1125,11 @@ func (p *localProvisioner) deprovisionService(ctx context.Context, req *provisio
 }
 
 // stopProcessByPID stops a process by its PID
-func (p *localProvisioner) stopProcessByPID(pid int) error {
+func (p *localProvisioner) stopProcessByPID(ctx context.Context, name string, pid int) error {
+	ctx, span := tracer.Start(ctx, "stopProcessByPID")
+	span.SetAttributes(attribute.String("service", name))
+	defer span.End()
+
 	// Check if process exists
 	process, err := os.FindProcess(pid)
 	if err != nil {
@@ -1170,14 +1160,14 @@ func (p *localProvisioner) stopProcessByPID(pid int) error {
 	}
 
 	// Wait for the process to actually exit
-	p.waitForProcessExit(process, 2*time.Second)
+	p.waitForProcessExit(ctx, process, 2*time.Second)
 
 	return nil
 }
 
 // waitForProcessExit waits for a process to exit by polling with Signal(0)
-func (p *localProvisioner) waitForProcessExit(process *os.Process, timeout time.Duration) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func (p *localProvisioner) waitForProcessExit(ctx context.Context, process *os.Process, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	r := retry.New(10*time.Millisecond, 1*time.Second)

--- a/go/tools/telemetry/subcommand.go
+++ b/go/tools/telemetry/subcommand.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func getTraceparent(ctx context.Context) string {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+
+		// Extract trace context to W3C Trace Context format
+		carrier := propagation.MapCarrier{}
+		propagator := otel.GetTextMapPropagator()
+		propagator.Inject(ctx, carrier)
+
+		// Get traceparent value (format: version-trace_id-span_id-flags)
+		if traceparent, ok := carrier["traceparent"]; ok {
+			return traceparent
+		}
+	}
+	return ""
+}
+
+func addTraceparent(ctx context.Context, cmd *exec.Cmd) {
+	var traceparent string
+	if cmd.Process == nil {
+		traceparent = getTraceparent(ctx)
+	}
+
+	if traceparent != "" {
+		// Initialize Env with current environment if not set
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
+		// Add TRACEPARENT environment variable
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TRACEPARENT=%s", traceparent))
+	}
+}
+
+func StartCmd(ctx context.Context, cmd *exec.Cmd) error {
+	addTraceparent(ctx, cmd)
+	return cmd.Start()
+}
+
+func RunCmd(ctx context.Context, cmd *exec.Cmd, clientSpan bool) error {
+	var span trace.Span
+	if clientSpan {
+		ctx, span = tracer.Start(ctx, cmd.Path)
+		defer span.End()
+	}
+
+	addTraceparent(ctx, cmd)
+	return cmd.Run()
+}


### PR DESCRIPTION
Mostly this is propagating context to associate HTTP & gRPC requests and subprocesses with the trace parent for the "multigres cluster start" and stop commands. Example trace of "start":

<img width="1513" height="668" alt="image" src="https://github.com/user-attachments/assets/2c36a374-039e-4645-86bf-a138f3ef067d" />

Example trace of "stop":

<img width="1511" height="330" alt="image" src="https://github.com/user-attachments/assets/2eb7a651-cc0c-4616-98ad-0aa083ca451c" />
