### PR TITLE
fix(lint): remove unnecessary DeepEqual

### DIFF
--- a/go/common/mterrors/errors_test.go
+++ b/go/common/mterrors/errors_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -155,7 +154,7 @@ func TestRootCause(t *testing.T) {
 
 	for i, tt := range tests {
 		got := RootCause(tt.err)
-		if !reflect.DeepEqual(got, tt.want) {
+		if got != tt.want {
 			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
 		}
 	}
@@ -185,7 +184,7 @@ func TestCause(t *testing.T) {
 
 	for i, tt := range tests {
 		got := Cause(tt.err)
-		if !reflect.DeepEqual(got, tt.want) {
+		if got != tt.want {
 			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
 		}
 	}


### PR DESCRIPTION
This was a subtle merge conflict between https://github.com/multigres/multigres/pull/274 adding the code and https://github.com/multigres/multigres/pull/276 enabling the linter