### PR TITLE
fix(shardsetup): do not rely on time when calling pg_reload_conf()

### DIFF
--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -705,7 +705,7 @@ func (pm *MultiPoolerManager) setSynchronousStandbyNames(ctx context.Context, sy
 		defer execCancel()
 
 		pm.logger.InfoContext(ctx, "Clearing synchronous_standby_names (empty standby list)")
-		if err := pm.exec(execCtx, "ALTER SYSTEM SET synchronous_standby_names = ''"); err != nil {
+		if err := pm.exec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
 			pm.logger.ErrorContext(ctx, "Failed to clear synchronous_standby_names", "error", err)
 			return mterrors.Wrap(err, "failed to clear synchronous_standby_names")
 		}
@@ -809,7 +809,7 @@ func (pm *MultiPoolerManager) clearSyncReplicationForDemotion(ctx context.Contex
 
 	// ALTER SYSTEM writes to postgresql.auto.conf (not WAL), so it doesn't require
 	// sync replication acknowledgment and won't block.
-	if err := pm.exec(execCtx, "ALTER SYSTEM SET synchronous_standby_names = ''"); err != nil {
+	if err := pm.exec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to clear synchronous_standby_names for demotion", "error", err)
 		return mterrors.Wrap(err, "failed to clear synchronous_standby_names for demotion")
 	}
@@ -833,7 +833,7 @@ func (pm *MultiPoolerManager) resetSynchronousReplication(ctx context.Context) e
 	defer execCancel()
 
 	// Clear synchronous_standby_names to remove all standbys
-	if err := pm.exec(execCtx, "ALTER SYSTEM SET synchronous_standby_names = ''"); err != nil {
+	if err := pm.exec(execCtx, "ALTER SYSTEM RESET synchronous_standby_names"); err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to clear synchronous_standby_names", "error", err)
 		return mterrors.Wrap(err, "failed to clear synchronous_standby_names")
 	}

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -1518,7 +1518,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 		{
 			name: "successful clear synchronous replication",
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names = ''", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
 			},
 			expectError: false,
@@ -1526,7 +1526,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 		{
 			name: "ALTER SYSTEM fails",
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnceWithError("ALTER SYSTEM SET synchronous_standby_names = ''", errors.New("permission denied"))
+				m.AddQueryPatternOnceWithError("ALTER SYSTEM RESET synchronous_standby_names", errors.New("permission denied"))
 			},
 			expectError:   true,
 			errorContains: "failed to clear synchronous_standby_names for demotion",
@@ -1534,7 +1534,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 		{
 			name: "pg_reload_conf fails",
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names = ''", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", errors.New("reload failed"))
 			},
 			expectError:   true,

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -1142,7 +1142,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
-				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names = ''", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries
@@ -1194,7 +1194,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
-				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names = ''", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries
@@ -1226,7 +1226,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
-				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names = ''", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries

--- a/go/test/endtoend/multipooler/main_test.go
+++ b/go/test/endtoend/multipooler/main_test.go
@@ -203,11 +203,10 @@ func restoreAfterEmergencyDemotion(t *testing.T, setup *MultipoolerTestSetup, pg
 	require.NoError(t, err)
 	defer poolerClient.Close()
 
-	_, err = poolerClient.ExecuteQuery(context.Background(), "ALTER SYSTEM SET synchronous_standby_names = ''", 1)
+	_, err = poolerClient.ExecuteQuery(context.Background(), "ALTER SYSTEM RESET synchronous_standby_names", 1)
 	require.NoError(t, err, "Should clear synchronous_standby_names on pooler: %s", multipoolerName)
 
-	_, err = poolerClient.ExecuteQuery(context.Background(), "SELECT pg_reload_conf()", 1)
-	require.NoError(t, err, "Should reload postgres config on pooler: %s", multipoolerName)
+	shardsetup.ReloadConfig(context.Background(), t, poolerClient, multipoolerName)
 
 	t.Logf("Pooler %s restored after emergency demotion", multipoolerName)
 }

--- a/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_replication_api_test.go
@@ -544,8 +544,7 @@ func TestReplicationAPIs(t *testing.T) {
 		setupPoolerTest(t, setup, WithDropTables("test_receiver_only"), WithResetGuc("synchronous_commit"))
 		_, err := primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "ALTER SYSTEM SET synchronous_commit = 'local'", 0)
 		require.NoError(t, err, "Failed to set synchronous_commit to local")
-		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "SELECT pg_reload_conf()", 0)
-		require.NoError(t, err, "Failed to reload config")
+		shardsetup.ReloadConfig(context.Background(), t, primaryPoolerClient, "primary")
 
 		// Verify replication is working by checking pg_stat_wal_receiver
 		t.Log("Verifying replication is streaming...")
