### PR TITLE
feat(webadmin): better animations during failures in the topo

### DIFF
--- a/web/multiadmin/components/topology-graph.css
+++ b/web/multiadmin/components/topology-graph.css
@@ -9,7 +9,6 @@
 }
 
 .disconnected-node {
-  position: relative !important;
   border: none !important;
 }
 

--- a/web/multiadmin/lib/api/client.ts
+++ b/web/multiadmin/lib/api/client.ts
@@ -38,20 +38,35 @@ export class MultiAdminClient {
     options?: RequestInit
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-      },
-    });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new ApiError(response.status, errorText, url);
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new ApiError(response.status, errorText, url);
+      }
+
+      return response.json();
+    } catch (error) {
+      // If already an ApiError, rethrow it
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      // Network error or other fetch failure
+      throw new ApiError(
+        0,
+        error instanceof Error ? error.message : "Network request failed",
+        url
+      );
     }
-
-    return response.json();
   }
 
   // Cell operations


### PR DESCRIPTION
# Desc
- Minor tweaks to UI such that clusters that are in a unhealthy state, are displayed correctly.

# Screenshots
1) Primary Down 

<img width="373" height="310" alt="image" src="https://github.com/user-attachments/assets/ace362fb-e278-423b-bf70-c0205f6626e0" />

2) One replica down:
<img width="347" height="267" alt="image" src="https://github.com/user-attachments/assets/5661ca0b-2258-47f9-829c-8c6be6b2661c" />

3) Cluster recovered / old dead primary still around
<img width="652" height="487" alt="image" src="https://github.com/user-attachments/assets/98e16688-44e4-40b8-9a13-b15bd8b0320b" />
