### PR TITLE
feat(pgctld): add POSTGRES_USER and POSTGRES_PASSWORD env var support

### DIFF
--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/multigres/multigres/go/services/pgctld"
 
@@ -58,8 +57,7 @@ start the PostgreSQL server. Configuration can be provided via config file,
 environment variables, or CLI flags. CLI flags take precedence over config
 file and environment variable settings.
 
-Password can be set via PGPASSWORD environment variable or by placing a
-password file at <pooler-dir>/pgpassword.txt.
+Password can be set via the POSTGRES_PASSWORD environment variable.
 
 Examples:
   # Initialize data directory
@@ -80,7 +78,7 @@ Examples:
 }
 
 // InitDataDirWithResult initializes PostgreSQL data directory and returns detailed result information
-func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pgUser string) (*InitResult, error) {
+func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pgUser string, pgPassword string) (*InitResult, error) {
 	result := &InitResult{}
 	dataDir := pgctld.PostgresDataDir(poolerDir)
 
@@ -93,7 +91,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 	}
 
 	logger.Info("Initializing PostgreSQL data directory", "data_dir", dataDir)
-	if err := initializeDataDir(logger, poolerDir, pgUser); err != nil {
+	if err := initializeDataDir(logger, poolerDir, pgUser, pgPassword); err != nil {
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}
 	// create server config using the pooler directory
@@ -110,7 +108,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
-	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, i.pgCtlCmd.pgPort.Get(), i.pgCtlCmd.pgUser.Get())
+	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, i.pgCtlCmd.pgPort.Get(), i.pgCtlCmd.pgUser.Get(), i.pgCtlCmd.pgPassword.Get())
 	if err != nil {
 		return err
 	}
