### PR TITLE
fix(connpoolmanager): prevent nil pointer dereference race in connection pool initialization

### DIFF
--- a/go/multipooler/connpoolmanager/config.go
+++ b/go/multipooler/connpoolmanager/config.go
@@ -301,8 +301,10 @@ func (c *Config) SettingsCacheSize() int {
 
 // NewManager creates a new connection pool manager from this config.
 // Call this after flags have been parsed and when you're ready to create the manager.
+// The manager starts in a closed state; call Open() before using it.
 func (c *Config) NewManager() *Manager {
 	return &Manager{
 		config: c,
+		closed: true, // Manager is closed until Open() is called
 	}
 }


### PR DESCRIPTION
### Description
- Fix race condition where background goroutines could access the connection pool manager before `Open()` was called, causing a nil pointer dereference panic
- Initialize `Manager.closed` to `true` in `NewManager()` so the manager is properly guarded until opened
- Reorder `Start()` to call `Open()` before spawning background goroutines that need database connections