### PR TITLE
fix(pgctld): improves process killer

### DIFF
--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -262,6 +262,12 @@ func startPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlCo
 			"-D", config.PostgresDataDir,
 			"-m", "fast",
 		)
+		// Put watchdog in its own process group so SIGINT/SIGTERM to parent doesn't kill it
+		// The watchdog needs to survive the parent's death to perform cleanup
+		watchdogCmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+			Pgid:    0,
+		}
 		// Environment variables automatically inherit
 		if err := watchdogCmd.Start(); err != nil {
 			logger.Warn("Failed to start watchdog process", "error", err)


### PR DESCRIPTION
  # Desc                                                                                                                  
  * If you run an endtoend test and CTRL-C, the watchdog process was receiving  the SIGINT and dying before it could kill postgres. This can be repro with: 
  ```     
go test -v ./go/test/endtoend/multipooler/...                                                                         
# CTRL-C when the test is waiting: checkBootstrapStatus              
```                                                                                                                                                       
  * This changes the process group of the watchdog so it doesn't receive the  signal when the test is cancelled, giving it a chance to clean up postgres.                                             
