### PR TITLE
refactor(test): introduce semantic DSN helpers and add env var overrides

### DIFF
--- a/demo/local/failover-test.go
+++ b/demo/local/failover-test.go
@@ -65,6 +65,7 @@ type PoolerInfo struct {
 	Cell      string
 	ServiceID string
 	PoolerDir string
+	PgUser    string
 	PgPort    int
 }
 
@@ -389,6 +390,7 @@ func getPoolerInfo(cell, serviceID string, config *Config) *PoolerInfo {
 		ServiceID: serviceID,
 		PoolerDir: cellConfig.Multipooler.PoolerDir,
 		PgPort:    cellConfig.Pgctld.PgPort,
+		PgUser:    cellConfig.Pgctld.PgUser,
 	}
 }
 
@@ -715,7 +717,7 @@ func printReplicationStatus(ctx context.Context, config *Config) {
 
 func runSQLQuery(poolerInfo *PoolerInfo, query string) string {
 	socketPath := filepath.Join(poolerInfo.PoolerDir, "pg_sockets")
-	connStr := fmt.Sprintf("host=%s port=%d user=postgres database=postgres sslmode=disable", socketPath, poolerInfo.PgPort)
+	connStr := fmt.Sprintf("host=%s port=%d user=%s database=postgres sslmode=disable", socketPath, poolerInfo.PgPort, poolerInfo.PgUser)
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/multigres/multigres/go/services/pgctld"
 
@@ -181,6 +182,17 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 	}
 
 	cmd := exec.Command("initdb", args...)
+
+	// On macOS, ensure locale environment variables are set for initdb.
+	// initdb requires valid locale settings to avoid "invalid locale settings" errors.
+	// This is specific to macOS where LC_ALL may not be set by default.
+	if runtime.GOOS == "darwin" {
+		cmd.Env = os.Environ()
+		if os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
+			// Set LC_ALL=C as a safe default if no locale is configured.
+			cmd.Env = append(cmd.Env, "LC_ALL=C")
+		}
+	}
 
 	// Capture both stdout and stderr to include in error messages
 	output, err := cmd.CombinedOutput()

