### PR TITLE
feat(telemetry): add OpenTelemetry spans for query execution and subprocess calls

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -304,7 +304,7 @@ func (s *PgCtldService) Status(ctx context.Context, req *pb.StatusRequest) (*pb.
 	}
 
 	// Use the pre-configured PostgreSQL config for status operation
-	result, err := GetStatusWithResult(s.logger, s.config)
+	result, err := GetStatusWithResult(ctx, s.logger, s.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get status: %w", err)
 	}
@@ -343,7 +343,7 @@ func (s *PgCtldService) Status(ctx context.Context, req *pb.StatusRequest) (*pb.
 
 func (s *PgCtldService) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
 	s.logger.DebugContext(ctx, "gRPC Version request")
-	result, err := GetVersionWithResult(s.config)
+	result, err := GetVersionWithResult(ctx, s.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get version: %w", err)
 	}

--- a/go/cmd/pgctld/command/status.go
+++ b/go/cmd/pgctld/command/status.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/services/pgctld"
+	"github.com/multigres/multigres/go/tools/telemetry"
 
 	"github.com/spf13/cobra"
 )
@@ -91,7 +93,7 @@ Examples:
 }
 
 // GetStatusWithResult gets PostgreSQL status with the given configuration and returns detailed result information
-func GetStatusWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*StatusResult, error) {
+func GetStatusWithResult(ctx context.Context, logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*StatusResult, error) {
 	result := &StatusResult{
 		DataDir: config.PostgresDataDir,
 		Port:    config.Port,
@@ -112,14 +114,14 @@ func GetStatusWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig) 
 	if pid, err := readPostmasterPID(config.PostgresDataDir); err == nil {
 		result.PID = pid
 	} else {
-		logger.Warn("Could not read postmaster PID", "error", err)
+		logger.WarnContext(ctx, "Could not read postmaster PID", "error", err)
 	}
 
 	// Check if server is accepting connections
-	result.Ready = isServerReadyWithConfig(config)
+	result.Ready = isServerReadyWithConfig(ctx, config)
 
 	// Get server version if possible
-	result.Version = getServerVersionWithConfig(config)
+	result.Version = getServerVersionWithConfig(ctx, config)
 
 	// Get uptime (approximate based on pidfile mtime)
 	pidFile := filepath.Join(config.PostgresDataDir, "postmaster.pid")
@@ -137,7 +139,7 @@ func (s *PgCtlStatusCmd) runStatus(cmd *cobra.Command, args []string) error {
 	}
 	// No local flag overrides needed - all flags are global now
 
-	result, err := GetStatusWithResult(s.pgCtlCmd.lg.GetLogger(), config)
+	result, err := GetStatusWithResult(cmd.Context(), s.pgCtlCmd.lg.GetLogger(), config)
 	if err != nil {
 		return err
 	}
@@ -198,7 +200,7 @@ func formatUptime(seconds int64) string {
 	}
 }
 
-func isServerReadyWithConfig(config *pgctld.PostgresCtlConfig) bool {
+func isServerReadyWithConfig(ctx context.Context, config *pgctld.PostgresCtlConfig) bool {
 	// Use Unix socket connection for pg_isready
 	socketDir := pgctld.PostgresSocketDir(config.PoolerDir)
 	cmd := exec.Command("pg_isready",
@@ -208,10 +210,10 @@ func isServerReadyWithConfig(config *pgctld.PostgresCtlConfig) bool {
 		"-d", config.Database,
 	)
 
-	return cmd.Run() == nil
+	return telemetry.RunCmd(ctx, cmd, true) == nil
 }
 
-func getServerVersionWithConfig(config *pgctld.PostgresCtlConfig) string {
+func getServerVersionWithConfig(ctx context.Context, config *pgctld.PostgresCtlConfig) string {
 	// Use Unix socket connection for psql
 	socketDir := pgctld.PostgresSocketDir(config.PoolerDir)
 	cmd := exec.Command("psql",
@@ -222,7 +224,7 @@ func getServerVersionWithConfig(config *pgctld.PostgresCtlConfig) string {
 		"-t", "-c", "SELECT version()",
 	)
 
-	output, err := cmd.Output()
+	output, err := telemetry.RunCmdOutput(ctx, cmd, true)
 	if err != nil {
 		return ""
 	}

--- a/go/cmd/pgctld/command/status_test.go
+++ b/go/cmd/pgctld/command/status_test.go
@@ -154,7 +154,7 @@ func TestIsServerReady(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			result := isServerReadyWithConfig(config)
+			result := isServerReadyWithConfig(t.Context(), config)
 			assert.Equal(t, tt.isReady, result)
 		})
 	}
@@ -212,7 +212,7 @@ func TestGetServerVersion(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			result := getServerVersionWithConfig(config)
+			result := getServerVersionWithConfig(t.Context(), config)
 			if tt.expectedOutput != "" {
 				assert.Contains(t, result, tt.expectedOutput)
 			} else {

--- a/go/cmd/pgctld/command/version.go
+++ b/go/cmd/pgctld/command/version.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -71,11 +72,11 @@ Examples:
 }
 
 // GetVersionWithResult gets PostgreSQL server version information and returns detailed result information
-func GetVersionWithResult(config *pgctld.PostgresCtlConfig) (*VersionResult, error) {
+func GetVersionWithResult(ctx context.Context, config *pgctld.PostgresCtlConfig) (*VersionResult, error) {
 	result := &VersionResult{}
 
 	// Get server version using the same method as the gRPC service
-	version := getServerVersionWithConfig(config)
+	version := getServerVersionWithConfig(ctx, config)
 	if version == "" {
 		return nil, fmt.Errorf("failed to get server version - ensure PostgreSQL server is running and accessible")
 	}
@@ -93,7 +94,7 @@ func (v *PgCtlVersionCmd) runVersion(cmd *cobra.Command, args []string) error {
 
 	// No local flag overrides needed - all flags are global now
 
-	result, err := GetVersionWithResult(config)
+	result, err := GetVersionWithResult(cmd.Context(), config)
 	if err != nil {
 		return err
 	}

--- a/go/multipooler/executor/internal_query.go
+++ b/go/multipooler/executor/internal_query.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/pgprotocol/client"
 )
 
 // TODO: We might want to make this a configuration. For now its a constant.
@@ -44,7 +45,13 @@ var _ InternalQueryService = (*Executor)(nil)
 
 // Query implements InternalQueryService for simple internal queries.
 // It executes a query using the "postgres" user and returns the first result.
+// Internal queries include SQL text in trace spans since they use system functions.
 func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	// Enable SQL text in trace spans for internal queries (safe - no user data)
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
 	conn, err := e.poolManager.GetRegularConn(ctx, DefaultInternalUser)
 	if err != nil {
 		return nil, err
@@ -66,7 +73,13 @@ func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result
 // them to the appropriate text format for PostgreSQL.
 // Supported argument types: nil, string, []byte, int, int32, int64, uint32, uint64,
 // float32, float64, bool, and time.Time.
+// Internal queries include SQL text in trace spans since they use system functions.
 func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
+	// Enable SQL text in trace spans for internal queries (safe - no user data)
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
 	conn, err := e.poolManager.GetRegularConn(ctx, DefaultInternalUser)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add tracing at two levels to help understand where time is spent:

1. PostgreSQL query execution (pgprotocol/client):
   - Spans created for all queries with database semantic conventions
   - SQL text is opt-in via context (only safe for internal queries)
   - InternalQueryService enables SQL text since queries use system functions

2. pgctld subprocess calls:
   - Add RunCmdOutput helper to telemetry package
   - pg_isready and psql calls now create spans
   - Context propagated through GetStatusWithResult and helpers