### PR TITLE
feat(observability): add more metrics to the Grafana dashboard

### DIFF
--- a/kind_demo/observability/grafana-dashboard.json
+++ b/kind_demo/observability/grafana-dashboard.json
@@ -9,6 +9,19 @@
   "links": [],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Multigateway - Client Gateway",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
@@ -21,10 +34,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 1,
       "targets": [
@@ -35,8 +48,8 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (job, http_response_status_code) (histogram_count(rate(http_server_request_duration_seconds[$__rate_interval])))",
-          "legendFormat": "{{job}} - HTTP {{http_response_status_code}}",
+          "expr": "sum by (http_response_status_code, http_request_method) (histogram_count(rate(http_server_request_duration_seconds{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "{{http_request_method}} [{{http_response_status_code}}]",
           "range": true,
           "refId": "A"
         }
@@ -57,12 +70,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 1
       },
-      "id": 3,
+      "id": 2,
       "targets": [
         {
           "datasource": {
@@ -71,8 +84,8 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (job, http_request_method) (rate(http_server_request_duration_seconds[$__rate_interval])))",
-          "legendFormat": "p95 - {{job}} {{http_request_method}}",
+          "expr": "histogram_quantile(0.95, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p95 - {{http_request_method}}",
           "range": true,
           "refId": "A"
         },
@@ -83,8 +96,8 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (job, http_request_method) (rate(http_server_request_duration_seconds[$__rate_interval])))",
-          "legendFormat": "p50 - {{job}} {{http_request_method}}",
+          "expr": "histogram_quantile(0.50, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p50 - {{http_request_method}}",
           "range": true,
           "refId": "B"
         }
@@ -97,7 +110,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "gRPC SERVER response status codes (incoming requests). Status code 0 = OK.",
+      "description": "Outgoing gRPC calls from multigateway to multipooler. Status code 0 = OK. Click on data points to view traces in Jaeger.",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"
@@ -105,12 +118,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 10
       },
-      "id": 2,
+      "id": 3,
       "targets": [
         {
           "datasource": {
@@ -119,13 +132,13 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (job, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_server_duration_milliseconds[$__rate_interval])))",
-          "legendFormat": "{{job}} {{rpc_method}} - {{rpc_grpc_status_code}}",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "gRPC Server Response Codes",
+      "title": "gRPC Client Response Codes",
       "type": "timeseries"
     },
     {
@@ -133,7 +146,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "gRPC SERVER request latency percentiles (incoming requests).",
+      "description": "Latency for multigateway -> multipooler gRPC calls. Click on data points to view traces in Jaeger.",
       "fieldConfig": {
         "defaults": {
           "unit": "s"
@@ -141,7 +154,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 10
@@ -155,8 +168,8 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (job, rpc_method) (rate(rpc_server_duration_milliseconds[$__rate_interval]))) / 1000",
-          "legendFormat": "p95 - {{job}} {{rpc_method}}",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multigateway\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
         },
@@ -167,21 +180,34 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (job, rpc_method) (rate(rpc_server_duration_milliseconds[$__rate_interval]))) / 1000",
-          "legendFormat": "p50 - {{job}} {{rpc_method}}",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multigateway\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "gRPC Server Latency",
+      "title": "gRPC Client Latency",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Multipooler - Connection Pooling",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "gRPC CLIENT response status codes (outgoing requests). Status code 0 = OK.",
+      "description": "Incoming gRPC requests to multipooler. Status code 0 = OK. Click on data points to view traces in Jaeger.",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"
@@ -189,7 +215,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 0,
         "y": 20
@@ -203,13 +229,13 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (job, rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds[$__rate_interval])))",
-          "legendFormat": "{{job}} -> {{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
+          "expr": "sum by (rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
+          "legendFormat": "{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "gRPC Client Response Codes",
+      "title": "gRPC Server Response Codes",
       "type": "timeseries"
     },
     {
@@ -217,7 +243,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "gRPC CLIENT request latency percentiles (outgoing requests).",
+      "description": "Latency for incoming multipooler gRPC requests. Click on data points to view traces in Jaeger.",
       "fieldConfig": {
         "defaults": {
           "unit": "s"
@@ -225,7 +251,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 12,
         "y": 20
@@ -239,8 +265,8 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (job, rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds[$__rate_interval]))) / 1000",
-          "legendFormat": "p95 - {{job}} -> {{rpc_service}}.{{rpc_method}}",
+          "expr": "histogram_quantile(0.95, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95 - {{rpc_method}}",
           "range": true,
           "refId": "A"
         },
