### PR TITLE
chore(pgregress): make pg_regress tests opt-in

### DIFF
--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -15,6 +15,7 @@
 package pgregresstest
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -32,11 +33,11 @@ import (
 // 4. Runs PostgreSQL regression tests (boolean, char) through multigateway using make installcheck-tests
 // 5. Reports results (logs failures but doesn't fail the test)
 //
-// The test is skipped in short mode and when build dependencies are not available.
+// The test is skipped by default. Set RUN_PGREGRESS=1 to run it.
 func TestPostgreSQLRegression(t *testing.T) {
-	// Skip in short mode
-	if testing.Short() {
-		t.Skip("skipping long-running PostgreSQL regression tests in short mode")
+	// Skip unless explicitly enabled via environment variable
+	if os.Getenv("RUN_PGREGRESS") != "1" {
+		t.Skip("skipping pg_regress tests (set RUN_PGREGRESS=1 to run)")
 	}
 
 	// Skip if PostgreSQL binaries not available
@@ -94,6 +95,7 @@ func TestPostgreSQLRegression(t *testing.T) {
 				t.Fatalf("Test harness failed to execute: %v", err)
 			}
 			t.Fatal("Test harness returned nil results")
+			return
 		}
 
 		// Always log results (even on success)


### PR DESCRIPTION
This makes the pg_regress tests opt in:

```
haritabhgupta@Haritabhs-MBP query-serving-copy-stdin % go test -v ./go/test/endtoend/pgregresstest/...
=== RUN   TestPostgreSQLRegression
    pgregress_test.go:40: skipping pg_regress tests (set RUN_PGREGRESS=1 to run)
--- SKIP: TestPostgreSQLRegression (0.00s)
PASS
ok      github.com/multigres/multigres/go/test/endtoend/pgregresstest   0.698s
```


Runs with the env `RUN_PGREGRESS=1`:
```
haritabhgupta@Haritabhs-MBP query-serving-copy-stdin % RUN_PGREGRESS=1 go test -v ./go/test/endtoend/pgregresstest/...
=== RUN   TestPostgreSQLRegression
    main_test.go:27: Starting etcd for topology...
...
--- PASS: TestPostgreSQLRegression (76.60s)
    --- PASS: TestPostgreSQLRegression/setup_postgres_source (0.02s)
    --- PASS: TestPostgreSQLRegression/build_postgres (64.42s)
    --- PASS: TestPostgreSQLRegression/run_regression_tests (1.11s)
PASS
ok      github.com/multigres/multigres/go/test/endtoend/pgregresstest   77.662s
haritabhgupta@Haritabhs-MBP query-serving-copy-stdin % 
```