### PR TITLE
fix(git): make precommit hooks work in git worktrees

### DIFF
--- a/misc/git/commit-msg
+++ b/misc/git/commit-msg
@@ -16,12 +16,10 @@
 # Runs any hooks in misc/git/commit-msg.*, and exits if any of them fail.
 set -e
 
-# This is necessary because the Emacs extensions don't set GIT_DIR.
-if [ -z "$GIT_DIR" ]; then
-  DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-  GIT_DIR="${DIR}/.."
-fi
+# Use git rev-parse to find the working tree root. This works correctly
+# in both regular repos and worktrees.
+REPO_ROOT=$(git rev-parse --show-toplevel)
 
-for hook in "$GIT_DIR"/../misc/git/commit-msg.*; do
+for hook in "$REPO_ROOT"/misc/git/commit-msg.*; do
   $hook "$@"
 done

--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -16,13 +16,11 @@
 # Runs any hooks in misc/hooks/, and exits if any of them fail.
 set -e
 
-# This is necessary because the Emacs extensions don't set GIT_DIR.
-if [ -z "$GIT_DIR" ]; then
-  DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-  GIT_DIR="${DIR}/.."
-fi
+# Use git rev-parse to find the working tree root. This works correctly
+# in both regular repos and worktrees.
+REPO_ROOT=$(git rev-parse --show-toplevel)
 
-for hook in "$GIT_DIR"/../misc/hooks/*; do
+for hook in "$REPO_ROOT"/misc/hooks/*; do
   if [ -x "$hook" ]; then
     $hook
   fi


### PR DESCRIPTION
Replace manual GIT_DIR calculation with `git rev-parse --show-toplevel` which correctly resolves the working tree root in both regular repos and worktrees.