@@ -125,27 +123,12 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) error {
+func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string, pgPassword string) error {
 	// Derive dataDir from poolerDir using the standard convention
 	dataDir := pgctld.PostgresDataDir(poolerDir)
 
 	// Note: initdb will create the data directory itself if it doesn't exist.
 	// We don't create it beforehand to avoid leaving empty directories if initdb fails.
-
-	// Get the effective password and validate it
-	effectivePassword, err := resolvePassword(poolerDir)
-	if err != nil {
-		return fmt.Errorf("failed to resolve password: %w", err)
-	}
-
-	// Determine password source for logging
-	pwfile := filepath.Join(poolerDir, "pgpassword.txt")
-	passwordSource := "default"
-	if _, err := os.Stat(pwfile); err == nil {
-		passwordSource = "password file"
-	} else if os.Getenv("PGPASSWORD") != "" {
-		passwordSource = "PGPASSWORD environment variable"
-	}
 
 	// Build initdb command
 	// It's generally a good idea to enable page data checksums. Furthermore,
@@ -156,7 +139,7 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 
 	// If password is provided, create a temporary password file for initdb
 	var tempPwFile string
-	if effectivePassword != "" {
+	if pgPassword != "" {
 		// Create temporary password file
 		tmpFile, err := os.CreateTemp("", "pgpassword-*.txt")
 		if err != nil {
@@ -165,7 +148,7 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 		tempPwFile = tmpFile.Name()
 		defer os.Remove(tempPwFile)
 
-		if _, err := tmpFile.WriteString(effectivePassword); err != nil {
+		if _, err := tmpFile.WriteString(pgPassword); err != nil {
 			tmpFile.Close()
 			return fmt.Errorf("failed to write password to temporary file: %w", err)
 		}
@@ -175,7 +158,7 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 
 		// Add pwfile argument to initdb
 		args = append(args, "--pwfile="+tempPwFile)
-		logger.Info("Setting password during initdb", "user", pgUser, "password_source", passwordSource)
+		logger.Info("Setting password during initdb", "user", pgUser, "password_source", "POSTGRES_PASSWORD environment variable")
 	} else {
 		logger.Warn("No password provided - skipping password setup", "user", pgUser, "warning", "PostgreSQL user will not have password authentication enabled")
 	}
@@ -189,8 +172,8 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 	}
 	logger.Info("initdb completed successfully", "output", string(output))
 
-	if effectivePassword != "" {
-		logger.Info("User password set successfully", "user", pgUser, "password_source", passwordSource)
+	if pgPassword != "" {
+		logger.Info("User password set successfully", "user", pgUser, "password_source", "POSTGRES_PASSWORD environment variable")
 	}
 
 	return nil

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -34,11 +34,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// PgCtlCommand holds the configuration for pgctld commands
+// PgCtlCommand holds the configuration for pgctld commands.
+// This contains all flags and information necessary to run any pgctld command.
 type PgCtlCommand struct {
 	reg                *viperutil.Registry
 	pgDatabase         viperutil.Value[string]
 	pgUser             viperutil.Value[string]
+	pgPassword         viperutil.Value[string]
 	poolerDir          viperutil.Value[string]
 	timeout            viperutil.Value[int]
 	pgPort             viperutil.Value[int]
@@ -65,7 +67,14 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 		pgUser: viperutil.Configure(reg, "pg-user", viperutil.Options[string]{
 			Default:  constants.DefaultPostgresUser,
 			FlagName: "pg-user",
+			EnvVars:  []string{constants.PgUserEnvVar},
 			Dynamic:  false,
+		}),
+		pgPassword: viperutil.Configure(reg, "pg-password", viperutil.Options[string]{
+			Default: "",
+			EnvVars: []string{constants.PgPasswordEnvVar},
+			Dynamic: false,
+			// No FlagName — env var only, no CLI flag
 		}),
 		timeout: viperutil.Configure(reg, "timeout", viperutil.Options[int]{
 			Default:  30,
@@ -136,7 +145,7 @@ management for PostgreSQL servers.`,
 	}
 
 	root.PersistentFlags().StringP("pg-database", "D", pc.pgDatabase.Default(), "PostgreSQL database name")
-	root.PersistentFlags().StringP("pg-user", "U", pc.pgUser.Default(), "PostgreSQL username")
+	root.PersistentFlags().StringP("pg-user", "U", pc.pgUser.Default(), "PostgreSQL username (overrides "+constants.PgUserEnvVar+" env var)")
 	root.PersistentFlags().IntP("timeout", "t", pc.timeout.Default(), "Operation timeout in seconds")
 	root.PersistentFlags().String("pooler-dir", pc.poolerDir.Default(), "The directory to multipooler data")
 	root.PersistentFlags().IntP("pg-port", "p", pc.pgPort.Default(), "PostgreSQL port")
@@ -150,6 +159,7 @@ management for PostgreSQL servers.`,
 	viperutil.BindFlags(root.PersistentFlags(),
 		pc.pgDatabase,
 		pc.pgUser,
+		pc.pgPassword,
 		pc.timeout,
 		pc.poolerDir,
 		pc.pgPort,

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -147,6 +147,7 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 		s.pgCtlCmd.pgPort.Get(),
 		s.pgCtlCmd.pgUser.Get(),
 		s.pgCtlCmd.pgDatabase.Get(),
+		s.pgCtlCmd.pgPassword.Get(),
 		s.pgCtlCmd.timeout.Get(),
 		poolerDir,
 		s.pgCtlCmd.pgListenAddresses.Get(),
@@ -212,6 +213,7 @@ type PgCtldService struct {
 	pgPort     int
 	pgUser     string
 	pgDatabase string
+	pgPassword string
 	timeout    int
 	poolerDir  string
 	config     *pgctld.PostgresCtlConfig
@@ -238,6 +240,7 @@ func NewPgCtldService(
 	pgPort int,
 	pgUser string,
 	pgDatabase string,
+	pgPassword string,
 	timeout int,
 	poolerDir string,
 	listenAddresses string,
@@ -311,6 +314,7 @@ func NewPgCtldService(
 		pgPort:     pgPort,
 		pgUser:     pgUser,
 		pgDatabase: pgDatabase,
+		pgPassword: pgPassword,
 		timeout:    timeout,
 		poolerDir:  poolerDir,
 		config:     config,
@@ -647,7 +651,7 @@ func (s *PgCtldService) InitDataDir(ctx context.Context, req *pb.InitDataDirRequ
 	s.logger.InfoContext(ctx, "gRPC InitDataDir request")
 
 	// Use the shared init function with detailed result
-	result, err := InitDataDirWithResult(s.logger, s.poolerDir, s.pgPort, s.pgUser)
+	result, err := InitDataDirWithResult(s.logger, s.poolerDir, s.pgPort, s.pgUser, s.pgPassword)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}
@@ -678,12 +682,6 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 		}
 	}
 
-	// Resolve password using existing function
-	password, err := resolvePassword(s.poolerDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve password: %w", err)
-	}
-
 	// Construct source server connection string (without password - will use PGPASSWORD env var)
 	// Include application_name if provided (used for replication identification)
 	sourceServer := fmt.Sprintf("host=%s port=%d user=postgres dbname=postgres",
@@ -693,7 +691,7 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	}
 
 	// Use the shared rewind function with detailed result, passing password separately
-	result, err := PgRewindWithResult(ctx, s.logger, s.poolerDir, sourceServer, password, req.GetDryRun(), req.GetExtraArgs())
+	result, err := PgRewindWithResult(ctx, s.logger, s.poolerDir, sourceServer, s.pgPassword, req.GetDryRun(), req.GetExtraArgs())
 	if err != nil {
 		s.logger.ErrorContext(ctx, "pg_rewind output", "output", result.Output)
 		return nil, fmt.Errorf("failed to rewind PostgreSQL: %w", err)

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -30,7 +30,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -136,7 +138,7 @@ func TestPgCtldServiceStart(t *testing.T) {
 				t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 			}
 
-			service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+			service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 			require.NoError(t, err)
 
 			resp, err := service.Start(context.Background(), tt.request)
@@ -160,7 +162,7 @@ func TestPgCtldServiceStart(t *testing.T) {
 
 func TestPgCtldServiceStart_MissingPoolerDir(t *testing.T) {
 	t.Run("missing pooler-dir", func(t *testing.T) {
-		_, err := NewPgCtldService(testLogger(), 0, "", "", 0, "", "", 0, "")
+		_, err := NewPgCtldService(testLogger(), 0, "", "", "", 0, "", "", 0, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "pooler-dir needs to be set")
 	})
@@ -225,7 +227,7 @@ func TestPgCtldServiceStop(t *testing.T) {
 				t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 			}
 
-			service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+			service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 			require.NoError(t, err)
 
 			resp, err := service.Stop(context.Background(), tt.request)
@@ -290,7 +292,7 @@ func TestPgCtldServiceStatus(t *testing.T) {
 
 			_ = tt.setupDataDir(baseDir)
 
-			service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+			service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 			require.NoError(t, err)
 
 			resp, err := service.Status(context.Background(), tt.request)
@@ -319,7 +321,7 @@ func TestPgCtldServiceRestart(t *testing.T) {
 
 		poolerDir := baseDir
 
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.RestartRequest{
@@ -351,7 +353,7 @@ func TestPgCtldServiceReloadConfig(t *testing.T) {
 		dataDir := testutil.CreateDataDir(t, baseDir, true)
 		testutil.CreatePIDFile(t, dataDir, 12345)
 
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.ReloadConfigRequest{}
@@ -372,7 +374,7 @@ func TestPgCtldServiceReloadConfig(t *testing.T) {
 		testutil.CreateDataDir(t, baseDir, true)
 		// No PID file = not running
 
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.ReloadConfigRequest{}
@@ -395,7 +397,7 @@ func TestPgCtldServiceVersion(t *testing.T) {
 		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 		poolerDir := baseDir
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.VersionRequest{
@@ -423,7 +425,7 @@ func TestPgCtldServiceInitDataDir(t *testing.T) {
 		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 		poolerDir := baseDir
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.InitDataDirRequest{
@@ -445,7 +447,7 @@ func TestPgCtldServiceInitDataDir(t *testing.T) {
 		_ = testutil.CreateDataDir(t, baseDir, true)
 
 		poolerDir := baseDir
-		service, err := NewPgCtldService(testLogger(), 5432, "postgres", "postgres", 30, poolerDir, "localhost", 0, "")
+		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
 		request := &pb.InitDataDirRequest{}
@@ -492,7 +494,7 @@ func TestGetPoolerDir(t *testing.T) {
 func TestPgCtldService_PgBackRestFields(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	service, err := NewPgCtldService(logger, 5432, "postgres", "postgres", 60, t.TempDir(), "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, t.TempDir(), "localhost", 0, "")
 	require.NoError(t, err)
 
 	// Verify service has pgBackRest management fields
@@ -502,7 +504,7 @@ func TestPgCtldService_PgBackRestFields(t *testing.T) {
 
 func TestPgCtldService_StatusMethods(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	service, err := NewPgCtldService(logger, 5432, "postgres", "postgres", 60, t.TempDir(), "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, t.TempDir(), "localhost", 0, "")
 	require.NoError(t, err)
 	defer service.Close()
 
@@ -530,7 +532,7 @@ func TestPgCtldService_StartPgBackRest_ValidationErrors(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
 
-	service, err := NewPgCtldService(logger, 5432, "postgres", "postgres", 60, tmpDir, "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
 	defer service.Close()
 
@@ -544,7 +546,7 @@ func TestPgCtldService_ManagePgBackRest_Lifecycle(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
 
-	service, err := NewPgCtldService(logger, 5432, "postgres", "postgres", 60, tmpDir, "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
 
 	// Create minimal config to prevent immediate failure
@@ -575,7 +577,7 @@ func TestPgCtldService_Status_IncludesPgBackRest(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
 
-	service, err := NewPgCtldService(logger, 5432, "postgres", "postgres", 60, tmpDir, "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
 	defer service.Close()
 

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -55,36 +55,6 @@ func NewPostgresCtlConfigFromDefaults(poolerDir string, pgPort int, pgListenAddr
 	return config, nil
 }
 
-// resolvePassword handles password resolution from file or environment variable.
-// It checks for a password file at the conventional location (poolerDir/pgpassword.txt).
-// If the file exists, it reads the password from it. Otherwise, it falls back to PGPASSWORD env var.
-// Returns error if both password file and PGPASSWORD are set.
-func resolvePassword(poolerDir string) (string, error) {
-	envPassword := os.Getenv("PGPASSWORD")
-	var filePassword string
-	var fileExists bool
-
-	// Check for password file at conventional location
-	pwfile := filepath.Join(poolerDir, "pgpassword.txt")
-	if filePasswordBytes, readErr := os.ReadFile(pwfile); readErr == nil {
-		// Remove trailing newline if present
-		filePassword = strings.TrimRight(string(filePasswordBytes), "\n\r")
-		fileExists = true
-	}
-
-	// Check if both file and environment variable are set
-	if fileExists && envPassword != "" {
-		return "", fmt.Errorf("both password file (%s) and PGPASSWORD environment variable are set, please use only one", pwfile)
-	}
-
-	// Use file password if set, otherwise use environment variable
-	if fileExists {
-		return filePassword, nil
-	}
-
-	return envPassword, nil
-}
-
 // AddStartCommand adds the start subcommand to the root command
 func AddStartCommand(root *cobra.Command, pc *PgCtlCommand) {
 	startCmd := &PgCtlStartCmd{

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 )
 
 func TestRunStart(t *testing.T) {
@@ -209,7 +211,7 @@ func TestInitializeDataDir(t *testing.T) {
 		defer os.Setenv("PATH", originalPath)
 
 		logger := slog.New(slog.DiscardHandler)
-		err := initializeDataDir(logger, poolerDir, "postgres")
+		err := initializeDataDir(logger, poolerDir, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
 		require.NoError(t, err)
 
 		// Verify directory was created (dataDir is poolerDir/pg_data)
@@ -225,7 +227,7 @@ func TestInitializeDataDir(t *testing.T) {
 		poolerDir := "/root/impossible_dir"
 
 		logger := slog.New(slog.DiscardHandler)
-		err := initializeDataDir(logger, poolerDir, "postgres")
+		err := initializeDataDir(logger, poolerDir, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "initdb failed")
 	})
@@ -311,8 +313,8 @@ func TestWaitForPostgreSQL(t *testing.T) {
 		// Create config that matches the test setup
 		config, err := pgctld.NewPostgresCtlConfig(
 			5432,
-			"postgres",
-			"postgres",
+			constants.DefaultPostgresUser,
+			constants.DefaultPostgresDatabase,
 			30, // timeout
 			pgctld.PostgresDataDir(baseDir),
 			pgctld.PostgresConfigFile(baseDir),

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 )
 
@@ -120,7 +121,7 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 			poolerDir := baseDir
 			pgDataDir := pgctld.PostgresDataDir(poolerDir)
 			pgConfigFile := pgctld.PostgresConfigFile(poolerDir)
-			config, err := pgctld.NewPostgresCtlConfig(5432, "postgres", "postgres", 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
+			config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
 			require.NoError(t, err)
 
 			logger := slog.New(slog.DiscardHandler)
@@ -290,7 +291,7 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 			pgDataDir := pgctld.PostgresDataDir(poolerDir)
 			pgConfigFile := pgctld.PostgresConfigFile(poolerDir)
 
-			config, err := pgctld.NewPostgresCtlConfig(5432, "postgres", "postgres", 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
+			config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
 			require.NoError(t, err)
 
 			logger := slog.New(slog.DiscardHandler)
@@ -319,7 +320,7 @@ func TestTakeCheckpoint(t *testing.T) {
 			config: func(baseDir string) *pgctld.PostgresCtlConfig {
 				pgDataDir := pgctld.PostgresDataDir(baseDir)
 				pgConfigFile := pgctld.PostgresConfigFile(baseDir)
-				config, err := pgctld.NewPostgresCtlConfig(5432, "postgres", "postgres", 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
+				config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
 				require.NoError(t, err)
 				return config
 			},
@@ -331,7 +332,7 @@ func TestTakeCheckpoint(t *testing.T) {
 			config: func(baseDir string) *pgctld.PostgresCtlConfig {
 				pgDataDir := pgctld.PostgresDataDir(baseDir)
 				pgConfigFile := pgctld.PostgresConfigFile(baseDir)
-				config, err := pgctld.NewPostgresCtlConfig(5432, "postgres", "postgres", 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
+				config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
 				require.NoError(t, err)
 				return config
 			},

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -21,8 +21,15 @@ import "time"
 // they represent different concepts that could diverge in the future.
 const (
 	// DefaultPostgresUser is the default PostgreSQL superuser name.
-	// This is the administrative user that owns the database cluster.
+	// This is the administrative user that owns the database cluster and is used
+	// by pgctld for all internal operations.
 	DefaultPostgresUser = "postgres"
+
+	// PgUserEnvVar is the environment variable for the PostgreSQL role used by pgctld.
+	PgUserEnvVar = "POSTGRES_USER"
+
+	// PgPasswordEnvVar is the environment variable for the PostgreSQL password.
+	PgPasswordEnvVar = "POSTGRES_PASSWORD" //nolint:gosec // This is an env var name, not a credential
 
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.

--- a/go/test/endtoend/pgctld/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld/pgctld_grpc_test.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/command"
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/tools/grpccommon"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
@@ -424,8 +426,9 @@ func TestGRPCPortableConfig(t *testing.T) {
 		service, err := command.NewPgCtldService(
 			slog.Default(),
 			initialPort,
-			"postgres",
-			"postgres",
+			constants.DefaultPostgresUser,
+			constants.DefaultPostgresDatabase,
+			shardsetup.TestPostgresPassword,
 			30,
 			dataDir,
 			"localhost",
@@ -449,8 +452,9 @@ func TestGRPCPortableConfig(t *testing.T) {
 		service2, err := command.NewPgCtldService(
 			slog.Default(),
 			differentPort,
-			"postgres",
-			"postgres",
+			constants.DefaultPostgresUser,
+			constants.DefaultPostgresDatabase,
+			shardsetup.TestPostgresPassword,
 			30,
 			dataDir,
 			"localhost",
@@ -478,8 +482,9 @@ func createTestGRPCServer(t *testing.T, dataDir, binDir string) (net.Listener, f
 	service, err := command.NewPgCtldService(
 		slog.Default(),
 		5432,
-		"postgres",
-		"postgres",
+		constants.DefaultPostgresUser,
+		constants.DefaultPostgresDatabase,
+		shardsetup.TestPostgresPassword,
 		30,
 		dataDir,
 		"localhost",

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -62,6 +62,12 @@ func setupTestEnv(cmd *exec.Cmd) {
 	}
 }
 
+// setupTestEnvWithPassword sets up environment variables for PostgreSQL tests, including the password.
+func setupTestEnvWithPassword(cmd *exec.Cmd, password string) {
+	setupTestEnv(cmd)
+	cmd.Env = append(cmd.Env, "POSTGRES_PASSWORD="+password)
+}
+
 // TestEndToEndWithRealPostgreSQL tests pgctld with real PostgreSQL binaries
 // This test requires PostgreSQL to be installed on the system
 func TestEndToEndWithRealPostgreSQL(t *testing.T) {
@@ -491,7 +497,7 @@ timeout: 30
 	require.NoError(t, err)
 }
 
-// TestPostgreSQLAuthentication tests PostgreSQL authentication with PGPASSWORD
+// TestPostgreSQLAuthentication tests PostgreSQL authentication with POSTGRES_PASSWORD
 func TestPostgreSQLAuthentication(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping authentication tests in short mode")
@@ -519,13 +525,13 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		// Test password
 		testPassword := "secure_test_password_123"
 
-		// Initialize with PGPASSWORD
-		t.Logf("Initializing PostgreSQL with PGPASSWORD")
+		// Initialize with POSTGRES_PASSWORD
+		t.Logf("Initializing PostgreSQL with POSTGRES_PASSWORD")
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
 
 		initCmd.Env = append(os.Environ(),
 			"PGCONNECT_TIMEOUT=5",
-			"PGPASSWORD="+testPassword,
+			"POSTGRES_PASSWORD="+testPassword,
 		)
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
 		if runtime.GOOS == "darwin" {
@@ -534,14 +540,14 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 
 		output, err := initCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld init should succeed, output: %s", string(output))
-		assert.Contains(t, string(output), "\"password_source\":\"PGPASSWORD environment variable\"", "Should use PGPASSWORD")
+		assert.Contains(t, string(output), "\"password_source\":\"POSTGRES_PASSWORD environment variable\"", "Should use POSTGRES_PASSWORD")
 
 		// Start the PostgreSQL server
 		t.Logf("Starting PostgreSQL server")
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
 		startCmd.Env = append(os.Environ(),
 			"PGCONNECT_TIMEOUT=5",
-			"PGPASSWORD="+testPassword,
+			"POSTGRES_PASSWORD="+testPassword,
 		)
 
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
@@ -652,103 +658,6 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		stopCmd.Env = append(os.Environ(), "PGCONNECT_TIMEOUT=5")
 		err = stopCmd.Run()
 		require.NoError(t, err, "pgctld stop should succeed")
-	})
-
-	t.Run("password_file_authentication", func(t *testing.T) {
-		// Set up temporary directory
-		baseDir, cleanup := testutil.TempDir(t, "pgctld_pwfile_test")
-		defer cleanup()
-
-		// Use cached pgctld binary for testing
-
-		// Get available port for PostgreSQL
-		port := utils.GetFreePort(t)
-		t.Logf("Password file test using port: %d", port)
-
-		// Test password
-		testPassword := "file_password_secure_456"
-
-		// Create password file at conventional location (poolerDir/pgpassword.txt)
-		pwfile := filepath.Join(baseDir, "pgpassword.txt")
-		err := os.WriteFile(pwfile, []byte(testPassword), 0o600)
-		require.NoError(t, err, "Should create password file")
-
-		// Build environment without PGPASSWORD to avoid conflicts with password file
-		cleanEnv := make([]string, 0, len(os.Environ()))
-		for _, env := range os.Environ() {
-			if !strings.HasPrefix(env, "PGPASSWORD=") {
-				cleanEnv = append(cleanEnv, env)
-			}
-		}
-		cleanEnv = append(cleanEnv, "PGCONNECT_TIMEOUT=5")
-
-		// Required to avoid "postmaster became multithreaded during startup" on macOS
-		if runtime.GOOS == "darwin" {
-			cleanEnv = append(cleanEnv, "LC_ALL=en_US.UTF-8")
-		}
-
-		// Initialize - pgctld will find password file at conventional location
-		t.Logf("Initializing PostgreSQL with password file at conventional location")
-		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
-		initCmd.Env = cleanEnv
-		output, err := initCmd.CombinedOutput()
-		require.NoError(t, err, "pgctld init should succeed, output: %s", string(output))
-		assert.Contains(t, string(output), "\"password_source\":\"password file\"", "Should use password file")
-
-		// Start the PostgreSQL server
-		t.Logf("Starting PostgreSQL server")
-		startCmd := exec.Command("pgctld", "start", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
-		startCmd.Env = cleanEnv
-		output, err = startCmd.CombinedOutput()
-		require.NoError(t, err, "pgctld start should succeed, output: %s", string(output))
-
-		// Give the server a moment to be fully ready
-		time.Sleep(2 * time.Second)
-
-		// Test TCP connection with password from file
-		t.Logf("Testing TCP connection with password from file")
-		tcpCmd := exec.Command("psql",
-			"-h", "localhost",
-			"-p", strconv.Itoa(port),
-			"-U", "postgres",
-			"-d", "postgres",
-			"-c", "SELECT 'Password file authentication works!' as result;",
-		)
-		tcpCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
-		output, err = tcpCmd.CombinedOutput()
-		require.NoError(t, err, "TCP connection with password from file should succeed, output: %s", string(output))
-		assert.Contains(t, string(output), "Password file authentication works!", "Should connect successfully")
-
-		// Clean shutdown
-		t.Logf("Shutting down PostgreSQL")
-		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", baseDir)
-		stopCmd.Env = cleanEnv
-		err = stopCmd.Run()
-		require.NoError(t, err, "pgctld stop should succeed")
-	})
-
-	t.Run("password_source_conflict", func(t *testing.T) {
-		// Set up temporary directory
-		baseDir, cleanup := testutil.TempDir(t, "pgctld_conflict_test")
-		defer cleanup()
-
-		// Use cached pgctld binary for testing
-
-		// Create password file at conventional location
-		pwfile := filepath.Join(baseDir, "pgpassword.txt")
-		err := os.WriteFile(pwfile, []byte("file_password"), 0o600)
-		require.NoError(t, err, "Should create password file")
-
-		// Try to initialize with both PGPASSWORD and password file at conventional location (should fail)
-		t.Logf("Testing conflict between PGPASSWORD and password file")
-		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir)
-		initCmd.Env = append(os.Environ(),
-			"PGCONNECT_TIMEOUT=5",
-			"PGPASSWORD=env_password",
-		)
-		output, err := initCmd.CombinedOutput()
-		assert.Error(t, err, "pgctld init should fail with both password sources")
-		assert.Contains(t, string(output), "both password file", "Should show conflict error")
 	})
 }
 
@@ -1257,12 +1166,8 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 	err := os.WriteFile(primaryConfigFile, []byte("log-level: info\ntimeout: 30\n"), 0o644)
 	require.NoError(t, err)
 
-	// Create password file for primary
 	testPassword := "test_pg_rewind_password_123" //nolint:gosec // Test password, not a real credential
-	primaryPasswordFile := filepath.Join(primaryDir, "pgpassword.txt")
 	err = os.MkdirAll(primaryDir, 0o755)
-	require.NoError(t, err)
-	err = os.WriteFile(primaryPasswordFile, []byte(testPassword), 0o600)
 	require.NoError(t, err)
 
 	primaryGrpcPort := utils.GetFreePort(t)
@@ -1275,7 +1180,7 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		"--grpc-port", strconv.Itoa(primaryGrpcPort),
 		"--pg-port", strconv.Itoa(primaryPgPort),
 		"--config-file", primaryConfigFile)
-	setupTestEnv(primaryServerCmd)
+	setupTestEnvWithPassword(primaryServerCmd, testPassword)
 	require.NoError(t, primaryServerCmd.Start())
 	defer func() {
 		if primaryServerCmd.Process != nil {
@@ -1306,11 +1211,7 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 	err = os.WriteFile(standbyConfigFile, []byte("log-level: info\ntimeout: 30\n"), 0o644)
 	require.NoError(t, err)
 
-	// Create password file for standby (same password for rewind authentication)
-	standbyPasswordFile := filepath.Join(standbyDir, "pgpassword.txt")
 	err = os.MkdirAll(standbyDir, 0o755)
-	require.NoError(t, err)
-	err = os.WriteFile(standbyPasswordFile, []byte(testPassword), 0o600)
 	require.NoError(t, err)
 
 	standbyGrpcPort := utils.GetFreePort(t)
@@ -1323,7 +1224,7 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		"--grpc-port", strconv.Itoa(standbyGrpcPort),
 		"--pg-port", strconv.Itoa(standbyPgPort),
 		"--config-file", standbyConfigFile)
-	setupTestEnv(standbyServerCmd)
+	setupTestEnvWithPassword(standbyServerCmd, testPassword)
 	require.NoError(t, standbyServerCmd.Start())
 	defer func() {
 		if standbyServerCmd.Process != nil {

--- a/go/test/endtoend/pgctld/test_helpers.go
+++ b/go/test/endtoend/pgctld/test_helpers.go
@@ -32,8 +32,10 @@ import (
 
 	"github.com/multigres/multigres/go/cmd/pgctld/command"
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/provisioner/local"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/tools/grpccommon"
 )
 
@@ -212,8 +214,9 @@ func createTestGRPCServerWithPgBackRest(t *testing.T, setup *TestSetup) (net.Lis
 	service, err := command.NewPgCtldService(
 		slog.Default(),
 		setup.PgPort,
-		"postgres",
-		"postgres",
+		constants.DefaultPostgresUser,
+		constants.DefaultPostgresDatabase,
+		shardsetup.TestPostgresPassword,
 		30,
 		setup.DataDir,
 		"localhost",

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -251,7 +251,7 @@ func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, 
 		PgBackRestPort:    pgbackrestPort,
 		PgBackRestCertDir: pgbackrestCertDir,
 		BackupLocation:    backupLocation,
-		Environment:       append(os.Environ(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "PGPASSWORD="+TestPostgresPassword),
+		Environment:       append(os.Environ(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "POSTGRES_PASSWORD="+TestPostgresPassword),
 	}
 }
 

--- a/go/test/endtoend/shardsetup/testmain.go
+++ b/go/test/endtoend/shardsetup/testmain.go
@@ -107,7 +107,6 @@ import (
 
 const (
 	// TestPostgresPassword is the password used for the postgres user in tests.
-	// This is set via PGPASSWORD env var before pgctld initializes PostgreSQL.
 	TestPostgresPassword = "test_password_123"
 )
 
@@ -161,9 +160,6 @@ func RunTestMain(m *testing.M) int {
 
 	// Set orphan detection environment variable as baseline protection
 	os.Setenv("MULTIGRES_TEST_PARENT_PID", strconv.Itoa(os.Getpid()))
-
-	// Set PGPASSWORD to a known value so tests can authenticate
-	os.Setenv("PGPASSWORD", TestPostgresPassword)
 
 	// Initialize telemetry (no-op if OTEL environment variables aren't set)
 	tel := telemetry.NewTelemetry()


### PR DESCRIPTION
Add `POSTGRES_USER` and `POSTGRES_PASSWORD` constants following the supabase/postgres convention. Wire `POSTGRES_USER` to the `--pg-user` flag and `POSTGRES_PASSWORD` to password handling in `pgctld` so both can be configured via environment without CLI flags (flags take precedence when both are set).

Replace the `resolvePassword()` mechanism (which checked `pgpassword.txt` and `PGPASSWORD`) with a single source: the `POSTGRES_PASSWORD` environment variable, wired through `PgCtlCommand.pgPassword` using viperutil. No CLI flag is exposed for the password.

Part of MUL-68