### PR TITLE
fix(test): race tests sometimes fail, probably due to timing issues

### DIFF
--- a/go/multipooler/manager/rpc_consensus_test.go
+++ b/go/multipooler/manager/rpc_consensus_test.go
@@ -154,7 +154,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "candidate-B",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				recentTime := time.Now().Add(-5 * time.Second).Format("2006-01-02 15:04:05.999999-07")
 				m.AddQueryPatternOnce("SELECT last_msg_receipt_time", mock.MakeQueryResult([]string{"last_msg_receipt_time"}, [][]any{{recentTime}}))
 			},
@@ -180,7 +180,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "candidate-B",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 			},
 			expectedAccepted:                    false,
 			expectedTerm:                        5,
@@ -204,7 +204,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "candidate-A",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPattern("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				recentTime := time.Now().Add(-5 * time.Second).Format("2006-01-02 15:04:05.999999-07")
 				m.AddQueryPatternOnce("SELECT last_msg_receipt_time", mock.MakeQueryResult([]string{"last_msg_receipt_time"}, [][]any{{recentTime}}))
 			},
@@ -225,7 +225,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "new-candidate",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// isInRecovery check - returns false (not in recovery = primary)
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 				// demoteLocked fails at checkDemotionState or another early step
@@ -248,7 +248,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "new-candidate",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// isInRecovery check - returns true (in recovery = standby/demoted)
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				// Since in recovery, check if caught up with replication
@@ -272,7 +272,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "new-candidate",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// isInRecovery check - returns true (in recovery = standby)
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				// WAL receiver query returns error (disconnected standby)
@@ -299,7 +299,7 @@ func TestBeginTerm(t *testing.T) {
 				Name:      "new-candidate",
 			},
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// isInRecovery check - returns true (standby)
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				// WAL receiver check - connected and caught up
@@ -344,7 +344,7 @@ func TestBeginTerm(t *testing.T) {
 			},
 			makeFilesystemReadOnly: true,
 			setupMocks: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				recentTime := time.Now().Add(-5 * time.Second).Format("2006-01-02 15:04:05.999999-07")
 				m.AddQueryPatternOnce("SELECT last_msg_receipt_time", mock.MakeQueryResult([]string{"last_msg_receipt_time"}, [][]any{{recentTime}}))
 			},
@@ -798,7 +798,7 @@ func TestConsensusStatus(t *testing.T) {
 			termInMemory: true,
 			setupMock: func(m *mock.QueryService) {
 				// Health check SELECT 1
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// Single pg_is_in_recovery check determines both role and which WAL position to query
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 				m.AddQueryPatternOnce("SELECT pg_current_wal_lsn", mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/4000000"}}))
@@ -818,7 +818,7 @@ func TestConsensusStatus(t *testing.T) {
 			termInMemory: true,
 			setupMock: func(m *mock.QueryService) {
 				// Health check SELECT 1
-				m.AddQueryPatternOnce("SELECT 1", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 				// Single pg_is_in_recovery check determines both role and which WAL position to query
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				// queryReplicationStatus() expects full replication status query
@@ -862,7 +862,7 @@ func TestConsensusStatus(t *testing.T) {
 			termInMemory: true,
 			setupMock: func(m *mock.QueryService) {
 				// Health check fails
-				m.AddQueryPatternOnceWithError("SELECT 1", fmt.Errorf("connection refused"))
+				m.AddQueryPatternOnceWithError("^SELECT 1$", fmt.Errorf("connection refused"))
 			},
 			expectedCurrentTerm: 4,
 			expectedIsHealthy:   false,

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -415,14 +415,14 @@ func initializeWithMultiOrch(t *testing.T, setup *ShardSetup, config *SetupConfi
 func waitForShardBootstrap(t *testing.T, setup *ShardSetup) (string, error) {
 	t.Helper()
 
-	ctx := utils.WithTimeout(t, 30*time.Second)
+	ctx := utils.WithTimeout(t, 60*time.Second)
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timeout waiting for shard bootstrap after 30s")
+			return "", fmt.Errorf("timeout waiting for shard bootstrap after 60s")
 		case <-ticker.C:
 			primaryName, allInitialized := checkBootstrapStatus(t, setup)
 			if primaryName != "" && allInitialized {
@@ -1026,6 +1026,7 @@ func (s *ShardSetup) DemotePrimary(t *testing.T) {
 	primary := s.GetMultipoolerInstance(s.PrimaryName)
 	if primary == nil {
 		t.Fatal("primary not found")
+		return // unreachable, but needed for linter
 	}
 
 	client, err := NewMultipoolerClient(primary.Multipooler.GrpcPort)
@@ -1060,6 +1061,7 @@ func (s *ShardSetup) NewClient(t *testing.T, name string) *MultipoolerClient {
 	inst := s.GetMultipoolerInstance(name)
 	if inst == nil {
 		t.Fatalf("multipooler %s not found", name)
+		return nil // unreachable, but needed for linter
 	}
 
 	client, err := NewMultipoolerClient(inst.Multipooler.GrpcPort)
@@ -1101,6 +1103,7 @@ func (s *ShardSetup) KillPostgres(t *testing.T, name string) {
 	inst := s.GetMultipoolerInstance(name)
 	if inst == nil {
 		t.Fatalf("node %s not found", name)
+		return // unreachable, but needed for linter
 	}
 
 	// Read the postgres PID from postmaster.pid


### PR DESCRIPTION
Increase timeouts, and tighten regex for queries.