### PR TITLE
fix(tests): use ReadyPGPort to connect to multigateway with PRIMARY access

### DIFF
--- a/go/test/endtoend/fix_replication_test.go
+++ b/go/test/endtoend/fix_replication_test.go
@@ -47,8 +47,8 @@ func TestFixReplication(t *testing.T) {
 	}
 
 	// Setup test cluster (2 zones: primary + replica)
-	clusterSetup := setupTestCluster(t)
-	t.Cleanup(clusterSetup.Cleanup)
+	clusterSetup, cleanup := setupTestCluster(t)
+	t.Cleanup(cleanup)
 	t.Logf("Test cluster ready in directory: %s", clusterSetup.TempDir)
 
 	// Identify primary and replica zones


### PR DESCRIPTION
The TestMultiGateway_ExtendedQueryProtocol test is flaking because it hardcoded connection to Zone 0's multigateway, but after bootstrap the PRIMARY pooler could be in any zone. Each multigateway only discovers poolers in its own zone.

In the future we should make all gates allow connecting to the primary pooler even across zones, but this is probably the quickest way to resolve the test flake.