### PR TITLE
feat(tests): Hardens primary failover tests 

### DIFF
--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -87,7 +87,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	require.NoError(t, err)
 	defer primaryClient.Close()
 
-	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t.Context(), primaryClient.Pooler,
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, primaryClient.Pooler,
 		shardsetup.WithWorkerCount(4),
 		shardsetup.WithWriteInterval(10*time.Millisecond),
 	)
@@ -95,7 +95,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	t.Cleanup(validatorCleanup)
 
 	t.Logf("Starting continuous writes to primary...")
-	validator.Start()
+	validator.Start(t)
 
 	// Let writes accumulate before failover
 	time.Sleep(200 * time.Millisecond)
@@ -183,7 +183,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		require.Len(t, poolers, 2, "should have 2 surviving poolers")
 
 		// Verify writes - deterministic now that replication has caught up
-		err = validator.Verify(utils.WithShortDeadline(t), poolers)
+		err = validator.Verify(t, poolers)
 		require.NoError(t, err, "all successful writes should be present on surviving nodes")
 
 		t.Logf("Write durability verified: %d successful writes present on surviving nodes", successfulWrites)

--- a/go/test/endtoend/shardsetup/shardsetup_test.go
+++ b/go/test/endtoend/shardsetup/shardsetup_test.go
@@ -336,13 +336,11 @@ func TestShardSetup_WriterValidator(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	ctx := t.Context()
-
 	// Create a writer validator pointing to the primary
 	primaryClient := setup.NewPrimaryClient(t)
 	defer primaryClient.Close()
 
-	validator, cleanup, err := NewWriterValidator(ctx, primaryClient.Pooler,
+	validator, cleanup, err := NewWriterValidator(t, primaryClient.Pooler,
 		WithWorkerCount(4),
 		WithWriteInterval(10*time.Millisecond),
 	)
@@ -350,7 +348,7 @@ func TestShardSetup_WriterValidator(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	// Start writes
-	validator.Start()
+	validator.Start(t)
 
 	// Let writes accumulate
 	time.Sleep(200 * time.Millisecond)
@@ -373,7 +371,7 @@ func TestShardSetup_WriterValidator(t *testing.T) {
 
 	// Wait for replication to catch up, then verify
 	require.Eventually(t, func() bool {
-		err := validator.Verify(ctx, poolers)
+		err := validator.Verify(t, poolers)
 		return err == nil
 	}, 5*time.Second, 100*time.Millisecond, "all successful writes should be present across poolers")
 }


### PR DESCRIPTION
# Desc
- This adds a writes validator that help us asserts that writes are not lost during a primary failover.
- It starts using it in the primary failover test that we have. 