### PR TITLE
fix(observability): configure Loki derived fields to use structured metadata for trace links

### DIFF
--- a/kind_demo/k8s-observability.yaml
+++ b/kind_demo/k8s-observability.yaml
@@ -143,9 +143,10 @@ data:
         jsonData:
           derivedFields:
             - datasourceUid: tempo-uid
-              matcherRegex: "trace_id[=:]\\s*(\\w+)"
-              name: "TraceID"
-              url: "$${__value.raw}"
+              matcherRegex: trace_id
+              matcherType: label
+              name: TraceID
+              url: $${__value.raw}
 ---
 # ConfigMap: Grafana dashboard provisioning
 apiVersion: v1


### PR DESCRIPTION
Fixes links from logs to the corresponding trace:

<img width="842" height="210" alt="image" src="https://github.com/user-attachments/assets/8b2647e3-72a1-44de-a549-cfffccc61cf8" />

The previous configuration used regex matching on log message bodies, but OpenTelemetry logs store trace_id in structured metadata. Updated the derived field to use matcherType: label to extract trace_id from structured metadata, enabling working log-to-trace navigation in Grafana.


