### PR TITLE
feat(multipooler): add OpenTelemetry connection pool metrics

### DIFF
--- a/go/multipooler/connpoolmanager/config.go
+++ b/go/multipooler/connpoolmanager/config.go
@@ -15,6 +15,7 @@
 package connpoolmanager
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -302,9 +303,16 @@ func (c *Config) SettingsCacheSize() int {
 // NewManager creates a new connection pool manager from this config.
 // Call this after flags have been parsed and when you're ready to create the manager.
 // The manager starts in a closed state; call Open() before using it.
-func (c *Config) NewManager() *Manager {
+func (c *Config) NewManager(logger *slog.Logger) *Manager {
+	metrics, err := NewMetrics()
+	if err != nil {
+		logger.Warn("failed to initialize some connection pool metrics (using noop fallbacks)", "error", err)
+	}
+
 	return &Manager{
-		config: c,
-		closed: true, // Manager is closed until Open() is called
+		config:  c,
+		logger:  logger,
+		metrics: metrics,
+		closed:  true, // Manager is closed until Open() is called
 	}
 }

--- a/go/multipooler/connpoolmanager/config_test.go
+++ b/go/multipooler/connpoolmanager/config_test.go
@@ -15,6 +15,7 @@
 package connpoolmanager
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -134,7 +135,7 @@ func TestConfig_NewManager(t *testing.T) {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
 
-	manager := config.NewManager()
+	manager := config.NewManager(slog.Default())
 
 	require.NotNil(t, manager)
 	assert.Equal(t, config, manager.config)

--- a/go/multipooler/connpoolmanager/interface.go
+++ b/go/multipooler/connpoolmanager/interface.go
@@ -16,7 +16,6 @@ package connpoolmanager
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/multigres/multigres/go/multipooler/pools/admin"
 	"github.com/multigres/multigres/go/multipooler/pools/regular"
@@ -41,7 +40,7 @@ type PoolManager interface {
 	// Open initializes all connection pools with the given connection configuration.
 	// Connection settings (socket file, host, port, database) come from connConfig,
 	// while credentials are managed internally via viper flags.
-	Open(ctx context.Context, logger *slog.Logger, connConfig *ConnectionConfig)
+	Open(ctx context.Context, connConfig *ConnectionConfig)
 
 	// Close shuts down all connection pools.
 	Close()

--- a/go/multipooler/connpoolmanager/manager.go
+++ b/go/multipooler/connpoolmanager/manager.go
@@ -38,8 +38,8 @@ import (
 //	cfg := connpoolmanager.NewConfig(reg)
 //	cfg.RegisterFlags(cmd.Flags())
 //	// ... parse flags ...
-//	mgr := cfg.NewManager()
-//	mgr.Open(ctx, logger, connConfig)
+//	mgr := cfg.NewManager(logger)
+//	mgr.Open(ctx, connConfig)
 //	defer mgr.Close()
 //
 //	// Get connections as needed
@@ -53,6 +53,7 @@ type Manager struct {
 
 	adminPool     *admin.Pool              // Shared admin pool for kill operations
 	settingsCache *connstate.SettingsCache // Shared settings cache for all users
+	metrics       *Metrics                 // OpenTelemetry metrics
 
 	mu        sync.Mutex
 	userPools map[string]*UserPool // Per-user connection pools
@@ -64,16 +65,11 @@ type Manager struct {
 //
 // Parameters:
 //   - ctx: Context for pool operations
-//   - logger: Logger for pool operations (uses slog.Default() if nil)
 //   - connConfig: Connection settings (socket file, host, port, database)
-func (m *Manager) Open(ctx context.Context, logger *slog.Logger, connConfig *ConnectionConfig) {
+func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if logger == nil {
-		logger = slog.Default()
-	}
-	m.logger = logger
 	m.connConfig = connConfig
 	m.userPools = make(map[string]*UserPool)
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
@@ -84,16 +80,17 @@ func (m *Manager) Open(ctx context.Context, logger *slog.Logger, connConfig *Con
 
 	// Build admin pool config
 	adminPoolConfig := &connpool.Config{
+		Name:     "admin",
 		Capacity: m.config.AdminCapacity(),
 		Logger:   m.logger,
 	}
 
 	// Create shared admin pool (used by all user pools for kill operations)
-	m.adminPool = admin.NewPool(&admin.PoolConfig{
+	m.adminPool = admin.NewPool(ctx, &admin.PoolConfig{
 		ClientConfig:   adminClientConfig,
 		ConnPoolConfig: adminPoolConfig,
 	})
-	m.adminPool.Open(ctx)
+	m.adminPool.Open()
 
 	m.logger.InfoContext(ctx, "connection pool manager opened",
 		"admin_user", m.config.AdminUser(),
@@ -143,23 +140,29 @@ func (m *Manager) getOrCreateUserPool(ctx context.Context, user string) (*UserPo
 		return nil, fmt.Errorf("maximum number of user pools (%d) reached", maxUsers)
 	}
 
-	// Create new user pool
+	// Create new user pool with per-user pool names for metric cardinality.
+	// Note: Including username in pool names enables per-user monitoring but increases
+	// metric cardinality. If this becomes an issue with many users, we can make it configurable.
 	pool := NewUserPool(ctx, &UserPoolConfig{
 		ClientConfig: m.buildClientConfig(user, ""), // Trust auth - no password
 		AdminPool:    m.adminPool,
 		RegularPoolConfig: &connpool.Config{
-			Capacity:     m.config.UserRegularCapacity(),
-			MaxIdleCount: m.config.UserRegularMaxIdle(),
-			IdleTimeout:  m.config.UserRegularIdleTimeout(),
-			MaxLifetime:  m.config.UserRegularMaxLifetime(),
-			Logger:       m.logger,
+			Name:            fmt.Sprintf("regular:%s", user),
+			Capacity:        m.config.UserRegularCapacity(),
+			MaxIdleCount:    m.config.UserRegularMaxIdle(),
+			IdleTimeout:     m.config.UserRegularIdleTimeout(),
+			MaxLifetime:     m.config.UserRegularMaxLifetime(),
+			ConnectionCount: m.metrics.RegularConnCount(),
+			Logger:          m.logger,
 		},
 		ReservedPoolConfig: &connpool.Config{
-			Capacity:     m.config.UserReservedCapacity(),
-			MaxIdleCount: m.config.UserReservedMaxIdle(),
-			IdleTimeout:  m.config.UserReservedIdleTimeout(),
-			MaxLifetime:  m.config.UserReservedMaxLifetime(),
-			Logger:       m.logger,
+			Name:            fmt.Sprintf("reserved:%s", user),
+			Capacity:        m.config.UserReservedCapacity(),
+			MaxIdleCount:    m.config.UserReservedMaxIdle(),
+			IdleTimeout:     m.config.UserReservedIdleTimeout(),
+			MaxLifetime:     m.config.UserReservedMaxLifetime(),
+			ConnectionCount: m.metrics.ReservedConnCount(),
+			Logger:          m.logger,
 		},
 		ReservedInactivityTimeout: m.config.UserReservedInactivityTimeout(),
 		Logger:                    m.logger,

--- a/go/multipooler/connpoolmanager/manager_test.go
+++ b/go/multipooler/connpoolmanager/manager_test.go
@@ -16,6 +16,7 @@ package connpoolmanager
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 
@@ -36,8 +37,8 @@ func newTestManager(t *testing.T, server *fakepgserver.Server) *Manager {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
 
-	manager := config.NewManager()
-	manager.Open(context.Background(), nil, &ConnectionConfig{
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &ConnectionConfig{
 		SocketFile: server.ClientConfig().SocketFile,
 		Host:       server.ClientConfig().Host,
 		Port:       server.ClientConfig().Port,

--- a/go/multipooler/connpoolmanager/metrics.go
+++ b/go/multipooler/connpoolmanager/metrics.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/multigres/multigres/go/multipooler/pools/connpool"
+)
+
+// Metrics holds OpenTelemetry metrics for connection pool management.
+type Metrics struct {
+	// regularConnCount tracks PostgreSQL connection states for regular pools
+	regularConnCount connpool.ConnectionCount
+
+	// reservedConnCount tracks PostgreSQL connection states for reserved pools
+	reservedConnCount connpool.ConnectionCount
+}
+
+// NewMetrics initializes OpenTelemetry metrics for connection pool management.
+// Individual metrics that fail to initialize will use noop implementations and be included
+// in the returned error. The returned Metrics instance is always usable (with noop fallbacks
+// for failed metrics), and the error indicates which specific metrics failed to initialize.
+func NewMetrics() (*Metrics, error) {
+	meter := otel.Meter("github.com/multigres/multigres/go/multipooler/connpoolmanager")
+
+	m := &Metrics{}
+
+	var errs []error
+
+	// ConnectionCount for regular pools
+	regularCount, err := connpool.NewConnectionCount(meter)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("regular pool ConnectionCount: %w", err))
+		m.regularConnCount = connpool.ConnectionCount{} // Use zero value (noop) on error
+	} else {
+		m.regularConnCount = regularCount
+	}
+
+	// ConnectionCount for reserved pools
+	reservedCount, err := connpool.NewConnectionCount(meter)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("reserved pool ConnectionCount: %w", err))
+		m.reservedConnCount = connpool.ConnectionCount{} // Use zero value (noop) on error
+	} else {
+		m.reservedConnCount = reservedCount
+	}
+
+	if len(errs) > 0 {
+		return m, errors.Join(errs...)
+	}
+
+	return m, nil
+}
+
+// RegularConnCount returns the ConnectionCount metric for regular pools.
+func (m *Metrics) RegularConnCount() connpool.ConnectionCount {
+	return m.regularConnCount
+}
+
+// ReservedConnCount returns the ConnectionCount metric for reserved pools.
+func (m *Metrics) ReservedConnCount() connpool.ConnectionCount {
+	return m.reservedConnCount
+}

--- a/go/multipooler/connpoolmanager/user_pool.go
+++ b/go/multipooler/connpoolmanager/user_pool.go
@@ -76,12 +76,12 @@ func NewUserPool(ctx context.Context, config *UserPoolConfig) *UserPool {
 	logger = logger.With("user", config.ClientConfig.User)
 
 	// Create regular pool for this user
-	regularPool := regular.NewPool(&regular.PoolConfig{
+	regularPool := regular.NewPool(ctx, &regular.PoolConfig{
 		ClientConfig:   config.ClientConfig,
 		ConnPoolConfig: config.RegularPoolConfig,
 		AdminPool:      config.AdminPool,
 	})
-	regularPool.Open(ctx)
+	regularPool.Open()
 
 	// Create reserved pool for this user (it manages its own internal regular pool)
 	// InactivityTimeout kills reserved connections if the client that reserved them

--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -194,7 +194,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, config *Config, loadT
 	// Create connection pool manager from config
 	var connPoolMgr connpoolmanager.PoolManager
 	if config.ConnPoolConfig != nil {
-		connPoolMgr = config.ConnPoolConfig.NewManager()
+		connPoolMgr = config.ConnPoolConfig.NewManager(logger)
 	}
 
 	pm := &MultiPoolerManager{
@@ -292,7 +292,7 @@ func (pm *MultiPoolerManager) Open() error {
 			Port:       pm.config.PgPort,
 			Database:   pm.config.Database,
 		}
-		pm.connPoolMgr.Open(pm.ctx, pm.logger, connConfig)
+		pm.connPoolMgr.Open(pm.ctx, connConfig)
 		pm.logger.Info("Connection pool manager opened")
 	}
 

--- a/go/multipooler/pools/admin/admin_pool.go
+++ b/go/multipooler/pools/admin/admin_pool.go
@@ -46,9 +46,10 @@ type Pool struct {
 }
 
 // NewPool creates a new admin connection pool.
-func NewPool(config *PoolConfig) *Pool {
-	pool := connpool.NewPool[*Conn](config.ConnPoolConfig)
-	pool.Name = "admin"
+// The context is used for background pool operations and OTel tracking.
+// The pool must be opened with Open() before use.
+func NewPool(ctx context.Context, config *PoolConfig) *Pool {
+	pool := connpool.NewPool[*Conn](ctx, config.ConnPoolConfig)
 
 	return &Pool{
 		pool:   pool,
@@ -58,7 +59,7 @@ func NewPool(config *PoolConfig) *Pool {
 
 // Open opens the pool and starts background workers.
 // Must be called before using the pool.
-func (p *Pool) Open(ctx context.Context) {
+func (p *Pool) Open() {
 	connector := func(ctx context.Context) (*Conn, error) {
 		conn, err := client.Connect(ctx, p.config.ClientConfig)
 		if err != nil {
@@ -67,7 +68,7 @@ func (p *Pool) Open(ctx context.Context) {
 		return NewConn(conn), nil
 	}
 
-	p.pool.Open(ctx, connector, nil)
+	p.pool.Open(connector, nil)
 }
 
 // Get acquires an admin connection from the pool.

--- a/go/multipooler/pools/admin/admin_test.go
+++ b/go/multipooler/pools/admin/admin_test.go
@@ -26,14 +26,14 @@ import (
 )
 
 func newTestPool(_ *testing.T, server *fakepgserver.Server) *Pool {
-	pool := NewPool(&PoolConfig{
+	pool := NewPool(context.Background(), &PoolConfig{
 		ClientConfig: server.ClientConfig(),
 		ConnPoolConfig: &connpool.Config{
 			Capacity:     2,
 			MaxIdleCount: 2,
 		},
 	})
-	pool.Open(context.Background())
+	pool.Open()
 	return pool
 }
 

--- a/go/multipooler/pools/connpool/metrics.go
+++ b/go/multipooler/pools/connpool/metrics.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpool
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/semconv/v1.37.0/dbconv"
+)
+
+// Attribute keys from OTel semantic conventions:
+// - semconv.DBClientConnectionPoolNameKey = "db.client.connection.pool.name"
+// - semconv.DBClientConnectionStateKey = "db.client.connection.state"
+const (
+	attrKeyPoolName = "db.client.connection.pool.name"
+	attrKeyState    = "db.client.connection.state"
+)
+
+// ConnectionCount wraps an Int64UpDownCounter for tracking connection counts by state.
+// This is a workaround for a bug in dbconv.ClientConnectionCount where pool name and
+// state attributes aren't added when no extra attributes are provided.
+// Consider contributing a fix upstream to opentelemetry-go/semconv/v1.37.0/dbconv.
+type ConnectionCount struct {
+	counter metric.Int64UpDownCounter
+}
+
+// NewConnectionCount creates a ConnectionCount instrument using the standard
+// db.client.connection.count metric name and description from OTel semconv.
+func NewConnectionCount(m metric.Meter) (ConnectionCount, error) {
+	// Metric name and description from dbconv.ClientConnectionCount
+	counter, err := m.Int64UpDownCounter(
+		"db.client.connection.count",
+		metric.WithDescription("The number of connections that are currently in state described by the state attribute."),
+		metric.WithUnit("{connection}"),
+	)
+	return ConnectionCount{counter: counter}, err
+}
+
+// Add records a connection count change for the given pool and state.
+func (c ConnectionCount) Add(ctx context.Context, delta int64, poolName string, state dbconv.ClientConnectionStateAttr) {
+	if c.counter == nil {
+		return
+	}
+	c.counter.Add(ctx, delta, metric.WithAttributes(
+		attribute.String(attrKeyPoolName, poolName),
+		attribute.String(attrKeyState, string(state)),
+	))
+}

--- a/go/multipooler/pools/connpool/otel_test.go
+++ b/go/multipooler/pools/connpool/otel_test.go
@@ -1,0 +1,305 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/multigres/multigres/go/tools/telemetry"
+)
+
+// getConnectionCountMetric extracts the db.client.connection.count metric data.
+func getConnectionCountMetric(t *testing.T, reader *sdkmetric.ManualReader) *metricdata.Sum[int64] {
+	t.Helper()
+
+	var metricData metricdata.ResourceMetrics
+	err := reader.Collect(t.Context(), &metricData)
+	require.NoError(t, err)
+
+	for _, scopeMetric := range metricData.ScopeMetrics {
+		for _, m := range scopeMetric.Metrics {
+			if m.Name == "db.client.connection.count" {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, "expected Sum[int64] data type for db.client.connection.count")
+				return &sum
+			}
+		}
+	}
+	return nil
+}
+
+// getStateCount extracts the count for a specific pool name and state from the metric data.
+func getStateCount(sum *metricdata.Sum[int64], poolName, state string) int64 {
+	if sum == nil {
+		return 0
+	}
+	for _, dp := range sum.DataPoints {
+		var dpPoolName, dpState string
+		for _, attr := range dp.Attributes.ToSlice() {
+			if string(attr.Key) == attrKeyPoolName {
+				dpPoolName = attr.Value.AsString()
+			}
+			if string(attr.Key) == attrKeyState {
+				dpState = attr.Value.AsString()
+			}
+		}
+		if dpPoolName == poolName && dpState == state {
+			return dp.Value
+		}
+	}
+	return 0
+}
+
+func TestOTelConnectionCount_GetAndRecycle(t *testing.T) {
+	setup := telemetry.SetupTestTelemetry(t)
+
+	ctx := t.Context()
+	err := setup.Telemetry.InitTelemetry(ctx, "test-service")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+
+	meter := setup.Telemetry.GetMeterProvider().Meter("test")
+	connCount, err := NewConnectionCount(meter)
+	require.NoError(t, err)
+
+	pool := NewPool[*mockConnection](ctx, &Config{
+		Name:            "test-pool",
+		Capacity:        2,
+		MaxIdleCount:    2,
+		ConnectionCount: connCount,
+	})
+	pool.Open(func(ctx context.Context) (*mockConnection, error) {
+		return newMockConnection(), nil
+	}, nil)
+	defer pool.Close()
+
+	// Initially, no connections exist
+	sum := getConnectionCountMetric(t, setup.MetricReader)
+	assert.Nil(t, sum, "should have no metrics before any connections")
+
+	// Get a connection - should be used=1, idle=0 (new connection, never went to idle)
+	conn1, err := pool.Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conn1)
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	require.NotNil(t, sum, "should have metrics after Get")
+	assert.Equal(t, int64(1), getStateCount(sum, "test-pool", "used"), "used should be 1 after Get")
+	assert.Equal(t, int64(0), getStateCount(sum, "test-pool", "idle"), "idle should be 0 (new connection never idled)")
+
+	// Recycle the connection - should be used=0, idle=1
+	conn1.Recycle()
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "test-pool", "used"), "used should be 0 after Recycle")
+	assert.Equal(t, int64(1), getStateCount(sum, "test-pool", "idle"), "idle should be 1 after Recycle")
+
+	// Get the same connection again - should be used=1, idle=0
+	conn2, err := pool.Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, conn2)
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(1), getStateCount(sum, "test-pool", "used"), "used should be 1 after second Get")
+	assert.Equal(t, int64(0), getStateCount(sum, "test-pool", "idle"), "idle should be 0 after second Get")
+
+	// Recycle again
+	conn2.Recycle()
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "test-pool", "used"), "used should be 0 after second Recycle")
+	assert.Equal(t, int64(1), getStateCount(sum, "test-pool", "idle"), "idle should be 1 after second Recycle")
+}
+
+func TestOTelConnectionCount_MultipleConnections(t *testing.T) {
+	setup := telemetry.SetupTestTelemetry(t)
+
+	ctx := t.Context()
+	err := setup.Telemetry.InitTelemetry(ctx, "test-service")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+
+	meter := setup.Telemetry.GetMeterProvider().Meter("test")
+	connCount, err := NewConnectionCount(meter)
+	require.NoError(t, err)
+
+	pool := NewPool[*mockConnection](ctx, &Config{
+		Name:            "multi-pool",
+		Capacity:        5,
+		MaxIdleCount:    5,
+		ConnectionCount: connCount,
+	})
+	pool.Open(func(ctx context.Context) (*mockConnection, error) {
+		return newMockConnection(), nil
+	}, nil)
+	defer pool.Close()
+
+	// Get 3 connections
+	conn1, err := pool.Get(ctx)
+	require.NoError(t, err)
+	conn2, err := pool.Get(ctx)
+	require.NoError(t, err)
+	conn3, err := pool.Get(ctx)
+	require.NoError(t, err)
+
+	sum := getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(3), getStateCount(sum, "multi-pool", "used"), "used should be 3 after 3 Gets")
+	assert.Equal(t, int64(0), getStateCount(sum, "multi-pool", "idle"), "idle should be 0")
+
+	// Return 2 connections
+	conn1.Recycle()
+	conn2.Recycle()
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(1), getStateCount(sum, "multi-pool", "used"), "used should be 1 after returning 2")
+	assert.Equal(t, int64(2), getStateCount(sum, "multi-pool", "idle"), "idle should be 2 after returning 2")
+
+	// Return last connection
+	conn3.Recycle()
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "multi-pool", "used"), "used should be 0 after returning all")
+	assert.Equal(t, int64(3), getStateCount(sum, "multi-pool", "idle"), "idle should be 3 after returning all")
+}
+
+func TestOTelConnectionCount_WaiterHandoff(t *testing.T) {
+	setup := telemetry.SetupTestTelemetry(t)
+
+	ctx := t.Context()
+	err := setup.Telemetry.InitTelemetry(ctx, "test-service")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+
+	meter := setup.Telemetry.GetMeterProvider().Meter("test")
+	connCount, err := NewConnectionCount(meter)
+	require.NoError(t, err)
+
+	// Pool with capacity 1 to force waiting
+	pool := NewPool[*mockConnection](ctx, &Config{
+		Name:            "waiter-pool",
+		Capacity:        1,
+		MaxIdleCount:    1,
+		ConnectionCount: connCount,
+	})
+	pool.Open(func(ctx context.Context) (*mockConnection, error) {
+		return newMockConnection(), nil
+	}, nil)
+	defer pool.Close()
+
+	// Get the only connection
+	conn1, err := pool.Get(ctx)
+	require.NoError(t, err)
+
+	sum := getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(1), getStateCount(sum, "waiter-pool", "used"), "used should be 1")
+
+	// Start a goroutine that will wait for a connection
+	gotConn := make(chan *Pooled[*mockConnection], 1)
+	go func() {
+		conn, err := pool.Get(ctx)
+		if err == nil {
+			gotConn <- conn
+		}
+	}()
+
+	// Give the waiter time to register
+	time.Sleep(50 * time.Millisecond)
+
+	// Return the connection - should go directly to the waiter
+	conn1.Recycle()
+
+	// Wait for the waiter to get the connection
+	var conn2 *Pooled[*mockConnection]
+	select {
+	case conn2 = <-gotConn:
+	case <-time.After(time.Second):
+		t.Fatal("waiter never got connection")
+	}
+
+	// Connection went directly from used -> used (waiter handoff)
+	// So used should still be 1, idle should be 0
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(1), getStateCount(sum, "waiter-pool", "used"), "used should be 1 (waiter handoff)")
+	assert.Equal(t, int64(0), getStateCount(sum, "waiter-pool", "idle"), "idle should be 0 (direct handoff)")
+
+	conn2.Recycle()
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "waiter-pool", "used"), "used should be 0 after final recycle")
+	assert.Equal(t, int64(1), getStateCount(sum, "waiter-pool", "idle"), "idle should be 1 after final recycle")
+}
+
+func TestOTelConnectionCount_SetCapacityReduction(t *testing.T) {
+	setup := telemetry.SetupTestTelemetry(t)
+
+	ctx := t.Context()
+	err := setup.Telemetry.InitTelemetry(ctx, "test-service")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+
+	meter := setup.Telemetry.GetMeterProvider().Meter("test")
+	connCount, err := NewConnectionCount(meter)
+	require.NoError(t, err)
+
+	pool := NewPool[*mockConnection](ctx, &Config{
+		Name:            "capacity-pool",
+		Capacity:        5,
+		MaxIdleCount:    5,
+		ConnectionCount: connCount,
+	})
+	pool.Open(func(ctx context.Context) (*mockConnection, error) {
+		return newMockConnection(), nil
+	}, nil)
+	defer pool.Close()
+
+	// Create 3 connections and return them to idle
+	conn1, err := pool.Get(ctx)
+	require.NoError(t, err)
+	conn2, err := pool.Get(ctx)
+	require.NoError(t, err)
+	conn3, err := pool.Get(ctx)
+	require.NoError(t, err)
+
+	conn1.Recycle()
+	conn2.Recycle()
+	conn3.Recycle()
+
+	sum := getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "capacity-pool", "used"), "used should be 0")
+	assert.Equal(t, int64(3), getStateCount(sum, "capacity-pool", "idle"), "idle should be 3")
+
+	// Reduce capacity to 1 - should close 2 idle connections
+	err = pool.SetCapacity(ctx, 1)
+	require.NoError(t, err)
+
+	sum = getConnectionCountMetric(t, setup.MetricReader)
+	assert.Equal(t, int64(0), getStateCount(sum, "capacity-pool", "used"), "used should still be 0")
+	assert.Equal(t, int64(1), getStateCount(sum, "capacity-pool", "idle"), "idle should be 1 after capacity reduction")
+}

--- a/go/multipooler/pools/connpool/pool_test.go
+++ b/go/multipooler/pools/connpool/pool_test.go
@@ -60,11 +60,12 @@ func (m *mockConnection) ResetSettings(ctx context.Context) error {
 }
 
 func newTestPool(capacity int64) *Pool[*mockConnection] {
-	pool := NewPool[*mockConnection](&Config{
+	pool := NewPool[*mockConnection](context.Background(), &Config{
+		Name:         "test",
 		Capacity:     capacity,
 		MaxIdleCount: capacity,
 	})
-	pool.Open(context.Background(), func(ctx context.Context) (*mockConnection, error) {
+	pool.Open(func(ctx context.Context) (*mockConnection, error) {
 		return newMockConnection(), nil
 	}, nil)
 	return pool

--- a/go/multipooler/pools/regular/pool_test.go
+++ b/go/multipooler/pools/regular/pool_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newTestPool(_ *testing.T, server *fakepgserver.Server) *Pool {
-	pool := NewPool(&PoolConfig{
+	pool := NewPool(context.Background(), &PoolConfig{
 		ClientConfig: server.ClientConfig(),
 		ConnPoolConfig: &connpool.Config{
 			Capacity:     2,
@@ -36,7 +36,7 @@ func newTestPool(_ *testing.T, server *fakepgserver.Server) *Pool {
 		},
 		AdminPool: nil, // Not needed for basic tests
 	})
-	pool.Open(context.Background())
+	pool.Open()
 	return pool
 }
 
@@ -162,7 +162,7 @@ func TestPool_InnerPool(t *testing.T) {
 
 	inner := pool.InnerPool()
 	require.NotNil(t, inner)
-	assert.Equal(t, "regular", inner.Name)
+	assert.Equal(t, "unnamed", inner.Name)
 }
 
 func TestConn_State(t *testing.T) {

--- a/go/multipooler/pools/reserved/reserved_pool.go
+++ b/go/multipooler/pools/reserved/reserved_pool.go
@@ -102,8 +102,8 @@ func NewPool(ctx context.Context, config *PoolConfig) *Pool {
 	poolCtx, cancel := context.WithCancel(ctx)
 
 	// Create the underlying regular pool.
-	regularPool := regular.NewPool(config.RegularPoolConfig)
-	regularPool.Open(ctx)
+	regularPool := regular.NewPool(ctx, config.RegularPoolConfig)
+	regularPool.Open()
 
 	p := &Pool{
 		config: config,

--- a/go/tools/telemetry/telemetry.go
+++ b/go/tools/telemetry/telemetry.go
@@ -58,6 +58,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -277,7 +278,7 @@ func (t *Telemetry) InitForCommand(cmd *cobra.Command, serviceName string, start
 	return span, nil
 }
 
-// GetTracerProvider returns the configured TracerProvider
+// GetTracerProvider returns the configured TracerProvider.
 func (t *Telemetry) GetTracerProvider() trace.TracerProvider {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -286,6 +287,17 @@ func (t *Telemetry) GetTracerProvider() trace.TracerProvider {
 		return otel.GetTracerProvider()
 	}
 	return t.tracerProvider
+}
+
+// GetMeterProvider returns the configured MeterProvider.
+func (t *Telemetry) GetMeterProvider() metric.MeterProvider {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.meterProvider == nil {
+		return otel.GetMeterProvider()
+	}
+	return t.meterProvider
 }
 
 // ShutdownTelemetry gracefully shuts down all telemetry providers

--- a/go/tools/telemetry/telemetry_test_helpers.go
+++ b/go/tools/telemetry/telemetry_test_helpers.go
@@ -25,13 +25,14 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
-// testTelemetrySetup holds test telemetry infrastructure
+// testTelemetrySetup holds test telemetry infrastructure.
 type testTelemetrySetup struct {
 	Telemetry    *Telemetry
 	SpanExporter *tracetest.InMemoryExporter
 	MetricReader *metric.ManualReader
 }
 
+// ForceFlush flushes both the tracer and meter providers.
 func (t *testTelemetrySetup) ForceFlush(ctx context.Context) error {
 	err := t.Telemetry.tracerProvider.ForceFlush(ctx)
 	if err != nil {


### PR DESCRIPTION
Implements the OpenTelemetry standard db.client.connection.count metric to track PostgreSQL connection pool health. Tracks connection states (idle/used) and provides per-user pool granularity for monitoring.

Changes:
- Add ConnectionCount metric wrapper in connpool package
- Wire up idle/used state tracking via stack callbacks
- Add per-user pool names in connection pool manager