### PR TITLE
fix(provisioner): pass POSTGRES_PASSWORD to pgctld

### DIFF
--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -139,7 +139,7 @@ type PgctldConfig struct {
 	PgPort            int    `yaml:"pg-port"`             // PostgreSQL port
 	PgDatabase        string `yaml:"pg-database"`         // PostgreSQL database name
 	PgUser            string `yaml:"pg-user"`             // PostgreSQL username
-	PgPwfile          string `yaml:"pg-pwfile"`           // Source password file path; copied to pooler-dir/pgpassword.txt during init
+	PgPassword        string `yaml:"pg-password"`         // PostgreSQL password (default: "postgres")
 	Timeout           int    `yaml:"timeout"`             // Operation timeout in seconds
 	LogLevel          string `yaml:"log-level"`           // Log level
 	PgBackRestPort    int    `yaml:"pgbackrest-port"`     // pgBackRest TLS server port
@@ -315,6 +315,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 					PgPort:            ports.DefaultLocalPostgresPort,
 					PgDatabase:        dbName,
 					PgUser:            constants.DefaultPostgresUser,
+					PgPassword:        "postgres",
 					Timeout:           30,
 					LogLevel:          "info",
 					PgBackRestPort:    ports.DefaultPgbackRestPort,
@@ -360,7 +361,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 					PgPort:            ports.DefaultLocalPostgresPort + 1,
 					PgDatabase:        dbName,
 					PgUser:            constants.DefaultPostgresUser,
-					PgPwfile:          filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone2), "pgpassword.txt"),
+					PgPassword:        "postgres",
 					Timeout:           30,
 					LogLevel:          "info",
 					PgBackRestPort:    ports.DefaultPgbackRestPort + 1,