--- a/go/test/endtoend/README.md
+++ b/go/test/endtoend/README.md
@@ -1,0 +1,197 @@
+# End-to-End Tests
+
+Integration tests that start real multigres components (multigateway, multipooler, pgctld,
+multiorch) and PostgreSQL, then exercise them end-to-end.
+
+## Prerequisites
+
+### 1. Build the binaries
+
+```bash
+make build
+```
+
+This must be run from the repository root before running integration tests. It compiles all service
+binaries into `bin/`.
+
+### 2. PostgreSQL binaries on PATH
+
+The tests look for `initdb`, `postgres`, `pg_ctl`, and `pg_isready`
+via `exec.LookPath`. If any are missing the tests skip the
+real-PostgreSQL paths and run in a degraded mode.
+
+On macOS with Homebrew, PostgreSQL is typically **not** on the default
+PATH. Prepend it explicitly:
+
+```bash
+# PostgreSQL 18 via Homebrew (adjust version as needed)
+export PATH="/opt/homebrew/Cellar/postgresql@18/18.2/bin:$PATH"
+
+# Verify
+which initdb   # should print the Homebrew path
+which postgres
+```
+
+On Linux, installing `postgresql` via the system package manager (apt,
+yum, etc.) usually puts the binaries on PATH automatically.
+
+## Running the Tests
+
+### Run all packages
+
+```bash
+go test -skip TestPostgreSQLRegression ./go/test/endtoend/...
+```
+
+If you run into issues with failing tests because of allocating shared
+memory segments, you can add `-p=1` to the test. Go runs test packages
+in parallel by default. Each package spins up its own PostgreSQL cluster,
+which allocates a shared memory segment via `shmget`. macOS has a hard
+system limit of 32 shared memory IDs (`kern.sysv.shmmni: 32`). Running
+all packages concurrently exhausts this pool, causing PostgreSQL's `initdb`
+to fail with the misleading error:
+
+```text
+FATAL: could not create shared memory segment: No space left on device
+```
+
+The `-p=1` flag forces packages to run sequentially, keeping at most
+one cluster bootstrapping at a time. This is not needed on Linux,
+which has a much higher default limit.
+
+**Why `-skip TestPostgreSQLRegression`?** The `pgregresstest` package
+clones PostgreSQL source and builds it from scratch (~10+
+minutes). Skip it during normal development; see
+[`pgregresstest/README.md`](pgregresstest/README.md) for how to run it
+explicitly.
+
+### Run a specific package
+
+```bash
+go test ./go/test/endtoend/multipooler/...
+```
+
+Single packages don't need `-p=1` (only one cluster at a time).
+
+### Run a specific test
+
+```bash
+go test -run TestFixReplication ./go/test/endtoend/multiorch/...
+```
+
+### Verbose output
+
+Add `-v` to see individual test names and log lines as they run:
+
+```bash
+go test -v -run TestConnPool ./go/test/endtoend/multipooler/...
+```
+
+### Print full logs inline (useful for CI or debugging)
+
+```bash
+TEST_PRINT_LOGS=1 go test -v -run TestFailover ./go/test/endtoend/multiorch/...
+```
+
+## Test Packages
+
+| Package            | What it tests                                      |
+| ------------------ | -------------------------------------------------- |
+| `endtoend`         | etcd topology, service discovery                   |
+| `localprovisioner` | local cluster provisioning                         |
+| `pgctld`           | PostgreSQL control daemon lifecycle                |
+| `shardsetup`       | shared cluster infrastructure                      |
+| `queryserving`     | query routing, SSL, sessions, transactions         |
+| `multipooler`      | connection pooling, backup, replication, consensus |
+| `multiorch`        | failover, bootstrap, replication repair            |
+| `pgregresstest`    | PostgreSQL official regression suite (opt-in)      |
+
+## Debugging Failures
+
+When a test fails, logs are preserved in a temp directory. The test output will show:
+
+```text
+==== TEST LOGS PRESERVED ====
+Logs available at: /tmp/shardsetup_test_XXXXXXXXXX
+Set TEST_PRINT_LOGS=1 to print log contents
+===========================
+```
+
+### Log directory structure
+
+```text
+/tmp/shardsetup_test_XXXXXXXXXX/
+├── multigateway.log
+├── temp-multiorch/
+│   └── multiorch.log
+├── pooler-1/
+│   ├── multipooler.log
+│   ├── pgctld.log
+│   └── data/
+│       ├── pg_data/postgresql.log
+│       └── pgbackrest/logs/
+├── pooler-2/  (same structure)
+├── pooler-3/  (same structure)
+├── etcd_data/
+└── backup-repo/
+```
+
+### Quick error search
+
+```bash
+# Find all errors across all logs
+grep -r "ERROR\|FATAL" /tmp/shardsetup_test_XXXXXXXXXX/
+
+# Tail a specific component
+tail -50 /tmp/shardsetup_test_XXXXXXXXXX/pooler-1/multipooler.log
+
+# Pretty-print JSON logs
+cat /tmp/shardsetup_test_XXXXXXXXXX/pooler-1/multipooler.log | jq '.'
+```
+
+### What to look at first
+
+| Failure type              | Start here                                                         |
+| ------------------------- | ------------------------------------------------------------------ |
+| Connection / query errors | `pooler-*/multipooler.log`, `pooler-*/data/pg_data/postgresql.log` |
+| Replication issues        | PostgreSQL logs on all poolers                                     |
+| Failover / consensus      | `pooler-*/multipooler.log`, `temp-multiorch/multiorch.log`         |
+| Backup / restore errors   | `pooler-*/data/pgbackrest/logs/`                                   |
+| Gateway routing issues    | `multigateway.log`                                                 |
+| Bootstrap failures        | `temp-multiorch/multiorch.log`, all pooler logs                    |
+
+## Troubleshooting
+
+### Tests skip PostgreSQL entirely
+
+**Symptom**: Tests pass instantly, output says "skipping" or reports 0 real operations.
+
+**Cause**: `initdb`/`postgres`/`pg_ctl`/`pg_isready` not found on PATH.
+
+**Fix**: Prepend the PostgreSQL bin directory as shown in Prerequisites above.
+
+### `No space left on device` during bootstrap
+
+**Symptom**: `FATAL: could not create shared memory segment: No space left on device` in test output
+or logs.
+
+**Cause**: macOS shared memory segment limit (`kern.sysv.shmmni: 32`) exhausted. This happens when
+packages run in parallel, or when a previous run crashed and left stale segments behind.
+
+**Fix 1**: Use `-p=1` when running multiple packages on macOS.
+
+**Fix 2**: Clean up stale segments from a previous crashed run:
+
+```bash
+# List shared memory segments owned by your user
+ipcs -m | grep $(whoami)
+
+# Remove them all
+for id in $(ipcs -m | grep $(whoami) | awk '{print $2}'); do ipcrm -m "$id"; done
+```
+
+### Build failure before tests run
+
+**Symptom**: `[build failed]` in the output before any test runs.
+
+**Fix**: Run `make build` manually to see the full compiler error.

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -95,8 +95,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	disableMonitoringOnAllNodes(t, setup)
 
 	// Connect to multigateway for continuous writes (automatically routes to current primary)
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	gatewayDB, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer gatewayDB.Close()

