### PR TITLE
refactor(multigateway): simplify SET/RESET to local-only state updates

### DIFF
--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -1,0 +1,53 @@
+# Session Settings (SET/RESET)
+
+## Overview
+
+Multigateway handles `SET` and `RESET` commands locally without forwarding them to PostgreSQL. Session variables are tracked in the gateway's connection state and propagated to backend connections via the pool's `ApplySettings` mechanism on each subsequent query.
+
+Inside transactions, the connection is reserved and bypasses the pool's normal `ApplySettings` path. To ensure settings changes (e.g., `SET search_path`) take effect on the reserved backend, the multipooler applies settings diffs to reserved connections before each query execution.
+
+## How It Works
+
+1. **SET variable = value**: The variable and value are stored in `SessionSettings`. A synthetic `CommandComplete (SET)` is returned to the client immediately.
+2. **RESET variable**: The variable is removed from `SessionSettings`. A synthetic `CommandComplete (RESET)` is returned.
+3. **RESET ALL**: All variables in `SessionSettings` are cleared. A synthetic `CommandComplete (RESET)` is returned.
+4. **SET LOCAL**: Passed through to PostgreSQL (transaction-scoped, not tracked by the gateway).
+
+On the next query, the pool merges `SessionSettings` with `StartupParams` (startup params from the client's initial connection). `SessionSettings` entries take precedence. The merged settings are applied to the backend connection before executing the query.
+
+When a variable is `RESET`, its entry is removed from `SessionSettings`, and the `StartupParams` value (if any) becomes visible again through the merge.
+
+## Behaviour Deviations from PostgreSQL
+
+### SET does not validate parameters
+
+`SET` commands are **not validated** against PostgreSQL. A client can `SET` an invalid variable name or an invalid value for a valid variable without receiving an immediate error.
+
+The error will surface on the **next query** when the connection pool attempts to apply the invalid setting to a backend connection. The client will receive repeated errors on every query until they `RESET` the problematic variable.
+
+**Example:**
+
+```sql
+SET nonexistent_variable = 'value';  -- Succeeds (no error)
+SELECT 1;                             -- Fails: unrecognized configuration parameter
+RESET nonexistent_variable;           -- Succeeds
+SELECT 1;                             -- Succeeds again
+```
+
+This trade-off was chosen to keep the SET/RESET code path simple. It may be revisited if stricter validation is needed.
+
+### SET inside a rolled-back transaction persists
+
+In PostgreSQL, `SET` (without `LOCAL`) inside a transaction that is later rolled back still reverts the variable to its pre-transaction value. Multigateway does **not** track transaction boundaries for session settings, so a `SET` inside a rolled-back transaction will persist in the gateway's tracked state.
+
+**Example:**
+
+```sql
+SET work_mem = '256MB';
+BEGIN;
+SET work_mem = '512MB';
+ROLLBACK;
+SHOW work_mem;  -- PostgreSQL: '256MB', Multigateway: '512MB'
+```
+
+**TODO:** Fix this by snapshotting session settings at `BEGIN` and restoring on `ROLLBACK`.

--- a/go/common/mterrors/grpc_test.go
+++ b/go/common/mterrors/grpc_test.go
@@ -274,3 +274,16 @@ func TestToGRPCPgErrorMessageTruncation(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Unknown, st.Code())
 }
+
+func TestNewFeatureNotSupported(t *testing.T) {
+	msg := "SET kind 99 is not supported"
+	diag := NewFeatureNotSupported(msg)
+
+	assert.Equal(t, byte('E'), diag.MessageType)
+	assert.Equal(t, "ERROR", diag.Severity)
+	assert.Equal(t, "0A000", diag.Code)
+	assert.Equal(t, msg, diag.Message)
+	assert.True(t, diag.IsError())
+	assert.Equal(t, "0A", diag.SQLSTATEClass())
+	assert.Contains(t, diag.Error(), msg)
+}

--- a/go/common/mterrors/pgdiagnostic.go
+++ b/go/common/mterrors/pgdiagnostic.go
@@ -179,6 +179,16 @@ func (d *PgDiagnostic) Validate() error {
 	return nil
 }
 
