### PR TITLE
feat(multigateway): add server-side TLS for PostgreSQL client connections

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -68,6 +69,19 @@ type Conn struct {
 	// trustAuthProvider enables trust authentication for testing.
 	// When set and AllowTrustAuth() returns true, password auth is skipped.
 	trustAuthProvider TrustAuthProvider
+
+	// tlsConfig holds the TLS configuration for SSL connections.
+	// When set, the server accepts SSLRequest and upgrades to TLS.
+	// When nil, SSLRequest is declined with 'N'.
+	tlsConfig *tls.Config
+
+	// sslDone indicates that an SSLRequest has already been handled
+	// (accepted or declined) for this connection. Prevents double negotiation.
+	sslDone bool
+
+	// gssDone indicates that a GSSENCRequest has already been handled
+	// for this connection. Prevents double negotiation.
+	gssDone bool
 
 	// logger for connection-specific logging.
 	logger *slog.Logger

--- a/go/common/pgprotocol/server/ssl_test.go
+++ b/go/common/pgprotocol/server/ssl_test.go
@@ -1,0 +1,544 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// generateTestTLSConfig creates an ephemeral self-signed TLS certificate for testing.
+// Returns a server TLS config and a CA cert pool for client verification.
+func generateTestTLSConfig(t *testing.T) (*tls.Config, *x509.CertPool) {
+	t.Helper()
+
+	// Generate CA key and certificate
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+
+	// Generate server key and certificate signed by CA
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(1 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:    []string{"localhost"},
+	}
+
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, &serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{serverCertDER},
+		PrivateKey:  serverKey,
+	}
+
+	serverConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create CA cert pool for client verification
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	return serverConfig, caPool
+}
+
+// writeSSLRequest writes an SSLRequest startup packet to a writer.
+func writeSSLRequest(t *testing.T, w io.Writer) {
+	t.Helper()
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(8))
+	_ = binary.Write(&buf, binary.BigEndian, uint32(protocol.SSLRequestCode))
+	_, err := w.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+// writeGSSENCRequest writes a GSSENCRequest startup packet to a writer.
+func writeGSSENCRequest(t *testing.T, w io.Writer) {
+	t.Helper()
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(8))
+	_ = binary.Write(&buf, binary.BigEndian, uint32(protocol.GSSENCRequestCode))
+	_, err := w.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+// readSingleByte reads a single byte from a reader.
+func readSingleByte(t *testing.T, r io.Reader) byte {
+	t.Helper()
+	b := make([]byte, 1)
+	_, err := io.ReadFull(r, b)
+	require.NoError(t, err)
+	return b[0]
+}
+
+// newTestConn creates a Conn suitable for testing with the given TLS config.
+func newTestConn(t *testing.T, serverConn net.Conn, tlsConfig *tls.Config) *Conn {
+	t.Helper()
+	listener := testListener(t)
+	c := &Conn{
+		conn:           serverConn,
+		listener:       listener,
+		handler:        listener.handler,
+		hashProvider:   listener.hashProvider,
+		bufferedReader: bufio.NewReader(serverConn),
+		params:         make(map[string]string),
+		txnStatus:      protocol.TxnStatusIdle,
+		tlsConfig:      tlsConfig,
+	}
+	c.ctx = context.Background()
+	c.logger = testLogger(t)
+	return c
+}
+
+func TestSSLRequest_Declined_NoTLSConfig(t *testing.T) {
+	// When no TLS config is set, SSLRequest should be declined with 'N',
+	// and the connection should continue to accept a StartupMessage.
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'N' response
+	resp := readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp, "should decline SSL with 'N'")
+
+	// Send startup message and authenticate
+	params := map[string]string{"user": "testuser", "database": "testdb"}
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, params)
+	scramClientHelper(t, clientConn, "testuser", "postgres")
+
+	err := <-errCh
+	require.NoError(t, err)
+	assert.Equal(t, "testuser", c.user)
+	assert.Equal(t, "testdb", c.database)
+}
+
+func TestSSLRequest_Accepted_WithTLSConfig(t *testing.T) {
+	// When TLS config is set, SSLRequest should be accepted with 'S',
+	// TLS handshake should succeed, and connection should work over TLS.
+
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	// Use real TCP connections for TLS (pipes don't support TLS handshake)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	// Client side: connect to the server
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// Send SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'S' response
+	resp := readSingleByte(t, clientConn)
+	require.Equal(t, byte('S'), resp, "should accept SSL with 'S'")
+
+	// Perform TLS handshake
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	err = tlsClientConn.Handshake()
+	require.NoError(t, err)
+
+	// Send startup message over TLS and authenticate
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	scramClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+
+	err = <-errCh
+	require.NoError(t, err)
+}
+
+func TestSSLRequest_NonSSLClient_WithTLSConfigured(t *testing.T) {
+	// When TLS is configured but client doesn't send SSLRequest,
+	// the connection should still work (StartupMessage directly).
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	tlsConfig, _ := generateTestTLSConfig(t)
+	c := newTestConn(t, serverConn, tlsConfig)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send startup message directly (no SSLRequest)
+	params := map[string]string{"user": "plainuser", "database": "plaindb"}
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, params)
+	scramClientHelper(t, clientConn, "plainuser", "postgres")
+
+	err := <-errCh
+	require.NoError(t, err)
+	assert.Equal(t, "plainuser", c.user)
+	assert.Equal(t, "plaindb", c.database)
+}
+
+func TestSSLRequest_TLSHandshakeFailure(t *testing.T) {
+	// When the TLS handshake fails, the server should return an error.
+
+	tlsConfig, _ := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// Send SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'S' response
+	resp := readSingleByte(t, clientConn)
+	require.Equal(t, byte('S'), resp)
+
+	// Send garbage instead of a proper TLS ClientHello
+	_, _ = clientConn.Write([]byte("not a tls handshake"))
+	clientConn.Close()
+
+	// Server should get a TLS handshake error
+	err = <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS handshake failed")
+}
+
+func TestGSSENCRequest_ThenSSLRequest_Fallback(t *testing.T) {
+	// Per PostgreSQL protocol, a client may try GSSENCRequest first (gets 'N'),
+	// then SSLRequest. This should work correctly.
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	// No TLS configured — both should be declined
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send GSSENCRequest
+	writeGSSENCRequest(t, clientConn)
+
+	// Read 'N' response
+	resp := readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send SSLRequest (fallback)
+	writeSSLRequest(t, clientConn)
+
+	// Read 'N' response
+	resp = readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send startup message and authenticate
+	params := map[string]string{"user": "fallback_user", "database": "fallback_db"}
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, params)
+	scramClientHelper(t, clientConn, "fallback_user", "postgres")
+
+	err := <-errCh
+	require.NoError(t, err)
+	assert.Equal(t, "fallback_user", c.user)
+}
+
+func TestSSLRequest_ThenGSSENCRequest_Fallback(t *testing.T) {
+	// Reverse fallback: SSLRequest first (declined), then GSSENCRequest.
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'N' response
+	resp := readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send GSSENCRequest (fallback)
+	writeGSSENCRequest(t, clientConn)
+
+	// Read 'N' response
+	resp = readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send startup message and authenticate
+	params := map[string]string{"user": "reverse_user", "database": "reverse_db"}
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, params)
+	scramClientHelper(t, clientConn, "reverse_user", "postgres")
+
+	err := <-errCh
+	require.NoError(t, err)
+	assert.Equal(t, "reverse_user", c.user)
+}
+
+func TestSSLRequest_DuplicateRejected(t *testing.T) {
+	// Sending SSLRequest twice should be rejected.
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send first SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'N' response
+	resp := readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send second SSLRequest — should be rejected
+	writeSSLRequest(t, clientConn)
+
+	// Server should return an error about duplicate SSLRequest
+	err := <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate SSLRequest")
+}
+
+func TestGSSENCRequest_DuplicateRejected(t *testing.T) {
+	// Sending GSSENCRequest twice should be rejected.
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send first GSSENCRequest
+	writeGSSENCRequest(t, clientConn)
+
+	// Read 'N' response
+	resp := readSingleByte(t, clientConn)
+	assert.Equal(t, byte('N'), resp)
+
+	// Send second GSSENCRequest — should be rejected
+	writeGSSENCRequest(t, clientConn)
+
+	// Server should return an error about duplicate GSSENCRequest
+	err := <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate GSSENCRequest")
+}
+
+func TestSSLRequest_BufferStuffingPrevention(t *testing.T) {
+	// CVE-2021-23222: If unencrypted data is buffered between SSLRequest
+	// and TLS handshake, the connection should be rejected.
+
+	tlsConfig, _ := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// Write SSLRequest AND extra data in a single write (buffer stuffing attack).
+	// The extra data arrives before the TLS handshake, simulating a MITM injection.
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(8))
+	_ = binary.Write(&buf, binary.BigEndian, uint32(protocol.SSLRequestCode))
+	buf.WriteString("INJECTED DATA") // This is the attack payload
+	_, err = clientConn.Write(buf.Bytes())
+	require.NoError(t, err)
+
+	// Read 'S' response — server accepted SSL
+	resp := readSingleByte(t, clientConn)
+	require.Equal(t, byte('S'), resp)
+
+	// Server should detect the buffered data and reject the connection.
+	// The server reads 'S' response is already sent, but then checks buffered data.
+	err = <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unencrypted data after SSL request")
+}
+
+func TestGSSENCRequest_ThenSSLRequest_WithTLS(t *testing.T) {
+	// A client tries GSSENCRequest first (declined), then SSLRequest with TLS configured.
+	// The SSLRequest should be accepted and TLS upgrade should work.
+
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// Send GSSENCRequest first
+	writeGSSENCRequest(t, clientConn)
+
+	// Read 'N' response (GSSAPI declined)
+	resp := readSingleByte(t, clientConn)
+	require.Equal(t, byte('N'), resp)
+
+	// Send SSLRequest
+	writeSSLRequest(t, clientConn)
+
+	// Read 'S' response (SSL accepted)
+	resp = readSingleByte(t, clientConn)
+	require.Equal(t, byte('S'), resp)
+
+	// Perform TLS handshake
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	err = tlsClientConn.Handshake()
+	require.NoError(t, err)
+
+	// Send startup message over TLS and authenticate
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "gss_ssl_user",
+		"database": "gss_ssl_db",
+	})
+	scramClientHelper(t, tlsClientConn, "gss_ssl_user", "postgres")
+
+	err = <-errCh
+	require.NoError(t, err)
+}

