### PR TITLE
fix(multipooler): prevent reserved connection ID collisions after restart

### DIFF
--- a/go/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/multipooler/pools/reserved/reserved_pool_test.go
@@ -420,3 +420,89 @@ func TestPool_KillConnection_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+func TestPool_TimestampBasedConnectionIDs(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Create multiple connections and verify IDs are unique and timestamp-based.
+	const numConns = 10
+	conns := make([]*Conn, numConns)
+	ids := make(map[int64]bool)
+	var prevID int64
+
+	for i := range numConns {
+		conn, err := pool.NewConn(ctx, nil)
+		require.NoError(t, err)
+		conns[i] = conn
+
+		// Verify ID is positive and large (timestamp-based).
+		assert.Greater(t, conn.ConnID, int64(0), "connection ID should be positive")
+		// Timestamps in nanoseconds since 1970 should be > 1e18 (2001+).
+		assert.Greater(t, conn.ConnID, int64(1e18), "connection ID should be timestamp-based")
+
+		// Verify uniqueness.
+		assert.False(t, ids[conn.ConnID], "connection ID should be unique")
+		ids[conn.ConnID] = true
+
+		// Verify IDs are sequential (each ID is larger than the previous).
+		if i > 0 {
+			assert.Greater(t, conn.ConnID, prevID, "connection IDs should be sequential")
+		}
+		prevID = conn.ConnID
+	}
+
+	// Clean up.
+	for _, conn := range conns {
+		conn.Release(ReleaseCommit)
+	}
+}
+
+func TestPool_NewConnAfterPoolRecreation(t *testing.T) {
+	// This test simulates the scenario where multipooler restarts:
+	// - Old pool had connections with certain IDs
+	// - New pool should have completely different IDs (no collision)
+	// because the new pool's lastID is initialized with a later timestamp.
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	// Create first pool and get connection IDs.
+	pool1 := newTestPool(t, server)
+	ctx := context.Background()
+
+	const numConns = 5
+	var maxPool1ID int64
+	for range numConns {
+		conn, err := pool1.NewConn(ctx, nil)
+		require.NoError(t, err)
+		if conn.ConnID > maxPool1ID {
+			maxPool1ID = conn.ConnID
+		}
+		conn.Release(ReleaseCommit)
+	}
+	pool1.Close()
+
+	// Small delay to ensure timestamp advances (though not strictly necessary
+	// since the new pool's initial timestamp will be later anyway).
+	time.Sleep(time.Millisecond)
+
+	// Create second pool (simulates restart) and verify IDs are greater.
+	pool2 := newTestPool(t, server)
+	defer pool2.Close()
+
+	for range numConns {
+		conn, err := pool2.NewConn(ctx, nil)
+		require.NoError(t, err)
+		// New pool's IDs should all be greater than the max from the old pool
+		// because they're based on a later timestamp.
+		assert.Greater(t, conn.ConnID, maxPool1ID, "new pool IDs should be greater than old pool IDs")
+		conn.Release(ReleaseCommit)
+	}
+}


### PR DESCRIPTION
### Description

Fixes an issue where reserved connection IDs could collide after multipooler restarts, potentially causing queries to execute on the wrong connection.

**The problem:** Connection IDs were generated sequentially starting from 1. After a multipooler restart, the counter would reset, and new connections could receive the same IDs as connections from before the restart. If a multigateway was still holding a reference to an old connection ID, it could inadvertently route queries to a different connection.

**The fix:** Initialize the connection ID counter (`lastID`) with the current Unix nanosecond timestamp when creating the pool. This ensures IDs from different pool instances never overlap, as each restart starts from a later timestamp.

Addresses https://github.com/multigres/multigres/pull/337#discussion_r2620745461