### PR TITLE
fix(multipooler): fix data race in TestBeginTerm save failure test

### DIFF
--- a/go/multipooler/manager/rpc_consensus_test.go
+++ b/go/multipooler/manager/rpc_consensus_test.go
@@ -421,9 +421,10 @@ func TestBeginTerm(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			// Create mock and set startup expectations BEFORE starting the manager
+			// Create mock and set ALL expectations BEFORE starting the manager
 			mockDB, mock := newMockDB(t)
 			expectPrimaryStartupQueries(mock)
+			tt.setupMocks(mock)
 
 			pm, tmpDir := setupManagerWithMockDB(t, mockDB)
 
@@ -447,9 +448,6 @@ func TestBeginTerm(t *testing.T) {
 					_ = os.Chmod(consensusDir, 0o755)
 				})
 			}
-
-			// Setup mocks
-			tt.setupMocks(mock)
 
 			// Make request
 			req := &consensusdatapb.BeginTermRequest{


### PR DESCRIPTION
# Desc   
Move mock expectation setup before manager start to prevent race between test thread writing expectations and manager goroutine reading them. This is the same patterns we already have in other tests in this file. 

# Fixes

It should fix this race:
```
WARNING: DATA RACE
	Read at 0x00c0004bf710 by goroutine 880:
	  github.com/DATA-DOG/go-sqlmock.(*sqlmock).query()
	  /home/runner/go/pkg/mod/github.com/!d!a!t!a-!d!o!g/go-sqlmock@v1.5.2/sqlmock_go18.go:202 +0x89
	  github.com/DATA-DOG/go-sqlmock.(*sqlmock).QueryContext()
	  /home/runner/go/pkg/mod/github.com/!d!a!t!a-!d!o!g/go-sqlmock@v1.5.2/sqlmock_go18.go:33 +0x9b
	  database/sql.ctxDriverQuery()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/ctxutil.go:48 +0xea
	  database/sql.(*DB).queryDC.func1()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1786 +0x265
	  database/sql.withLock()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:3572 +0xa2
	  database/sql.(*DB).queryDC()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1781 +0x324
	  database/sql.(*DB).query()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1764 +0x165
	  database/sql.(*DB).QueryContext.func1()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1742 +0xcf
	  database/sql.(*DB).retry()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1576 +0x4a
	  database/sql.(*DB).QueryContext()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1741 +0x184
	  database/sql.(*DB).QueryRowContext()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/database/sql/sql.go:1842 +0x128
	  github.com/multigres/multigres/go/multipooler/manager.(*MultiPoolerManager).querySchemaExists()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/pg_replication.go:128 +0xe9
	  github.com/multigres/multigres/go/multipooler/manager.(*MultiPoolerManager).isInitialized()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_initialization.go:279 +0xa8
	  github.com/multigres/multigres/go/multipooler/manager.(*MultiPoolerManager).tryAutoRestoreFromBackup()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_backup.go:687 +0x135
	  github.com/multigres/multigres/go/multipooler/manager.(*MultiPoolerManager).Start.gowrap3()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/manager.go:1377 +0x4f
	
	Previous write at 0x00c0004bf710 by goroutine 872:
	  github.com/DATA-DOG/go-sqlmock.(*sqlmock).ExpectPing()
	  /home/runner/go/pkg/mod/github.com/!d!a!t!a-!d!o!g/go-sqlmock@v1.5.2/sqlmock_go18.go:172 +0x16a
	  github.com/multigres/multigres/go/multipooler/manager.TestBeginTerm.func8()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_consensus_test.go:362 +0x4c
	  github.com/multigres/multigres/go/multipooler/manager.TestBeginTerm.func10()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_consensus_test.go:452 +0x365
	  testing.tRunner()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1934 +0x21c
	  testing.(*T).Run.gowrap1()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x44
	
	Goroutine 880 (running) created at:
	  github.com/multigres/multigres/go/multipooler/manager.(*MultiPoolerManager).Start()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/manager.go:1377 +0x249
	  github.com/multigres/multigres/go/multipooler/manager.setupManagerWithMockDB()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_consensus_test.go:98 +0xb96
	  github.com/multigres/multigres/go/multipooler/manager.TestBeginTerm.func10()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_consensus_test.go:428 +0x7b
	  testing.tRunner()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1934 +0x21c
	  testing.(*T).Run.gowrap1()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x44
	
	Goroutine 872 (running) created at:
	  testing.(*T).Run()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x9d2
	  github.com/multigres/multigres/go/multipooler/manager.TestBeginTerm()
	  /home/runner/work/multigres/multigres/go/multipooler/manager/rpc_consensus_test.go:421 +0x1531
	  testing.tRunner()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1934 +0x21c
	  testing.(*T).Run.gowrap1()
	  /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x44
	==================
	==================
```