### PR TITLE
feat(queryserving): preserve PostgreSQL error format through Multigres stack

### DIFF
--- a/go/common/mterrors/grpc_test.go
+++ b/go/common/mterrors/grpc_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mterrors
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+)
+
+func TestToGRPCNil(t *testing.T) {
+	got := ToGRPC(nil)
+	assert.Nil(t, got)
+}
+
+func TestToGRPCRegularError(t *testing.T) {
+	err := New(mtrpcpb.Code_INVALID_ARGUMENT, "invalid query")
+	grpcErr := ToGRPC(err)
+	require.NotNil(t, grpcErr)
+
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Equal(t, "invalid query", st.Message())
+}
+
+func TestToGRPCPgError(t *testing.T) {
+	pgDiag := &PgDiagnostic{
+		MessageType: protocol.MsgErrorResponse,
+		Severity:    "ERROR",
+		Code:        "42P01",
+		Message:     "relation does not exist",
+		Position:    15,
+	}
+
+	grpcErr := ToGRPC(pgDiag)
+	require.NotNil(t, grpcErr)
+
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unknown, st.Code()) // PgDiagnostic returns UNKNOWN code
+
+	// Check that RPCError with PgDiagnostic is in details
+	details := st.Details()
+	require.Len(t, details, 1)
+
+	rpcErr, ok := details[0].(*mtrpcpb.RPCError)
+	require.True(t, ok)
+	assert.Equal(t, "ERROR: relation does not exist", rpcErr.Message)
+	assert.Equal(t, mtrpcpb.Code_UNKNOWN, rpcErr.Code)
+
+	require.NotNil(t, rpcErr.PgDiagnostic)
+	assert.Equal(t, int32(protocol.MsgErrorResponse), rpcErr.PgDiagnostic.MessageType)
+	assert.Equal(t, "ERROR", rpcErr.PgDiagnostic.Severity)
+	assert.Equal(t, "42P01", rpcErr.PgDiagnostic.Code)
+	assert.Equal(t, "relation does not exist", rpcErr.PgDiagnostic.Message)
+	assert.Equal(t, int32(15), rpcErr.PgDiagnostic.Position)
+}
+
+func TestFromGRPCNil(t *testing.T) {
+	got := FromGRPC(nil)
+	assert.Nil(t, got)
+}
+
+func TestFromGRPCEOF(t *testing.T) {
+	// io.EOF should pass through unchanged
+	got := FromGRPC(io.EOF)
+	assert.Equal(t, io.EOF, got)
+}
+
+func TestFromGRPCRegularError(t *testing.T) {
+	grpcErr := status.Error(codes.NotFound, "resource not found")
+	got := FromGRPC(grpcErr)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "resource not found", got.Error())
+	assert.Equal(t, mtrpcpb.Code_NOT_FOUND, Code(got))
+
+	// Should NOT be a PgDiagnostic
+	var pgDiag *PgDiagnostic
+	assert.False(t, errors.As(got, &pgDiag))
+}
+
+func TestFromGRPCWithPgDiagnostic(t *testing.T) {
+	// Create a gRPC error with RPCError containing PgDiagnostic
+	st := status.New(codes.Unknown, "ERROR: test error")
+	rpcErr := &mtrpcpb.RPCError{
+		Message: "ERROR: test error",
+		Code:    mtrpcpb.Code_UNKNOWN,
+		PgDiagnostic: PgDiagnosticToProto(&PgDiagnostic{
+			MessageType: protocol.MsgErrorResponse,
+			Severity:    "ERROR",
+			Code:        "42000",
+			Message:     "test error",
+			Hint:        "check your query",
+		}),
+	}
+	stWithDetails, err := st.WithDetails(rpcErr)
+	require.NoError(t, err)
+
+	got := FromGRPC(stWithDetails.Err())
+	require.NotNil(t, got)
+
+	// Should be a PgDiagnostic
+	var diag *PgDiagnostic
+	require.True(t, errors.As(got, &diag))
+
+	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "42000", diag.Code)
+	assert.Equal(t, "test error", diag.Message)
+	assert.Equal(t, "check your query", diag.Hint)
+}
+
+func TestFromGRPCNonStatusError(t *testing.T) {
+	// Non-gRPC errors should still be converted
+	got := FromGRPC(errors.New("plain error"))
+	require.NotNil(t, got)
+	assert.Equal(t, "plain error", got.Error())
+	assert.Equal(t, mtrpcpb.Code_UNKNOWN, Code(got))
+}
+
+func TestPgErrorGRPCRoundTrip(t *testing.T) {
+	// Test that all 14 PostgreSQL fields are preserved through gRPC round-trip
+	originalDiag := &PgDiagnostic{
+		MessageType:      protocol.MsgErrorResponse,
+		Severity:         "ERROR",
+		Code:             "23505",
+		Message:          "duplicate key value violates unique constraint",
+		Detail:           "Key (id)=(1) already exists.",
+		Hint:             "Use a different key value.",
+		Position:         25,
+		InternalPosition: 10,
+		InternalQuery:    "SELECT internal_func()",
+		Where:            "SQL function \"my_func\" statement 1",
+		Schema:           "public",
+		Table:            "users",
+		Column:           "id",
+		DataType:         "integer",
+		Constraint:       "users_pkey",
+	}
+
+	// Convert to gRPC
+	grpcErr := ToGRPC(originalDiag)
+
+	// Convert back from gRPC
+	recovered := FromGRPC(grpcErr)
+	require.NotNil(t, recovered)
+
+	// Should be a PgDiagnostic
+	var diag *PgDiagnostic
+	require.True(t, errors.As(recovered, &diag))
+
+	// Verify all 14 fields are preserved
+	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "23505", diag.Code)
+	assert.Equal(t, "duplicate key value violates unique constraint", diag.Message)
+	assert.Equal(t, "Key (id)=(1) already exists.", diag.Detail)
+	assert.Equal(t, "Use a different key value.", diag.Hint)
+	assert.Equal(t, int32(25), diag.Position)
+	assert.Equal(t, int32(10), diag.InternalPosition)
+	assert.Equal(t, "SELECT internal_func()", diag.InternalQuery)
+	assert.Equal(t, "SQL function \"my_func\" statement 1", diag.Where)
+	assert.Equal(t, "public", diag.Schema)
+	assert.Equal(t, "users", diag.Table)
+	assert.Equal(t, "id", diag.Column)
+	assert.Equal(t, "integer", diag.DataType)
+	assert.Equal(t, "users_pkey", diag.Constraint)
+
+	// Verify Error() message is preserved
+	assert.Equal(t, "ERROR: duplicate key value violates unique constraint", diag.Error())
+}
+
+func TestPgErrorGRPCRoundTripMinimalFields(t *testing.T) {
+	// Test round-trip with only required fields (severity, code, message)
+	originalDiag := &PgDiagnostic{
+		MessageType: protocol.MsgErrorResponse,
+		Severity:    "FATAL",
+		Code:        "28P01",
+		Message:     "password authentication failed",
+	}
+
+	grpcErr := ToGRPC(originalDiag)
+	recovered := FromGRPC(grpcErr)
+
+	var diag *PgDiagnostic
+	require.True(t, errors.As(recovered, &diag))
+	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "28P01", diag.Code)
+	assert.Equal(t, "password authentication failed", diag.Message)
+	// Optional fields should be empty/zero
+	assert.Empty(t, diag.Detail)
+	assert.Empty(t, diag.Hint)
+	assert.Equal(t, int32(0), diag.Position)
+}
+
+func TestNonPgErrorGRPCRoundTrip(t *testing.T) {
+	// Non-PostgreSQL errors should continue working
+	originalErr := New(mtrpcpb.Code_UNAVAILABLE, "service unavailable")
+	grpcErr := ToGRPC(originalErr)
+	recovered := FromGRPC(grpcErr)
+
+	require.NotNil(t, recovered)
+	assert.Equal(t, "service unavailable", recovered.Error())
+	assert.Equal(t, mtrpcpb.Code_UNAVAILABLE, Code(recovered))
+
+	// Should NOT be a PgDiagnostic
+	var pgDiag *PgDiagnostic
+	assert.False(t, errors.As(recovered, &pgDiag))
+}
+
+func TestTruncateError(t *testing.T) {
+	// Short error should not be truncated
+	shortErr := errors.New("short error")
+	assert.Equal(t, "short error", truncateError(shortErr))
+
+	// Long error should be truncated
+	longMsg := make([]byte, 10000)
+	for i := range longMsg {
+		longMsg[i] = 'a'
+	}
+	longErr := errors.New(string(longMsg))
+	truncated := truncateError(longErr)
+	assert.Less(t, len(truncated), len(longMsg))
+	assert.Contains(t, truncated, "truncated")
+}
+
+func TestToGRPCPgErrorMessageTruncation(t *testing.T) {
+	// Test that large messages are truncated in the warning log.
+	// We can't easily test that slog.Warn is called (would require mocking),
+	// but we can verify that ToGRPC still returns a valid error even with
+	// a very large diagnostic message.
+	largeMsg := make([]byte, 10000)
+	for i := range largeMsg {
+		largeMsg[i] = 'x'
+	}
+
+	pgDiag := &PgDiagnostic{
+		MessageType: protocol.MsgErrorResponse,
+		Severity:    "ERROR",
+		Code:        "42P01",
+		Message:     string(largeMsg),
+		Where:       string(largeMsg), // Large Where field that may exceed gRPC limits
+	}
+
+	// ToGRPC should still work, potentially falling back to basic error
+	grpcErr := ToGRPC(pgDiag)
+	require.NotNil(t, grpcErr)
+
+	// Should be a valid gRPC error
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unknown, st.Code())
+}

--- a/go/common/mterrors/pgdiagnostic.go
+++ b/go/common/mterrors/pgdiagnostic.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mterrors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/multigres/multigres/go/pb/query"
+)
+
+// PgDiagnostic represents a PostgreSQL diagnostic message (error or notice).
+// PostgreSQL uses the same wire format for both ErrorResponse ('E') and NoticeResponse ('N'),
+// differentiated by the MessageType field.
+type PgDiagnostic struct {
+	// MessageType is the PostgreSQL protocol message type byte.
+	// 'E' (0x45 = 69) for ErrorResponse, 'N' (0x4E = 78) for NoticeResponse.
+	MessageType      byte
+	Severity         string
+	Code             string
+	Message          string
+	Detail           string
+	Hint             string
+	Position         int32
+	InternalPosition int32
+	InternalQuery    string
+	Where            string
+	Schema           string
+	Table            string
+	Column           string
+	DataType         string
+	Constraint       string
+}
+
+// IsError returns true if this diagnostic represents an error (MessageType == 'E').
+func (d *PgDiagnostic) IsError() bool {
+	return d.MessageType == 'E'
+}
+
+// IsNotice returns true if this diagnostic represents a notice (MessageType == 'N').
+func (d *PgDiagnostic) IsNotice() bool {
+	return d.MessageType == 'N'
+}
+
+// SQLSTATE returns the PostgreSQL SQLSTATE error code.
+// This is an alias for the Code field, provided for clarity.
+//
+// SQLSTATE codes are 5-character strings where:
+//   - First 2 characters = class (e.g., "42" = syntax/access error)
+//   - Last 3 characters = specific condition
+//
+// Example: "42P01" means undefined table (class 42 = syntax error or access rule violation).
+//
+// See: https://www.postgresql.org/docs/current/errcodes-appendix.html
+func (d *PgDiagnostic) SQLSTATE() string {
+	return d.Code
+}
+
+// SQLSTATEClass returns the first 2 characters of the SQLSTATE code,
+// which identifies the error class.
+//
+// Common classes:
+//   - "00" = Successful completion
+//   - "22" = Data exception
+//   - "23" = Integrity constraint violation
+//   - "42" = Syntax error or access rule violation
+//   - "XX" = Internal error
+//
+// Returns empty string if Code is empty or less than 2 characters.
+//
+// Example:
+//
+//	diag := &PgDiagnostic{Code: "42P01"}
+//	diag.SQLSTATEClass() // returns "42"
+func (d *PgDiagnostic) SQLSTATEClass() string {
+	if len(d.Code) < 2 {
+		return ""
+	}
+	return d.Code[:2]
+}
+
+// IsClass returns true if the SQLSTATE code belongs to the specified class.
+// The class is the first 2 characters of the SQLSTATE code.
+//
+// Example:
+//
+//	diag := &PgDiagnostic{Code: "42P01"} // undefined table
+//	diag.IsClass("42") // returns true (syntax/access error class)
+//	diag.IsClass("23") // returns false
+func (d *PgDiagnostic) IsClass(class string) bool {
+	return d.SQLSTATEClass() == class
+}
+
+// IsFatal returns true if the severity indicates a fatal condition.
+// Fatal conditions include FATAL and PANIC severities.
+//
+// Per PostgreSQL protocol:
+//   - FATAL: The session is terminated
+//   - PANIC: All database sessions are terminated (server restart required)
+//
+// ERROR severity is not considered fatal - the session can continue.
+func (d *PgDiagnostic) IsFatal() bool {
+	return d.Severity == "FATAL" || d.Severity == "PANIC"
+}
+
+// Error implements the error interface.
+// Returns PostgreSQL-native format: "SEVERITY: message".
+// This matches the primary error line format that PostgreSQL displays.
+// Use [PgDiagnostic.FullError] to include the SQLSTATE code for debugging.
+func (d *PgDiagnostic) Error() string {
+	if d == nil {
+		return "ERROR: unknown error"
+	}
+	return d.Severity + ": " + d.Message
+}
+
+// FullError returns the error with SQLSTATE code for debugging purposes.
+// Format: "SEVERITY: message (SQLSTATE code)"
+func (d *PgDiagnostic) FullError() string {
+	if d == nil {
+		return "ERROR: unknown error (SQLSTATE 00000)"
+	}
+	return d.Severity + ": " + d.Message + " (SQLSTATE " + d.Code + ")"
+}
+
+// Validate checks that required PostgreSQL diagnostic fields are present.
+// This is a lenient validation - it returns an error describing what's missing
+// but callers should typically log a warning rather than fail.
+//
+// Required fields per PostgreSQL protocol:
+//   - MessageType must be 'E' (ErrorResponse) or 'N' (NoticeResponse)
+//   - Severity must not be empty
+//   - Code (SQLSTATE) must not be empty
+//   - Message must not be empty
+func (d *PgDiagnostic) Validate() error {
+	if d == nil {
+		return errors.New("diagnostic is nil")
+	}
+
+	var issues []string
+
+	if d.MessageType != 'E' && d.MessageType != 'N' {
+		if d.MessageType == 0 {
+			issues = append(issues, "MessageType is unset (0x00): must be 'E' or 'N'")
+		} else {
+			issues = append(issues, fmt.Sprintf("invalid MessageType '%c' (0x%02x): must be 'E' or 'N'", d.MessageType, d.MessageType))
+		}
+	}
+
+	if d.Severity == "" {
+		issues = append(issues, "Severity is empty")
+	}
+
+	if d.Code == "" {
+		issues = append(issues, "Code (SQLSTATE) is empty")
+	}
+
+	if d.Message == "" {
+		issues = append(issues, "Message is empty")
+	}
+
+	if len(issues) > 0 {
+		return fmt.Errorf("invalid PgDiagnostic: %s", strings.Join(issues, "; "))
+	}
+
+	return nil
+}
+
+// PgDiagnosticToProto converts mterrors PgDiagnostic to proto format for gRPC serialization.
+func PgDiagnosticToProto(d *PgDiagnostic) *query.PgDiagnostic {
+	if d == nil {
+		return nil
+	}
+	return &query.PgDiagnostic{
+		MessageType:      int32(d.MessageType),
+		Severity:         d.Severity,
+		Code:             d.Code,
+		Message:          d.Message,
+		Detail:           d.Detail,
+		Hint:             d.Hint,
+		Position:         d.Position,
+		InternalPosition: d.InternalPosition,
+		InternalQuery:    d.InternalQuery,
+		Where:            d.Where,
+		SchemaName:       d.Schema,
+		TableName:        d.Table,
+		ColumnName:       d.Column,
+		DataTypeName:     d.DataType,
+		ConstraintName:   d.Constraint,
+	}
+}
+
+// PgDiagnosticFromProto converts proto PgDiagnostic to mterrors PgDiagnostic.
+func PgDiagnosticFromProto(pd *query.PgDiagnostic) *PgDiagnostic {
+	if pd == nil {
+		return nil
+	}
+	return &PgDiagnostic{
+		MessageType:      byte(pd.MessageType),
+		Severity:         pd.Severity,
+		Code:             pd.Code,
+		Message:          pd.Message,
+		Detail:           pd.Detail,
+		Hint:             pd.Hint,
+		Position:         pd.Position,
+		InternalPosition: pd.InternalPosition,
+		InternalQuery:    pd.InternalQuery,
+		Where:            pd.Where,
+		Schema:           pd.SchemaName,
+		Table:            pd.TableName,
+		Column:           pd.ColumnName,
+		DataType:         pd.DataTypeName,
+		Constraint:       pd.ConstraintName,
+	}
+}

