### PR TITLE
docs: normalize MultiGres to Multigres

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -1,8 +1,8 @@
-# Connection Pooling in MultiGres
+# Connection Pooling in Multigres
 
 ## Overview
 
-MultiGres implements a **per-user connection pooling** architecture in the
+Multigres implements a **per-user connection pooling** architecture in the
 MultiPooler service to efficiently manage PostgreSQL connections. Each user
 gets their own dedicated connection pools that authenticate directly as that
 user via trust/peer authentication. This design ensures strong security

--- a/docs/query_serving/prepared_statements_design.md
+++ b/docs/query_serving/prepared_statements_design.md
@@ -1,9 +1,9 @@
-# Prepared Statements and Portals in MultiGres
+# Prepared Statements and Portals in Multigres
 
 ## Overview
 
 This document outlines the design for implementing prepared statements and
-portals in MultiGres, leveraging PostgreSQL's Extended Query Protocol to
+portals in Multigres, leveraging PostgreSQL's Extended Query Protocol to
 optimize query execution performance.
 
 ## Background: Extended Query Protocol


### PR DESCRIPTION
### Summary
- Replaces all instances of `MultiGres` with `Multigres` in documentation for consistent project naming