### PR TITLE
fix(topo): cleanup in memory topo from registering in the factory

### DIFF
--- a/go/clustermetadata/topo/memorytopo/store.go
+++ b/go/clustermetadata/topo/memorytopo/store.go
@@ -482,11 +482,3 @@ func (f *Factory) getOperationError(op Operation, path string) error {
 	}
 	return nil
 }
-
-func init() {
-	// TODO: @rafael
-	// This is short lived, I will remove this enterilely once we have a real topo server.
-	// Adding it to have all the wiring set up and get the tests to pass with an in memory topo.
-	_, factory := NewServerAndFactory(context.Background(), "global")
-	topo.RegisterFactory("memory", factory)
-}


### PR DESCRIPTION
# Desc
- Follows up with the TODO. We don't want the memory topo to be actually available for real use. This was added just for testing when I did not have the etcd implementation available. 