--- a/go/common/pgprotocol/client/diagnostic_test.go
+++ b/go/common/pgprotocol/client/diagnostic_test.go
@@ -1,0 +1,785 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// TestParseDiagnosticFieldsMissingRequiredFields tests parsing diagnostics with missing required fields.
+func TestParseDiagnosticFieldsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name             string
+		fields           map[byte]string
+		expectedSeverity string
+		expectedCode     string
+		expectedMessage  string
+	}{
+		{
+			name:             "missing severity",
+			fields:           map[byte]string{protocol.FieldCode: "42P01", protocol.FieldMessage: "relation does not exist"},
+			expectedSeverity: "",
+			expectedCode:     "42P01",
+			expectedMessage:  "relation does not exist",
+		},
+		{
+			name:             "missing code",
+			fields:           map[byte]string{protocol.FieldSeverity: "ERROR", protocol.FieldMessage: "relation does not exist"},
+			expectedSeverity: "ERROR",
+			expectedCode:     "",
+			expectedMessage:  "relation does not exist",
+		},
+		{
+			name:             "missing message",
+			fields:           map[byte]string{protocol.FieldSeverity: "ERROR", protocol.FieldCode: "42P01"},
+			expectedSeverity: "ERROR",
+			expectedCode:     "42P01",
+			expectedMessage:  "",
+		},
+		{
+			name:             "all required fields missing",
+			fields:           map[byte]string{protocol.FieldDetail: "Some detail"},
+			expectedSeverity: "",
+			expectedCode:     "",
+			expectedMessage:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build wire format message body
+			w := NewMessageWriter()
+			for fieldType, value := range tc.fields {
+				w.WriteByte(fieldType)
+				w.WriteString(value)
+			}
+			w.WriteByte(0) // Terminator
+
+			// Parse as error (warning should be logged)
+			diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+			require.NotNil(t, diag)
+
+			// Verify fields are parsed (even if incomplete)
+			assert.Equal(t, tc.expectedSeverity, diag.Severity)
+			assert.Equal(t, tc.expectedCode, diag.Code)
+			assert.Equal(t, tc.expectedMessage, diag.Message)
+
+			// Validate should return error for incomplete diagnostics
+			err := diag.Validate()
+			assert.Error(t, err, "expected validation error for incomplete diagnostic")
+		})
+	}
+}
+
+// TestParseDiagnosticFieldsAllFieldsPopulated tests parsing diagnostics with all 14 fields.
+func TestParseDiagnosticFieldsAllFieldsPopulated(t *testing.T) {
+	// Build wire format message with all 14 fields
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("23505")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("duplicate key value violates unique constraint")
+	w.WriteByte(protocol.FieldDetail)
+	w.WriteString("Key (id)=(1) already exists.")
+	w.WriteByte(protocol.FieldHint)
+	w.WriteString("Use a different key value.")
+	w.WriteByte(protocol.FieldPosition)
+	w.WriteString("42")
+	w.WriteByte(protocol.FieldInternalPosition)
+	w.WriteString("15")
+	w.WriteByte(protocol.FieldInternalQuery)
+	w.WriteString("SELECT * FROM internal_table")
+	w.WriteByte(protocol.FieldWhere)
+	w.WriteString("PL/pgSQL function check_email() line 5")
+	w.WriteByte(protocol.FieldSchema)
+	w.WriteString("public")
+	w.WriteByte(protocol.FieldTable)
+	w.WriteString("users")
+	w.WriteByte(protocol.FieldColumn)
+	w.WriteString("email")
+	w.WriteByte(protocol.FieldDataType)
+	w.WriteString("text")
+	w.WriteByte(protocol.FieldConstraint)
+	w.WriteString("users_email_key")
+	w.WriteByte(0) // Terminator
+
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	// Verify all 14 fields
+	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "23505", diag.Code)
+	assert.Equal(t, "duplicate key value violates unique constraint", diag.Message)
+	assert.Equal(t, "Key (id)=(1) already exists.", diag.Detail)
+	assert.Equal(t, "Use a different key value.", diag.Hint)
+	assert.Equal(t, int32(42), diag.Position)
+	assert.Equal(t, int32(15), diag.InternalPosition)
+	assert.Equal(t, "SELECT * FROM internal_table", diag.InternalQuery)
+	assert.Equal(t, "PL/pgSQL function check_email() line 5", diag.Where)
+	assert.Equal(t, "public", diag.Schema)
+	assert.Equal(t, "users", diag.Table)
+	assert.Equal(t, "email", diag.Column)
+	assert.Equal(t, "text", diag.DataType)
+	assert.Equal(t, "users_email_key", diag.Constraint)
+
+	// Validate should pass
+	err := diag.Validate()
+	assert.NoError(t, err)
+}
+
+// TestParseDiagnosticFieldsOnlyRequiredFields tests parsing diagnostics with only required fields.
+func TestParseDiagnosticFieldsOnlyRequiredFields(t *testing.T) {
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("FATAL")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("28P01")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("password authentication failed")
+	w.WriteByte(0) // Terminator
+
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	// Verify required fields
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, "28P01", diag.Code)
+	assert.Equal(t, "password authentication failed", diag.Message)
+
+	// Verify optional fields are empty/zero
+	assert.Empty(t, diag.Detail)
+	assert.Empty(t, diag.Hint)
+	assert.Equal(t, int32(0), diag.Position)
+	assert.Equal(t, int32(0), diag.InternalPosition)
+	assert.Empty(t, diag.InternalQuery)
+	assert.Empty(t, diag.Where)
+	assert.Empty(t, diag.Schema)
+	assert.Empty(t, diag.Table)
+	assert.Empty(t, diag.Column)
+	assert.Empty(t, diag.DataType)
+	assert.Empty(t, diag.Constraint)
+
+	// Validate should pass
+	err := diag.Validate()
+	assert.NoError(t, err)
+}
+
+// TestParseDiagnosticFieldsUnknownFieldTypes tests that unknown field types are ignored.
+func TestParseDiagnosticFieldsUnknownFieldTypes(t *testing.T) {
+	w := NewMessageWriter()
+	// Known fields
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	// Unknown field type 'Z'
+	w.WriteByte('Z')
+	w.WriteString("unknown value 1")
+	// Known field
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("42601")
+	// Another unknown field type '!'
+	w.WriteByte('!')
+	w.WriteString("unknown value 2")
+	// Known field
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("syntax error")
+	// Unknown field type that looks like it could be a field
+	w.WriteByte(0x7F)
+	w.WriteString("high byte value")
+	w.WriteByte(0) // Terminator
+
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	// Verify known fields are parsed correctly
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "42601", diag.Code)
+	assert.Equal(t, "syntax error", diag.Message)
+
+	// Unknown fields should not affect parsing
+	// Validate should pass since required fields are present
+	err := diag.Validate()
+	assert.NoError(t, err)
+}
+
+// TestParseDiagnosticFieldsNoticeMessageType tests parsing notices (not errors).
+func TestParseDiagnosticFieldsNoticeMessageType(t *testing.T) {
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("WARNING")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("01000")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("this is a warning")
+	w.WriteByte(0) // Terminator
+
+	diag := parseDiagnosticFields(protocol.MsgNoticeResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	// Verify message type
+	assert.Equal(t, byte(protocol.MsgNoticeResponse), diag.MessageType)
+	assert.True(t, diag.IsNotice())
+	assert.False(t, diag.IsError())
+
+	// Verify fields
+	assert.Equal(t, "WARNING", diag.Severity)
+	assert.Equal(t, "01000", diag.Code)
+	assert.Equal(t, "this is a warning", diag.Message)
+}
+
+// TestDiagnosticRoundTripParseProtoWriteParse tests the full round-trip:
+// parse → PgDiagnostic → proto → PgDiagnostic → write → parse
+func TestDiagnosticRoundTripParseProtoWriteParse(t *testing.T) {
+	tests := []struct {
+		name string
+		diag *mterrors.PgDiagnostic
+	}{
+		{
+			name: "error with all fields",
+			diag: &mterrors.PgDiagnostic{
+				MessageType:      protocol.MsgErrorResponse,
+				Severity:         "ERROR",
+				Code:             "23505",
+				Message:          "duplicate key value violates unique constraint",
+				Detail:           "Key (id)=(1) already exists.",
+				Hint:             "Use a different key value.",
+				Position:         42,
+				InternalPosition: 15,
+				InternalQuery:    "SELECT * FROM internal_table",
+				Where:            "PL/pgSQL function check_email() line 5",
+				Schema:           "public",
+				Table:            "users",
+				Column:           "email",
+				DataType:         "text",
+				Constraint:       "users_email_key",
+			},
+		},
+		{
+			name: "error with minimal fields",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgErrorResponse,
+				Severity:    "FATAL",
+				Code:        "28P01",
+				Message:     "password authentication failed",
+			},
+		},
+		{
+			name: "notice with warning",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgNoticeResponse,
+				Severity:    "WARNING",
+				Code:        "01000",
+				Message:     "implicit zero-padding warning",
+				Detail:      "The value was truncated",
+			},
+		},
+		{
+			name: "error with position only",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgErrorResponse,
+				Severity:    "ERROR",
+				Code:        "42601",
+				Message:     "syntax error at or near \"FORM\"",
+				Position:    15,
+			},
+		},
+		{
+			name: "error with schema context only",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgErrorResponse,
+				Severity:    "ERROR",
+				Code:        "23503",
+				Message:     "insert or update on table violates foreign key constraint",
+				Schema:      "myschema",
+				Table:       "orders",
+				Constraint:  "orders_customer_id_fkey",
+			},
+		},
+		{
+			name: "unicode characters",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: protocol.MsgErrorResponse,
+				Severity:    "ERROR",
+				Code:        "22P02",
+				Message:     "invalid input syntax: 日本語 émoji 🎉",
+				Detail:      "详细信息 with unicode",
+				Hint:        "Подсказка на русском",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Step 1: PgDiagnostic → proto
+			protoDiag := mterrors.PgDiagnosticToProto(tc.diag)
+			require.NotNil(t, protoDiag)
+
+			// Step 2: proto → PgDiagnostic
+			recoveredDiag := mterrors.PgDiagnosticFromProto(protoDiag)
+			require.NotNil(t, recoveredDiag)
+
+			// Verify proto round-trip preserves all fields
+			assertDiagnosticsEqual(t, tc.diag, recoveredDiag)
+
+			// Step 3: Build wire format message from recovered diagnostic
+			wireBytes := buildDiagnosticWireFormat(recoveredDiag)
+
+			// Step 4: Parse wire format back to PgDiagnostic
+			finalDiag := parseDiagnosticFields(tc.diag.MessageType, wireBytes)
+			require.NotNil(t, finalDiag)
+
+			// Verify full round-trip preserves all fields
+			assertDiagnosticsEqual(t, tc.diag, finalDiag)
+		})
+	}
+}
+
+// TestDiagnosticIsFatalAllSeverities tests IsFatal() with all known severity values.
+func TestDiagnosticIsFatalAllSeverities(t *testing.T) {
+	severities := []struct {
+		severity string
+		isFatal  bool
+	}{
+		// Fatal severities
+		{"FATAL", true},
+		{"PANIC", true},
+
+		// Non-fatal error severities
+		{"ERROR", false},
+
+		// Notice severities (never fatal)
+		{"WARNING", false},
+		{"NOTICE", false},
+		{"INFO", false},
+		{"LOG", false},
+		{"DEBUG", false},
+
+		// Edge cases
+		{"", false},
+		{"fatal", false}, // Case sensitive
+		{"Fatal", false},
+		{"UNKNOWN", false},
+	}
+
+	for _, tc := range severities {
+		t.Run("severity_"+tc.severity, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Severity: tc.severity}
+			assert.Equal(t, tc.isFatal, diag.IsFatal(),
+				"IsFatal() for severity %q should be %v", tc.severity, tc.isFatal)
+		})
+	}
+}
+
+// TestDiagnosticIsClassAllCategories tests IsClass() with various SQLSTATE codes.
+func TestDiagnosticIsClassAllCategories(t *testing.T) {
+	// Common SQLSTATE classes and example codes
+	tests := []struct {
+		code  string
+		class string
+		match bool
+	}{
+		// Class 00 - Successful completion
+		{"00000", "00", true},
+		{"00000", "42", false},
+
+		// Class 01 - Warning
+		{"01000", "01", true},
+		{"01003", "01", true},
+		{"01000", "00", false},
+
+		// Class 02 - No data
+		{"02000", "02", true},
+		{"02001", "02", true},
+
+		// Class 08 - Connection exception
+		{"08000", "08", true},
+		{"08003", "08", true},
+		{"08006", "08", true},
+
+		// Class 22 - Data exception
+		{"22P02", "22", true}, // invalid_text_representation
+		{"22000", "22", true},
+		{"22001", "22", true}, // string_data_right_truncation
+		{"22P02", "23", false},
+
+		// Class 23 - Integrity constraint violation
+		{"23000", "23", true},
+		{"23505", "23", true}, // unique_violation
+		{"23503", "23", true}, // foreign_key_violation
+		{"23502", "23", true}, // not_null_violation
+		{"23505", "22", false},
+
+		// Class 25 - Invalid transaction state
+		{"25000", "25", true},
+		{"25001", "25", true},
+		{"25P02", "25", true}, // in_failed_sql_transaction
+
+		// Class 42 - Syntax error or access rule violation
+		{"42601", "42", true}, // syntax_error
+		{"42P01", "42", true}, // undefined_table
+		{"42703", "42", true}, // undefined_column
+		{"42P01", "23", false},
+
+		// Class 53 - Insufficient resources
+		{"53000", "53", true},
+		{"53100", "53", true}, // disk_full
+		{"53200", "53", true}, // out_of_memory
+
+		// Class XX - Internal error
+		{"XX000", "XX", true},
+		{"XX001", "XX", true},
+		{"XX000", "00", false},
+
+		// Edge cases
+		{"", "00", false},
+		{"4", "42", false},   // Too short
+		{"42", "42", true},   // Exact match
+		{"X", "XX", false},   // Single char
+		{"", "", true},       // Both empty (empty class matches empty code)
+		{"42601", "", false}, // Empty class
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.code+"_in_"+tc.class, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Code: tc.code}
+			assert.Equal(t, tc.match, diag.IsClass(tc.class),
+				"IsClass(%q) for code %q should be %v", tc.class, tc.code, tc.match)
+		})
+	}
+}
+
+// TestDiagnosticValidationCatchesAllInvalidStates tests that validation catches all invalid states.
+func TestDiagnosticValidationCatchesAllInvalidStates(t *testing.T) {
+	tests := []struct {
+		name          string
+		diag          *mterrors.PgDiagnostic
+		expectError   bool
+		errorContains []string
+	}{
+		{
+			name:          "nil diagnostic",
+			diag:          nil,
+			expectError:   true,
+			errorContains: []string{"diagnostic is nil"},
+		},
+		{
+			name: "valid error",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "relation does not exist",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid notice",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "NOTICE",
+				Code:        "00000",
+				Message:     "this is a notice",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid message type X",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'X',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "test",
+			},
+			expectError:   true,
+			errorContains: []string{"invalid MessageType 'X' (0x58)"},
+		},
+		{
+			name: "invalid message type zero",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 0,
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "test",
+			},
+			expectError:   true,
+			errorContains: []string{"MessageType is unset (0x00)"},
+		},
+		{
+			name: "empty severity",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "",
+				Code:        "42P01",
+				Message:     "test",
+			},
+			expectError:   true,
+			errorContains: []string{"Severity is empty"},
+		},
+		{
+			name: "empty code",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "",
+				Message:     "test",
+			},
+			expectError:   true,
+			errorContains: []string{"Code (SQLSTATE) is empty"},
+		},
+		{
+			name: "empty message",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "",
+			},
+			expectError:   true,
+			errorContains: []string{"Message is empty"},
+		},
+		{
+			name: "all fields invalid",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'Z',
+				Severity:    "",
+				Code:        "",
+				Message:     "",
+			},
+			expectError:   true,
+			errorContains: []string{"invalid MessageType", "Severity is empty", "Code (SQLSTATE) is empty", "Message is empty"},
+		},
+		{
+			name: "lowercase severity accepted (validation lenient)",
+			diag: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "error", // Lowercase is unusual but not invalid per validation
+				Code:        "42P01",
+				Message:     "test",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.diag.Validate()
+			if tc.expectError {
+				require.Error(t, err)
+				for _, contains := range tc.errorContains {
+					assert.Contains(t, err.Error(), contains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestPgDiagnosticErrorWrapping tests that *mterrors.PgDiagnostic works correctly with errors.As.
+func TestPgDiagnosticErrorWrapping(t *testing.T) {
+	// Create a PgDiagnostic error
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("42P01")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("relation does not exist")
+	w.WriteByte(0)
+
+	conn := &Conn{}
+	err := conn.parseError(w.Bytes())
+	require.Error(t, err)
+
+	// Test errors.As - now directly to *mterrors.PgDiagnostic
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag))
+	assert.Equal(t, "42P01", diag.Code)
+
+	// Test Error() format
+	assert.Equal(t, "ERROR: relation does not exist", err.Error())
+
+	// Test FullError()
+	assert.Equal(t, "ERROR: relation does not exist (SQLSTATE 42P01)", diag.FullError())
+}
+
+// Helper function to assert two PgDiagnostics are equal
+func assertDiagnosticsEqual(t *testing.T, expected, actual *mterrors.PgDiagnostic) {
+	t.Helper()
+	assert.Equal(t, expected.MessageType, actual.MessageType, "MessageType mismatch")
+	assert.Equal(t, expected.Severity, actual.Severity, "Severity mismatch")
+	assert.Equal(t, expected.Code, actual.Code, "Code mismatch")
+	assert.Equal(t, expected.Message, actual.Message, "Message mismatch")
+	assert.Equal(t, expected.Detail, actual.Detail, "Detail mismatch")
+	assert.Equal(t, expected.Hint, actual.Hint, "Hint mismatch")
+	assert.Equal(t, expected.Position, actual.Position, "Position mismatch")
+	assert.Equal(t, expected.InternalPosition, actual.InternalPosition, "InternalPosition mismatch")
+	assert.Equal(t, expected.InternalQuery, actual.InternalQuery, "InternalQuery mismatch")
+	assert.Equal(t, expected.Where, actual.Where, "Where mismatch")
+	assert.Equal(t, expected.Schema, actual.Schema, "Schema mismatch")
+	assert.Equal(t, expected.Table, actual.Table, "Table mismatch")
+	assert.Equal(t, expected.Column, actual.Column, "Column mismatch")
+	assert.Equal(t, expected.DataType, actual.DataType, "DataType mismatch")
+	assert.Equal(t, expected.Constraint, actual.Constraint, "Constraint mismatch")
+}
+
+// Helper function to build wire format from PgDiagnostic
+func buildDiagnosticWireFormat(diag *mterrors.PgDiagnostic) []byte {
+	w := NewMessageWriter()
+
+	if diag.Severity != "" {
+		w.WriteByte(protocol.FieldSeverity)
+		w.WriteString(diag.Severity)
+	}
+	if diag.Code != "" {
+		w.WriteByte(protocol.FieldCode)
+		w.WriteString(diag.Code)
+	}
+	if diag.Message != "" {
+		w.WriteByte(protocol.FieldMessage)
+		w.WriteString(diag.Message)
+	}
+	if diag.Detail != "" {
+		w.WriteByte(protocol.FieldDetail)
+		w.WriteString(diag.Detail)
+	}
+	if diag.Hint != "" {
+		w.WriteByte(protocol.FieldHint)
+		w.WriteString(diag.Hint)
+	}
+	if diag.Position != 0 {
+		w.WriteByte(protocol.FieldPosition)
+		w.WriteString(positionToString(diag.Position))
+	}
+	if diag.InternalPosition != 0 {
+		w.WriteByte(protocol.FieldInternalPosition)
+		w.WriteString(positionToString(diag.InternalPosition))
+	}
+	if diag.InternalQuery != "" {
+		w.WriteByte(protocol.FieldInternalQuery)
+		w.WriteString(diag.InternalQuery)
+	}
+	if diag.Where != "" {
+		w.WriteByte(protocol.FieldWhere)
+		w.WriteString(diag.Where)
+	}
+	if diag.Schema != "" {
+		w.WriteByte(protocol.FieldSchema)
+		w.WriteString(diag.Schema)
+	}
+	if diag.Table != "" {
+		w.WriteByte(protocol.FieldTable)
+		w.WriteString(diag.Table)
+	}
+	if diag.Column != "" {
+		w.WriteByte(protocol.FieldColumn)
+		w.WriteString(diag.Column)
+	}
+	if diag.DataType != "" {
+		w.WriteByte(protocol.FieldDataType)
+		w.WriteString(diag.DataType)
+	}
+	if diag.Constraint != "" {
+		w.WriteByte(protocol.FieldConstraint)
+		w.WriteString(diag.Constraint)
+	}
+
+	w.WriteByte(0) // Terminator
+	return w.Bytes()
+}
+
+func positionToString(pos int32) string {
+	return strconv.FormatInt(int64(pos), 10)
+}
+
+// TestParseDiagnosticFieldsSeverityVOnly tests parsing when only FieldSeverityV ('V') is present.
+func TestParseDiagnosticFieldsSeverityVOnly(t *testing.T) {
+	// Build wire format message with only FieldSeverityV (non-localized severity)
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverityV)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("42P01")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("relation does not exist")
+	w.WriteByte(0) // Terminator
+
+	diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+	require.NotNil(t, diag)
+
+	// Severity should be set from FieldSeverityV when FieldSeverity is absent
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "42P01", diag.Code)
+	assert.Equal(t, "relation does not exist", diag.Message)
+
+	// Validation should pass since all required fields are present
+	err := diag.Validate()
+	assert.NoError(t, err)
+}
+
+// TestParseDiagnosticFieldsBothSeverityFields tests parsing when both FieldSeverity and FieldSeverityV are present.
+func TestParseDiagnosticFieldsBothSeverityFields(t *testing.T) {
+	// Test case 1: FieldSeverity ('S') comes before FieldSeverityV ('V')
+	// Expected: Use FieldSeverity value
+	t.Run("S_before_V", func(t *testing.T) {
+		w := NewMessageWriter()
+		w.WriteByte(protocol.FieldSeverity)
+		w.WriteString("ERREUR") // Localized (e.g., French)
+		w.WriteByte(protocol.FieldSeverityV)
+		w.WriteString("ERROR") // Non-localized
+		w.WriteByte(protocol.FieldCode)
+		w.WriteString("42P01")
+		w.WriteByte(protocol.FieldMessage)
+		w.WriteString("relation does not exist")
+		w.WriteByte(0)
+
+		diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+		require.NotNil(t, diag)
+
+		// Should use FieldSeverity ('S') value since it was set first
+		assert.Equal(t, "ERREUR", diag.Severity)
+	})
+
+	// Test case 2: FieldSeverityV ('V') comes before FieldSeverity ('S')
+	// Expected: Use FieldSeverity value (overrides V)
+	t.Run("V_before_S", func(t *testing.T) {
+		w := NewMessageWriter()
+		w.WriteByte(protocol.FieldSeverityV)
+		w.WriteString("ERROR") // Non-localized (set first)
+		w.WriteByte(protocol.FieldSeverity)
+		w.WriteString("ERREUR") // Localized (overrides)
+		w.WriteByte(protocol.FieldCode)
+		w.WriteString("42P01")
+		w.WriteByte(protocol.FieldMessage)
+		w.WriteString("relation does not exist")
+		w.WriteByte(0)
+
+		diag := parseDiagnosticFields(protocol.MsgErrorResponse, w.Bytes())
+		require.NotNil(t, diag)
+
+		// Should use FieldSeverity ('S') value since it unconditionally overwrites
+		assert.Equal(t, "ERREUR", diag.Severity)
+	})
+}

