### PR TITLE
fix(kind_demo): bypass DNS for load testing to prevent resolution errors

### DIFF
--- a/kind_demo/k8s-multigateway.yaml
+++ b/kind_demo/k8s-multigateway.yaml
@@ -62,6 +62,8 @@ kind: Service
 metadata:
   name: multigateway
 spec:
+  # Fixed ClusterIP for load testing to bypass DNS
+  clusterIP: 10.96.100.1
   selector:
     app: multigateway
   ports:

--- a/kind_demo/k8s-supafirehose-init.yaml
+++ b/kind_demo/k8s-supafirehose-init.yaml
@@ -28,6 +28,10 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      hostAliases:
+        - ip: "10.96.100.1"
+          hostnames:
+            - "multigateway"
       containers:
         - name: init
           image: postgres:15-alpine

--- a/kind_demo/k8s-supafirehose.yaml
+++ b/kind_demo/k8s-supafirehose.yaml
@@ -14,6 +14,12 @@ spec:
       labels:
         app: supafirehose
     spec:
+      # Bypass DNS for multigateway - resolve via /etc/hosts instead
+      # This uses the ClusterIP service IP which is stable
+      hostAliases:
+        - ip: "10.96.100.1"
+          hostnames:
+            - "multigateway"
       containers:
         - name: supafirehose
           image: supafirehose:latest

--- a/kind_demo/launch.sh
+++ b/kind_demo/launch.sh
@@ -29,6 +29,15 @@ fi
 
 # Initialize the cluster with etcd
 kind create cluster --config=kind.yaml --name=multidemo
+
+# Increase limits on all Kind nodes for high-connection workloads
+for node in $(kind get nodes --name=multidemo); do
+  docker exec "$node" sh -c "sysctl -w fs.file-max=2097152"
+  docker exec "$node" sh -c "sysctl -w fs.nr_open=2097152"
+  docker exec "$node" sh -c "sysctl -w net.core.somaxconn=65535"
+  docker exec "$node" sh -c "sysctl -w net.ipv4.ip_local_port_range='1024 65535'"
+done
+
 kind load docker-image multigres/multigres multigres/pgctld-postgres multigres/multiadmin-web --name=multidemo
 # This single etcd will be used for both the global topo and cell topo.
 kubectl apply -f k8s-etcd.yaml


### PR DESCRIPTION
### Summary
- Add fixed ClusterIP (`10.96.100.1`) to multigateway service for predictable addressing
- Add `hostAliases` to supafirehose pods to resolve multigateway via `/etc/hosts` instead of DNS
- Add sysctl tuning on Kind nodes for high-connection workloads

### Problem
Under high load, supafirehose was failing with DNS resolution errors: `lookup multigateway on 10.96.0.10:53: dial udp: connect: resource temporarily unavailable`
CoreDNS was getting overwhelmed by the volume of DNS lookups. By using a fixed ClusterIP and hostAliases, we bypass DNS entirely for the load testing path.