### PR TITLE
fix(multipooler): pass --type to pgbackrest restore

### DIFF
--- a/go/multipooler/manager/rpc_backup.go
+++ b/go/multipooler/manager/rpc_backup.go
@@ -413,6 +413,7 @@ func (pm *MultiPoolerManager) executePgBackrestRestore(ctx context.Context, back
 	args := []string{
 		"--stanza=" + pm.stanzaName(),
 		"--config=" + configPath,
+		"--type=standby",
 	}
 
 	if backupID != "" {


### PR DESCRIPTION
We were previously *not* passing --type to `pgbackrest restore`. This caused:
1. creation of `recovery.signal`
2. setting of `recovery_command`

This combination existed even after a replica was promoted, then
demoted. The demotion caused a problem if the demoted Postgres instance
came up before the demotion finished. Postgres would enter recovery
mode. Once it comnpleted recovery it would then start a new timeline
(thinking it was still the primary).

The change makes it so that pgbackrest creates `standby.signal`, not
`recovery.signal`. `standby.signal` combined with `recovery_command`
does not cause recovery to occur. Since there's no recovery, there's no
new timeline created.
