### PR TITLE
feat(multipooler): wire up PrimaryObservation in health stream at every consensus transition

### DIFF
--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -643,6 +643,17 @@ func (pm *MultiPoolerManager) checkAndSetReady() {
 		default:
 			close(pm.readyChan)
 		}
+
+		// Set initial primary observation from loaded consensus state.
+		// Use GetInconsistentTerm (safe without action lock) to read the term.
+		if pm.consensusState != nil {
+			if term, _ := pm.consensusState.GetInconsistentTerm(); term != nil && term.GetPrimaryTerm() > 0 {
+				pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
+					PrimaryID:   pm.serviceID,
+					PrimaryTerm: term.GetPrimaryTerm(),
+				})
+			}
+		}
 	}
 }
 

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -338,6 +338,8 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 				return mterrors.Wrap(err, "failed to clear primary_term after restore")
 			}
 		}
+		pm.healthStreamer.UpdatePrimaryObservation(nil)
+
 		return nil
 	}); err != nil {
 		return err

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -1354,6 +1354,15 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, updatedPooler.Type,
 					"Pooler type should be updated to REPLICA in topology")
+
+				// Verify health streamer reports the new primary (source)
+				healthState := pm.healthStreamer.getState()
+				require.NotNil(t, healthState.PrimaryObservation,
+					"health streamer should have primary observation pointing to new primary after DemoteStalePrimary")
+				assert.Equal(t, sourcePooler.Id, healthState.PrimaryObservation.PrimaryID,
+					"primary observation should point to the source (new primary)")
+				assert.Equal(t, tt.requestTerm, healthState.PrimaryObservation.PrimaryTerm,
+					"primary observation term should match the consensus term from the request")
 			}
 
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -31,6 +31,7 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 	"github.com/multigres/multigres/go/tools/retry"
 )
 
@@ -153,6 +154,11 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 			return nil, mterrors.Wrap(err, "failed to set primary term")
 		}
 	}
+
+	pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
+		PrimaryID:   pm.serviceID,
+		PrimaryTerm: req.ConsensusTerm,
+	})
 
 	// Create initial backup for standby initialization
 	pm.logger.InfoContext(ctx, "Creating initial backup for standby initialization", "shard", pm.getShardID())

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -32,6 +32,7 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 )
 
 // WaitForLSN waits for PostgreSQL server to reach a specific LSN position
@@ -993,6 +994,8 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 		return nil, err
 	}
 
+	pm.healthStreamer.UpdatePrimaryObservation(nil)
+
 	pm.logger.InfoContext(ctx, "Demote completed successfully",
 		"final_lsn", finalLSN,
 		"consensus_term", consensusTerm,
@@ -1147,6 +1150,12 @@ func (pm *MultiPoolerManager) DemoteStalePrimary(
 		return nil, mterrors.Wrap(err, "failed to clear primary term")
 	}
 
+	// Report the new primary (source) so the gateway can use this observation.
+	pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
+		PrimaryID:   source.Id,
+		PrimaryTerm: consensusTerm,
+	})
+
 	// Update consensus term to match the correct primary's term after successful demotion
 	if err := pm.updateTermIfNewer(ctx, consensusTerm); err != nil {
 		return nil, mterrors.Wrap(err, "failed to update consensus term")
@@ -1280,6 +1289,11 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 	if err := pm.consensusState.SetPrimaryTerm(ctx, consensusTerm, force); err != nil {
 		return nil, mterrors.Wrap(err, "failed to set primary term")
 	}
+
+	pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
+		PrimaryID:   pm.serviceID,
+		PrimaryTerm: consensusTerm,
+	})
 
 	// Write leadership history record - this validates that sync replication is working.
 	// If this fails (typically due to timeout waiting for standby acknowledgment), we fail

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -1182,6 +1182,12 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.multipooler.Type)
 	pm.mu.Unlock()
 
+	// Verify health streamer has primary observation with self as primary
+	healthState := pm.healthStreamer.getState()
+	require.NotNil(t, healthState.PrimaryObservation, "health streamer should have primary observation after Promote")
+	assert.Equal(t, serviceID, healthState.PrimaryObservation.PrimaryID, "primary observation should point to self")
+	assert.Equal(t, int64(10), healthState.PrimaryObservation.PrimaryTerm, "primary observation term should match consensus term")
+
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
The gateway's `selectPrimaryByTerm()` uses `PrimaryObservation` from pooler health streams for term-based primary reconciliation, but `UpdatePrimaryObservation()` was never called with real consensus data — only from tests. The health stream always sent `nil` for `PrimaryObservation`.

This PR wires up `UpdatePrimaryObservation()` alongside every `SetPrimaryTerm` call so the gateway receives real term-based primary info. The pattern is straightforward: when a pooler becomes primary (`SetPrimaryTerm(term > 0)`), it broadcasts `{self, term}`. When it stops being primary (`SetPrimaryTerm(0)`), it clears the observation or, in the case of `DemoteStalePrimary`, reports the new primary (`{source.Id, consensusTerm}`) since it knows who took over. At startup, `checkAndSetReady` sets the initial observation from loaded consensus state using `GetInconsistentTerm()`.

Six call sites across four files: `InitializeEmptyPrimary`, `Promote`, `DemoteStalePrimary`, `emergencyDemoteLocked`, restore from backup, and `checkAndSetReady`. Test assertions added to existing Promote and DemoteStalePrimary unit tests to verify the health streamer state after each operation.

Closes MUL-137