### PR TITLE
refactor(multipooler): removes noisy logging

### DIFF
--- a/go/multipooler/manager/rpc_manager.go
+++ b/go/multipooler/manager/rpc_manager.go
@@ -32,7 +32,6 @@ func (pm *MultiPoolerManager) WaitForLSN(ctx context.Context, targetLsn string) 
 	if err := pm.checkReady(); err != nil {
 		return err
 	}
-	pm.logger.InfoContext(ctx, "WaitForLSN called", "target_lsn", targetLsn)
 
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err := pm.checkReplicaGuardrails(ctx); err != nil {
@@ -41,8 +40,6 @@ func (pm *MultiPoolerManager) WaitForLSN(ctx context.Context, targetLsn string) 
 
 	// Wait for the standby to replay WAL up to the target LSN
 	// We use a polling approach to check if the replay LSN has reached the target
-	pm.logger.InfoContext(ctx, "Waiting for standby to reach target LSN", "target_lsn", targetLsn)
-
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -82,14 +79,6 @@ func (pm *MultiPoolerManager) SetPrimaryConnInfo(ctx context.Context, host strin
 		return err
 	}
 	defer pm.actionLock.Release(ctx)
-
-	pm.logger.InfoContext(ctx, "SetPrimaryConnInfo called",
-		"host", host,
-		"port", port,
-		"stop_replication_before", stopReplicationBefore,
-		"start_replication_after", startReplicationAfter,
-		"current_term", currentTerm,
-		"force", force)
 
 	// Validate and update consensus term following consensus rules
 	if err = pm.validateAndUpdateTerm(ctx, currentTerm, force); err != nil {
@@ -170,7 +159,12 @@ func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 		}
 	}
 
-	pm.logger.InfoContext(ctx, "SetPrimaryConnInfo completed successfully")
+	pm.logger.InfoContext(ctx, "SetPrimaryConnInfo completed successfully",
+		"host", host,
+		"port", port,
+		"stop_replication_before", stopReplicationBefore,
+		"start_replication_after", startReplicationAfter)
+
 	return nil
 }
 
@@ -187,8 +181,6 @@ func (pm *MultiPoolerManager) StartReplication(ctx context.Context) error {
 	}
 	defer pm.actionLock.Release(ctx)
 
-	pm.logger.InfoContext(ctx, "StartReplication called")
-
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err = pm.checkReplicaGuardrails(ctx); err != nil {
 		return err
@@ -199,7 +191,6 @@ func (pm *MultiPoolerManager) StartReplication(ctx context.Context) error {
 		return err
 	}
 
-	pm.logger.InfoContext(ctx, "StartReplication completed successfully")
 	return nil
 }
 
@@ -216,8 +207,6 @@ func (pm *MultiPoolerManager) StopReplication(ctx context.Context, mode multipoo
 	}
 	defer pm.actionLock.Release(ctx)
 
-	pm.logger.InfoContext(ctx, "StopReplication called", "mode", mode, "wait", wait)
-
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err = pm.checkReplicaGuardrails(ctx); err != nil {
 		return err
@@ -228,7 +217,6 @@ func (pm *MultiPoolerManager) StopReplication(ctx context.Context, mode multipoo
 		return err
 	}
 
-	pm.logger.InfoContext(ctx, "StopReplication completed successfully")
 	return nil
 }
 
