### PR TITLE
test(pg_regress): add e2e test to run pg_regress against multigres cluster

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
         run: make build
 
       - name: Run tests with direct coverage
-        run: go test -json -v -cover -covermode=atomic -coverprofile=coverage-direct.txt -coverpkg=./... ./... | tee coverage-direct-test-results.jsonl | go tool tparse -follow
+        run: go test -json -v -skip TestPostgreSQLRegression -cover -covermode=atomic -coverprofile=coverage-direct.txt -coverpkg=./... ./... | tee coverage-direct-test-results.jsonl | go tool tparse -follow
 
       - name: Upload direct coverage artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -86,7 +86,7 @@ jobs:
         run: |
           mkdir -p coverage-subprocess-raw
           export GOCOVERDIR="$PWD/coverage-subprocess-raw"
-          go test -json -v ./... | tee coverage-subprocess-test-results.jsonl | go tool tparse -follow
+          go test -json -v -skip TestPostgreSQLRegression ./... | tee coverage-subprocess-test-results.jsonl | go tool tparse -follow
 
       - name: Convert subprocess coverage to text format
         run: go tool covdata textfmt -i=coverage-subprocess-raw -o=coverage-subprocess.txt

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -44,7 +44,7 @@ jobs:
         run: make build
 
       - name: Run integration tests
-        run: go test -json -v ./go/test/endtoend/... | tee integration-test-results.jsonl | go tool tparse -follow
+        run: go test -json -v -skip TestPostgreSQLRegression ./go/test/endtoend/... | tee integration-test-results.jsonl | go tool tparse -follow
 
       - name: Test Report
         uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -1,0 +1,212 @@