+// NewFeatureNotSupported returns a PgDiagnostic error with SQLSTATE 0A000 (feature_not_supported).
+func NewFeatureNotSupported(message string) *PgDiagnostic {
+	return &PgDiagnostic{
+		MessageType: 'E',
+		Severity:    "ERROR",
+		Code:        "0A000",
+		Message:     message,
+	}
+}
+
 // PgDiagnosticToProto converts mterrors PgDiagnostic to proto format for gRPC serialization.
 func PgDiagnosticToProto(d *PgDiagnostic) *query.PgDiagnostic {
 	if d == nil {

--- a/go/multipooler/connpoolmanager/interface.go
+++ b/go/multipooler/connpoolmanager/interface.go
@@ -71,6 +71,12 @@ type PoolManager interface {
 	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
 	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)
 
+	// ApplySettingsToConn ensures the connection's settings match the given
+	// session settings. If they differ, executes SET commands on the connection
+	// and updates its tracked state. This is needed because reserved connections
+	// bypass the pool's normal ApplySettings mechanism.
+	ApplySettingsToConn(ctx context.Context, conn *regular.Conn, settings map[string]string) error
+
 	// --- Stats ---
 
 	// Stats returns statistics for all pools.

--- a/go/multipooler/connpoolmanager/manager.go
+++ b/go/multipooler/connpoolmanager/manager.go
@@ -376,6 +376,22 @@ func (m *Manager) GetReservedConn(connID int64, user string) (*reserved.Conn, bo
 	return pool.GetReservedConn(connID)
 }
 
+// ApplySettingsToConn ensures the connection's settings match the given session
+// settings. ApplySettings handles the diff internally: it resets removed
+// variables via individual RESET commands (safe inside transactions, unlike
+// RESET ALL) and applies desired variables via SET SESSION.
+func (m *Manager) ApplySettingsToConn(ctx context.Context, conn *regular.Conn, settings map[string]string) error {
+	desired := m.settingsCache.GetOrCreate(settings)
+	current := conn.Settings()
+
+	// Pointer equality — same *Settings means same settings (via cache interning)
+	if desired == current {
+		return nil
+	}
+
+	return conn.ApplySettings(ctx, desired)
+}
+
 // --- Stats ---
 
 // Stats returns statistics for all pools.

--- a/go/multipooler/connpoolmanager/manager_test.go
+++ b/go/multipooler/connpoolmanager/manager_test.go
@@ -472,6 +472,119 @@ func TestManager_SettingsCacheIntegration(t *testing.T) {
 	assert.Same(t, settings1, settings2)
 }
 
+// --- ApplySettingsToConn tests ---
+
+func TestManager_ApplySettingsToConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection with initial settings.
+	initialSettings := map[string]string{"search_path": "public"}
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser")
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseCommit)
+
+	// Record how many SET calls have been made so far.
+	setsBefore := server.GetPatternCalledNum(`SET SESSION .+ = .+`)
+
+	// Apply different settings — should trigger SET commands.
+	newSettings := map[string]string{"search_path": "public", "statement_timeout": "200ms"}
+	err = manager.ApplySettingsToConn(ctx, conn.Conn(), newSettings)
+	require.NoError(t, err)
+
+	// Verify SET was called again.
+	setsAfter := server.GetPatternCalledNum(`SET SESSION .+ = .+`)
+	assert.Greater(t, setsAfter, setsBefore, "SET should have been called for new settings")
+}
+
+func TestManager_ApplySettingsToConn_SameSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	settings := map[string]string{"search_path": "public"}
+	conn, err := manager.NewReservedConn(ctx, settings, "testuser")
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseCommit)
+
+	// Record SET calls.
+	setsBefore := server.GetPatternCalledNum(`SET SESSION .+ = .+`)
+
+	// Apply the same settings — should be a no-op (pointer equality via cache).
+	err = manager.ApplySettingsToConn(ctx, conn.Conn(), settings)
+	require.NoError(t, err)
+
+	setsAfter := server.GetPatternCalledNum(`SET SESSION .+ = .+`)
+	assert.Equal(t, setsBefore, setsAfter, "no SET should have been called for same settings")
+}
+
+func TestManager_ApplySettingsToConn_NilSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseCommit)
+
+	// Apply nil settings — should be a no-op.
+	err = manager.ApplySettingsToConn(ctx, conn.Conn(), nil)
+	require.NoError(t, err)
+}
+
+func TestManager_ApplySettingsToConn_RemovedSettings(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET, individual RESET, and combined RESET+SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+	server.AddQueryPattern(`RESET search_path`, &sqltypes.Result{})
+	server.AddQueryPattern(`RESET search_path; SET SESSION .+ = .+`, &sqltypes.Result{})
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Create a reserved connection with two settings.
+	initialSettings := map[string]string{"search_path": "public", "work_mem": "256MB"}
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser")
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseCommit)
+
+	// Record calls so far.
+	combinedBefore := server.GetPatternCalledNum(`RESET search_path; SET SESSION .+ = .+`)
+
+	// Apply new settings with search_path removed.
+	newSettings := map[string]string{"work_mem": "256MB"}
+	err = manager.ApplySettingsToConn(ctx, conn.Conn(), newSettings)
+	require.NoError(t, err)
+
+	// Verify combined RESET+SET was called for the removed setting.
+	combinedAfter := server.GetPatternCalledNum(`RESET search_path; SET SESSION .+ = .+`)
+	assert.Greater(t, combinedAfter, combinedBefore, "combined RESET+SET should have been called for removed setting")
+}
+
 // --- InternalUser tests ---
 
 func TestManager_InternalUser_Default(t *testing.T) {

--- a/go/multipooler/executor/executor.go
+++ b/go/multipooler/executor/executor.go
@@ -79,6 +79,15 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 
+		// Apply settings if they changed (e.g., SET inside a transaction).
+		// Reserved connections bypass the pool's normal ApplySettings mechanism,
+		// so we must explicitly apply settings changes here.
+		if options.SessionSettings != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), options.SessionSettings); err != nil {
+				return nil, fmt.Errorf("failed to apply settings to reserved connection: %w", err)
+			}
+		}
+
 		results, err := reservedConn.Query(ctx, sql)
 		if err != nil {
 			return nil, wrapQueryError(err)
@@ -145,6 +154,15 @@ func (e *Executor) StreamExecute(
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			return fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+		}
+
+		// Apply settings if they changed (e.g., SET inside a transaction).
+		// Reserved connections bypass the pool's normal ApplySettings mechanism,
+		// so we must explicitly apply settings changes here.
+		if options.SessionSettings != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), options.SessionSettings); err != nil {
+				return fmt.Errorf("failed to apply settings to reserved connection: %w", err)
+			}
 		}
 
 		if err := reservedConn.QueryStreaming(ctx, sql, callback); err != nil {

--- a/go/multipooler/pools/admin/admin_conn.go
+++ b/go/multipooler/pools/admin/admin_conn.go
@@ -83,8 +83,8 @@ func (c *Conn) ApplySettings(_ context.Context, _ *connstate.Settings) error {
 	panic("admin connections do not support ApplySettings")
 }
 
-// ResetSettings is a no-op because admin connections don't have settings.
-func (c *Conn) ResetSettings(_ context.Context) error {
+// ResetAllSettings is a no-op because admin connections don't have settings.
+func (c *Conn) ResetAllSettings(_ context.Context) error {
 	return nil
 }
 

--- a/go/multipooler/pools/admin/admin_test.go
+++ b/go/multipooler/pools/admin/admin_test.go
@@ -223,7 +223,7 @@ func TestConn_ApplySettings_Panics(t *testing.T) {
 	})
 }
 
