### PR TITLE
feat(telemetry): add more resource attributes for service identification

### DIFF
--- a/go/common/servenv/servenv.go
+++ b/go/common/servenv/servenv.go
@@ -47,6 +47,18 @@ type ServiceIdentity struct {
 
 	// Cell is the availability zone/cell this service runs in.
 	Cell string
+
+	// Shard is the shard range this service handles (multipooler-specific).
+	// Example: "0-inf"
+	Shard string
+
+	// Database is the PostgreSQL database this service manages (multipooler-specific).
+	// Example: "postgres"
+	Database string
+
+	// TableGroup is the table group this service handles (multipooler-specific).
+	// Example: "default"
+	TableGroup string
 }
 
 // GenerateRandomServiceID generates a random 8-character service instance ID.

--- a/go/common/servenv/servenv_unix.go
+++ b/go/common/servenv/servenv_unix.go
@@ -54,6 +54,16 @@ func (sv *ServEnv) Init(id ServiceIdentity) error {
 	if id.Cell != "" {
 		attrs = append(attrs, semconv.CloudAvailabilityZone(id.Cell))
 	}
+	// Add multigres-specific resource attributes (multipooler only)
+	if id.Shard != "" {
+		attrs = append(attrs, attribute.String("multigres.shard", id.Shard))
+	}
+	if id.Database != "" {
+		attrs = append(attrs, attribute.String("multigres.database", id.Database))
+	}
+	if id.TableGroup != "" {
+		attrs = append(attrs, attribute.String("multigres.tablegroup", id.TableGroup))
+	}
 
 	// Initialize OpenTelemetry with service identity attributes
 	if err := sv.telemetry.InitTelemetry(context.TODO(), id.ServiceName, attrs...); err != nil {

--- a/go/multipooler/init.go
+++ b/go/multipooler/init.go
@@ -236,6 +236,9 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 		ServiceName:       constants.ServiceMultipooler,
 		ServiceInstanceID: serviceID,
 		Cell:              cell,
+		Shard:             mp.shard.Get(),
+		Database:          mp.database.Get(),
+		TableGroup:        mp.tableGroup.Get(),
 	}); err != nil {
 		return fmt.Errorf("servenv init: %w", err)
 	}

--- a/kind_demo/k8s-multipooler-statefulset.yaml
+++ b/kind_demo/k8s-multipooler-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - --database=postgres
             - --table-group=default
             - --shard=0-inf
-            - --service-id=$(POD_INDEX)
+            - --service-id=multipooler-$(MT_CELL)-$(POD_INDEX)
             - --pooler-dir=/data
             - --pgctld-addr=localhost:16200
             - --pg-port=5432
@@ -160,6 +160,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: MT_CELL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['cell']
             - name: OTEL_SERVICE_NAME
               value: "multipooler"
           envFrom:


### PR DESCRIPTION
Changes:
- Change K8s multipooler service.instance.id from "0"/"1"/"2" to "multipooler-zone1-0" format
- Add custom multigres.* resource attributes: shard, database, tablegroup
- Extend ServiceIdentity struct with multipooler-specific fields

K8s StatefulSet changes:
- Add MT_CELL environment variable from cell label
- Update --service-id flag to use "multipooler-$(MT_CELL)-$(POD_INDEX)" pattern

This provides deployment-agnostic service identification that works consistently across K8s and local provisioner deployments. Resource attributes now include:
- service.name: "multipooler"
- service.instance.id: "multipooler-zone1-0" (K8s) or "pbjbl5pp" (local)
- cloud.availability_zone: "zone1"
- (NEW) multigres.shard: "0-inf"
- (NEW) multigres.database: "postgres"
- (NEW) multigres.tablegroup: "default"