### PR TITLE
feat(notice): show notices while running commands

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -400,8 +400,15 @@ func (c *Conn) handleQuery() error {
 		}
 
 		// If CommandTag is set, this is the last packet of the current result set.
-		// Send CommandComplete and reset state for the next result set.
+		// Send notices (if any) before CommandComplete, then reset state for next result set.
 		if result.CommandTag != "" {
+			// Send any notices before CommandComplete.
+			for _, notice := range result.Notices {
+				if err := c.writeNoticeResponse(notice); err != nil {
+					return fmt.Errorf("writing notice response: %w", err)
+				}
+			}
+
 			if err := c.writeCommandComplete(result.CommandTag); err != nil {
 				return fmt.Errorf("writing command complete: %w", err)
 			}
@@ -654,8 +661,15 @@ func (c *Conn) handleExecute() error {
 		}
 
 		// If CommandTag is set, this is the last packet.
-		// Send CommandComplete.
+		// Send notices (if any) before CommandComplete.
 		if result.CommandTag != "" {
+			// Send any notices before CommandComplete.
+			for _, notice := range result.Notices {
+				if err := c.writeNoticeResponse(notice); err != nil {
+					return fmt.Errorf("writing notice response: %w", err)
+				}
+			}
+
 			if err := c.writeCommandComplete(result.CommandTag); err != nil {
 				return fmt.Errorf("writing command complete: %w", err)
 			}

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -352,17 +353,44 @@ func (c *Conn) writeErrorResponse(severity, sqlState, message, detail, hint stri
 
 // writeNoticeResponse writes an 'N' (NoticeResponse) message.
 // Format is identical to ErrorResponse but with different severity levels.
-func (c *Conn) writeNoticeResponse(severity, sqlState, message, detail, hint string) error {
+func (c *Conn) writeNoticeResponse(notice *sqltypes.Notice) error {
 	fields := make(map[byte]string)
-	fields[protocol.FieldSeverity] = severity
-	fields[protocol.FieldSeverityV] = severity
-	fields[protocol.FieldCode] = sqlState
-	fields[protocol.FieldMessage] = message
-	if detail != "" {
-		fields[protocol.FieldDetail] = detail
+	fields[protocol.FieldSeverity] = notice.Severity
+	fields[protocol.FieldSeverityV] = notice.Severity
+	fields[protocol.FieldCode] = notice.Code
+	fields[protocol.FieldMessage] = notice.Message
+	if notice.Detail != "" {
+		fields[protocol.FieldDetail] = notice.Detail
 	}
-	if hint != "" {
-		fields[protocol.FieldHint] = hint
+	if notice.Hint != "" {
+		fields[protocol.FieldHint] = notice.Hint
+	}
+	if notice.Position != 0 {
+		fields[protocol.FieldPosition] = strconv.Itoa(int(notice.Position))
+	}
+	if notice.InternalPosition != 0 {
+		fields[protocol.FieldInternalPosition] = strconv.Itoa(int(notice.InternalPosition))
+	}
+	if notice.InternalQuery != "" {
+		fields[protocol.FieldInternalQuery] = notice.InternalQuery
+	}
+	if notice.Where != "" {
+		fields[protocol.FieldWhere] = notice.Where
+	}
+	if notice.Schema != "" {
+		fields[protocol.FieldSchema] = notice.Schema
+	}
+	if notice.Table != "" {
+		fields[protocol.FieldTable] = notice.Table
+	}
+	if notice.Column != "" {
+		fields[protocol.FieldColumn] = notice.Column
+	}
+	if notice.DataType != "" {
+		fields[protocol.FieldDataType] = notice.DataType
+	}
+	if notice.Constraint != "" {
+		fields[protocol.FieldConstraint] = notice.Constraint
 	}
 
 	return c.writeErrorOrNotice(protocol.MsgNoticeResponse, fields)

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -52,7 +52,10 @@ type QueryResult struct {
 	// When streaming results, this should only be set on the final packet of a result set.
 	// When set, the protocol layer will send CommandComplete and reset state for the next result set.
 	// Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3", "CREATE TABLE"
-	CommandTag    string `protobuf:"bytes,4,opt,name=command_tag,json=commandTag,proto3" json:"command_tag,omitempty"`
+	CommandTag string `protobuf:"bytes,4,opt,name=command_tag,json=commandTag,proto3" json:"command_tag,omitempty"`
+	// notices contains any PostgreSQL notices received during query execution.
+	// These are non-fatal messages like warnings or informational notices.
+	Notices       []*Notice `protobuf:"bytes,5,rep,name=notices,proto3" json:"notices,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -113,6 +116,13 @@ func (x *QueryResult) GetCommandTag() string {
 		return x.CommandTag
 	}
 	return ""
+}
+
+func (x *QueryResult) GetNotices() []*Notice {
+	if x != nil {
+		return x.Notices
+	}
+	return nil
 }
 
 // Field represents metadata about a column in the result set.
@@ -282,6 +292,171 @@ func (x *Row) GetValues() []byte {
 	return nil
 }
 
+// Notice represents a PostgreSQL notice response (non-fatal messages).
+// These include warnings, informational messages, and other diagnostics
+// that don't cause the query to fail.
+type Notice struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// severity is the notice severity level (e.g., "NOTICE", "WARNING", "INFO")
+	Severity string `protobuf:"bytes,1,opt,name=severity,proto3" json:"severity,omitempty"`
+	// code is the SQLSTATE error code
+	Code string `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"`
+	// message is the primary human-readable notice message
+	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	// detail provides additional detail about the notice (optional)
+	Detail string `protobuf:"bytes,4,opt,name=detail,proto3" json:"detail,omitempty"`
+	// hint provides a hint about how to address the notice (optional)
+	Hint string `protobuf:"bytes,5,opt,name=hint,proto3" json:"hint,omitempty"`
+	// position is the cursor position in the original query string (1-indexed, 0 if not available)
+	Position int32 `protobuf:"varint,6,opt,name=position,proto3" json:"position,omitempty"`
+	// internal_position is the cursor position in the internal query (1-indexed, 0 if not available)
+	InternalPosition int32 `protobuf:"varint,7,opt,name=internal_position,json=internalPosition,proto3" json:"internal_position,omitempty"`
+	// internal_query is the text of the internally-generated query (optional)
+	InternalQuery string `protobuf:"bytes,8,opt,name=internal_query,json=internalQuery,proto3" json:"internal_query,omitempty"`
+	// where is the context in which the notice occurred, e.g., PL/pgSQL call stack (optional)
+	Where string `protobuf:"bytes,9,opt,name=where,proto3" json:"where,omitempty"`
+	// schema_name is the name of the schema associated with the notice (optional)
+	SchemaName string `protobuf:"bytes,10,opt,name=schema_name,json=schemaName,proto3" json:"schema_name,omitempty"`
+	// table_name is the name of the table associated with the notice (optional)
+	TableName string `protobuf:"bytes,11,opt,name=table_name,json=tableName,proto3" json:"table_name,omitempty"`
+	// column_name is the name of the column associated with the notice (optional)
+	ColumnName string `protobuf:"bytes,12,opt,name=column_name,json=columnName,proto3" json:"column_name,omitempty"`
+	// data_type_name is the name of the data type associated with the notice (optional)
+	DataTypeName string `protobuf:"bytes,13,opt,name=data_type_name,json=dataTypeName,proto3" json:"data_type_name,omitempty"`
+	// constraint_name is the name of the constraint associated with the notice (optional)
+	ConstraintName string `protobuf:"bytes,14,opt,name=constraint_name,json=constraintName,proto3" json:"constraint_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Notice) Reset() {
+	*x = Notice{}
+	mi := &file_query_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Notice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Notice) ProtoMessage() {}
+
+func (x *Notice) ProtoReflect() protoreflect.Message {
+	mi := &file_query_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Notice.ProtoReflect.Descriptor instead.
+func (*Notice) Descriptor() ([]byte, []int) {
+	return file_query_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *Notice) GetSeverity() string {
+	if x != nil {
+		return x.Severity
+	}
+	return ""
+}
+
+func (x *Notice) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *Notice) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *Notice) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+func (x *Notice) GetHint() string {
+	if x != nil {
+		return x.Hint
+	}
+	return ""
+}
+
+func (x *Notice) GetPosition() int32 {
+	if x != nil {
+		return x.Position
+	}
+	return 0
+}
+
+func (x *Notice) GetInternalPosition() int32 {
+	if x != nil {
+		return x.InternalPosition
+	}
+	return 0
+}
+
+func (x *Notice) GetInternalQuery() string {
+	if x != nil {
+		return x.InternalQuery
+	}
+	return ""
+}
+
+func (x *Notice) GetWhere() string {
+	if x != nil {
+		return x.Where
+	}
+	return ""
+}
+
+func (x *Notice) GetSchemaName() string {
+	if x != nil {
+		return x.SchemaName
+	}
+	return ""
+}
+
+func (x *Notice) GetTableName() string {
+	if x != nil {
+		return x.TableName
+	}
+	return ""
+}
+
+func (x *Notice) GetColumnName() string {
+	if x != nil {
+		return x.ColumnName
+	}
+	return ""
+}
+
+func (x *Notice) GetDataTypeName() string {
+	if x != nil {
+		return x.DataTypeName
+	}
+	return ""
+}
+
+func (x *Notice) GetConstraintName() string {
+	if x != nil {
+		return x.ConstraintName
+	}
+	return ""
+}
+
 // StatementDescription describes a prepared statement or portal.
 // Used for the Describe message ('D') response in the extended query protocol.
 type StatementDescription struct {
@@ -298,7 +473,7 @@ type StatementDescription struct {
 
 func (x *StatementDescription) Reset() {
 	*x = StatementDescription{}
-	mi := &file_query_proto_msgTypes[3]
+	mi := &file_query_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -310,7 +485,7 @@ func (x *StatementDescription) String() string {
 func (*StatementDescription) ProtoMessage() {}
 
 func (x *StatementDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[3]
+	mi := &file_query_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -323,7 +498,7 @@ func (x *StatementDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatementDescription.ProtoReflect.Descriptor instead.
 func (*StatementDescription) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{3}
+	return file_query_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StatementDescription) GetParameters() []*ParameterDescription {
@@ -351,7 +526,7 @@ type ParameterDescription struct {
 
 func (x *ParameterDescription) Reset() {
 	*x = ParameterDescription{}
-	mi := &file_query_proto_msgTypes[4]
+	mi := &file_query_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -363,7 +538,7 @@ func (x *ParameterDescription) String() string {
 func (*ParameterDescription) ProtoMessage() {}
 
 func (x *ParameterDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[4]
+	mi := &file_query_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -376,7 +551,7 @@ func (x *ParameterDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParameterDescription.ProtoReflect.Descriptor instead.
 func (*ParameterDescription) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{4}
+	return file_query_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ParameterDescription) GetDataTypeOid() uint32 {
@@ -406,7 +581,7 @@ type Target struct {
 
 func (x *Target) Reset() {
 	*x = Target{}
-	mi := &file_query_proto_msgTypes[5]
+	mi := &file_query_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -418,7 +593,7 @@ func (x *Target) String() string {
 func (*Target) ProtoMessage() {}
 
 func (x *Target) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[5]
+	mi := &file_query_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -431,7 +606,7 @@ func (x *Target) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Target.ProtoReflect.Descriptor instead.
 func (*Target) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{5}
+	return file_query_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Target) GetTableGroup() string {
@@ -474,7 +649,7 @@ type PreparedStatement struct {
 
 func (x *PreparedStatement) Reset() {
 	*x = PreparedStatement{}
-	mi := &file_query_proto_msgTypes[6]
+	mi := &file_query_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +661,7 @@ func (x *PreparedStatement) String() string {
 func (*PreparedStatement) ProtoMessage() {}
 
 func (x *PreparedStatement) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[6]
+	mi := &file_query_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +674,7 @@ func (x *PreparedStatement) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedStatement.ProtoReflect.Descriptor instead.
 func (*PreparedStatement) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{6}
+	return file_query_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *PreparedStatement) GetName() string {
@@ -554,7 +729,7 @@ type Portal struct {
 
 func (x *Portal) Reset() {
 	*x = Portal{}
-	mi := &file_query_proto_msgTypes[7]
+	mi := &file_query_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -566,7 +741,7 @@ func (x *Portal) String() string {
 func (*Portal) ProtoMessage() {}
 
 func (x *Portal) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[7]
+	mi := &file_query_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -579,7 +754,7 @@ func (x *Portal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Portal.ProtoReflect.Descriptor instead.
 func (*Portal) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{7}
+	return file_query_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Portal) GetName() string {
@@ -650,7 +825,7 @@ type ExecuteOptions struct {
 
 func (x *ExecuteOptions) Reset() {
 	*x = ExecuteOptions{}
-	mi := &file_query_proto_msgTypes[8]
+	mi := &file_query_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -662,7 +837,7 @@ func (x *ExecuteOptions) String() string {
 func (*ExecuteOptions) ProtoMessage() {}
 
 func (x *ExecuteOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[8]
+	mi := &file_query_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -675,7 +850,7 @@ func (x *ExecuteOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteOptions.ProtoReflect.Descriptor instead.
 func (*ExecuteOptions) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{8}
+	return file_query_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ExecuteOptions) GetSessionSettings() map[string]string {
@@ -710,14 +885,15 @@ var File_query_proto protoreflect.FileDescriptor
 
 const file_query_proto_rawDesc = "" +
 	"\n" +
-	"\vquery.proto\x12\x05query\x1a\x15clustermetadata.proto\"\x99\x01\n" +
+	"\vquery.proto\x12\x05query\x1a\x15clustermetadata.proto\"\xc2\x01\n" +
 	"\vQueryResult\x12$\n" +
 	"\x06fields\x18\x01 \x03(\v2\f.query.FieldR\x06fields\x12#\n" +
 	"\rrows_affected\x18\x02 \x01(\x04R\frowsAffected\x12\x1e\n" +
 	"\x04rows\x18\x03 \x03(\v2\n" +
 	".query.RowR\x04rows\x12\x1f\n" +
 	"\vcommand_tag\x18\x04 \x01(\tR\n" +
-	"commandTag\"\x89\x02\n" +
+	"commandTag\x12'\n" +
+	"\anotices\x18\x05 \x03(\v2\r.query.NoticeR\anotices\"\x89\x02\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1b\n" +
@@ -729,7 +905,26 @@ const file_query_proto_rawDesc = "" +
 	"\x06format\x18\b \x01(\x05R\x06format\"7\n" +
 	"\x03Row\x12\x18\n" +
 	"\alengths\x18\x01 \x03(\x12R\alengths\x12\x16\n" +
-	"\x06values\x18\x02 \x01(\fR\x06values\"y\n" +
+	"\x06values\x18\x02 \x01(\fR\x06values\"\xb4\x03\n" +
+	"\x06Notice\x12\x1a\n" +
+	"\bseverity\x18\x01 \x01(\tR\bseverity\x12\x12\n" +
+	"\x04code\x18\x02 \x01(\tR\x04code\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12\x16\n" +
+	"\x06detail\x18\x04 \x01(\tR\x06detail\x12\x12\n" +
+	"\x04hint\x18\x05 \x01(\tR\x04hint\x12\x1a\n" +
+	"\bposition\x18\x06 \x01(\x05R\bposition\x12+\n" +
+	"\x11internal_position\x18\a \x01(\x05R\x10internalPosition\x12%\n" +
+	"\x0einternal_query\x18\b \x01(\tR\rinternalQuery\x12\x14\n" +
+	"\x05where\x18\t \x01(\tR\x05where\x12\x1f\n" +
+	"\vschema_name\x18\n" +
+	" \x01(\tR\n" +
+	"schemaName\x12\x1d\n" +
+	"\n" +
+	"table_name\x18\v \x01(\tR\ttableName\x12\x1f\n" +
+	"\vcolumn_name\x18\f \x01(\tR\n" +
+	"columnName\x12$\n" +
+	"\x0edata_type_name\x18\r \x01(\tR\fdataTypeName\x12'\n" +
+	"\x0fconstraint_name\x18\x0e \x01(\tR\x0econstraintName\"y\n" +
 	"\x14StatementDescription\x12;\n" +
 	"\n" +
 	"parameters\x18\x01 \x03(\v2\x1b.query.ParameterDescriptionR\n" +
@@ -776,32 +971,34 @@ func file_query_proto_rawDescGZIP() []byte {
 	return file_query_proto_rawDescData
 }
 
-var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_query_proto_goTypes = []any{
 	(*QueryResult)(nil),             // 0: query.QueryResult
 	(*Field)(nil),                   // 1: query.Field
 	(*Row)(nil),                     // 2: query.Row
-	(*StatementDescription)(nil),    // 3: query.StatementDescription
-	(*ParameterDescription)(nil),    // 4: query.ParameterDescription
-	(*Target)(nil),                  // 5: query.Target
-	(*PreparedStatement)(nil),       // 6: query.PreparedStatement
-	(*Portal)(nil),                  // 7: query.Portal
-	(*ExecuteOptions)(nil),          // 8: query.ExecuteOptions
-	nil,                             // 9: query.ExecuteOptions.SessionSettingsEntry
-	(clustermetadata.PoolerType)(0), // 10: clustermetadata.PoolerType
+	(*Notice)(nil),                  // 3: query.Notice
+	(*StatementDescription)(nil),    // 4: query.StatementDescription
+	(*ParameterDescription)(nil),    // 5: query.ParameterDescription
+	(*Target)(nil),                  // 6: query.Target
+	(*PreparedStatement)(nil),       // 7: query.PreparedStatement
+	(*Portal)(nil),                  // 8: query.Portal
+	(*ExecuteOptions)(nil),          // 9: query.ExecuteOptions
+	nil,                             // 10: query.ExecuteOptions.SessionSettingsEntry
+	(clustermetadata.PoolerType)(0), // 11: clustermetadata.PoolerType
 }
 var file_query_proto_depIdxs = []int32{
 	1,  // 0: query.QueryResult.fields:type_name -> query.Field
 	2,  // 1: query.QueryResult.rows:type_name -> query.Row
-	4,  // 2: query.StatementDescription.parameters:type_name -> query.ParameterDescription
-	1,  // 3: query.StatementDescription.fields:type_name -> query.Field
-	10, // 4: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
-	9,  // 5: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
-	6,  // [6:6] is the sub-list for method output_type
-	6,  // [6:6] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	3,  // 2: query.QueryResult.notices:type_name -> query.Notice
+	5,  // 3: query.StatementDescription.parameters:type_name -> query.ParameterDescription
+	1,  // 4: query.StatementDescription.fields:type_name -> query.Field
+	11, // 5: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
+	10, // 6: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
+	7,  // [7:7] is the sub-list for method output_type
+	7,  // [7:7] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }
@@ -815,7 +1012,7 @@ func file_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_proto_rawDesc), len(file_query_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/test/endtoend/multipooler/notice_test.go
+++ b/go/test/endtoend/multipooler/notice_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPgProtocolClientNotices tests that PostgreSQL NOTICE messages are forwarded to the client.
+// This addresses issue #573 where NOTICE messages (e.g., from table inheritance merging)
+// were silently dropped instead of being forwarded to the client.
+func TestPgProtocolClientNotices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	conn, err := client.Connect(ctx, &client.Config{
+		Host:        "localhost",
+		Port:        setup.PrimaryPgctld.PgPort,
+		User:        "postgres",
+		Password:    testPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Test 1: Table inheritance with column merge produces NOTICE
+	t.Run("table_inheritance_column_merge_notice", func(t *testing.T) {
+		// Create parent table
+		_, err := conn.Query(ctx, "CREATE TEMP TABLE parent_notice_test (id int, name text)")
+		require.NoError(t, err)
+
+		// Create child table with same column name - PostgreSQL merges the columns and emits a NOTICE
+		// The NOTICE message is: "merging column "name" with inherited definition"
+		results, err := conn.Query(ctx, "CREATE TEMP TABLE child_notice_test (name text) INHERITS (parent_notice_test)")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		require.NotEmpty(t, result.Notices, "expected NOTICE from table inheritance column merge")
+
+		// Verify the notice has the expected fields
+		notice := result.Notices[0]
+		assert.Equal(t, "NOTICE", notice.Severity)
+		assert.Equal(t, "00000", notice.Code) // successful_completion SQLSTATE (informational notice)
+		assert.Contains(t, notice.Message, "merging column")
+		assert.Contains(t, notice.Message, "name")
+		t.Logf("Received NOTICE: %s - %s", notice.Code, notice.Message)
+	})
+
+	// Test 2: Simple query that produces no NOTICE
+	t.Run("no_notice_on_simple_select", func(t *testing.T) {
+		results, err := conn.Query(ctx, "SELECT 1")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		assert.Empty(t, result.Notices, "expected no NOTICE from simple SELECT")
+	})
+
+	// Test 3: RAISE NOTICE in DO block
+	t.Run("raise_notice_in_do_block", func(t *testing.T) {
+		results, err := conn.Query(ctx, "DO $$ BEGIN RAISE NOTICE 'test notice message'; END $$")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		require.NotEmpty(t, result.Notices, "expected NOTICE from RAISE NOTICE")
+
+		notice := result.Notices[0]
+		assert.Equal(t, "NOTICE", notice.Severity)
+		assert.Equal(t, "00000", notice.Code) // successful_completion SQLSTATE (default for RAISE NOTICE)
+		assert.Contains(t, notice.Message, "test notice message")
+		t.Logf("Received NOTICE: %s - %s", notice.Code, notice.Message)
+	})
+
+	// Test 4: Multiple NOTICEs in single statement
+	t.Run("multiple_notices", func(t *testing.T) {
+		results, err := conn.Query(ctx, `DO $$
+		BEGIN
+			RAISE NOTICE 'first notice';
+			RAISE NOTICE 'second notice';
+			RAISE NOTICE 'third notice';
+		END
+		$$`)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		require.Len(t, result.Notices, 3, "expected 3 NOTICEs from DO block")
+
+		assert.Contains(t, result.Notices[0].Message, "first notice")
+		assert.Contains(t, result.Notices[1].Message, "second notice")
+		assert.Contains(t, result.Notices[2].Message, "third notice")
+	})
+
+	// Test 5: NOTICE with DETAIL and HINT
+	t.Run("notice_with_detail_and_hint", func(t *testing.T) {
+		results, err := conn.Query(ctx, `DO $$
+		BEGIN
+			RAISE NOTICE 'main message'
+				USING DETAIL = 'detailed info',
+				      HINT = 'helpful hint';
+		END
+		$$`)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		require.NotEmpty(t, result.Notices, "expected NOTICE with DETAIL and HINT")
+
+		notice := result.Notices[0]
+		assert.Equal(t, "NOTICE", notice.Severity)
+		assert.Contains(t, notice.Message, "main message")
+		assert.Equal(t, "detailed info", notice.Detail)
+		assert.Equal(t, "helpful hint", notice.Hint)
+		t.Logf("Received NOTICE: %s - %s (Detail: %s, Hint: %s)",
+			notice.Code, notice.Message, notice.Detail, notice.Hint)
+	})
+
+	// Test 6: Streaming query with NOTICEs
+	t.Run("streaming_query_with_notices", func(t *testing.T) {
+		var results []*sqltypes.Result
+		var totalNotices int
+
+		err := conn.QueryStreaming(ctx, `DO $$
+		BEGIN
+			RAISE NOTICE 'streaming notice';
+		END
+		$$`,
+			func(ctx context.Context, result *sqltypes.Result) error {
+				results = append(results, result)
+				totalNotices += len(result.Notices)
+				return nil
+			})
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, totalNotices, "expected 1 NOTICE from streaming query")
+	})
+
+	// Test 7: NOTICE with Where field showing PL/pgSQL call stack
+	t.Run("notice_with_where_field_plpgsql_stack", func(t *testing.T) {
+		// Create a PL/pgSQL function that calls another function which raises a NOTICE
+		// This tests that the Where field contains the call stack information
+		_, err := conn.Query(ctx, `
+			CREATE OR REPLACE FUNCTION notice_test_inner() RETURNS void AS $$
+			BEGIN
+				RAISE NOTICE 'notice from inner function';
+			END;
+			$$ LANGUAGE plpgsql;
+		`)
+		require.NoError(t, err)
+
+		_, err = conn.Query(ctx, `
+			CREATE OR REPLACE FUNCTION notice_test_outer() RETURNS void AS $$
+			BEGIN
+				PERFORM notice_test_inner();
+			END;
+			$$ LANGUAGE plpgsql;
+		`)
+		require.NoError(t, err)
+
+		// Call the outer function which triggers the notice in the inner function
+		results, err := conn.Query(ctx, "SELECT notice_test_outer()")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		result := results[0]
+		require.NotEmpty(t, result.Notices, "expected NOTICE from nested function call")
+
+		notice := result.Notices[0]
+		assert.Equal(t, "NOTICE", notice.Severity)
+		assert.Contains(t, notice.Message, "notice from inner function")
+
+		// The Where field should contain the PL/pgSQL call stack
+		// It will look something like:
+		// "PL/pgSQL function notice_test_inner() line 3 at RAISE
+		// PL/pgSQL function notice_test_outer() line 3 at PERFORM"
+		assert.NotEmpty(t, notice.Where, "expected Where field to contain call stack")
+		assert.Contains(t, notice.Where, "notice_test_inner", "Where should contain inner function name")
+		assert.Contains(t, notice.Where, "notice_test_outer", "Where should contain outer function name")
+		t.Logf("Received NOTICE with Where field:\n  Message: %s\n  Where: %s", notice.Message, notice.Where)
+
+		// Cleanup
+		_, err = conn.Query(ctx, "DROP FUNCTION IF EXISTS notice_test_outer()")
+		require.NoError(t, err)
+		_, err = conn.Query(ctx, "DROP FUNCTION IF EXISTS notice_test_inner()")
+		require.NoError(t, err)
+	})
+}
+
+// TestPgProtocolClientNoticesExtendedQuery tests that NOTICE messages are forwarded
+// through the extended query protocol.
+func TestPgProtocolClientNoticesExtendedQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	conn, err := client.Connect(ctx, &client.Config{
+		Host:        "localhost",
+		Port:        setup.PrimaryPgctld.PgPort,
+		User:        "postgres",
+		Password:    testPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Test extended query protocol with PrepareAndExecute
+	t.Run("prepare_and_execute_with_notice", func(t *testing.T) {
+		var results []*sqltypes.Result
+
+		// Use a DO block that raises a NOTICE
+		err := conn.PrepareAndExecute(ctx, "", `DO $$
+		BEGIN
+			RAISE NOTICE 'prepared statement notice';
+		END
+		$$`,
+			nil, // no parameters
+			func(ctx context.Context, result *sqltypes.Result) error {
+				results = append(results, result)
+				return nil
+			})
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// Find the result with the notice
+		var foundNotice bool
+		for _, result := range results {
+			if len(result.Notices) > 0 {
+				foundNotice = true
+				notice := result.Notices[0]
+				assert.Equal(t, "NOTICE", notice.Severity)
+				assert.Contains(t, notice.Message, "prepared statement notice")
+				t.Logf("Received NOTICE via extended query: %s - %s", notice.Code, notice.Message)
+				break
+			}
+		}
+		assert.True(t, foundNotice, "expected NOTICE from extended query protocol")
+	})
+
+	// Test BindAndExecute with NOTICE
+	t.Run("bind_and_execute_with_notice", func(t *testing.T) {
+		// Parse a DO block that raises a NOTICE
+		err := conn.Parse(ctx, "notice_stmt", `DO $$
+		BEGIN
+			RAISE NOTICE 'bind and execute notice';
+		END
+		$$`, nil)
+		require.NoError(t, err)
+
+		var results []*sqltypes.Result
+		completed, err := conn.BindAndExecute(ctx, "notice_stmt", nil, nil, nil, 0,
+			func(ctx context.Context, result *sqltypes.Result) error {
+				results = append(results, result)
+				return nil
+			})
+		require.NoError(t, err)
+		assert.True(t, completed)
+
+		// Find the result with the notice
+		var foundNotice bool
+		for _, result := range results {
+			if len(result.Notices) > 0 {
+				foundNotice = true
+				notice := result.Notices[0]
+				assert.Equal(t, "NOTICE", notice.Severity)
+				assert.Contains(t, notice.Message, "bind and execute notice")
+				break
+			}
+		}
+		assert.True(t, foundNotice, "expected NOTICE from BindAndExecute")
+
+		// Cleanup
+		err = conn.CloseStatement(ctx, "notice_stmt")
+		require.NoError(t, err)
+	})
+}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -244,8 +244,8 @@ func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context,
 
 	cmd := exec.CommandContext(ctx, "make",
 		"-C", filepath.Join(pb.BuildDir, "src/test/regress"), // Regress directory
-		"installcheck-tests", // Target for running specific tests against existing server
-		"TESTS=boolean char", // Run only boolean and char tests
+		"installcheck-tests",            // Target for running specific tests against existing server
+		"TESTS=test_setup boolean char", // Run only boolean and char tests
 	)
 
 	// Set environment variables for connection

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -40,6 +40,10 @@ message QueryResult {
   // When set, the protocol layer will send CommandComplete and reset state for the next result set.
   // Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3", "CREATE TABLE"
   string command_tag = 4;
+
+  // notices contains any PostgreSQL notices received during query execution.
+  // These are non-fatal messages like warnings or informational notices.
+  repeated Notice notices = 5;
 }
 
 // Field represents metadata about a column in the result set.
@@ -79,6 +83,53 @@ message Row {
   // values contains all non-null values concatenated together.
   // Use lengths to split this into individual column values.
   bytes values = 2;
+}
+
+// Notice represents a PostgreSQL notice response (non-fatal messages).
+// These include warnings, informational messages, and other diagnostics
+// that don't cause the query to fail.
+message Notice {
+  // severity is the notice severity level (e.g., "NOTICE", "WARNING", "INFO")
+  string severity = 1;
+
+  // code is the SQLSTATE error code
+  string code = 2;
+
+  // message is the primary human-readable notice message
+  string message = 3;
+
+  // detail provides additional detail about the notice (optional)
+  string detail = 4;
+
+  // hint provides a hint about how to address the notice (optional)
+  string hint = 5;
+
+  // position is the cursor position in the original query string (1-indexed, 0 if not available)
+  int32 position = 6;
+
+  // internal_position is the cursor position in the internal query (1-indexed, 0 if not available)
+  int32 internal_position = 7;
+
+  // internal_query is the text of the internally-generated query (optional)
+  string internal_query = 8;
+
+  // where is the context in which the notice occurred, e.g., PL/pgSQL call stack (optional)
+  string where = 9;
+
+  // schema_name is the name of the schema associated with the notice (optional)
+  string schema_name = 10;
+
+  // table_name is the name of the table associated with the notice (optional)
+  string table_name = 11;
+
+  // column_name is the name of the column associated with the notice (optional)
+  string column_name = 12;
+
+  // data_type_name is the name of the data type associated with the notice (optional)
+  string data_type_name = 13;
+
+  // constraint_name is the name of the constraint associated with the notice (optional)
+  string constraint_name = 14;
 }
 
 // StatementDescription describes a prepared statement or portal.


### PR DESCRIPTION
This PR adds support for forwarding PostgreSQL NOTICE messages to clients during query execution.                                                
                                                                                                                                                   
  Previously, informational messages like NOTICE: merging multiple inherited definitions of column "name" were silently dropped when queries passed
   through the multigateway/multipooler stack. This caused a compatibility gap with standard PostgreSQL behavior, particularly noticeable when     
  running DDL commands that produce diagnostic output (e.g., table inheritance, implicit index creation).                                          
                                                                                                                                                   
  The fix extends the query protocol to carry notice messages alongside query results. Both simple and extended query protocols now propagate these
   messages back to the client, matching native PostgreSQL behavior.                                                                               
                                                                                                                                                   
  Resolves #573                                                                                                                                    