@@ -724,8 +723,7 @@ func TestReplicationAPIs(t *testing.T) {
 		setupPoolerTest(t, setup, WithDropTables("test_replay_and_receiver"), WithResetGuc("synchronous_commit"))
 		_, err := primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "ALTER SYSTEM SET synchronous_commit = 'local'", 0)
 		require.NoError(t, err, "Failed to set synchronous_commit to local")
-		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "SELECT pg_reload_conf()", 0)
-		require.NoError(t, err, "Failed to reload config")
+		shardsetup.ReloadConfig(context.Background(), t, primaryPoolerClient, "primary")
 		// Verify replication is working
 		t.Log("Verifying replication is streaming...")
 		require.Eventually(t, func() bool {
@@ -898,8 +896,7 @@ func TestReplicationAPIs(t *testing.T) {
 		setupPoolerTest(t, setup, WithDropTables("test_reset_replication"), WithResetGuc("synchronous_commit"))
 		_, err := primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "ALTER SYSTEM SET synchronous_commit = 'local'", 0)
 		require.NoError(t, err, "Failed to set synchronous_commit to local")
-		_, err = primaryPoolerClient.ExecuteQuery(utils.WithShortDeadline(t), "SELECT pg_reload_conf()", 0)
-		require.NoError(t, err, "Failed to reload config")
+		shardsetup.ReloadConfig(context.Background(), t, primaryPoolerClient, "primary")
 
 		// This test verifies that ResetReplication successfully disconnects the standby from the primary
 		// and that data inserted after reset does not replicate until replication is re-enabled

--- a/go/test/endtoend/shardsetup/cleanup.go
+++ b/go/test/endtoend/shardsetup/cleanup.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensuspb "github.com/multigres/multigres/go/pb/consensus"
@@ -136,10 +139,55 @@ func SaveGUCs(ctx context.Context, client *MultiPoolerTestClient, gucNames []str
 	return saved
 }
 
-// RestoreGUCs restores GUC values from a saved map using ALTER SYSTEM.
+// ReloadConfig calls pg_reload_conf() and waits for the reload to complete
+// using pg_conf_load_time() as an event-based completion signal.
+//
+// pg_reload_conf() sends SIGHUP and returns immediately, before postgres has
+// processed the signal. This function waits until pg_conf_load_time() advances
+// past the pre-reload value, which happens atomically when postgres finishes
+// processing the SIGHUP — at which point all GUC values are guaranteed to
+// reflect the latest postgresql.auto.conf.
+//
+// ctx is used only for the pg_reload_conf() call. The reload-completion wait
+// uses its own internal context so that a short caller deadline does not cut
+// off the wait on a loaded system.
+func ReloadConfig(ctx context.Context, t *testing.T, client *MultiPoolerTestClient, instanceName string) {
+	t.Helper()
+
+	loadTimeBefore, err := QueryStringValue(ctx, client, "SELECT pg_conf_load_time()")
+	// pg_conf_load_tim() should not normally fail, but if it does, log the
+	// error so that we can debug the issue.
+	require.NoError(t, err, "Failed to get pg_conf_load_time on %s: %v", instanceName, err)
+
+	_, err = client.ExecuteQuery(ctx, "SELECT pg_reload_conf()", 1)
+	require.NoError(t, err, "Failed to reload config on %s: %v", instanceName, err)
+
+	// Use a fresh context for polling so a short caller ctx does not cut off the wait.
+	pollCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var funcCallError error
+	require.Eventually(t, func() bool {
+		loadTimeAfter, err := QueryStringValue(pollCtx, client, "SELECT pg_conf_load_time()")
+		// pg_conf_load_tim() should not normally fail, but if it does, stop
+		// polling and report it, instead of polling until timeout.
+		if err != nil {
+			funcCallError = err
+			return true
+		}
+		return loadTimeAfter != loadTimeBefore
+	}, 30*time.Second, 10*time.Millisecond,
+		"%s: pg_conf_load_time did not advance after pg_reload_conf()", instanceName)
+
+	require.NoError(t, funcCallError, "Error calling pg_conf_load_time on %s: %v", instanceName, funcCallError)
+}
+
+// RestoreGUCs restores GUC values from a saved map using ALTER SYSTEM, then
+// calls ReloadConfig to apply the changes and wait for the reload to complete.
 // Empty values are treated as RESET (restore to default).
 func RestoreGUCs(ctx context.Context, t *testing.T, client *MultiPoolerTestClient, savedGucs map[string]string, instanceName string) {
 	t.Helper()
+
 	for gucName, gucValue := range savedGucs {
 		var query string
 		if gucValue == "" {
@@ -153,11 +201,7 @@ func RestoreGUCs(ctx context.Context, t *testing.T, client *MultiPoolerTestClien
 		}
 	}
 
-	// Reload configuration to apply changes
-	_, err := client.ExecuteQuery(ctx, "SELECT pg_reload_conf()", 1)
-	if err != nil {
-		t.Logf("Warning: Failed to reload config on %s in cleanup: %v", instanceName, err)
-	}
+	ReloadConfig(ctx, t, client, instanceName)
 }
 
 // ValidateGUCValue queries a GUC and returns an error if it doesn't match the expected value.

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1239,10 +1239,13 @@ func (s *ShardSetup) SetupTest(t *testing.T, opts ...SetupTestOption) {
 		// Ensure monitor is disabled (in case something during test re-enabled it)
 		s.disableMonitorOnAll(t, cleanupCtx)
 
-		// Validate cleanup worked
+		// Validate cleanup worked.
+		// Use a generous timeout: GUC values written by RestoreGUCs are already
+		// waited on inside that function, so this is a final sanity check that
+		// should pass quickly. The extra headroom guards against slow CI runners.
 		require.Eventually(t, func() bool {
 			return s.ValidateCleanState() == nil
-		}, 2*time.Second, 50*time.Millisecond, "Test cleanup failed: state did not return to clean state")
+		}, 15*time.Second, 50*time.Millisecond, "Test cleanup failed: state did not return to clean state")
 	})
 }
 
