### PR TITLE
feat(demo): fetch primary info from topo for pgbackrest

### DIFF
--- a/go/multipooler/init.go
+++ b/go/multipooler/init.go
@@ -271,9 +271,11 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 	multipooler.PortMap["grpc"] = int32(mp.grpcServer.Port())
 	multipooler.PortMap["http"] = int32(mp.senv.GetHTTPPort())
 	multipooler.PortMap["postgres"] = int32(mp.pgPort.Get())
+	multipooler.PortMap["pgbackrest"] = int32(mp.pgBackRestPort.Get())
 	multipooler.Database = mp.database.Get()
 	multipooler.Shard = mp.shard.Get()
 	multipooler.ServingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
+	multipooler.PoolerDir = mp.poolerDir.Get()
 
 	logger.InfoContext(startCtx, "Initializing MultiPoolerManager")
 	poolerManager, err := manager.NewMultiPoolerManager(logger, &manager.Config{
@@ -346,6 +348,7 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 						mp.PortMap = multipooler.PortMap
 						mp.Hostname = multipooler.Hostname
 						mp.ServingStatus = multipooler.ServingStatus
+						mp.PoolerDir = multipooler.PoolerDir
 						return nil
 					})
 				return err

--- a/go/multipooler/manager/rpc_initialization.go
+++ b/go/multipooler/manager/rpc_initialization.go
@@ -500,7 +500,7 @@ func (pm *MultiPoolerManager) waitForDatabaseConnection(ctx context.Context) err
 // configureArchiveMode configures archive_mode in postgresql.auto.conf for pgbackrest
 // This must be called after InitDataDir but BEFORE starting PostgreSQL
 func (pm *MultiPoolerManager) configureArchiveMode(ctx context.Context) error {
-	configPath, err := pm.initPgBackRest(NotForBackup)
+	configPath, err := pm.initPgBackRest(ctx, NotForBackup)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to initialize pgbackrest")
 	}
@@ -547,7 +547,7 @@ archive_command = 'pgbackrest --stanza=%s --config=%s archive-push %%p'
 // initializePgBackRestStanza initializes the pgbackrest stanza
 // This must be called after PostgreSQL is initialized and running
 func (pm *MultiPoolerManager) initializePgBackRestStanza(ctx context.Context) error {
-	configPath, err := pm.initPgBackRest(NotForBackup)
+	configPath, err := pm.initPgBackRest(ctx, NotForBackup)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to initialize pgbackrest")
 	}

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -562,7 +562,9 @@ type MultiPooler struct {
 	// Fully qualified domain name of the host.
 	Hostname string `protobuf:"bytes,8,opt,name=hostname,proto3" json:"hostname,omitempty"`
 	// Map of named ports. These are ports that the pooler exposes. Initially, this will only be gRPC
-	PortMap       map[string]int32 `protobuf:"bytes,9,rep,name=port_map,json=portMap,proto3" json:"port_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	PortMap map[string]int32 `protobuf:"bytes,9,rep,name=port_map,json=portMap,proto3" json:"port_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	// PoolerDir is used by pgBackRest to compute the primary's data directory.
+	PoolerDir     string `protobuf:"bytes,10,opt,name=pooler_dir,json=poolerDir,proto3" json:"pooler_dir,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -658,6 +660,13 @@ func (x *MultiPooler) GetPortMap() map[string]int32 {
 		return x.PortMap
 	}
 	return nil
+}
+
+func (x *MultiPooler) GetPoolerDir() string {
+	if x != nil {
+		return x.PoolerDir
+	}
+	return ""
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -1094,7 +1103,7 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12'\n" +
 	"\x0fbackup_location\x18\x02 \x01(\tR\x0ebackupLocation\x12+\n" +
 	"\x11durability_policy\x18\x03 \x01(\tR\x10durabilityPolicy\x12\x14\n" +
-	"\x05cells\x18\x04 \x03(\tR\x05cells\"\xd9\x03\n" +
+	"\x05cells\x18\x04 \x03(\tR\x05cells\"\xf8\x03\n" +
 	"\vMultiPooler\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x1a\n" +
 	"\bdatabase\x18\x02 \x01(\tR\bdatabase\x12\x1f\n" +
@@ -1105,7 +1114,10 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x04type\x18\x06 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\x04type\x12K\n" +
 	"\x0eserving_status\x18\a \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12\x1a\n" +
 	"\bhostname\x18\b \x01(\tR\bhostname\x12D\n" +
-	"\bport_map\x18\t \x03(\v2).clustermetadata.MultiPooler.PortMapEntryR\aportMap\x1a:\n" +
+	"\bport_map\x18\t \x03(\v2).clustermetadata.MultiPooler.PortMapEntryR\aportMap\x12\x1d\n" +
+	"\n" +
+	"pooler_dir\x18\n" +
+	" \x01(\tR\tpoolerDir\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xd2\x01\n" +

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -107,6 +107,8 @@ message MultiPooler {
   // Map of named ports. These are ports that the pooler exposes. Initially, this will only be gRPC
   map<string, int32> port_map = 9;
 
+  // PoolerDir is used by pgBackRest to compute the primary's data directory.
+  string pooler_dir = 10;
 
 }
 


### PR DESCRIPTION
We now populate the pgbackrest server port and the pooler dir for multipoolers into topo. This info is fetched by backup to populate the pgbackrest config.