### PR TITLE
build: correct docker dependencies for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.25-alpine AS builder
 WORKDIR /src
 
 # Install build dependencies like git and make
-RUN apk add --no-cache git=2.49.1-r0 make=4.4.1-r3 bash=5.2.37-r0
+RUN apk add --no-cache git=2.52.0-r0 make=4.4.1-r3 bash=5.3.3-r1
 
 # Cache dependencies
 COPY go.mod go.sum ./


### PR DESCRIPTION
Docker build failed with the following error

```console
 > [builder 3/7] RUN apk add --no-cache git=2.49.1-r0 make=4.4.1-r3 bash=5.2.37-r0:
0.701 ERROR: unable to select packages:
0.702   bash-5.3.3-r1:
0.702     breaks: world[bash=5.2.37-r0]
0.702   git-2.52.0-r0:
0.702     breaks: world[git=2.49.1-r0]
------
```

This update makes sure that the version is appropriate for the build setup.