### PR TITLE
fix(scram): always use startup message username, ignore client-first-message username

### DIFF
--- a/go/common/pgprotocol/scram/scram.go
+++ b/go/common/pgprotocol/scram/scram.go
@@ -126,9 +126,6 @@ func parseClientFirstMessage(msg string) (*clientFirstMessage, error) {
 		// Ignore other attributes (extensions).
 	}
 
-	// Note: username CAN be empty. PostgreSQL allows this and uses the username
-	// from the startup message. We handle this in HandleClientFirst by accepting
-	// a fallback username parameter.
 	if clientNonce == "" {
 		return nil, errors.New("missing nonce in client-first-message")
 	}


### PR DESCRIPTION
PostgreSQL ALWAYS ignores the username from the SCRAM client-first-message and uses the startup message username to avoid encoding issues (PostgreSQL supports multiple encodings while SCRAM mandates UTF-8).

The previous implementation incorrectly used the client-first-message username when present.