--- a/go/test/endtoend/multipooler/pgprotocol_client_test.go
+++ b/go/test/endtoend/multipooler/pgprotocol_client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -44,7 +45,7 @@ func TestPgProtocolClientConnection(t *testing.T) {
 		conn, err := client.Connect(ctx, ctx, &client.Config{
 			Host:        "localhost",
 			Port:        setup.PrimaryPgctld.PgPort,
-			User:        "postgres",
+			User:        constants.DefaultPostgresUser,
 			Password:    testPostgresPassword,
 			Database:    "postgres",
 			DialTimeout: 5 * time.Second,
@@ -74,7 +75,7 @@ func TestPgProtocolClientConnection(t *testing.T) {
 		conn, err := client.Connect(ctx, ctx, &client.Config{
 			Host:        "localhost",
 			Port:        setup.PrimaryPgctld.PgPort,
-			User:        "postgres",
+			User:        constants.DefaultPostgresUser,
 			Password:    testPostgresPassword,
 			Database:    "postgres",
 			DialTimeout: 5 * time.Second,
@@ -104,7 +105,7 @@ func TestPgProtocolClientSimpleQuery(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,
@@ -218,7 +219,7 @@ func TestPgProtocolClientExtendedQuery(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,
@@ -339,7 +340,7 @@ func TestPgProtocolClientDataTypes(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,
@@ -460,7 +461,7 @@ func TestPgProtocolClientErrors(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,
@@ -524,7 +525,7 @@ func TestPgProtocolClientTransactions(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,
@@ -596,7 +597,7 @@ func TestPgProtocolClientStreaming(t *testing.T) {
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.PrimaryPgctld.PgPort,
-		User:        "postgres",
+		User:        constants.DefaultPostgresUser,
 		Password:    testPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,

--- a/go/test/endtoend/queryserving/authentication_test.go
+++ b/go/test/endtoend/queryserving/authentication_test.go
@@ -39,8 +39,7 @@ func TestMultiGateway_Authentication(t *testing.T) {
 	setup.SetupTest(t)
 
 	// Connect as postgres (superuser) to create test users
-	adminConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	adminConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	adminDB, err := sql.Open("postgres", adminConnStr)
 	require.NoError(t, err)
 	defer adminDB.Close()

--- a/go/test/endtoend/queryserving/copy_test.go
+++ b/go/test/endtoend/queryserving/copy_test.go
@@ -44,8 +44,7 @@ func TestMultiGateway_CopyCommands(t *testing.T) {
 	setup.SetupTest(t)
 
 	// Connect to multigateway using pgx for COPY protocol support
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 
 	ctx := utils.WithTimeout(t, 150*time.Second)
 
@@ -500,8 +499,7 @@ func TestMultiGateway_CopyInTransaction(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 
 	ctx := utils.WithTimeout(t, 60*time.Second)
 
@@ -660,8 +658,7 @@ func TestMultiGateway_CopyInMultiStatement(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 
 	ctx := utils.WithTimeout(t, 60*time.Second)
 

--- a/go/test/endtoend/queryserving/error_format_test.go
+++ b/go/test/endtoend/queryserving/error_format_test.go
@@ -49,8 +49,7 @@ func TestErrorFormat_UndefinedColumnPosition(t *testing.T) {
 
 	t.Run("simple_query_undefined_column", func(t *testing.T) {
 		// Connect to multigateway
-		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		conn, err := pgx.Connect(ctx, connStr)
 		require.NoError(t, err)
 		defer conn.Close(ctx)
@@ -86,15 +85,13 @@ func TestErrorFormat_UndefinedColumnPosition(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)
@@ -143,8 +140,7 @@ func TestErrorFormat_TypeErrorSQLState(t *testing.T) {
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
 	t.Run("simple_query_type_error", func(t *testing.T) {
-		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		conn, err := pgx.Connect(ctx, connStr)
 		require.NoError(t, err)
 		defer conn.Close(ctx)
@@ -167,15 +163,13 @@ func TestErrorFormat_TypeErrorSQLState(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)
@@ -211,8 +205,7 @@ func TestErrorFormat_ConstraintViolation(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err)
 	defer conn.Close(ctx)
@@ -289,15 +282,13 @@ func TestErrorFormat_ConstraintViolation(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)
@@ -335,8 +326,7 @@ func TestErrorFormat_PLpgSQLWhereField(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err)
 	defer conn.Close(ctx)
@@ -394,15 +384,13 @@ func TestErrorFormat_PLpgSQLWhereField(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)
@@ -438,8 +426,7 @@ func TestErrorFormat_HintAndDetail(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err)
 	defer conn.Close(ctx)
@@ -471,15 +458,13 @@ func TestErrorFormat_HintAndDetail(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)
@@ -523,8 +508,7 @@ func TestErrorFormat_UndefinedTable(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err)
 	defer conn.Close(ctx)
@@ -545,15 +529,13 @@ func TestErrorFormat_UndefinedTable(t *testing.T) {
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
 		// Connect directly to PostgreSQL
-		directConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
 		directConn, err := pgx.Connect(ctx, directConnStr)
 		require.NoError(t, err)
 		defer directConn.Close(ctx)
 
 		// Connect to multigateway
-		mgConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		mgConn, err := pgx.Connect(ctx, mgConnStr)
 		require.NoError(t, err)
 		defer mgConn.Close(ctx)

--- a/go/test/endtoend/queryserving/multigateway_pg_test.go
+++ b/go/test/endtoend/queryserving/multigateway_pg_test.go
@@ -46,8 +46,7 @@ func TestMultiGateway_PostgreSQLConnection(t *testing.T) {
 	setup.SetupTest(t)
 
 	// Connect to the multigateway
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "failed to open database connection")
 	defer db.Close()
@@ -198,8 +197,7 @@ func TestMultiGateway_ExtendedQueryProtocol(t *testing.T) {
 	setup.SetupTest(t)
 
 	// Connect using pgx (which uses Extended Query Protocol by default)
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 
 	ctx := utils.WithTimeout(t, 30*time.Second)
 

--- a/go/test/endtoend/queryserving/notice_test.go
+++ b/go/test/endtoend/queryserving/notice_test.go
@@ -58,10 +58,8 @@ func (nc *noticeCollector) reset() {
 }
 
 // connectWithNotices creates a pgx connection with an OnNotice handler that collects notices.
-func connectWithNotices(ctx context.Context, t *testing.T, host string, port int, password string) (*pgx.Conn, *noticeCollector) {
+func connectWithNotices(ctx context.Context, t *testing.T, connStr string) (*pgx.Conn, *noticeCollector) {
 	t.Helper()
-	connStr := fmt.Sprintf("host=%s port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		host, port, password)
 	config, err := pgx.ParseConfig(connStr)
 	require.NoError(t, err)
 
@@ -88,7 +86,8 @@ func TestNoticeFormat_TableInheritanceColumnMerge(t *testing.T) {
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
 	t.Run("simple_query_inheritance_notice", func(t *testing.T) {
-		conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		conn, collector := connectWithNotices(ctx, t, connStr)
 		defer conn.Close(ctx)
 
 		parentTable := fmt.Sprintf("parent_notice_%d", time.Now().UnixNano())
@@ -121,10 +120,12 @@ func TestNoticeFormat_TableInheritanceColumnMerge(t *testing.T) {
 	})
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
-		directConn, directCollector := connectWithNotices(ctx, t, "localhost", setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
+		directConn, directCollector := connectWithNotices(ctx, t, directConnStr)
 		defer directConn.Close(ctx)
 
-		mgConn, mgCollector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		mgConn, mgCollector := connectWithNotices(ctx, t, mgConnStr)
 		defer mgConn.Close(ctx)
 
 		suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -179,7 +180,8 @@ func TestNoticeFormat_RaiseNotice(t *testing.T) {
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
 	t.Run("single_raise_notice", func(t *testing.T) {
-		conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		conn, collector := connectWithNotices(ctx, t, connStr)
 		defer conn.Close(ctx)
 
 		_, err := conn.Exec(ctx, "DO $$ BEGIN RAISE NOTICE 'test notice message'; END $$")
@@ -196,7 +198,8 @@ func TestNoticeFormat_RaiseNotice(t *testing.T) {
 	})
 
 	t.Run("multiple_notices", func(t *testing.T) {
-		conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		conn, collector := connectWithNotices(ctx, t, connStr)
 		defer conn.Close(ctx)
 
 		_, err := conn.Exec(ctx, `DO $$
@@ -217,7 +220,8 @@ func TestNoticeFormat_RaiseNotice(t *testing.T) {
 	})
 
 	t.Run("no_notice_on_simple_select", func(t *testing.T) {
-		conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		conn, collector := connectWithNotices(ctx, t, connStr)
 		defer conn.Close(ctx)
 
 		_, err := conn.Exec(ctx, "SELECT 1")
@@ -228,10 +232,12 @@ func TestNoticeFormat_RaiseNotice(t *testing.T) {
 	})
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
-		directConn, directCollector := connectWithNotices(ctx, t, "localhost", setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
+		directConn, directCollector := connectWithNotices(ctx, t, directConnStr)
 		defer directConn.Close(ctx)
 
-		mgConn, mgCollector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		mgConn, mgCollector := connectWithNotices(ctx, t, mgConnStr)
 		defer mgConn.Close(ctx)
 
 		query := "DO $$ BEGIN RAISE NOTICE 'comparison notice'; END $$"
@@ -268,7 +274,8 @@ func TestNoticeFormat_DetailAndHint(t *testing.T) {
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
 	t.Run("notice_with_detail_and_hint", func(t *testing.T) {
-		conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		conn, collector := connectWithNotices(ctx, t, connStr)
 		defer conn.Close(ctx)
 
 		_, err := conn.Exec(ctx, `DO $$
@@ -293,10 +300,12 @@ func TestNoticeFormat_DetailAndHint(t *testing.T) {
 	})
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
-		directConn, directCollector := connectWithNotices(ctx, t, "localhost", setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
+		directConn, directCollector := connectWithNotices(ctx, t, directConnStr)
 		defer directConn.Close(ctx)
 
-		mgConn, mgCollector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		mgConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		mgConn, mgCollector := connectWithNotices(ctx, t, mgConnStr)
 		defer mgConn.Close(ctx)
 
 		query := `DO $$
@@ -340,7 +349,8 @@ func TestNoticeFormat_PLpgSQLWhereField(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	conn, collector := connectWithNotices(ctx, t, "localhost", setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+	conn, collector := connectWithNotices(ctx, t, connStr)
 	defer conn.Close(ctx)
 
 	innerFunc := fmt.Sprintf("notice_inner_%d", time.Now().UnixNano())
@@ -389,7 +399,8 @@ func TestNoticeFormat_PLpgSQLWhereField(t *testing.T) {
 	})
 
 	t.Run("compare_with_direct_postgres", func(t *testing.T) {
-		directConn, directCollector := connectWithNotices(ctx, t, "localhost", setup.GetPrimary(t).Pgctld.PgPort, shardsetup.TestPostgresPassword)
+		directConnStr := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable")
+		directConn, directCollector := connectWithNotices(ctx, t, directConnStr)
 		defer directConn.Close(ctx)
 
 		// Create the same functions on direct connection

--- a/go/test/endtoend/queryserving/postgres_crash_recovery_test.go
+++ b/go/test/endtoend/queryserving/postgres_crash_recovery_test.go
@@ -17,7 +17,6 @@ package queryserving
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -44,8 +43,7 @@ func TestMultiGateway_PostgresCrashRecovery(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t, shardsetup.WithEnabledMonitor())
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 
 	// Step 1: Verify baseline query works through multigateway.
 	db, err := sql.Open("postgres", connStr)

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -46,8 +46,7 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 	setup.SetupTest(t)
 
 	// Connect to multigateway
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "failed to open database connection")
 	defer db.Close()
@@ -292,8 +291,7 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 	// Test 8: Extended query protocol with pgx
 	t.Run("extended query protocol", func(t *testing.T) {
 		// Create pgx connection
-		pgxConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		pgxConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 		conn, err := pgx.Connect(ctx, pgxConnStr)
 		require.NoError(t, err, "failed to create pgx connection")
 		defer conn.Close(ctx)

--- a/go/test/endtoend/queryserving/ssl_test.go
+++ b/go/test/endtoend/queryserving/ssl_test.go
@@ -44,8 +44,7 @@ func TestMultiGateway_SSL_RequireMode(t *testing.T) {
 	setup := getTLSSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=require", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer db.Close()
@@ -70,8 +69,7 @@ func TestMultiGateway_SSL_VerifyCA(t *testing.T) {
 	setup.SetupTest(t)
 	require.NotNil(t, setup.MultigatewayTLSCertPaths, "TLS cert paths should be set")
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-ca sslrootcert=%s connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, setup.MultigatewayTLSCertPaths.CACertFile)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=verify-ca", "sslrootcert="+setup.MultigatewayTLSCertPaths.CACertFile, "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer db.Close()
@@ -98,8 +96,7 @@ func TestMultiGateway_SSL_VerifyFull(t *testing.T) {
 
 	// verify-full checks that the server hostname matches the certificate SAN.
 	// Our test certs have SAN=localhost, and we connect to localhost, so this should work.
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-full sslrootcert=%s connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, setup.MultigatewayTLSCertPaths.CACertFile)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=verify-full", "sslrootcert="+setup.MultigatewayTLSCertPaths.CACertFile, "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer db.Close()
@@ -125,8 +122,7 @@ func TestMultiGateway_SSL_DisableStillWorks(t *testing.T) {
 	setup.SetupTest(t)
 
 	// sslmode=disable means the client won't try SSL at all - sends StartupMessage directly.
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer db.Close()
@@ -151,8 +147,7 @@ func TestMultiGateway_SSL_AuthOverTLS(t *testing.T) {
 	setup.SetupTest(t)
 
 	// First create a test user via the admin connection (using sslmode=require over TLS)
-	adminConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	adminConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=require", "connect_timeout=5")
 	adminDB, err := sql.Open("postgres", adminConnStr)
 	require.NoError(t, err)
 	defer adminDB.Close()
@@ -201,8 +196,7 @@ func TestMultiGateway_SSL_MultipleQueries(t *testing.T) {
 	setup := getTLSSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=require connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=require", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer db.Close()
@@ -230,8 +224,7 @@ func TestMultiGateway_SSL_PreferMode_WithTLS(t *testing.T) {
 	setup := getTLSSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=prefer connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=prefer", "connect_timeout=5")
 	ctx := utils.WithTimeout(t, 10*time.Second)
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err, "pgx connect with sslmode=prefer should succeed")
@@ -261,8 +254,7 @@ func TestMultiGateway_SSL_PreferMode_FallbackToPlaintext(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=prefer connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=prefer", "connect_timeout=5")
 	ctx := utils.WithTimeout(t, 10*time.Second)
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err, "pgx connect with sslmode=prefer should succeed (fallback to plaintext)")
@@ -291,8 +283,7 @@ func TestMultiGateway_SSL_VerifyCA_WrongRootCert(t *testing.T) {
 
 	t.Run("missing root cert", func(t *testing.T) {
 		// sslrootcert points to a nonexistent file — client cannot verify the server cert.
-		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-ca sslrootcert=/nonexistent/ca.crt connect_timeout=5",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=verify-ca", "sslrootcert=/nonexistent/ca.crt", "connect_timeout=5")
 		ctx := utils.WithTimeout(t, 10*time.Second)
 		_, err := pgx.Connect(ctx, connStr)
 		require.Error(t, err, "verify-ca with missing root cert should fail")
@@ -304,8 +295,7 @@ func TestMultiGateway_SSL_VerifyCA_WrongRootCert(t *testing.T) {
 		emptyCAFile := filepath.Join(t.TempDir(), "empty-ca.crt")
 		require.NoError(t, os.WriteFile(emptyCAFile, nil, 0o600))
 
-		connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-ca sslrootcert=%s connect_timeout=5",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, emptyCAFile)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=verify-ca", "sslrootcert="+emptyCAFile, "connect_timeout=5")
 		ctx := utils.WithTimeout(t, 10*time.Second)
 		_, err := pgx.Connect(ctx, connStr)
 		require.Error(t, err, "verify-ca with empty root cert pool should fail")
@@ -329,8 +319,7 @@ func TestMultiGateway_SSL_VerifyFull_HostnameMismatch(t *testing.T) {
 	require.NotNil(t, setup.MultigatewayTLSCertPaths, "TLS cert paths should be set")
 
 	// Parse a valid config with verify-full and correct root cert.
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-full sslrootcert=%s connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword, setup.MultigatewayTLSCertPaths.CACertFile)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=verify-full", "sslrootcert="+setup.MultigatewayTLSCertPaths.CACertFile, "connect_timeout=5")
 	config, err := pgx.ParseConfig(connStr)
 	require.NoError(t, err)
 
@@ -360,8 +349,7 @@ func TestMultiGateway_SSL_AllowMode(t *testing.T) {
 	setup := getTLSSharedSetup(t)
 	setup.SetupTest(t)
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=allow connect_timeout=5",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=allow", "connect_timeout=5")
 	ctx := utils.WithTimeout(t, 10*time.Second)
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err, "pgx connect with sslmode=allow should succeed")

--- a/go/test/endtoend/queryserving/startup_params_test.go
+++ b/go/test/endtoend/queryserving/startup_params_test.go
@@ -16,7 +16,6 @@ package queryserving
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -45,9 +44,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 	ctx := utils.WithTimeout(t, 150*time.Second)
 
 	t.Run("DateStyle via pgx RuntimeParams", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["DateStyle"] = "German"
 
@@ -62,9 +60,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 	})
 
 	t.Run("multiple startup parameters", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["DateStyle"] = "SQL"
 		connCfg.RuntimeParams["TimeZone"] = "US/Pacific"
@@ -91,9 +88,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 	})
 
 	t.Run("SET overrides startup parameter", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["idle_in_transaction_session_timeout"] = "7s"
 
@@ -121,9 +117,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 
 	t.Run("connection pooling isolation", func(t *testing.T) {
 		// Connection 1 with lock_timeout=11s
-		connCfg1, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr1 := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg1, err := pgx.ParseConfig(connStr1)
 		require.NoError(t, err)
 		connCfg1.RuntimeParams["lock_timeout"] = "11s"
 
@@ -132,9 +127,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 		defer conn1.Close(ctx)
 
 		// Connection 2 with lock_timeout=22s
-		connCfg2, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr2 := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg2, err := pgx.ParseConfig(connStr2)
 		require.NoError(t, err)
 		connCfg2.RuntimeParams["lock_timeout"] = "22s"
 
@@ -158,9 +152,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 
 	t.Run("server_version unchanged", func(t *testing.T) {
 		// Get baseline server_version without startup params
-		baselineCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		baselineConnStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		baselineCfg, err := pgx.ParseConfig(baselineConnStr)
 		require.NoError(t, err)
 
 		baselineConn, err := pgx.ConnectConfig(ctx, baselineCfg)
@@ -171,9 +164,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 		baselineConn.Close(ctx)
 
 		// Connect with startup params and verify server_version is the same
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["TimeZone"] = "US/Eastern"
 
@@ -188,9 +180,8 @@ func TestMultiGateway_StartupParamForwarding(t *testing.T) {
 	})
 
 	t.Run("invalid startup parameter allows connection but fails queries", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["completely_invalid_guc_12345"] = "some_value"
 
@@ -222,9 +213,7 @@ func TestMultiGateway_PGOPTIONSMultipleFlags(t *testing.T) {
 	ctx := utils.WithTimeout(t, 150*time.Second)
 
 	t.Run("single -c flag via lib/pq", func(t *testing.T) {
-		connStr := fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5 options='-c work_mem=64MB'",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5", "options='-c work_mem=64MB'")
 
 		db, err := sql.Open("postgres", connStr)
 		require.NoError(t, err)
@@ -237,9 +226,7 @@ func TestMultiGateway_PGOPTIONSMultipleFlags(t *testing.T) {
 	})
 
 	t.Run("multiple -c flags", func(t *testing.T) {
-		connStr := fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5 options='-c work_mem=32MB -c lock_timeout=5s'",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5", "options='-c work_mem=32MB -c lock_timeout=5s'")
 
 		db, err := sql.Open("postgres", connStr)
 		require.NoError(t, err)
@@ -257,9 +244,7 @@ func TestMultiGateway_PGOPTIONSMultipleFlags(t *testing.T) {
 	})
 
 	t.Run("--key=value with hyphen-to-underscore", func(t *testing.T) {
-		connStr := fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5 options='--statement-timeout=10s'",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5", "options='--statement-timeout=10s'")
 
 		db, err := sql.Open("postgres", connStr)
 		require.NoError(t, err)
@@ -272,9 +257,7 @@ func TestMultiGateway_PGOPTIONSMultipleFlags(t *testing.T) {
 	})
 
 	t.Run("mixed -c and -- formats", func(t *testing.T) {
-		connStr := fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5 options='-c work_mem=48MB --lock-timeout=3s'",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5", "options='-c work_mem=48MB --lock-timeout=3s'")
 
 		db, err := sql.Open("postgres", connStr)
 		require.NoError(t, err)

--- a/go/test/endtoend/queryserving/statement_timeout_test.go
+++ b/go/test/endtoend/queryserving/statement_timeout_test.go
@@ -17,7 +17,6 @@ package queryserving
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -356,9 +355,8 @@ func TestMultiGateway_StatementTimeoutStartupParam(t *testing.T) {
 	ctx := utils.WithTimeout(t, 150*time.Second)
 
 	t.Run("startup param sets default", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["statement_timeout"] = "2000"
 
@@ -373,9 +371,8 @@ func TestMultiGateway_StatementTimeoutStartupParam(t *testing.T) {
 	})
 
 	t.Run("SET overrides startup param", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["statement_timeout"] = "2000"
 
@@ -393,9 +390,8 @@ func TestMultiGateway_StatementTimeoutStartupParam(t *testing.T) {
 	})
 
 	t.Run("RESET reverts to startup param default", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["statement_timeout"] = "7000"
 
@@ -416,9 +412,8 @@ func TestMultiGateway_StatementTimeoutStartupParam(t *testing.T) {
 	})
 
 	t.Run("startup param enforces timeout", func(t *testing.T) {
-		connCfg, err := pgx.ParseConfig(fmt.Sprintf(
-			"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-			setup.MultigatewayPgPort, shardsetup.TestPostgresPassword))
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
 		require.NoError(t, err)
 		connCfg.RuntimeParams["statement_timeout"] = "500"
 
@@ -442,8 +437,7 @@ func TestMultiGateway_StatementTimeoutStartupParam(t *testing.T) {
 // connectPgx creates a pgx connection to the multigateway (extended query protocol).
 func connectPgx(t *testing.T, ctx context.Context, setup *shardsetup.ShardSetup) *pgx.Conn {
 	t.Helper()
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
 	conn, err := pgx.Connect(ctx, connStr)
 	require.NoError(t, err, "failed to connect with pgx")
 	return conn
@@ -455,7 +449,7 @@ func connectClient(t *testing.T, ctx context.Context, setup *shardsetup.ShardSet
 	conn, err := client.Connect(ctx, ctx, &client.Config{
 		Host:        "localhost",
 		Port:        setup.MultigatewayPgPort,
-		User:        "postgres",
+		User:        shardsetup.DefaultTestUser,
 		Password:    shardsetup.TestPostgresPassword,
 		Database:    "postgres",
 		DialTimeout: 5 * time.Second,

--- a/go/test/endtoend/queryserving/transaction_test.go
+++ b/go/test/endtoend/queryserving/transaction_test.go
@@ -72,7 +72,7 @@ func runTransactionTests(t *testing.T, setup *shardsetup.ShardSetup, testCases [
 			conn, err := client.Connect(ctx, ctx, &client.Config{
 				Host:        "localhost",
 				Port:        setup.MultigatewayPgPort,
-				User:        "postgres",
+				User:        shardsetup.DefaultTestUser,
 				Password:    shardsetup.TestPostgresPassword,
 				Database:    "postgres",
 				DialTimeout: 5 * time.Second,
@@ -89,7 +89,7 @@ func runTransactionTests(t *testing.T, setup *shardsetup.ShardSetup, testCases [
 				cleanupConn, cleanupErr := client.Connect(cleanupCtx, cleanupCtx, &client.Config{
 					Host:        "localhost",
 					Port:        setup.MultigatewayPgPort,
-					User:        "postgres",
+					User:        shardsetup.DefaultTestUser,
 					Password:    shardsetup.TestPostgresPassword,
 					Database:    "postgres",
 					DialTimeout: 5 * time.Second,

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -35,6 +35,12 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
+const (
+	// DefaultTestUser is the PostgreSQL user that tests use when connecting to
+	// multigateway or multipooler as a regular client.
+	DefaultTestUser = "postgres"
+)
+
 // MultipoolerInstance represents a multipooler instance, which is a pair of pgctld + multipooler processes.
 // In multigres, a multipooler always has both: pgctld manages PostgreSQL, multipooler handles pooling.
 type MultipoolerInstance struct {
@@ -371,8 +377,7 @@ func (s *ShardSetup) CreateMultigatewayInstance(t *testing.T, name string, pgPor
 func (s *ShardSetup) WaitForMultigatewayQueryServing(t *testing.T) {
 	t.Helper()
 
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=2",
-		s.MultigatewayPgPort, TestPostgresPassword)
+	connStr := GetTestUserDSN("localhost", s.MultigatewayPgPort, "sslmode=disable", "connect_timeout=2")
 
 	ctx := utils.WithTimeout(t, 60*time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/go/test/endtoend/shardsetup/multigateway_test.go
+++ b/go/test/endtoend/shardsetup/multigateway_test.go
@@ -46,8 +46,7 @@ func TestMultigatewaySetup(t *testing.T) {
 	require.Greater(t, setup.MultigatewayPgPort, 0, "multigateway PG port should be allocated")
 
 	// Connect to multigateway
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, TestPostgresPassword)
+	connStr := GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err, "failed to open database connection")
 	defer db.Close()

--- a/go/test/endtoend/shardsetup/shardsetup_test.go
+++ b/go/test/endtoend/shardsetup/shardsetup_test.go
@@ -266,8 +266,7 @@ func TestShardSetup_WriterValidator(t *testing.T) {
 
 	// Connect to multigateway for writes (realistic client path)
 	require.NotNil(t, setup.Multigateway, "multigateway should be available in shared setup")
-	gatewayConnStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
-		setup.MultigatewayPgPort, TestPostgresPassword)
+	gatewayConnStr := GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
 	gatewayDB, err := sql.Open("postgres", gatewayConnStr)
 	require.NoError(t, err)
 	defer gatewayDB.Close()

--- a/go/test/endtoend/shardsetup/testmain.go
+++ b/go/test/endtoend/shardsetup/testmain.go
@@ -95,10 +95,12 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/tools/pathutil"
 	"github.com/multigres/multigres/go/tools/telemetry"
 )
@@ -108,6 +110,23 @@ const (
 	// This is set via PGPASSWORD env var before pgctld initializes PostgreSQL.
 	TestPostgresPassword = "test_password_123"
 )
+
+// GetTestUserDSN returns a DSN for connecting to multigateway as a regular
+// test client. Uses DefaultTestUser and TestPostgresPassword.
+func GetTestUserDSN(host string, port int, args ...string) string {
+	return fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=postgres %s",
+		host, port, DefaultTestUser, TestPostgresPassword, strings.Join(args, " "))
+}
+
+// GetPostgresDSN returns a DSN for connecting directly to PostgreSQL as the
+// cluster owner (DefaultPostgresUser). Used for pgctld-level test connections
+// that bypass multigateway (e.g. backup restore verification).
+func GetPostgresDSN(host string, port int, args ...string) string {
+	return fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=postgres %s",
+		host, port, constants.DefaultPostgresUser, TestPostgresPassword, strings.Join(args, " "))
+}
 
 // SetupFunc is a function that creates a ShardSetup for testing.
 // It receives a testing.T that can be used for logging during setup.


### PR DESCRIPTION
Introduce semantic DSN helpers: GetTestUserDSN for test-client connections via multigateway, GetPostgresDSN for pgctld-level direct PostgreSQL connections. Simplify notice test helpers.

Add environment variables `POSTGRES_USER` and `POSTGRES_PASSWORD`. RunTestMain reads `POSTGRES_PASSWORD` (falling back to TestPostgresPassword) and sets `PGPASSWORD` for postgres binary invocations. `POSTGRES_USER` is set if not already present so `pgctld` subprocesses inherit it.

The `POSTGRES_USER` environment variable is wired to the `pgctld` flag `--pg-user` and the CLI flag takes precedence when both the flag and the environment variable is set.