-func TestConn_ResetSettings_Noop(t *testing.T) {
+func TestConn_ResetAllSettings_Noop(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 	server.SetNeverFail(true)
@@ -237,8 +237,8 @@ func TestConn_ResetSettings_Noop(t *testing.T) {
 	require.NoError(t, err)
 	defer pooled.Recycle()
 
-	// ResetSettings should be a no-op for admin connections.
-	err = pooled.Conn.ResetSettings(ctx)
+	// ResetAllSettings should be a no-op for admin connections.
+	err = pooled.Conn.ResetAllSettings(ctx)
 	assert.NoError(t, err)
 }
 

--- a/go/multipooler/pools/connpool/interfaces.go
+++ b/go/multipooler/pools/connpool/interfaces.go
@@ -35,12 +35,13 @@ type Connection interface {
 	// Close closes the connection and releases associated resources.
 	Close() error
 
-	// ApplySettings applies the given settings to the connection by executing
-	// the necessary SQL commands (e.g., SET commands).
-	// Returns an error if the settings cannot be applied.
-	ApplySettings(ctx context.Context, settings *connstate.Settings) error
+	// ApplySettings transitions the connection to the desired settings state.
+	// It diffs current tracked settings against desired: executes individual
+	// RESET commands for removed variables, then SET SESSION commands for all
+	// desired variables. Updates tracked state to desired.
+	ApplySettings(ctx context.Context, desired *connstate.Settings) error
 
-	// ResetSettings resets the connection to a clean state with no settings.
-	// This typically involves running RESET ALL or equivalent SQL.
-	ResetSettings(ctx context.Context) error
+	// ResetAllSettings resets the connection to a clean state with no settings.
+	// This executes RESET ALL to clear all session variables at once.
+	ResetAllSettings(ctx context.Context) error
 }

--- a/go/multipooler/pools/connpool/pool.go
+++ b/go/multipooler/pools/connpool/pool.go
@@ -708,7 +708,7 @@ func (pool *Pool[C]) get(ctx context.Context) (*Pooled[C], error) {
 	if settings := conn.Conn.Settings(); settings != nil && !settings.IsEmpty() {
 		pool.Metrics.resetState.Add(1)
 
-		err = conn.Conn.ResetSettings(ctx)
+		err = conn.Conn.ResetAllSettings(ctx)
 		if err != nil {
 			conn.Close()
 			err = pool.connReopen(ctx, conn, monotonicNow())
@@ -790,7 +790,7 @@ func (pool *Pool[C]) getWithSettings(ctx context.Context, settings *connstate.Se
 		if connSettings != nil && !connSettings.IsEmpty() {
 			pool.Metrics.diffState.Add(1)
 
-			err = conn.Conn.ResetSettings(ctx)
+			err = conn.Conn.ResetAllSettings(ctx)
 			if err != nil {
 				conn.Close()
 				err = pool.connReopen(ctx, conn, monotonicNow())

--- a/go/multipooler/pools/connpool/pool_test.go
+++ b/go/multipooler/pools/connpool/pool_test.go
@@ -54,7 +54,7 @@ func (m *mockConnection) ApplySettings(ctx context.Context, settings *connstate.
 	return nil
 }
 
-func (m *mockConnection) ResetSettings(ctx context.Context) error {
+func (m *mockConnection) ResetAllSettings(ctx context.Context) error {
 	m.settings = nil
 	return nil
 }

--- a/go/multipooler/pools/regular/pool_test.go
+++ b/go/multipooler/pools/regular/pool_test.go
@@ -202,7 +202,7 @@ func TestConn_Settings(t *testing.T) {
 	assert.Nil(t, pooled.Conn.Settings())
 }
 
-func TestConn_ResetSettings(t *testing.T) {
+func TestConn_ResetAllSettings(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 
@@ -224,7 +224,7 @@ func TestConn_ResetSettings(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset settings.
-	err = pooled.Conn.ResetSettings(ctx)
+	err = pooled.Conn.ResetAllSettings(ctx)
 	require.NoError(t, err)
 
 	// Settings should be nil after reset.
@@ -235,4 +235,131 @@ func TestConn_ResetSettings(t *testing.T) {
 	// Verify both SET and RESET were actually called.
 	assert.Greater(t, server.GetPatternCalledNum(`SET SESSION .+ = .+`), 0, "SET command should have been called")
 	assert.Greater(t, server.GetPatternCalledNum(`RESET .+`), 0, "RESET command should have been called")
+}
+
+func TestConn_ApplySettings_ResetsRemovedVariables(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// Accept SET, individual RESET, and combined RESET+SET commands.
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+	server.AddQueryPattern(`RESET search_path`, &sqltypes.Result{})
+	server.AddQueryPattern(`RESET search_path; SET SESSION .+ = .+`, &sqltypes.Result{})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	initial := connstate.NewSettings(map[string]string{
+		"search_path": "public",
+		"work_mem":    "256MB",
+	}, 0)
+
+	// Get connection with settings.
+	pooled, err := pool.GetWithSettings(ctx, initial)
+	require.NoError(t, err)
+
+	// Apply desired state that only has work_mem (search_path removed).
+	desired := connstate.NewSettings(map[string]string{
+		"work_mem": "256MB",
+	}, 0)
+	err = pooled.Conn.ApplySettings(ctx, desired)
+	require.NoError(t, err)
+
+	// Verify RESET+SET was called for the combined command.
+	assert.Greater(t, server.GetPatternCalledNum(`RESET search_path; SET SESSION .+ = .+`), 0, "combined RESET+SET should have been called")
+
+	// Verify tracked state is updated to desired.
+	assert.Equal(t, desired, pooled.Conn.Settings())
+
+	pooled.Recycle()
+}
+
+func TestConn_ApplySettings_NilDesiredResetsAll(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+	server.AddQueryPattern(`RESET ALL`, &sqltypes.Result{})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	initial := connstate.NewSettings(map[string]string{
+		"search_path": "public",
+	}, 0)
+
+	// Get connection with settings.
+	pooled, err := pool.GetWithSettings(ctx, initial)
+	require.NoError(t, err)
+
+	// Apply nil desired — should reset all since current has settings.
+	err = pooled.Conn.ApplySettings(ctx, nil)
+	require.NoError(t, err)
+
+	// Verify RESET ALL was called.
+	assert.Greater(t, server.GetPatternCalledNum(`RESET ALL`), 0, "RESET ALL should have been called")
+
+	// Tracked state should be nil.
+	assert.Nil(t, pooled.Conn.Settings())
+
+	pooled.Recycle()
+}
+
+func TestConn_ApplySettings_NilDesiredNoopWhenClean(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Get a clean connection (no settings).
+	pooled, err := pool.Get(ctx)
+	require.NoError(t, err)
+
+	// Apply nil desired — should be a no-op since no current settings.
+	err = pooled.Conn.ApplySettings(ctx, nil)
+	require.NoError(t, err)
+
+	assert.Nil(t, pooled.Conn.Settings())
+
+	pooled.Recycle()
+}
+
+func TestConn_ApplySettings_OverwritesExistingVariable(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.AddQueryPattern(`SET SESSION .+ = .+`, &sqltypes.Result{})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	first := connstate.NewSettings(map[string]string{
+		"work_mem": "256MB",
+	}, 0)
+
+	// Get connection with initial settings.
+	pooled, err := pool.GetWithSettings(ctx, first)
+	require.NoError(t, err)
+
+	// Apply new value for the same variable.
+	second := connstate.NewSettings(map[string]string{
+		"work_mem": "512MB",
+	}, 0)
+	err = pooled.Conn.ApplySettings(ctx, second)
+	require.NoError(t, err)
+
+	// Tracked state should have the second value.
+	assert.Equal(t, second, pooled.Conn.Settings())
+
+	pooled.Recycle()
 }

--- a/go/multipooler/pools/regular/regular_conn.go
+++ b/go/multipooler/pools/regular/regular_conn.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -100,32 +101,64 @@ func (c *Conn) Close() error {
 	return c.conn.Close()
 }
 
-// ApplySettings applies the given settings to the connection.
-// This executes SET commands for each variable in the settings.
-func (c *Conn) ApplySettings(ctx context.Context, settings *connstate.Settings) error {
-	if settings == nil || settings.IsEmpty() {
+// ApplySettings transitions the connection to the desired settings state.
+// It diffs current tracked settings against desired: executes individual RESET
+// commands for removed variables, then SET SESSION commands for all desired
+// variables. This is safe inside transactions (individual RESETs don't destroy
+// SET LOCAL settings, unlike RESET ALL).
+func (c *Conn) ApplySettings(ctx context.Context, desired *connstate.Settings) error {
+	current := c.State().GetSettings()
+
+	// If desired is nil/empty, reset all current settings to reach a clean state.
+	if desired == nil || desired.IsEmpty() {
+		if current == nil || current.IsEmpty() {
+			return nil
+		}
+		return c.ResetAllSettings(ctx)
+	}
+
+	// Build SQL: RESET removed variables, then SET desired variables.
+	var b strings.Builder
+
+	// RESET variables present in current but absent from desired.
+	if current != nil {
+		for name := range current.Vars {
+			if _, ok := desired.Vars[name]; !ok {
+				if b.Len() > 0 {
+					b.WriteString("; ")
+				}
+				b.WriteString("RESET ")
+				b.WriteString(name)
+			}
+		}
+	}
+
+	// SET all desired variables.
+	applySQL := desired.ApplyQuery()
+	if applySQL != "" {
+		if b.Len() > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(applySQL)
+	}
+
+	if b.Len() == 0 {
 		return nil
 	}
 
-	// Generate and execute the SET commands.
-	sql := settings.ApplyQuery()
-	if sql == "" {
-		return nil
-	}
-
-	_, err := c.Query(ctx, sql)
+	_, err := c.Query(ctx, b.String())
 	if err != nil {
 		return fmt.Errorf("failed to apply settings: %w", err)
 	}
 
-	// Update state.
-	c.State().SetSettings(settings)
+	// Update tracked state.
+	c.State().SetSettings(desired)
 	return nil
 }
 
-// ResetSettings resets the connection to a clean state.
+// ResetAllSettings resets the connection to a clean state.
 // This executes RESET ALL to clear all session variables.
-func (c *Conn) ResetSettings(ctx context.Context) error {
+func (c *Conn) ResetAllSettings(ctx context.Context) error {
 	state := c.State()
 	if state == nil {
 		return nil

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -17,79 +17,161 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// ApplySessionState updates local session state after a SET/RESET command
-// executes successfully on PostgreSQL.
+// ApplySessionState handles SET/RESET commands by updating local session state only.
 //
-// This primitive does NOT execute queries - it only updates the local state
-// tracking. It should be composed after a Route primitive in a Sequence.
+// Neither SET nor RESET is routed to PostgreSQL. Both are applied locally and
+// return a synthetic CommandComplete response. The pool propagates these settings
+// to the backend connection on the next query via ApplySettings.
+//
+// Behaviour deviation from PostgreSQL:
+// SET commands are NOT validated against PostgreSQL. This means a client can SET
+// an invalid variable name or value without receiving an immediate error. The error
+// will surface on the next query when the pool tries to apply the setting to a
+// backend connection. The client must RESET the bad variable to recover. This
+// trade-off was chosen intentionally to keep the SET/RESET path simple. It may
+// be revisited in the future if stricter validation is needed.
+//
+// For RESET/RESET ALL:
+// The variable is removed from SessionSettings. On the next query, the merged
+// settings (SessionSettings overlaid on StartupParams) will fall back to the
+// startup parameter value, and the pool will apply the correct SET commands.
 type ApplySessionState struct {
-	VariableStmt *ast.VariableSetStmt // The SET/RESET statement from AST
-	Value        string               // Extracted value (for SET commands)
+	// VariableStmt is the SET/RESET statement from the AST.
+	VariableStmt *ast.VariableSetStmt
+
+	// Query is the original SQL string.
+	Query string
 }
 
 // NewApplySessionState creates a new ApplySessionState primitive.
-func NewApplySessionState(stmt *ast.VariableSetStmt, value string) *ApplySessionState {
+func NewApplySessionState(sql string, stmt *ast.VariableSetStmt) *ApplySessionState {
 	return &ApplySessionState{
 		VariableStmt: stmt,
-		Value:        value,
+		Query:        sql,
 	}
 }
 
-// StreamExecute updates the local session state based on the command type.
-func (a *ApplySessionState) StreamExecute(
+// StreamExecute handles the SET/RESET command.
+func (s *ApplySessionState) StreamExecute(
 	ctx context.Context,
-	exec IExecute,
-	conn *server.Conn,
+	_ IExecute,
+	_ *server.Conn,
 	state *handler.MultiGatewayConnectionState,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// Update local session state based on the command type
-	// Uses AST enums directly - no wrapper types needed
-	switch a.VariableStmt.Kind {
+	switch s.VariableStmt.Kind {
 	case ast.VAR_SET_VALUE:
-		// SET variable = value
-		state.SetSessionVariable(a.VariableStmt.Name, a.Value)
+		return s.executeSet(ctx, state, callback)
+	case ast.VAR_RESET, ast.VAR_RESET_ALL:
+		return s.executeReset(ctx, state, callback)
+	default:
+		return mterrors.NewFeatureNotSupported(fmt.Sprintf("SET/RESET kind %d is not supported", s.VariableStmt.Kind))
+	}
+}
 
+// executeSet handles SET commands: update local state and return synthetic response.
+// The value is NOT validated against PostgreSQL — see ApplySessionState doc comment.
+func (s *ApplySessionState) executeSet(
+	ctx context.Context,
+	state *handler.MultiGatewayConnectionState,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	value := extractVariableValue(s.VariableStmt.Args)
+	state.SetSessionVariable(s.VariableStmt.Name, value)
+	return callback(ctx, &sqltypes.Result{
+		CommandTag: "SET",
+	})
+}
+
+// executeReset handles RESET/RESET ALL: update state, return synthetic response.
+func (s *ApplySessionState) executeReset(
+	ctx context.Context,
+	state *handler.MultiGatewayConnectionState,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	switch s.VariableStmt.Kind {
 	case ast.VAR_RESET:
 		// RESET variable
-		state.ResetSessionVariable(a.VariableStmt.Name)
+		state.ResetSessionVariable(s.VariableStmt.Name)
 
 	case ast.VAR_RESET_ALL:
-		// RESET ALL
 		state.ResetAllSessionVariables()
 		// Also reset gateway-managed variables that live outside SessionSettings.
 		state.ResetStatementTimeout()
-
-		// VAR_SET_DEFAULT, VAR_SET_CURRENT, VAR_SET_MULTI are not tracked locally
-		// They are passed through to PostgreSQL only
+	default:
+		return mterrors.NewFeatureNotSupported(fmt.Sprintf("RESET kind %d is not supported", s.VariableStmt.Kind))
 	}
 
-	// This primitive doesn't produce results - the previous Route primitive
-	// already streamed results to the callback. Just return success.
-	return nil
+	// Return synthetic CommandComplete
+	return callback(ctx, &sqltypes.Result{
+		CommandTag: "RESET",
+	})
 }
 
-// GetTableGroup returns empty string as this primitive doesn't target a tablegroup.
-func (a *ApplySessionState) GetTableGroup() string {
-	return "" // Doesn't target a tablegroup
+// GetTableGroup returns empty string — SET/RESET are local-only and don't target a tablegroup.
+func (s *ApplySessionState) GetTableGroup() string {
+	return ""
 }
 
-// GetQuery returns empty string as this primitive doesn't execute a query.
-func (a *ApplySessionState) GetQuery() string {
-	return "" // Doesn't execute a query
+// GetQuery returns the original SQL string.
+func (s *ApplySessionState) GetQuery() string {
+	return s.Query
 }
 
 // String returns a string representation for debugging.
-// Reuses AST's existing SqlString() method instead of reimplementing.
-func (a *ApplySessionState) String() string {
-	return fmt.Sprintf("ApplySessionState(%s)", a.VariableStmt.SqlString())
+func (s *ApplySessionState) String() string {
+	return fmt.Sprintf("ApplySessionState(%s)", s.VariableStmt.SqlString())
+}
+
+// extractVariableValue converts AST NodeList arguments to a string value.
+func extractVariableValue(args *ast.NodeList) string {
+	if args == nil || args.Len() == 0 {
+		return ""
+	}
+
+	var values []string
+	for _, arg := range args.Items {
+		switch v := arg.(type) {
+		case *ast.A_Const:
+			values = append(values, extractConstValue(v))
+		case *ast.String:
+			values = append(values, v.SVal)
+		case *ast.Integer:
+			values = append(values, strconv.Itoa(v.IVal))
+		default:
+			values = append(values, arg.SqlString())
+		}
+	}
+
+	return strings.Join(values, ", ")
+}
+
+// extractConstValue extracts string value from A_Const node.
+func extractConstValue(aConst *ast.A_Const) string {
+	if aConst == nil || aConst.Val == nil {
+		return ""
+	}
+
+	switch val := aConst.Val.(type) {
+	case *ast.String:
+		return val.SVal
+	case *ast.Integer:
+		return strconv.Itoa(val.IVal)
+	case *ast.Float:
+		return val.FVal
+	default:
+		return aConst.SqlString()
+	}
 }
 
 // Ensure ApplySessionState implements Primitive interface.

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// collectCallback returns a callback that appends results to the given slice.
+func collectCallback(results *[]*sqltypes.Result) func(context.Context, *sqltypes.Result) error {
+	return func(_ context.Context, r *sqltypes.Result) error {
+		*results = append(*results, r)
+		return nil
+	}
+}
+
+func TestApplySessionState_SET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultiGatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "work_mem",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
+	}
+
+	ssr := NewApplySessionState("SET work_mem = '256MB'", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.NoError(t, err)
+
+	val, exists := state.GetSessionVariable("work_mem")
+	assert.True(t, exists)
+	assert.Equal(t, "256MB", val)
+
+	// Should receive synthetic CommandComplete with SET tag
+	require.Len(t, results, 1)
+	assert.Equal(t, "SET", results[0].CommandTag)
+}
+
+func TestApplySessionState_SET_InvalidParam_Succeeds(t *testing.T) {
+	// Invalid params are accepted locally — errors surface on next query.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultiGatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "totally_invalid_variable",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "whatever"}}}},
+	}
+
+	ssr := NewApplySessionState("SET totally_invalid_variable = 'whatever'", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.NoError(t, err, "SET with invalid param should succeed locally")
+
+	val, exists := state.GetSessionVariable("totally_invalid_variable")
+	assert.True(t, exists)
+	assert.Equal(t, "whatever", val)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "SET", results[0].CommandTag)
+}
+
+func TestApplySessionState_RESET_NeverSetVariable(t *testing.T) {
+	// RESET of a variable that was never SET should succeed (matches PostgreSQL behaviour).
+	state := &handler.MultiGatewayConnectionState{}
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_RESET,
+		Name: "never_set_var",
+	}
+
+	ssr := NewApplySessionState("RESET never_set_var", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.NoError(t, err, "RESET of never-set variable should succeed")
+
+	_, exists := state.GetSessionVariable("never_set_var")
+	assert.False(t, exists)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "RESET", results[0].CommandTag)
+}
+
+func TestApplySessionState_RESET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
+	state := &handler.MultiGatewayConnectionState{}
+	state.SetSessionVariable("work_mem", "256MB")
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_RESET,
+		Name: "work_mem",
+	}
+
+	ssr := NewApplySessionState("RESET work_mem", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.NoError(t, err)
+
+	// Variable should be removed
+	_, exists := state.GetSessionVariable("work_mem")
+	assert.False(t, exists, "variable should be removed after RESET")
+
+	// Should receive synthetic CommandComplete
+	require.Len(t, results, 1)
+	assert.Equal(t, "RESET", results[0].CommandTag)
+}
+
+func TestApplySessionState_RESET_ALL_ClearsAllVariables(t *testing.T) {
+	state := &handler.MultiGatewayConnectionState{}
+	state.SetSessionVariable("work_mem", "256MB")
+	state.SetSessionVariable("search_path", "myschema")
+	state.SetSessionVariable("statement_timeout", "30s")
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_RESET_ALL,
+	}
+
+	ssr := NewApplySessionState("RESET ALL", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.NoError(t, err)
+
+	// All variables should be cleared
+	_, exists := state.GetSessionVariable("work_mem")
+	assert.False(t, exists)
+	_, exists = state.GetSessionVariable("search_path")
+	assert.False(t, exists)
+	_, exists = state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists)
+
+	// Should receive synthetic CommandComplete
+	require.Len(t, results, 1)
+	assert.Equal(t, "RESET", results[0].CommandTag)
+}
+
+func TestApplySessionState_UnsupportedKind(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultiGatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_DEFAULT,
+		Name: "work_mem",
+	}
+
+	ssr := NewApplySessionState("SET work_mem TO DEFAULT", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, collectCallback(&results))
+	require.Error(t, err)
+
+	var pgDiag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &pgDiag)
+	assert.Equal(t, "0A000", pgDiag.Code)
+}
+
+func TestApplySessionState_GetTableGroup(t *testing.T) {
+	stmt := &ast.VariableSetStmt{Kind: ast.VAR_SET_VALUE, Name: "x"}
+	ssr := NewApplySessionState("SET x = 1", stmt)
+	assert.Equal(t, "", ssr.GetTableGroup(), "SET/RESET are local-only, no tablegroup")
+}
+
+func TestApplySessionState_GetQuery(t *testing.T) {
+	stmt := &ast.VariableSetStmt{Kind: ast.VAR_SET_VALUE, Name: "x"}
+	ssr := NewApplySessionState("SET x = 1", stmt)
+	assert.Equal(t, "SET x = 1", ssr.GetQuery())
+}
+
+func TestApplySessionState_String(t *testing.T) {
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "work_mem",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
+	}
+	ssr := NewApplySessionState("SET work_mem = '256MB'", stmt)
+	result := ssr.String()
+	assert.Contains(t, result, "ApplySessionState")
+}
+
+func TestExtractVariableValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     *ast.NodeList
+		expected string
+	}{
+		{
+			name:     "nil args",
+			args:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty args",
+			args:     &ast.NodeList{},
+			expected: "",
+		},
+		{
+			name: "string constant",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.A_Const{Val: &ast.String{SVal: "myschema"}},
+			}},
+			expected: "myschema",
+		},
+		{
+			name: "integer constant",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.A_Const{Val: &ast.Integer{IVal: 42}},
+			}},
+			expected: "42",
+		},
+		{
+			name: "float constant",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.A_Const{Val: &ast.Float{FVal: "3.14"}},
+			}},
+			expected: "3.14",
+		},
+		{
+			name: "bare string node",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.String{SVal: "public"},
+			}},
+			expected: "public",
+		},
+		{
+			name: "bare integer node",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.Integer{IVal: 7},
+			}},
+			expected: "7",
+		},
+		{
+			name: "multiple values joined with comma",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.String{SVal: "public"},
+				&ast.String{SVal: "pg_catalog"},
+			}},
+			expected: "public, pg_catalog",
+		},
+		{
+			name: "fallback node uses SqlString",
+			args: &ast.NodeList{Items: []ast.Node{
+				&ast.Float{FVal: "2.5"},
+			}},
+			expected: "2.5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractVariableValue(tc.args)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractConstValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *ast.A_Const
+		expected string
+	}{
+		{
+			name:     "nil const",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "nil val",
+			input:    &ast.A_Const{Val: nil},
+			expected: "",
+		},
+		{
+			name:     "string val",
+			input:    &ast.A_Const{Val: &ast.String{SVal: "hello"}},
+			expected: "hello",
+		},
+		{
+			name:     "integer val",
+			input:    &ast.A_Const{Val: &ast.Integer{IVal: 99}},
+			expected: "99",
+		},
+		{
+			name:     "float val",
+			input:    &ast.A_Const{Val: &ast.Float{FVal: "1.5"}},
+			expected: "1.5",
+		},
+		{
+			name:     "fallback val uses SqlString",
+			input:    &ast.A_Const{Val: &ast.Boolean{BoolVal: true}},
+			expected: "TRUE",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := extractConstValue(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/go/services/multigateway/engine/copy_statement_test.go
+++ b/go/services/multigateway/engine/copy_statement_test.go
@@ -32,8 +32,11 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// mockIExecute is a mock implementation of IExecute for testing CopyStatement.
+// mockIExecute is a mock implementation of IExecute for testing.
 type mockIExecute struct {
+	// StreamExecute behavior
+	streamExecuteErr error
+
 	// CopyInitiate behavior
 	copyInitiateErr     error
 	copyInitiateFormat  int16
@@ -59,7 +62,7 @@ func (m *mockIExecute) StreamExecute(
 	state *handler.MultiGatewayConnectionState,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	return nil
+	return m.streamExecuteErr
 }
 
 func (m *mockIExecute) PortalStreamExecute(

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -232,16 +232,14 @@ func (m *MultiGatewayConnectionState) SetSessionVariable(name, value string) {
 func (m *MultiGatewayConnectionState) ResetSessionVariable(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.SessionSettings != nil {
-		delete(m.SessionSettings, name)
-	}
+	delete(m.SessionSettings, name)
 }
 
 // ResetAllSessionVariables clears all session variables (from RESET ALL command).
 func (m *MultiGatewayConnectionState) ResetAllSessionVariables() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.SessionSettings = make(map[string]string)
+	m.SessionSettings = nil
 }
 
 // SetStatementTimeout sets the session-level statement timeout override.
@@ -307,9 +305,6 @@ func (m *MultiGatewayConnectionState) GetSessionSettings() map[string]string {
 func (m *MultiGatewayConnectionState) GetSessionVariable(name string) (string, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.SessionSettings == nil {
-		return "", false
-	}
 	value, exists := m.SessionSettings[name]
 	return value, exists
 }
@@ -325,18 +320,4 @@ func (m *MultiGatewayConnectionState) GetStartupParams() map[string]string {
 	params := make(map[string]string, len(m.StartupParams))
 	maps.Copy(params, m.StartupParams)
 	return params
-}
-
-// RestoreSessionSettings replaces the current session settings with a new map.
-// Used for rolling back RESET ALL failures.
-func (m *MultiGatewayConnectionState) RestoreSessionSettings(settings map[string]string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if settings == nil {
-		m.SessionSettings = nil
-	} else {
-		// Make a copy to prevent external mutation
-		m.SessionSettings = make(map[string]string, len(settings))
-		maps.Copy(m.SessionSettings, settings)
-	}
 }

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -50,7 +50,7 @@ func NewPlanner(defaultTableGroup string, logger *slog.Logger) *Planner {
 // with switch on NodeTag for extensibility.
 //
 // Supported statement types:
-// - VariableSetStmt: SET/RESET commands → Sequence[Route, ApplySessionState]
+// - VariableSetStmt: SET/RESET commands → ApplySessionState
 // - Regular queries: Route only
 //
 // Future phases will add more statement handlers for:

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
@@ -28,7 +27,9 @@ import (
 )
 
 // planVariableSetStmt plans SET/RESET commands.
-// Creates a sequence that executes on PostgreSQL first, then updates local state.
+// Creates an ApplySessionState that handles SET and RESET as local state updates
+// with synthetic responses. PG validation is deferred to the next query when
+// the pool applies settings to the backend connection.
 func (p *Planner) planVariableSetStmt(
 	sql string,
 	stmt *ast.VariableSetStmt,
@@ -64,32 +65,17 @@ func (p *Planner) planVariableSetStmt(
 	case ast.VAR_SET_VALUE, ast.VAR_RESET, ast.VAR_RESET_ALL:
 		// These are tracked locally
 	default:
-		// VAR_SET_DEFAULT, VAR_SET_CURRENT, VAR_SET_MULTI - pass through
-		return p.planDefault(sql, conn)
+		// TODO: support VAR_SET_DEFAULT, VAR_SET_CURRENT, VAR_SET_MULTI when needed
+		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET kind %d is not yet supported", stmt.Kind))
 	}
 
-	// Extract value for SET commands
-	value := ""
-	if stmt.Kind == ast.VAR_SET_VALUE {
-		value = extractVariableValue(stmt.Args)
-	}
-
-	// SET/RESET command: Execute on PostgreSQL, then update local state
 	p.logger.Debug("planning SET/RESET command",
 		"kind", stmt.Kind,
-		"variable", stmt.Name,
-		"value", value)
+		"variable", stmt.Name)
 
-	// 1. Route: Send to PostgreSQL for validation and execution
-	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql)
+	primitive := engine.NewApplySessionState(sql, stmt)
 
-	// 2. ApplySessionState: Update local tracking after successful execution
-	applyState := engine.NewApplySessionState(stmt, value)
-
-	// 3. Compose in sequence (pessimistic: state update only if remote succeeds)
-	seq := engine.NewSequence([]engine.Primitive{route, applyState})
-
-	plan := engine.NewPlan(sql, seq)
+	plan := engine.NewPlan(sql, primitive)
 	p.logger.Debug("created SET/RESET plan", "plan", plan.String())
 	return plan, nil
 }

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+)
+
+func TestPlanVariableSetStmt_SET(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "work_mem",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
+	}
+
+	plan, err := p.planVariableSetStmt("SET work_mem = '256MB'", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// The primitive should be an ApplySessionState
+	_, ok := plan.Primitive.(*engine.ApplySessionState)
+	assert.True(t, ok, "expected ApplySessionState primitive")
+}
+
+func TestPlanVariableSetStmt_RESET(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_RESET,
+		Name: "work_mem",
+	}
+
+	plan, err := p.planVariableSetStmt("RESET work_mem", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	_, ok := plan.Primitive.(*engine.ApplySessionState)
+	assert.True(t, ok, "expected ApplySessionState primitive")
+}
+
+func TestPlanVariableSetStmt_RESET_ALL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_RESET_ALL,
+	}
+
+	plan, err := p.planVariableSetStmt("RESET ALL", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	_, ok := plan.Primitive.(*engine.ApplySessionState)
+	assert.True(t, ok, "expected ApplySessionState primitive")
+}
+
+func TestPlanVariableSetStmt_SET_LOCAL_PassesThrough(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind:    ast.VAR_SET_VALUE,
+		Name:    "work_mem",
+		IsLocal: true,
+		Args:    &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "256MB"}}}},
+	}
+
+	plan, err := p.planVariableSetStmt("SET LOCAL work_mem = '256MB'", stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	// SET LOCAL should produce a plain Route, not ApplySessionState
+	_, ok := plan.Primitive.(*engine.ApplySessionState)
+	assert.False(t, ok, "SET LOCAL should not produce ApplySessionState")
+}
+
+func TestPlanVariableSetStmt_UnsupportedKind(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_DEFAULT,
+		Name: "work_mem",
+	}
+
+	_, err := p.planVariableSetStmt("SET work_mem TO DEFAULT", stmt, testConn.Conn)
+	require.Error(t, err)
+
+	var pgDiag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &pgDiag)
+	assert.Equal(t, "0A000", pgDiag.Code)
+}

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -341,27 +342,38 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 		}
 	})
 