--- a/go/common/pgprotocol/client/query.go
+++ b/go/common/pgprotocol/client/query.go
@@ -17,12 +17,14 @@ package client
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -95,11 +97,23 @@ func (c *Conn) Query(ctx context.Context, queryStr string) ([]*sqltypes.Result, 
 	var currentResult *sqltypes.Result
 
 	err := c.QueryStreaming(ctx, queryStr, func(ctx context.Context, result *sqltypes.Result) error {
+		// Handle notice-only results (zero-buffering notice delivery).
+		if len(result.Notices) > 0 && len(result.Rows) == 0 && result.CommandTag == "" {
+			// Accumulate notices into current result.
+			if currentResult == nil {
+				currentResult = &sqltypes.Result{}
+			}
+			currentResult.Notices = append(currentResult.Notices, result.Notices...)
+			return nil
+		}
+
 		// Accumulate rows into the current result.
 		if currentResult == nil {
 			currentResult = result
 		} else {
 			currentResult.Rows = append(currentResult.Rows, result.Rows...)
+			// Also accumulate any notices that came with row data.
+			currentResult.Notices = append(currentResult.Notices, result.Notices...)
 		}
 
 		// CommandTag being set signals the end of a result set.
@@ -196,7 +210,6 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 	var currentFields []*query.Field
 	var batchedRows []*sqltypes.Row
 	var batchedSize int
-	var notices []*sqltypes.Notice
 
 	// Track the first error encountered. We continue processing messages to drain
 	// the connection, then return this error after ReadyForQuery.
@@ -210,16 +223,14 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			return
 		}
 		result := &sqltypes.Result{
-			Fields:  currentFields,
-			Rows:    batchedRows,
-			Notices: notices,
+			Fields: currentFields,
+			Rows:   batchedRows,
 		}
 		if firstErr == nil {
 			firstErr = callback(ctx, result)
 		}
 		batchedRows = nil
 		batchedSize = 0
-		notices = nil
 	}
 
 	for {
@@ -267,7 +278,6 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 					Rows:         batchedRows,
 					CommandTag:   tag,
 					RowsAffected: parseRowsAffected(tag),
-					Notices:      notices,
 				}
 				firstErr = callback(ctx, result)
 			}
@@ -276,7 +286,6 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			currentFields = nil
 			batchedRows = nil
 			batchedSize = 0
-			notices = nil
 
 		case protocol.MsgEmptyQueryResponse:
 			// Empty query, call callback with empty result.
@@ -296,8 +305,15 @@ func (c *Conn) processQueryResponses(ctx context.Context, callback func(ctx cont
 			}
 
 		case protocol.MsgNoticeResponse:
-			// Parse and accumulate notices to be included in the Result.
-			notices = append(notices, c.parseNotice(body))
+			// Stream notice immediately via callback (zero-buffering notice delivery).
+			// Notices are sent as separate Results with no rows or command tag.
+			if callback != nil && firstErr == nil {
+				notice := c.parseNotice(body)
+				noticeResult := &sqltypes.Result{
+					Notices: []*mterrors.PgDiagnostic{notice},
+				}
+				firstErr = callback(ctx, noticeResult)
+			}
 
 		case protocol.MsgParameterStatus:
 			// Handle parameter status updates. Capture error but continue draining.
@@ -461,11 +477,19 @@ func parseRowsAffected(tag string) uint64 {
 	return 0
 }
 
-// parseError parses an ErrorResponse message into an error.
-func (c *Conn) parseError(body []byte) error {
+// parseDiagnosticFields parses all 14 PostgreSQL diagnostic fields from the wire format.
+// This is a shared helper used by both parseError() and parseNotice() since PostgreSQL
+// uses the same field format for ErrorResponse ('E') and NoticeResponse ('N') messages.
+// The msgType parameter should be protocol.MsgErrorResponse or protocol.MsgNoticeResponse.
+//
+// If the parsed diagnostic fails validation (missing required fields), a warning is logged
+// but the diagnostic is still returned. This allows lenient handling of malformed messages.
+func parseDiagnosticFields(msgType byte, body []byte) *mterrors.PgDiagnostic {
 	reader := NewMessageReader(body)
 
-	var severity, code, message, detail, hint string
+	diag := &mterrors.PgDiagnostic{
+		MessageType: msgType,
+	}
 
 	for reader.Remaining() > 0 {
 		fieldType, err := reader.ReadByte()
@@ -483,122 +507,70 @@ func (c *Conn) parseError(body []byte) error {
 
 		switch fieldType {
 		case protocol.FieldSeverity:
-			severity = value
+			diag.Severity = value
+		case protocol.FieldSeverityV:
+			// FieldSeverityV ('V') is the non-localized severity.
+			// Only use it if FieldSeverity ('S') wasn't already set.
+			if diag.Severity == "" {
+				diag.Severity = value
+			}
 		case protocol.FieldCode:
-			code = value
+			diag.Code = value
 		case protocol.FieldMessage:
-			message = value
+			diag.Message = value
 		case protocol.FieldDetail:
-			detail = value
+			diag.Detail = value
 		case protocol.FieldHint:
-			hint = value
-		}
-	}
-
-	return &Error{
-		Severity: severity,
-		Code:     code,
-		Message:  message,
-		Detail:   detail,
-		Hint:     hint,
-	}
-}
-
-// parseNotice parses a NoticeResponse message into a sqltypes.Notice.
-func (c *Conn) parseNotice(body []byte) *sqltypes.Notice {
-	reader := NewMessageReader(body)
-
-	var severity, code, message, detail, hint string
-	var internalQuery, where string
-	var schema, table, column, dataType, constraint string
-	var position, internalPosition int32
-
-	for reader.Remaining() > 0 {
-		fieldType, err := reader.ReadByte()
-		if err != nil {
-			break
-		}
-		if fieldType == 0 {
-			break // End of fields.
-		}
-
-		value, err := reader.ReadString()
-		if err != nil {
-			break
-		}
-
-		switch fieldType {
-		case protocol.FieldSeverity:
-			severity = value
-		case protocol.FieldCode:
-			code = value
-		case protocol.FieldMessage:
-			message = value
-		case protocol.FieldDetail:
-			detail = value
-		case protocol.FieldHint:
-			hint = value
+			diag.Hint = value
 		case protocol.FieldPosition:
 			if pos, err := strconv.ParseInt(value, 10, 32); err == nil {
-				position = int32(pos)
+				diag.Position = int32(pos)
 			}
 		case protocol.FieldInternalPosition:
 			if pos, err := strconv.ParseInt(value, 10, 32); err == nil {
-				internalPosition = int32(pos)
+				diag.InternalPosition = int32(pos)
 			}
 		case protocol.FieldInternalQuery:
-			internalQuery = value
+			diag.InternalQuery = value
 		case protocol.FieldWhere:
-			where = value
+			diag.Where = value
 		case protocol.FieldSchema:
-			schema = value
+			diag.Schema = value
 		case protocol.FieldTable:
-			table = value
+			diag.Table = value
 		case protocol.FieldColumn:
-			column = value
+			diag.Column = value
 		case protocol.FieldDataType:
-			dataType = value
+			diag.DataType = value
 		case protocol.FieldConstraint:
-			constraint = value
+			diag.Constraint = value
 		}
 	}
 
-	return &sqltypes.Notice{
-		Severity:         severity,
-		Code:             code,
-		Message:          message,
-		Detail:           detail,
-		Hint:             hint,
-		Position:         position,
-		InternalPosition: internalPosition,
-		InternalQuery:    internalQuery,
-		Where:            where,
-		Schema:           schema,
-		Table:            table,
-		Column:           column,
-		DataType:         dataType,
-		Constraint:       constraint,
+	// Validate the parsed diagnostic. Log a warning if validation fails,
+	// but still return the diagnostic to allow lenient handling.
+	if err := diag.Validate(); err != nil {
+		slog.Warn("parsed PostgreSQL diagnostic with missing required fields",
+			"error", err,
+			// Convert single byte to string directly (msgType is 'E' or 'N')
+			"message_type", string([]byte{msgType}),
+			"severity", diag.Severity,
+			"code", diag.Code,
+		)
 	}
+
+	return diag
 }
 
-// Error represents a PostgreSQL error response.
-type Error struct {
-	Severity string
-	Code     string
-	Message  string
-	Detail   string
-	Hint     string
+// parseError parses an ErrorResponse message into a *mterrors.PgDiagnostic.
+// Since mterrors.PgDiagnostic implements the error interface, it can be returned
+// directly as an error. This eliminates the need for a separate wrapper type.
+// It captures all 14 PostgreSQL error fields defined in the protocol.
+func (c *Conn) parseError(body []byte) error {
+	return parseDiagnosticFields(protocol.MsgErrorResponse, body)
 }
 
-// Error implements the error interface.
-func (e *Error) Error() string {
-	if e.Detail != "" {
-		return fmt.Sprintf("%s: %s (SQLSTATE %s)\nDETAIL: %s", e.Severity, e.Message, e.Code, e.Detail)
-	}
-	return fmt.Sprintf("%s: %s (SQLSTATE %s)", e.Severity, e.Message, e.Code)
-}
-
-// IsSQLState checks if the error has the given SQLSTATE code.
-func (e *Error) IsSQLState(code string) bool {
-	return e.Code == code
+// parseNotice parses a NoticeResponse message into a mterrors.PgDiagnostic.
+func (c *Conn) parseNotice(body []byte) *mterrors.PgDiagnostic {
+	return parseDiagnosticFields(protocol.MsgNoticeResponse, body)
 }

--- a/go/common/pgprotocol/client/query_test.go
+++ b/go/common/pgprotocol/client/query_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 )
 
@@ -133,7 +134,7 @@ func TestParseCommandComplete(t *testing.T) {
 }
 
 func TestParseError(t *testing.T) {
-	// Build an ErrorResponse message body.
+	// Build an ErrorResponse message body with basic fields.
 	w := NewMessageWriter()
 	w.WriteByte(protocol.FieldSeverity)
 	w.WriteString("ERROR")
@@ -151,32 +152,184 @@ func TestParseError(t *testing.T) {
 	err := conn.parseError(w.Bytes())
 	require.Error(t, err)
 
-	var pgErr *Error
-	require.True(t, errors.As(err, &pgErr))
-	assert.Equal(t, "ERROR", pgErr.Severity)
-	assert.Equal(t, "42P01", pgErr.Code)
-	assert.Equal(t, "relation \"foo\" does not exist", pgErr.Message)
-	assert.Equal(t, "Some detail", pgErr.Detail)
-	assert.Equal(t, "Check your table name", pgErr.Hint)
-	assert.True(t, pgErr.IsSQLState("42P01"))
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag))
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "42P01", diag.Code)
+	assert.Equal(t, "relation \"foo\" does not exist", diag.Message)
+	assert.Equal(t, "Some detail", diag.Detail)
+	assert.Equal(t, "Check your table name", diag.Hint)
+	assert.Equal(t, "42P01", diag.SQLSTATE())
 }
 
-func TestErrorString(t *testing.T) {
-	err := &Error{
-		Severity: "ERROR",
-		Code:     "42P01",
-		Message:  "relation \"foo\" does not exist",
-	}
-	assert.Equal(t, "ERROR: relation \"foo\" does not exist (SQLSTATE 42P01)", err.Error())
+func TestParseErrorAllFields(t *testing.T) {
+	// Build an ErrorResponse message body with all 14 fields.
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("23505")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("duplicate key value violates unique constraint \"users_email_key\"")
+	w.WriteByte(protocol.FieldDetail)
+	w.WriteString("Key (email)=(test@example.com) already exists.")
+	w.WriteByte(protocol.FieldHint)
+	w.WriteString("Try a different email address")
+	w.WriteByte(protocol.FieldPosition)
+	w.WriteString("42")
+	w.WriteByte(protocol.FieldInternalPosition)
+	w.WriteString("15")
+	w.WriteByte(protocol.FieldInternalQuery)
+	w.WriteString("SELECT * FROM internal_table")
+	w.WriteByte(protocol.FieldWhere)
+	w.WriteString("PL/pgSQL function check_email() line 5")
+	w.WriteByte(protocol.FieldSchema)
+	w.WriteString("public")
+	w.WriteByte(protocol.FieldTable)
+	w.WriteString("users")
+	w.WriteByte(protocol.FieldColumn)
+	w.WriteString("email")
+	w.WriteByte(protocol.FieldDataType)
+	w.WriteString("text")
+	w.WriteByte(protocol.FieldConstraint)
+	w.WriteString("users_email_key")
+	w.WriteByte(0) // Terminator
 
-	errWithDetail := &Error{
-		Severity: "ERROR",
-		Code:     "42P01",
-		Message:  "relation \"foo\" does not exist",
-		Detail:   "Some additional detail",
-	}
-	expected := "ERROR: relation \"foo\" does not exist (SQLSTATE 42P01)\nDETAIL: Some additional detail"
-	assert.Equal(t, expected, errWithDetail.Error())
+	conn := &Conn{}
+	err := conn.parseError(w.Bytes())
+	require.Error(t, err)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag))
+
+	// Verify all 14 fields.
+	require.NotNil(t, diag)
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "23505", diag.Code)
+	assert.Equal(t, "duplicate key value violates unique constraint \"users_email_key\"", diag.Message)
+	assert.Equal(t, "Key (email)=(test@example.com) already exists.", diag.Detail)
+	assert.Equal(t, "Try a different email address", diag.Hint)
+	assert.Equal(t, int32(42), diag.Position)
+	assert.Equal(t, int32(15), diag.InternalPosition)
+	assert.Equal(t, "SELECT * FROM internal_table", diag.InternalQuery)
+	assert.Equal(t, "PL/pgSQL function check_email() line 5", diag.Where)
+	assert.Equal(t, "public", diag.Schema)
+	assert.Equal(t, "users", diag.Table)
+	assert.Equal(t, "email", diag.Column)
+	assert.Equal(t, "text", diag.DataType)
+	assert.Equal(t, "users_email_key", diag.Constraint)
+}
+
+func TestPgDiagnosticFields(t *testing.T) {
+	// Build an ErrorResponse message body with all 14 fields.
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("22P02")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("invalid input syntax for type boolean")
+	w.WriteByte(protocol.FieldDetail)
+	w.WriteString("Some detail")
+	w.WriteByte(protocol.FieldHint)
+	w.WriteString("Check your input")
+	w.WriteByte(protocol.FieldPosition)
+	w.WriteString("25")
+	w.WriteByte(protocol.FieldInternalPosition)
+	w.WriteString("10")
+	w.WriteByte(protocol.FieldInternalQuery)
+	w.WriteString("SELECT internal()")
+	w.WriteByte(protocol.FieldWhere)
+	w.WriteString("function context")
+	w.WriteByte(protocol.FieldSchema)
+	w.WriteString("public")
+	w.WriteByte(protocol.FieldTable)
+	w.WriteString("mytable")
+	w.WriteByte(protocol.FieldColumn)
+	w.WriteString("mycolumn")
+	w.WriteByte(protocol.FieldDataType)
+	w.WriteString("boolean")
+	w.WriteByte(protocol.FieldConstraint)
+	w.WriteString("myconstraint")
+	w.WriteByte(0) // Terminator
+
+	conn := &Conn{}
+	err := conn.parseError(w.Bytes())
+	require.Error(t, err)
+
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag))
+
+	// Verify MessageType is set to 'E' (ErrorResponse).
+	assert.Equal(t, byte(protocol.MsgErrorResponse), diag.MessageType)
+	assert.True(t, diag.IsError())
+	assert.False(t, diag.IsNotice())
+
+	// Verify all fields are set correctly.
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "22P02", diag.Code)
+	assert.Equal(t, "invalid input syntax for type boolean", diag.Message)
+	assert.Equal(t, "Some detail", diag.Detail)
+	assert.Equal(t, "Check your input", diag.Hint)
+	assert.Equal(t, int32(25), diag.Position)
+	assert.Equal(t, int32(10), diag.InternalPosition)
+	assert.Equal(t, "SELECT internal()", diag.InternalQuery)
+	assert.Equal(t, "function context", diag.Where)
+	assert.Equal(t, "public", diag.Schema)
+	assert.Equal(t, "mytable", diag.Table)
+	assert.Equal(t, "mycolumn", diag.Column)
+	assert.Equal(t, "boolean", diag.DataType)
+	assert.Equal(t, "myconstraint", diag.Constraint)
+}
+
+func TestPgDiagnosticErrorString(t *testing.T) {
+	// Build an error without detail.
+	w := NewMessageWriter()
+	w.WriteByte(protocol.FieldSeverity)
+	w.WriteString("ERROR")
+	w.WriteByte(protocol.FieldCode)
+	w.WriteString("42P01")
+	w.WriteByte(protocol.FieldMessage)
+	w.WriteString("relation \"foo\" does not exist")
+	w.WriteByte(0)
+
+	conn := &Conn{}
+	err := conn.parseError(w.Bytes())
+	require.Error(t, err)
+
+	// Error() returns PostgreSQL-native format without SQLSTATE
+	assert.Equal(t, "ERROR: relation \"foo\" does not exist", err.Error())
+
+	// FullError() includes SQLSTATE for debugging
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag))
+	assert.Equal(t, "ERROR: relation \"foo\" does not exist (SQLSTATE 42P01)", diag.FullError())
+
+	// Build an error with detail - Error() should still be clean
+	w2 := NewMessageWriter()
+	w2.WriteByte(protocol.FieldSeverity)
+	w2.WriteString("FATAL")
+	w2.WriteByte(protocol.FieldCode)
+	w2.WriteString("28P01")
+	w2.WriteByte(protocol.FieldMessage)
+	w2.WriteString("password authentication failed")
+	w2.WriteByte(protocol.FieldDetail)
+	w2.WriteString("Some additional detail")
+	w2.WriteByte(0)
+
+	err2 := conn.parseError(w2.Bytes())
+	require.Error(t, err2)
+
+	// Error() still returns clean format (no SQLSTATE, no DETAIL)
+	assert.Equal(t, "FATAL: password authentication failed", err2.Error())
+
+	// FullError() includes SQLSTATE
+	var diag2 *mterrors.PgDiagnostic
+	require.True(t, errors.As(err2, &diag2))
+	assert.Equal(t, "FATAL: password authentication failed (SQLSTATE 28P01)", diag2.FullError())
+
+	// Detail is still accessible directly on the diagnostic
+	assert.Equal(t, "Some additional detail", diag2.Detail)
 }
 
 func TestWriteQueryMessage(t *testing.T) {

--- a/go/common/pgprotocol/server/query_test.go
+++ b/go/common/pgprotocol/server/query_test.go
@@ -392,8 +392,8 @@ func TestWriteCommandComplete(t *testing.T) {
 	}
 }
 
