### PR TITLE
fix(pgregresstest): fix timeout handling and report generation

### DIFF
--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -52,7 +52,7 @@ func TestPostgreSQLRegression(t *testing.T) {
 	// Create PostgresBuilder for managing source and build
 	// We need to build PostgreSQL BEFORE setting up the cluster so that pgctld
 	// uses the same PostgreSQL version as the regression test library (regress.so)
-	ctx := utils.WithTimeout(t, 60*time.Minute)
+	ctx := utils.WithTimeout(t, 20*time.Minute)
 	builder := NewPostgresBuilder(t, t.TempDir())
 	t.Cleanup(func() {
 		builder.Cleanup()


### PR DESCRIPTION
The regression test suite was hanging on `copyselect` (COPY FROM STDIN in a multi-statement query) and the report was never generated because `exec.CommandContext` only killed the direct child (`make`), leaving `pg_regress` and `psql` alive. This prevented `cmd.Run()` from returning, so Go's test timeout would panic before any results could be parsed.

This fixes it by running the process in its own group (`Setpgid` + `cmd.Cancel`) so the entire tree gets killed on context cancellation. Also sets the context timeout to 15m (CI timeout 20m), switches to parsing `regression.out` from disk (which pg_regress writes incrementally), and fixes the TAP regex to match parallel test output (`+`).

Test run with report generated: https://github.com/haritabh17/multigres/actions/runs/22157636134