-	// Test 10: Error handling
+	// Test 10: Error handling — invalid SET params
+	//
+	// Behaviour deviation from PostgreSQL: SET commands are applied locally
+	// without validation. Invalid variables are accepted at SET time; errors
+	// surface on the next query when the pool tries to apply the setting.
 	t.Run("error handling", func(t *testing.T) {
 		// Set valid value first
 		_, err := db.ExecContext(ctx, "SET work_mem = '64MB'")
 		require.NoError(t, err, "failed to SET valid value")
 
-		// Try invalid SET (should fail)
+		// SET with invalid variable succeeds locally (not validated against PG)
 		_, err = db.ExecContext(ctx, "SET invalid_variable_12345 = 'value'")
-		require.Error(t, err, "invalid SET should return error")
+		require.NoError(t, err, "invalid SET should succeed locally (behaviour deviation from PG)")
 
-		// Verify connection still usable and setting persists across 100 queries
+		// Next query should fail because the pool tries to apply the bad setting
+		var result string
+		err = db.QueryRowContext(ctx, "SHOW work_mem").Scan(&result)
+		require.Error(t, err, "query after invalid SET should fail when pool applies bad setting")
+
+		// RESET the bad variable to recover
+		_, err = db.ExecContext(ctx, "RESET invalid_variable_12345")
+		require.NoError(t, err, "RESET of invalid variable should succeed")
+
+		// Connection should be usable again with original work_mem intact
 		for i := range 100 {
-			var result string
 			err = db.QueryRowContext(ctx, "SHOW work_mem").Scan(&result)
-			require.NoError(t, err, "iteration %d: previous setting should still work after error", i)
+			require.NoError(t, err, "iteration %d: should work after RESET of bad variable", i)
 			require.Equal(t, "64MB", result, "iteration %d: work_mem should still be 64MB", i)
 
-			// Verify can execute other queries
 			var one int
 			err = db.QueryRowContext(ctx, "SELECT 1").Scan(&one)
-			require.NoError(t, err, "iteration %d: connection should still be usable after error", i)
+			require.NoError(t, err, "iteration %d: connection should be usable after recovery", i)
 			require.Equal(t, 1, one)
 		}
 	})
