### PR TITLE
feat(demo): add interactive backup and restore demo script

### DIFF
--- a/kind_demo/backup-restore.sh
+++ b/kind_demo/backup-restore.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demo script for Multigres backup and restore functionality.
+#
+# Prerequisites:
+#   - Kind cluster running (see launch.sh)
+#   - Multigres cluster deployed and healthy
+#   - kubectl configured to access the cluster
+#   - psql client installed
+#
+# Usage:
+#   cd kind_demo
+#   ./demo-backup-restore.sh
+#
+# The script will interactively demonstrate:
+#   - Listing backups via MultiAdmin gRPC API
+#   - Performing incremental backups
+#   - Creating test data (animals table with 10,000 rows)
+#   - Verifying backups after data changes
+#
+# Press ENTER at each pause to continue to the next step.
+# Press Ctrl+C to exit (port forwards will be cleaned up automatically).
+
+set -e
+
+# Ensure we're in the kind_demo directory
+if [[ $(basename "$PWD") != "kind_demo" ]]; then
+  echo "Error: This script must be run from the kind_demo directory"
+  exit 1
+fi
+
+# Helper function to display and execute a command
+run_cmd() {
+  echo "+ $*"
+  "$@"
+}
+
+# Helper function to display and execute a command in the background
+run_cmd_bg() {
+  echo "+ $* &"
+  "$@" >/dev/null 2>&1 &
+}
+
+# Helper function to pause and wait for user input
+pause_for_input() {
+  echo ""
+  echo "press ENTER to continue"
+  read -r
+}
+
+# Cleanup function to kill port forwards on exit
+cleanup() {
+  echo ""
+  echo "Cleaning up port forwards..."
+  if [[ -n "$PG_PF_PID" ]] && kill -0 "$PG_PF_PID" 2>/dev/null; then
+    kill "$PG_PF_PID"
+  fi
+  if [[ -n "$ADMIN_PF_PID" ]] && kill -0 "$ADMIN_PF_PID" 2>/dev/null; then
+    kill "$ADMIN_PF_PID"
+  fi
+  echo "Cleanup complete."
+}
+
+# Set up traps - explicitly exit on interrupt/terminate to avoid hanging
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+trap cleanup EXIT
+
+# Port forward to PostgreSQL
+echo ""
+echo "Setting up PostgreSQL port forward"
+echo "==================================="
+run_cmd_bg kubectl port-forward service/multigateway 15432:15432
+PG_PF_PID=$!
+sleep 2
+echo "PostgreSQL port forward established (PID: $PG_PF_PID)"
+
+# Port forward to MultiAdmin gRPC
+echo ""
+echo "Setting up MultiAdmin gRPC port forward"
+echo "========================================"
+run_cmd_bg kubectl port-forward service/multiadmin 18000:18000 18070:18070
+ADMIN_PF_PID=$!
+sleep 2
+echo "MultiAdmin gRPC port forward established (PID: $ADMIN_PF_PID)"
+
+# List existing backups (should show initial backup of primary)
+echo ""
+echo "Listing existing backups"
+echo "========================"
+run_cmd ../bin/multigres cluster list-backups \
+  --admin-server localhost:18070 \
+  --database postgres \
+  --config-file-not-found-handling ignore
+
+pause_for_input
+
+# Perform first incremental backup
+echo ""
+echo "Performing incremental backup"
+echo "=============================="
+run_cmd ../bin/multigres cluster backup \
+  --admin-server localhost:18070 \
+  --database postgres \
+  --type incremental \
+  --config-file-not-found-handling ignore
+
+pause_for_input
+
+# Show new backup in list backups
+echo ""
+echo "Listing backups after first backup"
+echo "==================================="
+run_cmd ../bin/multigres cluster list-backups \
+  --admin-server localhost:18070 \
+  --database postgres \
+  --config-file-not-found-handling ignore
+
+pause_for_input
+
+# Create animals table
+echo ""
+echo "Creating 'animals' table"
+echo "========================"
+run_cmd psql --host=localhost --port=15432 -U postgres -d postgres -c "
+CREATE TABLE IF NOT EXISTS animals (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);"
+
+echo ""
+echo "Verifying table structure:"
+run_cmd psql --host=localhost --port=15432 -U postgres -d postgres -c "\d animals"
+
+pause_for_input
+
+# Insert data
+echo ""
+echo "Inserting rows into 'animals' table"
+echo "===================================="
+run_cmd psql --host=localhost --port=15432 -U postgres -d postgres -c "
+INSERT INTO animals (name)
+SELECT (ARRAY['cat', 'dog', 'bird', 'fish', 'rabbit', 'hamster'])[(random() * 5)::int + 1] || '_' || generate_series(1, 100000);"
+
+echo ""
+echo "Verifying row count:"
+run_cmd psql --host=localhost --port=15432 -U postgres -d postgres -c "
+SELECT COUNT(*) as total_animals FROM animals;"
+
+pause_for_input
+
+# Perform full backup
+echo ""
+echo "Performing full backup"
+echo "======================="
+run_cmd ../bin/multigres cluster backup \
+  --admin-server localhost:18070 \
+  --database postgres \
+  --type full \
+  --config-file-not-found-handling ignore
+
+pause_for_input
+
+# List final backups
+echo ""
+echo "Listing all backups (final)"
+echo "==========================="
+run_cmd ../bin/multigres cluster list-backups \
+  --admin-server localhost:18070 \
+  --database postgres \
+  --config-file-not-found-handling ignore


### PR DESCRIPTION
Add demo-backup-restore.sh script that demonstrates:
- Setting up port forwards to PostgreSQL and MultiAdmin
- Listing existing backups via MultiAdmin gRPC API
- Performing incremental backups
- Creating test data (animals table with 10,000 rows using random types)
- Verifying backups after data changes

The script is interactive with pause points between steps, uses clean command display with run_cmd/run_cmd_bg functions, and includes proper cleanup handlers for graceful exit on interruption.