@@ -237,7 +225,6 @@ func (pm *MultiPoolerManager) StandbyReplicationStatus(ctx context.Context) (*mu
 	if err := pm.checkReady(); err != nil {
 		return nil, err
 	}
-	pm.logger.InfoContext(ctx, "StandbyReplicationStatus called")
 
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err := pm.checkReplicaGuardrails(ctx); err != nil {
@@ -251,13 +238,6 @@ func (pm *MultiPoolerManager) StandbyReplicationStatus(ctx context.Context) (*mu
 		return nil, err
 	}
 
-	pm.logger.InfoContext(ctx, "StandbyReplicationStatus completed",
-		"last_replay_lsn", status.LastReplayLsn,
-		"last_receive_lsn", status.LastReceiveLsn,
-		"is_paused", status.IsWalReplayPaused,
-		"pause_state", status.WalReplayPauseState,
-		"primary_conn_info", status.PrimaryConnInfo)
-
 	return status, nil
 }
 
@@ -266,8 +246,6 @@ func (pm *MultiPoolerManager) StandbyReplicationStatus(ctx context.Context) (*mu
 // database access will be nil/empty in that case. This allows callers to always get
 // initialization status without needing a separate RPC.
 func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerdatapb.Status, error) {
-	pm.logger.InfoContext(ctx, "Status called")
-
 	// Build status with initialization fields (always available)
 	poolerStatus := &multipoolermanagerdatapb.Status{
 		PoolerType:       pm.getPoolerType(),
@@ -288,10 +266,6 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 
 	// If database is not connected, return early with just initialization status
 	if pm.db == nil {
-		pm.logger.InfoContext(ctx, "Status completed (db not connected)",
-			"pooler_type", poolerStatus.PoolerType,
-			"is_initialized", poolerStatus.IsInitialized,
-			"postgres_running", poolerStatus.PostgresRunning)
 		return poolerStatus, nil
 	}
 
@@ -317,23 +291,16 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 			return poolerStatus, nil
 		}
 		poolerStatus.PrimaryStatus = primaryStatus
-		pm.logger.InfoContext(ctx, "Status completed (acting as primary)",
-			"pooler_type", poolerStatus.PoolerType,
-			"lsn", primaryStatus.Lsn)
-	} else {
-		// Acting as standby - get replication status (skip guardrails since we already checked isPrimary)
-		replStatus, err := pm.getStandbyStatusInternal(ctx)
-		if err != nil {
-			pm.logger.WarnContext(ctx, "Failed to get standby replication status", "error", err)
-			// Return partial status instead of error
-			return poolerStatus, nil
-		}
-		poolerStatus.ReplicationStatus = replStatus
-		pm.logger.InfoContext(ctx, "Status completed (acting as standby)",
-			"pooler_type", poolerStatus.PoolerType,
-			"last_replay_lsn", replStatus.LastReplayLsn)
+		return poolerStatus, nil
 	}
-
+	// Acting as standby - get replication status (skip guardrails since we already checked isPrimary)
+	replStatus, err := pm.getStandbyStatusInternal(ctx)
+	if err != nil {
+		pm.logger.WarnContext(ctx, "Failed to get standby replication status", "error", err)
+		// Return partial status instead of error
+		return poolerStatus, nil
+	}
+	poolerStatus.ReplicationStatus = replStatus
 	return poolerStatus, nil
 }
 
@@ -353,8 +320,6 @@ func (pm *MultiPoolerManager) ResetReplication(ctx context.Context) error {
 	}
 	defer pm.actionLock.Release(ctx)
 
-	pm.logger.InfoContext(ctx, "ResetReplication called")
-
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err = pm.checkReplicaGuardrails(ctx); err != nil {
 		return err
@@ -366,7 +331,6 @@ func (pm *MultiPoolerManager) ResetReplication(ctx context.Context) error {
 		return err
 	}
 
-	pm.logger.InfoContext(ctx, "ResetReplication completed successfully - standby disconnected from primary")
 	return nil
 }
 
@@ -382,13 +346,6 @@ func (pm *MultiPoolerManager) ConfigureSynchronousReplication(ctx context.Contex
 		return err
 	}
 	defer pm.actionLock.Release(ctx)
-
-	pm.logger.InfoContext(ctx, "ConfigureSynchronousReplication called",
-		"synchronous_commit", synchronousCommit,
-		"synchronous_method", synchronousMethod,
-		"num_sync", numSync,
-		"standby_ids", standbyIDs,
-		"reload_config", reloadConfig)
 
 	// Validate input parameters
 	if err = validateSyncReplicationParams(numSync, standbyIDs); err != nil {
@@ -417,7 +374,13 @@ func (pm *MultiPoolerManager) ConfigureSynchronousReplication(ctx context.Contex
 		}
 	}
 
-	pm.logger.InfoContext(ctx, "ConfigureSynchronousReplication completed successfully")
+	pm.logger.InfoContext(ctx, "ConfigureSynchronousReplication completed successfully",
+		"synchronous_commit", synchronousCommit,
+		"synchronous_method", synchronousMethod,
+		"num_sync", numSync,
+		"standby_ids", standbyIDs,
+		"reload_config", reloadConfig)
+
 	return nil
 }
 
