### PR TITLE
feat(pgctld): add /live HTTP endpoint, remove multipooler /ready

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -161,6 +161,7 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	s.senv.OnRun(func() {
 		logger.Info("pgctld server starting up",
 			"grpc_port", s.grpcServer.Port(),
+			"http_port", s.senv.GetHTTPPort(),
 		)
 
 		// Start pgBackRest management
@@ -170,7 +171,6 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 		if s.grpcServer.CheckServiceMap(constants.ServicePgctld, s.senv) {
 			pb.RegisterPgCtldServer(s.grpcServer.Server, pgctldService)
 		}
-		// TODO(sougou): Add http server
 	})
 
 	s.senv.OnClose(func() {

--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -132,6 +132,7 @@ type MultiadminConfig struct {
 // PgctldConfig holds pgctld service configuration
 type PgctldConfig struct {
 	Path              string `yaml:"path"`
+	HttpPort          int    `yaml:"http-port"`           // HTTP port for health endpoints
 	PoolerDir         string `yaml:"pooler-dir"`          // Base directory for this pgctld instance
 	GrpcPort          int    `yaml:"grpc-port"`           // gRPC port for pgctld server
 	GRPCSocketFile    string `yaml:"grpc-socket-file"`    // Unix socket file path for gRPC
@@ -307,6 +308,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 				},
 				Pgctld: PgctldConfig{
 					Path:              filepath.Join(binDir, "pgctld"),
+					HttpPort:          ports.DefaultPgctldHTTP,
 					PoolerDir:         GeneratePoolerDir(baseDir, serviceIDZone1),
 					GrpcPort:          ports.DefaultPgctldGRPC,
 					GRPCSocketFile:    filepath.Join(baseDir, "sockets", "pgctld-zone1.sock"),
@@ -351,6 +353,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 				},
 				Pgctld: PgctldConfig{
 					Path:              filepath.Join(binDir, "pgctld"),
+					HttpPort:          ports.DefaultPgctldHTTP + 1,
 					PoolerDir:         GeneratePoolerDir(baseDir, serviceIDZone2),
 					GrpcPort:          ports.DefaultPgctldGRPC + 1,
 					GRPCSocketFile:    filepath.Join(baseDir, "sockets", "pgctld-zone2.sock"),
@@ -396,6 +399,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 				},
 				Pgctld: PgctldConfig{
 					Path:              filepath.Join(binDir, "pgctld"),
+					HttpPort:          ports.DefaultPgctldHTTP + 2,
 					PoolerDir:         GeneratePoolerDir(baseDir, serviceIDZone3),
 					GrpcPort:          ports.DefaultPgctldGRPC + 2,
 					GRPCSocketFile:    filepath.Join(baseDir, "sockets", "pgctld-zone3.sock"),
@@ -496,6 +500,7 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 	case constants.ServicePgctld:
 		return map[string]any{
 			"path":                cellServices.Pgctld.Path,
+			"http_port":           cellServices.Pgctld.HttpPort,
 			"pooler_dir":          cellServices.Pgctld.PoolerDir,
 			"grpc_port":           cellServices.Pgctld.GrpcPort,
 			"grpc_socket_file":    cellServices.Pgctld.GRPCSocketFile,

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -190,6 +190,12 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 		grpcPort = port
 	}
 
+	// Get HTTP port from config or use default
+	httpPort := ports.DefaultPgctldHTTP
+	if port, ok := pgctldConfig["http_port"].(int); ok && port > 0 {
+		httpPort = port
+	}
+
 	// Get PostgreSQL port from config or use default
 	pgPort := ports.DefaultLocalPostgresPort
 	if port, ok := pgctldConfig["pg_port"].(int); ok && port > 0 {
@@ -245,12 +251,13 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	// primary/standby replication across zones.
 
 	// Start pgctld server
-	fmt.Printf("▶️  - Starting pgctld server (gRPC:%d)...", grpcPort)
+	fmt.Printf("▶️  - Starting pgctld server (gRPC:%d, HTTP:%d)...", grpcPort, httpPort)
 
 	serverArgs := []string{
 		"server",
 		"--pooler-dir", poolerDir,
 		"--grpc-port", strconv.Itoa(grpcPort),
+		"--http-port", strconv.Itoa(httpPort),
 		"--pg-port", strconv.Itoa(pgPort),
 		"--pg-database", pgDatabase,
 		"--pg-user", pgUser,
@@ -297,7 +304,7 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	}
 
 	// Wait for pgctld to be ready
-	servicePorts := map[string]int{"grpc_port": grpcPort}
+	servicePorts := map[string]int{"grpc_port": grpcPort, "http_port": httpPort}
 	if err := p.waitForServiceReady(ctx, "pgctld", "localhost", servicePorts, 60*time.Second); err != nil {
 		logs := p.readServiceLogs(pgctldLogFile, 20)
 		return nil, fmt.Errorf("pgctld readiness check failed: %w\n\nLast 20 lines from pgctld logs:\n%s", err, logs)

--- a/go/provisioner/local/ports/ports.go
+++ b/go/provisioner/local/ports/ports.go
@@ -40,6 +40,7 @@ const (
 	DefaultMultiorchGRPC = 15370
 
 	// Pgctld
+	DefaultPgctldHTTP = 15400
 	DefaultPgctldGRPC = 15470
 
 	// pgBackRest server

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -160,7 +160,6 @@ func NewMultiPooler(telemetry *telemetry.Telemetry) *MultiPooler {
 			Links: []Link{
 				{"Config", "Server configuration details", "/config"},
 				{"Live", "URL for liveness check", "/live"},
-				{"Ready", "URL for readiness check", "/ready"},
 			},
 		},
 	}
@@ -310,7 +309,6 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 	grpcpoolerservice.RegisterPoolerServices(mp.senv, mp.grpcServer)
 
 	mp.senv.HTTPHandleFunc("/", mp.handleIndex)
-	mp.senv.HTTPHandleFunc("/ready", mp.handleReady)
 
 	mp.senv.OnRun(
 		func() {

--- a/go/services/multipooler/status.go
+++ b/go/services/multipooler/status.go
@@ -67,18 +67,3 @@ func (mp *MultiPooler) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-
-// handleReady serves the readiness check
-func (mp *MultiPooler) handleReady(w http.ResponseWriter, r *http.Request) {
-	mp.serverStatus.mu.Lock()
-	defer mp.serverStatus.mu.Unlock()
-
-	isReady := (len(mp.serverStatus.InitError) == 0)
-	if !isReady {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}
-	if err := web.Templates.ExecuteTemplate(w, "isok.html", isReady); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
-		return
-	}
-}

--- a/go/test/endtoend/pgctld/health_test.go
+++ b/go/test/endtoend/pgctld/health_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgctld
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPgctldLiveEndpoint verifies that pgctld exposes an HTTP /live endpoint
+// that returns 200 OK when the process is running.
+func TestPgctldLiveEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	if !utils.HasPostgreSQLBinaries() {
+		t.Fatal("PostgreSQL binaries not found")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_health_test")
+	defer cleanup()
+
+	grpcPort := utils.GetFreePort(t)
+	httpPort := utils.GetFreePort(t)
+	pgPort := utils.GetFreePort(t)
+
+	// Start pgctld server with HTTP port
+	cmd := exec.Command("pgctld",
+		"server",
+		"--pooler-dir", tempDir,
+		"--grpc-port", strconv.Itoa(grpcPort),
+		"--http-port", strconv.Itoa(httpPort),
+		"--pg-port", strconv.Itoa(pgPort),
+		"--timeout", "30",
+	)
+	setupTestEnv(cmd)
+
+	err := cmd.Start()
+	require.NoError(t, err, "pgctld should start")
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	// Wait for HTTP /live endpoint to return 200
+	liveURL := fmt.Sprintf("http://localhost:%d/live", httpPort)
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(liveURL) //nolint:gosec // Test code, URL is constructed from local port
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 200*time.Millisecond, "/live endpoint should return 200")
+
+	// Verify a second request also succeeds (not a one-time thing)
+	resp, err := http.Get(liveURL) //nolint:gosec // Test code
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -209,9 +209,12 @@ func (s *ShardSetup) CreateMultipoolerInstance(t *testing.T, name string, grpcPo
 	// Allocate a port for pgBackRest server (one per multipooler)
 	pgbackrestPort := utils.GetFreePort(t)
 
+	// Allocate an HTTP port for pgctld health endpoints
+	pgctldHttpPort := utils.GetFreePort(t)
+
 	// Create pgctld instance
 	pgbackrestCertDir := filepath.Join(s.TempDir, "certs")
-	pgctld := CreatePgctldInstance(t, name, s.TempDir, grpcPort, pgPort, pgbackrestPort, pgbackrestCertDir, s.BackupLocation)
+	pgctld := CreatePgctldInstance(t, name, s.TempDir, grpcPort, pgPort, pgctldHttpPort, pgbackrestPort, pgbackrestCertDir, s.BackupLocation)
 
 	// Create multipooler instance with pgBackRest cert paths and port
 	// The name (e.g., "primary") is used as the service-id, combined with cell in the topology
@@ -231,7 +234,7 @@ func (s *ShardSetup) CreateMultipoolerInstance(t *testing.T, name string, grpcPo
 
 // CreatePgctldInstance creates a new pgctld process instance configuration.
 // Follows the pattern from multipooler/setup_test.go:createPgctldInstance.
-func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, pgbackrestPort int, pgbackrestCertDir string, backupLocation *clustermetadatapb.BackupLocation) *ProcessInstance {
+func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, httpPort, pgbackrestPort int, pgbackrestCertDir string, backupLocation *clustermetadatapb.BackupLocation) *ProcessInstance {
 	t.Helper()
 
 	dataDir := filepath.Join(baseDir, name, "data")
@@ -246,6 +249,7 @@ func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, 
 		DataDir:           dataDir,
 		LogFile:           logFile,
 		GrpcPort:          grpcPort,
+		HttpPort:          httpPort,
 		PgPort:            pgPort,
 		Binary:            "pgctld",
 		PgBackRestPort:    pgbackrestPort,

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -56,7 +56,7 @@ type ProcessInstance struct {
 	Environment []string
 
 	// Multiorch-specific fields
-	HttpPort                            int      // HTTP port (used by multiorch for /ready endpoint)
+	HttpPort                            int      // HTTP port (used by pgctld and multiorch for health endpoints)
 	Cell                                string   // Cell name (used by multipooler and multiorch)
 	WatchTargets                        []string // Database/tablegroup/shard targets to watch (multiorch)
 	ServiceID                           string   // Service ID (used by multipooler and multiorch)
@@ -110,6 +110,11 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 		"--pg-port", strconv.Itoa(p.PgPort),
 		"--timeout", "60",
 		"--log-output", p.LogFile,
+	}
+
+	// Add HTTP port if configured
+	if p.HttpPort > 0 {
+		args = append(args, "--http-port", strconv.Itoa(p.HttpPort))
 	}
 
 	// Add pgBackRest configuration if provided


### PR DESCRIPTION
Add DefaultPgctldHTTP port (15400) and wire --http-port through the local provisioner and endtoend test infrastructure. This enables Kubernetes liveness probes for pgctld via the existing servenv /live handler.

Remove multipooler's misleading /ready endpoint which only checked InitError without verifying postgres connectivity.

Partly fixes #696 (but not issue 3)
Addresses part of #688