### PR TITLE
test(multipooler): Add unit tests for connpoolmanager package

### DIFF
--- a/go/multipooler/connpoolmanager/config_test.go
+++ b/go/multipooler/connpoolmanager/config_test.go
@@ -1,0 +1,190 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/tools/viperutil"
+)
+
+func TestNewConfig(t *testing.T) {
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	require.NotNil(t, config)
+}
+
+func TestConfig_DefaultValues(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	// Register flags with a command to use defaults.
+	cmd := &cobra.Command{}
+	config.RegisterFlags(cmd.Flags())
+
+	// Verify default values.
+	assert.Equal(t, "postgres", config.adminUser.Default())
+	assert.Equal(t, "", config.adminPassword.Default())
+	assert.Equal(t, int64(5), config.adminCapacity.Default())
+
+	assert.Equal(t, int64(10), config.userRegularCapacity.Default())
+	assert.Equal(t, int64(5), config.userRegularMaxIdle.Default())
+	assert.Equal(t, 5*time.Minute, config.userRegularIdleTimeout.Default())
+	assert.Equal(t, 1*time.Hour, config.userRegularMaxLifetime.Default())
+
+	assert.Equal(t, int64(5), config.userReservedCapacity.Default())
+	assert.Equal(t, int64(2), config.userReservedMaxIdle.Default())
+	assert.Equal(t, 30*time.Second, config.userReservedInactivityTimeout.Default())
+	assert.Equal(t, 5*time.Minute, config.userReservedIdleTimeout.Default())
+	assert.Equal(t, 1*time.Hour, config.userReservedMaxLifetime.Default())
+
+	assert.Equal(t, int64(0), config.maxUsers.Default())
+	assert.Equal(t, int64(1024), config.settingsCacheSize.Default())
+}
+
+func TestConfig_RegisterFlags(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	cmd := &cobra.Command{}
+	config.RegisterFlags(cmd.Flags())
+
+	// Verify flags are registered.
+	adminUserFlag := cmd.Flags().Lookup("connpool-admin-user")
+	require.NotNil(t, adminUserFlag)
+	assert.Equal(t, "postgres", adminUserFlag.DefValue)
+
+	adminCapFlag := cmd.Flags().Lookup("connpool-admin-capacity")
+	require.NotNil(t, adminCapFlag)
+	assert.Equal(t, "5", adminCapFlag.DefValue)
+
+	regularCapFlag := cmd.Flags().Lookup("connpool-user-regular-capacity")
+	require.NotNil(t, regularCapFlag)
+	assert.Equal(t, "10", regularCapFlag.DefValue)
+
+	reservedCapFlag := cmd.Flags().Lookup("connpool-user-reserved-capacity")
+	require.NotNil(t, reservedCapFlag)
+	assert.Equal(t, "5", reservedCapFlag.DefValue)
+
+	maxUsersFlag := cmd.Flags().Lookup("connpool-max-users")
+	require.NotNil(t, maxUsersFlag)
+	assert.Equal(t, "0", maxUsersFlag.DefValue)
+}
+
+func TestConfig_Getters_ReturnDefaults(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	cmd := &cobra.Command{}
+	config.RegisterFlags(cmd.Flags())
+
+	// Verify getters return the default values (viperutil.Value returns defaults
+	// when no flags are parsed and no env vars are set).
+	assert.Equal(t, "postgres", config.AdminUser())
+	assert.Equal(t, "", config.AdminPassword())
+	assert.Equal(t, int64(5), config.AdminCapacity())
+
+	assert.Equal(t, int64(10), config.UserRegularCapacity())
+	assert.Equal(t, int64(5), config.UserRegularMaxIdle())
+	assert.Equal(t, 5*time.Minute, config.UserRegularIdleTimeout())
+	assert.Equal(t, 1*time.Hour, config.UserRegularMaxLifetime())
+
+	assert.Equal(t, int64(5), config.UserReservedCapacity())
+	assert.Equal(t, int64(2), config.UserReservedMaxIdle())
+	assert.Equal(t, 30*time.Second, config.UserReservedInactivityTimeout())
+	assert.Equal(t, 5*time.Minute, config.UserReservedIdleTimeout())
+	assert.Equal(t, 1*time.Hour, config.UserReservedMaxLifetime())
+
+	assert.Equal(t, int64(0), config.MaxUsers())
+	assert.Equal(t, 1024, config.SettingsCacheSize())
+}
+
+func TestConfig_NewManager(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	manager := config.NewManager()
+
+	require.NotNil(t, manager)
+	assert.Equal(t, config, manager.config)
+}
+
+func TestConnectionConfig(t *testing.T) {
+	connConfig := &ConnectionConfig{
+		SocketFile: "/var/run/postgresql/.s.PGSQL.5432",
+		Host:       "localhost",
+		Port:       5432,
+		Database:   "testdb",
+	}
+
+	assert.Equal(t, "/var/run/postgresql/.s.PGSQL.5432", connConfig.SocketFile)
+	assert.Equal(t, "localhost", connConfig.Host)
+	assert.Equal(t, 5432, connConfig.Port)
+	assert.Equal(t, "testdb", connConfig.Database)
+}
+
+func TestConnectionConfig_TCPOnly(t *testing.T) {
+	connConfig := &ConnectionConfig{
+		Host:     "db.example.com",
+		Port:     5432,
+		Database: "production",
+	}
+
+	assert.Empty(t, connConfig.SocketFile)
+	assert.Equal(t, "db.example.com", connConfig.Host)
+	assert.Equal(t, 5432, connConfig.Port)
+	assert.Equal(t, "production", connConfig.Database)
+}
+
+func TestManagerStats(t *testing.T) {
+	stats := ManagerStats{
+		UserPools: make(map[string]UserPoolStats),
+	}
+
+	// Add some user pool stats.
+	stats.UserPools["user1"] = UserPoolStats{Username: "user1"}
+	stats.UserPools["user2"] = UserPoolStats{Username: "user2"}
+
+	assert.Len(t, stats.UserPools, 2)
+	assert.Contains(t, stats.UserPools, "user1")
+	assert.Contains(t, stats.UserPools, "user2")
+}
+
+func TestUserPoolStats(t *testing.T) {
+	stats := UserPoolStats{
+		Username: "testuser",
+	}
+
+	assert.Equal(t, "testuser", stats.Username)
+}

