### PR TITLE
fix(telemetry): reduce log noise by lowering init/shutdown to debug

### DIFF
--- a/go/tools/telemetry/telemetry.go
+++ b/go/tools/telemetry/telemetry.go
@@ -293,7 +293,7 @@ func (t *Telemetry) ShutdownTelemetry(ctx context.Context) error {
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Shutting down OpenTelemetry")
+	slog.DebugContext(ctx, "Shutting down OpenTelemetry")
 
 	var errs []error
 


### PR DESCRIPTION
OpenTelemetry init and shutdown messages are operational details that don't need to appear at INFO level in normal operation.