@@ -1296,7 +1299,7 @@ func (s *ShardSetup) breakReplication(t *testing.T, ctx context.Context) {
 		if err == nil {
 			_, _ = client.Pooler.ExecuteQuery(ctx, "ALTER SYSTEM RESET synchronous_standby_names", 0)
 			_, _ = client.Pooler.ExecuteQuery(ctx, "ALTER SYSTEM RESET synchronous_commit", 0)
-			_, _ = client.Pooler.ExecuteQuery(ctx, "SELECT pg_reload_conf()", 0)
+			ReloadConfig(ctx, t, client.Pooler, s.PrimaryName)
 			client.Close()
 			t.Logf("SetupTest: Cleared synchronous_standby_names on primary %s", s.PrimaryName)
 		}
@@ -1315,10 +1318,10 @@ func (s *ShardSetup) breakReplication(t *testing.T, ctx context.Context) {
 		}
 
 		_, _ = client.Pooler.ExecuteQuery(ctx, "ALTER SYSTEM RESET primary_conninfo", 0)
-		_, _ = client.Pooler.ExecuteQuery(ctx, "SELECT pg_reload_conf()", 0)
+		ReloadConfig(ctx, t, client.Pooler, name)
 
-		// Wait for primary_conninfo to be cleared and WAL receiver to stop
-		// pg_reload_conf() is async, so we need to wait for changes to take effect
+		// Wait for the WAL receiver to stop. ReloadConfig has already confirmed
+		// primary_conninfo is cleared; this waits for postgres to act on it.
 		require.Eventually(t, func() bool {
 			connInfo, err := QueryStringValue(ctx, client.Pooler, "SHOW primary_conninfo")
 			if err != nil || connInfo != "" {

--- a/go/test/endtoend/shardsetup/shardsetup_test.go
+++ b/go/test/endtoend/shardsetup/shardsetup_test.go
@@ -228,7 +228,7 @@ func TestShardSetup_GUCModificationAndReset(t *testing.T) {
 		} else {
 			_, _ = client.Pooler.ExecuteQuery(ctx, "ALTER SYSTEM SET primary_conninfo = 'host=modified_host'", 0)
 		}
-		_, _ = client.Pooler.ExecuteQuery(ctx, "SELECT pg_reload_conf()", 0)
+		ReloadConfig(ctx, t, client.Pooler, name)
 		client.Close()
 		t.Logf("%s GUCs modified", name)
 	}


### PR DESCRIPTION
Add `ReloadConfig()` to `shardsetup`, which calls `pg_reload_conf()` and waits for completion using `pg_conf_load_time()` as an event-based signal. Once the timestamp advances, postgres has fully processed the SIGHUP and all GUC values are guaranteed to reflect the latest postgresql.auto.conf. This replaces a fixed 2s polling timeout that was too short on loaded CI runners, causing the next test's SetupTest to see stale values (e.g. `primary_conninfo=''`) and fail with 'previous test leaked state'.

Replace all bare `pg_reload_conf()` calls across the test infrastructure (`breakReplication`, `RestoreGUCs`, `restoreAfterEmergencyDemotion`, and three `synchronous_commit` setup sites in `rpc_manager_replication_api_test.go`) with `ReloadConfig()`. Also raise the final `ValidateCleanState` timeout in the cleanup handler from 2s to 15s.

Also use `ALTER SYSTEM RESET synchronous_standby_names` instead of `ALTER SYSTEM SET synchronous_standby_names = ''`. `ALTER SYSTEM RESET` removes the entry from `postgresql.auto.conf` entirely, restoring whatever value `postgresql.conf` specifies. If not removed, it will shadow whatever value is present in `postgresql.conf`. As a result, changes to `postgresql.conf` might not take effect, which complicates debugging.