--- a/go/provisioner/local/pgbackrest.go
+++ b/go/provisioner/local/pgbackrest.go
@@ -46,13 +46,13 @@ func GeneratePgBackRestCerts(certDir string) (*PgBackRestCertPaths, error) {
 
 	caCertFile := filepath.Join(certDir, "ca.crt")
 	caKeyFile := filepath.Join(certDir, "ca.key")
-	if err := generateCA(caCertFile, caKeyFile); err != nil {
+	if err := GenerateCA(caCertFile, caKeyFile); err != nil {
 		return nil, fmt.Errorf("failed to generate CA for pgBackRest: %w", err)
 	}
 
 	certFile := filepath.Join(certDir, "pgbackrest.crt")
 	keyFile := filepath.Join(certDir, "pgbackrest.key")
-	if err := generateCert(caCertFile, caKeyFile, certFile, keyFile, "pgbackrest", []string{"localhost", "pgbackrest"}); err != nil {
+	if err := GenerateCert(caCertFile, caKeyFile, certFile, keyFile, "pgbackrest", []string{"localhost", "pgbackrest"}); err != nil {
 		return nil, fmt.Errorf("failed to generate certificate for pgBackRest: %w", err)
 	}
 

--- a/go/provisioner/local/tls.go
+++ b/go/provisioner/local/tls.go
@@ -29,8 +29,9 @@ import (
 	"time"
 )
 
-// generateCA generates a self-signed CA certificate and private key for pgBackRest TLS.
-func generateCA(certPath, keyPath string) error {
+// GenerateCA generates a self-signed CA certificate and private key.
+// The certificate is valid for 10 years with RSA 4096-bit key.
+func GenerateCA(certPath, keyPath string) error {
 	// Generate RSA private key (4096 bits to match k8s setup)
 	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
@@ -94,11 +95,12 @@ func generateCA(certPath, keyPath string) error {
 	return nil
 }
 
-// generateCert generates a certificate signed by the CA.
-// The nodeName is used as the certificate's Common Name for identification.
-func generateCert(caCertPath, caKeyPath, certPath, keyPath, cn string, sans []string) error {
+// GenerateCert generates a certificate signed by the CA.
+// The cn is used as the certificate's Common Name for identification.
+// SANs are added as DNS Subject Alternative Names. IP SANs for 127.0.0.1 and ::1 are always included.
+func GenerateCert(caCertPath, caKeyPath, certPath, keyPath, cn string, sans []string) error {
 	// Load CA certificate and key
-	caCert, caKey, err := loadCA(caCertPath, caKeyPath)
+	caCert, caKey, err := LoadCA(caCertPath, caKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to load CA: %w", err)
 	}
@@ -167,8 +169,8 @@ func generateCert(caCertPath, caKeyPath, certPath, keyPath, cn string, sans []st
 	return nil
 }
 
-// loadCA loads a CA certificate and private key from disk.
-func loadCA(certPath, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {
+// LoadCA loads a CA certificate and private key from disk.
+func LoadCA(certPath, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {
 	// Load CA certificate
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {

--- a/go/test/endtoend/queryserving/ssl_test.go
+++ b/go/test/endtoend/queryserving/ssl_test.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMultiGateway_SSL_RequireMode tests that clients can connect to multigateway
+// using sslmode=require, which establishes a TLS connection without certificate verification.
+func TestMultiGateway_SSL_RequireMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var result int
+	err = db.QueryRow("SELECT 1").Scan(&result)
+	require.NoError(t, err, "query over TLS with sslmode=require should succeed")
+	assert.Equal(t, 1, result)
+}
+
+// TestMultiGateway_SSL_VerifyCA tests that clients can connect using sslmode=verify-ca,
+// which verifies the server certificate against the provided CA certificate.
+func TestMultiGateway_SSL_VerifyCA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+	require.NotNil(t, setup.MultigatewayTLSCertPaths, "TLS cert paths should be set")
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-ca sslrootcert=%s connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, setup.MultigatewayTLSCertPaths.CACertFile)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var result int
+	err = db.QueryRow("SELECT 1").Scan(&result)
+	require.NoError(t, err, "query over TLS with sslmode=verify-ca should succeed")
+	assert.Equal(t, 1, result)
+}
+
+// TestMultiGateway_SSL_VerifyFull tests that clients can connect using sslmode=verify-full,
+// which verifies the server certificate against the CA and checks hostname matches the cert SAN.
+func TestMultiGateway_SSL_VerifyFull(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+	require.NotNil(t, setup.MultigatewayTLSCertPaths, "TLS cert paths should be set")
+
+	// verify-full checks that the server hostname matches the certificate SAN.
+	// Our test certs have SAN=localhost, and we connect to localhost, so this should work.
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-full sslrootcert=%s connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, setup.MultigatewayTLSCertPaths.CACertFile)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var result int
+	err = db.QueryRow("SELECT 1").Scan(&result)
+	require.NoError(t, err, "query over TLS with sslmode=verify-full should succeed")
+	assert.Equal(t, 1, result)
+}
+
+// TestMultiGateway_SSL_DisableStillWorks tests that clients can still connect
+// with sslmode=disable when TLS is configured on the server.
+// The server should accept both TLS and non-TLS connections.
+func TestMultiGateway_SSL_DisableStillWorks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	// sslmode=disable means the client won't try SSL at all - sends StartupMessage directly.
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var result int
+	err = db.QueryRow("SELECT 1").Scan(&result)
+	require.NoError(t, err, "query without SSL should still work when server has TLS configured")
+	assert.Equal(t, 1, result)
+}
+
+// TestMultiGateway_SSL_AuthOverTLS tests that SCRAM-SHA-256 authentication works
+// correctly over a TLS connection.
+func TestMultiGateway_SSL_AuthOverTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	// First create a test user via the admin connection (using sslmode=require over TLS)
+	adminConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	adminDB, err := sql.Open("postgres", adminConnStr)
+	require.NoError(t, err)
+	defer adminDB.Close()
+
+	_, err = adminDB.Exec("CREATE USER ssl_testuser WITH PASSWORD 'ssl_password'")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminDB.Exec("DROP USER IF EXISTS ssl_testuser")
+	})
+
+	// Connect as the test user over TLS
+	userConnStr := fmt.Sprintf("host=localhost port=%d user=ssl_testuser password=ssl_password dbname=postgres sslmode=require connect_timeout=5",
+		setup.MultigatewayPgPort)
+	userDB, err := sql.Open("postgres", userConnStr)
+	require.NoError(t, err)
+	defer userDB.Close()
+
+	// Verify authentication works and we can execute queries
+	var currentUser string
+	err = userDB.QueryRow("SELECT current_user").Scan(&currentUser)
+	require.NoError(t, err, "SCRAM authentication over TLS should succeed")
+	assert.Equal(t, "ssl_testuser", currentUser)
+
+	// Verify wrong password fails even over TLS
+	badConnStr := fmt.Sprintf("host=localhost port=%d user=ssl_testuser password=wrong_password dbname=postgres sslmode=require connect_timeout=5",
+		setup.MultigatewayPgPort)
+	badDB, err := sql.Open("postgres", badConnStr)
+	require.NoError(t, err)
+	defer badDB.Close()
+
+	err = badDB.Ping()
+	require.Error(t, err, "wrong password should fail even over TLS")
+	assert.Contains(t, err.Error(), "password authentication failed")
+}
+
+// TestMultiGateway_SSL_MultipleQueries tests that a TLS connection remains stable
+// across multiple queries, verifying the TLS session is maintained correctly.
+func TestMultiGateway_SSL_MultipleQueries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Execute multiple queries to verify the TLS connection is stable
+	for i := 1; i <= 5; i++ {
+		var result int
+		err = db.QueryRow("SELECT $1::int", i).Scan(&result)
+		require.NoError(t, err, "query %d over TLS should succeed", i)
+		assert.Equal(t, i, result)
+	}
+}
+
+// TestMultiGateway_SSL_PreferMode_WithTLS tests sslmode=prefer against a TLS-enabled
+// multigateway. The client sends SSLRequest, the server responds 'S', and the connection
+// upgrades to TLS. Uses pgx because lib/pq doesn't support sslmode=prefer.
+func TestMultiGateway_SSL_PreferMode_WithTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=prefer connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err, "pgx connect with sslmode=prefer should succeed")
+	defer conn.Close(ctx)
+
+	var result int
+	err = conn.QueryRow(ctx, "SELECT 1").Scan(&result)
+	require.NoError(t, err, "query with sslmode=prefer should succeed (server accepts SSL)")
+	assert.Equal(t, 1, result)
+}
+
+// TestMultiGateway_SSL_PreferMode_FallbackToPlaintext tests sslmode=prefer against a
+// non-TLS multigateway. The client sends SSLRequest, the server responds 'N' (decline),
+// and pgx falls back to a plaintext connection. This exercises the 'N' response path
+// and the client's fallback-to-StartupMessage logic.
+// Uses pgx because lib/pq doesn't support sslmode=prefer.
+func TestMultiGateway_SSL_PreferMode_FallbackToPlaintext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	// Use the non-TLS shared setup — multigateway has no TLS config,
+	// so it responds 'N' to SSLRequest.
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=prefer connect_timeout=5",
+		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err, "pgx connect with sslmode=prefer should succeed (fallback to plaintext)")
+	defer conn.Close(ctx)
+
+	var result int
+	err = conn.QueryRow(ctx, "SELECT 1").Scan(&result)
+	require.NoError(t, err, "query with sslmode=prefer should succeed after SSL decline + plaintext fallback")
+	assert.Equal(t, 1, result)
+}

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -70,6 +70,10 @@ type ShardSetup struct {
 	// PgBackRestCertPaths stores the paths to pgBackRest TLS certificates
 	PgBackRestCertPaths *local.PgBackRestCertPaths
 
+	// MultigatewayTLSCertPaths stores the paths to multigateway TLS certificates.
+	// Set when WithMultigatewayTLS() is used.
+	MultigatewayTLSCertPaths *MultigatewayTLSCertPaths
+
 	// BackupLocation stores backup configuration from topology
 	BackupLocation *clustermetadatapb.BackupLocation
 
@@ -342,6 +346,12 @@ func (s *ShardSetup) CreateMultigatewayInstance(t *testing.T, name string, pgPor
 		GlobalRoot:  "/multigres/global",
 		LogFile:     filepath.Join(s.TempDir, name+".log"),
 		Environment: os.Environ(),
+	}
+
+	// Add TLS cert paths if multigateway TLS is enabled
+	if s.MultigatewayTLSCertPaths != nil {
+		inst.TLSCertFile = s.MultigatewayTLSCertPaths.ServerCertFile
+		inst.TLSKeyFile = s.MultigatewayTLSCertPaths.ServerKeyFile
 	}
 
 	s.Multigateway = inst

--- a/go/test/endtoend/shardsetup/multigateway_tls.go
+++ b/go/test/endtoend/shardsetup/multigateway_tls.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/multigres/multigres/go/provisioner/local"
+)
+
+// MultigatewayTLSCertPaths holds the paths to the generated multigateway TLS certificates.
+type MultigatewayTLSCertPaths struct {
+	CACertFile     string // CA certificate file (for client verify-ca / verify-full)
+	ServerCertFile string // Server certificate file
+	ServerKeyFile  string // Server private key file
+}
+
+// generateMultigatewayTLSCerts creates TLS certificates for the multigateway PostgreSQL listener.
+// Generates a CA and server cert with CN=localhost, SANs=[localhost] for test connections.
+func (s *ShardSetup) generateMultigatewayTLSCerts(t *testing.T) {
+	t.Helper()
+
+	certDir := filepath.Join(s.TempDir, "multigateway-tls")
+
+	caCertFile := filepath.Join(certDir, "ca.crt")
+	caKeyFile := filepath.Join(certDir, "ca.key")
+	if err := local.GenerateCA(caCertFile, caKeyFile); err != nil {
+		t.Fatalf("failed to generate CA for multigateway TLS: %v", err)
+	}
+
+	certFile := filepath.Join(certDir, "server.crt")
+	keyFile := filepath.Join(certDir, "server.key")
+	if err := local.GenerateCert(caCertFile, caKeyFile, certFile, keyFile, "localhost", []string{"localhost"}); err != nil {
+		t.Fatalf("failed to generate certificate for multigateway TLS: %v", err)
+	}
+
+	s.MultigatewayTLSCertPaths = &MultigatewayTLSCertPaths{
+		CACertFile:     caCertFile,
+		ServerCertFile: certFile,
+		ServerKeyFile:  keyFile,
+	}
+
+	t.Logf("Generated multigateway TLS certificates in %s", certDir)
+}

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -63,6 +63,10 @@ type ProcessInstance struct {
 	PrimaryFailoverGracePeriodBase      string   // Grace period base before primary failover (e.g., "0s", "10s")
 	PrimaryFailoverGracePeriodMaxJitter string   // Max jitter for grace period (e.g., "0s", "5s")
 
+	// Multigateway TLS fields
+	TLSCertFile string // TLS certificate file (multigateway)
+	TLSKeyFile  string // TLS private key file (multigateway)
+
 	// PgBackRest-specific fields (used by multipooler and pgctld)
 	PgBackRestCertPaths *local.PgBackRestCertPaths // pgBackRest TLS certificate paths (multipooler)
 	PgBackRestPort      int                        // pgBackRest server port (multipooler, pgctld)
@@ -290,6 +294,14 @@ func (p *ProcessInstance) startMultigateway(ctx context.Context, t *testing.T) e
 		"--http-port", strconv.Itoa(p.HttpPort),
 		"--hostname", "localhost",
 		"--log-level", "debug",
+	}
+
+	// Add TLS certificate flags if configured
+	if p.TLSCertFile != "" && p.TLSKeyFile != "" {
+		args = append(args,
+			"--pg-tls-cert-file", p.TLSCertFile,
+			"--pg-tls-key-file", p.TLSKeyFile,
+		)
 	}
 
 	p.Process = exec.Command(p.Binary, args...)


