### PR TITLE
ci(workflows): upload test log artifacts for offline analysis

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -50,6 +50,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test-secret-key
         run: go test -json -v -skip TestPostgreSQLRegression ./go/test/endtoend/... | tee integration-test-results.jsonl | go tool tparse -follow
 
+      - name: Upload test logs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: integration-test-logs
+          path: integration-test-results.jsonl
+          retention-days: 7
+
       - name: Test Report
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Run race detection tests
         run: go test -json -short -v -race ./... | tee race-test-results.jsonl | go tool tparse -follow
 
+      - name: Upload test logs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: race-test-logs
+          path: race-test-results.jsonl
+          retention-days: 7
+
       - name: Test Report
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Run short tests
         run: go test -json -short -v ./... | tee short-test-results.jsonl | go tool tparse -follow
 
+      - name: Upload test logs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: short-test-logs
+          path: short-test-results.jsonl
+          retention-days: 7
+
       - name: Test Report
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Add an upload-artifact step to the integration, short, and race detection test workflows so that the raw JSONL test logs can be downloaded and analyzed offline after a CI run.