### PR TITLE
feat(multipooler): few cleanups related to promote/demote

### DIFF
--- a/go/multipooler/manager/manager.go
+++ b/go/multipooler/manager/manager.go
@@ -952,23 +952,6 @@ func (pm *MultiPoolerManager) setServingReadOnly(ctx context.Context, state *dem
 	return nil
 }
 
-// runCheckpointAsync runs a CHECKPOINT in a background goroutine
-func (pm *MultiPoolerManager) runCheckpointAsync(ctx context.Context) chan error {
-	checkpointDone := make(chan error, 1)
-	go func() {
-		pm.logger.InfoContext(ctx, "Starting checkpoint")
-		err := pm.exec(ctx, "CHECKPOINT")
-		if err != nil {
-			pm.logger.WarnContext(ctx, "Checkpoint failed", "error", err)
-			checkpointDone <- err
-		} else {
-			pm.logger.InfoContext(ctx, "Checkpoint completed")
-			checkpointDone <- nil
-		}
-	}()
-	return checkpointDone
-}
-
 // stopPostgresForEmergencyDemote stops PostgreSQL during emergency demotion without restarting.
 // This is used when a primary needs to step down immediately during consensus term changes.
 // The node will be left in a stopped state and will require pg_rewind to rejoin the cluster.
@@ -1115,13 +1098,10 @@ func (pm *MultiPoolerManager) terminateWriteConnections(ctx context.Context) (in
 	return int32(len(pids)), nil
 }
 
-// drainAndCheckpoint handles the drain timeout and checkpoint in parallel
-// During the drain, it monitors for write activity every 100ms
-// If 2 consecutive checks show no writes, exits early
-func (pm *MultiPoolerManager) drainAndCheckpoint(ctx context.Context, drainTimeout time.Duration) error {
-	// Start checkpoint in background
-	checkpointDone := pm.runCheckpointAsync(ctx)
-
+// drainWriteActivity monitors for write activity during emergency demotion.
+// During the drain, it monitors for write activity every 100ms.
+// If 2 consecutive checks show no writes, exits early.
+func (pm *MultiPoolerManager) drainWriteActivity(ctx context.Context, drainTimeout time.Duration) error {
 	// Monitor for write activity during drain
 	pm.logger.InfoContext(ctx, "Monitoring for write activity during drain", "duration", drainTimeout)
 	drainCtx, cancel := context.WithTimeout(ctx, drainTimeout)
@@ -1138,13 +1118,6 @@ func (pm *MultiPoolerManager) drainAndCheckpoint(ctx context.Context, drainTimeo
 		case <-drainCtx.Done():
 			pm.logger.InfoContext(ctx, "Drain timeout completed")
 			drainComplete = true
-
-		case err := <-checkpointDone:
-			if err != nil {
-				pm.logger.WarnContext(ctx, "Checkpoint completed with error during drain", "error", err)
-			} else {
-				pm.logger.InfoContext(ctx, "Checkpoint completed during drain")
-			}
 
 		case <-monitorTicker.C:
 			// Check for write activity
@@ -1166,18 +1139,6 @@ func (pm *MultiPoolerManager) drainAndCheckpoint(ctx context.Context, drainTimeo
 				}
 			}
 		}
-	}
-
-	// Wait for checkpoint if it's still running
-	select {
-	case err := <-checkpointDone:
-		if err != nil {
-			pm.logger.WarnContext(ctx, "Checkpoint failed", "error", err)
-			// Don't fail - checkpoint is an optimization
-		}
-	default:
-		// Checkpoint still running, continue
-		pm.logger.InfoContext(ctx, "Checkpoint still running, continuing with demotion")
 	}
 
 	return nil

--- a/go/multipooler/manager/rpc_manager.go
+++ b/go/multipooler/manager/rpc_manager.go
@@ -888,9 +888,9 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 		return nil, err
 	}
 
-	// Drain & Checkpoint (Parallel)
+	// Drain write connections
 
-	if err := pm.drainAndCheckpoint(ctx, drainTimeout); err != nil {
+	if err := pm.drainWriteActivity(ctx, drainTimeout); err != nil {
 		return nil, err
 	}
 
@@ -1223,9 +1223,9 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 		pm.replTracker.MakePrimary()
 	}
 
-	// Update topology if needed
+	// Update topology if needed (best-effort, don't fail promotion)
 	if err := pm.updateTopologyAfterPromotion(ctx, state); err != nil {
-		return nil, err
+		pm.logger.WarnContext(ctx, "Failed to update topology after promotion", "error", err)
 	}
 
 	pm.logger.InfoContext(ctx, "Promote completed successfully",


### PR DESCRIPTION
# Desc

Two small fixes:
- Per discussion, let's not do a checkpoint during emergency demote. There is no need to do this if we are in fast  emergency mode. 
- Also, we don't need to fail the promotion if we fail to update the topo.

# Tests
- Added unit tests to check the topology fail update case. 