+# PostgreSQL Regression Tests
+
+This test package validates multigres compatibility by running PostgreSQL's official regression test suite against a multigres cluster.
+
+## Overview
+
+The test performs the following steps:
+
+1. **Checkout PostgreSQL source**: Clones PostgreSQL 17.6 (REL_17_6) from GitHub
+2. **Build with make**: Compiles PostgreSQL using traditional ./configure and make
+3. **Spin up multigres cluster**: Creates a 2-node cluster with multigateway
+4. **Run regression tests**: Executes specific PostgreSQL tests through multigateway using make installcheck-tests
+5. **Report results**: Logs test outcomes (failures are logged but don't fail the test)
+
+## Requirements
+
+### Build Dependencies
+
+The following tools must be installed:
+
+- **make** - Build tool
+- **gcc** - C compiler
+- **git** - For cloning PostgreSQL source
+- Standard build tools (autoconf, automake, etc.)
+
+### Install on Ubuntu/Debian
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential git
+```
+
+### Install on macOS
+
+```bash
+# Xcode Command Line Tools (includes make, gcc, git)
+xcode-select --install
+```
+
+## Running Tests
+
+### Basic Usage
+
+```bash
+# Navigate to test directory
+cd go/test/endtoend/pgregresstest
+
+# Run all regression tests (includes PostgreSQL clone, build, and test execution)
+go test -v -timeout 60m  # Adjust the timeout based on the number of tests running
+```
+
+### First Run vs Cached Runs
+
+**First run** (no cache):
+
+- Clones PostgreSQL source (~200MB)
+- Builds PostgreSQL
+- Runs regression tests
+
+**Subsequent runs** (cached source):
+
+- Reuses cached source
+- Rebuilds PostgreSQL
+- Runs regression tests
+
+**Note**: Running all ~200+ PostgreSQL regression tests takes significantly longer than running a subset. For faster iteration during development, consider running specific tests only (see "Running Specific Tests Only" section).
+
+### Skip in Short Mode
+
+```bash
+# Short mode skips this test
+go test -v -short
+# Output: "skipping long-running PostgreSQL regression tests in short mode"
+```
+
+### Run Without Caching
+
+To force a fresh clone and build every time (useful for testing cache behavior or CI):
+
+```bash
+# Option 1: Remove cache before running
+rm -rf /tmp/multigres_pg_cache
+go test -v -timeout 60m
+
+# Option 2: Use a different cache directory each time
+export MULTIGRES_PG_CACHE_DIR="/tmp/multigres_pg_test_$(date +%s)"
+go test -v -timeout 60m
+
+# Option 3: Use a custom temporary cache location
+export MULTIGRES_PG_CACHE_DIR="$(mktemp -d)"
+go test -v -timeout 60m
+# Cache will be in a unique temp directory
+```
+
+### Run from Root
+
+```bash
+# From repository root
+cd /path/to/multigres
+go test -v -timeout 60m ./go/test/endtoend/pgregresstest/...
+```
+
+## Troubleshooting
+
+### Build failures
+
+**Symptom**: `configure failed` or `make failed`
+
+**Solutions**:
+
+1. Ensure all build dependencies are installed: `sudo apt-get install build-essential`
+2. Check for errors in the configure output
+3. Try clearing cache: `rm -rf /tmp/multigres_pg_cache`
+
+### Git clone failures
+
+**Symptom**: `failed to clone PostgreSQL`
+
+**Solutions**:
+
+1. Check network connectivity
+2. Verify GitHub is accessible
+3. Try manual clone: `git clone --depth=1 --branch REL_17_6 https://github.com/postgres/postgres /tmp/test-clone`
+
+### Connection failures
+
+**Symptom**: Test hangs or times out when running tests
+
+**Solutions**:
+
+1. Verify multigateway is running (check test output)
+2. Check that PostgreSQL binaries are in PATH
+3. Ensure no firewall blocking localhost connections
+
+### Disk space issues
+
+**Symptom**: `No space left on device`
+
+**Solutions**:
+
+1. Clear build cache: `rm -rf /tmp/multigres_pg_cache/builds`
+2. Free up space (source ~200MB, builds ~500MB)
+3. Use custom cache location: `export MULTIGRES_PG_CACHE_DIR=~/multigres_cache`
+
+## Architecture
+
+### Component Flow
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ TestPostgreSQLRegression                                    │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ PostgresBuilder                                         │ │
+│ │ ┌────────────┐  ┌──────────┐  ┌──────────────────────┐ │ │
+│ │ │EnsureSource│─▶│  Build   │─▶│RunRegressionTests    │ │ │
+│ │ └────────────┘  └──────────┘  └──────────────────────┘ │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Multigres Cluster (ShardSetup)                              │
+│ ┌──────────┐  ┌──────────┐  ┌─────────────┐               │
+│ │multipooler│  │multipooler│  │multigateway │               │
+│ │ (primary) │  │(standby)  │  │ (port 5432) │               │
+│ └─────┬─────┘  └─────┬─────┘  └──────┬──────┘               │
+│       │              │               │                       │
+│       ▼              ▼               ▼                       │
+│ ┌─────────┐    ┌─────────┐    ┌─────────┐                  │
+│ │PostgreSQL│   │PostgreSQL│   │  Proxy   │                 │
+│ └─────────┘    └─────────┘    └─────────┘                  │
+└─────────────────────────────────────────────────────────────┘
+                            ▲
+                            │
+                ┌───────────┴──────────┐
+                │ PostgreSQL Tests     │
+                │ (PGHOST=localhost)   │
+                │ (PGPORT=multigateway)│
+                └──────────────────────┘
+```
+
+<!-- markdownlint-enable MD013 -->
+
+### File Structure
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+go/test/endtoend/pgregresstest/
+├── README.md              # This file
+├── main_test.go          # TestMain, shared setup management
+├── postgres_builder.go   # PostgreSQL build and test execution
+└── pgregress_test.go     # Main test implementation
+```
+
+<!-- markdownlint-enable MD013 -->
+
+## Contributing
+
+When adding new tests or expanding the test suite:
+
+1. **Test selection**: Modify the `TESTS` variable in `RunRegressionTests()`
+2. **Timeout**: Adjust timeout in `pgregress_test.go` if running more tests
+3. **Documentation**: Update this README with new test scope
+
+## References
+
+- [PostgreSQL Source](https://github.com/postgres/postgres)
+- [PostgreSQL Build Documentation](https://www.postgresql.org/docs/current/installation.html)
+- [PostgreSQL Regression Tests](https://www.postgresql.org/docs/current/regress.html)

--- a/go/test/endtoend/pgregresstest/main_test.go
+++ b/go/test/endtoend/pgregresstest/main_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// setupManager manages the shared test setup for tests in this package.
+var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardsetup.ShardSetup {
+	// Create a 2-node cluster with multigateway for PostgreSQL regression tests
+	return shardsetup.New(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby
+		shardsetup.WithMultigateway(),      // enable multigateway for PostgreSQL connections
+	)
+})
+
+// TestMain sets the path and cleans up after all tests.
+func TestMain(m *testing.M) {
+	exitCode := shardsetup.RunTestMain(m)
+	if exitCode != 0 {
+		setupManager.DumpLogs()
+	}
+	setupManager.Cleanup()
+	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+}
+
+// getSharedSetup returns the shared setup for tests.
+func getSharedSetup(t *testing.T) *shardsetup.ShardSetup {
+	t.Helper()
+	return setupManager.Get(t)
+}

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPostgreSQLRegression tests PostgreSQL compatibility by running the official
+// PostgreSQL regression test suite against a multigres cluster.
+//
+// This test performs the following steps:
+// 1. Checks out PostgreSQL source code (REL_17_6) from GitHub
+// 2. Builds PostgreSQL using ./configure and make
+// 3. Spins up a multigres cluster (2 nodes + multigateway)
+// 4. Runs PostgreSQL regression tests (boolean, char) through multigateway using make installcheck-tests
+// 5. Reports results (logs failures but doesn't fail the test)
+//
+// The test is skipped in short mode and when build dependencies are not available.
+func TestPostgreSQLRegression(t *testing.T) {
+	// Skip in short mode
+	if testing.Short() {
+		t.Skip("skipping long-running PostgreSQL regression tests in short mode")
+	}
+
+	// Skip if PostgreSQL binaries not available
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping regression tests")
+	}
+
+	// Get shared cluster setup (2 nodes + multigateway)
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	// Create PostgresBuilder for managing source and build
+	ctx := utils.WithTimeout(t, 60*time.Minute)
+	builder := NewPostgresBuilder(t, setup.TempDir)
+	t.Cleanup(func() {
+		builder.Cleanup()
+	})
+
+	// Track if build succeeded
+	buildSucceeded := false
+
+	// Phase 1: Setup PostgreSQL source
+	t.Run("setup_postgres_source", func(t *testing.T) {
+		// Check build dependencies first
+		if err := CheckBuildDependencies(t); err != nil {
+			t.Skipf("Build dependencies not available: %v", err)
+		}
+
+		// Ensure PostgreSQL source is available (clone if needed)
+		if err := builder.EnsureSource(t, ctx); err != nil {
+			t.Fatalf("Failed to setup PostgreSQL source: %v", err)
+		}
+	})
+
+	// Phase 2: Build PostgreSQL
+	t.Run("build_postgres", func(t *testing.T) {
+		if err := builder.Build(t, ctx); err != nil {
+			t.Fatalf("Failed to build PostgreSQL: %v", err)
+		}
+		buildSucceeded = true
+	})
+
+	// Phase 3: Run regression tests - ONLY if build succeeded
+	t.Run("run_regression_tests", func(t *testing.T) {
+		if !buildSucceeded {
+			t.Skip("Skipping regression tests because PostgreSQL build failed")
+		}
+
+		// Run tests against multigateway
+		results, err := builder.RunRegressionTests(t, ctx, setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+
+		// Handle nil results gracefully
+		if results == nil {
+			if err != nil {
+				t.Fatalf("Test harness failed to execute: %v", err)
+			}
+			t.Fatal("Test harness returned nil results")
+		}
+
+		// Always log results (even on success)
+		t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		t.Logf("PostgreSQL Regression Test Results:")
+		t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		t.Logf("  Total:   %d", results.TotalTests)
+		t.Logf("  Passed:  %d", results.PassedTests)
+		t.Logf("  Failed:  %d", results.FailedTests)
+		t.Logf("  Skipped: %d", results.SkippedTests)
+		t.Logf("  Duration: %v", results.Duration)
+		t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		// Log failure details if any
+		if results.FailedTests > 0 {
+			t.Logf("")
+			t.Logf("Failed Tests:")
+			for _, failure := range results.FailureDetails {
+				t.Logf("  ❌ %s - %s", failure.TestName, failure.Error)
+			}
+			t.Logf("")
+			t.Logf("⚠️  WARNING: %d regression test(s) failed.", results.FailedTests)
+			t.Logf("   This is logged for investigation but won't fail the Go test.")
+			t.Logf("   Review the test output above for details.")
+		} else if results.PassedTests > 0 {
+			t.Logf("")
+			t.Logf("✅ All %d regression tests passed!", results.PassedTests)
+		}
+
+		// Only fail if test harness crashed (no tests ran at all)
+		if err != nil && results.TotalTests == 0 {
+			t.Fatalf("Test harness failed to execute: %v", err)
+		}
+	})
+}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -1,0 +1,405 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// PostgresGitRepo is the official PostgreSQL git repository
+	PostgresGitRepo = "https://github.com/postgres/postgres"
+
+	// PostgresVersion is the git tag to checkout
+	PostgresVersion = "REL_17_6"
+
+	// PostgresCacheDir is the default cache directory for PostgreSQL source and builds
+	PostgresCacheDir = "/tmp/multigres_pg_cache"
+)
+
+// PostgresBuilder manages PostgreSQL source checkout, build, and test execution
+type PostgresBuilder struct {
+	SourceDir  string // Shared source cache: /tmp/multigres_pg_cache/source/postgres
+	BuildDir   string // Per-test build: /tmp/multigres_pg_cache/builds/<timestamp>/build
+	InstallDir string // Per-test install: /tmp/multigres_pg_cache/builds/<timestamp>/install
+	OutputDir  string // Persistent test results: /tmp/multigres_pg_cache/results/<timestamp>
+}
+
+// TestResults contains the results from running PostgreSQL regression tests
+type TestResults struct {
+	TotalTests     int
+	PassedTests    int
+	FailedTests    int
+	SkippedTests   int
+	Duration       time.Duration
+	FailureDetails []TestFailure
+}
+
+// TestFailure represents a single test failure
+type TestFailure struct {
+	TestName string
+	Error    string
+}
+
+// NewPostgresBuilder creates a new PostgresBuilder with unique build directories
+func NewPostgresBuilder(t *testing.T, baseTempDir string) *PostgresBuilder {
+	t.Helper()
+
+	// Get cache directory from environment or use default
+	cacheDir := os.Getenv("MULTIGRES_PG_CACHE_DIR")
+	if cacheDir == "" {
+		cacheDir = PostgresCacheDir
+	}
+
+	// Create unique build directory using timestamp
+	timestamp := time.Now().Format("20060102-150405")
+	buildRoot := filepath.Join(cacheDir, "builds", timestamp)
+
+	return &PostgresBuilder{
+		SourceDir:  filepath.Join(cacheDir, "source", "postgres"),
+		BuildDir:   filepath.Join(buildRoot, "build"),
+		InstallDir: filepath.Join(buildRoot, "install"),
+		OutputDir:  filepath.Join(cacheDir, "results", timestamp), // Persistent results directory
+	}
+}
+
+// CheckBuildDependencies verifies that required build tools are available
+func CheckBuildDependencies(t *testing.T) error {
+	t.Helper()
+
+	required := []string{"make", "gcc"}
+	var missing []string
+
+	for _, tool := range required {
+		if _, err := exec.LookPath(tool); err != nil {
+			missing = append(missing, tool)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing build dependencies: %v. Install with: apt-get install build-essential", missing)
+	}
+
+	return nil
+}
+
+// EnsureSource ensures PostgreSQL source is available, cloning if necessary
+func (pb *PostgresBuilder) EnsureSource(t *testing.T, ctx context.Context) error {
+	t.Helper()
+
+	// Check if cached source exists and is correct version
+	if _, err := os.Stat(pb.SourceDir); err == nil {
+		t.Logf("Found cached PostgreSQL source at %s, verifying version...", pb.SourceDir)
+
+		// Verify it's the correct version
+		cmd := exec.CommandContext(ctx, "git", "-C", pb.SourceDir, "describe", "--tags", "--exact-match")
+		output, err := cmd.Output()
+		if err == nil && strings.TrimSpace(string(output)) == PostgresVersion {
+			t.Logf("Using cached PostgreSQL source (version %s)", PostgresVersion)
+			return nil
+		}
+
+		t.Logf("Cached source version mismatch or invalid, re-cloning...")
+		if err := os.RemoveAll(pb.SourceDir); err != nil {
+			return fmt.Errorf("failed to remove old cache: %w", err)
+		}
+	}
+
+	// Create parent directory
+	if err := os.MkdirAll(filepath.Dir(pb.SourceDir), 0o755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	// Clone PostgreSQL repository
+	t.Logf("Cloning PostgreSQL %s from %s...", PostgresVersion, PostgresGitRepo)
+	cmd := exec.CommandContext(ctx, "git", "clone",
+		"--depth=1",
+		"--branch", PostgresVersion,
+		PostgresGitRepo,
+		pb.SourceDir)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to clone PostgreSQL: %w (stderr: %s)", err, stderr.String())
+	}
+
+	t.Logf("Successfully cloned PostgreSQL %s", PostgresVersion)
+	return nil
+}
+
+// Build builds PostgreSQL using traditional ./configure and make
+func (pb *PostgresBuilder) Build(t *testing.T, ctx context.Context) error {
+	t.Helper()
+
+	// Create build directory
+	if err := os.MkdirAll(pb.BuildDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create build directory: %w", err)
+	}
+
+	// Step 1: Run ./configure
+	t.Logf("Configuring PostgreSQL with ./configure...")
+	configureCmd := exec.CommandContext(ctx, filepath.Join(pb.SourceDir, "configure"),
+		"--prefix="+pb.InstallDir,
+		"--enable-cassert=no",
+		"--enable-tap-tests=no",
+		"--without-icu", // Disable ICU support to avoid dependency
+	)
+	configureCmd.Dir = pb.BuildDir
+	configureCmd.Stdout = os.Stdout
+	configureCmd.Stderr = os.Stderr
+
+	if err := configureCmd.Run(); err != nil {
+		return fmt.Errorf("configure failed: %w", err)
+	}
+
+	// Step 2: Run make
+	t.Logf("Building PostgreSQL with make...")
+	makeCmd := exec.CommandContext(ctx, "make", "-j", "4") // Use 4 parallel jobs
+	makeCmd.Dir = pb.BuildDir
+	makeCmd.Stdout = os.Stdout
+	makeCmd.Stderr = os.Stderr
+
+	if err := makeCmd.Run(); err != nil {
+		return fmt.Errorf("make failed: %w", err)
+	}
+
+	// Step 3: Run make install
+	t.Logf("Installing PostgreSQL to %s...", pb.InstallDir)
+	installCmd := exec.CommandContext(ctx, "make", "install")
+	installCmd.Dir = pb.BuildDir
+	installCmd.Stdout = os.Stdout
+	installCmd.Stderr = os.Stderr
+
+	if err := installCmd.Run(); err != nil {
+		return fmt.Errorf("make install failed: %w", err)
+	}
+
+	t.Logf("PostgreSQL build completed successfully")
+	return nil
+}
+
+// RunRegressionTests runs PostgreSQL regression tests against multigateway
+func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context, multigatewayPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	t.Logf("Running PostgreSQL regression tests against multigateway on port %d...", multigatewayPort)
+
+	// Create output directory for test results (persistent, outside build dir)
+	if err := os.MkdirAll(pb.OutputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	t.Logf("Test results will be saved to: %s", pb.OutputDir)
+
+	// Use make installcheck-tests with TESTS variable to run specific regression tests
+	// against the existing PostgreSQL server (multigateway).
+	//
+	// The installcheck-tests target runs specific tests against an already-running
+	// PostgreSQL server, unlike installcheck which runs the entire parallel_schedule.
+	//
+	// From PostgreSQL's src/test/regress/GNUmakefile:
+	//   installcheck: runs --schedule=parallel_schedule (all tests)
+	//   installcheck-tests: runs $(TESTS) (specific tests only)
+	//
+	// Examples:
+	//
+	// 1. Run specific tests:
+	//    make installcheck-tests TESTS="boolean char"
+	//
+	// 2. Run a single test:
+	//    make installcheck-tests TESTS="boolean"
+	//
+	// 3. Run all tests (use installcheck instead):
+	//    make installcheck
+	//
+	// Environment variables that pg_regress reads:
+	//   PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE - connection params
+	//
+	// Reference: https://github.com/postgres/postgres/blob/master/src/test/regress/GNUmakefile
+
+	cmd := exec.CommandContext(ctx, "make",
+		"-C", filepath.Join(pb.BuildDir, "src/test/regress"), // Regress directory
+		"installcheck-tests", // Target for running specific tests against existing server
+		"TESTS=boolean char", // Run only boolean and char tests
+	)
+
+	// Set environment variables for connection
+	cmd.Env = append(os.Environ(),
+		"PGHOST=localhost",
+		fmt.Sprintf("PGPORT=%d", multigatewayPort),
+		"PGUSER=postgres",
+		"PGPASSWORD="+password,
+		"PGDATABASE=postgres",
+		"PGCONNECT_TIMEOUT=10",
+	)
+
+	// Capture output
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&stdout, os.Stdout)
+	cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
+
+	startTime := time.Now()
+	err := cmd.Run()
+	duration := time.Since(startTime)
+
+	// Parse results even if command failed (some tests may have passed)
+	results := pb.ParseTestResults(&stdout, &stderr)
+	results.Duration = duration
+
+	t.Logf("Test execution completed in %v", duration)
+
+	// Copy regression test result files from build directory to persistent OutputDir
+	// The make installcheck-tests target writes results to <builddir>/src/test/regress/
+	buildRegressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
+
+	// Define source and destination paths
+	srcDiffs := filepath.Join(buildRegressDir, "regression.diffs")
+	srcOut := filepath.Join(buildRegressDir, "regression.out")
+	regressionDiffs := filepath.Join(pb.OutputDir, "regression.diffs")
+	regressionOut := filepath.Join(pb.OutputDir, "regression.out")
+
+	// Copy regression.diffs if it exists
+	if diffsData, err := os.ReadFile(srcDiffs); err == nil {
+		if err := os.WriteFile(regressionDiffs, diffsData, 0o644); err != nil {
+			t.Logf("Warning: Failed to copy regression.diffs: %v", err)
+		}
+	}
+
+	// Copy regression.out if it exists
+	if outData, err := os.ReadFile(srcOut); err == nil {
+		if err := os.WriteFile(regressionOut, outData, 0o644); err != nil {
+			t.Logf("Warning: Failed to copy regression.out: %v", err)
+		}
+	}
+
+	t.Logf("")
+	t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	t.Logf("Test results saved to: %s", pb.OutputDir)
+	t.Logf("  • Summary:     %s", regressionOut)
+	t.Logf("  • Differences: %s", regressionDiffs)
+	t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	t.Logf("")
+
+	// If there are failures, read and display the regression.diffs content
+	if results.FailedTests > 0 {
+		if diffsContent, err := os.ReadFile(regressionDiffs); err == nil {
+			t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+			t.Logf("Regression Differences (from %s):", regressionDiffs)
+			t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+			t.Logf("%s", string(diffsContent))
+			t.Logf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		} else {
+			t.Logf("Warning: Could not read regression.diffs: %v", err)
+		}
+	}
+
+	// If tests ran, return results even if some failed
+	if results.TotalTests > 0 {
+		return results, err
+	}
+
+	// No tests ran - this is a test harness error
+	if err != nil {
+		return nil, fmt.Errorf("test harness failed to execute: %w", err)
+	}
+
+	return results, nil
+}
+
+// ParseTestResults parses pg_regress output to extract test results
+func (pb *PostgresBuilder) ParseTestResults(stdout, stderr *bytes.Buffer) *TestResults {
+	results := &TestResults{
+		FailureDetails: []TestFailure{},
+	}
+
+	output := stdout.String()
+	combinedOutput := output + "\n" + stderr.String()
+
+	// Parse pg_regress output format
+	// Example line: "test test_setup                   ... ok"
+	// Example line: "test boolean                      ... FAILED"
+	// Example line: "test char                         ... ok"
+
+	// Count individual test results
+	okPattern := regexp.MustCompile(`(?m)^test\s+(\S+)\s+\.+\s+ok`)
+	failedPattern := regexp.MustCompile(`(?m)^test\s+(\S+)\s+\.+\s+FAILED`)
+
+	okMatches := okPattern.FindAllStringSubmatch(combinedOutput, -1)
+	results.PassedTests = len(okMatches)
+
+	failedMatches := failedPattern.FindAllStringSubmatch(combinedOutput, -1)
+	results.FailedTests = len(failedMatches)
+
+	// Extract failure details
+	for _, match := range failedMatches {
+		if len(match) > 1 {
+			testName := match[1]
+			results.FailureDetails = append(results.FailureDetails, TestFailure{
+				TestName: testName,
+				Error:    "Test failed (see regression.diffs for details)",
+			})
+		}
+	}
+
+	// Parse summary line
+	// Example: " 3 of 3 tests failed."
+	// Example: " All 3 tests passed."
+	summaryPassPattern := regexp.MustCompile(`All (\d+) tests? passed`)
+	summaryFailPattern := regexp.MustCompile(`(\d+) of (\d+) tests? failed`)
+
+	if matches := summaryPassPattern.FindStringSubmatch(combinedOutput); len(matches) > 1 {
+		total, _ := strconv.Atoi(matches[1])
+		results.TotalTests = total
+		results.PassedTests = total
+		results.FailedTests = 0
+	} else if matches := summaryFailPattern.FindStringSubmatch(combinedOutput); len(matches) > 2 {
+		failed, _ := strconv.Atoi(matches[1])
+		total, _ := strconv.Atoi(matches[2])
+		results.TotalTests = total
+		results.FailedTests = failed
+		results.PassedTests = total - failed
+	}
+
+	// If we didn't find a summary but found individual results, calculate total
+	if results.TotalTests == 0 && (results.PassedTests > 0 || results.FailedTests > 0) {
+		results.TotalTests = results.PassedTests + results.FailedTests + results.SkippedTests
+	}
+
+	return results
+}
+
+// Cleanup removes build artifacts but preserves source cache
+func (pb *PostgresBuilder) Cleanup() {
+	// Remove the build root directory (contains both build and install directories)
+	if pb.BuildDir != "" {
+		buildRoot := filepath.Dir(pb.BuildDir) // Go up from build/ to builds/<timestamp>/
+		_ = os.RemoveAll(buildRoot)            // Best-effort cleanup
+	}
+
+	// Keep source cache for next run
+}


### PR DESCRIPTION
## Summary
This PR adds end-to-end testing infrastructure that validates multigres compatibility by running PostgreSQL's regression test suite against a multigres cluster. The test clones PostgreSQL 17.6 source, builds it, spins up a 2-node multigres cluster with multigateway, and runs regression tests through the multigateway endpoint to verify compatibility.

## Running the Test
```
cd go/test/endtoend/pgregresstest
go test -v -timeout 60m
```
The first run clones and builds PostgreSQL (~200MB source, ~500MB builds), while subsequent runs reuse the cached source. The cache location can be customized via MULTIGRES_PG_CACHE_DIR environment variable.

> Note: This test is not yet integrated into the GitHub CI pipeline. It requires standard build tools (make, gcc, git)

## Test Plan
Run the test locally and verify it completes successfully. It will be added to CI pipeline in later iterations to have the compatibility report