@@ -434,13 +397,6 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 		return err
 	}
 	defer pm.actionLock.Release(ctx)
-
-	pm.logger.InfoContext(ctx, "UpdateSynchronousStandbyList called",
-		"operation", operation,
-		"standby_ids", standbyIDs,
-		"reload_config", reloadConfig,
-		"consensus_term", consensusTerm,
-		"force", force)
 
 	// === Validation ===
 	// TODO: We need to validate consensus term here.
@@ -484,8 +440,6 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 		return err
 	}
 
-	pm.logger.InfoContext(ctx, "Current synchronous_standby_names", "value", currentValue)
-
 	// === Apply Operation ===
 
 	// Apply the requested operation using the current standby list
@@ -521,13 +475,8 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 
 	// Check if there are any changes (idempotent)
 	if currentValue == newValue {
-		pm.logger.InfoContext(ctx, "No changes needed - configuration already matches desired state")
 		return nil
 	}
-
-	pm.logger.InfoContext(ctx, "Updating synchronous_standby_names",
-		"old_value", currentValue,
-		"new_value", newValue)
 
 	// Apply the setting using shared helper
 	if err = applySynchronousStandbyNames(ctx, pm.db, pm.logger, newValue); err != nil {
@@ -541,7 +490,13 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 		}
 	}
 
-	pm.logger.InfoContext(ctx, "UpdateSynchronousStandbyList completed successfully")
+	pm.logger.InfoContext(ctx, "UpdateSynchronousStandbyList completed successfully",
+		"operation", operation,
+		"old_value", currentValue,
+		"new_value", newValue,
+		"reload_config", reloadConfig,
+		"consensus_term", consensusTerm,
+		"force", force)
 	return nil
 }
 
@@ -587,8 +542,6 @@ func (pm *MultiPoolerManager) PrimaryStatus(ctx context.Context) (*multipoolerma
 		return nil, err
 	}
 
-	pm.logger.InfoContext(ctx, "PrimaryStatus called")
-
 	// Check PRIMARY guardrails (pooler type and non-recovery mode)
 	if err := pm.checkPrimaryGuardrails(ctx); err != nil {
 		return nil, err
@@ -599,7 +552,6 @@ func (pm *MultiPoolerManager) PrimaryStatus(ctx context.Context) (*multipoolerma
 		return nil, err
 	}
 
-	pm.logger.InfoContext(ctx, "PrimaryStatus completed", "lsn", status.Lsn, "followers_count", len(status.ConnectedFollowers))
 	return status, nil
 }
 
@@ -608,8 +560,6 @@ func (pm *MultiPoolerManager) PrimaryPosition(ctx context.Context) (string, erro
 	if err := pm.checkReady(); err != nil {
 		return "", err
 	}
-
-	pm.logger.InfoContext(ctx, "PrimaryPosition called")
 
 	// Check PRIMARY guardrails (pooler type and non-recovery mode)
 	if err := pm.checkPrimaryGuardrails(ctx); err != nil {
@@ -632,8 +582,6 @@ func (pm *MultiPoolerManager) StopReplicationAndGetStatus(ctx context.Context, m
 		return nil, err
 	}
 	defer pm.actionLock.Release(ctx)
-
-	pm.logger.InfoContext(ctx, "StopReplicationAndGetStatus called", "mode", mode, "wait", wait)
 
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err = pm.checkReplicaGuardrails(ctx); err != nil {
@@ -723,8 +671,6 @@ func (pm *MultiPoolerManager) ChangeType(ctx context.Context, poolerType string)
 			fmt.Sprintf("invalid pooler type: %s, must be PRIMARY or REPLICA", poolerType))
 	}
 
-	pm.logger.InfoContext(ctx, "ChangeType called", "pooler_type", poolerType, "service_id", pm.serviceID.String())
-
 	// Call the locked version
 	return pm.changeTypeLocked(ctx, newType)
 }
