### PR TITLE
docs(local): add observability workflow to README and local cluster skill

### DIFF
--- a/.claude/skills/mt-local-cluster/SKILL.md
+++ b/.claude/skills/mt-local-cluster/SKILL.md
@@ -12,6 +12,8 @@ Manage local multigres cluster - both cluster-wide operations and individual com
 Invoke this skill when the user asks to:
 
 - Start/stop/restart the entire cluster or individual components
+- Start cluster with observability (OTel, Grafana, Prometheus)
+- Teardown and restart the full stack (cluster + observability)
 - View logs for any component
 - Connect to multipooler or multigateway with psql
 - Check status of cluster components
@@ -202,6 +204,65 @@ tail -f ./multigres_local/data/pooler_*/pg_data/log/pgbackrest-*.log
 aws s3 ls <s3-bucket-path> --region <region>
 ```
 
+## Observability Stack
+
+Start the observability stack (Grafana + Prometheus + Loki + Tempo) for metrics, traces, and logs visualization.
+
+**Start cluster with observability**:
+
+```bash
+# 1. Start observability stack (separate terminal, runs in foreground)
+demo/local/run-observability.sh
+
+# 2. Start cluster with OTel export (separate terminal)
+demo/local/multigres-with-otel.sh cluster start --config-path <config-path>
+```
+
+**Generate traffic with pgbench**:
+
+```bash
+PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -i postgres
+PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -c 4 -j 2 -T 300 -P 5 postgres
+```
+
+**View telemetry**:
+
+- Grafana Dashboard: <http://localhost:3000/d/multigres-overview>
+- Grafana Explore (ad-hoc PromQL): <http://localhost:3000/explore>
+- Prometheus UI: <http://localhost:9090>
+
+**Teardown** (stop in this order to avoid OTel export errors):
+
+```bash
+# 1. Stop the cluster first
+./bin/multigres cluster stop --config-path <config-path>
+
+# 2. Stop the observability stack
+docker rm -f multigres-observability
+```
+
+**Full restart**:
+
+```bash
+# Teardown
+./bin/multigres cluster stop --config-path <config-path>
+docker rm -f multigres-observability
+
+# Start
+demo/local/run-observability.sh          # terminal 1
+demo/local/multigres-with-otel.sh cluster start --config-path <config-path>  # terminal 2
+```
+
+**Observability ports**:
+
+| Service | Port |
+|---|---|
+| Grafana | 3000 |
+| OTLP (HTTP) | 4318 |
+| Prometheus | 9090 |
+| Loki | 3100 |
+| Tempo | 3200 |
+
 ## Individual Component Operations
 
 ### Configuration
@@ -326,6 +387,26 @@ User: "check zone1 multipooler status"
 
 - Look up service ID for zone1
 - Execute: `./bin/multigres getpoolerstatus --cell zone1 --service-id <id>`
+
+**Observability:**
+
+User: "start cluster with otel" or "start cluster with observability"
+
+- Start `demo/local/run-observability.sh` (if not running)
+- Start `demo/local/multigres-with-otel.sh cluster start --config-path <path>`
+
+User: "teardown everything" or "stop everything"
+
+- Stop cluster: `./bin/multigres cluster stop --config-path <path>`
+- Stop observability: `docker rm -f multigres-observability`
+
+User: "restart everything" or "full restart"
+
+- Teardown, then start observability + cluster
+
+User: "push traffic" or "generate load"
+
+- Run pgbench init + pgbench with `-P 5` for progress
 
 **Individual components:**
 

--- a/.claude/skills/mt-local-cluster/SKILL.md
+++ b/.claude/skills/mt-local-cluster/SKILL.md
@@ -255,13 +255,13 @@ demo/local/multigres-with-otel.sh cluster start --config-path <config-path>  # t
 
 **Observability ports**:
 
-| Service | Port |
-|---|---|
-| Grafana | 3000 |
+| Service     | Port |
+| ----------- | ---- |
+| Grafana     | 3000 |
 | OTLP (HTTP) | 4318 |
-| Prometheus | 9090 |
-| Loki | 3100 |
-| Tempo | 3200 |
+| Prometheus  | 9090 |
+| Loki        | 3100 |
+| Tempo       | 3200 |
 
 ## Individual Component Operations
 

--- a/demo/local/README.md
+++ b/demo/local/README.md
@@ -61,10 +61,10 @@ demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres
 
 ### Ports
 
-| Service | Port |
-|---|---|
-| Grafana | 3000 |
+| Service     | Port |
+| ----------- | ---- |
+| Grafana     | 3000 |
 | OTLP (HTTP) | 4318 |
-| Prometheus | 9090 |
-| Loki | 3100 |
-| Tempo | 3200 |
+| Prometheus  | 9090 |
+| Loki        | 3100 |
+| Tempo       | 3200 |

--- a/demo/local/README.md
+++ b/demo/local/README.md
@@ -11,26 +11,60 @@ multigres cluster start --config-path /path/to/multigres_local
 
 ## Observability (Optional)
 
-For development with metrics, traces, and logs visualization:
+For development with metrics, traces, and logs visualization.
 
-### 1. Start observability stack
-
-```bash
-cd demo/local
-./run-observability.sh
-```
-
-The container runs in the foreground. Press **Ctrl-C** to stop it.
-
-### 2. Start Multigres with telemetry
+### Start
 
 ```bash
-cd demo/local
-./multigres-with-otel.sh --config-path /path/to/multigres_local
+# 1. Start observability stack (runs in foreground — use a separate terminal)
+demo/local/run-observability.sh
+
+# 2. Start cluster with OTel export (separate terminal)
+demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local
+
+# 3. Generate traffic (optional — pgbench with progress every 5s)
+PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -i postgres
+PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -c 4 -j 2 -T 300 -P 5 postgres
 ```
 
-Uses `go run` by default - no rebuild needed after code changes.
+`multigres-with-otel.sh` uses `go run` by default — no rebuild needed after code changes.
 
-### 3. View telemetry
+### View Telemetry
 
 - **Grafana Dashboard**: <http://localhost:3000/d/multigres-overview>
+- **Grafana Explore** (ad-hoc queries): <http://localhost:3000/explore>
+- **Prometheus UI**: <http://localhost:9090>
+
+### Teardown
+
+Stop in this order to avoid OTel export errors at shutdown:
+
+```bash
+# 1. Stop the cluster
+./bin/multigres cluster stop --config-path /path/to/multigres_local
+
+# 2. Stop the observability stack (Ctrl-C in run-observability.sh terminal, or:)
+docker rm -f multigres-observability
+```
+
+### Full Restart
+
+```bash
+# 1. Stop everything
+./bin/multigres cluster stop --config-path /path/to/multigres_local
+docker rm -f multigres-observability
+
+# 2. Start everything
+demo/local/run-observability.sh          # terminal 1
+demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local  # terminal 2
+```
+
+### Ports
+
+| Service | Port |
+|---|---|
+| Grafana | 3000 |
+| OTLP (HTTP) | 4318 |
+| Prometheus | 9090 |
+| Loki | 3100 |
+| Tempo | 3200 |


### PR DESCRIPTION
Documents the full observability workflow for local development in `demo/local/README.md` — start, teardown, restart, and ports reference. The existing README only had a barebones 3-step guide that didn't cover teardown order (which matters to avoid OTel export errors at shutdown) or the full restart flow.

Also adds an observability section to the `mt-local-cluster` Claude Code skill so it can help with commands like "start cluster with otel" and "teardown everything".