@@ -370,6 +382,124 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 	t.Run("SET LOCAL behavior", func(t *testing.T) {
 		t.Skip("SET LOCAL requires transaction support (Phase 2)")
 		// TODO Phase 2: Implement transaction-scoped settings tracking
+	})
+}
+
+// TestMultiGateway_SetResetGUCRestoration verifies that RESET actually restores
+// the GUC value at the PostgreSQL level, not just in the gateway's session tracking.
+//
+// This catches a specific bug where:
+// 1. SET runs on connection A (pool tracks the setting)
+// 2. RESET removes from session tracking
+// 3. Connection A is returned to the "clean" pool — but PG-side GUC is still dirty
+// 4. Subsequent queries may get connection A with the stale GUC value
+func TestMultiGateway_SetResetGUCRestoration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping GUC restoration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping GUC restoration tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	t.Run("SET then RESET restores GUC on all pool connections", func(t *testing.T) {
+		db, err := sql.Open("postgres", connStr)
+		require.NoError(t, err)
+		defer db.Close()
+
+		err = db.PingContext(ctx)
+		require.NoError(t, err)
+
+		// Get the default value of extra_float_digits
+		var defaultVal string
+		err = db.QueryRowContext(ctx, "SHOW extra_float_digits").Scan(&defaultVal)
+		require.NoError(t, err, "failed to get default extra_float_digits")
+		t.Logf("Default extra_float_digits = %s", defaultVal)
+
+		// Pick a value that differs from the default
+		defaultInt, err := strconv.Atoi(defaultVal)
+		require.NoError(t, err, "failed to parse default extra_float_digits")
+		nonDefaultVal := defaultInt - 1
+		nonDefaultStr := strconv.Itoa(nonDefaultVal)
+
+		// SET to a non-default value
+		_, err = db.ExecContext(ctx, fmt.Sprintf("SET extra_float_digits = %d", nonDefaultVal))
+		require.NoError(t, err, "failed to SET extra_float_digits")
+
+		// Verify it took effect
+		var customVal string
+		err = db.QueryRowContext(ctx, "SHOW extra_float_digits").Scan(&customVal)
+		require.NoError(t, err)
+		assert.Equal(t, nonDefaultStr, customVal, "SET should have changed the value")
+
+		// RESET the GUC
+		_, err = db.ExecContext(ctx, "RESET extra_float_digits")
+		require.NoError(t, err, "failed to RESET extra_float_digits")
+
+		// Now verify across many iterations that the value is truly restored.
+		// The bug: connection A still has extra_float_digits=0 at the PG level
+		// even though the gateway thinks it's clean. If the pool hands us
+		// connection A, SHOW will return 0 instead of the default.
+		for i := range 100 {
+			var result string
+			err = db.QueryRowContext(ctx, "SHOW extra_float_digits").Scan(&result)
+			require.NoError(t, err, "iteration %d: failed to SHOW", i)
+			require.Equal(t, defaultVal, result,
+				"iteration %d: extra_float_digits should be restored to default %q but got %q (stale pool connection)",
+				i, defaultVal, result)
+		}
+	})
+
+	t.Run("SET then RESET ALL restores all GUCs on all pool connections", func(t *testing.T) {
+		db, err := sql.Open("postgres", connStr)
+		require.NoError(t, err)
+		defer db.Close()
+
+		err = db.PingContext(ctx)
+		require.NoError(t, err)
+
+		// Get defaults
+		var defaultFloatDigits, defaultByteaOutput string
+		err = db.QueryRowContext(ctx, "SHOW extra_float_digits").Scan(&defaultFloatDigits)
+		require.NoError(t, err)
+		err = db.QueryRowContext(ctx, "SHOW bytea_output").Scan(&defaultByteaOutput)
+		require.NoError(t, err)
+
+		// Pick a non-default value for extra_float_digits
+		defaultInt, err := strconv.Atoi(defaultFloatDigits)
+		require.NoError(t, err)
+		nonDefaultFloatDigits := defaultInt - 1
+
+		// SET multiple GUCs to non-default values
+		_, err = db.ExecContext(ctx, fmt.Sprintf("SET extra_float_digits = %d", nonDefaultFloatDigits))
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "SET bytea_output = 'escape'")
+		require.NoError(t, err)
+
+		// RESET ALL
+		_, err = db.ExecContext(ctx, "RESET ALL")
+		require.NoError(t, err, "failed to RESET ALL")
+
+		// Verify both are restored across many iterations
+		for i := range 100 {
+			var floatDigits, byteaOut string
+			err = db.QueryRowContext(ctx, "SHOW extra_float_digits").Scan(&floatDigits)
+			require.NoError(t, err, "iteration %d: failed to SHOW extra_float_digits", i)
+			require.Equal(t, defaultFloatDigits, floatDigits,
+				"iteration %d: extra_float_digits not restored after RESET ALL", i)
+
+			err = db.QueryRowContext(ctx, "SHOW bytea_output").Scan(&byteaOut)
+			require.NoError(t, err, "iteration %d: failed to SHOW bytea_output", i)
+			require.Equal(t, defaultByteaOutput, byteaOut,
+				"iteration %d: bytea_output not restored after RESET ALL", i)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

Simplifies SET/RESET command handling in multigateway by making both operations local-only — neither is routed to PostgreSQL.

**Previous approach:** SET commands were routed to PG for validation (with optimistic local state update and rollback on error). RESET was already local-only. This involved save/restore logic, rollback on PG rejection, and a Route dependency.

**New approach:** Both SET and RESET update local `SessionSettings` and return a synthetic `CommandComplete` immediately. The pool propagates these settings to backend connections on subsequent queries via `ApplySettings`.

**Trade-off:** Invalid SET values (bad variable names or values) are accepted at SET time without error. The error surfaces on the next query when the pool tries to apply the setting. The client must RESET the bad variable to recover. This deviation from PostgreSQL behaviour is documented in code comments and in `docs/query_serving/session_settings.md`.