### PR TITLE
feat(bootstrap): set primary pooler info on standby pooler during initialization

### DIFF
--- a/go/multiorch/recovery/actions/bootstrap_shard.go
+++ b/go/multiorch/recovery/actions/bootstrap_shard.go
@@ -337,8 +337,7 @@ func (a *BootstrapShardAction) initializeStandbys(ctx context.Context, shardKey 
 // initializeSingleStandby initializes a single node as a standby of the given primary.
 func (a *BootstrapShardAction) initializeSingleStandby(ctx context.Context, node *multiorchdatapb.PoolerHealthState, primary *multiorchdatapb.PoolerHealthState, backupID string) error {
 	req := &multipoolermanagerdatapb.InitializeAsStandbyRequest{
-		PrimaryHost:   primary.MultiPooler.Hostname,
-		PrimaryPort:   primary.MultiPooler.PortMap["postgres"],
+		Primary:       primary.MultiPooler,
 		ConsensusTerm: 1,
 		Force:         false,
 		BackupId:      backupID,

--- a/go/multipooler/manager/rpc_initialization.go
+++ b/go/multipooler/manager/rpc_initialization.go
@@ -154,9 +154,26 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 // InitializeAsStandby initializes this pooler as a standby from a primary backup
 // Used during bootstrap initialization of a new shard or when adding a new standby
 func (pm *MultiPoolerManager) InitializeAsStandby(ctx context.Context, req *multipoolermanagerdatapb.InitializeAsStandbyRequest) (*multipoolermanagerdatapb.InitializeAsStandbyResponse, error) {
+	// Validate primary is provided
+	if req.Primary == nil {
+		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "primary is required")
+	}
+
+	// Extract primary connection info
+	primaryHost := req.Primary.Hostname
+	primaryPort, ok := req.Primary.PortMap["postgres"]
+	if !ok {
+		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "primary MultiPooler has no postgres port configured")
+	}
+
+	// Store primary pooler ID so we can track which primary we're replicating from
+	pm.mu.Lock()
+	pm.primaryPoolerID = req.Primary.Id
+	pm.mu.Unlock()
+
 	pm.logger.InfoContext(ctx, "InitializeAsStandby called",
 		"shard", pm.getShardID(),
-		"primary", fmt.Sprintf("%s:%d", req.PrimaryHost, req.PrimaryPort),
+		"primary", fmt.Sprintf("%s:%d", primaryHost, primaryPort),
 		"term", req.ConsensusTerm,
 		"force", req.Force)
 
@@ -182,9 +199,9 @@ func (pm *MultiPoolerManager) InitializeAsStandby(ctx context.Context, req *mult
 
 	// 2. Restore from the specified backup (or latest if not specified)
 	if req.BackupId != "" {
-		pm.logger.InfoContext(ctx, "Restoring from specified backup", "backup_id", req.BackupId, "primary", fmt.Sprintf("%s:%d", req.PrimaryHost, req.PrimaryPort))
+		pm.logger.InfoContext(ctx, "Restoring from specified backup", "backup_id", req.BackupId, "primary", fmt.Sprintf("%s:%d", primaryHost, primaryPort))
 	} else {
-		pm.logger.InfoContext(ctx, "Restoring from latest backup on primary", "primary", fmt.Sprintf("%s:%d", req.PrimaryHost, req.PrimaryPort))
+		pm.logger.InfoContext(ctx, "Restoring from latest backup on primary", "primary", fmt.Sprintf("%s:%d", primaryHost, primaryPort))
 	}
 
 	// Restore from backup (empty string means latest)
@@ -225,8 +242,8 @@ func (pm *MultiPoolerManager) InitializeAsStandby(ctx context.Context, req *mult
 
 	// 4. Configure primary_conninfo now that PostgreSQL is running
 	// Use the locked version since we're already holding the action lock
-	pm.logger.InfoContext(ctx, "Configuring primary connection info", "primary_host", req.PrimaryHost, "primary_port", req.PrimaryPort)
-	if err := pm.setPrimaryConnInfoLocked(ctx, req.PrimaryHost, req.PrimaryPort, false, true); err != nil {
+	pm.logger.InfoContext(ctx, "Configuring primary connection info", "primary_host", primaryHost, "primary_port", primaryPort)
+	if err := pm.setPrimaryConnInfoLocked(ctx, primaryHost, primaryPort, false, true); err != nil {
 		return nil, mterrors.Wrap(err, "failed to set primary_conninfo")
 	}
 

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -3028,17 +3028,15 @@ func (x *InitializeEmptyPrimaryResponse) GetBackupId() string {
 // Used during bootstrap initialization of a new shard or when adding a new standby
 type InitializeAsStandbyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Primary server hostname to backup from
-	PrimaryHost string `protobuf:"bytes,1,opt,name=primary_host,json=primaryHost,proto3" json:"primary_host,omitempty"`
-	// Primary server port
-	PrimaryPort int32 `protobuf:"varint,2,opt,name=primary_port,json=primaryPort,proto3" json:"primary_port,omitempty"`
+	// Primary pooler to replicate from
+	Primary *clustermetadata.MultiPooler `protobuf:"bytes,1,opt,name=primary,proto3" json:"primary,omitempty"`
 	// Consensus term to set for this standby
-	ConsensusTerm int64 `protobuf:"varint,3,opt,name=consensus_term,json=consensusTerm,proto3" json:"consensus_term,omitempty"`
+	ConsensusTerm int64 `protobuf:"varint,2,opt,name=consensus_term,json=consensusTerm,proto3" json:"consensus_term,omitempty"`
 	// Whether to force reinitialization (removes existing data directory)
-	Force bool `protobuf:"varint,4,opt,name=force,proto3" json:"force,omitempty"`
+	Force bool `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`
 	// Optional: Specific backup ID to restore from
 	// If empty, restore from the latest backup
-	BackupId      string `protobuf:"bytes,5,opt,name=backup_id,json=backupId,proto3" json:"backup_id,omitempty"`
+	BackupId      string `protobuf:"bytes,4,opt,name=backup_id,json=backupId,proto3" json:"backup_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3073,18 +3071,11 @@ func (*InitializeAsStandbyRequest) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{48}
 }
 
-func (x *InitializeAsStandbyRequest) GetPrimaryHost() string {
+func (x *InitializeAsStandbyRequest) GetPrimary() *clustermetadata.MultiPooler {
 	if x != nil {
-		return x.PrimaryHost
+		return x.Primary
 	}
-	return ""
-}
-
-func (x *InitializeAsStandbyRequest) GetPrimaryPort() int32 {
-	if x != nil {
-		return x.PrimaryPort
-	}
-	return 0
+	return nil
 }
 
 func (x *InitializeAsStandbyRequest) GetConsensusTerm() int64 {
@@ -4022,13 +4013,12 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x1eInitializeEmptyPrimaryResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x1b\n" +
-	"\tbackup_id\x18\x03 \x01(\tR\bbackupId\"\xbc\x01\n" +
-	"\x1aInitializeAsStandbyRequest\x12!\n" +
-	"\fprimary_host\x18\x01 \x01(\tR\vprimaryHost\x12!\n" +
-	"\fprimary_port\x18\x02 \x01(\x05R\vprimaryPort\x12%\n" +
-	"\x0econsensus_term\x18\x03 \x01(\x03R\rconsensusTerm\x12\x14\n" +
-	"\x05force\x18\x04 \x01(\bR\x05force\x12\x1b\n" +
-	"\tbackup_id\x18\x05 \x01(\tR\bbackupId\"y\n" +
+	"\tbackup_id\x18\x03 \x01(\tR\bbackupId\"\xae\x01\n" +
+	"\x1aInitializeAsStandbyRequest\x126\n" +
+	"\aprimary\x18\x01 \x01(\v2\x1c.clustermetadata.MultiPoolerR\aprimary\x12%\n" +
+	"\x0econsensus_term\x18\x02 \x01(\x03R\rconsensusTerm\x12\x14\n" +
+	"\x05force\x18\x03 \x01(\bR\x05force\x12\x1b\n" +
+	"\tbackup_id\x18\x04 \x01(\tR\bbackupId\"y\n" +
 	"\x1bInitializeAsStandbyResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12\x1b\n" +
@@ -4230,17 +4220,18 @@ var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	72, // 37: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
 	70, // 38: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
 	73, // 39: multipoolermanagerdata.InitializeEmptyPrimaryRequest.durability_quorum_rule:type_name -> clustermetadata.QuorumRule
-	63, // 40: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
-	63, // 41: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	4,  // 42: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	71, // 43: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	74, // 44: multipoolermanagerdata.GetDurabilityPolicyResponse.policy:type_name -> clustermetadata.DurabilityPolicy
-	73, // 45: multipoolermanagerdata.CreateDurabilityPolicyRequest.quorum_rule:type_name -> clustermetadata.QuorumRule
-	46, // [46:46] is the sub-list for method output_type
-	46, // [46:46] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	69, // 40: multipoolermanagerdata.InitializeAsStandbyRequest.primary:type_name -> clustermetadata.MultiPooler
+	63, // 41: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
+	63, // 42: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
+	4,  // 43: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
+	71, // 44: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	74, // 45: multipoolermanagerdata.GetDurabilityPolicyResponse.policy:type_name -> clustermetadata.DurabilityPolicy
+	73, // 46: multipoolermanagerdata.CreateDurabilityPolicyRequest.quorum_rule:type_name -> clustermetadata.QuorumRule
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -560,21 +560,18 @@ message InitializeEmptyPrimaryResponse {
 // InitializeAsStandby initializes this pooler as a standby from a primary backup
 // Used during bootstrap initialization of a new shard or when adding a new standby
 message InitializeAsStandbyRequest {
-  // Primary server hostname to backup from
-  string primary_host = 1;
-
-  // Primary server port
-  int32 primary_port = 2;
+  // Primary pooler to replicate from
+  clustermetadata.MultiPooler primary = 1;
 
   // Consensus term to set for this standby
-  int64 consensus_term = 3;
+  int64 consensus_term = 2;
 
   // Whether to force reinitialization (removes existing data directory)
-  bool force = 4;
+  bool force = 3;
 
   // Optional: Specific backup ID to restore from
   // If empty, restore from the latest backup
-  string backup_id = 5;
+  string backup_id = 4;
 }
 
 message InitializeAsStandbyResponse {


### PR DESCRIPTION
Following up on #388, it turns out that `InitializeAsStandby` calls `setPrimaryConnInfoLocked` directly, so the primary poolerID was not being set on standbys during bootstrap. This PR fixes that.