### PR TITLE
feat: Add instructions and scripts to run qs demo

### DIFF
--- a/go/multigateway/init.go
+++ b/go/multigateway/init.go
@@ -161,7 +161,7 @@ func (mg *MultiGateway) Init() error {
 
 	// Create and start PostgreSQL protocol listener
 	pgHandler := handler.NewMultiGatewayHandler(mg.executor, logger)
-	pgAddr := fmt.Sprintf("localhost:%d", mg.pgPort.Get())
+	pgAddr := fmt.Sprintf("0.0.0.0:%d", mg.pgPort.Get())
 	mg.pgListener, err = server.NewListener(server.ListenerConfig{
 		Address: pgAddr,
 		Handler: pgHandler,

--- a/kind_demo/k8s-multigateway.yaml
+++ b/kind_demo/k8s-multigateway.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: multigateway
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     matchLabels:
       app: multigateway

--- a/kind_demo/k8s-supafirehose-init.yaml
+++ b/kind_demo/k8s-supafirehose-init.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: supafirehose-init-sql
+data:
+  init.sql: |
+    -- SupaFirehose Demo Database Schema
+    CREATE TABLE IF NOT EXISTS users (
+        id         BIGSERIAL PRIMARY KEY,
+        username   VARCHAR(255) NOT NULL,
+        email      VARCHAR(255) NOT NULL,
+        created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    );
+
+    INSERT INTO users (username, email)
+    SELECT 'user_' || i, 'user_' || i || '@example.com'
+    FROM generate_series(1, 100000) AS i
+    ON CONFLICT DO NOTHING;
+
+    ANALYZE users;
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: supafirehose-db-init
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: init
+        image: postgres:15-alpine
+        command:
+        - sh
+        - -c
+        - |
+          psql -h multigateway -p 15432 -U postgres -c "CREATE DATABASE pooler_demo;" || true
+          psql -h multigateway -p 15432 -U postgres -d pooler_demo -f /sql/init.sql
+        volumeMounts:
+        - name: init-sql
+          mountPath: /sql
+      volumes:
+      - name: init-sql
+        configMap:
+          name: supafirehose-init-sql

--- a/kind_demo/k8s-supafirehose.yaml
+++ b/kind_demo/k8s-supafirehose.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: supafirehose
+  labels:
+    app: supafirehose
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: supafirehose
+  template:
+    metadata:
+      labels:
+        app: supafirehose
+    spec:
+      containers:
+      - name: supafirehose
+        image: supafirehose:latest
+        imagePullPolicy: Never  # Use local image loaded into kind
+        ports:
+        - containerPort: 8080
+        env:
+        - name: DATABASE_URL
+          value: "postgres://postgres:postgres@multigateway:15432/pooler_demo"
+        - name: HTTP_PORT
+          value: "8080"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+        securityContext:
+          capabilities:
+            add:
+            - SYS_RESOURCE
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: supafirehose
+spec:
+  selector:
+    app: supafirehose
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP

--- a/kind_demo/start-qs.sh
+++ b/kind_demo/start-qs.sh
@@ -1,0 +1,32 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# 1. Docker image for supafirehose should be built already. Run this in supafirehose directory.
+# docker build -t supafirehose:latest .
+
+# 2. Load image into kind
+kind load docker-image supafirehose:latest --name multidemo
+
+# 3. Init the database (creates DB + seeds 100k users)
+kubectl apply -f k8s-supafirehose-init.yaml
+
+# 4. Deploy supafirehose
+kubectl apply -f k8s-supafirehose.yaml
+
+# 5. Port-forward to access the UI
+# kubectl port-forward svc/supafirehose 8080:8080
+echo "Supafirehose UI:"
+echo "  kubectl port-forward svc/supafirehose 8080:8080"


### PR DESCRIPTION
### Description

This PR adds the scripts and other files to run the query-serving demo. Had to make one change to multigateways too that should go into main as well. They should be listening on `0.0.0.0` and not localhost because the latter prevents any traffic from outside, and that is not ideal. 

On `main` we should make the bind-address a flag. 