--- a/go/multipooler/connpoolmanager/manager_test.go
+++ b/go/multipooler/connpoolmanager/manager_test.go
@@ -1,0 +1,481 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/multipooler/pools/reserved"
+	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/tools/viperutil"
+)
+
+// newTestManager creates a Manager configured for testing with the given fake server.
+// Note: The default admin user is "postgres" which matches the fakepgserver's default user.
+func newTestManager(t *testing.T, server *fakepgserver.Server) *Manager {
+	t.Helper()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	manager := config.NewManager()
+	manager.Open(context.Background(), nil, &ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	})
+
+	return manager
+}
+
+func TestManager_Open(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	// Verify manager is open and admin pool is created.
+	require.NotNil(t, manager.adminPool)
+	require.NotNil(t, manager.settingsCache)
+	require.NotNil(t, manager.userPools)
+	assert.False(t, manager.closed)
+}
+
+func TestManager_Close(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+
+	ctx := context.Background()
+
+	// Get a connection to create a user pool.
+	conn, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	conn.Recycle()
+
+	// Verify user pool exists.
+	assert.Len(t, manager.userPools, 1)
+
+	// Close the manager.
+	manager.Close()
+
+	// Verify closed state.
+	assert.True(t, manager.closed)
+	assert.Nil(t, manager.userPools)
+	assert.Nil(t, manager.adminPool)
+}
+
+func TestManager_Close_Idempotent(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+
+	// Double close should not panic.
+	manager.Close()
+	manager.Close()
+
+	assert.True(t, manager.closed)
+}
+
+func TestManager_GetAdminConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Get an admin connection.
+	conn, err := manager.GetAdminConn(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify connection is working.
+	assert.False(t, conn.Conn.IsClosed())
+
+	conn.Recycle()
+}
+
+func TestManager_GetRegularConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Get a regular connection for a user.
+	conn, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify connection is working.
+	assert.False(t, conn.Conn.IsClosed())
+
+	conn.Recycle()
+
+	// Verify user pool was created.
+	manager.mu.Lock()
+	_, ok := manager.userPools["testuser"]
+	manager.mu.Unlock()
+	assert.True(t, ok)
+}
+
+func TestManager_GetRegularConn_EmptyUser(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Empty user should error.
+	_, err := manager.GetRegularConn(ctx, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user cannot be empty")
+}
+
+func TestManager_GetRegularConn_ClosedManager(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	manager.Close()
+
+	ctx := context.Background()
+
+	// Closed manager should error.
+	_, err := manager.GetRegularConn(ctx, "testuser")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manager is closed")
+}
+
+func TestManager_GetRegularConnWithSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET and RESET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &query.QueryResult{})
+	server.AddQueryPattern(`RESET .+`, &query.QueryResult{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	settings := map[string]string{
+		"search_path": "public",
+	}
+
+	// Get a connection with settings.
+	conn, err := manager.GetRegularConnWithSettings(ctx, settings, "testuser")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify settings were applied.
+	assert.NotNil(t, conn.Conn.Settings())
+
+	conn.Recycle()
+
+	// Verify SET was called.
+	assert.Greater(t, server.GetPatternCalledNum(`SET SESSION .+ = .+`), 0)
+}
+
+func TestManager_NewReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection.
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify connection has a unique ID.
+	assert.Greater(t, conn.ConnID, int64(0))
+
+	conn.Release(reserved.ReleaseCommit) // ReleaseCommit
+}
+
+func TestManager_NewReservedConn_WithSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &query.QueryResult{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	settings := map[string]string{
+		"timezone": "UTC",
+	}
+
+	// Create a reserved connection with settings.
+	conn, err := manager.NewReservedConn(ctx, settings, "testuser")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	conn.Release(reserved.ReleaseCommit)
+
+	// Verify SET was called.
+	assert.Greater(t, server.GetPatternCalledNum(`SET SESSION .+ = .+`), 0)
+}
+
+func TestManager_GetReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection.
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	require.NoError(t, err)
+	connID := conn.ConnID
+
+	// Retrieve by ID.
+	retrieved, ok := manager.GetReservedConn(connID, "testuser")
+	require.True(t, ok)
+	assert.Equal(t, connID, retrieved.ConnID)
+
+	conn.Release(reserved.ReleaseCommit)
+}
+
+func TestManager_GetReservedConn_NotFound(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	// Non-existent connection ID.
+	_, ok := manager.GetReservedConn(999999, "testuser")
+	assert.False(t, ok)
+}
+
+func TestManager_GetReservedConn_UserNotFound(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	// No user pools exist yet.
+	_, ok := manager.GetReservedConn(1, "unknownuser")
+	assert.False(t, ok)
+}
+
+func TestManager_Stats(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Initial stats - no user pools.
+	stats := manager.Stats()
+	assert.NotNil(t, stats.Admin)
+	assert.Empty(t, stats.UserPools)
+
+	// Create some user pools.
+	conn1, err := manager.GetRegularConn(ctx, "user1")
+	require.NoError(t, err)
+	conn1.Recycle()
+
+	conn2, err := manager.GetRegularConn(ctx, "user2")
+	require.NoError(t, err)
+	conn2.Recycle()
+
+	// Verify stats include user pools.
+	stats = manager.Stats()
+	assert.Len(t, stats.UserPools, 2)
+	assert.Contains(t, stats.UserPools, "user1")
+	assert.Contains(t, stats.UserPools, "user2")
+}
+
+func TestManager_UserPoolReuse(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Get connections for the same user multiple times.
+	conn1, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	conn1.Recycle()
+
+	conn2, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	conn2.Recycle()
+
+	conn3, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	conn3.Recycle()
+
+	// Only one user pool should exist.
+	manager.mu.Lock()
+	numPools := len(manager.userPools)
+	manager.mu.Unlock()
+	assert.Equal(t, 1, numPools)
+}
+
+func TestManager_ConcurrentUserPoolCreation(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	numGoroutines := 10
+
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines)
+
+	// Concurrently create connections for the same user.
+	for range numGoroutines {
+		wg.Go(func() {
+			conn, err := manager.GetRegularConn(ctx, "concurrent-user")
+			if err != nil {
+				errs <- err
+				return
+			}
+			conn.Recycle()
+		})
+	}
+
+	wg.Wait()
+	close(errs)
+
+	// Collect any errors.
+	for err := range errs {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Only one user pool should exist.
+	manager.mu.Lock()
+	numPools := len(manager.userPools)
+	manager.mu.Unlock()
+	assert.Equal(t, 1, numPools)
+}
+
+func TestManager_ConcurrentDifferentUsers(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	numUsers := 5
+
+	var wg sync.WaitGroup
+
+	// Concurrently create connections for different users.
+	for i := range numUsers {
+		wg.Add(1)
+		go func(userNum int) {
+			defer wg.Done()
+			user := "user" + string(rune('A'+userNum))
+			conn, err := manager.GetRegularConn(ctx, user)
+			if err != nil {
+				t.Errorf("unexpected error for %s: %v", user, err)
+				return
+			}
+			conn.Recycle()
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All user pools should exist.
+	manager.mu.Lock()
+	numPools := len(manager.userPools)
+	manager.mu.Unlock()
+	assert.Equal(t, numUsers, numPools)
+}
+
+func TestManager_SettingsCacheIntegration(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &query.QueryResult{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	settings := map[string]string{
+		"search_path": "public",
+	}
+
+	// Get connections with the same settings multiple times.
+	conn1, err := manager.GetRegularConnWithSettings(ctx, settings, "user1")
+	require.NoError(t, err)
+	settings1 := conn1.Conn.Settings()
+	conn1.Recycle()
+
+	conn2, err := manager.GetRegularConnWithSettings(ctx, settings, "user2")
+	require.NoError(t, err)
+	settings2 := conn2.Conn.Settings()
+	conn2.Recycle()
+
+	// Settings should be the same pointer (from cache).
+	assert.Same(t, settings1, settings2)
+}

--- a/go/multipooler/connpoolmanager/user_pool_test.go
+++ b/go/multipooler/connpoolmanager/user_pool_test.go
@@ -1,0 +1,359 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/multipooler/connstate"
+	"github.com/multigres/multigres/go/multipooler/pools/connpool"
+	"github.com/multigres/multigres/go/multipooler/pools/reserved"
+	"github.com/multigres/multigres/go/pb/query"
+)
+
+// newTestUserPool creates a UserPool configured for testing with the given fake server.
+func newTestUserPool(t *testing.T, server *fakepgserver.Server) *UserPool {
+	t.Helper()
+
+	ctx := context.Background()
+	config := &UserPoolConfig{
+		ClientConfig: server.ClientConfig(),
+		AdminPool:    nil, // Not needed for basic tests
+		RegularPoolConfig: &connpool.Config{
+			Capacity:     4,
+			MaxIdleCount: 4,
+		},
+		ReservedPoolConfig: &connpool.Config{
+			Capacity:     4,
+			MaxIdleCount: 4,
+		},
+		ReservedInactivityTimeout: 5 * time.Second,
+	}
+
+	return NewUserPool(ctx, config)
+}
+
+func TestUserPool_Username(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	// Verify username matches the client config.
+	assert.Equal(t, server.ClientConfig().User, pool.Username())
+}
+
+func TestUserPool_GetRegularConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Get a regular connection.
+	conn, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify connection is working.
+	assert.False(t, conn.Conn.IsClosed())
+
+	conn.Recycle()
+
+	// Verify stats.
+	stats := pool.Stats()
+	assert.Equal(t, int64(1), stats.Regular.Active)
+	assert.Equal(t, int64(1), stats.Regular.Idle)
+}
+
+func TestUserPool_GetRegularConnWithSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET and RESET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &query.QueryResult{})
+	server.AddQueryPattern(`RESET .+`, &query.QueryResult{})
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	settings := connstate.NewSettings(map[string]string{
+		"search_path": "public",
+	}, 1)
+
+	// Get a connection with settings.
+	conn, err := pool.GetRegularConnWithSettings(ctx, settings)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify settings were applied.
+	assert.Equal(t, settings, conn.Conn.Settings())
+
+	conn.Recycle()
+
+	// Verify SET was called.
+	assert.Greater(t, server.GetPatternCalledNum(`SET SESSION .+ = .+`), 0)
+}
+
+func TestUserPool_NewReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection.
+	conn, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// Verify connection has a unique ID.
+	assert.Greater(t, conn.ConnID, int64(0))
+
+	// Verify stats.
+	stats := pool.Stats()
+	assert.Equal(t, 1, stats.Reserved.Active)
+
+	conn.Release(reserved.ReleaseCommit)
+}
+
+func TestUserPool_NewReservedConn_WithSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &query.QueryResult{})
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	settings := connstate.NewSettings(map[string]string{
+		"timezone": "UTC",
+	}, 1)
+
+	// Create a reserved connection with settings.
+	conn, err := pool.NewReservedConn(ctx, settings)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	conn.Release(reserved.ReleaseCommit)
+
+	// Verify SET was called.
+	assert.Greater(t, server.GetPatternCalledNum(`SET SESSION .+ = .+`), 0)
+}
+
+func TestUserPool_GetReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection.
+	conn, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+	connID := conn.ConnID
+
+	// Retrieve by ID.
+	retrieved, ok := pool.GetReservedConn(connID)
+	require.True(t, ok)
+	assert.Equal(t, connID, retrieved.ConnID)
+
+	conn.Release(reserved.ReleaseCommit)
+}
+
+func TestUserPool_GetReservedConn_NotFound(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	// Non-existent connection ID.
+	_, ok := pool.GetReservedConn(999999)
+	assert.False(t, ok)
+}
+
+func TestUserPool_Close(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+
+	ctx := context.Background()
+
+	// Create some connections.
+	regularConn, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+	regularConn.Recycle()
+
+	reservedConn, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+
+	// Close the pool.
+	pool.Close()
+
+	// Verify closed state.
+	assert.True(t, pool.closed)
+
+	// Reserved connection should be closed.
+	assert.True(t, reservedConn.IsClosed())
+}
+
+func TestUserPool_Close_Idempotent(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+
+	// Double close should not panic.
+	pool.Close()
+	pool.Close()
+
+	assert.True(t, pool.closed)
+}
+
+func TestUserPool_Stats(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Initial stats.
+	stats := pool.Stats()
+	assert.Equal(t, pool.Username(), stats.Username)
+	assert.Equal(t, int64(0), stats.Regular.Active)
+	assert.Equal(t, 0, stats.Reserved.Active)
+
+	// Get a regular connection.
+	regularConn, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+
+	stats = pool.Stats()
+	assert.Equal(t, int64(1), stats.Regular.Active)
+	assert.Equal(t, int64(1), stats.Regular.Borrowed)
+
+	regularConn.Recycle()
+
+	stats = pool.Stats()
+	assert.Equal(t, int64(1), stats.Regular.Idle)
+	assert.Equal(t, int64(0), stats.Regular.Borrowed)
+
+	// Create a reserved connection.
+	reservedConn, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+
+	stats = pool.Stats()
+	assert.Equal(t, 1, stats.Reserved.Active)
+
+	reservedConn.Release(reserved.ReleaseCommit)
+
+	stats = pool.Stats()
+	assert.Equal(t, 0, stats.Reserved.Active)
+}
+
+func TestUserPool_MultipleRegularConnections(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Get multiple connections.
+	conn1, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+
+	conn2, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+
+	conn3, err := pool.GetRegularConn(ctx)
+	require.NoError(t, err)
+
+	// Verify stats.
+	stats := pool.Stats()
+	assert.Equal(t, int64(3), stats.Regular.Borrowed)
+
+	// Return all connections.
+	conn1.Recycle()
+	conn2.Recycle()
+	conn3.Recycle()
+
+	stats = pool.Stats()
+	assert.Equal(t, int64(0), stats.Regular.Borrowed)
+	assert.Equal(t, int64(3), stats.Regular.Idle)
+}
+
+func TestUserPool_MultipleReservedConnections(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestUserPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Create multiple reserved connections.
+	conn1, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+
+	conn2, err := pool.NewReservedConn(ctx, nil)
+	require.NoError(t, err)
+
+	// Verify unique IDs.
+	assert.NotEqual(t, conn1.ConnID, conn2.ConnID)
+
+	// Verify stats.
+	stats := pool.Stats()
+	assert.Equal(t, 2, stats.Reserved.Active)
+
+	// Release all.
+	conn1.Release(0) // ReleaseCommit
+	conn2.Release(0)
+
+	stats = pool.Stats()
+	assert.Equal(t, 0, stats.Reserved.Active)
+}


### PR DESCRIPTION
### Description
- Add comprehensive unit tests for the `connpoolmanager` package covering Manager, UserPool, and Config
- Tests cover lifecycle management, connection acquisition, concurrency, and error handling