### PR TITLE
fix(pgctld): suppress usage output on runtime errors

### DIFF
--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -121,6 +121,9 @@ It provides lifecycle management including start, stop, restart, and configurati
 management for PostgreSQL servers.`,
 		Args: cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Flags parsed successfully at this point — suppress usage for any subsequent
+			// runtime errors so the error message is not buried under the usage text.
+			cmd.Root().SilenceUsage = true
 			pc.lg.SetupLogging()
 			// Initialize telemetry for CLI commands (server command will re-initialize via ServEnv.Init)
 			var err error

--- a/go/cmd/pgctld/command/root_test.go
+++ b/go/cmd/pgctld/command/root_test.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -239,5 +240,46 @@ work_mem = {{.WorkMem}}
 
 		// Verify template was NOT changed
 		assert.Equal(t, originalTemplate, config.PostgresConfigDefaultTmpl)
+	})
+}
+
+func TestSilenceUsage(t *testing.T) {
+	t.Run("SilenceUsage_is_false_initially", func(t *testing.T) {
+		root, _ := GetRootCommand()
+		assert.False(t, root.SilenceUsage)
+	})
+
+	t.Run("flag_error_keeps_SilenceUsage_false", func(t *testing.T) {
+		root, _ := GetRootCommand()
+		root.SetArgs([]string{"--nonexistent-flag-xyz"})
+		_ = root.Execute()
+		assert.False(t, root.SilenceUsage, "PersistentPreRunE should not have run for a flag parse error")
+	})
+
+	t.Run("flag_error_prints_usage", func(t *testing.T) {
+		root, _ := GetRootCommand()
+		var outBuf bytes.Buffer
+		root.SetOut(&outBuf) // cobra writes usage via c.Print → OutOrStderr (the "out" writer)
+		root.SetArgs([]string{"--nonexistent-flag-xyz"})
+		err := root.Execute()
+		require.Error(t, err)
+		assert.Contains(t, outBuf.String(), "Usage:")
+	})
+
+	t.Run("runtime_error_sets_SilenceUsage_true", func(t *testing.T) {
+		root, _ := GetRootCommand()
+		root.SetArgs([]string{"status", "--pooler-dir", ""})
+		_ = root.Execute()
+		assert.True(t, root.SilenceUsage, "PersistentPreRunE should have set SilenceUsage=true before the runtime error")
+	})
+
+	t.Run("runtime_error_does_not_print_usage", func(t *testing.T) {
+		root, _ := GetRootCommand()
+		var outBuf bytes.Buffer
+		root.SetOut(&outBuf) // cobra writes usage via c.Print → OutOrStderr (the "out" writer)
+		root.SetArgs([]string{"status", "--pooler-dir", ""})
+		err := root.Execute()
+		require.Error(t, err)
+		assert.NotContains(t, outBuf.String(), "Usage:", "usage should be suppressed for runtime errors")
 	})
 }


### PR DESCRIPTION
Cobra prints the full usage message whenever RunE returns an error. This is only useful for flag parsing errors; for runtime failures like initdb crashing the usage output is noise that buries the actual error.

pgctld runs as a daemon and writes structured JSON log output to stdout. Interleaving plain-text usage messages into this stream breaks log readers, which expect every line to be valid JSON and would need to detect and discard the usage block to process the log correctly.

To avoid printing usage messages during normal execution, this commit sets SilenceUsage in PersistentPreRunE, which only runs after flags have been parsed successfully. This means flag errors still print usage, but runtime errors do not.