### PR TITLE
feat(pgctld,multipooler): read database name from POSTGRES_DB env var

### DIFF
--- a/go/cmd/multipooler/main_test.go
+++ b/go/cmd/multipooler/main_test.go
@@ -19,7 +19,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
 )
+
+// TestDatabaseEnvVar verifies that the --database flag reads from POSTGRES_DB
+// and that an explicit flag value overrides the env var.
+func TestDatabaseEnvVar(t *testing.T) {
+	t.Run("defaults to postgres when POSTGRES_DB not set", func(t *testing.T) {
+		_, mp := CreateMultiPoolerCommand()
+		assert.Equal(t, constants.DefaultPostgresDatabase, mp.Database())
+	})
+
+	t.Run("POSTGRES_DB env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgDatabaseEnvVar, "mydb")
+		_, mp := CreateMultiPoolerCommand()
+		assert.Equal(t, "mydb", mp.Database())
+	})
+
+	t.Run("flag overrides POSTGRES_DB env var", func(t *testing.T) {
+		t.Setenv(constants.PgDatabaseEnvVar, "envdb")
+		cmd, mp := CreateMultiPoolerCommand()
+		cmd.SetArgs([]string{"--database", "flagdb"})
+		// Parse flags without executing to avoid topo validation
+		require.NoError(t, cmd.ParseFlags([]string{"--database", "flagdb"}))
+		assert.Equal(t, "flagdb", mp.Database())
+	})
+}
 
 // TestInit_TopoMissingAddresses verifies that Init() returns an error when
 // topo-global-server-addresses is not configured.

--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -19,7 +19,29 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/multigres/multigres/go/common/constants"
 )
+
+func TestPgDatabaseEnvVar(t *testing.T) {
+	t.Run("defaults to postgres when POSTGRES_DB not set", func(t *testing.T) {
+		_, pc := GetRootCommand()
+		assert.Equal(t, constants.DefaultPostgresDatabase, pc.pgDatabase.Get())
+	})
+
+	t.Run("POSTGRES_DB env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgDatabaseEnvVar, "mydb")
+		_, pc := GetRootCommand()
+		assert.Equal(t, "mydb", pc.pgDatabase.Get())
+	})
+
+	t.Run("flag overrides POSTGRES_DB env var", func(t *testing.T) {
+		t.Setenv(constants.PgDatabaseEnvVar, "envdb")
+		_, pc := GetRootCommand()
+		pc.pgDatabase.Set("flagdb")
+		assert.Equal(t, "flagdb", pc.pgDatabase.Get())
+	})
+}
 
 func TestPgBackRestFlags(t *testing.T) {
 	// Test default values

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -19,7 +19,9 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 
 	"github.com/spf13/cobra"
@@ -77,8 +79,10 @@ Examples:
 	return cmd
 }
 
-// InitDataDirWithResult initializes PostgreSQL data directory and returns detailed result information
-func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pgUser string, pgPassword string) (*InitResult, error) {
+// InitDataDirWithResult initializes PostgreSQL data directory and returns detailed result information.
+// When pgDatabase differs from the default "postgres" database, it starts PostgreSQL transiently
+// and creates the target database — mirroring docker-library/postgres's docker_setup_db behaviour.
+func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pgUser string, pgPassword string, pgDatabase string) (*InitResult, error) {
 	result := &InitResult{}
 	dataDir := pgctld.PostgresDataDir(poolerDir)
 
@@ -100,6 +104,14 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 		return nil, fmt.Errorf("failed to create postgres config: %w", err)
 	}
 
+	// If the target database is not the default "postgres" (always created by initdb),
+	// start PostgreSQL transiently and create it — same as docker-library/postgres does.
+	if pgDatabase != constants.DefaultPostgresDatabase {
+		if err := setupDatabase(logger, poolerDir, pgPort, pgUser, pgDatabase); err != nil {
+			return nil, fmt.Errorf("failed to create database %q: %w", pgDatabase, err)
+		}
+	}
+
 	result.AlreadyInitialized = false
 	result.Message = "Data directory initialized successfully"
 	logger.Info("PostgreSQL data directory initialized successfully")
@@ -108,7 +120,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
-	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, i.pgCtlCmd.pgPort.Get(), i.pgCtlCmd.pgUser.Get(), i.pgCtlCmd.pgPassword.Get())
+	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, i.pgCtlCmd.pgPort.Get(), i.pgCtlCmd.pgUser.Get(), i.pgCtlCmd.pgPassword.Get(), i.pgCtlCmd.pgDatabase.Get())
 	if err != nil {
 		return err
 	}
@@ -120,6 +132,49 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Data directory initialized successfully: %s\n", pgctld.PostgresDataDir(poolerDir))
 	}
 
+	return nil
+}
+
+// setupDatabase starts a transient pgInstance and creates pgDatabase if it does
+// not already exist, then stops the instance.  This mirrors what the official
+// docker-library/postgres image does in its docker_setup_db() entrypoint function.
+func setupDatabase(logger *slog.Logger, poolerDir string, pgPort int, pgUser, pgDatabase string) error {
+	dataDir := pgctld.PostgresDataDir(poolerDir)
+	configFile := pgctld.PostgresConfigFile(poolerDir)
+
+	logger.Info("Starting PostgreSQL transiently to create database", "database", pgDatabase)
+	pg, err := newPgInstance(logger, dataDir, configFile, pgPort, pgUser)
+	if err != nil {
+		return err
+	}
+	defer pg.stop()
+
+	// Check whether the target database already exists.
+	// Use Go string formatting to build the SQL — the database name comes from
+	// operator config, not untrusted user input, so simple quoting is safe.
+	// Single quotes in the name are escaped as '' per the SQL standard.
+	checkOut, err := pg.psql(constants.DefaultPostgresDatabase,
+		"-Atc", fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname = '%s'",
+			strings.ReplaceAll(pgDatabase, "'", "''")),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to query pg_database for %q: %w\nOutput: %s", pgDatabase, err, checkOut)
+	}
+	if strings.TrimSpace(string(checkOut)) == "1" {
+		logger.Info("Database already exists, skipping creation", "database", pgDatabase)
+		return nil
+	}
+
+	// CREATE DATABASE with a double-quoted identifier; double quotes in the name
+	// are escaped as "" per the SQL standard.
+	logger.Info("Creating database", "database", pgDatabase)
+	if out, err := pg.psql(constants.DefaultPostgresDatabase,
+		"-c", fmt.Sprintf(`CREATE DATABASE "%s"`, strings.ReplaceAll(pgDatabase, `"`, `""`)),
+	); err != nil {
+		return fmt.Errorf("failed to create database %q: %w\nOutput: %s", pgDatabase, err, out)
+	}
+
+	logger.Info("Database created successfully", "database", pgDatabase)
 	return nil
 }
 

