### PR TITLE
build(coverage): Report code coverage for integration test runs

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -94,7 +94,7 @@ jobs:
           reporter: golang-json
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: always()
         with:
           name: coverage-data
@@ -114,7 +114,6 @@ jobs:
           name: coverage-data
 
       - name: Upload coverage reports to Coveralls
-        if: success() || failure()
         uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
         with:
           file: ./coverage.txt


### PR DESCRIPTION
Output at https://coveralls.io/github/multigres/multigres

It may be theoretically possible to track lines covered by both the tests themselves and also subprocesses they execute, but it seems like it'd be a mess. You can't just use the `GOCOVERDIR` environment variable with `go test`, so getting full coverage might involve something crazy like compiling all the test binaries manually and invoking them with both `GOCOVERDIR` and `-test.coverprofile`. It's maybe not impossible, but the script to run tests would be a mess.