-// TestWriteErrorResponse tests encoding of ErrorResponse messages.
-func TestWriteErrorResponse(t *testing.T) {
+// TestWriteSimpleErrorWithDetail tests encoding of ErrorResponse messages.
+func TestWriteSimpleErrorWithDetail(t *testing.T) {
 	tests := []struct {
 		name     string
 		severity string
@@ -433,7 +433,7 @@ func TestWriteErrorResponse(t *testing.T) {
 			var buf bytes.Buffer
 			conn := createTestConn(t, &buf)
 
-			err := conn.writeErrorResponse(tt.severity, tt.sqlState, tt.message, tt.detail, tt.hint)
+			err := conn.writeSimpleErrorWithDetail(tt.severity, tt.sqlState, tt.message, tt.detail, tt.hint)
 			assert.NoError(t, err)
 
 			// Verify message type.

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -451,7 +451,7 @@ func (c *Conn) readSASLResponse() (string, error) {
 
 // sendAuthError sends an authentication error to the client.
 func (c *Conn) sendAuthError(message string) error {
-	if err := c.writeErrorResponse("FATAL", "28P01", message, "", ""); err != nil {
+	if err := c.writeSimpleErrorWithDetail("FATAL", "28P01", message, "", ""); err != nil {
 		return err
 	}
 	return c.flush()

--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -12,12 +12,84 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sqltypes provides internal types for query results that preserve
-// NULL vs empty string distinction. These types are used throughout the
-// codebase, while the proto types are only used for gRPC serialization.
+// Package sqltypes provides internal types for query results and PostgreSQL diagnostics.
+//
+// # Query Result Types
+//
+// The package provides types that preserve NULL vs empty string distinction:
+//   - [Value]: Represents a nullable column value (nil = NULL, []byte{} = empty string)
+//   - [Row]: Contains a slice of Values representing a database row
+//   - [Result]: Complete query result with fields, rows, command tag, and diagnostics
+//
+// These types are used throughout the codebase, while the proto types
+// (in go/pb/query) are only used for gRPC serialization.
+//
+// # PostgreSQL Diagnostic System
+//
+// [PgDiagnostic] is the unified type for PostgreSQL error and notice messages.
+// PostgreSQL uses identical wire format for ErrorResponse ('E') and NoticeResponse ('N'),
+// so a single type handles both. PgDiagnostic implements the error interface directly,
+// so it can be returned as an error without needing a wrapper type.
+// The diagnostic flow through Multigres is:
+//
+//	PostgreSQL ErrorResponse/NoticeResponse
+//	        ↓
+//	*PgDiagnostic (parse all 14 fields, implements error)
+//	        ↓
+//	mterrors.PgError (wraps PgDiagnostic for system-level handling)
+//	        ↓
+//	gRPC: RPCError.pg_diagnostic (proto serialization)
+//	        ↓
+//	mterrors.PgError (reconstructed from gRPC)
+//	        ↓
+//	server.writePgDiagnosticResponse (write all 14 fields)
+//	        ↓
+//	Client sees native PostgreSQL error format
+//
+// # MessageType vs Severity
+//
+// MessageType and Severity serve different purposes:
+//
+//   - MessageType (byte): Protocol-level message type from PostgreSQL wire protocol.
+//     'E' (0x45) = ErrorResponse, 'N' (0x4E) = NoticeResponse.
+//     Use [PgDiagnostic.IsError] and [PgDiagnostic.IsNotice] to check.
+//
+//   - Severity (string): Application-level severity from the Severity field.
+//     Errors: "ERROR", "FATAL", "PANIC"
+//     Notices: "WARNING", "NOTICE", "DEBUG", "INFO", "LOG"
+//     Use [PgDiagnostic.IsFatal] to check for fatal severities.
+//
+// The MessageType determines how to handle the message (error vs notice),
+// while Severity provides additional context about the message's importance.
+//
+// # PostgreSQL Protocol Fields
+//
+// PgDiagnostic captures all 14 PostgreSQL diagnostic fields:
+//
+//	Field             Code  Description
+//	─────────────────────────────────────────────────────────
+//	Severity          S     ERROR, FATAL, PANIC, WARNING, etc.
+//	Code              C     SQLSTATE error code (e.g., "42P01")
+//	Message           M     Primary human-readable message
+//	Detail            D     Optional detailed explanation
+//	Hint              H     Optional suggestion for fixing
+//	Position          P     Cursor position in original query
+//	InternalPosition  p     Position in internal query
+//	InternalQuery     q     Text of internal query
+//	Where             W     Call stack for PL/pgSQL errors
+//	Schema            s     Schema name (constraint errors)
+//	Table             t     Table name (constraint errors)
+//	Column            c     Column name (constraint errors)
+//	DataType          d     Data type name
+//	Constraint        n     Constraint name
+//
+// See: https://www.postgresql.org/docs/current/protocol-error-fields.html
 package sqltypes
 
-import "github.com/multigres/multigres/go/pb/query"
+import (
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/pb/query"
+)
 
 // Value represents a nullable column value.
 // nil means NULL, []byte{} means empty string.
@@ -32,24 +104,6 @@ func (v Value) IsNull() bool {
 type Row struct {
 	// Values contains the column values. nil entry means NULL.
 	Values []Value
-}
-
-// Notice represents a PostgreSQL notice response (non-fatal messages).
-type Notice struct {
-	Severity         string
-	Code             string
-	Message          string
-	Detail           string
-	Hint             string
-	Position         int32
-	InternalPosition int32
-	InternalQuery    string
-	Where            string
-	Schema           string
-	Table            string
-	Column           string
-	DataType         string
-	Constraint       string
 }
 
 // Result represents a query result with nullable values.
@@ -67,8 +121,9 @@ type Result struct {
 	// Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3"
 	CommandTag string
 
-	// Notices contains any PostgreSQL notices received during query execution.
-	Notices []*Notice
+	// Notices contains any PostgreSQL diagnostic messages received during query execution.
+	// These are typically non-fatal messages like warnings or informational notices.
+	Notices []*mterrors.PgDiagnostic
 }
 
 // ToProto converts Result to proto format for gRPC serialization.
@@ -80,16 +135,11 @@ func (r *Result) ToProto() *query.QueryResult {
 	for i, row := range r.Rows {
 		protoRows[i] = row.ToProto()
 	}
-	protoNotices := make([]*query.Notice, len(r.Notices))
-	for i, notice := range r.Notices {
-		protoNotices[i] = NoticeToProto(notice)
-	}
 	return &query.QueryResult{
 		Fields:       r.Fields,
 		RowsAffected: r.RowsAffected,
 		Rows:         protoRows,
 		CommandTag:   r.CommandTag,
-		Notices:      protoNotices,
 	}
 }
 
@@ -102,62 +152,11 @@ func ResultFromProto(pr *query.QueryResult) *Result {
 	for i, row := range pr.Rows {
 		rows[i] = RowFromProto(row)
 	}
-	notices := make([]*Notice, len(pr.Notices))
-	for i, notice := range pr.Notices {
-		notices[i] = NoticeFromProto(notice)
-	}
 	return &Result{
 		Fields:       pr.Fields,
 		RowsAffected: pr.RowsAffected,
 		Rows:         rows,
 		CommandTag:   pr.CommandTag,
-		Notices:      notices,
-	}
-}
-
-// NoticeToProto converts sqltypes Notice to proto format for gRPC serialization.
-func NoticeToProto(n *Notice) *query.Notice {
-	if n == nil {
-		return nil
-	}
-	return &query.Notice{
-		Severity:         n.Severity,
-		Code:             n.Code,
-		Message:          n.Message,
-		Detail:           n.Detail,
-		Hint:             n.Hint,
-		Position:         n.Position,
-		InternalPosition: n.InternalPosition,
-		InternalQuery:    n.InternalQuery,
-		Where:            n.Where,
-		SchemaName:       n.Schema,
-		TableName:        n.Table,
-		ColumnName:       n.Column,
-		DataTypeName:     n.DataType,
-		ConstraintName:   n.Constraint,
-	}
-}
-
-// NoticeFromProto converts proto Notice to sqltypes Notice.
-func NoticeFromProto(pn *query.Notice) *Notice {
-	if pn == nil {
-		return nil
-	}
-	return &Notice{
-		Severity:         pn.Severity,
-		Code:             pn.Code,
-		Message:          pn.Message,
-		Detail:           pn.Detail,
-		Hint:             pn.Hint,
-		Position:         pn.Position,
-		InternalPosition: pn.InternalPosition,
-		InternalQuery:    pn.InternalQuery,
-		Where:            pn.Where,
-		Schema:           pn.SchemaName,
-		Table:            pn.TableName,
-		Column:           pn.ColumnName,
-		DataType:         pn.DataTypeName,
-		Constraint:       pn.ConstraintName,
 	}
 }
 

--- a/go/common/sqltypes/sqltypes_test.go
+++ b/go/common/sqltypes/sqltypes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/pb/query"
 )
 
@@ -260,14 +261,15 @@ func TestMakeRow(t *testing.T) {
 	assert.Equal(t, "hello", string(row.Values[2]))
 }
 
-func TestNoticeToProtoAndBack(t *testing.T) {
+func TestPgDiagnosticToProtoAndBack(t *testing.T) {
 	tests := []struct {
-		name   string
-		notice *Notice
+		name       string
+		diagnostic *mterrors.PgDiagnostic
 	}{
 		{
 			name: "all fields populated",
-			notice: &Notice{
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType:      'N',
 				Severity:         "WARNING",
 				Code:             "01000",
 				Message:          "This is a test notice",
@@ -286,57 +288,63 @@ func TestNoticeToProtoAndBack(t *testing.T) {
 		},
 		{
 			name: "only required fields",
-			notice: &Notice{
-				Severity: "NOTICE",
-				Code:     "00000",
-				Message:  "Simple notice",
-				Detail:   "",
-				Hint:     "",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "NOTICE",
+				Code:        "00000",
+				Message:     "Simple notice",
+				Detail:      "",
+				Hint:        "",
 			},
 		},
 		{
 			name: "empty strings for optional fields",
-			notice: &Notice{
-				Severity: "INFO",
-				Code:     "00000",
-				Message:  "Notice with empty optional fields",
-				Detail:   "",
-				Hint:     "",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "INFO",
+				Code:        "00000",
+				Message:     "Notice with empty optional fields",
+				Detail:      "",
+				Hint:        "",
 			},
 		},
 		{
 			name: "unicode characters in message",
-			notice: &Notice{
-				Severity: "WARNING",
-				Code:     "01000",
-				Message:  "Unicode test: 日本語 🎉 émoji café",
-				Detail:   "详细信息 with unicode",
-				Hint:     "Подсказка на русском",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "WARNING",
+				Code:        "01000",
+				Message:     "Unicode test: 日本語 🎉 émoji café",
+				Detail:      "详细信息 with unicode",
+				Hint:        "Подсказка на русском",
 			},
 		},
 		{
-			name: "special characters",
-			notice: &Notice{
-				Severity: "ERROR",
-				Code:     "42P01",
-				Message:  "relation \"users\" does not exist",
-				Detail:   "Line 1: SELECT * FROM \"users\"\n        ^",
-				Hint:     "Check if table name is quoted correctly",
+			name: "error with special characters",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "relation \"users\" does not exist",
+				Detail:      "Line 1: SELECT * FROM \"users\"\n        ^",
+				Hint:        "Check if table name is quoted correctly",
 			},
 		},
 		{
 			name: "empty message",
-			notice: &Notice{
-				Severity: "NOTICE",
-				Code:     "00000",
-				Message:  "",
-				Detail:   "",
-				Hint:     "",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "NOTICE",
+				Code:        "00000",
+				Message:     "",
+				Detail:      "",
+				Hint:        "",
 			},
 		},
 		{
 			name: "context fields only",
-			notice: &Notice{
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType:      'N',
 				Severity:         "NOTICE",
 				Code:             "00000",
 				Message:          "Notice with context",
@@ -348,43 +356,47 @@ func TestNoticeToProtoAndBack(t *testing.T) {
 		},
 		{
 			name: "position fields only",
-			notice: &Notice{
-				Severity: "WARNING",
-				Code:     "01000",
-				Message:  "Position test",
-				Position: 1,
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "WARNING",
+				Code:        "01000",
+				Message:     "Position test",
+				Position:    1,
 			},
 		},
 		{
 			name: "where field with newlines",
-			notice: &Notice{
-				Severity: "NOTICE",
-				Code:     "00000",
-				Message:  "Call stack test",
-				Where:    "PL/pgSQL function outer_func() line 3\nPL/pgSQL function inner_func() line 1",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "NOTICE",
+				Code:        "00000",
+				Message:     "Call stack test",
+				Where:       "PL/pgSQL function outer_func() line 3\nPL/pgSQL function inner_func() line 1",
 			},
 		},
 		{
-			name: "schema object fields only",
-			notice: &Notice{
-				Severity:   "ERROR",
-				Code:       "23505",
-				Message:    "duplicate key value violates unique constraint",
-				Schema:     "myschema",
-				Table:      "mytable",
-				Column:     "mycolumn",
-				DataType:   "integer",
-				Constraint: "mytable_pkey",
+			name: "error with schema object fields",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "23505",
+				Message:     "duplicate key value violates unique constraint",
+				Schema:      "myschema",
+				Table:       "mytable",
+				Column:      "mycolumn",
+				DataType:    "integer",
+				Constraint:  "mytable_pkey",
 			},
 		},
 		{
 			name: "partial schema object fields",
-			notice: &Notice{
-				Severity: "WARNING",
-				Code:     "01000",
-				Message:  "Partial schema info",
-				Schema:   "public",
-				Table:    "orders",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "WARNING",
+				Code:        "01000",
+				Message:     "Partial schema info",
+				Schema:      "public",
+				Table:       "orders",
 			},
 		},
 	}
@@ -392,52 +404,467 @@ func TestNoticeToProtoAndBack(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Convert to proto
-			protoNotice := NoticeToProto(tc.notice)
-			require.NotNil(t, protoNotice)
+			protoDiag := mterrors.PgDiagnosticToProto(tc.diagnostic)
+			require.NotNil(t, protoDiag)
 
 			// Verify proto has correct values
-			assert.Equal(t, tc.notice.Severity, protoNotice.Severity)
-			assert.Equal(t, tc.notice.Code, protoNotice.Code)
-			assert.Equal(t, tc.notice.Message, protoNotice.Message)
-			assert.Equal(t, tc.notice.Detail, protoNotice.Detail)
-			assert.Equal(t, tc.notice.Hint, protoNotice.Hint)
-			assert.Equal(t, tc.notice.Position, protoNotice.Position)
-			assert.Equal(t, tc.notice.InternalPosition, protoNotice.InternalPosition)
-			assert.Equal(t, tc.notice.InternalQuery, protoNotice.InternalQuery)
-			assert.Equal(t, tc.notice.Where, protoNotice.Where)
-			assert.Equal(t, tc.notice.Schema, protoNotice.SchemaName)
-			assert.Equal(t, tc.notice.Table, protoNotice.TableName)
-			assert.Equal(t, tc.notice.Column, protoNotice.ColumnName)
-			assert.Equal(t, tc.notice.DataType, protoNotice.DataTypeName)
-			assert.Equal(t, tc.notice.Constraint, protoNotice.ConstraintName)
+			assert.Equal(t, int32(tc.diagnostic.MessageType), protoDiag.MessageType)
+			assert.Equal(t, tc.diagnostic.Severity, protoDiag.Severity)
+			assert.Equal(t, tc.diagnostic.Code, protoDiag.Code)
+			assert.Equal(t, tc.diagnostic.Message, protoDiag.Message)
+			assert.Equal(t, tc.diagnostic.Detail, protoDiag.Detail)
+			assert.Equal(t, tc.diagnostic.Hint, protoDiag.Hint)
+			assert.Equal(t, tc.diagnostic.Position, protoDiag.Position)
+			assert.Equal(t, tc.diagnostic.InternalPosition, protoDiag.InternalPosition)
+			assert.Equal(t, tc.diagnostic.InternalQuery, protoDiag.InternalQuery)
+			assert.Equal(t, tc.diagnostic.Where, protoDiag.Where)
+			assert.Equal(t, tc.diagnostic.Schema, protoDiag.SchemaName)
+			assert.Equal(t, tc.diagnostic.Table, protoDiag.TableName)
+			assert.Equal(t, tc.diagnostic.Column, protoDiag.ColumnName)
+			assert.Equal(t, tc.diagnostic.DataType, protoDiag.DataTypeName)
+			assert.Equal(t, tc.diagnostic.Constraint, protoDiag.ConstraintName)
 
 			// Convert back
-			recovered := NoticeFromProto(protoNotice)
+			recovered := mterrors.PgDiagnosticFromProto(protoDiag)
 			require.NotNil(t, recovered)
 
 			// Verify roundtrip preserves all fields
-			assert.Equal(t, tc.notice.Severity, recovered.Severity)
-			assert.Equal(t, tc.notice.Code, recovered.Code)
-			assert.Equal(t, tc.notice.Message, recovered.Message)
-			assert.Equal(t, tc.notice.Detail, recovered.Detail)
-			assert.Equal(t, tc.notice.Hint, recovered.Hint)
-			assert.Equal(t, tc.notice.Position, recovered.Position)
-			assert.Equal(t, tc.notice.InternalPosition, recovered.InternalPosition)
-			assert.Equal(t, tc.notice.InternalQuery, recovered.InternalQuery)
-			assert.Equal(t, tc.notice.Where, recovered.Where)
-			assert.Equal(t, tc.notice.Schema, recovered.Schema)
-			assert.Equal(t, tc.notice.Table, recovered.Table)
-			assert.Equal(t, tc.notice.Column, recovered.Column)
-			assert.Equal(t, tc.notice.DataType, recovered.DataType)
-			assert.Equal(t, tc.notice.Constraint, recovered.Constraint)
+			assert.Equal(t, tc.diagnostic.MessageType, recovered.MessageType)
+			assert.Equal(t, tc.diagnostic.Severity, recovered.Severity)
+			assert.Equal(t, tc.diagnostic.Code, recovered.Code)
+			assert.Equal(t, tc.diagnostic.Message, recovered.Message)
+			assert.Equal(t, tc.diagnostic.Detail, recovered.Detail)
+			assert.Equal(t, tc.diagnostic.Hint, recovered.Hint)
+			assert.Equal(t, tc.diagnostic.Position, recovered.Position)
+			assert.Equal(t, tc.diagnostic.InternalPosition, recovered.InternalPosition)
+			assert.Equal(t, tc.diagnostic.InternalQuery, recovered.InternalQuery)
+			assert.Equal(t, tc.diagnostic.Where, recovered.Where)
+			assert.Equal(t, tc.diagnostic.Schema, recovered.Schema)
+			assert.Equal(t, tc.diagnostic.Table, recovered.Table)
+			assert.Equal(t, tc.diagnostic.Column, recovered.Column)
+			assert.Equal(t, tc.diagnostic.DataType, recovered.DataType)
+			assert.Equal(t, tc.diagnostic.Constraint, recovered.Constraint)
 		})
 	}
 }
 
-func TestNoticeFromProtoNil(t *testing.T) {
-	assert.Nil(t, NoticeFromProto(nil))
+func TestPgDiagnosticFromProtoNil(t *testing.T) {
+	assert.Nil(t, mterrors.PgDiagnosticFromProto(nil))
 }
 
-func TestNoticeToProtoNil(t *testing.T) {
-	assert.Nil(t, NoticeToProto(nil))
+func TestPgDiagnosticToProtoNil(t *testing.T) {
+	assert.Nil(t, mterrors.PgDiagnosticToProto(nil))
+}
+
+func TestPgDiagnosticIsError(t *testing.T) {
+	errDiag := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "ERROR"}
+	noticeDiag := &mterrors.PgDiagnostic{MessageType: 'N', Severity: "NOTICE"}
+
+	assert.True(t, errDiag.IsError())
+	assert.False(t, errDiag.IsNotice())
+	assert.False(t, noticeDiag.IsError())
+	assert.True(t, noticeDiag.IsNotice())
+}
+
+func TestPgDiagnosticValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		diagnostic  *mterrors.PgDiagnostic
+		expectError bool
+		errorSubstr string
+	}{
+		{
+			name: "valid error diagnostic",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "relation does not exist",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid notice diagnostic",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'N',
+				Severity:    "NOTICE",
+				Code:        "00000",
+				Message:     "this is a notice",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid error with all fields",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType:      'E',
+				Severity:         "ERROR",
+				Code:             "23505",
+				Message:          "duplicate key value",
+				Detail:           "Key already exists",
+				Hint:             "Use ON CONFLICT",
+				Position:         10,
+				InternalPosition: 5,
+				InternalQuery:    "SELECT ...",
+				Where:            "trigger",
+				Schema:           "public",
+				Table:            "users",
+				Column:           "id",
+				DataType:         "integer",
+				Constraint:       "users_pkey",
+			},
+			expectError: false,
+		},
+		{
+			name:        "nil diagnostic",
+			diagnostic:  nil,
+			expectError: true,
+			errorSubstr: "diagnostic is nil",
+		},
+		{
+			name: "invalid MessageType",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'X',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "test error",
+			},
+			expectError: true,
+			errorSubstr: "invalid MessageType 'X' (0x58)",
+		},
+		{
+			name: "zero MessageType",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 0,
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "test error",
+			},
+			expectError: true,
+			errorSubstr: "MessageType is unset (0x00)",
+		},
+		{
+			name: "empty Severity",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "",
+				Code:        "42P01",
+				Message:     "test error",
+			},
+			expectError: true,
+			errorSubstr: "Severity is empty",
+		},
+		{
+			name: "empty Code",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "",
+				Message:     "test error",
+			},
+			expectError: true,
+			errorSubstr: "Code (SQLSTATE) is empty",
+		},
+		{
+			name: "empty Message",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'E',
+				Severity:    "ERROR",
+				Code:        "42P01",
+				Message:     "",
+			},
+			expectError: true,
+			errorSubstr: "Message is empty",
+		},
+		{
+			name: "multiple validation failures",
+			diagnostic: &mterrors.PgDiagnostic{
+				MessageType: 'X',
+				Severity:    "",
+				Code:        "",
+				Message:     "",
+			},
+			expectError: true,
+			errorSubstr: "invalid MessageType",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.diagnostic.Validate()
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPgDiagnosticValidateMultipleFailures(t *testing.T) {
+	// Test that multiple failures are all reported
+	diag := &mterrors.PgDiagnostic{
+		MessageType: 'X',
+		Severity:    "",
+		Code:        "",
+		Message:     "",
+	}
+
+	err := diag.Validate()
+	require.Error(t, err)
+
+	errStr := err.Error()
+	assert.Contains(t, errStr, "invalid MessageType")
+	assert.Contains(t, errStr, "Severity is empty")
+	assert.Contains(t, errStr, "Code (SQLSTATE) is empty")
+	assert.Contains(t, errStr, "Message is empty")
+}
+
+func TestPgDiagnosticSQLSTATE(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			name:     "syntax error",
+			code:     "42601",
+			expected: "42601",
+		},
+		{
+			name:     "undefined table",
+			code:     "42P01",
+			expected: "42P01",
+		},
+		{
+			name:     "successful completion",
+			code:     "00000",
+			expected: "00000",
+		},
+		{
+			name:     "data exception",
+			code:     "22P02",
+			expected: "22P02",
+		},
+		{
+			name:     "internal error",
+			code:     "XX000",
+			expected: "XX000",
+		},
+		{
+			name:     "empty code",
+			code:     "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Code: tc.code}
+			assert.Equal(t, tc.expected, diag.SQLSTATE())
+		})
+	}
+}
+
+func TestPgDiagnosticSQLSTATEClass(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			name:     "syntax error class",
+			code:     "42601",
+			expected: "42",
+		},
+		{
+			name:     "undefined table",
+			code:     "42P01",
+			expected: "42",
+		},
+		{
+			name:     "successful completion",
+			code:     "00000",
+			expected: "00",
+		},
+		{
+			name:     "data exception",
+			code:     "22P02",
+			expected: "22",
+		},
+		{
+			name:     "integrity constraint violation",
+			code:     "23505",
+			expected: "23",
+		},
+		{
+			name:     "internal error",
+			code:     "XX000",
+			expected: "XX",
+		},
+		{
+			name:     "empty code",
+			code:     "",
+			expected: "",
+		},
+		{
+			name:     "single character code",
+			code:     "X",
+			expected: "",
+		},
+		{
+			name:     "two character code",
+			code:     "42",
+			expected: "42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Code: tc.code}
+			assert.Equal(t, tc.expected, diag.SQLSTATEClass())
+		})
+	}
+}
+
+func TestPgDiagnosticIsClass(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		class    string
+		expected bool
+	}{
+		{
+			name:     "syntax error in class 42",
+			code:     "42601",
+			class:    "42",
+			expected: true,
+		},
+		{
+			name:     "syntax error not in class 22",
+			code:     "42601",
+			class:    "22",
+			expected: false,
+		},
+		{
+			name:     "undefined table in class 42",
+			code:     "42P01",
+			class:    "42",
+			expected: true,
+		},
+		{
+			name:     "data exception in class 22",
+			code:     "22P02",
+			class:    "22",
+			expected: true,
+		},
+		{
+			name:     "integrity constraint in class 23",
+			code:     "23505",
+			class:    "23",
+			expected: true,
+		},
+		{
+			name:     "internal error in class XX",
+			code:     "XX000",
+			class:    "XX",
+			expected: true,
+		},
+		{
+			name:     "empty code is not in any class",
+			code:     "",
+			class:    "42",
+			expected: false,
+		},
+		{
+			name:     "short code is not in any class",
+			code:     "X",
+			class:    "XX",
+			expected: false,
+		},
+		{
+			name:     "empty class comparison",
+			code:     "42601",
+			class:    "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Code: tc.code}
+			assert.Equal(t, tc.expected, diag.IsClass(tc.class))
+		})
+	}
+}
+
+func TestPgDiagnosticIsFatal(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity string
+		expected bool
+	}{
+		{
+			name:     "ERROR is not fatal",
+			severity: "ERROR",
+			expected: false,
+		},
+		{
+			name:     "FATAL is fatal",
+			severity: "FATAL",
+			expected: true,
+		},
+		{
+			name:     "PANIC is fatal",
+			severity: "PANIC",
+			expected: true,
+		},
+		{
+			name:     "WARNING is not fatal",
+			severity: "WARNING",
+			expected: false,
+		},
+		{
+			name:     "NOTICE is not fatal",
+			severity: "NOTICE",
+			expected: false,
+		},
+		{
+			name:     "INFO is not fatal",
+			severity: "INFO",
+			expected: false,
+		},
+		{
+			name:     "LOG is not fatal",
+			severity: "LOG",
+			expected: false,
+		},
+		{
+			name:     "DEBUG is not fatal",
+			severity: "DEBUG",
+			expected: false,
+		},
+		{
+			name:     "empty severity is not fatal",
+			severity: "",
+			expected: false,
+		},
+		{
+			name:     "lowercase fatal is not fatal (strict matching)",
+			severity: "fatal",
+			expected: false,
+		},
+		{
+			name:     "lowercase panic is not fatal (strict matching)",
+			severity: "panic",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diag := &mterrors.PgDiagnostic{Severity: tc.severity}
+			assert.Equal(t, tc.expected, diag.IsFatal())
+		})
+	}
 }

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -480,8 +480,8 @@ func (x *PortalStreamExecuteRequest) GetOptions() *query.ExecuteOptions {
 // PortalStreamExecuteResponse represents a response in the portal execution stream
 type PortalStreamExecuteResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// result contains the query result data (rows, fields, etc.)
-	Result *query.QueryResult `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	// result contains the query result data (rows, fields, etc.) or diagnostics
+	Result *query.QueryResultPayload `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
 	// reserved_connection_id is the ID of the reserved connection
 	// This is returned in the first response and should be used for subsequent queries
 	ReservedConnectionId uint64 `protobuf:"varint,2,opt,name=reserved_connection_id,json=reservedConnectionId,proto3" json:"reserved_connection_id,omitempty"`
@@ -521,7 +521,7 @@ func (*PortalStreamExecuteResponse) Descriptor() ([]byte, []int) {
 	return file_multipoolerservice_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *PortalStreamExecuteResponse) GetResult() *query.QueryResult {
+func (x *PortalStreamExecuteResponse) GetResult() *query.QueryResultPayload {
 	if x != nil {
 		return x.Result
 	}
@@ -1012,9 +1012,9 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x12prepared_statement\x18\x02 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x12%\n" +
 	"\x06portal\x18\x03 \x01(\v2\r.query.PortalR\x06portal\x12,\n" +
 	"\tcaller_id\x18\x04 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
-	"\aoptions\x18\x05 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"\xb1\x01\n" +
-	"\x1bPortalStreamExecuteResponse\x12*\n" +
-	"\x06result\x18\x01 \x01(\v2\x12.query.QueryResultR\x06result\x124\n" +
+	"\aoptions\x18\x05 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"\xb8\x01\n" +
+	"\x1bPortalStreamExecuteResponse\x121\n" +
+	"\x06result\x18\x01 \x01(\v2\x19.query.QueryResultPayloadR\x06result\x124\n" +
 	"\x16reserved_connection_id\x18\x02 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x03 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\"\x87\x02\n" +
 	"\x0fDescribeRequest\x12%\n" +
@@ -1058,10 +1058,10 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x04DATA\x10\x01\x12\n" +
 	"\n" +
 	"\x06RESULT\x10\x02\x12\t\n" +
-	"\x05ERROR\x10\x032\x95\x05\n" +
+	"\x05ERROR\x10\x032\x85\x05\n" +
 	"\x12MultiPoolerService\x12a\n" +
-	"\fExecuteQuery\x12'.multipoolerservice.ExecuteQueryRequest\x1a(.multipoolerservice.ExecuteQueryResponse\x12f\n" +
-	"\rStreamExecute\x12(.multipoolerservice.StreamExecuteRequest\x1a).multipoolerservice.StreamExecuteResponse0\x01\x12x\n" +
+	"\fExecuteQuery\x12'.multipoolerservice.ExecuteQueryRequest\x1a(.multipoolerservice.ExecuteQueryResponse\x12V\n" +
+	"\rStreamExecute\x12(.multipoolerservice.StreamExecuteRequest\x1a\x19.query.QueryResultPayload0\x01\x12x\n" +
 	"\x13PortalStreamExecute\x12..multipoolerservice.PortalStreamExecuteRequest\x1a/.multipoolerservice.PortalStreamExecuteResponse0\x01\x12U\n" +
 	"\bDescribe\x12#.multipoolerservice.DescribeRequest\x1a$.multipoolerservice.DescribeResponse\x12s\n" +
 	"\x12GetAuthCredentials\x12-.multipoolerservice.GetAuthCredentialsRequest\x1a..multipoolerservice.GetAuthCredentialsResponse\x12n\n" +
@@ -1102,8 +1102,9 @@ var file_multipoolerservice_proto_goTypes = []any{
 	(*query.QueryResult)(nil),           // 17: query.QueryResult
 	(*query.PreparedStatement)(nil),     // 18: query.PreparedStatement
 	(*query.Portal)(nil),                // 19: query.Portal
-	(*clustermetadata.ID)(nil),          // 20: clustermetadata.ID
-	(*query.StatementDescription)(nil),  // 21: query.StatementDescription
+	(*query.QueryResultPayload)(nil),    // 20: query.QueryResultPayload
+	(*clustermetadata.ID)(nil),          // 21: clustermetadata.ID
+	(*query.StatementDescription)(nil),  // 22: query.StatementDescription
 }
 var file_multipoolerservice_proto_depIdxs = []int32{
 	14, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
@@ -1119,20 +1120,20 @@ var file_multipoolerservice_proto_depIdxs = []int32{
 	19, // 10: multipoolerservice.PortalStreamExecuteRequest.portal:type_name -> query.Portal
 	15, // 11: multipoolerservice.PortalStreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
 	16, // 12: multipoolerservice.PortalStreamExecuteRequest.options:type_name -> query.ExecuteOptions
-	17, // 13: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResult
-	20, // 14: multipoolerservice.PortalStreamExecuteResponse.pooler_id:type_name -> clustermetadata.ID
+	20, // 13: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResultPayload
+	21, // 14: multipoolerservice.PortalStreamExecuteResponse.pooler_id:type_name -> clustermetadata.ID
 	14, // 15: multipoolerservice.DescribeRequest.target:type_name -> query.Target
 	18, // 16: multipoolerservice.DescribeRequest.prepared_statement:type_name -> query.PreparedStatement
 	19, // 17: multipoolerservice.DescribeRequest.portal:type_name -> query.Portal
 	15, // 18: multipoolerservice.DescribeRequest.caller_id:type_name -> mtrpc.CallerID
 	16, // 19: multipoolerservice.DescribeRequest.options:type_name -> query.ExecuteOptions
-	21, // 20: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
+	22, // 20: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
 	0,  // 21: multipoolerservice.CopyBidiExecuteRequest.phase:type_name -> multipoolerservice.CopyBidiExecuteRequest.Phase
 	14, // 22: multipoolerservice.CopyBidiExecuteRequest.target:type_name -> query.Target
 	15, // 23: multipoolerservice.CopyBidiExecuteRequest.caller_id:type_name -> mtrpc.CallerID
 	16, // 24: multipoolerservice.CopyBidiExecuteRequest.options:type_name -> query.ExecuteOptions
 	1,  // 25: multipoolerservice.CopyBidiExecuteResponse.phase:type_name -> multipoolerservice.CopyBidiExecuteResponse.Phase
-	20, // 26: multipoolerservice.CopyBidiExecuteResponse.pooler_id:type_name -> clustermetadata.ID
+	21, // 26: multipoolerservice.CopyBidiExecuteResponse.pooler_id:type_name -> clustermetadata.ID
 	17, // 27: multipoolerservice.CopyBidiExecuteResponse.result:type_name -> query.QueryResult
 	2,  // 28: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
 	4,  // 29: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
@@ -1141,7 +1142,7 @@ var file_multipoolerservice_proto_depIdxs = []int32{
 	10, // 32: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
 	12, // 33: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
 	3,  // 34: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
-	5,  // 35: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
+	20, // 35: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> query.QueryResultPayload
 	7,  // 36: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
 	9,  // 37: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
 	11, // 38: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -39,6 +39,91 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// QueryResultPayload is a union type for streaming query results.
+// Each stream item is either row data OR a diagnostic (error/notice).
+// This enables zero-buffering notice delivery during query execution.
+type QueryResultPayload struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*QueryResultPayload_Result
+	//	*QueryResultPayload_Diagnostic
+	Payload       isQueryResultPayload_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryResultPayload) Reset() {
+	*x = QueryResultPayload{}
+	mi := &file_query_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryResultPayload) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryResultPayload) ProtoMessage() {}
+
+func (x *QueryResultPayload) ProtoReflect() protoreflect.Message {
+	mi := &file_query_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryResultPayload.ProtoReflect.Descriptor instead.
+func (*QueryResultPayload) Descriptor() ([]byte, []int) {
+	return file_query_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *QueryResultPayload) GetPayload() isQueryResultPayload_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *QueryResultPayload) GetResult() *QueryResult {
+	if x != nil {
+		if x, ok := x.Payload.(*QueryResultPayload_Result); ok {
+			return x.Result
+		}
+	}
+	return nil
+}
+
+func (x *QueryResultPayload) GetDiagnostic() *PgDiagnostic {
+	if x != nil {
+		if x, ok := x.Payload.(*QueryResultPayload_Diagnostic); ok {
+			return x.Diagnostic
+		}
+	}
+	return nil
+}
+
+type isQueryResultPayload_Payload interface {
+	isQueryResultPayload_Payload()
+}
+
+type QueryResultPayload_Result struct {
+	Result *QueryResult `protobuf:"bytes,1,opt,name=result,proto3,oneof"` // Row data with fields/rows/command_tag
+}
+
+type QueryResultPayload_Diagnostic struct {
+	Diagnostic *PgDiagnostic `protobuf:"bytes,2,opt,name=diagnostic,proto3,oneof"` // Individual error or notice
+}
+
+func (*QueryResultPayload_Result) isQueryResultPayload_Payload() {}
+
+func (*QueryResultPayload_Diagnostic) isQueryResultPayload_Payload() {}
+
 // QueryResult represents the result of executing a query
 type QueryResult struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -52,17 +137,14 @@ type QueryResult struct {
 	// When streaming results, this should only be set on the final packet of a result set.
 	// When set, the protocol layer will send CommandComplete and reset state for the next result set.
 	// Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3", "CREATE TABLE"
-	CommandTag string `protobuf:"bytes,4,opt,name=command_tag,json=commandTag,proto3" json:"command_tag,omitempty"`
-	// notices contains any PostgreSQL notices received during query execution.
-	// These are non-fatal messages like warnings or informational notices.
-	Notices       []*Notice `protobuf:"bytes,5,rep,name=notices,proto3" json:"notices,omitempty"`
+	CommandTag    string `protobuf:"bytes,4,opt,name=command_tag,json=commandTag,proto3" json:"command_tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *QueryResult) Reset() {
 	*x = QueryResult{}
-	mi := &file_query_proto_msgTypes[0]
+	mi := &file_query_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -74,7 +156,7 @@ func (x *QueryResult) String() string {
 func (*QueryResult) ProtoMessage() {}
 
 func (x *QueryResult) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[0]
+	mi := &file_query_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -87,7 +169,7 @@ func (x *QueryResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryResult.ProtoReflect.Descriptor instead.
 func (*QueryResult) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{0}
+	return file_query_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *QueryResult) GetFields() []*Field {
@@ -118,13 +200,6 @@ func (x *QueryResult) GetCommandTag() string {
 	return ""
 }
 
-func (x *QueryResult) GetNotices() []*Notice {
-	if x != nil {
-		return x.Notices
-	}
-	return nil
-}
-
 // Field represents metadata about a column in the result set.
 // This includes all PostgreSQL wire protocol metadata needed for RowDescription messages.
 type Field struct {
@@ -151,7 +226,7 @@ type Field struct {
 
 func (x *Field) Reset() {
 	*x = Field{}
-	mi := &file_query_proto_msgTypes[1]
+	mi := &file_query_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -163,7 +238,7 @@ func (x *Field) String() string {
 func (*Field) ProtoMessage() {}
 
 func (x *Field) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[1]
+	mi := &file_query_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -176,7 +251,7 @@ func (x *Field) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Field.ProtoReflect.Descriptor instead.
 func (*Field) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{1}
+	return file_query_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Field) GetName() string {
@@ -250,7 +325,7 @@ type Row struct {
 
 func (x *Row) Reset() {
 	*x = Row{}
-	mi := &file_query_proto_msgTypes[2]
+	mi := &file_query_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -262,7 +337,7 @@ func (x *Row) String() string {
 func (*Row) ProtoMessage() {}
 
 func (x *Row) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[2]
+	mi := &file_query_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -275,7 +350,7 @@ func (x *Row) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Row.ProtoReflect.Descriptor instead.
 func (*Row) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{2}
+	return file_query_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Row) GetLengths() []int64 {
@@ -292,20 +367,30 @@ func (x *Row) GetValues() []byte {
 	return nil
 }
 
-// Notice represents a PostgreSQL notice response (non-fatal messages).
-// These include warnings, informational messages, and other diagnostics
-// that don't cause the query to fail.
-type Notice struct {
+// PgDiagnostic represents a PostgreSQL diagnostic message (error or notice).
+// PostgreSQL uses the same wire format for both ErrorResponse ('E') and NoticeResponse ('N'),
+// differentiated by the message_type field. This unified structure captures all 14 fields
+// defined in the PostgreSQL protocol for diagnostic messages.
+//
+// Error severities: ERROR, FATAL, PANIC
+// Notice severities: WARNING, NOTICE, DEBUG, INFO, LOG
+//
+// Reference: https://www.postgresql.org/docs/current/protocol-error-fields.html
+type PgDiagnostic struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// severity is the notice severity level (e.g., "NOTICE", "WARNING", "INFO")
+	// message_type is the PostgreSQL protocol message type byte.
+	// 'E' (0x45 = 69) for ErrorResponse, 'N' (0x4E = 78) for NoticeResponse.
+	// This determines whether the diagnostic is an error or notice.
+	MessageType int32 `protobuf:"varint,15,opt,name=message_type,json=messageType,proto3" json:"message_type,omitempty"`
+	// severity is the severity level (e.g., "ERROR", "FATAL", "WARNING", "NOTICE", "INFO")
 	Severity string `protobuf:"bytes,1,opt,name=severity,proto3" json:"severity,omitempty"`
-	// code is the SQLSTATE error code
+	// code is the SQLSTATE error code (e.g., "42P01", "22P02")
 	Code string `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"`
-	// message is the primary human-readable notice message
+	// message is the primary human-readable diagnostic message
 	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	// detail provides additional detail about the notice (optional)
+	// detail provides additional detail about the diagnostic (optional)
 	Detail string `protobuf:"bytes,4,opt,name=detail,proto3" json:"detail,omitempty"`
-	// hint provides a hint about how to address the notice (optional)
+	// hint provides a hint about how to address the issue (optional)
 	Hint string `protobuf:"bytes,5,opt,name=hint,proto3" json:"hint,omitempty"`
 	// position is the cursor position in the original query string (1-indexed, 0 if not available)
 	Position int32 `protobuf:"varint,6,opt,name=position,proto3" json:"position,omitempty"`
@@ -313,37 +398,37 @@ type Notice struct {
 	InternalPosition int32 `protobuf:"varint,7,opt,name=internal_position,json=internalPosition,proto3" json:"internal_position,omitempty"`
 	// internal_query is the text of the internally-generated query (optional)
 	InternalQuery string `protobuf:"bytes,8,opt,name=internal_query,json=internalQuery,proto3" json:"internal_query,omitempty"`
-	// where is the context in which the notice occurred, e.g., PL/pgSQL call stack (optional)
+	// where is the context in which the diagnostic occurred, e.g., PL/pgSQL call stack (optional)
 	Where string `protobuf:"bytes,9,opt,name=where,proto3" json:"where,omitempty"`
-	// schema_name is the name of the schema associated with the notice (optional)
+	// schema_name is the name of the schema associated with the diagnostic (optional)
 	SchemaName string `protobuf:"bytes,10,opt,name=schema_name,json=schemaName,proto3" json:"schema_name,omitempty"`
-	// table_name is the name of the table associated with the notice (optional)
+	// table_name is the name of the table associated with the diagnostic (optional)
 	TableName string `protobuf:"bytes,11,opt,name=table_name,json=tableName,proto3" json:"table_name,omitempty"`
-	// column_name is the name of the column associated with the notice (optional)
+	// column_name is the name of the column associated with the diagnostic (optional)
 	ColumnName string `protobuf:"bytes,12,opt,name=column_name,json=columnName,proto3" json:"column_name,omitempty"`
-	// data_type_name is the name of the data type associated with the notice (optional)
+	// data_type_name is the name of the data type associated with the diagnostic (optional)
 	DataTypeName string `protobuf:"bytes,13,opt,name=data_type_name,json=dataTypeName,proto3" json:"data_type_name,omitempty"`
-	// constraint_name is the name of the constraint associated with the notice (optional)
+	// constraint_name is the name of the constraint associated with the diagnostic (optional)
 	ConstraintName string `protobuf:"bytes,14,opt,name=constraint_name,json=constraintName,proto3" json:"constraint_name,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
-func (x *Notice) Reset() {
-	*x = Notice{}
-	mi := &file_query_proto_msgTypes[3]
+func (x *PgDiagnostic) Reset() {
+	*x = PgDiagnostic{}
+	mi := &file_query_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *Notice) String() string {
+func (x *PgDiagnostic) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Notice) ProtoMessage() {}
+func (*PgDiagnostic) ProtoMessage() {}
 
-func (x *Notice) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[3]
+func (x *PgDiagnostic) ProtoReflect() protoreflect.Message {
+	mi := &file_query_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -354,103 +439,110 @@ func (x *Notice) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Notice.ProtoReflect.Descriptor instead.
-func (*Notice) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{3}
+// Deprecated: Use PgDiagnostic.ProtoReflect.Descriptor instead.
+func (*PgDiagnostic) Descriptor() ([]byte, []int) {
+	return file_query_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *Notice) GetSeverity() string {
+func (x *PgDiagnostic) GetMessageType() int32 {
+	if x != nil {
+		return x.MessageType
+	}
+	return 0
+}
+
+func (x *PgDiagnostic) GetSeverity() string {
 	if x != nil {
 		return x.Severity
 	}
 	return ""
 }
 
-func (x *Notice) GetCode() string {
+func (x *PgDiagnostic) GetCode() string {
 	if x != nil {
 		return x.Code
 	}
 	return ""
 }
 
-func (x *Notice) GetMessage() string {
+func (x *PgDiagnostic) GetMessage() string {
 	if x != nil {
 		return x.Message
 	}
 	return ""
 }
 
-func (x *Notice) GetDetail() string {
+func (x *PgDiagnostic) GetDetail() string {
 	if x != nil {
 		return x.Detail
 	}
 	return ""
 }
 
-func (x *Notice) GetHint() string {
+func (x *PgDiagnostic) GetHint() string {
 	if x != nil {
 		return x.Hint
 	}
 	return ""
 }
 
-func (x *Notice) GetPosition() int32 {
+func (x *PgDiagnostic) GetPosition() int32 {
 	if x != nil {
 		return x.Position
 	}
 	return 0
 }
 
-func (x *Notice) GetInternalPosition() int32 {
+func (x *PgDiagnostic) GetInternalPosition() int32 {
 	if x != nil {
 		return x.InternalPosition
 	}
 	return 0
 }
 
-func (x *Notice) GetInternalQuery() string {
+func (x *PgDiagnostic) GetInternalQuery() string {
 	if x != nil {
 		return x.InternalQuery
 	}
 	return ""
 }
 
-func (x *Notice) GetWhere() string {
+func (x *PgDiagnostic) GetWhere() string {
 	if x != nil {
 		return x.Where
 	}
 	return ""
 }
 
-func (x *Notice) GetSchemaName() string {
+func (x *PgDiagnostic) GetSchemaName() string {
 	if x != nil {
 		return x.SchemaName
 	}
 	return ""
 }
 
-func (x *Notice) GetTableName() string {
+func (x *PgDiagnostic) GetTableName() string {
 	if x != nil {
 		return x.TableName
 	}
 	return ""
 }
 
-func (x *Notice) GetColumnName() string {
+func (x *PgDiagnostic) GetColumnName() string {
 	if x != nil {
 		return x.ColumnName
 	}
 	return ""
 }
 
-func (x *Notice) GetDataTypeName() string {
+func (x *PgDiagnostic) GetDataTypeName() string {
 	if x != nil {
 		return x.DataTypeName
 	}
 	return ""
 }
 
-func (x *Notice) GetConstraintName() string {
+func (x *PgDiagnostic) GetConstraintName() string {
 	if x != nil {
 		return x.ConstraintName
 	}
@@ -473,7 +565,7 @@ type StatementDescription struct {
 
 func (x *StatementDescription) Reset() {
 	*x = StatementDescription{}
-	mi := &file_query_proto_msgTypes[4]
+	mi := &file_query_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -485,7 +577,7 @@ func (x *StatementDescription) String() string {
 func (*StatementDescription) ProtoMessage() {}
 
 func (x *StatementDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[4]
+	mi := &file_query_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -498,7 +590,7 @@ func (x *StatementDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatementDescription.ProtoReflect.Descriptor instead.
 func (*StatementDescription) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{4}
+	return file_query_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StatementDescription) GetParameters() []*ParameterDescription {
@@ -526,7 +618,7 @@ type ParameterDescription struct {
 
 func (x *ParameterDescription) Reset() {
 	*x = ParameterDescription{}
-	mi := &file_query_proto_msgTypes[5]
+	mi := &file_query_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -538,7 +630,7 @@ func (x *ParameterDescription) String() string {
 func (*ParameterDescription) ProtoMessage() {}
 
 func (x *ParameterDescription) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[5]
+	mi := &file_query_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -551,7 +643,7 @@ func (x *ParameterDescription) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParameterDescription.ProtoReflect.Descriptor instead.
 func (*ParameterDescription) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{5}
+	return file_query_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ParameterDescription) GetDataTypeOid() uint32 {
@@ -581,7 +673,7 @@ type Target struct {
 
 func (x *Target) Reset() {
 	*x = Target{}
-	mi := &file_query_proto_msgTypes[6]
+	mi := &file_query_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -593,7 +685,7 @@ func (x *Target) String() string {
 func (*Target) ProtoMessage() {}
 
 func (x *Target) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[6]
+	mi := &file_query_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -606,7 +698,7 @@ func (x *Target) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Target.ProtoReflect.Descriptor instead.
 func (*Target) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{6}
+	return file_query_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Target) GetTableGroup() string {
@@ -649,7 +741,7 @@ type PreparedStatement struct {
 
 func (x *PreparedStatement) Reset() {
 	*x = PreparedStatement{}
-	mi := &file_query_proto_msgTypes[7]
+	mi := &file_query_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -661,7 +753,7 @@ func (x *PreparedStatement) String() string {
 func (*PreparedStatement) ProtoMessage() {}
 
 func (x *PreparedStatement) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[7]
+	mi := &file_query_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -674,7 +766,7 @@ func (x *PreparedStatement) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedStatement.ProtoReflect.Descriptor instead.
 func (*PreparedStatement) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{7}
+	return file_query_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PreparedStatement) GetName() string {
@@ -729,7 +821,7 @@ type Portal struct {
 
 func (x *Portal) Reset() {
 	*x = Portal{}
-	mi := &file_query_proto_msgTypes[8]
+	mi := &file_query_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -741,7 +833,7 @@ func (x *Portal) String() string {
 func (*Portal) ProtoMessage() {}
 
 func (x *Portal) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[8]
+	mi := &file_query_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -754,7 +846,7 @@ func (x *Portal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Portal.ProtoReflect.Descriptor instead.
 func (*Portal) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{8}
+	return file_query_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Portal) GetName() string {
@@ -825,7 +917,7 @@ type ExecuteOptions struct {
 
 func (x *ExecuteOptions) Reset() {
 	*x = ExecuteOptions{}
-	mi := &file_query_proto_msgTypes[9]
+	mi := &file_query_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -837,7 +929,7 @@ func (x *ExecuteOptions) String() string {
 func (*ExecuteOptions) ProtoMessage() {}
 
 func (x *ExecuteOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[9]
+	mi := &file_query_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -850,7 +942,7 @@ func (x *ExecuteOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteOptions.ProtoReflect.Descriptor instead.
 func (*ExecuteOptions) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{9}
+	return file_query_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExecuteOptions) GetSessionSettings() map[string]string {
@@ -885,15 +977,20 @@ var File_query_proto protoreflect.FileDescriptor
 
 const file_query_proto_rawDesc = "" +
 	"\n" +
-	"\vquery.proto\x12\x05query\x1a\x15clustermetadata.proto\"\xc2\x01\n" +
+	"\vquery.proto\x12\x05query\x1a\x15clustermetadata.proto\"\x84\x01\n" +
+	"\x12QueryResultPayload\x12,\n" +
+	"\x06result\x18\x01 \x01(\v2\x12.query.QueryResultH\x00R\x06result\x125\n" +
+	"\n" +
+	"diagnostic\x18\x02 \x01(\v2\x13.query.PgDiagnosticH\x00R\n" +
+	"diagnosticB\t\n" +
+	"\apayload\"\xa8\x01\n" +
 	"\vQueryResult\x12$\n" +
 	"\x06fields\x18\x01 \x03(\v2\f.query.FieldR\x06fields\x12#\n" +
 	"\rrows_affected\x18\x02 \x01(\x04R\frowsAffected\x12\x1e\n" +
 	"\x04rows\x18\x03 \x03(\v2\n" +
 	".query.RowR\x04rows\x12\x1f\n" +
 	"\vcommand_tag\x18\x04 \x01(\tR\n" +
-	"commandTag\x12'\n" +
-	"\anotices\x18\x05 \x03(\v2\r.query.NoticeR\anotices\"\x89\x02\n" +
+	"commandTagJ\x04\b\x05\x10\x06R\anotices\"\x89\x02\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1b\n" +
@@ -905,8 +1002,9 @@ const file_query_proto_rawDesc = "" +
 	"\x06format\x18\b \x01(\x05R\x06format\"7\n" +
 	"\x03Row\x12\x18\n" +
 	"\alengths\x18\x01 \x03(\x12R\alengths\x12\x16\n" +
-	"\x06values\x18\x02 \x01(\fR\x06values\"\xb4\x03\n" +
-	"\x06Notice\x12\x1a\n" +
+	"\x06values\x18\x02 \x01(\fR\x06values\"\xdd\x03\n" +
+	"\fPgDiagnostic\x12!\n" +
+	"\fmessage_type\x18\x0f \x01(\x05R\vmessageType\x12\x1a\n" +
 	"\bseverity\x18\x01 \x01(\tR\bseverity\x12\x12\n" +
 	"\x04code\x18\x02 \x01(\tR\x04code\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12\x16\n" +
@@ -971,34 +1069,36 @@ func file_query_proto_rawDescGZIP() []byte {
 	return file_query_proto_rawDescData
 }
 
-var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_query_proto_goTypes = []any{
-	(*QueryResult)(nil),             // 0: query.QueryResult
-	(*Field)(nil),                   // 1: query.Field
-	(*Row)(nil),                     // 2: query.Row
-	(*Notice)(nil),                  // 3: query.Notice
-	(*StatementDescription)(nil),    // 4: query.StatementDescription
-	(*ParameterDescription)(nil),    // 5: query.ParameterDescription
-	(*Target)(nil),                  // 6: query.Target
-	(*PreparedStatement)(nil),       // 7: query.PreparedStatement
-	(*Portal)(nil),                  // 8: query.Portal
-	(*ExecuteOptions)(nil),          // 9: query.ExecuteOptions
-	nil,                             // 10: query.ExecuteOptions.SessionSettingsEntry
-	(clustermetadata.PoolerType)(0), // 11: clustermetadata.PoolerType
+	(*QueryResultPayload)(nil),      // 0: query.QueryResultPayload
+	(*QueryResult)(nil),             // 1: query.QueryResult
+	(*Field)(nil),                   // 2: query.Field
+	(*Row)(nil),                     // 3: query.Row
+	(*PgDiagnostic)(nil),            // 4: query.PgDiagnostic
+	(*StatementDescription)(nil),    // 5: query.StatementDescription
+	(*ParameterDescription)(nil),    // 6: query.ParameterDescription
+	(*Target)(nil),                  // 7: query.Target
+	(*PreparedStatement)(nil),       // 8: query.PreparedStatement
+	(*Portal)(nil),                  // 9: query.Portal
+	(*ExecuteOptions)(nil),          // 10: query.ExecuteOptions
+	nil,                             // 11: query.ExecuteOptions.SessionSettingsEntry
+	(clustermetadata.PoolerType)(0), // 12: clustermetadata.PoolerType
 }
 var file_query_proto_depIdxs = []int32{
-	1,  // 0: query.QueryResult.fields:type_name -> query.Field
-	2,  // 1: query.QueryResult.rows:type_name -> query.Row
-	3,  // 2: query.QueryResult.notices:type_name -> query.Notice
-	5,  // 3: query.StatementDescription.parameters:type_name -> query.ParameterDescription
-	1,  // 4: query.StatementDescription.fields:type_name -> query.Field
-	11, // 5: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
-	10, // 6: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
-	7,  // [7:7] is the sub-list for method output_type
-	7,  // [7:7] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	1,  // 0: query.QueryResultPayload.result:type_name -> query.QueryResult
+	4,  // 1: query.QueryResultPayload.diagnostic:type_name -> query.PgDiagnostic
+	2,  // 2: query.QueryResult.fields:type_name -> query.Field
+	3,  // 3: query.QueryResult.rows:type_name -> query.Row
+	6,  // 4: query.StatementDescription.parameters:type_name -> query.ParameterDescription
+	2,  // 5: query.StatementDescription.fields:type_name -> query.Field
+	12, // 6: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
+	11, // 7: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
+	8,  // [8:8] is the sub-list for method output_type
+	8,  // [8:8] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }
@@ -1006,13 +1106,17 @@ func file_query_proto_init() {
 	if File_query_proto != nil {
 		return
 	}
+	file_query_proto_msgTypes[0].OneofWrappers = []any{
+		(*QueryResultPayload_Result)(nil),
+		(*QueryResultPayload_Diagnostic)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_proto_rawDesc), len(file_query_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/multipoolerservice"
@@ -94,37 +95,58 @@ func (g *grpcQueryService) StreamExecute(
 	// Call the gRPC StreamExecute
 	stream, err := g.client.StreamExecute(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to start stream execute: %w", err)
+		// Convert gRPC error - if it's a PostgreSQL error, preserve it
+		grpcErr := mterrors.FromGRPC(err)
+		var pgDiag *mterrors.PgDiagnostic
+		if errors.As(grpcErr, &pgDiag) {
+			return grpcErr
+		}
+		return mterrors.Wrapf(grpcErr, "failed to start stream execute")
 	}
 
 	// Stream results back via callback
 	for {
-		response, err := stream.Recv()
+		payload, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
 			// Stream completed successfully
 			g.logger.DebugContext(ctx, "stream completed", "pooler_id", g.poolerID)
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("stream receive error: %w", err)
+			// Convert gRPC error - if it's a PostgreSQL error, preserve it
+			grpcErr := mterrors.FromGRPC(err)
+			var pgDiag *mterrors.PgDiagnostic
+			if errors.As(grpcErr, &pgDiag) {
+				return grpcErr
+			}
+			return mterrors.Wrapf(grpcErr, "stream receive error")
 		}
 
-		// Extract result from response
-		if response.Result == nil {
-			g.logger.WarnContext(ctx, "received response with nil result", "pooler_id", g.poolerID)
-			continue
-		}
-
-		// Convert proto result to sqltypes (preserves NULL vs empty string)
-		result := sqltypes.ResultFromProto(response.Result)
-
-		// Call the callback with the result
-		if err := callback(ctx, result); err != nil {
-			// Callback returned error, stop streaming
-			g.logger.DebugContext(ctx, "callback returned error, stopping stream",
-				"pooler_id", g.poolerID,
-				"error", err)
-			return err
+		// Handle the union type payload
+		switch p := payload.GetPayload().(type) {
+		case *query.QueryResultPayload_Result:
+			// Row data - convert and send to callback
+			result := sqltypes.ResultFromProto(p.Result)
+			if err := callback(ctx, result); err != nil {
+				g.logger.DebugContext(ctx, "callback returned error, stopping stream",
+					"pooler_id", g.poolerID,
+					"error", err)
+				return err
+			}
+		case *query.QueryResultPayload_Diagnostic:
+			// Diagnostic (notice or error) - convert to Result with notice for backwards compat
+			diag := mterrors.PgDiagnosticFromProto(p.Diagnostic)
+			noticeResult := &sqltypes.Result{
+				Notices: []*mterrors.PgDiagnostic{diag},
+			}
+			if err := callback(ctx, noticeResult); err != nil {
+				g.logger.DebugContext(ctx, "callback returned error on notice, stopping stream",
+					"pooler_id", g.poolerID,
+					"error", err)
+				return err
+			}
+		default:
+			g.logger.WarnContext(ctx, "received response with unknown payload type", "pooler_id", g.poolerID)
 		}
 	}
 }
@@ -186,7 +208,13 @@ func (g *grpcQueryService) PortalStreamExecute(
 	// Call the gRPC PortalStreamExecute
 	stream, err := g.client.PortalStreamExecute(ctx, req)
 	if err != nil {
-		return queryservice.ReservedState{}, fmt.Errorf("failed to start portal stream execute: %w", err)
+		// Convert gRPC error - if it's a PostgreSQL error, preserve it
+		grpcErr := mterrors.FromGRPC(err)
+		var pgDiag *mterrors.PgDiagnostic
+		if errors.As(grpcErr, &pgDiag) {
+			return queryservice.ReservedState{}, grpcErr
+		}
+		return queryservice.ReservedState{}, mterrors.Wrapf(grpcErr, "failed to start portal stream execute")
 	}
 
 	var reservedState queryservice.ReservedState
@@ -200,7 +228,13 @@ func (g *grpcQueryService) PortalStreamExecute(
 			return reservedState, nil
 		}
 		if err != nil {
-			return reservedState, fmt.Errorf("portal stream receive error: %w", err)
+			// Convert gRPC error - if it's a PostgreSQL error, preserve it
+			grpcErr := mterrors.FromGRPC(err)
+			var pgDiag *mterrors.PgDiagnostic
+			if errors.As(grpcErr, &pgDiag) {
+				return reservedState, grpcErr
+			}
+			return reservedState, mterrors.Wrapf(grpcErr, "portal stream receive error")
 		}
 
 		// Extract reserved state if present
@@ -212,22 +246,33 @@ func (g *grpcQueryService) PortalStreamExecute(
 				"pooler_id", response.PoolerId.String())
 		}
 
-		// Extract result from response
-		if response.Result == nil {
-			g.logger.WarnContext(ctx, "received response with nil result", "pooler_id", g.poolerID)
-			continue
-		}
-
-		// Convert proto result to sqltypes (preserves NULL vs empty string)
-		result := sqltypes.ResultFromProto(response.Result)
-
-		// Call the callback with the result
-		if err := callback(ctx, result); err != nil {
-			// Callback returned error, stop streaming
-			g.logger.DebugContext(ctx, "callback returned error, stopping stream",
-				"pooler_id", g.poolerID,
-				"error", err)
-			return reservedState, err
+		// Handle the union type payload (if present)
+		if response.Result != nil {
+			switch p := response.Result.GetPayload().(type) {
+			case *query.QueryResultPayload_Result:
+				// Row data - convert and send to callback
+				result := sqltypes.ResultFromProto(p.Result)
+				if err := callback(ctx, result); err != nil {
+					g.logger.DebugContext(ctx, "callback returned error, stopping stream",
+						"pooler_id", g.poolerID,
+						"error", err)
+					return reservedState, err
+				}
+			case *query.QueryResultPayload_Diagnostic:
+				// Diagnostic (notice or error) - convert to Result with notice for backwards compat
+				diag := mterrors.PgDiagnosticFromProto(p.Diagnostic)
+				noticeResult := &sqltypes.Result{
+					Notices: []*mterrors.PgDiagnostic{diag},
+				}
+				if err := callback(ctx, noticeResult); err != nil {
+					g.logger.DebugContext(ctx, "callback returned error on notice, stopping stream",
+						"pooler_id", g.poolerID,
+						"error", err)
+					return reservedState, err
+				}
+			default:
+				g.logger.WarnContext(ctx, "received response with unknown payload type", "pooler_id", g.poolerID)
+			}
 		}
 	}
 }
@@ -258,7 +303,13 @@ func (g *grpcQueryService) Describe(
 	// Call the gRPC Describe
 	response, err := g.client.Describe(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("describe failed: %w", err)
+		// Convert gRPC error - if it's a PostgreSQL error, preserve it
+		grpcErr := mterrors.FromGRPC(err)
+		var pgDiag *mterrors.PgDiagnostic
+		if errors.As(grpcErr, &pgDiag) {
+			return nil, grpcErr
+		}
+		return nil, mterrors.Wrapf(grpcErr, "describe failed")
 	}
 
 	g.logger.DebugContext(ctx, "describe completed successfully", "pooler_id", g.poolerID)

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -89,7 +89,7 @@ func (m *mockMultiPoolerServiceClient) ExecuteQuery(ctx context.Context, in *mul
 	return nil, nil
 }
 
-func (m *mockMultiPoolerServiceClient) StreamExecute(ctx context.Context, in *multipoolerservice.StreamExecuteRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[multipoolerservice.StreamExecuteResponse], error) {
+func (m *mockMultiPoolerServiceClient) StreamExecute(ctx context.Context, in *multipoolerservice.StreamExecuteRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[query.QueryResultPayload], error) {
 	return nil, nil
 }
 

--- a/go/test/endtoend/multipooler/pgprotocol_client_test.go
+++ b/go/test/endtoend/multipooler/pgprotocol_client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/test/utils"
@@ -471,30 +472,30 @@ func TestPgProtocolClientErrors(t *testing.T) {
 		_, err := conn.Query(ctx, "SELEC 1") // typo
 		require.Error(t, err)
 
-		var pgErr *client.Error
-		require.True(t, errors.As(err, &pgErr), "expected *client.Error, got %T", err)
-		assert.Equal(t, "ERROR", pgErr.Severity)
-		assert.NotEmpty(t, pgErr.Code)
-		assert.NotEmpty(t, pgErr.Message)
-		t.Logf("Error: %s", pgErr.Error())
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag), "expected *mterrors.PgDiagnostic, got %T", err)
+		assert.Equal(t, "ERROR", diag.Severity)
+		assert.NotEmpty(t, diag.Code)
+		assert.NotEmpty(t, diag.Message)
+		t.Logf("Error: %s", diag.Error())
 	})
 
 	t.Run("undefined_table", func(t *testing.T) {
 		_, err := conn.Query(ctx, "SELECT * FROM nonexistent_table_xyz")
 		require.Error(t, err)
 
-		var pgErr *client.Error
-		require.True(t, errors.As(err, &pgErr), "expected *client.Error, got %T", err)
-		assert.Equal(t, "42P01", pgErr.Code) // undefined_table
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag), "expected *mterrors.PgDiagnostic, got %T", err)
+		assert.Equal(t, "42P01", diag.Code) // undefined_table
 	})
 
 	t.Run("division_by_zero", func(t *testing.T) {
 		_, err := conn.Query(ctx, "SELECT 1/0")
 		require.Error(t, err)
 
-		var pgErr *client.Error
-		require.True(t, errors.As(err, &pgErr), "expected *client.Error, got %T", err)
-		assert.Equal(t, "22012", pgErr.Code) // division_by_zero
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag), "expected *mterrors.PgDiagnostic, got %T", err)
+		assert.Equal(t, "22012", diag.Code) // division_by_zero
 	})
 
 	t.Run("connection_recovers_after_error", func(t *testing.T) {

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -244,8 +244,8 @@ func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context,
 
 	cmd := exec.CommandContext(ctx, "make",
 		"-C", filepath.Join(pb.BuildDir, "src/test/regress"), // Regress directory
-		"installcheck-tests",            // Target for running specific tests against existing server
-		"TESTS=test_setup boolean char", // Run only boolean and char tests
+		"installcheck-tests", // Target for running specific tests against existing server
+		"TESTS=test_setup boolean char name varchar int2 int4 oid float4 bit uuid enum money pg_lsn regproc", // Run only boolean and char tests
 	)
 
 	// Set environment variables for connection

--- a/go/test/endtoend/queryserving/error_format_test.go
+++ b/go/test/endtoend/queryserving/error_format_test.go
@@ -1,0 +1,575 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestErrorFormat_UndefinedColumnPosition tests that undefined column errors preserve the Position field,
+// which enables psql to show LINE indicator and ^ marker pointing to the error location.
+// Note: Pure syntax errors (like "SELECT * FORM users") are caught by multigateway's own parser
+// before reaching PostgreSQL. This test uses queries that parse correctly but fail at PostgreSQL
+// with Position information.
+func TestErrorFormat_UndefinedColumnPosition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	t.Run("simple_query_undefined_column", func(t *testing.T) {
+		// Connect to multigateway
+		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		conn, err := pgx.Connect(ctx, connStr)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		// Create a temp table and query a non-existent column
+		// This parses correctly but PostgreSQL will return an error with Position
+		tableName := fmt.Sprintf("pos_test_%d", time.Now().UnixNano())
+		_, err = conn.Exec(ctx, fmt.Sprintf("CREATE TABLE %s (id int, name text)", tableName))
+		require.NoError(t, err)
+		defer func() {
+			_, _ = conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+tableName)
+		}()
+
+		// Query a non-existent column - PostgreSQL will report Position
+		_, err = conn.Exec(ctx, "SELECT nonexistent_column FROM "+tableName)
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// Verify error fields - 42703 = undefined_column
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "42703", pgErr.Code)
+		assert.Contains(t, pgErr.Message, "nonexistent_column")
+		assert.Greater(t, pgErr.Position, int32(0), "Position should be set for undefined column errors")
+		t.Logf("Undefined column error at position %d: %s", pgErr.Position, pgErr.Message)
+	})
+
+	// Note: Extended query protocol tests are skipped for now because they involve
+	// Describe operations that have different error handling paths. The simple query
+	// protocol tests and compare_with_direct_postgres tests verify the core error
+	// format preservation functionality.
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		// Create table on both (via multigateway it replicates)
+		tableName := fmt.Sprintf("pos_cmp_%d", time.Now().UnixNano())
+		_, err = mgConn.Exec(ctx, fmt.Sprintf("CREATE TABLE %s (id int)", tableName))
+		require.NoError(t, err)
+		defer func() {
+			_, _ = mgConn.Exec(context.Background(), "DROP TABLE IF EXISTS "+tableName)
+		}()
+
+		// Execute same bad query on both
+		query := "SELECT missing_col FROM " + tableName
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.Message, mgPgErr.Message, "Message should match")
+		assert.Equal(t, directPgErr.Position, mgPgErr.Position, "Position should match")
+		t.Logf("Direct PG: Severity=%s Code=%s Position=%d Message=%s",
+			directPgErr.Severity, directPgErr.Code, directPgErr.Position, directPgErr.Message)
+		t.Logf("Multigres: Severity=%s Code=%s Position=%d Message=%s",
+			mgPgErr.Severity, mgPgErr.Code, mgPgErr.Position, mgPgErr.Message)
+	})
+}
+
+// TestErrorFormat_TypeErrorSQLState tests that type conversion errors preserve the SQLSTATE code.
+func TestErrorFormat_TypeErrorSQLState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	t.Run("simple_query_type_error", func(t *testing.T) {
+		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		conn, err := pgx.Connect(ctx, connStr)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		// Invalid boolean literal
+		_, err = conn.Exec(ctx, "SELECT bool 'invalid_bool'")
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// 22P02 = invalid_text_representation
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "22P02", pgErr.Code, "SQLSTATE should be 22P02 for invalid boolean")
+		assert.Contains(t, pgErr.Message, "invalid input syntax for type boolean")
+		t.Logf("Type error: Code=%s Message=%s", pgErr.Code, pgErr.Message)
+	})
+
+	// Note: Extended query protocol tests skipped - see TestErrorFormat_UndefinedColumnPosition comment
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		// Execute same bad query on both
+		query := "SELECT bool 'invalid_bool'"
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.Message, mgPgErr.Message, "Message should match")
+	})
+}
+
+// TestErrorFormat_ConstraintViolation tests that constraint violation errors include
+// Schema, Table, and Constraint fields.
+func TestErrorFormat_ConstraintViolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	tableName := fmt.Sprintf("error_test_%d", time.Now().UnixNano())
+
+	// Create a table with constraints
+	_, err = conn.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id INT PRIMARY KEY,
+			email TEXT UNIQUE,
+			value INT CHECK (value > 0)
+		)
+	`, tableName))
+	require.NoError(t, err)
+	defer func() {
+		_, _ = conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+tableName)
+	}()
+
+	t.Run("unique_constraint_violation", func(t *testing.T) {
+		// Insert a row
+		_, err := conn.Exec(ctx, fmt.Sprintf("INSERT INTO %s (id, email, value) VALUES (1, 'test@example.com', 10)", tableName))
+		require.NoError(t, err)
+
+		// Try to insert duplicate email (unique constraint violation)
+		_, err = conn.Exec(ctx, fmt.Sprintf("INSERT INTO %s (id, email, value) VALUES (2, 'test@example.com', 20)", tableName))
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// 23505 = unique_violation
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "23505", pgErr.Code, "SQLSTATE should be 23505 for unique violation")
+		assert.Equal(t, "public", pgErr.SchemaName, "Schema should be 'public'")
+		assert.Equal(t, tableName, pgErr.TableName, "Table name should match")
+		assert.NotEmpty(t, pgErr.ConstraintName, "Constraint name should be set")
+		t.Logf("Constraint violation: Code=%s Schema=%s Table=%s Constraint=%s",
+			pgErr.Code, pgErr.SchemaName, pgErr.TableName, pgErr.ConstraintName)
+	})
+
+	t.Run("check_constraint_violation", func(t *testing.T) {
+		// Try to insert with invalid value (check constraint violation)
+		_, err := conn.Exec(ctx, fmt.Sprintf("INSERT INTO %s (id, email, value) VALUES (3, 'other@example.com', -5)", tableName))
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// 23514 = check_violation
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "23514", pgErr.Code, "SQLSTATE should be 23514 for check violation")
+		assert.Equal(t, "public", pgErr.SchemaName, "Schema should be 'public'")
+		assert.Equal(t, tableName, pgErr.TableName, "Table name should match")
+		assert.NotEmpty(t, pgErr.ConstraintName, "Constraint name should be set")
+		t.Logf("Check constraint violation: Code=%s Schema=%s Table=%s Constraint=%s",
+			pgErr.Code, pgErr.SchemaName, pgErr.TableName, pgErr.ConstraintName)
+	})
+
+	t.Run("primary_key_violation", func(t *testing.T) {
+		// Try to insert duplicate primary key
+		_, err := conn.Exec(ctx, fmt.Sprintf("INSERT INTO %s (id, email, value) VALUES (1, 'another@example.com', 30)", tableName))
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// 23505 = unique_violation (primary key is implemented as unique constraint)
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "23505", pgErr.Code)
+		assert.Equal(t, "public", pgErr.SchemaName)
+		assert.Equal(t, tableName, pgErr.TableName)
+	})
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		// Execute same constraint violation on both
+		query := fmt.Sprintf("INSERT INTO %s (id, email, value) VALUES (1, 'dup@example.com', 50)", tableName)
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.SchemaName, mgPgErr.SchemaName, "Schema should match")
+		assert.Equal(t, directPgErr.TableName, mgPgErr.TableName, "Table should match")
+		assert.Equal(t, directPgErr.ConstraintName, mgPgErr.ConstraintName, "Constraint should match")
+	})
+}
+
+// TestErrorFormat_PLpgSQLWhereField tests that PL/pgSQL errors include the Where field
+// showing the call stack.
+func TestErrorFormat_PLpgSQLWhereField(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	// Create nested functions that raise an error
+	innerFunc := fmt.Sprintf("error_inner_%d", time.Now().UnixNano())
+	outerFunc := fmt.Sprintf("error_outer_%d", time.Now().UnixNano())
+
+	_, err = conn.Exec(ctx, fmt.Sprintf(`
+		CREATE OR REPLACE FUNCTION %s() RETURNS void AS $$
+		BEGIN
+			RAISE EXCEPTION 'error from inner function';
+		END;
+		$$ LANGUAGE plpgsql;
+	`, innerFunc))
+	require.NoError(t, err)
+	defer func() {
+		_, _ = conn.Exec(context.Background(), "DROP FUNCTION IF EXISTS "+innerFunc+"()")
+	}()
+
+	_, err = conn.Exec(ctx, fmt.Sprintf(`
+		CREATE OR REPLACE FUNCTION %s() RETURNS void AS $$
+		BEGIN
+			PERFORM %s();
+		END;
+		$$ LANGUAGE plpgsql;
+	`, outerFunc, innerFunc))
+	require.NoError(t, err)
+	defer func() {
+		_, _ = conn.Exec(context.Background(), "DROP FUNCTION IF EXISTS "+outerFunc+"()")
+	}()
+
+	t.Run("simple_query_plpgsql_error", func(t *testing.T) {
+		// Call the outer function which triggers error in inner function
+		_, err := conn.Exec(ctx, fmt.Sprintf("SELECT %s()", outerFunc))
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// P0001 = raise_exception
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "P0001", pgErr.Code, "SQLSTATE should be P0001 for RAISE EXCEPTION")
+		assert.Contains(t, pgErr.Message, "error from inner function")
+
+		// The Where field should contain the PL/pgSQL call stack
+		assert.NotEmpty(t, pgErr.Where, "Where field should contain call stack")
+		assert.Contains(t, pgErr.Where, innerFunc, "Where should contain inner function name")
+		assert.Contains(t, pgErr.Where, outerFunc, "Where should contain outer function name")
+		t.Logf("PL/pgSQL error: Code=%s Message=%s\nWhere:\n%s",
+			pgErr.Code, pgErr.Message, pgErr.Where)
+	})
+
+	// Note: Extended query protocol tests skipped - see TestErrorFormat_UndefinedColumnPosition comment
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		// Execute same function call on both
+		query := fmt.Sprintf("SELECT %s()", outerFunc)
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.Message, mgPgErr.Message, "Message should match")
+		assert.Equal(t, directPgErr.Where, mgPgErr.Where, "Where (call stack) should match")
+	})
+}
+
+// TestErrorFormat_HintAndDetail tests that errors preserve Hint and Detail fields.
+func TestErrorFormat_HintAndDetail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	t.Run("error_with_hint_and_detail", func(t *testing.T) {
+		// Use DO block to raise an error with DETAIL and HINT
+		_, err := conn.Exec(ctx, `
+			DO $$
+			BEGIN
+				RAISE EXCEPTION 'custom error message'
+					USING DETAIL = 'This is the detailed explanation',
+					      HINT = 'Try doing something else';
+			END
+			$$
+		`)
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "P0001", pgErr.Code) // raise_exception
+		assert.Equal(t, "custom error message", pgErr.Message)
+		assert.Equal(t, "This is the detailed explanation", pgErr.Detail)
+		assert.Equal(t, "Try doing something else", pgErr.Hint)
+		t.Logf("Error with Hint/Detail: Message=%s, Detail=%s, Hint=%s",
+			pgErr.Message, pgErr.Detail, pgErr.Hint)
+	})
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		query := `
+			DO $$
+			BEGIN
+				RAISE EXCEPTION 'test error'
+					USING DETAIL = 'test detail',
+					      HINT = 'test hint';
+			END
+			$$
+		`
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.Message, mgPgErr.Message, "Message should match")
+		assert.Equal(t, directPgErr.Detail, mgPgErr.Detail, "Detail should match")
+		assert.Equal(t, directPgErr.Hint, mgPgErr.Hint, "Hint should match")
+	})
+}
+
+// TestErrorFormat_UndefinedTable tests that undefined object errors work correctly.
+func TestErrorFormat_UndefinedTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping error format test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping error format tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	t.Run("undefined_table_error", func(t *testing.T) {
+		_, err := conn.Exec(ctx, "SELECT * FROM nonexistent_table_xyz")
+		require.Error(t, err)
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+
+		// 42P01 = undefined_table
+		assert.Equal(t, "ERROR", pgErr.Severity)
+		assert.Equal(t, "42P01", pgErr.Code, "SQLSTATE should be 42P01 for undefined table")
+		assert.Contains(t, pgErr.Message, "nonexistent_table_xyz")
+		t.Logf("Undefined table error: Code=%s Message=%s", pgErr.Code, pgErr.Message)
+	})
+
+	t.Run("compare_with_direct_postgres", func(t *testing.T) {
+		// Connect directly to PostgreSQL
+		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConn, err := pgx.Connect(ctx, directConnStr)
+		require.NoError(t, err)
+		defer directConn.Close(ctx)
+
+		// Connect to multigateway
+		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConn, err := pgx.Connect(ctx, mgConnStr)
+		require.NoError(t, err)
+		defer mgConn.Close(ctx)
+
+		query := "SELECT * FROM nonexistent_table_xyz"
+
+		_, directErr := directConn.Exec(ctx, query)
+		_, mgErr := mgConn.Exec(ctx, query)
+
+		var directPgErr, mgPgErr *pgconn.PgError
+		require.True(t, errors.As(directErr, &directPgErr))
+		require.True(t, errors.As(mgErr, &mgPgErr))
+
+		// Compare error fields
+		assert.Equal(t, directPgErr.Severity, mgPgErr.Severity, "Severity should match")
+		assert.Equal(t, directPgErr.Code, mgPgErr.Code, "SQLSTATE Code should match")
+		assert.Equal(t, directPgErr.Message, mgPgErr.Message, "Message should match")
+	})
+}

