### PR TITLE
test: fix non-random port assignment for etcd in endtoend tests

### DIFF
--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -321,9 +321,10 @@ func (p *localProvisioner) getServiceConfig(service string) map[string]any {
 	switch service {
 	case "etcd":
 		return map[string]any{
-			"version":  p.config.Etcd.Version,
-			"data-dir": p.config.Etcd.DataDir,
-			"port":     p.config.Etcd.Port,
+			"version":   p.config.Etcd.Version,
+			"data-dir":  p.config.Etcd.DataDir,
+			"port":      p.config.Etcd.Port,
+			"peer-port": p.config.Etcd.PeerPort,
 		}
 	case "multiadmin":
 		return map[string]any{


### PR DESCRIPTION
The `PeerPort` setting was getting dropped during transformation which falls back to the default behavior of assuming the peer port can be the client port plus one. That's not a safe assumption

Example failure on CI: https://github.com/multigres/multigres/actions/runs/19683063519/job/56381654237