### PR TITLE
fix(test): fix race condition in TestCanReachPrimary

### DIFF
--- a/go/multipooler/manager/rpc_consensus_test.go
+++ b/go/multipooler/manager/rpc_consensus_test.go
@@ -96,7 +96,7 @@ func setupManagerWithMockDB(t *testing.T, mockDB *sql.DB) (*MultiPoolerManager, 
 	pm.db = mockDB
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
-	go pm.Start(senv)
+	pm.Start(senv)
 
 	require.Eventually(t, func() bool {
 		return pm.GetState() == ManagerStateReady


### PR DESCRIPTION
CI run: https://github.com/multigres/multigres/actions/runs/19812593771

multipoler's manager.Start() was called in a goroutine. This could cause an ordering problem: the test case could begin running queries before the manager queries from Start() finish. We're doing in-order expectations with sqlmock, so the order of SQL queries needs to be deterministic.

The fix is just to change "go pm.Start()" in the test setup to "pm.Start()" to make sure the start work is definitely finished before doing any test-sepecific SQL queries.