### PR TITLE
fix(pgctld): use configured pgUser in pg_rewind connection string

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -684,8 +684,8 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 
 	// Construct source server connection string (without password - will use PGPASSWORD env var)
 	// Include application_name if provided (used for replication identification)
-	sourceServer := fmt.Sprintf("host=%s port=%d user=postgres dbname=postgres",
-		req.GetSourceHost(), req.GetSourcePort())
+	sourceServer := fmt.Sprintf("host=%s port=%d user=%s dbname=postgres",
+		req.GetSourceHost(), req.GetSourcePort(), s.pgUser)
 	if req.GetApplicationName() != "" {
 		sourceServer = fmt.Sprintf("%s application_name=%s", sourceServer, req.GetApplicationName())
 	}


### PR DESCRIPTION
use configured pgUser in pg_rewind connection string

Closes MUL-68