### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
The newest zizmor linter will flag a missing "cooldown": https://github.com/multigres/multigres/actions/runs/19812481121/job/56757427790?pr=297

The cooldown setting prevents dependabot from upgrading to dependencies that are too recent, which is good for supply chain safety since many hacks are short-lived. A 7-day cooldown means a supply chain hack would have to survive 7 days of public scrutiny before we'd upgrade to it.

More background: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns