### PR TITLE
fix(multipooler): deadlock in closeIdleResources from mutex re-entry

### DIFF
--- a/go/services/multipooler/pools/connpool/pool.go
+++ b/go/services/multipooler/pools/connpool/pool.go
@@ -911,29 +911,29 @@ func (pool *Pool[C]) closeIdleResources(now time.Time) {
 		// besides the head. When clients pop from the stack, they'll immediately
 		// notice the expired connection and ignore it.
 		// see: timestamp.expired
+		var expiredCount int
 		s.ForEach(func(conn *Pooled[C]) bool {
 			if conn.timeUsed.expired(mono, timeout) {
 				pool.Metrics.idleClosed.Add(1)
 
 				conn.Close()
 				pool.closedConn()
-
-				// Try to open a new connection to replace the closed one
-				c, err := pool.getNew(pool.ctx)
-				if err != nil {
-					// If we couldn't open a new connection, just continue
-					return true
-				}
-
-				// Opening a new connection might have raced with other goroutines,
-				// so it's possible that we got back `nil` here
-				if c != nil {
-					// Return the new connection to the pool
-					pool.tryReturnConn(c)
-				}
+				expiredCount++
 			}
 			return true // continue iteration
 		})
+
+		// Create replacement connections AFTER ForEach releases the stack
+		// mutex. Calling getNew/tryReturnConn inside ForEach would deadlock:
+		// tryReturnConn may Push to the same stack whose mutex ForEach holds,
+		// and sync.Mutex is not reentrant.
+		for range expiredCount {
+			c, err := pool.getNew(pool.ctx)
+			if err != nil || c == nil {
+				return
+			}
+			pool.tryReturnConn(c)
+		}
 	}
 
 	for i := 0; i <= stackMask; i++ {

--- a/go/services/multipooler/pools/connpool/pool_deadlock_test.go
+++ b/go/services/multipooler/pools/connpool/pool_deadlock_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpool
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestCloseIdleResources_MutexDeadlock verifies that closeIdleResources does not
+// deadlock when replacing expired idle connections.
+//
+// The bug: closeIdleResources calls getNew() and tryReturnConn() inside a
+// ForEach callback that holds the stack mutex. When getNew() succeeds and
+// tryReturnConn() pushes the replacement connection to the same stack,
+// Push() tries to acquire the same mutex → self-deadlock (sync.Mutex is
+// not reentrant).
+//
+// This test creates a pool with capacity=1, gets and returns a connection
+// (so it sits idle on the clean stack), then calls closeIdleResources with
+// a time far enough in the future to expire it. If the deadlock exists,
+// closeIdleResources will hang and the subsequent Get will also hang
+// (blocked on the locked mutex). The test uses a timeout to detect this.
+func TestCloseIdleResources_MutexDeadlock(t *testing.T) {
+	idleTimeout := 100 * time.Millisecond
+
+	pool := NewPool[*mockConnection](context.Background(), &Config{
+		Name:         "deadlock-test",
+		Capacity:     1,
+		MaxIdleCount: 1,
+		IdleTimeout:  idleTimeout,
+	})
+	pool.Open(func(ctx context.Context, poolCtx context.Context) (*mockConnection, error) {
+		return newMockConnection(), nil
+	}, nil)
+	defer pool.Close()
+
+	// Get a connection and return it so it sits idle on the clean stack.
+	conn, err := pool.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	conn.Recycle()
+
+	// Wait for the connection to become idle long enough to expire.
+	time.Sleep(idleTimeout + 50*time.Millisecond)
+
+	// Call closeIdleResources. If the deadlock exists, this will hang
+	// forever because tryReturnConn → clean.Push tries to lock the
+	// same mutex that ForEach is holding.
+	done := make(chan struct{})
+	go func() {
+		pool.closeIdleResources(time.Now())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// closeIdleResources completed without deadlocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("closeIdleResources deadlocked: ForEach holds stack mutex while tryReturnConn tries to Push to the same stack")
+	}
+
+	// Verify the pool is still usable — a Get should not hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn2, err := pool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after closeIdleResources: %v", err)
+	}
+	conn2.Recycle()
+}


### PR DESCRIPTION
## Summary

- Fix self-deadlock in `closeIdleResources` where `getNew`/`tryReturnConn` were called inside a `ForEach` callback that holds the stack mutex
- Move replacement connection creation outside the `ForEach` loop so the mutex is released first
- Add `TestCloseIdleResources_MutexDeadlock` to verify the fix (deadlocks without it, passes with it)

## Problem

`closeIdleResources` called `getNew()` and `tryReturnConn()` inside a `ForEach` callback. `ForEach` holds `connStack.mu` for the duration of iteration. When the replacement connection had no waiters, `tryReturnConn` called `clean.Push()`, which tries to acquire the same `mu`, a self-deadlock since `sync.Mutex` is not reentrant. This made the entire pool permanently unusable (all `Get`, `Pop`, `Push`, and `Close` operations block on the locked mutex).

## Solution

Count expired connections during `ForEach`, then create replacements in a separate loop after `ForEach` returns and the mutex is released.
