### PR TITLE
feat(multiorch): update sync replication mode to ON

### DIFF
--- a/go/services/multiorch/consensus/sync_replication.go
+++ b/go/services/multiorch/consensus/sync_replication.go
@@ -134,7 +134,7 @@ func BuildSyncReplicationConfig(
 		"total_standbys", len(eligibleStandbys))
 
 	return &multipoolermanagerdatapb.ConfigureSynchronousReplicationRequest{
-		SynchronousCommit: multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE,
+		SynchronousCommit: multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_ON,
 		SynchronousMethod: multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
 		NumSync:           numSync,
 		StandbyIds:        standbyIDs,

--- a/go/services/multiorch/consensus/sync_replication_test.go
+++ b/go/services/multiorch/consensus/sync_replication_test.go
@@ -79,7 +79,7 @@ func TestBuildSyncReplicationConfig(t *testing.T) {
 		config, err := BuildSyncReplicationConfig(c.logger, rule, standbys, candidate)
 		require.NoError(t, err)
 		require.NotNil(t, config)
-		require.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE, config.SynchronousCommit)
+		require.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_ON, config.SynchronousCommit)
 		require.Equal(t, multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY, config.SynchronousMethod)
 		require.Equal(t, int32(1), config.NumSync, "num_sync should be required_count - 1")
 		require.Len(t, config.StandbyIds, 1)
@@ -197,7 +197,7 @@ func TestBuildSyncReplicationConfig(t *testing.T) {
 		require.True(t, names["mp-gamma"])
 	})
 
-	t.Run("uses REMOTE_WRITE commit level", func(t *testing.T) {
+	t.Run("uses ON commit level", func(t *testing.T) {
 		rule := &clustermetadatapb.QuorumRule{
 			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_ANY_N,
 			RequiredCount: 2,
@@ -208,7 +208,7 @@ func TestBuildSyncReplicationConfig(t *testing.T) {
 		config, err := BuildSyncReplicationConfig(c.logger, rule, standbys, candidate)
 		require.NoError(t, err)
 		require.NotNil(t, config)
-		require.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE, config.SynchronousCommit)
+		require.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_ON, config.SynchronousCommit)
 	})
 
 	t.Run("uses ANY synchronous method", func(t *testing.T) {

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -332,6 +332,11 @@ func TestBootstrapInitialization(t *testing.T) {
 		// Verify it contains ANY keyword (for ANY_2 policy)
 		assert.Contains(t, strings.ToUpper(syncStandbyNames), "ANY",
 			"should use ANY method for ANY_2 policy")
+
+		// Verify synchronous_commit is set to 'on'
+		syncCommit, err := shardsetup.QueryStringValue(ctx, primaryClient.Pooler, "SHOW synchronous_commit")
+		require.NoError(t, err, "should query synchronous_commit")
+		assert.Equal(t, "on", syncCommit, "synchronous_commit should be 'on'")
 	})
 
 	t.Run("verify auto-restore on startup", func(t *testing.T) {

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -349,6 +349,11 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		err := db.QueryRow("SHOW synchronous_standby_names").Scan(&syncStandbyNames)
 		require.NoError(t, err, "Should be able to query synchronous_standby_names")
 		require.NotEmpty(t, syncStandbyNames, "Final primary should have synchronous_standby_names configured after failovers")
+
+		var syncCommit string
+		err = db.QueryRow("SHOW synchronous_commit").Scan(&syncCommit)
+		require.NoError(t, err, "Should be able to query synchronous_commit")
+		assert.Equal(t, "on", syncCommit, "synchronous_commit should be 'on' after failover")
 	})
 
 	// Verify leadership_history records all failovers


### PR DESCRIPTION
# Desc

Updates synchronous configuration to use `on`, instead of `remote_write`, per postgres docs this provides better durability [guarantees](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION-CONFIG):
> Setting synchronous_commit to remote_write will cause each commit to wait for confirmation that the standby has received the commit record and written it out to its own operating system, but not for the data to be flushed to disk on the standby. This setting provides a weaker guarantee of durability than on does: the standby could lose the data in the event of an operating system crash, though not a PostgreSQL crash. However, it's a useful setting in practice because it can decrease the response time for the transaction. Data loss could only occur if both the primary and the standby crash and the database of the primary gets corrupted at the same time.

# Tests
- Relevant tests were updated. Also added a few more assertions to make sure we get the expected values