### PR TITLE
refactor(mterrors): always wrap PgDiagnostic errors instead of special-casing them

### DIFF
--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -359,12 +359,6 @@ func (c *Conn) writeNoticeResponse(diag *mterrors.PgDiagnostic) error {
 	return c.writePgDiagnosticResponse(protocol.MsgNoticeResponse, diag)
 }
 
-// writeErrorFromDiagnostic writes an 'E' (ErrorResponse) message using a PgDiagnostic.
-// This preserves all PostgreSQL error fields for native error format output.
-func (c *Conn) writeErrorFromDiagnostic(diag *mterrors.PgDiagnostic) error {
-	return c.writePgDiagnosticResponse(protocol.MsgErrorResponse, diag)
-}
-
 // writeError writes an error response to the client.
 // It handles both PostgreSQL errors (preserving all diagnostic fields)
 // and generic errors (creating synthetic PgDiagnostic).

--- a/go/multipooler/executor/executor.go
+++ b/go/multipooler/executor/executor.go
@@ -680,21 +680,13 @@ func int32ToInt16Slice(in []int32) []int16 {
 	return out
 }
 
-// wrapQueryError handles error wrapping for query execution.
-// PostgreSQL errors (*mterrors.PgDiagnostic) pass through unchanged,
-// preserving the original error format. Non-PostgreSQL errors are wrapped with context.
+// wrapQueryError wraps query execution errors with context.
+// PostgreSQL errors (*mterrors.PgDiagnostic) are wrapped like any other error;
+// the display boundary (writeError) extracts the underlying diagnostic via errors.As.
 func wrapQueryError(err error) error {
 	if err == nil {
 		return nil
 	}
-
-	// PostgreSQL errors (*mterrors.PgDiagnostic) pass through unchanged
-	var diag *mterrors.PgDiagnostic
-	if errors.As(err, &diag) {
-		return diag
-	}
-
-	// Non-PostgreSQL errors get wrapped with context
 	return mterrors.Wrapf(err, "query execution failed")
 }
 

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -95,13 +95,7 @@ func (g *grpcQueryService) StreamExecute(
 	// Call the gRPC StreamExecute
 	stream, err := g.client.StreamExecute(ctx, req)
 	if err != nil {
-		// Convert gRPC error - if it's a PostgreSQL error, preserve it
-		grpcErr := mterrors.FromGRPC(err)
-		var pgDiag *mterrors.PgDiagnostic
-		if errors.As(grpcErr, &pgDiag) {
-			return grpcErr
-		}
-		return mterrors.Wrapf(grpcErr, "failed to start stream execute")
+		return mterrors.Wrapf(mterrors.FromGRPC(err), "failed to start stream execute")
 	}
 
 	// Stream results back via callback
@@ -113,13 +107,7 @@ func (g *grpcQueryService) StreamExecute(
 			return nil
 		}
 		if err != nil {
-			// Convert gRPC error - if it's a PostgreSQL error, preserve it
-			grpcErr := mterrors.FromGRPC(err)
-			var pgDiag *mterrors.PgDiagnostic
-			if errors.As(grpcErr, &pgDiag) {
-				return grpcErr
-			}
-			return mterrors.Wrapf(grpcErr, "stream receive error")
+			return mterrors.Wrapf(mterrors.FromGRPC(err), "stream receive error")
 		}
 
 		// Handle the union type payload
@@ -208,13 +196,7 @@ func (g *grpcQueryService) PortalStreamExecute(
 	// Call the gRPC PortalStreamExecute
 	stream, err := g.client.PortalStreamExecute(ctx, req)
 	if err != nil {
-		// Convert gRPC error - if it's a PostgreSQL error, preserve it
-		grpcErr := mterrors.FromGRPC(err)
-		var pgDiag *mterrors.PgDiagnostic
-		if errors.As(grpcErr, &pgDiag) {
-			return queryservice.ReservedState{}, grpcErr
-		}
-		return queryservice.ReservedState{}, mterrors.Wrapf(grpcErr, "failed to start portal stream execute")
+		return queryservice.ReservedState{}, mterrors.Wrapf(mterrors.FromGRPC(err), "failed to start portal stream execute")
 	}
 
 	var reservedState queryservice.ReservedState
@@ -228,13 +210,7 @@ func (g *grpcQueryService) PortalStreamExecute(
 			return reservedState, nil
 		}
 		if err != nil {
-			// Convert gRPC error - if it's a PostgreSQL error, preserve it
-			grpcErr := mterrors.FromGRPC(err)
-			var pgDiag *mterrors.PgDiagnostic
-			if errors.As(grpcErr, &pgDiag) {
-				return reservedState, grpcErr
-			}
-			return reservedState, mterrors.Wrapf(grpcErr, "portal stream receive error")
+			return reservedState, mterrors.Wrapf(mterrors.FromGRPC(err), "portal stream receive error")
 		}
 
 		// Extract reserved state if present
@@ -303,13 +279,7 @@ func (g *grpcQueryService) Describe(
 	// Call the gRPC Describe
 	response, err := g.client.Describe(ctx, req)
 	if err != nil {
-		// Convert gRPC error - if it's a PostgreSQL error, preserve it
-		grpcErr := mterrors.FromGRPC(err)
-		var pgDiag *mterrors.PgDiagnostic
-		if errors.As(grpcErr, &pgDiag) {
-			return nil, grpcErr
-		}
-		return nil, mterrors.Wrapf(grpcErr, "describe failed")
+		return nil, mterrors.Wrapf(mterrors.FromGRPC(err), "describe failed")
 	}
 
 	g.logger.DebugContext(ctx, "describe completed successfully", "pooler_id", g.poolerID)


### PR DESCRIPTION
## Summary

- Remove the scattered pattern of checking `errors.As(*PgDiagnostic)` at every call site to avoid wrapping PostgreSQL errors
- Instead, wrap all errors uniformly with context, since the display boundaries (`writeError`, `ToGRPC`) already use `RootCause`, and `errors.As` to extract the underlying `PgDiagnostic`
- This centralizes the PG error extraction logic to a single place (the wire protocol boundary) and gives all errors useful debugging context

## Motivation

The previous pattern required every error-handling site to repeat the same check:

```go
grpcErr := mterrors.FromGRPC(err)
var pgDiag *mterrors.PgDiagnostic
if errors.As(grpcErr, &pgDiag) {
    return grpcErr // don't wrap!
}
return mterrors.Wrapf(grpcErr, "context")
```

This was fragile (easy to forget), scattered across multiple files, and threw away useful call-site context on PG errors. Since `RootCause` traverses wrapped error chains, wrapping a `PgDiagnostic` never loses the ability to detect or extract it downstream.
