### PR TITLE
fix: make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,10 @@ test-race: ## Run tests with race detection.
 clean: ## Remove build artifacts and temp files.
 	rm -f go/common/web/templates/css/pico.*
 	go clean -i ./go/...
-	rm -f $(BIN_DIR)/*
+	@for cmd in $(CMDS); do \
+		echo "Removing $(BIN_DIR)/$$cmd"; \
+		rm -f $(BIN_DIR)/$$cmd; \
+	done
 
 # Clean build and dependencies
 clean-all: clean ## Remove build dependencies and distribution files.


### PR DESCRIPTION
make clean was deleting all files under bin. This would delete other tools like etcd. Subsequent `make tools` or `make` would not restore etcd, and this causes `multigres cluster start` to break.