--- a/go/test/endtoend/queryserving/transaction_test.go
+++ b/go/test/endtoend/queryserving/transaction_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
@@ -182,9 +183,9 @@ func multiStatementTestCases() []transactionTestCase {
 				`)
 				require.Error(t, err, "Expected error from duplicate key")
 
-				var pgErr *client.Error
-				require.True(t, errors.As(err, &pgErr), "Expected PostgreSQL error")
-				assert.Equal(t, "23505", pgErr.Code, "Expected unique_violation error code")
+				var diag *mterrors.PgDiagnostic
+				require.True(t, errors.As(err, &diag), "Expected PostgreSQL error")
+				assert.Equal(t, "23505", diag.Code, "Expected unique_violation error code")
 				return err
 			},
 			verifyFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) {
@@ -394,9 +395,9 @@ func ddlTransactionTestCases() []transactionTestCase {
 				_, err := conn.Query(ctx, "SELECT * FROM temp_ddl_test")
 				require.Error(t, err, "Table should not exist after rollback")
 
-				var pgErr *client.Error
-				require.True(t, errors.As(err, &pgErr), "Expected PostgreSQL error")
-				assert.Equal(t, "42P01", pgErr.Code, "Expected undefined_table error code")
+				var diag *mterrors.PgDiagnostic
+				require.True(t, errors.As(err, &diag), "Expected PostgreSQL error")
+				assert.Equal(t, "42P01", diag.Code, "Expected undefined_table error code")
 			},
 		},
 		{
@@ -419,9 +420,9 @@ func ddlTransactionTestCases() []transactionTestCase {
 				_, err := conn.Query(ctx, "SELECT * FROM t1_ddl_test")
 				require.Error(t, err, "Table should not exist after rollback")
 
-				var pgErr *client.Error
-				require.True(t, errors.As(err, &pgErr), "Expected PostgreSQL error")
-				assert.Equal(t, "42P01", pgErr.Code, "Expected undefined_table error code")
+				var diag *mterrors.PgDiagnostic
+				require.True(t, errors.As(err, &diag), "Expected PostgreSQL error")
+				assert.Equal(t, "42P01", diag.Code, "Expected undefined_table error code")
 			},
 		},
 		{
@@ -468,9 +469,9 @@ func ddlTransactionTestCases() []transactionTestCase {
 				`)
 				require.Error(t, err, "CREATE DATABASE should fail inside transaction")
 
