### PR TITLE
feat(ctxutil): add Detach() and StartLinkedSpan() for background tasks

### DIFF
--- a/go/cmd/multigres/command/cluster/backup.go
+++ b/go/cmd/multigres/command/cluster/backup.go
@@ -106,8 +106,7 @@ func (bcmd *backupCmd) runBackup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create context with timeout for the initial Backup call
-	//nolint:gocritic // CLI entry point - no parent context available
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
 	defer cancel()
 
 	backupResp, err := client.Backup(ctx, &multiadminpb.BackupRequest{
@@ -140,8 +139,7 @@ func pollBackupJobStatus(cmd *cobra.Command, client multiadminpb.MultiAdminServi
 			return fmt.Errorf("backup job %s timed out after %v", jobID, backupPollTimeout)
 		case <-ticker.C:
 			// Create a fresh timeout context for each GetBackupJobStatus call
-			//nolint:gocritic // CLI entry point - no parent context available
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			resp, err := client.GetBackupJobStatus(ctx, &multiadminpb.GetBackupJobStatusRequest{
 				JobId: jobID,
 			})

--- a/go/cmd/multigres/command/cluster/list_backups.go
+++ b/go/cmd/multigres/command/cluster/list_backups.go
@@ -55,8 +55,7 @@ func runListBackups(cmd *cobra.Command, args []string) error {
 	defer client.Close()
 
 	// Create context with timeout
-	//nolint:gocritic // CLI entry point - no parent context available
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	// Note: TableGroup and Shard are currently hardcoded to defaults because

--- a/go/common/topoclient/locks.go
+++ b/go/common/topoclient/locks.go
@@ -203,11 +203,8 @@ func (l *Lock) lock(ctx context.Context, ts *store, lt iTopoLock, opts ...LockOp
 // unlock unlocks a previously locked key.
 func (l *Lock) unlock(ctx context.Context, ts *store, lt iTopoLock, lockDescriptor LockDescriptor, actionError error) error {
 	// Detach from the parent timeout, but preserve the trace span.
-	// We need to still release the lock even if the parent
-	// context timed out.
-	span := trace.SpanFromContext(ctx)
-	//nolint:gocritic // Intentionally detaching from parent context - unlock must complete even if parent was cancelled
-	ctx = trace.ContextWithSpan(context.Background(), span)
+	// We need to still release the lock even if the parent context timed out.
+	ctx = context.WithoutCancel(ctx)
 	ctx, cancel := context.WithTimeout(ctx, ts.getRemoteOperationTimeout())
 	defer cancel()
 

--- a/go/tools/ctxutil/ctxutil.go
+++ b/go/tools/ctxutil/ctxutil.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ctxutil provides utilities for context manipulation, particularly
+// for creating detached contexts that preserve telemetry metadata.
+package ctxutil
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type parentSpanContextKey struct{}
+
+// Detach creates a new context that is NOT cancelled when the parent is cancelled,
+// but preserves telemetry metadata (baggage, parent span context for linking).
+//
+// Use this for long-lived background tasks that should outlive the initiating request:
+//   - Health checks for newly-pooled connections
+//   - Graceful shutdown sequences
+//   - Periodic maintenance tasks
+//
+// The returned context preserves:
+//   - All baggage from the parent context
+//   - Parent span context (retrievable via ParentSpanContext for optional linking)
+//
+// Unlike context.WithoutCancel() which preserves the parent span (making background
+// work appear as children), Detach() stores the span context separately so callers
+// can optionally link new spans without making them child spans.
+//
+// Example - starting a linked span:
+//
+//	bgCtx := ctxutil.Detach(requestCtx)
+//	bgCtx, span := ctxutil.StartLinkedSpan(bgCtx, tracer, "background-task")
+//	defer span.End()
+func Detach(parent context.Context) context.Context {
+	// Start fresh - no cancellation inheritance
+	//nolint:gocritic // This is the legitimate entry point for detached contexts
+	ctx := context.Background()
+
+	// Preserve baggage (service metadata, etc.)
+	if bag := baggage.FromContext(parent); bag.Len() > 0 {
+		ctx = baggage.ContextWithBaggage(ctx, bag)
+	}
+
+	// Store parent span context for optional linking (but not as parent span)
+	if span := trace.SpanFromContext(parent); span.SpanContext().IsValid() {
+		ctx = context.WithValue(ctx, parentSpanContextKey{}, span.SpanContext())
+	}
+
+	return ctx
+}
+
+// ParentSpanContext retrieves the span context from the original parent context,
+// if it was present when Detach was called. This allows callers to link new spans
+// to the original context without making them child spans.
+//
+// Returns the parent span context and true if present, or an empty span context
+// and false if no parent span was available when Detach was called.
+func ParentSpanContext(ctx context.Context) (trace.SpanContext, bool) {
+	psc, ok := ctx.Value(parentSpanContextKey{}).(trace.SpanContext)
+	return psc, ok
+}
+
+// StartLinkedSpan creates a new root span that is linked to the parent span context
+// stored in the context (if any). This is useful for background tasks that should
+// have their own trace but maintain correlation with the originating request.
+//
+// The span is created with trace.WithNewRoot() so it starts a new trace, and if
+// a parent span context is available (from a prior Detach call), it's linked via
+// trace.WithLinks().
+//
+// Example:
+//
+//	bgCtx := ctxutil.Detach(requestCtx)
+//	bgCtx, span := ctxutil.StartLinkedSpan(bgCtx, tracer, "background-task")
+//	defer span.End()
+func StartLinkedSpan(ctx context.Context, tracer trace.Tracer, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	spanOpts := []trace.SpanStartOption{trace.WithNewRoot()}
+	if psc, ok := ParentSpanContext(ctx); ok {
+		spanOpts = append(spanOpts, trace.WithLinks(trace.Link{SpanContext: psc}))
+	}
+	spanOpts = append(spanOpts, opts...)
+	return tracer.Start(ctx, name, spanOpts...)
+}

--- a/go/tools/ctxutil/ctxutil_test.go
+++ b/go/tools/ctxutil/ctxutil_test.go
@@ -1,0 +1,318 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctxutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestDetach_NotCancelledWhenParentCancelled(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+
+	detached := Detach(parent)
+
+	// Cancel the parent
+	cancel()
+
+	// Parent should be cancelled
+	select {
+	case <-parent.Done():
+		// Expected
+	default:
+		t.Fatal("parent context should be cancelled")
+	}
+
+	// Detached should NOT be cancelled
+	select {
+	case <-detached.Done():
+		t.Fatal("detached context should not be cancelled when parent is cancelled")
+	default:
+		// Expected - detached is still active
+	}
+
+	// Verify detached has no deadline
+	_, hasDeadline := detached.Deadline()
+	assert.False(t, hasDeadline, "detached context should have no deadline")
+
+	// Verify detached has no error
+	assert.NoError(t, detached.Err(), "detached context should have no error")
+}
+
+func TestDetach_PreservesBaggage(t *testing.T) {
+	// Create baggage with test values
+	member1, err := baggage.NewMember("service", "multiorch")
+	require.NoError(t, err)
+	member2, err := baggage.NewMember("request-id", "abc123")
+	require.NoError(t, err)
+	bag, err := baggage.New(member1, member2)
+	require.NoError(t, err)
+
+	parent := baggage.ContextWithBaggage(context.Background(), bag)
+
+	detached := Detach(parent)
+
+	// Verify baggage is preserved
+	preservedBag := baggage.FromContext(detached)
+	assert.Equal(t, "multiorch", preservedBag.Member("service").Value())
+	assert.Equal(t, "abc123", preservedBag.Member("request-id").Value())
+}
+
+func TestDetach_WorksWithNoBaggage(t *testing.T) {
+	parent := context.Background()
+
+	detached := Detach(parent)
+
+	// Should work without panicking
+	assert.NotNil(t, detached)
+
+	// Baggage should be empty
+	bag := baggage.FromContext(detached)
+	assert.Equal(t, 0, bag.Len())
+}
+
+func TestDetach_StoresParentSpanContext(t *testing.T) {
+	// Create a mock span context
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	// Create a context with this span context
+	parent := trace.ContextWithSpanContext(context.Background(), sc)
+
+	detached := Detach(parent)
+
+	// Verify parent span context is retrievable
+	psc, ok := ParentSpanContext(detached)
+	require.True(t, ok, "should have parent span context")
+	assert.Equal(t, traceID, psc.TraceID())
+	assert.Equal(t, spanID, psc.SpanID())
+	assert.True(t, psc.IsSampled())
+}
+
+func TestDetach_WorksWithNoSpan(t *testing.T) {
+	parent := context.Background()
+
+	detached := Detach(parent)
+
+	// Should work without panicking
+	assert.NotNil(t, detached)
+
+	// ParentSpanContext should return false
+	_, ok := ParentSpanContext(detached)
+	assert.False(t, ok, "should not have parent span context when parent had no span")
+}
+
+func TestDetach_DoesNotInheritParentSpan(t *testing.T) {
+	// Create a mock span context
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	parent := trace.ContextWithSpanContext(context.Background(), sc)
+
+	detached := Detach(parent)
+
+	// The detached context should NOT have a span (trace.SpanFromContext returns noop)
+	span := trace.SpanFromContext(detached)
+	assert.False(t, span.SpanContext().IsValid(), "detached context should not have an active span")
+}
+
+func TestDetach_CanAddOwnCancellation(t *testing.T) {
+	parent := context.Background()
+	detached := Detach(parent)
+
+	// Add cancellation to the detached context
+	ctx, cancel := context.WithCancel(detached)
+	defer cancel()
+
+	// Add timeout to the detached context
+	ctxWithTimeout, cancelTimeout := context.WithTimeout(detached, time.Hour)
+	defer cancelTimeout()
+
+	// Both should work
+	assert.NotNil(t, ctx)
+	assert.NotNil(t, ctxWithTimeout)
+
+	// Cancel should work
+	cancel()
+	select {
+	case <-ctx.Done():
+		// Expected
+	default:
+		t.Fatal("derived context should be cancellable")
+	}
+
+	// Original detached should still be active
+	select {
+	case <-detached.Done():
+		t.Fatal("original detached context should not be affected")
+	default:
+		// Expected
+	}
+}
+
+func TestParentSpanContext_ReturnsEmptyWhenNotDetached(t *testing.T) {
+	// Regular context (not from Detach)
+	ctx := context.Background()
+
+	psc, ok := ParentSpanContext(ctx)
+	assert.False(t, ok)
+	assert.False(t, psc.IsValid())
+}
+
+func TestDetach_PreservesBothBaggageAndSpan(t *testing.T) {
+	// Create baggage
+	member, err := baggage.NewMember("key", "value")
+	require.NoError(t, err)
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+
+	// Create span context
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	})
+
+	// Create parent with both
+	parent := context.Background()
+	parent = baggage.ContextWithBaggage(parent, bag)
+	parent = trace.ContextWithSpanContext(parent, sc)
+
+	detached := Detach(parent)
+
+	// Verify both are preserved
+	preservedBag := baggage.FromContext(detached)
+	assert.Equal(t, "value", preservedBag.Member("key").Value())
+
+	psc, ok := ParentSpanContext(detached)
+	require.True(t, ok)
+	assert.Equal(t, traceID, psc.TraceID())
+}
+
+func TestStartLinkedSpan_LinksToParentSpan(t *testing.T) {
+	// Create a parent span context
+	parentTraceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	parentSpanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+
+	parentSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    parentTraceID,
+		SpanID:     parentSpanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	parent := trace.ContextWithSpanContext(context.Background(), parentSC)
+	detached := Detach(parent)
+
+	// Set up an in-memory exporter to capture spans
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+
+	// Create a linked span
+	ctx, span := StartLinkedSpan(detached, tracer, "test-span")
+	span.End()
+
+	// Verify the span was created
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	// Verify it's a new root (different trace ID from parent)
+	createdSpan := spans[0]
+	assert.NotEqual(t, parentTraceID, createdSpan.SpanContext.TraceID(),
+		"linked span should have a new trace ID (new root)")
+
+	// Verify it has a link to the parent span
+	require.Len(t, createdSpan.Links, 1, "should have exactly one link")
+	link := createdSpan.Links[0]
+	assert.Equal(t, parentTraceID, link.SpanContext.TraceID(),
+		"link should reference parent trace ID")
+	assert.Equal(t, parentSpanID, link.SpanContext.SpanID(),
+		"link should reference parent span ID")
+
+	// Verify the context has the new span
+	spanFromCtx := trace.SpanFromContext(ctx)
+	assert.Equal(t, createdSpan.SpanContext.SpanID(), spanFromCtx.SpanContext().SpanID())
+}
+
+func TestStartLinkedSpan_WorksWithoutParentSpan(t *testing.T) {
+	// Detach from a context with no span
+	detached := Detach(context.Background())
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+
+	// Should not panic and should create a span without links
+	ctx, span := StartLinkedSpan(detached, tracer, "test-span")
+	span.End()
+
+	assert.NotNil(t, ctx)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Empty(t, spans[0].Links, "should have no links when parent had no span")
+}
+
+func TestStartLinkedSpan_PassesAdditionalOptions(t *testing.T) {
+	detached := Detach(context.Background())
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	tracer := tp.Tracer("test")
+
+	// Pass additional span options
+	_, span := StartLinkedSpan(detached, tracer, "test-span",
+		trace.WithSpanKind(trace.SpanKindServer))
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, trace.SpanKindServer, spans[0].SpanKind)
+}

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -61,5 +61,5 @@ func requireContextBackgroundJustification(m dsl.Matcher) {
 		Where(
 			!m.File().Name.Matches(`_test\.go$`) &&
 				!m.File().PkgPath.Matches(`/test/|/testutil/|testutil$`)).
-		Report("context.Background() requires justification. Use context.TODO() if no context is available, or add //nolint:gocritic // <reason> for legitimate entry points")
+		Report("context.Background() requires justification. Use context.TODO() if no context is available, ctxutil.Detach(ctx) for long-lived background tasks, or add //nolint:gocritic // <reason> for legitimate entry points")
 }


### PR DESCRIPTION
Add ctxutil package with helpers for long-lived background tasks:

- Detach(ctx): Creates a context that outlives its parent while preserving telemetry metadata (baggage and parent span context for linking)
- StartLinkedSpan(ctx, tracer, name): Creates a new root span linked to the parent span context, useful for async work that should be correlated with but not appear as children of the originating request
- ParentSpanContext(ctx): Retrieves stored parent span context for manual linking

Key differences from context.WithoutCancel():
- WithoutCancel: keeps span as parent (child relationship preserved)
- Detach: stores span for optional linking (new trace root, linked to parent)

Migration of existing context.Background() usages:
- locks.go: use context.WithoutCancel() - unlock should complete even if parent cancelled, but remain part of same trace
- backup.go: use ctxutil.Detach() + StartLinkedSpan() - async backup/restore are separate traces linked to the originating request
- CLI commands: use cmd.Context() - Cobra provides parent context

After this change, context.Background() in non-test code only appears in ctxutil.Detach() itself, with all other usages migrated to appropriate alternatives.