### PR TITLE
fix(pgctld,provisioner): move locale handling from pgctld to  the provisioner

### DIFF
--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/multigres/multigres/go/services/pgctld"
 
@@ -182,17 +181,6 @@ func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string) err
 	}
 
 	cmd := exec.Command("initdb", args...)
-
-	// On macOS, ensure locale environment variables are set for initdb.
-	// initdb requires valid locale settings to avoid "invalid locale settings" errors.
-	// This is specific to macOS where LC_ALL may not be set by default.
-	if runtime.GOOS == "darwin" {
-		cmd.Env = os.Environ()
-		if os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
-			// Set LC_ALL=C as a safe default if no locale is configured.
-			cmd.Env = append(cmd.Env, "LC_ALL=C")
-		}
-	}
 
 	// Capture both stdout and stderr to include in error messages
 	output, err := cmd.CombinedOutput()

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -293,17 +292,6 @@ func startPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlCo
 	cmd := exec.Command("pg_ctl", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	// On macOS, ensure locale environment variables are set for PostgreSQL
-	// PostgreSQL 17+ requires valid locale settings to avoid multithreading errors during startup
-	// This is specific to macOS where LC_ALL may not be set by default
-	if runtime.GOOS == "darwin" {
-		cmd.Env = os.Environ()
-		if os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
-			// Set LC_ALL=C as a safe default if no locale is configured
-			cmd.Env = append(cmd.Env, "LC_ALL=C")
-		}
-	}
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to start PostgreSQL with pg_ctl: %w", err)

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -278,6 +279,13 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	}
 
 	pgctldCmd := exec.CommandContext(ctx, pgctldBinary, serverArgs...)
+
+	// On macOS, ensure a valid locale is set for pgctld and its children (initdb, pg_ctl).
+	// Without LC_ALL or LANG, initdb fails with "invalid locale settings".
+	// Only inject when neither is set; an existing value in either variable is left untouched.
+	if runtime.GOOS == "darwin" && os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
+		pgctldCmd.Env = append(os.Environ(), "LC_ALL=C")
+	}
 
 	if err := telemetry.StartCmd(ctx, pgctldCmd); err != nil {
 		return nil, fmt.Errorf("failed to start pgctld server: %w", err)

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -187,6 +187,11 @@ timeout: 30
 			"PGCONNECT_TIMEOUT=5",
 		)
 
+		// Required to avoid "postmaster became multithreaded during startup" on macOS
+		if runtime.GOOS == "darwin" {
+			serverCmd.Env = append(serverCmd.Env, "LC_ALL=en_US.UTF-8")
+		}
+
 		err := serverCmd.Start()
 		require.NoError(t, err)
 		defer func() {
@@ -522,6 +527,11 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"PGCONNECT_TIMEOUT=5",
 			"PGPASSWORD="+testPassword,
 		)
+		// Required to avoid "postmaster became multithreaded during startup" on macOS
+		if runtime.GOOS == "darwin" {
+			initCmd.Env = append(initCmd.Env, "LC_ALL=en_US.UTF-8")
+		}
+
 		output, err := initCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld init should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "\"password_source\":\"PGPASSWORD environment variable\"", "Should use PGPASSWORD")
@@ -533,6 +543,12 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"PGCONNECT_TIMEOUT=5",
 			"PGPASSWORD="+testPassword,
 		)
+
+		// Required to avoid "postmaster became multithreaded during startup" on macOS
+		if runtime.GOOS == "darwin" {
+			startCmd.Env = append(startCmd.Env, "LC_ALL=en_US.UTF-8")
+		}
+
 		output, err = startCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld start should succeed, output: %s", string(output))
 
@@ -665,6 +681,11 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			}
 		}
 		cleanEnv = append(cleanEnv, "PGCONNECT_TIMEOUT=5")
+
+		// Required to avoid "postmaster became multithreaded during startup" on macOS
+		if runtime.GOOS == "darwin" {
+			cleanEnv = append(cleanEnv, "LC_ALL=en_US.UTF-8")
+		}
 
 		// Initialize - pgctld will find password file at conventional location
 		t.Logf("Initializing PostgreSQL with password file at conventional location")
@@ -1134,6 +1155,12 @@ func TestOrphanDetectionWithRealPostgreSQL(t *testing.T) {
 		"MULTIGRES_TESTDATA_DIR="+dataDir,
 		"PGCONNECT_TIMEOUT=5",
 		"PATH="+endtoendDir+":"+os.Getenv("PATH"))
+
+	// Required to avoid "postmaster became multithreaded during startup" on macOS
+	if runtime.GOOS == "darwin" {
+		serverCmd.Env = append(serverCmd.Env, "LC_ALL=en_US.UTF-8")
+	}
+
 	require.NoError(t, serverCmd.Start())
 
 	// Wait for gRPC server to be ready


### PR DESCRIPTION
`pgctld` was injecting `LC_ALL=C` into the environment of `initdb` and `pg_ctl` on macOS. Production code should not override the caller's locale: it can mask misconfigured deployments, change collation and encoding of the initialized cluster, and violates the principle of least surprise.

Remove the `LC_ALL` injection from `pgctld` and move it to the provisioner, which is responsible for providing a correct execution environment to the processes it spawns. `LC_ALL=C` is only injected when neither `LC_ALL` nor `LANG` is set in the caller's environment, so an existing locale is always preserved unchanged.

Fix tests that built Env slices manually without locale vars by adding inline darwin checks in all affected test sites.