-				var pgErr *client.Error
-				require.True(t, errors.As(err, &pgErr), "Expected PostgreSQL error")
-				assert.Equal(t, "25001", pgErr.Code,
+				var diag *mterrors.PgDiagnostic
+				require.True(t, errors.As(err, &diag), "Expected PostgreSQL error")
+				assert.Equal(t, "25001", diag.Code,
 					"Expected active_sql_transaction error for CREATE DATABASE in transaction")
 
 				_, _ = conn.Query(ctx, "ROLLBACK")
@@ -593,9 +594,9 @@ func explicitTransactionTestCases() []transactionTestCase {
 				_, err = conn.Query(ctx, "INSERT INTO txn_abort_test VALUES (2, 'Bob')")
 				require.Error(t, err, "Should fail in aborted transaction")
 
-				var pgErr *client.Error
-				require.True(t, errors.As(err, &pgErr), "Expected PostgreSQL error")
-				assert.Equal(t, "25P02", pgErr.Code, "Expected in_failed_sql_transaction error")
+				var diag *mterrors.PgDiagnostic
+				require.True(t, errors.As(err, &diag), "Expected PostgreSQL error")
+				assert.Equal(t, "25P02", diag.Code, "Expected in_failed_sql_transaction error")
 
 				_, err = conn.Query(ctx, "ROLLBACK")
 				require.NoError(t, err)

--- a/proto/mtrpc.proto
+++ b/proto/mtrpc.proto
@@ -20,6 +20,8 @@ syntax = "proto3";
 
 package mtrpc;
 
+import "query.proto";
+
 option go_package = "github.com/multigres/multigres/go/pb/mtrpc";
 
 // CallerID is passed along RPCs to identify the originating client
@@ -188,4 +190,11 @@ enum Code {
 message RPCError {
   string message = 1;
   Code code = 2;
+
+  // pg_diagnostic contains the full PostgreSQL diagnostic information when the error
+  // originated from PostgreSQL. This allows preserving all 14 PostgreSQL error fields
+  // (SQLSTATE, position, hint, detail, etc.) through gRPC serialization, enabling
+  // proper PostgreSQL-format error display to clients.
+  // When present, this should be used to format the error response to the client.
+  optional query.PgDiagnostic pg_diagnostic = 3;
 }

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -34,7 +34,7 @@ service MultiPoolerService {
   rpc ExecuteQuery(ExecuteQueryRequest) returns (ExecuteQueryResponse);
 
   // StreamExecute executes a SQL query and streams the results back
-  rpc StreamExecute(StreamExecuteRequest) returns (stream StreamExecuteResponse);
+  rpc StreamExecute(StreamExecuteRequest) returns (stream query.QueryResultPayload);
 
   // PortalStreamExecute executes a portal (bound prepared statement) and streams results
   // Returns reserved connection information for session affinity
@@ -122,8 +122,8 @@ message PortalStreamExecuteRequest {
 
 // PortalStreamExecuteResponse represents a response in the portal execution stream
 message PortalStreamExecuteResponse {
-  // result contains the query result data (rows, fields, etc.)
-  query.QueryResult result = 1;
+  // result contains the query result data (rows, fields, etc.) or diagnostics
+  query.QueryResultPayload result = 1;
 
   // reserved_connection_id is the ID of the reserved connection
   // This is returned in the first response and should be used for subsequent queries

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -24,6 +24,16 @@ import "clustermetadata.proto";
 
 option go_package = "github.com/multigres/multigres/go/pb/query";
 
+// QueryResultPayload is a union type for streaming query results.
+// Each stream item is either row data OR a diagnostic (error/notice).
+// This enables zero-buffering notice delivery during query execution.
+message QueryResultPayload {
+  oneof payload {
+    QueryResult result = 1;      // Row data with fields/rows/command_tag
+    PgDiagnostic diagnostic = 2; // Individual error or notice
+  }
+}
+
 // QueryResult represents the result of executing a query
 message QueryResult {
   // fields describes the columns in the result set (nil if no rows returned)
@@ -41,9 +51,9 @@ message QueryResult {
   // Examples: "SELECT 42", "INSERT 0 5", "UPDATE 10", "DELETE 3", "CREATE TABLE"
   string command_tag = 4;
 
-  // notices contains any PostgreSQL notices received during query execution.
-  // These are non-fatal messages like warnings or informational notices.
-  repeated Notice notices = 5;
+  // Field 5 removed - use QueryResultPayload.diagnostic instead
+  reserved 5;
+  reserved "notices";
 }
 
 // Field represents metadata about a column in the result set.
@@ -85,23 +95,34 @@ message Row {
   bytes values = 2;
 }
 
-// Notice represents a PostgreSQL notice response (non-fatal messages).
-// These include warnings, informational messages, and other diagnostics
-// that don't cause the query to fail.
-message Notice {
-  // severity is the notice severity level (e.g., "NOTICE", "WARNING", "INFO")
+// PgDiagnostic represents a PostgreSQL diagnostic message (error or notice).
+// PostgreSQL uses the same wire format for both ErrorResponse ('E') and NoticeResponse ('N'),
+// differentiated by the message_type field. This unified structure captures all 14 fields
+// defined in the PostgreSQL protocol for diagnostic messages.
+//
+// Error severities: ERROR, FATAL, PANIC
+// Notice severities: WARNING, NOTICE, DEBUG, INFO, LOG
+//
+// Reference: https://www.postgresql.org/docs/current/protocol-error-fields.html
+message PgDiagnostic {
+  // message_type is the PostgreSQL protocol message type byte.
+  // 'E' (0x45 = 69) for ErrorResponse, 'N' (0x4E = 78) for NoticeResponse.
+  // This determines whether the diagnostic is an error or notice.
+  int32 message_type = 15;
+
+  // severity is the severity level (e.g., "ERROR", "FATAL", "WARNING", "NOTICE", "INFO")
   string severity = 1;
 
-  // code is the SQLSTATE error code
+  // code is the SQLSTATE error code (e.g., "42P01", "22P02")
   string code = 2;
 
-  // message is the primary human-readable notice message
+  // message is the primary human-readable diagnostic message
   string message = 3;
 
-  // detail provides additional detail about the notice (optional)
+  // detail provides additional detail about the diagnostic (optional)
   string detail = 4;
 
-  // hint provides a hint about how to address the notice (optional)
+  // hint provides a hint about how to address the issue (optional)
   string hint = 5;
 
   // position is the cursor position in the original query string (1-indexed, 0 if not available)
@@ -113,22 +134,22 @@ message Notice {
   // internal_query is the text of the internally-generated query (optional)
   string internal_query = 8;
 
-  // where is the context in which the notice occurred, e.g., PL/pgSQL call stack (optional)
+  // where is the context in which the diagnostic occurred, e.g., PL/pgSQL call stack (optional)
   string where = 9;
 
-  // schema_name is the name of the schema associated with the notice (optional)
+  // schema_name is the name of the schema associated with the diagnostic (optional)
   string schema_name = 10;
 
-  // table_name is the name of the table associated with the notice (optional)
+  // table_name is the name of the table associated with the diagnostic (optional)
   string table_name = 11;
 
-  // column_name is the name of the column associated with the notice (optional)
+  // column_name is the name of the column associated with the diagnostic (optional)
   string column_name = 12;
 
-  // data_type_name is the name of the data type associated with the notice (optional)
+  // data_type_name is the name of the data type associated with the diagnostic (optional)
   string data_type_name = 13;
 
-  // constraint_name is the name of the constraint associated with the notice (optional)
+  // constraint_name is the name of the constraint associated with the diagnostic (optional)
   string constraint_name = 14;
 }
 


### PR DESCRIPTION
Closes #574

## Summary

Preserves all 14 PostgreSQL diagnostic fields (Position, Schema, Table, Constraint, Hint, Detail, Where, etc.) as errors flow through the Multigres stack. Previously, clients lost this debugging context.

## Changes

- Unify error/notice handling with `PgDiagnostic` type implementing `error` interface
- Add `PgError` wrapper for system-level propagation
- Preserve diagnostics through gRPC via `RPCError.pg_diagnostic`
- Add `parseDiagnosticFields()` and `writePgDiagnosticResponse()` for unified parsing/writing

## Test plan

- Unit tests for `PgDiagnostic`, `PgError`, and gRPC round-trip
- E2E tests comparing error output between direct PostgreSQL and Multigres