### PR TITLE
fix(multipooler): release action lock on timeout

### DIFF
--- a/go/services/multipooler/pools/admin/admin_conn.go
+++ b/go/services/multipooler/pools/admin/admin_conn.go
@@ -119,13 +119,55 @@ func (c *Conn) GetRolPassword(ctx context.Context, username string) (string, err
 	return scramHash, nil
 }
 
+// QueryWithRetry executes a query with automatic retry and reconnection on
+// connection error. Safe for stateless internal queries (heartbeat, replication tracking).
+func (c *Conn) QueryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
+	return c.queryWithRetry(ctx, sql)
+}
+
+// QueryArgsWithRetry executes a parameterized query with automatic retry and
+// reconnection on connection error.
+func (c *Conn) QueryArgsWithRetry(ctx context.Context, sql string, args ...any) ([]*sqltypes.Result, error) {
+	for attempt := 1; attempt <= maxQueryAttempts; attempt++ {
+		results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
+			return c.conn.QueryArgs(ctx, sql, args...)
+		})
+		switch {
+		case err == nil:
+			return results, nil
+		case !mterrors.IsConnectionError(err):
+			return nil, err
+		case attempt == maxQueryAttempts:
+			c.conn.Close()
+			return nil, err
+		}
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		backoffTimer := time.NewTimer(retryBackoff)
+		select {
+		case <-backoffTimer.C:
+		case <-ctx.Done():
+			backoffTimer.Stop()
+			return nil, context.Cause(ctx)
+		}
+		if reconnectErr := c.conn.Reconnect(ctx); reconnectErr != nil {
+			c.conn.Close()
+			return nil, reconnectErr
+		}
+	}
+	panic("unreachable")
+}
+
 // queryWithRetry executes a query with automatic retry on connection error.
 // If the first attempt fails with a connection error, it reconnects and retries
 // up to maxQueryAttempts total. This handles stale connections that occur when
 // PostgreSQL restarts while the pool holds old socket FDs.
 func (c *Conn) queryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Result, error) {
 	for attempt := 1; attempt <= maxQueryAttempts; attempt++ {
-		results, err := c.conn.Query(ctx, sql)
+		results, err := execQueryWithContextCancel(ctx, c.conn, func() ([]*sqltypes.Result, error) {
+			return c.conn.Query(ctx, sql)
+		})
 		switch {
 		case err == nil:
 			return results, nil
@@ -156,6 +198,44 @@ func (c *Conn) queryWithRetry(ctx context.Context, sql string) ([]*sqltypes.Resu
 		}
 	}
 	panic("unreachable")
+}
+
+// execQueryWithContextCancel executes a query operation in a goroutine so that
+// context cancellation can interrupt a blocking network read.
+//
+// When the context is cancelled while a query is blocked waiting for PostgreSQL
+// (e.g. an INSERT waiting for synchronous standby acknowledgement), the underlying
+// connection is force-closed to unblock the goroutine's read. The goroutine is
+// waited on before returning to prevent goroutine leaks.
+//
+// ForceClose is used instead of Close to avoid a concurrent write race: the
+// goroutine may hold bufmu while reading from the buffered reader, and Close
+// would also write to the same buffered writer.
+//
+// After a force-close, IsClosed() returns true. The caller's Recycle() will
+// then signal the pool to replace the connection rather than returning it.
+func execQueryWithContextCancel(ctx context.Context, conn *client.Conn, op func() ([]*sqltypes.Result, error)) ([]*sqltypes.Result, error) {
+	type result struct {
+		results []*sqltypes.Result
+		err     error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		results, err := op()
+		ch <- result{results: results, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Force-close the connection to unblock the goroutine's blocking network read.
+		conn.ForceClose()
+		// Wait for the goroutine to finish (it returns quickly after ForceClose).
+		<-ch
+		return nil, context.Cause(ctx)
+	case res := <-ch:
+		return res.results, res.err
+	}
 }
 
 // TerminateBackend terminates a backend process using pg_terminate_backend().

--- a/go/services/multipooler/pools/admin/admin_test.go
+++ b/go/services/multipooler/pools/admin/admin_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -537,6 +538,65 @@ func TestTerminateBackend_ReconnectsOnConnectionError(t *testing.T) {
 	assert.True(t, success)
 
 	server.VerifyAllExecutedOrFail()
+}
+
+// TestQueryWithRetry_ContextCancelledWhileBlocked is a regression test for the
+// action lock bug: previously, when a PostgreSQL backend stalled (e.g. an INSERT
+// waiting for synchronous standby acknowledgement), the admin conn goroutine
+// remained stuck in readMessage() after the caller's context expired, holding
+// the action lock and causing all subsequent RPCs that need the lock to time out.
+//
+// With execQueryWithContextCancel, context cancellation force-closes the connection
+// to unblock readMessage, and the call returns promptly with context.Canceled.
+func TestQueryWithRetry_ContextCancelledWhileBlocked(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	// blockCh simulates a stalled PostgreSQL backend. The server withholds its
+	// response until blockCh is closed, mimicking an INSERT waiting for a
+	// synchronous standby that never acknowledges.
+	blockCh := make(chan struct{})
+	serverReceived := make(chan struct{})
+
+	server.AddQueryPatternWithCallback(
+		`SELECT pg_sleep\(100\)`,
+		fakepgserver.MakeResult([]string{"pg_sleep"}, [][]any{{""}}),
+		func(_ string) {
+			close(serverReceived) // signal: server accepted the query and is now stalled
+			<-blockCh
+		},
+	)
+
+	conn := newTestDirectConn(t, server)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := conn.QueryWithRetry(ctx, "SELECT pg_sleep(100)")
+		errCh <- err
+	}()
+
+	// Wait until the server has stalled, then cancel — this is the trigger that
+	// should force-close the connection and unblock the goroutine in readMessage.
+	<-serverReceived
+	cancel()
+
+	// QueryWithRetry must return promptly, not hang indefinitely holding the lock.
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("QueryWithRetry did not return after context cancellation")
+	}
+
+	// After force-close, IsClosed() must be true so that Recycle() replaces the
+	// connection rather than returning a broken one to the idle pool.
+	assert.True(t, conn.IsClosed())
+
+	// Release the blocked server goroutine so it can exit cleanly.
+	close(blockCh)
 }
 
 func TestCancelBackend_ReconnectsOnConnectionError(t *testing.T) {


### PR DESCRIPTION
Before this fix, admin connections blocked indefinitely in readMessage() when the PostgreSQL backend was stalled (e.g. an INSERT waiting for synchronous standby acknowledgement). When the gRPC caller's context expired, the goroutine remained stuck holding the action lock, causing all subsequent RPCs that need the lock to time out.

Regular connections already had this handled via execOnce/execWithContextCancel in regular_conn.go, which runs the query in a goroutine and calls pg_cancel_backend (or ForceClose) on context cancellation. Admin connections had no equivalent mechanism.

Fix: add execQueryWithContextCancel to admin_conn.go that runs each query attempt in a goroutine. On context cancellation it force-closes the connection (unblocking readMessage), waits for the goroutine, then returns the context error. queryWithRetry and QueryArgsWithRetry both use this helper.

After force-close, IsClosed() returns true so Recycle() signals the pool to replace the connection rather than returning it broken.