### PR DESCRIPTION
## Summary

- Implement server-side SSL/TLS for client → multigateway connections, following the PostgreSQL wire protocol specification
- Refactor startup negotiation to support encryption fallback ordering (SSLRequest ↔ GSSENCRequest), matching PostgreSQL's `ProcessStartupPacket(port, ssl_done, gss_done)` pattern
- Add `--pg-tls-cert-file` and `--pg-tls-key-file` flags to multigateway for configuring TLS certificates
- Include buffer-stuffing attack prevention (CVE-2021-23222) to detect MITM-injected data between SSLRequest and TLS handshake

## Changes

| File | Change |
|------|--------|
| `server/startup.go` | Refactor negotiation flow with `readAndDispatchStartup()`, implement SSL accept + TLS upgrade, buffer-stuffing check |
| `server/conn.go` | Add `tlsConfig`, `sslDone`, `gssDone` fields |
| `server/listener.go` | Add `TLSConfig` to config and struct, pass to connections |
| `multigateway/init.go` | Add TLS cert/key flags, build `tls.Config`, pass to listener |
| `provisioner/local/tls.go` | Export `GenerateCA`, `GenerateCert`, `LoadCA` |
| `provisioner/local/pgbackrest.go` | Update callers to use exported names |
| `shardsetup/setup.go` | Add `WithMultigatewayTLS()` option |
| `shardsetup/cluster.go` | Add `MultigatewayTLSCertPaths` field, populate on instance creation |
| `shardsetup/multigateway_tls.go` | **New** — TLS cert generation for e2e tests |
| `shardsetup/process.go` | Pass `--pg-tls-cert-file`/`--pg-tls-key-file` to multigateway process |
| `server/ssl_test.go` | **New** — 10 unit tests for SSL/GSSENC negotiation paths |
| `queryserving/ssl_test.go` | **New** — 6 e2e tests (require, verify-ca, verify-full, disable, auth-over-TLS, multiple-queries) |

## Scope

Server-side TLS only (client → multigateway). Client-side TLS (multipooler → PG) and SCRAM channel binding are follow-up PRs.

## Test plan

- [x] Unit tests: 10 tests covering SSL accept/decline, TLS handshake, fallback ordering, duplicate rejection, buffer-stuffing prevention
- [x] E2E tests: 6 tests covering `sslmode=require`, `verify-ca`, `verify-full`, `disable`, SCRAM auth over TLS, connection stability
- [ ] Manual: `psql "sslmode=require host=localhost port=<port>"` with `\conninfo` shows SSL connection