@@ -251,13 +277,365 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (job, rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds[$__rate_interval]))) / 1000",
-          "legendFormat": "p50 - {{job}} -> {{rpc_service}}.{{rpc_method}}",
+          "expr": "histogram_quantile(0.50, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50 - {{rpc_method}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "gRPC Client Latency",
+      "title": "gRPC Server Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Outgoing gRPC calls from multipooler to pgctld. Status code 0 = OK. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
+          "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Client Response Codes (to pgctld)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Latency for multipooler -> pgctld gRPC calls. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 8,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "gRPC Client Latency (to pgctld)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "PostgreSQL connection states by pool. Idle = available connections, Used = active connections. Stacked to show total pool size. Will appear once db.client.connection.count is wired up.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 9,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "db_client_connection_count{job=\"multipooler\"}",
+          "legendFormat": "{{db_client_connection_pool_name}} - {{db_client_connection_state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PostgreSQL Connection Pool States",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Cached gRPC connections to downstream services (pgctld).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rpcclient_connection_cache_size",
+          "legendFormat": "Cache size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Connection Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "gRPC connection pool efficiency. High reuse rate is good. High create rate may indicate connection churn.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(rpcclient_connection_reuses_total[$__rate_interval])",
+          "legendFormat": "Reuses/s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(rpcclient_connection_creates_total[$__rate_interval])",
+          "legendFormat": "Creates/s",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "gRPC Connection Pool Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Time to establish gRPC connections by dial path. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
+          "legendFormat": "p95 - {{path}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
+          "legendFormat": "p50 - {{path}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "gRPC Connection Dial Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Multiorch - Orchestration & Recovery",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Outgoing gRPC calls from multiorch to multipooler. Status code 0 = OK. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
+          "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Client Response Codes (to multipooler)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Latency for multiorch -> multipooler gRPC calls. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 14,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "gRPC Client Latency (to multipooler)",
       "type": "timeseries"
     },
     {
@@ -273,12 +651,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 66
       },
-      "id": 7,
+      "id": 15,
       "targets": [
         {
           "datasource": {
@@ -287,7 +665,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (action, status) (histogram_count(increase(multiorch_recovery_action_duration_milliseconds[$__rate_interval])))",
+          "expr": "sum by (action, status) (histogram_count(rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "{{action}} [{{status}}]",
           "range": true,
           "refId": "A"
@@ -309,12 +687,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 66
       },
-      "id": 8,
+      "id": 16,
       "targets": [
         {
           "datasource": {
@@ -323,7 +701,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{action}}",
           "range": true,
           "refId": "A"
@@ -335,7 +713,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{action}}",
           "range": true,
           "refId": "B"
@@ -343,13 +721,346 @@
       ],
       "title": "Recovery Action Duration",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Active problems detected by recovery analyzer. Value of 1 indicates problem is present. Empty when no problems detected.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 17,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "multiorch_recovery_detected_problems{job=\"multiorch\"}",
+          "legendFormat": "{{analysis_type}} - {{db_namespace}}/{{shard}} [{{pooler_id}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Detected Problems",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Time to poll individual pooler instances for health. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 18,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
+          "legendFormat": "p95 - {{db_namespace}} [{{status}}]",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
+          "legendFormat": "p50 - {{db_namespace}} [{{status}}]",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pooler Health Check Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Number of poolers tracked by recovery engine.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 84
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "multiorch_recovery_pooler_store_size{job=\"multiorch\"}",
+          "legendFormat": "Poolers",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pooler Store Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Time to refresh cluster metadata from topology. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 18,
+        "x": 6,
+        "y": 84
+      },
+      "id": 20,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval]))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval]))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Metadata Refresh Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 93
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Topology & Consensus",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Topology lock operations by type and result. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 21,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (operation, result, resource_type) (histogram_count(rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "legendFormat": "{{operation}} on {{resource_type}} [{{result}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Topology Lock Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Time to acquire/release topology locks. High duration indicates contention or etcd issues. Click on data points to view traces in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 22,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "legendFormat": "p95 - {{operation}} on {{resource_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "legendFormat": "p50 - {{operation}} on {{resource_type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Topology Lock Duration",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": ["multigres", "exemplars"],
+  "tags": [
+    "multigres",
+    "production"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values(up, job)",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        }
+      }
+    ]
   },
   "time": {
     "from": "now-15m",
@@ -357,8 +1068,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Multigres Metrics with Exemplars",
-  "uid": "multigres-exemplars",
+  "title": "Multigres Overview",
+  "uid": "multigres-overview",
   "version": 0,
   "weekStart": ""
 }

--- a/kind_demo/update-grafana-dashboard.sh
+++ b/kind_demo/update-grafana-dashboard.sh
@@ -28,9 +28,9 @@ kubectl create configmap grafana-dashboard-multigres \
   --from-file=multigres.json=observability/grafana-dashboard.json \
   --dry-run=client -o yaml | kubectl apply -f -
 
-echo "Triggering Grafana dashboard reload..."
-kubectl exec deployment/observability -c grafana -- \
-  curl -s -u admin:admin -X POST http://localhost:3000/api/admin/provisioning/dashboards/reload # gitleaks:allow
+echo "Restarting observability deployment to reload dashboards..."
+kubectl rollout restart deployment/observability
+kubectl rollout status deployment/observability --timeout=60s
 
 echo ""
 echo "Dashboard updated successfully."


### PR DESCRIPTION
Changes include:
- Rename: "Multigres Overview" with clean UID (multigres-overview)
- Organize by service: Use rows for multigateway, multipooler, multiorch, topology
- Add connection pool metrics: PostgreSQL pool states, gRPC connection cache
- Add multiorch health checks: pooler poll, cluster metadata refresh, store size
- Add topology lock operations: duration by operation type
- Add detected problems gauge: multiorch.recovery.detected_problems
- Add template variables: Service filtering with $service variable