### PR TITLE
feat(telemetry): add grpccommon.NewClient() for consistent gRPC client instrumentation

### DIFF
--- a/go/cmd/multigres/command/admin/client.go
+++ b/go/cmd/multigres/command/admin/client.go
@@ -26,6 +26,7 @@ import (
 
 	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
 	"github.com/multigres/multigres/go/provisioner/local"
+	"github.com/multigres/multigres/go/tools/grpccommon"
 )
 
 // Conn wraps a gRPC connection to the multiadmin server.
@@ -45,7 +46,7 @@ func NewClient(cmd *cobra.Command) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpccommon.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to admin server at %s: %w", addr, err)
 	}

--- a/go/common/rpcclient/conn_cache.go
+++ b/go/common/rpcclient/conn_cache.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/tools/grpccommon"
+
 	consensuspb "github.com/multigres/multigres/go/pb/consensus"
 	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
 	"github.com/multigres/multigres/go/tools/viperutil"
@@ -287,7 +289,7 @@ func (cc *connCache) pollOnce(ctx context.Context, addr string) (client *cachedC
 // It returns the two-tuple of connection and closer that getOrDial returns.
 func (cc *connCache) newDial(ctx context.Context, addr string) (*cachedConn, closeFunc, error) {
 	// TODO: Add proper TLS configuration for production
-	grpcConn, err := grpc.NewClient(
+	grpcConn, err := grpccommon.NewClient(
 		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/go/multigateway/poolergateway/pooler_gateway.go
+++ b/go/multigateway/poolergateway/pooler_gateway.go
@@ -34,6 +34,7 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/tools/grpccommon"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -211,7 +212,7 @@ func (pg *PoolerGateway) getOrCreateConnection(
 		"addr", addr)
 
 	// Create gRPC connection (non-blocking in newer gRPC)
-	conn, err := grpc.NewClient(addr,
+	conn, err := grpccommon.NewClient(addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/multigres/multigres/go/multipooler/executor"
 	"github.com/multigres/multigres/go/multipooler/heartbeat"
 	"github.com/multigres/multigres/go/multipooler/poolerserver"
+	"github.com/multigres/multigres/go/tools/grpccommon"
 	"github.com/multigres/multigres/go/tools/retry"
 
 	"google.golang.org/grpc"
@@ -179,7 +180,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, config *Config, loadT
 	// Create pgctld gRPC client
 	var pgctldClient pgctldpb.PgCtldClient
 	if config.PgctldAddr != "" {
-		conn, err := grpc.NewClient(config.PgctldAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpccommon.NewClient(config.PgctldAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			logger.ErrorContext(ctx, "Failed to create pgctld gRPC client", "error", err, "addr", config.PgctldAddr)
 			// Continue without client - operations that need it will fail gracefully

--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -23,8 +23,6 @@ import (
 	"syscall"
 	"time"
 
-	"google.golang.org/grpc"
-
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/tools/grpccommon"
 	"github.com/multigres/multigres/go/tools/retry"
@@ -164,7 +162,7 @@ func (p *localProvisioner) checkPgctldGrpcHealth(ctx context.Context, address st
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
+	conn, err := grpccommon.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -21,8 +21,6 @@ import (
 	"os/exec"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"github.com/multigres/multigres/go/common/constants"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/provisioner/local/ports"
@@ -37,7 +35,7 @@ func (p *localProvisioner) startPostgreSQLViaPgctld(ctx context.Context, address
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
+	conn, err := grpccommon.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}
@@ -95,7 +93,7 @@ func (p *localProvisioner) stopPostgreSQLViaPgctld(ctx context.Context, address 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.NewClient(address, grpccommon.LocalClientDialOptions()...)
+	conn, err := grpccommon.NewClient(address, grpccommon.LocalClientDialOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to pgctld gRPC server: %w", err)
 	}

--- a/go/tools/grpccommon/options.go
+++ b/go/tools/grpccommon/options.go
@@ -63,6 +63,15 @@ func LocalClientDialOptions() []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDisableServiceConfig(),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
+}
+
+// NewClient creates a gRPC client connection with OpenTelemetry instrumentation.
+// Use this instead of grpc.NewClient() directly to ensure consistent telemetry.
+func NewClient(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	// Prepend our telemetry handler so caller's options can override if needed
+	allOpts := append([]grpc.DialOption{
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+	}, opts...)
+	return grpc.NewClient(target, allOpts...)
 }

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -63,3 +63,13 @@ func requireContextBackgroundJustification(m dsl.Matcher) {
 				!m.File().PkgPath.Matches(`/test/|/testutil/|testutil$`)).
 		Report("context.Background() requires justification. Use context.TODO() if no context is available, or add //nolint:gocritic // <reason> for legitimate entry points")
 }
+
+func requireGrpcCommonNewClient(m dsl.Matcher) {
+	m.Import("google.golang.org/grpc")
+
+	m.Match(`grpc.NewClient($*_)`).
+		Where(
+			!m.File().Name.Matches(`_test\.go$`) &&
+				!m.File().PkgPath.Matches(`/grpccommon$|/test/|/testutil/|testutil$`)).
+		Report("use grpccommon.NewClient() instead of grpc.NewClient() to ensure telemetry instrumentation")
+}


### PR DESCRIPTION
- Add grpccommon.NewClient() wrapper that automatically includes OTel stats handler for all gRPC client connections
- Add ruleguard rule to enforce using the wrapper instead of direct grpc.NewClient() calls (excludes test files and grpccommon itself)
- Update all production gRPC client creation sites to use the new wrapper
- Avoid duplicate OTel handler in LocalClientDialOptions()

This ensures all gRPC client metrics are automatically instrumented, enabling visibility into outbound RPC calls in Prometheus/Grafana.