--- a/go/cmd/pgctld/command/pg_instance.go
+++ b/go/cmd/pgctld/command/pg_instance.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/multigres/multigres/go/common/constants"
+)
+
+// pgInstance represents a transiently-running PostgreSQL server started for
+// one-off setup tasks such as creating a database after initdb.  The server
+// listens only on a private temporary Unix socket directory so it is invisible
+// to multipooler's background goroutines.
+//
+// # Why a private temporary socket directory?
+//
+// setupDatabase is called while the multipooler process that issued the
+// InitDataDir RPC is still alive with its background goroutines running.
+// Those goroutines (heartbeat writer, status poller) continuously poll
+// pgctld.PostgresSocketDir(poolerDir) — the same path the permanent
+// PostgreSQL server will use.  If we started the transient server on that
+// path, multipooler could connect to it, find it alive, and misreport the
+// pooler as a functioning primary before the multigres schema has been
+// created.  It would also suffer an abrupt connection teardown when we stop
+// the transient server.
+//
+// By using an os.MkdirTemp directory as the socket path, the transient server
+// is completely invisible to multipooler.  The real socket only appears once
+// pgctld processes the subsequent Start RPC.
+//
+// Create with newPgInstance; always call stop() when done (typically via defer).
+type pgInstance struct {
+	dataDir   string
+	socketDir string // private temp dir owned by this instance
+	port      int
+	user      string
+	logger    *slog.Logger
+}
+
+// newPgInstance starts a transient PostgreSQL server on a private temporary
+// socket directory and blocks until it is ready to accept connections.
+// The caller must call stop() when done (typically via defer pg.stop()).
+func newPgInstance(logger *slog.Logger, dataDir, configFile string, port int, user string) (*pgInstance, error) {
+	socketDir, err := os.MkdirTemp("", "pgctld-setup-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary socket directory: %w", err)
+	}
+
+	pg := &pgInstance{
+		dataDir:   dataDir,
+		socketDir: socketDir,
+		port:      port,
+		user:      user,
+		logger:    logger,
+	}
+
+	if err := pg.start(configFile); err != nil {
+		os.RemoveAll(socketDir)
+		return nil, err
+	}
+	return pg, nil
+}
+
+// start launches the PostgreSQL server via pg_ctl and waits for readiness.
+func (p *pgInstance) start(configFile string) error {
+	logFile := filepath.Join(p.dataDir, "setup.log")
+
+	// No TCP (listen_addresses=), private socket, config file already written by
+	// GeneratePostgresServerConfig.  -W tells pg_ctl not to wait; we poll below
+	// with pg_isready so we can target the exact socket path.
+	postgresOpts := fmt.Sprintf(
+		"-c config_file=%s -c port=%d -c listen_addresses= -c unix_socket_directories=%s",
+		configFile, p.port, p.socketDir,
+	)
+	if out, err := exec.Command("pg_ctl",
+		"start", "-D", p.dataDir, "-o", postgresOpts, "-l", logFile, "-W",
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to start transient PostgreSQL: %w\nOutput: %s", err, out)
+	}
+
+	return p.waitReady()
+}
+
+// waitReady polls pg_isready until PostgreSQL accepts connections or the
+// attempt limit is reached.
+func (p *pgInstance) waitReady() error {
+	const maxAttempts = 30
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := exec.Command("pg_isready",
+			"-h", p.socketDir,
+			"-p", strconv.Itoa(p.port),
+			"-d", constants.DefaultPostgresDatabase,
+		).Run(); err == nil {
+			return nil
+		}
+		if attempt == maxAttempts {
+			return fmt.Errorf("transient PostgreSQL did not become ready after %d seconds", maxAttempts)
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil
+}
+
+// stop shuts down the transient PostgreSQL server and removes the private
+// socket directory.  Errors are logged as warnings because stop is typically
+// called from a defer and must not shadow the caller's primary error.
+func (p *pgInstance) stop() {
+	// pg_ctl stop targets the data directory directly and reads the PID from
+	// postmaster.pid, so it works regardless of the socket path in use.
+	if out, err := exec.Command("pg_ctl",
+		"stop", "-D", p.dataDir, "-m", "fast",
+	).CombinedOutput(); err != nil {
+		p.logger.Warn("Failed to stop transient PostgreSQL",
+			"error", err, "output", string(out))
+	}
+	os.RemoveAll(p.socketDir)
+}
+
+// psql runs a psql command against this instance connected to database,
+// appending args after the standard -h/-p/-U/-d connection flags.
+// Returns combined stdout+stderr and any error.
+func (p *pgInstance) psql(database string, args ...string) ([]byte, error) {
+	baseArgs := []string{
+		"-h", p.socketDir,
+		"-p", strconv.Itoa(p.port),
+		"-U", p.user,
+		"-d", database,
+	}
+	return exec.Command("psql", append(baseArgs, args...)...).CombinedOutput()
+}

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -62,6 +62,7 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 		pgDatabase: viperutil.Configure(reg, "pg-database", viperutil.Options[string]{
 			Default:  constants.DefaultPostgresDatabase,
 			FlagName: "pg-database",
+			EnvVars:  []string{constants.PgDatabaseEnvVar},
 			Dynamic:  false,
 		}),
 		pgUser: viperutil.Configure(reg, "pg-user", viperutil.Options[string]{
@@ -147,7 +148,7 @@ management for PostgreSQL servers.`,
 		},
 	}
 
-	root.PersistentFlags().StringP("pg-database", "D", pc.pgDatabase.Default(), "PostgreSQL database name")
+	root.PersistentFlags().StringP("pg-database", "D", pc.pgDatabase.Default(), "PostgreSQL database name (overrides "+constants.PgDatabaseEnvVar+" env var)")
 	root.PersistentFlags().StringP("pg-user", "U", pc.pgUser.Default(), "PostgreSQL username (overrides "+constants.PgUserEnvVar+" env var)")
 	root.PersistentFlags().IntP("timeout", "t", pc.timeout.Default(), "Operation timeout in seconds")
 	root.PersistentFlags().String("pooler-dir", pc.poolerDir.Default(), "The directory to multipooler data")

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -651,7 +651,7 @@ func (s *PgCtldService) InitDataDir(ctx context.Context, req *pb.InitDataDirRequ
 	s.logger.InfoContext(ctx, "gRPC InitDataDir request")
 
 	// Use the shared init function with detailed result
-	result, err := InitDataDirWithResult(s.logger, s.poolerDir, s.pgPort, s.pgUser, s.pgPassword)
+	result, err := InitDataDirWithResult(s.logger, s.poolerDir, s.pgPort, s.pgUser, s.pgPassword, s.pgDatabase)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -31,6 +31,9 @@ const (
 	// PgPasswordEnvVar is the environment variable for the PostgreSQL password.
 	PgPasswordEnvVar = "POSTGRES_PASSWORD" //nolint:gosec // This is an env var name, not a credential
 
+	// PgDatabaseEnvVar is the environment variable for the PostgreSQL database name.
+	PgDatabaseEnvVar = "POSTGRES_DB"
+
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.
 	DefaultPostgresDatabase = "postgres"

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -90,8 +90,9 @@ func NewMultiPooler(telemetry *telemetry.Telemetry) *MultiPooler {
 			EnvVars:  []string{"MT_CELL"},
 		}),
 		database: viperutil.Configure(reg, "database", viperutil.Options[string]{
-			Default:  "",
+			Default:  constants.DefaultPostgresDatabase,
 			FlagName: "database",
+			EnvVars:  []string{constants.PgDatabaseEnvVar},
 			Dynamic:  false,
 		}),
 		tableGroup: viperutil.Configure(reg, "table-group", viperutil.Options[string]{
@@ -173,7 +174,7 @@ func NewMultiPooler(telemetry *telemetry.Telemetry) *MultiPooler {
 func (mp *MultiPooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.String("pgctld-addr", mp.pgctldAddr.Default(), "Address of pgctld gRPC service")
 	flags.String("cell", mp.cell.Default(), "cell to use")
-	flags.String("database", mp.database.Default(), "database name this multipooler serves (required)")
+	flags.String("database", mp.database.Default(), "database name this multipooler serves (overrides "+constants.PgDatabaseEnvVar+" env var)")
 	flags.String("table-group", mp.tableGroup.Default(), "table group this multipooler serves (required)")
 	flags.String("shard", mp.shard.Default(), "shard this multipooler serves (required)")
 	flags.String("service-id", mp.serviceID.Default(), "optional service ID (if empty, a random ID will be generated)")
@@ -342,6 +343,11 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 		mp.Shutdown()
 	})
 	return nil
+}
+
+// Database returns the configured database name.
+func (mp *MultiPooler) Database() string {
+	return mp.database.Get()
 }
 
 func (mp *MultiPooler) RunDefault() error {

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -169,9 +169,15 @@ func cleanupTestProcesses(tempDir string) error {
 	return nil
 }
 
-// createTestConfigWithPorts creates a test configuration file with custom ports
-// The number of zones is determined by len(portConfig.Zones)
+// createTestConfigWithPorts creates a test configuration file with custom ports using "postgres"
+// as the database name. The number of zones is determined by len(portConfig.Zones).
 func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (string, error) {
+	return createTestConfigWithDatabase(tempDir, portConfig, "postgres")
+}
+
+// createTestConfigWithDatabase creates a test configuration file with custom ports and a specified
+// database name. The number of zones is determined by len(portConfig.Zones).
+func createTestConfigWithDatabase(tempDir string, portConfig *testPortConfig, dbName string) (string, error) {
 	numZones := len(portConfig.Zones)
 	if numZones == 0 {
 		return "", errors.New("portConfig must have at least one zone")
@@ -188,7 +194,7 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 
 	localConfig := &local.LocalProvisionerConfig{
 		RootWorkingDir: tempDir,
-		DefaultDbName:  "postgres",
+		DefaultDbName:  dbName,
 		Etcd: local.EtcdConfig{
 			Version:  "3.5.9",
 			DataDir:  filepath.Join(tempDir, "data", "etcd-data"),
@@ -224,7 +230,7 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 			},
 			Multipooler: local.MultipoolerConfig{
 				Path:           "multipooler",
-				Database:       "postgres",
+				Database:       dbName,
 				TableGroup:     constants.DefaultTableGroup,
 				Shard:          constants.DefaultShard,
 				ServiceID:      serviceID,
@@ -241,7 +247,7 @@ func createTestConfigWithPorts(tempDir string, portConfig *testPortConfig) (stri
 				GrpcPort:       zonePort.PgctldGRPCPort,
 				GRPCSocketFile: filepath.Join(tempDir, "sockets", fmt.Sprintf("pgctld-%s.sock", zoneName)),
 				PgPort:         zonePort.PgctldPGPort,
-				PgDatabase:     "postgres",
+				PgDatabase:     dbName,
 				PgUser:         "postgres",
 				PgPassword:     "postgres",
 				Timeout:        60,
@@ -328,6 +334,15 @@ func checkCellExistsInTopology(etcdAddress, globalRootPath, cellName string) err
 	}
 
 	return nil
+}
+
+// getProcessArgs returns the full command-line of a running process as a single space-separated string.
+func getProcessArgs(pid int) (string, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if err != nil {
+		return "", fmt.Errorf("ps -p %d failed: %w", pid, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // checkMultipoolerTopoRegistration checks if multipooler is registered with correct database, tablegroup, and shard in topology
@@ -1259,43 +1274,84 @@ func TestClusterLifecycle(t *testing.T) {
 		t.Log("Cluster lifecycle test completed successfully")
 	})
 
-	t.Run("multipooler requires database flag", func(t *testing.T) {
-		// This test verifies that multipooler binary requires --database flag
-		// We'll test this by trying to run the provisioned multipooler directly
-		// without the --database flag and expecting it to fail
-
-		tempDir, err := os.MkdirTemp("/tmp", "mlt")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
+	t.Run("multipooler database flag defaults to postgres", func(t *testing.T) {
+		// This test verifies that multipooler's --database flag defaults to "postgres"
+		// when not explicitly provided (reads from POSTGRES_DB env var, falls back to "postgres").
 
 		projectRoot, err := getProjectRoot()
 		require.NoError(t, err)
 		require.NotEmpty(t, projectRoot, "projectRoot should not be empty")
 
-		// Try to run multipooler without --database flag (should fail)
-		t.Log("Testing multipooler without --database flag (should fail)...")
+		// Run multipooler without --database flag: it should not fail on database validation,
+		// instead defaulting to "postgres" and failing on the next required flag (table-group).
+		t.Log("Testing multipooler without --database flag (should default to postgres)...")
 		cmd := exec.Command("multipooler",
 			"--topo-global-server-addresses", "fake-address",
 			"--topo-global-root", "fake-root",
 		)
-		output, err := cmd.CombinedOutput()
-
-		// Should fail with database flag required error
-		require.Error(t, err, "multipooler should fail when --database flag is missing")
+		output, _ := cmd.CombinedOutput()
 		outputStr := string(output)
-		assert.Contains(t, outputStr, "database is required",
-			"Error message should mention database is required. Got: %s", outputStr)
 
-		// Try to run multipooler with --database flag (should succeed with setup)
-		t.Log("Testing multipooler with --database flag (should not show database error)...")
+		assert.NotContains(t, outputStr, "database is required",
+			"Should not show database required error when flag has a default. Got: %s", outputStr)
+		assert.Contains(t, outputStr, "database\":\"postgres\"",
+			"Should use postgres as default database. Got: %s", outputStr)
+
+		// Run with explicit --database flag to verify it is accepted.
+		t.Log("Testing multipooler with explicit --database flag...")
 		cmd = exec.Command("multipooler", "--cell", "testcell", "--database", "testdb", "--help")
 		output, err = cmd.CombinedOutput()
 		require.NoError(t, err)
 
-		// Should not fail due to database flag (may fail for other reasons like missing topo)
 		outputStr = string(output)
-		assert.NotContains(t, outputStr, "--database flag is required",
-			"Should not show database flag error when flag is provided. Got: %s", outputStr)
+		assert.NotContains(t, outputStr, "database is required",
+			"Should not show database error when flag is provided. Got: %s", outputStr)
+	})
+
+	// Verifies that the provisioner passes the configured database name as --database to
+	// multipooler and --pg-database to pgctld when a non-default database name is used.
+	t.Run("provisioner passes database name to child processes", func(t *testing.T) {
+		const customDB = "testdb"
+
+		tempDir, err := os.MkdirTemp("/tmp", "mlt")
+		require.NoError(t, err)
+		defer func() {
+			if cleanupErr := cleanupTestProcesses(tempDir); cleanupErr != nil {
+				t.Logf("Warning: cleanup failed: %v", cleanupErr)
+			}
+			os.RemoveAll(tempDir)
+		}()
+
+		testPorts := getTestPortConfig(t, 1)
+		_, err = createTestConfigWithDatabase(tempDir, testPorts, customDB)
+		require.NoError(t, err, "failed to create test config with database %q", customDB)
+
+		output, err := executeStartCommand(t, []string{"--config-path", tempDir}, tempDir)
+		require.NoError(t, err, "cluster start failed: %s", output)
+
+		serviceStates, err := getServiceStates(tempDir)
+		require.NoError(t, err, "failed to read service states")
+
+		// multipooler must have been launched with --database <customDB>
+		multipoolerState, exists := serviceStates[constants.ServiceMultipooler]
+		require.True(t, exists, "multipooler state file should exist")
+		multipoolerArgs, err := getProcessArgs(multipoolerState.PID)
+		require.NoError(t, err, "failed to read multipooler process args (PID %d)", multipoolerState.PID)
+		t.Logf("multipooler args: %s", multipoolerArgs)
+		assert.Contains(t, multipoolerArgs, "--database "+customDB,
+			"multipooler should have been launched with --database %s", customDB)
+
+		// pgctld must have been launched with --pg-database <customDB>
+		pgctldState, exists := serviceStates[constants.ServicePgctld]
+		require.True(t, exists, "pgctld state file should exist")
+		pgctldArgs, err := getProcessArgs(pgctldState.PID)
+		require.NoError(t, err, "failed to read pgctld process args (PID %d)", pgctldState.PID)
+		t.Logf("pgctld args: %s", pgctldArgs)
+		assert.Contains(t, pgctldArgs, "--pg-database "+customDB,
+			"pgctld should have been launched with --pg-database %s", customDB)
+
+		stopOutput, err := executeStopCommand(t, []string{"--config-path", tempDir})
+		require.NoError(t, err, "cluster stop failed: %s", stopOutput)
 	})
 
 	// Verifies that if a required service port is already in use by another process,

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -661,6 +661,100 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 	})
 }
 
+// TestCustomDatabaseCreation verifies that pgctld init creates a non-default database
+// when POSTGRES_DB (or --pg-database) names a database other than "postgres".
+// This mirrors the behaviour of the docker-library/postgres entrypoint's docker_setup_db().
+func TestCustomDatabaseCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping custom database creation tests in short mode")
+	}
+
+	if !utils.HasPostgreSQLBinaries() {
+		t.Fatal("PostgreSQL binaries not found, skipping custom database creation test")
+	}
+
+	// runDatabaseCreationTest is shared by both sub-tests below.
+	// It initialises pgctld with the given extra env vars / CLI args, starts PostgreSQL,
+	// then verifies that targetDB exists and is connectable.
+	runDatabaseCreationTest := func(t *testing.T, targetDB string, extraEnv []string, extraInitArgs []string) {
+		t.Helper()
+
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_customdb_test")
+		defer cleanup()
+
+		port := utils.GetFreePort(t)
+		socketDir := filepath.Join(baseDir, "pg_sockets")
+
+		baseEnv := append(os.Environ(), "PGCONNECT_TIMEOUT=5")
+		if runtime.GOOS == "darwin" {
+			baseEnv = append(baseEnv, "LC_ALL=en_US.UTF-8")
+		}
+
+		// -- init --
+		initArgs := []string{"init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port)}
+		initArgs = append(initArgs, extraInitArgs...)
+		initCmd := exec.Command("pgctld", initArgs...)
+		initCmd.Env = append(baseEnv, extraEnv...)
+		out, err := initCmd.CombinedOutput()
+		require.NoError(t, err, "pgctld init should succeed, output: %s", string(out))
+
+		// -- start --
+		startCmd := exec.Command("pgctld", "start", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
+		startCmd.Env = append(baseEnv, extraEnv...)
+		out, err = startCmd.CombinedOutput()
+		require.NoError(t, err, "pgctld start should succeed, output: %s", string(out))
+
+		defer func() {
+			stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", baseDir)
+			stopCmd.Env = baseEnv
+			_ = stopCmd.Run()
+		}()
+
+		// -- verify: targetDB exists in pg_database --
+		dbCheckCmd := exec.Command("psql",
+			"-h", socketDir,
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", "postgres",
+			"-Atc", fmt.Sprintf("SELECT datname FROM pg_database WHERE datname = '%s'",
+				strings.ReplaceAll(targetDB, "'", "''")),
+		)
+		out, err = dbCheckCmd.CombinedOutput()
+		require.NoError(t, err, "pg_database query should succeed, output: %s", string(out))
+		assert.Contains(t, strings.TrimSpace(string(out)), targetDB,
+			"database %q should appear in pg_database after init", targetDB)
+
+		// -- verify: we can connect directly to targetDB --
+		connCheckCmd := exec.Command("psql",
+			"-h", socketDir,
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", targetDB,
+			"-Atc", "SELECT current_database();",
+		)
+		out, err = connCheckCmd.CombinedOutput()
+		require.NoError(t, err, "connecting to %q should succeed, output: %s", targetDB, string(out))
+		assert.Contains(t, strings.TrimSpace(string(out)), targetDB,
+			"current_database() should return %q when connected to it", targetDB)
+	}
+
+	t.Run("via_cli_flag", func(t *testing.T) {
+		// --pg-database flag explicitly names the custom database.
+		runDatabaseCreationTest(t, "mydb", nil, []string{"--pg-database", "mydb"})
+	})
+
+	t.Run("via_postgres_db_env_var", func(t *testing.T) {
+		// POSTGRES_DB env var — the standard Docker postgres convention.
+		runDatabaseCreationTest(t, "mydb", []string{"POSTGRES_DB=mydb"}, nil)
+	})
+
+	t.Run("default_database_unchanged", func(t *testing.T) {
+		// When the target database is the default "postgres", no transient start
+		// should occur and the standard postgres database must still be accessible.
+		runDatabaseCreationTest(t, "postgres", nil, nil)
+	})
+}
+
 // TestPostgreSQLLifecycleIntegration tests the complete PostgreSQL lifecycle using CLI
 func TestPostgreSQLLifecycleIntegration(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Add support for the POSTGRES_DB environment variable (and --pg-database CLI flag) to pgctld and multipooler, mirroring the docker-library/postgres convention.

When POSTGRES_DB names a database other than the default "postgres", pgctld init now creates that database after initdb using a transient PostgreSQL server started on a private socket directory. The private socket prevents multipooler's background goroutines from connecting to the transient server and misreporting the pooler as ready before the multigres schema is created.

The transient server logic is encapsulated in a pgInstance struct (pg_instance.go) with methods for construction (newPgInstance), cleanup (stop), and command execution (psql).

Fixes MUL-247
