### PR TITLE
test: Fix flaky test `TestPool_TimestampBasedConnectionIDs`

### DIFF
--- a/go/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/multipooler/pools/reserved/reserved_pool_test.go
@@ -426,7 +426,17 @@ func TestPool_TimestampBasedConnectionIDs(t *testing.T) {
 	defer server.Close()
 	server.SetNeverFail(true)
 
-	pool := newTestPool(t, server)
+	// Use a pool with enough capacity to hold all test connections concurrently.
+	pool := NewPool(context.Background(), &PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     10, // Enough for all test connections
+				MaxIdleCount: 10,
+			},
+		},
+	})
 	defer pool.Close()
 
 	ctx := context.Background()


### PR DESCRIPTION
### Description

There is a flaky test - 
```
panic: test timed out after 10m0s
    running tests:
        TestPool_TimestampBasedConnectionIDs (10m0s)

goroutine 133 [running]:
testing.(*M).startAlarm.func1()
    /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:2682 +0x345
created by time.goFunc
    /opt/hostedtoolcache/go/1.25.1/x64/src/time/sleep.go:215 +0x2d
```


Problem: `TestPool_TimestampBasedConnectionIDs` tried to create and hold 10 connections simultaneously, but used newTestPool which only had capacity 4. When the pool was full, NewConn blocked waiting for the inactivity timeout (5 seconds) to free slots, causing the test to take 10+ seconds locally and potentially timeout on CI.

  Fix: Changed the test to create its own pool with capacity 10 to match the number of connections it needs to hold concurrently.