### PR TITLE
fix(parser): preserve schema qualification for non-built-in types 

### DIFF
--- a/go/parser/ast/ddl_statements.go
+++ b/go/parser/ast/ddl_statements.go
@@ -740,12 +740,12 @@ func normalizeTypeName(nameParts []string) string {
 
 	// For qualified names, handle schema qualification
 	if len(nameParts) > 1 {
-		// Strip pg_catalog or public schema for built-in types
+		// Strip pg_catalog or public schema for built-in types only
 		if len(nameParts) == 2 && (nameParts[0] == "pg_catalog" || nameParts[0] == "public") {
-			// Check if it's a built-in type
 			typeName := nameParts[1]
-			normalized := normalizeSingleTypeName(typeName)
-			return normalized
+			if isBuiltInType(typeName) {
+				return normalizeSingleTypeName(typeName)
+			}
 		}
 
 		// For other qualified names, quote each part individually if needed
@@ -758,6 +758,21 @@ func normalizeTypeName(nameParts []string) string {
 
 	// For single names, normalize if it's a built-in type
 	return normalizeSingleTypeName(nameParts[0])
+}
+
+// isBuiltInType checks if a type name is a built-in PostgreSQL type
+func isBuiltInType(typeName string) bool {
+	switch strings.ToLower(typeName) {
+	case "int4", "int", "int8", "bigint", "int2", "smallint",
+		"float", "float4", "real", "float8", "double precision",
+		"bool", "boolean", "bpchar", "char", "varchar", "text",
+		"numeric", "decimal", "timestamp", "timestamptz",
+		"time", "timetz", "date", "interval", "bytea",
+		"uuid", "json", "jsonb", "xml":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeSingleTypeName(typeName string) string {

--- a/go/parser/testdata/postgres/foreign_key.json
+++ b/go/parser/testdata/postgres/foreign_key.json
@@ -3088,22 +3088,22 @@
   {
     "comment": "foreign_key - Statement 670",
     "query": "UPDATE fkpart11.pk SET a = a + 1 RETURNING tableoid::pg_catalog.regclass, *",
-    "expected": "UPDATE fkpart11.pk SET a = a + 1 RETURNING CAST(tableoid AS regclass), *"
+    "expected": "UPDATE fkpart11.pk SET a = a + 1 RETURNING CAST(tableoid AS pg_catalog.regclass), *"
   },
   {
     "comment": "foreign_key - Statement 671",
     "query": "SELECT tableoid::pg_catalog.regclass, * FROM fkpart11.fk",
-    "expected": "SELECT CAST(tableoid AS regclass), * FROM fkpart11.fk"
+    "expected": "SELECT CAST(tableoid AS pg_catalog.regclass), * FROM fkpart11.fk"
   },
   {
     "comment": "foreign_key - Statement 672",
     "query": "SELECT tableoid::pg_catalog.regclass, * FROM fkpart11.fk_parted",
-    "expected": "SELECT CAST(tableoid AS regclass), * FROM fkpart11.fk_parted"
+    "expected": "SELECT CAST(tableoid AS pg_catalog.regclass), * FROM fkpart11.fk_parted"
   },
   {
     "comment": "foreign_key - Statement 673",
     "query": "SELECT tableoid::pg_catalog.regclass, * FROM fkpart11.fk_another",
-    "expected": "SELECT CAST(tableoid AS regclass), * FROM fkpart11.fk_another"
+    "expected": "SELECT CAST(tableoid AS pg_catalog.regclass), * FROM fkpart11.fk_another"
   },
   {
     "comment": "foreign_key - Statement 674",
@@ -3129,7 +3129,7 @@
   {
     "comment": "foreign_key - Statement 679",
     "query": "SELECT tableoid::pg_catalog.regclass, * FROM fkpart11.pk",
-    "expected": "SELECT CAST(tableoid AS regclass), * FROM fkpart11.pk"
+    "expected": "SELECT CAST(tableoid AS pg_catalog.regclass), * FROM fkpart11.pk"
   },
   {
     "comment": "foreign_key - Statement 680",


### PR DESCRIPTION
### Description
- Fix bug where `pg_catalog` and `public` schemas were incorrectly stripped from all types, not just built-in types                    
- Add `isBuiltInType()` helper to check if a type is a known PostgreSQL built-in type                                                  

### Problem 
Previously, statements like `COMMENT ON TYPE public.type_name IS 'type comment';` would incorrectly have the `public` schema stripped, resulting in `COMMENT ON TYPE type_name IS 'type comment';`. This should only happen for built-in types like `pg_catalog.int4` → `INT`.