### PR TITLE
fix(provisioner): escalate to SIGKILL when process doesn't exit after SIGTERM

### DIFF
--- a/go/test/endtoend/cluster_test.go
+++ b/go/test/endtoend/cluster_test.go
@@ -1015,8 +1015,8 @@ func TestClusterLifecycle(t *testing.T) {
 
 		// Start cluster again and verify state is preserved after restart
 		t.Log("Starting cluster again to verify state is preserved after restart...")
-		_, err = executeStartCommand(t, []string{"--config-path", tempDir}, tempDir)
-		require.NoError(t, err, "Second start should succeed")
+		startOutput, err := executeStartCommand(t, []string{"--config-path", tempDir}, tempDir)
+		require.NoError(t, err, "Second start should succeed, output: %s", startOutput)
 
 		// Wait for both zones to be ready after restart (same as initial bootstrap)
 		t.Log("Waiting for zone1 to be ready after restart...")


### PR DESCRIPTION
### Description
- Fix flaky `TestClusterLifecycle` test caused by race condition in process termination
- When stopping a cluster, `waitForProcessExit` now escalates to SIGKILL if the process doesn't exit within 2 seconds after SIGTERM
- Improved test error logging to include start command output on failure for easier debugging

### Problem
In CI environments (which are slower), processes sometimes don't exit within the 2-second window after SIGTERM. The code would just print a warning and continue, leaving processes running. When the test tried to restart the cluster, it would fail with "exit status 1" because ports were still in use.

### Solution
- After the SIGTERM timeout, send SIGKILL to force process termination
- Wait up to 5 additional seconds for SIGKILL to take effect
- Add proper error handling for the SIGKILL path