### PR TITLE
build: adjust image name definition to remove stutter

### DIFF
--- a/.github/workflows/docker-build-pgctld.yml
+++ b/.github/workflows/docker-build-pgctld.yml
@@ -54,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ghcr.io/${{ github.repository }}/pgctld
+          images: ghcr.io/${{ github.repository_owner }}/pgctld
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/multigres
           # PR event reference is explicitly three, as Docker build could take
           # place for each PR updates in the future.
           tags: |


### PR DESCRIPTION
Before this change the images were named:

```
ghcr.io/multigres/multigres:main
ghcr.io/multigres/multigres/pgctld:main
```

With this change, `pgctld` would be updated:

```
ghcr.io/multigres/multigres:main
ghcr.io/multigres/pgctld:main
```

Note that the new pgctld will be a new package, and would require some visibility adjustments.