### PR TITLE
fix(tests): small fix for end-to-end tests

### DIFF
--- a/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
@@ -1683,8 +1683,6 @@ func TestConfigureSynchronousReplication(t *testing.T) {
 				len(config.StandbyIds) == 1
 		}, "Synchronous replication configuration should converge")
 
-		// Ensure standby is connected and replicating
-
 		_, err = standbyManagerClient.SetTerm(utils.WithShortDeadline(t), &multipoolermanagerdatapb.SetTermRequest{
 			Term: &multipoolermanagerdatapb.ConsensusTerm{
 				TermNumber: 1,


### PR DESCRIPTION
# Desc
- The previous assertion worked by luck. 
- This changes to use the same helper we now are using in all tests when waiting for synchronous configuration to converge after updating it.  