### PR TITLE
fix(kind): fix admin proxy 502 errors by using POD_IP for hostname

### DIFF
--- a/kind_demo/k8s-multigateway.yaml
+++ b/kind_demo/k8s-multigateway.yaml
@@ -24,11 +24,19 @@ spec:
             - --http-port=15000
             - --grpc-port=15100
             - --pg-port=15432
+            # Use POD_IP as hostname since pod hostnames are not DNS-resolvable
+            # in Deployments (unlike StatefulSets). This allows the admin proxy
+            # to connect to individual gateway instances.
+            - --hostname=$(POD_IP)
             - --topo-global-server-addresses=etcd:2379
             - --topo-global-root=/multigres/test/global
             - --cell=zone1
             - --pprof-http=true
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: OTEL_SERVICE_NAME
               value: "multigateway"
           envFrom:

--- a/kind_demo/k8s-multiorch.yaml
+++ b/kind_demo/k8s-multiorch.yaml
@@ -23,6 +23,10 @@ spec:
           args:
             - --http-port=17000
             - --grpc-port=17100
+            # Use POD_IP as hostname since pod hostnames are not DNS-resolvable
+            # in Deployments (unlike StatefulSets). This allows the admin proxy
+            # to connect to individual orch instances.
+            - --hostname=$(POD_IP)
             - --topo-global-server-addresses=etcd:2379
             - --topo-global-root=/multigres/test/global
             - --cell=zone1
@@ -32,6 +36,10 @@ spec:
             - --recovery-cycle-interval=500ms
             - --pprof-http=true
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: OTEL_SERVICE_NAME
               value: "multiorch"
           envFrom:


### PR DESCRIPTION
The admin proxy was failing to connect to multigateway and multiorch instances because pod hostnames are not DNS-resolvable in Kubernetes Deployments. Configure services to register using their pod IP instead via --hostname=$(POD_IP).