### PR TITLE
fix(provisioner): use absolute paths for pgbackrest and pq driver

### DIFF
--- a/go/tools/pathutil/pathutil.go
+++ b/go/tools/pathutil/pathutil.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package pathutil provides a command to append a path to PATH.
+// Package pathutil provides path manipulation utilities.
 package pathutil
 
 import (
@@ -20,6 +20,18 @@ import (
 	"os"
 	"path/filepath"
 )
+
+// EnsureAbs converts the path pointed to by p to an absolute path in place.
+// If the path is already absolute, it remains unchanged.
+// This is useful when you need to ensure a path from configuration is absolute.
+func EnsureAbs(p *string) error {
+	abs, err := filepath.Abs(*p)
+	if err != nil {
+		return err
+	}
+	*p = abs
+	return nil
+}
 
 // PrependPath prepends a given path to the PATH environment variable.
 // It ensures the path is absolute and takes precedence over existing paths.

--- a/go/tools/pathutil/pathutil_test.go
+++ b/go/tools/pathutil/pathutil_test.go
@@ -20,6 +20,51 @@ import (
 	"testing"
 )
 
+func TestEnsureAbs(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get working directory: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "relative path becomes absolute",
+			input:    "foo/bar",
+			expected: filepath.Join(cwd, "foo/bar"),
+		},
+		{
+			name:     "absolute path stays unchanged",
+			input:    "/usr/local/bin",
+			expected: "/usr/local/bin",
+		},
+		{
+			name:     "dot-relative path becomes absolute",
+			input:    "./config",
+			expected: filepath.Join(cwd, "config"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tc.input
+			err := EnsureAbs(&path)
+			if err != nil {
+				t.Fatalf("EnsureAbs(%q) failed: %v", tc.input, err)
+			}
+			if path != tc.expected {
+				t.Errorf("EnsureAbs(%q) = %q, want %q", tc.input, path, tc.expected)
+			}
+			if !filepath.IsAbs(path) {
+				t.Errorf("EnsureAbs(%q) returned non-absolute path: %q", tc.input, path)
+			}
+		})
+	}
+}
+
 func TestAppendPath(t *testing.T) {
 	originalPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", originalPath)


### PR DESCRIPTION
pgbackrest requires absolute paths for all directory configurations, and the pq driver requires paths starting with '/' for Unix sockets. Add EnsureAbs utility to pathutil and use it in config generation and db connection setup to ensure paths are absolute.

The motivation for this is that in local testing I was getting bootstrap failures that left poolers stuck without being assigned a replica type. These changes seemed to help, for me at least.