### PR TITLE
refactor(multiadmin): propagate context to Init and remove nolint

### DIFF
--- a/go/cmd/multiadmin/main.go
+++ b/go/cmd/multiadmin/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 
@@ -39,7 +40,7 @@ func CreateMultiAdminCommand() (*cobra.Command, *multiadmin.MultiAdmin) {
 			return ma.CobraPreRunE(cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(ma)
+			return run(cmd.Context(), ma)
 		},
 	}
 
@@ -57,8 +58,8 @@ func main() {
 	}
 }
 
-func run(ma *multiadmin.MultiAdmin) error {
-	if err := ma.Init(); err != nil {
+func run(ctx context.Context, ma *multiadmin.MultiAdmin) error {
+	if err := ma.Init(ctx); err != nil {
 		return err
 	}
 	return ma.RunDefault()


### PR DESCRIPTION
Pass context from Cobra command through to Init(), replacing context.Background() with the propagated context. The grpc-gateway generated code doesn't actually use the ctx parameter (handlers derive context from req.Context()), but this follows context propagation best practices and removes a nolint suppression.