### PR TITLE
feat(ci): improves coverall job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -166,8 +166,8 @@ jobs:
   coveralls-finish:
     name: Finish Coveralls upload
     runs-on: ubuntu-24.04
-    needs: [merge-and-upload]
-    if: always()
+    needs: [coverage-direct, coverage-subprocess, merge-and-upload]
+    if: success()
 
     steps:
       - name: Coveralls Finished


### PR DESCRIPTION
Desc
* This makes sure we don't close the coverall job, until all the other jobs are successful. This fixes an issue where if direct coverage fails, but subprocess succeeds we were uploading the results and closing the build. Subsequent retries would fail the job  