### PR TITLE
fix(multipooler): fix flaky TestDynamicAllocation_UserArrivalDuringLoad under race detector

### DIFF
--- a/go/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
+++ b/go/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
@@ -272,11 +272,15 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 			"user %s should have capacity after new user arrived", user)
 	}
 
-	// User3 should have acquired at least 1 connection
-	mu.Lock()
-	user3Conns := len(conns["user3"])
-	mu.Unlock()
-	assert.GreaterOrEqual(t, user3Conns, 1, "user3 should have acquired at least 1 connection")
+	// User3 should have acquired at least 1 connection.
+	// Use Eventually because user3's goroutines may still be completing their
+	// connection acquisition after the pool is created (pool creation makes the
+	// pool visible to UserPoolCount before GetRegularConn returns).
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(conns["user3"]) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "user3 should have acquired at least 1 connection")
 
 	// Cleanup
 	mu.Lock()


### PR DESCRIPTION
## Summary

- Fix race condition in `TestDynamicAllocation_UserArrivalDuringLoad` where the assertion at line 279 checked `conns["user3"]` immediately after detecting user3's pool existed, before user3's goroutines had finished acquiring connections
- Replace the immediate `assert.GreaterOrEqual` with `require.Eventually` to wait for user3's goroutines to complete connection acquisition, consistent with the pattern used throughout the rest of the test file

## Root Cause

`UserPoolCount()` becomes 3 as soon as `createUserPoolSlow` atomically publishes the new pool, but the goroutine hasn't yet finished `GetRegularConn` (which creates a TCP connection to the database). Under `-race`, goroutine scheduling overhead is large enough that the main goroutine reaches the assertion before any user3 goroutine stores a connection.