@@ -751,8 +697,6 @@ func (pm *MultiPoolerManager) GetFollowers(ctx context.Context) (*multipoolerman
 	if err := pm.checkReady(); err != nil {
 		return nil, err
 	}
-
-	pm.logger.InfoContext(ctx, "GetFollowers called")
 
 	// Check PRIMARY guardrails (only primary can have followers)
 	if err := pm.checkPrimaryGuardrails(ctx); err != nil {
@@ -792,10 +736,6 @@ func (pm *MultiPoolerManager) GetFollowers(ctx context.Context) (*multipoolerman
 
 		followers = append(followers, followerInfo)
 	}
-
-	pm.logger.InfoContext(ctx, "GetFollowers completed",
-		"total_configured", len(followers),
-		"connected_count", len(connectedMap))
 
 	return &multipoolermanagerdatapb.GetFollowersResponse{
 		Followers:  followers,
@@ -840,10 +780,6 @@ func (pm *MultiPoolerManager) demoteLocked(ctx context.Context, consensusTerm in
 		return nil, err
 	}
 
-	pm.logger.InfoContext(ctx, "demoteLocked called",
-		"consensus_term", consensusTerm,
-		"drain_timeout", drainTimeout)
-
 	// === Validation & State Check ===
 
 	// Guard rail: Demote can only be called on a PRIMARY
@@ -859,8 +795,6 @@ func (pm *MultiPoolerManager) demoteLocked(ctx context.Context, consensusTerm in
 
 	// If everything is already complete, return early (fully idempotent)
 	if state.isServingReadOnly && state.isReplicaInTopology && state.isReadOnly {
-		pm.logger.InfoContext(ctx, "Demotion already complete (idempotent)",
-			"lsn", state.finalLSN)
 		return &multipoolermanagerdatapb.DemoteResponse{
 			WasAlreadyDemoted:     true,
 			ConsensusTerm:         consensusTerm,
@@ -966,11 +900,6 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 	}
 	defer pm.actionLock.Release(ctx)
 
-	pm.logger.InfoContext(ctx, "Promote called",
-		"consensus_term", consensusTerm,
-		"expected_lsn", expectedLSN,
-		"force", force)
-
 	// Validation & Readiness
 
 	// Validate term - strict equality, no automatic updates
@@ -1016,9 +945,6 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 					state.isPrimaryInPostgres, state.syncReplicationMatches))
 		}
 
-		// With force flag, attempt to fix the inconsistency by completing missing steps
-		pm.logger.WarnContext(ctx, "Force flag set - attempting to fix inconsistent state by completing missing steps")
-		// Fall through to execute missing promotion steps below
 	}
 
 	// If PostgreSQL is not promoted yet, validate expected LSN before promotion
@@ -1079,8 +1005,6 @@ func (pm *MultiPoolerManager) SetTerm(ctx context.Context, term *multipoolermana
 	}
 	defer pm.actionLock.Release(ctx)
 
-	pm.logger.InfoContext(ctx, "SetTerm called", "current_term", term.GetTermNumber())
-
 	// Initialize consensus state if needed
 	pm.mu.Lock()
 	if pm.consensusState == nil {
@@ -1095,7 +1019,6 @@ func (pm *MultiPoolerManager) SetTerm(ctx context.Context, term *multipoolermana
 		return mterrors.Wrap(err, "failed to set consensus term")
 	}
 
-	pm.logger.InfoContext(ctx, "SetTerm completed successfully", "current_term", term.GetTermNumber())
 	return nil
 }
 
@@ -1137,7 +1060,6 @@ func (pm *MultiPoolerManager) createDurabilityPolicyLocked(ctx context.Context, 
 		return err
 	}
 
-	pm.logger.InfoContext(ctx, "Durability policy created successfully", "policy_name", policyName)
 	return nil
 }
 
@@ -1178,11 +1100,6 @@ func (pm *MultiPoolerManager) CreateDurabilityPolicy(ctx context.Context, req *m
 		pm.logger.ErrorContext(ctx, "Failed to insert durability policy", "error", err)
 		return nil, err
 	}
-
-	pm.logger.InfoContext(ctx, "Successfully created durability policy",
-		"policy_name", req.PolicyName,
-		"quorum_type", req.QuorumRule.QuorumType,
-		"required_count", req.QuorumRule.RequiredCount)
 
 	return &multipoolermanagerdatapb.CreateDurabilityPolicyResponse{}, nil
 }


### PR DESCRIPTION
# Desc
- Removes some noisy logging that was not adding value. 
- General idea that I'm thinking: 
   -  Most of these are captured by metrics already. 
   - I kept logging for operations that mutate the state in a significant way and it would be good to keep a trail for forensics. 