### PR TITLE
refactor: enforce tools/ package isolation with depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,16 @@ linters:
             - github.com/spf13/pflag
             - github.com/spf13/viper
             - github.com/stretchr/testify
+        tools-isolation:
+          files:
+            - "**/go/tools/**/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "github.com/multigres/multigres/go"
+              desc: "tools packages must not depend on internal multigres packages (except other tools)"
+          allow:
+            - $gostd
+            - github.com/multigres/multigres/go/tools
         provisioner:
           files:
             - "!$test"

--- a/go/clustermetadata/topo/id.go
+++ b/go/clustermetadata/topo/id.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topo
+
+import (
+	"strings"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// ComponentTypeToString converts a ComponentType enum to its string representation.
+// This function uses the generated name map to be resilient to refactors.
+// It's not specific to any single component type and can be used across the topology system.
+func ComponentTypeToString(component clustermetadatapb.ID_ComponentType) string {
+	// Use the generated name map for resilience - this automatically updates when the proto changes
+	if name, exists := clustermetadatapb.ID_ComponentType_name[int32(component)]; exists {
+		// Convert the generated name (e.g., "MULTIPOOLER") to lowercase for consistency
+		return strings.ToLower(name)
+	}
+	return "unknown"
+}

--- a/go/clustermetadata/topo/multigateway.go
+++ b/go/clustermetadata/topo/multigateway.go
@@ -83,7 +83,7 @@ func NewMultiGatewayInfo(multigateway *clustermetadatapb.MultiGateway, version V
 
 // MultiGatewayIDString returns the string representation of a MultiGateway ID
 func MultiGatewayIDString(id *clustermetadatapb.ID) string {
-	return fmt.Sprintf("%s-%s-%s", stringutil.ComponentTypeToString(id.Component), id.Cell, id.Name)
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Name)
 }
 
 // GetMultiGateway is a high level function to read multigateway data.

--- a/go/clustermetadata/topo/multiorch.go
+++ b/go/clustermetadata/topo/multiorch.go
@@ -83,7 +83,7 @@ func NewMultiOrchInfo(multiorch *clustermetadatapb.MultiOrch, version Version) *
 
 // MultiOrchIDString returns the string representation of a MultiOrch ID
 func MultiOrchIDString(id *clustermetadatapb.ID) string {
-	return fmt.Sprintf("%s-%s-%s", stringutil.ComponentTypeToString(id.Component), id.Cell, id.Name)
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Name)
 }
 
 // GetMultiOrch is a high level function to read multiorch data.

--- a/go/clustermetadata/topo/multipooler.go
+++ b/go/clustermetadata/topo/multipooler.go
@@ -84,7 +84,7 @@ func NewMultiPoolerInfo(multipooler *clustermetadatapb.MultiPooler, version Vers
 
 // MultiPoolerIDString returns the string representation of a MultiPooler ID
 func MultiPoolerIDString(id *clustermetadatapb.ID) string {
-	return fmt.Sprintf("%s-%s-%s", stringutil.ComponentTypeToString(id.Component), id.Cell, id.Name)
+	return fmt.Sprintf("%s-%s-%s", ComponentTypeToString(id.Component), id.Cell, id.Name)
 }
 
 // GetMultiPooler is a high level function to read multipooler data.

--- a/go/tools/stringutil/randomstring.go
+++ b/go/tools/stringutil/randomstring.go
@@ -16,24 +16,9 @@ package stringutil
 
 import (
 	"math/rand/v2"
-	"strings"
 	"sync"
 	"time"
-
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
-
-// ComponentTypeToString converts a ComponentType enum to its string representation.
-// This function uses the generated name map to be resilient to refactors.
-// It's not specific to any single component type and can be used across the topology system.
-func ComponentTypeToString(component clustermetadatapb.ID_ComponentType) string {
-	// Use the generated name map for resilience - this automatically updates when the proto changes
-	if name, exists := clustermetadatapb.ID_ComponentType_name[int32(component)]; exists {
-		// Convert the generated name (e.g., "MULTIPOOLER") to lowercase for consistency
-		return strings.ToLower(name)
-	}
-	return "unknown"
-}
 
 // Random string generation utilities copied from Kubernetes codebase
 var rng = struct {


### PR DESCRIPTION
Add depguard rule to prevent go/tools packages from depending on internal multigres packages (except other tools packages). This enforces the architectural boundary that tools should be pure utilities with no internal dependencies.

As part of this change:
- Add tools-isolation depguard rule to .golangci.yml
- Move ComponentTypeToString from go/tools/stringutil to go/clustermetadata/topo/id.go since it depends on go/pb
- Update callers in multigateway.go, multipooler.go, multiorch.go