### PR TITLE
MUL-153 feat: forward client startup parameters to backend PostgreSQL

### DIFF
--- a/go/common/pgprotocol/server/handler.go
+++ b/go/common/pgprotocol/server/handler.go
@@ -96,10 +96,3 @@ type Handler interface {
 	// Called at the end of an extended query cycle to indicate transaction boundary.
 	HandleSync(ctx context.Context, conn *Conn) error
 }
-
-// StartupValidator is an optional interface that handlers can implement
-// to validate startup parameters during connection establishment.
-// If the handler does not implement this interface, validation is skipped.
-type StartupValidator interface {
-	ValidateStartup(ctx context.Context, conn *Conn) error
-}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -334,13 +334,6 @@ func (c *Conn) authenticateTrust() error {
 		return fmt.Errorf("failed to send BackendKeyData: %w", err)
 	}
 
-	// Validate startup parameters if the handler supports it.
-	if validator, ok := c.handler.(StartupValidator); ok {
-		if err := validator.ValidateStartup(c.ctx, c); err != nil {
-			return fmt.Errorf("startup parameter validation failed: %w", err)
-		}
-	}
-
 	// Send initial ParameterStatus messages.
 	if err := c.sendParameterStatuses(); err != nil {
 		return fmt.Errorf("failed to send ParameterStatus messages: %w", err)
@@ -426,13 +419,6 @@ func (c *Conn) authenticateSCRAM() error {
 	// Send BackendKeyData for query cancellation.
 	if err := c.sendBackendKeyData(); err != nil {
 		return fmt.Errorf("failed to send BackendKeyData: %w", err)
-	}
-
-	// Validate startup parameters if the handler supports it.
-	if validator, ok := c.handler.(StartupValidator); ok {
-		if err := validator.ValidateStartup(c.ctx, c); err != nil {
-			return fmt.Errorf("startup parameter validation failed: %w", err)
-		}
 	}
 
 	// Send initial ParameterStatus messages.

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -152,22 +152,5 @@ func (e *Executor) Describe(
 	return e.exec.Describe(ctx, e.planner.GetDefaultTableGroup(), "", conn, state, portalInfo, preparedStatementInfo)
 }
 
-// ValidateStartupParams validates startup parameters by running a test query
-// with the startup params as session settings.
-func (e *Executor) ValidateStartupParams(
-	ctx context.Context,
-	conn *server.Conn,
-	state *handler.MultiGatewayConnectionState,
-) error {
-	e.logger.DebugContext(ctx, "validating startup parameters",
-		"user", conn.User(),
-		"database", conn.Database(),
-		"connection_id", conn.ConnectionID())
-
-	return e.exec.StreamExecute(ctx, conn, e.planner.GetDefaultTableGroup(), "", "SELECT 1", state, func(ctx context.Context, res *sqltypes.Result) error {
-		return nil
-	})
-}
-
 // Ensure Executor implements handler.Executor interface.
 var _ handler.Executor = (*Executor)(nil)

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -40,10 +40,6 @@ type Executor interface {
 	// Describe returns metadata about a prepared statement or portal.
 	// The options should contain PreparedStatement or Portal information and the reserved connection ID.
 	Describe(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState, portalInfo *preparedstatement.PortalInfo, preparedStatementInfo *preparedstatement.PreparedStatementInfo) (*query.StatementDescription, error)
-
-	// ValidateStartupParams validates startup parameters by executing a test query
-	// with the parameters as session settings.
-	ValidateStartupParams(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState) error
 }
 
 // MultiGatewayHandler implements the pgprotocol Handler interface for multigateway.
@@ -220,27 +216,5 @@ func (h *MultiGatewayHandler) HandleSync(ctx context.Context, conn *server.Conn)
 	return nil
 }
 
-// ValidateStartup validates startup parameters during connection establishment.
-// It skips validation if no startup params are present.
-// On failure, the connection state is cleared so the connection is not left in a dirty state.
-func (h *MultiGatewayHandler) ValidateStartup(ctx context.Context, conn *server.Conn) error {
-	startupParams := conn.GetStartupParams()
-	if startupParams == nil {
-		return nil
-	}
-
-	state := h.getConnectionState(conn)
-	err := h.executor.ValidateStartupParams(ctx, conn, state)
-	if err != nil {
-		// Clear connection state on failure.
-		conn.SetConnectionState(nil)
-		return err
-	}
-	return nil
-}
-
 // Ensure MultiGatewayHandler implements server.Handler interface.
 var _ server.Handler = (*MultiGatewayHandler)(nil)
-
-// Ensure MultiGatewayHandler implements server.StartupValidator interface.
-var _ server.StartupValidator = (*MultiGatewayHandler)(nil)

--- a/go/services/multigateway/handler/handler_test.go
+++ b/go/services/multigateway/handler/handler_test.go
@@ -68,10 +68,6 @@ func (m *mockExecutor) Describe(ctx context.Context, conn *server.Conn, state *M
 	}, nil
 }
 
-func (m *mockExecutor) ValidateStartupParams(ctx context.Context, conn *server.Conn, state *MultiGatewayConnectionState) error {
-	return nil
-}
-
 // TestHandleQueryEmptyQuery tests that empty queries are handled correctly.
 func TestHandleQueryEmptyQuery(t *testing.T) {
 	logger := slog.Default()


### PR DESCRIPTION
Fixes startup parameters like PGDATESTYLE and PGOPTIONS being ignored by multigres.

Previously, when clients set parameters during connection startup (e.g., `PGDATESTYLE="Postgres, MDY"`), multigres would parse them but not forward to PostgreSQL. Clients always received hardcoded defaults like `DateStyle = "ISO, MDY"` regardless of what they requested.

Now startup params are properly forwarded. The implementation validates them during connection setup by establishing a backend connection before sending ReadyForQuery. Invalid params fail the connection immediately (matching PostgreSQL), and ParameterStatus messages reflect actual backend values. Connection pooling routes based on combined startup + session settings.

Example:
```bash
$ PGDATESTYLE="Postgres, MDY" psql -h localhost -p 15432
postgres=> show datestyle;
 DateStyle
-------------
 Postgres, MDY  ✅
```