### PR TITLE
feat(demo): fix config file generation for pgbackrest

### DIFF
--- a/go/multipooler/manager/rpc_initialization.go
+++ b/go/multipooler/manager/rpc_initialization.go
@@ -500,7 +500,7 @@ func (pm *MultiPoolerManager) waitForDatabaseConnection(ctx context.Context) err
 // configureArchiveMode configures archive_mode in postgresql.auto.conf for pgbackrest
 // This must be called after InitDataDir but BEFORE starting PostgreSQL
 func (pm *MultiPoolerManager) configureArchiveMode(ctx context.Context) error {
-	configPath, err := pm.initPgbackrest()
+	configPath, err := pm.initPgbackrest(NotForBackup)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to initialize pgbackrest")
 	}
@@ -547,7 +547,7 @@ archive_command = 'pgbackrest --stanza=%s --config=%s archive-push %%p'
 // initializePgBackRestStanza initializes the pgbackrest stanza
 // This must be called after PostgreSQL is initialized and running
 func (pm *MultiPoolerManager) initializePgBackRestStanza(ctx context.Context) error {
-	configPath, err := pm.initPgbackrest()
+	configPath, err := pm.initPgbackrest(NotForBackup)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to initialize pgbackrest")
 	}

--- a/kind_demo/kftray.json
+++ b/kind_demo/kftray.json
@@ -58,5 +58,15 @@
     "workload_type": "service",
     "protocol": "tcp",
     "alias": "Jaeger"
+  },
+  {
+    "service": "multiadmin",
+    "namespace": "default",
+    "local_port": 18070,
+    "remote_port": 18070,
+    "context": "kind-multidemo",
+    "workload_type": "service",
+    "protocol": "tcp",
+    "alias": "AdminGrpc"
   }
 ]


### PR DESCRIPTION
The initial config file generated for postgres wal archive and other tooling like pgbackrest server will be created in a persistent location without a reference to a primary and will not be modified after. This is because those use cases don't need access to the primary. For the backup invocation, we create a temp config file based on the current primary at a different location. This avoids any races between us and the other tooling that may simultaneously be using the existing config file.

Also, I've added a missing port-forward config in kftray.