@@ -406,7 +407,7 @@ func (p *localProvisioner) DefaultConfig(configPaths []string, backupConfig map[
 					PgPort:            ports.DefaultLocalPostgresPort + 2,
 					PgDatabase:        dbName,
 					PgUser:            constants.DefaultPostgresUser,
-					PgPwfile:          filepath.Join(GeneratePoolerDir(baseDir, serviceIDZone3), "pgpassword.txt"),
+					PgPassword:        "postgres",
 					Timeout:           30,
 					LogLevel:          "info",
 					PgBackRestPort:    ports.DefaultPgbackRestPort + 2,
@@ -507,6 +508,7 @@ func (p *localProvisioner) getCellServiceConfig(cellName, service string) (map[s
 			"pg_port":             cellServices.Pgctld.PgPort,
 			"pg_database":         cellServices.Pgctld.PgDatabase,
 			"pg_user":             cellServices.Pgctld.PgUser,
+			"password":            cellServices.Pgctld.PgPassword,
 			"timeout":             cellServices.Pgctld.Timeout,
 			"log_level":           cellServices.Pgctld.LogLevel,
 			"pgbackrest_port":     cellServices.Pgctld.PgBackRestPort,

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -71,57 +71,23 @@ func (p *localProvisioner) Name() string {
 	return "local"
 }
 
-// createPoolerDirectoryWithPassword creates the pooler directory structure and password file
-// at the conventional location (poolerDir/pgpassword.txt).
-// If sourcePasswordFile is provided and exists, its content is copied; otherwise "postgres" is used.
-func createPoolerDirectoryWithPassword(poolerDir, sourcePasswordFile string) error {
-	// Create the pooler directory structure
-	if err := os.MkdirAll(poolerDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create pooler directory %s: %w", poolerDir, err)
-	}
-
-	// Conventional password file location
-	conventionalPwfile := filepath.Join(poolerDir, "pgpassword.txt")
-
-	// Determine password content
-	password := []byte("postgres")
-	if sourcePasswordFile != "" {
-		if content, err := os.ReadFile(sourcePasswordFile); err == nil {
-			password = content
-		}
-		// If source file doesn't exist, fall back to default "postgres"
-	}
-
-	// Create the password file at the conventional location
-	if err := os.WriteFile(conventionalPwfile, password, 0o600); err != nil {
-		return fmt.Errorf("failed to create password file %s: %w", conventionalPwfile, err)
-	}
-
-	return nil
-}
-
-// initializePgctldDirectories initializes all pgctld directories and password files based on the config
+// initializePgctldDirectories creates all pgctld pooler directories based on the config.
 func (p *localProvisioner) initializePgctldDirectories() error {
-	// Get the typed configuration
 	config := p.config
 
-	// Initialize directories for each cell's pgctld configuration
 	for cellName, cellConfig := range config.Cells {
 		fmt.Printf("Setting up pgctld directory for cell %s...\n", cellName)
 
 		poolerDir := cellConfig.Pgctld.PoolerDir
-
 		if poolerDir == "" {
 			return fmt.Errorf("pooler-dir not found in config for pgtctld in cell %s", cellName)
 		}
 
-		if err := createPoolerDirectoryWithPassword(poolerDir, cellConfig.Pgctld.PgPwfile); err != nil {
-			return fmt.Errorf("failed to initialize pgctld directory for cell %s: %w", cellName, err)
+		if err := os.MkdirAll(poolerDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create pooler directory %s for cell %s: %w", poolerDir, cellName, err)
 		}
 
-		conventionalPwfile := filepath.Join(poolerDir, "pgpassword.txt")
 		fmt.Printf("✓ Created pooler directory: %s\n", poolerDir)
-		fmt.Printf("✓ Created password file: %s\n", conventionalPwfile)
 	}
 
 	return nil

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -287,11 +287,21 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 
 	pgctldCmd := exec.CommandContext(ctx, pgctldBinary, serverArgs...)
 
+	// Build environment: start from the current process environment,
+	// then layer on macOS locale fix and the PostgreSQL password.
+	pgctldCmd.Env = os.Environ()
+
 	// On macOS, ensure a valid locale is set for pgctld and its children (initdb, pg_ctl).
 	// Without LC_ALL or LANG, initdb fails with "invalid locale settings".
 	// Only inject when neither is set; an existing value in either variable is left untouched.
 	if runtime.GOOS == "darwin" && os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
-		pgctldCmd.Env = append(os.Environ(), "LC_ALL=C")
+		pgctldCmd.Env = append(pgctldCmd.Env, "LC_ALL=C")
+	}
+
+	// Pass the PostgreSQL password so pgctld can use it during init (--pwfile)
+	// and pg_hba.conf setup.
+	if password, ok := pgctldConfig["password"].(string); ok && password != "" {
+		pgctldCmd.Env = append(pgctldCmd.Env, constants.PgPasswordEnvVar+"="+password)
 	}
 
 	if err := telemetry.StartCmd(ctx, pgctldCmd); err != nil {

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -185,11 +185,6 @@ func PostgresConfigFile(poolerDir string) string {
 	return path.Join(PostgresDataDir(poolerDir), "postgresql.conf")
 }
 
-// PostgresPasswordFile returns the conventional location of the PostgreSQL password file.
-func PostgresPasswordFile(poolerDir string) string {
-	return path.Join(poolerDir, "pgpassword.txt")
-}
-
 // MakePostgresConf will substitute values in the template
 func (cnf *PostgresServerConfig) MakePostgresConf(templateContent string) (string, error) {
 	pgTemplate, err := template.New("").Parse(templateContent)

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -243,7 +243,7 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 				Timeout:        60,
 				LogLevel:       "info",
 				PoolerDir:      local.GeneratePoolerDir(tempDir, serviceID),
-				// PgPwfile not set - provisioner will create pgpassword.txt with default "postgres" password
+				// PgPassword not set - defaults to "postgres"
 			},
 		}
 
@@ -816,18 +816,18 @@ func testPostgreSQLConnection(t *testing.T, tempDir string, port int, zone strin
 	t.Logf("Zone %s PostgreSQL (port %d) is responding correctly", zone, port)
 
 	// Also test TCP connection with password to validate password was set correctly
-	// The default password is "postgres" (set by the local provisioner at pgpassword.txt)
+	// The default password is "postgres" (set by PgPassword in local provisioner config)
 	testPostgreSQLTCPConnection(t, port, zone)
 }
 
 // testPostgreSQLTCPConnection tests TCP connection with password authentication.
-// This validates that the password file convention is working correctly.
+// This validates that the password configuration is working correctly.
 func testPostgreSQLTCPConnection(t *testing.T, port int, zone string) {
 	t.Helper()
 
 	t.Logf("Testing PostgreSQL TCP connection with password on port %d (Zone %s)...", port, zone)
 
-	// Connect via TCP using the default password "postgres" (from pgpassword.txt)
+	// Connect via TCP using the default password "postgres" (from PgPassword config)
 	cmd := exec.Command("psql", "-h", "127.0.0.1", "-p", strconv.Itoa(port), "-U", "postgres", "-d", "postgres", "-c", fmt.Sprintf("SELECT 'Zone %s TCP auth works!' as status;", zone))
 	cmd.Env = append(os.Environ(), "PGPASSWORD=postgres")
 


### PR DESCRIPTION
## Motivation

Running the following didn't work:
1. `multigres cluster init && multigres cluster start`
2. `PGPASSWORD=postgres psql -h localhost -p 15432 -U postgres`
    - This was failing with a failed auth error.

The second command line is copied from the output of `multigres cluster start`. When support for `PGPASSWORD` was added to `pgctld`, the local provisioner wasn't modified to inject that into `pgctld`'s environment. This meant that the `postgres` user had no password, making it impossible to log into Postgres through a TCP connection.

## Summary
- Pass `POSTGRES_PASSWORD` env var to pgctld so it can use it during `initdb` (`--pwfile`) and `pg_hba.conf` setup
- Refactor: replace `PgPwfile` (file path) with `PgPassword` (string) on `PgctldConfig`, eliminating the intermediate `pgpassword.txt` file
- Remove `createPoolerDirectoryWithPassword`, `readPasswordFile`, `pgPasswordFile` constant, and their tests
- Simplify `initializePgctldDirectories` to only create the pooler directory