### PR TITLE
refactor(telemetry): fix pooler ID duplication regression and improve span attribute design

### DIFF
--- a/go/common/rpcclient/conn_cache.go
+++ b/go/common/rpcclient/conn_cache.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/tools/grpccommon"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -295,8 +294,7 @@ func (cc *connCache) newDial(ctx context.Context, addr string, poolerID *cluster
 		grpccommon.WithDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
 	}
 	if poolerID != nil {
-		poolerIDStr := topoclient.MultiPoolerIDString(poolerID)
-		clientOpts = append(clientOpts, grpccommon.WithMultipoolerTarget(poolerIDStr))
+		clientOpts = append(clientOpts, grpccommon.WithAttributes(PoolerSpanAttributes(poolerID)...))
 	}
 
 	// TODO: Add proper TLS configuration for production

--- a/go/common/rpcclient/options.go
+++ b/go/common/rpcclient/options.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcclient
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// PoolerSpanAttributes returns OpenTelemetry span attributes for gRPC clients
+// connecting to multipooler instances. It sets:
+// - multigres.pooler.id: the global pooler identifier (e.g., "multipooler-zone1-0")
+//
+// Use with grpccommon.WithAttributes() when creating gRPC clients:
+//
+//	grpccommon.NewClient(addr, grpccommon.WithAttributes(rpcclient.PoolerSpanAttributes(poolerID)...))
+//
+// TODO: Add peer.service="multipooler" to match OTel semantic conventions where
+// peer.service should match the remote service's service.name resource attribute.
+func PoolerSpanAttributes(poolerID *clustermetadatapb.ID) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("multigres.pooler.id", topoclient.MultiPoolerIDString(poolerID)),
+	}
+}

--- a/go/multigateway/poolergateway/pooler_gateway.go
+++ b/go/multigateway/poolergateway/pooler_gateway.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/queryservice"
+	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -213,7 +214,7 @@ func (pg *PoolerGateway) getOrCreateConnection(
 
 	// Create gRPC connection (non-blocking in newer gRPC)
 	conn, err := grpccommon.NewClient(addr,
-		grpccommon.WithMultipoolerTarget(poolerID),
+		grpccommon.WithAttributes(rpcclient.PoolerSpanAttributes(pooler.Id)...),
 		grpccommon.WithDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
 	)
 	if err != nil {

--- a/go/tools/grpccommon/options.go
+++ b/go/tools/grpccommon/options.go
@@ -78,20 +78,13 @@ type clientConfig struct {
 	dialOptions []grpc.DialOption
 }
 
-// WithMultipoolerTarget configures OpenTelemetry attributes for gRPC clients
-// connecting to multipooler instances. It sets:
-// - peer.service: "multipooler" (the logical service name per OTel semconv)
-// - multigres.pooler.id: the specific pooler instance identifier
-//
-// This follows OpenTelemetry semantic conventions where peer.service should match
-// the remote service's service.name resource attribute, while custom attributes
-// identify the specific instance within that service.
-func WithMultipoolerTarget(poolerID string) ClientOption {
+// WithAttributes adds custom OpenTelemetry attributes to gRPC client spans.
+// This is a generic helper that can be used by domain-specific code to add
+// custom span attributes without making grpccommon domain-aware.
+func WithAttributes(attrs ...attribute.KeyValue) ClientOption {
 	return funcOption(func(c *clientConfig) {
 		c.otelOptions = append(c.otelOptions,
-			otelgrpc.WithSpanAttributes(
-				attribute.String("multigres.pooler.id", poolerID),
-			),
+			otelgrpc.WithSpanAttributes(attrs...),
 		)
 	})
 }

--- a/kind_demo/k8s-multipooler-statefulset.yaml
+++ b/kind_demo/k8s-multipooler-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
             - --database=postgres
             - --table-group=default
             - --shard=0-inf
-            - --service-id=multipooler-$(MT_CELL)-$(POD_INDEX)
+            - --service-id=$(POD_INDEX)
             - --pooler-dir=/data
             - --pgctld-addr=localhost:16200
             - --pg-port=5432


### PR DESCRIPTION
PR #464 was trying to improve service IDs in telemetry to make them globally unique but also unintentionally impacted etcd, changing paths from  /multigres/.../poolers/multipooler-zone1-0 to /multigres/.../poolers/multipooler-zone1-multipooler-zone1-0 (with duplication)

Also refactors gRPC client span attributes for cleaner architecture:
- Moves domain-specific PoolerSpanAttributes to go/common/rpcclient
- Makes grpccommon.WithAttributes() generic and domain-agnostic
- Uses type-safe proto ID parameter instead of strings
- Renames to PoolerSpanAttributes for clarity (span vs resource attributes)