### PR TITLE
feat: use PGDATA env var as source of truth for PostgreSQL data directory

### DIFF
--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -171,6 +171,8 @@ spec:
               value: "multipooler"
             - name: POSTGRES_PASSWORD
               value: postgres
+            - name: PGDATA
+              value: /data/pg_data
           envFrom:
             - configMapRef:
                 name: otel-config
@@ -212,6 +214,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: PGDATA
+              value: /data/pg_data
 
       volumes:
         # We have to give different mount points.

--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -22,6 +22,8 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/multigres/multigres/go/services/pgctld"
 )
 
 // postgresAlreadyRunningPattern matches postgres error when it's already running
@@ -30,8 +32,8 @@ var postgresAlreadyRunningPattern = regexp.MustCompile(`lock file ".*" already e
 
 // isPostgresCleanlyStopped checks if PostgreSQL is in a clean shutdown state.
 // Returns true if state is "shut down" or "shut down in recovery", false otherwise.
-func isPostgresCleanlyStopped(ctx context.Context, poolerDir string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "pg_controldata", poolerDir+"/pg_data")
+func isPostgresCleanlyStopped(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, "pg_controldata", pgctld.PostgresDataDir())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("pg_controldata failed: %w (output: %s)", err, string(output))
@@ -63,13 +65,13 @@ func extractClusterState(output string) string {
 
 // runCrashRecovery performs crash recovery in single-user mode.
 // This runs postgres --single to complete crash recovery, then exits cleanly.
-func runCrashRecovery(ctx context.Context, logger *slog.Logger, poolerDir string) error {
+func runCrashRecovery(ctx context.Context, logger *slog.Logger) error {
 	logger.InfoContext(ctx, "Starting single-user crash recovery")
 
 	// Run postgres in single-user mode to perform crash recovery
 	// postgres --single starts in single-user mode, performs recovery, and exits on EOF
 	// Using /dev/null for stdin is simpler than pipe management
-	cmd := exec.CommandContext(ctx, "postgres", "--single", "-D", poolerDir+"/pg_data", "template1")
+	cmd := exec.CommandContext(ctx, "postgres", "--single", "-D", pgctld.PostgresDataDir(), "template1")
 
 	// Open /dev/null for stdin
 	devNull, err := os.Open("/dev/null")

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -84,10 +84,10 @@ Examples:
 // and creates the target database — mirroring docker-library/postgres's docker_setup_db behaviour.
 func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pgUser string, pgPassword string, pgDatabase string) (*InitResult, error) {
 	result := &InitResult{}
-	dataDir := pgctld.PostgresDataDir(poolerDir)
+	dataDir := pgctld.PostgresDataDir()
 
 	// Check if data directory is already initialized
-	if pgctld.IsDataDirInitialized(poolerDir) {
+	if pgctld.IsDataDirInitialized() {
 		logger.Info("Data directory is already initialized", "data_dir", dataDir)
 		result.AlreadyInitialized = true
 		result.Message = "Data directory is already initialized"
@@ -95,7 +95,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 	}
 
 	logger.Info("Initializing PostgreSQL data directory", "data_dir", dataDir)
-	if err := initializeDataDir(logger, poolerDir, pgUser, pgPassword); err != nil {
+	if err := initializeDataDir(logger, pgUser, pgPassword); err != nil {
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}
 	// create server config using the pooler directory
@@ -107,7 +107,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, pgPort int, pg
 	// If the target database is not the default "postgres" (always created by initdb),
 	// start PostgreSQL transiently and create it — same as docker-library/postgres does.
 	if pgDatabase != constants.DefaultPostgresDatabase {
-		if err := setupDatabase(logger, poolerDir, pgPort, pgUser, pgDatabase); err != nil {
+		if err := setupDatabase(logger, pgPort, pgUser, pgDatabase); err != nil {
 			return nil, fmt.Errorf("failed to create database %q: %w", pgDatabase, err)
 		}
 	}
@@ -127,9 +127,9 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 
 	// Display appropriate message for CLI users
 	if result.AlreadyInitialized {
-		fmt.Printf("Data directory is already initialized: %s\n", pgctld.PostgresDataDir(poolerDir))
+		fmt.Printf("Data directory is already initialized: %s\n", pgctld.PostgresDataDir())
 	} else {
-		fmt.Printf("Data directory initialized successfully: %s\n", pgctld.PostgresDataDir(poolerDir))
+		fmt.Printf("Data directory initialized successfully: %s\n", pgctld.PostgresDataDir())
 	}
 
 	return nil
@@ -138,9 +138,9 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 // setupDatabase starts a transient pgInstance and creates pgDatabase if it does
 // not already exist, then stops the instance.  This mirrors what the official
 // docker-library/postgres image does in its docker_setup_db() entrypoint function.
-func setupDatabase(logger *slog.Logger, poolerDir string, pgPort int, pgUser, pgDatabase string) error {
-	dataDir := pgctld.PostgresDataDir(poolerDir)
-	configFile := pgctld.PostgresConfigFile(poolerDir)
+func setupDatabase(logger *slog.Logger, pgPort int, pgUser, pgDatabase string) error {
+	dataDir := pgctld.PostgresDataDir()
+	configFile := pgctld.PostgresConfigFile()
 
 	logger.Info("Starting PostgreSQL transiently to create database", "database", pgDatabase)
 	pg, err := newPgInstance(logger, dataDir, configFile, pgPort, pgUser)
@@ -178,9 +178,9 @@ func setupDatabase(logger *slog.Logger, poolerDir string, pgPort int, pgUser, pg
 	return nil
 }
 
-func initializeDataDir(logger *slog.Logger, poolerDir string, pgUser string, pgPassword string) error {
+func initializeDataDir(logger *slog.Logger, pgUser string, pgPassword string) error {
 	// Derive dataDir from poolerDir using the standard convention
-	dataDir := pgctld.PostgresDataDir(poolerDir)
+	dataDir := pgctld.PostgresDataDir()
 
 	// Note: initdb will create the data directory itself if it doesn't exist.
 	// We don't create it beforehand to avoid leaving empty directories if initdb fails.

--- a/go/cmd/pgctld/command/rewind.go
+++ b/go/cmd/pgctld/command/rewind.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+
+	"github.com/multigres/multigres/go/services/pgctld"
 )
 
 type PgRewindResult struct {
@@ -28,12 +30,13 @@ type PgRewindResult struct {
 	Output  string
 }
 
-func PgRewindWithResult(ctx context.Context, logger *slog.Logger, poolerDir, sourceServer, password string, dryRun bool, extraArgs []string) (*PgRewindResult, error) {
+func PgRewindWithResult(ctx context.Context, logger *slog.Logger, sourceServer, password string, dryRun bool, extraArgs []string) (*PgRewindResult, error) {
 	result := &PgRewindResult{}
+	dataDir := pgctld.PostgresDataDir()
 
 	args := []string{
 		"--source-server", sourceServer,
-		"--target-pgdata", poolerDir + "/pg_data",
+		"--target-pgdata", dataDir,
 	}
 	if dryRun {
 		args = append(args, "--dry-run")
@@ -44,7 +47,7 @@ func PgRewindWithResult(ctx context.Context, logger *slog.Logger, poolerDir, sou
 		"command", "pg_rewind",
 		"args", args,
 		"source_server", sourceServer,
-		"target_pgdata", poolerDir+"/pg_data",
+		"target_pgdata", dataDir,
 		"dry_run", dryRun)
 
 	cmd := exec.CommandContext(ctx, "pg_rewind", args...)

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -193,6 +193,10 @@ func (pc *PgCtlCommand) validateGlobalFlags(cmd *cobra.Command, args []string) e
 		return errors.New("pooler-dir needs to be set")
 	}
 
+	if os.Getenv(constants.PgDataDirEnvVar) == "" {
+		return fmt.Errorf("%s environment variable is required", constants.PgDataDirEnvVar)
+	}
+
 	// If pg-hba-template is specified, read and replace the default template
 	pgHbaTemplatePath := pc.pgHbaTemplate.Get()
 	if pgHbaTemplatePath != "" {
@@ -249,10 +253,8 @@ func (pc *PgCtlCommand) validateInitialized(cmd *cobra.Command, args []string) e
 	}
 
 	// Check if data directory is initialized
-	poolerDir := pc.GetPoolerDir()
-
-	if !pgctld.IsDataDirInitialized(poolerDir) {
-		dataDir := pgctld.PostgresDataDir(poolerDir)
+	if !pgctld.IsDataDirInitialized() {
+		dataDir := pgctld.PostgresDataDir()
 		return fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 

--- a/go/cmd/pgctld/command/root_test.go
+++ b/go/cmd/pgctld/command/root_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/config"
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 )
 
 func TestPgHbaTemplate(t *testing.T) {
@@ -37,6 +38,7 @@ func TestPgHbaTemplate(t *testing.T) {
 	t.Run("custom template replaces default", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_hba_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Create a custom pg_hba.conf template file
 		customTemplate := `# Custom pg_hba.conf template for testing
@@ -67,6 +69,7 @@ host    all             all             ::1/128                 scram-sha-256
 	t.Run("non-existent template file returns error", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_hba_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		nonExistentPath := filepath.Join(baseDir, "nonexistent.conf")
 
@@ -91,6 +94,7 @@ host    all             all             ::1/128                 scram-sha-256
 	t.Run("empty template flag does not replace default", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_hba_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Reset template before test
 		config.PostgresHbaDefaultTmpl = originalTemplate
@@ -110,6 +114,7 @@ host    all             all             ::1/128                 scram-sha-256
 	t.Run("template with empty content is accepted", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_hba_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Create an empty template file
 		emptyTemplate := ""
@@ -135,6 +140,7 @@ host    all             all             ::1/128                 scram-sha-256
 	t.Run("unreadable template file returns error", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_hba_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Create a template file with no read permissions
 		templatePath := filepath.Join(baseDir, "unreadable_pg_hba.conf")
@@ -172,6 +178,7 @@ func TestPostgresConfigTemplate(t *testing.T) {
 	t.Run("custom template replaces default", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_pg_config_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Create a custom postgresql.conf template file
 		customTemplate := `# Custom postgresql.conf template for testing
@@ -202,6 +209,7 @@ work_mem = {{.WorkMem}}
 	t.Run("non-existent template file returns error", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_pg_config_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		nonExistentPath := filepath.Join(baseDir, "nonexistent.conf")
 
@@ -226,6 +234,7 @@ work_mem = {{.WorkMem}}
 	t.Run("empty template flag does not replace default", func(t *testing.T) {
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_pg_config_test")
 		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
 
 		// Reset template before test
 		config.PostgresConfigDefaultTmpl = originalTemplate
@@ -240,6 +249,36 @@ work_mem = {{.WorkMem}}
 
 		// Verify template was NOT changed
 		assert.Equal(t, originalTemplate, config.PostgresConfigDefaultTmpl)
+	})
+}
+
+func TestPGDATARequired(t *testing.T) {
+	t.Run("missing PGDATA returns error", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_pgdata_test")
+		defer cleanup()
+		// Do NOT set PGDATA — it must be absent for this test
+		t.Setenv(constants.PgDataDirEnvVar, "")
+
+		_, pc := GetRootCommand()
+		pc.poolerDir.Set(baseDir)
+
+		err := pc.validateGlobalFlags(nil, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PGDATA environment variable is required")
+	})
+
+	t.Run("PGDATA set allows validation to proceed", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_pgdata_test")
+		defer cleanup()
+		t.Setenv(constants.PgDataDirEnvVar, baseDir+"/pg_data")
+
+		_, pc := GetRootCommand()
+		pc.poolerDir.Set(baseDir)
+
+		err := pc.validateGlobalFlags(nil, nil)
+
+		require.NoError(t, err)
 	})
 }
 

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -275,8 +275,8 @@ func NewPgCtldService(
 		pgUser,
 		pgDatabase,
 		timeout,
-		pgctld.PostgresDataDir(poolerDir),
-		pgctld.PostgresConfigFile(poolerDir),
+		pgctld.PostgresDataDir(),
+		pgctld.PostgresConfigFile(),
 		poolerDir,
 		listenAddresses,
 		pgctld.PostgresSocketDir(poolerDir),
@@ -293,7 +293,7 @@ func NewPgCtldService(
 			Port:          pgbackrestPort,
 			Pg1Port:       pgPort,
 			Pg1SocketPath: pgctld.PostgresSocketDir(poolerDir),
-			Pg1Path:       pgctld.PostgresDataDir(poolerDir),
+			Pg1Path:       pgctld.PostgresDataDir(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate pgbackrest-server.conf: %w", err)
@@ -489,8 +489,8 @@ func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.St
 	s.logger.InfoContext(ctx, "gRPC Start request", "port", req.Port)
 
 	// Check if data directory is initialized
-	if !pgctld.IsDataDirInitialized(s.poolerDir) {
-		dataDir := pgctld.PostgresDataDir(s.poolerDir)
+	if !pgctld.IsDataDirInitialized() {
+		dataDir := pgctld.PostgresDataDir()
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
@@ -515,8 +515,8 @@ func (s *PgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.Stop
 	s.logger.InfoContext(ctx, "gRPC Stop request", "mode", req.Mode)
 
 	// Check if data directory is initialized
-	if !pgctld.IsDataDirInitialized(s.poolerDir) {
-		dataDir := pgctld.PostgresDataDir(s.poolerDir)
+	if !pgctld.IsDataDirInitialized() {
+		dataDir := pgctld.PostgresDataDir()
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
@@ -535,8 +535,8 @@ func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*p
 	s.logger.InfoContext(ctx, "gRPC Restart request", "mode", req.Mode, "port", req.Port, "as_standby", req.AsStandby)
 
 	// Check if data directory is initialized
-	if !pgctld.IsDataDirInitialized(s.poolerDir) {
-		dataDir := pgctld.PostgresDataDir(s.poolerDir)
+	if !pgctld.IsDataDirInitialized() {
+		dataDir := pgctld.PostgresDataDir()
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
@@ -561,8 +561,8 @@ func (s *PgCtldService) ReloadConfig(ctx context.Context, req *pb.ReloadConfigRe
 	s.logger.InfoContext(ctx, "gRPC ReloadConfig request")
 
 	// Check if data directory is initialized
-	if !pgctld.IsDataDirInitialized(s.poolerDir) {
-		dataDir := pgctld.PostgresDataDir(s.poolerDir)
+	if !pgctld.IsDataDirInitialized() {
+		dataDir := pgctld.PostgresDataDir()
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
@@ -581,14 +581,14 @@ func (s *PgCtldService) Status(ctx context.Context, req *pb.StatusRequest) (*pb.
 	s.logger.DebugContext(ctx, "gRPC Status request")
 
 	// First check if data directory is initialized
-	if !pgctld.IsDataDirInitialized(s.poolerDir) {
+	if !pgctld.IsDataDirInitialized() {
 		port, err := intToInt32(s.pgPort)
 		if err != nil {
 			return nil, fmt.Errorf("invalid port: %w", err)
 		}
 		return &pb.StatusResponse{
 			Status:           pb.ServerStatus_NOT_INITIALIZED,
-			DataDir:          pgctld.PostgresDataDir(s.poolerDir),
+			DataDir:          pgctld.PostgresDataDir(),
 			Port:             port,
 			Message:          "Data directory is not initialized",
 			PgbackrestStatus: s.getPgBackRestStatus(),
@@ -671,13 +671,13 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	// If not, try crash recovery - this is needed for rewind dry-run to work
 	// This check is best effort. It's not harmful to try the pg_rewind if
 	// crash recovery fails, the dry run is just unlikely to succeed in that case.
-	cleanlyStopped, err := isPostgresCleanlyStopped(ctx, s.poolerDir)
+	cleanlyStopped, err := isPostgresCleanlyStopped(ctx)
 	if err != nil {
 		s.logger.WarnContext(ctx, "Failed to check postgres state (continuing anyway)", "error", err)
 	} else if !cleanlyStopped {
 		// Try to run crash recovery.
 		// It's not harmful to do this if postgres is already running.
-		if err := runCrashRecovery(ctx, s.logger, s.poolerDir); err != nil {
+		if err := runCrashRecovery(ctx, s.logger); err != nil {
 			s.logger.WarnContext(ctx, "Crash recovery failed (continuing anyway)", "error", err)
 		}
 	}
@@ -691,7 +691,7 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	}
 
 	// Use the shared rewind function with detailed result, passing password separately
-	result, err := PgRewindWithResult(ctx, s.logger, s.poolerDir, sourceServer, s.pgPassword, req.GetDryRun(), req.GetExtraArgs())
+	result, err := PgRewindWithResult(ctx, s.logger, sourceServer, s.pgPassword, req.GetDryRun(), req.GetExtraArgs())
 	if err != nil {
 		s.logger.ErrorContext(ctx, "pg_rewind output", "output", result.Output)
 		return nil, fmt.Errorf("failed to rewind PostgreSQL: %w", err)

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -397,6 +397,7 @@ func TestPgCtldServiceVersion(t *testing.T) {
 		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 		poolerDir := baseDir
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(poolerDir, "pg_data"))
 		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
@@ -425,6 +426,7 @@ func TestPgCtldServiceInitDataDir(t *testing.T) {
 		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 		poolerDir := baseDir
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(poolerDir, "pg_data"))
 		service, err := NewPgCtldService(testLogger(), 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 30, poolerDir, "localhost", 0, "")
 		require.NoError(t, err)
 
@@ -493,8 +495,10 @@ func TestGetPoolerDir(t *testing.T) {
 
 func TestPgCtldService_PgBackRestFields(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	tmpDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
 
-	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, t.TempDir(), "localhost", 0, "")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
 
 	// Verify service has pgBackRest management fields
@@ -504,7 +508,9 @@ func TestPgCtldService_PgBackRestFields(t *testing.T) {
 
 func TestPgCtldService_StatusMethods(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, t.TempDir(), "localhost", 0, "")
+	tmpDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
+	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
 	defer service.Close()
 
@@ -531,6 +537,7 @@ func TestPgCtldService_StatusMethods(t *testing.T) {
 func TestPgCtldService_StartPgBackRest_ValidationErrors(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
 
 	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
@@ -545,6 +552,7 @@ func TestPgCtldService_StartPgBackRest_ValidationErrors(t *testing.T) {
 func TestPgCtldService_ManagePgBackRest_Lifecycle(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
 
 	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)
@@ -576,6 +584,7 @@ func TestPgCtldService_ManagePgBackRest_Lifecycle(t *testing.T) {
 func TestPgCtldService_Status_IncludesPgBackRest(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	tmpDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
 
 	service, err := NewPgCtldService(logger, 5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, shardsetup.TestPostgresPassword, 60, tmpDir, "localhost", 0, "")
 	require.NoError(t, err)

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -42,13 +42,13 @@ type StartResult struct {
 // NewPostgresCtlConfigFromDefaults creates a PostgresCtlConfig using command-line parameters
 // Port, listen_addresses, and unix_socket_directories come from CLI flags, not from the config file
 func NewPostgresCtlConfigFromDefaults(poolerDir string, pgPort int, pgListenAddresses string, pgUser string, pgDatabase string, timeout int) (*pgctld.PostgresCtlConfig, error) {
-	postgresConfigFile := pgctld.PostgresConfigFile(poolerDir)
+	postgresConfigFile := pgctld.PostgresConfigFile()
 
 	effectivePort := pgPort
 	effectiveListenAddresses := pgListenAddresses
 	effectiveUnixSocketDirectories := pgctld.PostgresSocketDir(poolerDir)
 
-	config, err := pgctld.NewPostgresCtlConfig(effectivePort, pgUser, pgDatabase, timeout, pgctld.PostgresDataDir(poolerDir), postgresConfigFile, poolerDir, effectiveListenAddresses, effectiveUnixSocketDirectories)
+	config, err := pgctld.NewPostgresCtlConfig(effectivePort, pgUser, pgDatabase, timeout, pgctld.PostgresDataDir(), postgresConfigFile, poolerDir, effectiveListenAddresses, effectiveUnixSocketDirectories)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -131,7 +131,9 @@ func TestIsDataDirInitialized(t *testing.T) {
 		{
 			name: "non-existent directory",
 			setupDir: func(baseDir string) string {
-				return filepath.Join(baseDir, "nonexistent")
+				nonExistent := filepath.Join(baseDir, "nonexistent")
+				t.Setenv(constants.PgDataDirEnvVar, nonExistent)
+				return nonExistent
 			},
 			initialized: false,
 		},
@@ -143,7 +145,7 @@ func TestIsDataDirInitialized(t *testing.T) {
 			defer cleanup()
 
 			tt.setupDir(baseDir)
-			result := pgctld.IsDataDirInitialized(baseDir)
+			result := pgctld.IsDataDirInitialized()
 			assert.Equal(t, tt.initialized, result)
 		})
 	}
@@ -199,6 +201,7 @@ func TestInitializeDataDir(t *testing.T) {
 
 		// baseDir serves as poolerDir; dataDir will be poolerDir/pg_data
 		poolerDir := baseDir
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(poolerDir, "pg_data"))
 
 		// Setup mock initdb binary
 		binDir := filepath.Join(baseDir, "bin")
@@ -211,7 +214,7 @@ func TestInitializeDataDir(t *testing.T) {
 		defer os.Setenv("PATH", originalPath)
 
 		logger := slog.New(slog.DiscardHandler)
-		err := initializeDataDir(logger, poolerDir, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
+		err := initializeDataDir(logger, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
 		require.NoError(t, err)
 
 		// Verify directory was created (dataDir is poolerDir/pg_data)
@@ -223,11 +226,13 @@ func TestInitializeDataDir(t *testing.T) {
 	})
 
 	t.Run("fails with invalid directory permissions", func(t *testing.T) {
-		// Try to create data dir in a read-only location
-		poolerDir := "/root/impossible_dir"
-
+		// Try to create data dir in a read-only location (simulate permission
+		// error). The function initializeDataDir reads the PGDATA env var to
+		// determine where to initialize, so we set it to a location that should
+		// fail.
+		t.Setenv(constants.PgDataDirEnvVar, "/root/impossible_dir")
 		logger := slog.New(slog.DiscardHandler)
-		err := initializeDataDir(logger, poolerDir, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
+		err := initializeDataDir(logger, constants.DefaultPostgresUser, shardsetup.TestPostgresPassword)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "initdb failed")
 	})
@@ -316,8 +321,8 @@ func TestWaitForPostgreSQL(t *testing.T) {
 			constants.DefaultPostgresUser,
 			constants.DefaultPostgresDatabase,
 			30, // timeout
-			pgctld.PostgresDataDir(baseDir),
-			pgctld.PostgresConfigFile(baseDir),
+			pgctld.PostgresDataDir(),
+			pgctld.PostgresConfigFile(),
 			baseDir,
 			"localhost",
 			pgctld.PostgresSocketDir(baseDir),
@@ -351,8 +356,8 @@ func TestWaitForPostgreSQL(t *testing.T) {
 			"postgres",
 			"postgres",
 			1, // 1 second timeout
-			pgctld.PostgresDataDir(baseDir),
-			pgctld.PostgresConfigFile(baseDir),
+			pgctld.PostgresDataDir(),
+			pgctld.PostgresConfigFile(),
 			baseDir,
 			"localhost",
 			pgctld.PostgresSocketDir(baseDir),
@@ -391,8 +396,8 @@ func TestWaitForPostgreSQLCrashDetection(t *testing.T) {
 			"postgres",
 			"postgres",
 			5, // 5 second timeout
-			pgctld.PostgresDataDir(baseDir),
-			pgctld.PostgresConfigFile(baseDir),
+			pgctld.PostgresDataDir(),
+			pgctld.PostgresConfigFile(),
 			baseDir,
 			"localhost",
 			pgctld.PostgresSocketDir(baseDir),

--- a/go/cmd/pgctld/command/status_test.go
+++ b/go/cmd/pgctld/command/status_test.go
@@ -25,12 +25,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 )
 
 func TestRunStatus(t *testing.T) {
 	baseDir, cleanup := testutil.TempDir(t, "pgctld_status_test")
 	defer cleanup()
+
+	// Set PGDATA to the expected data directory location (may not exist yet for not_initialized test)
+	t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
 
 	// Setup mock binaries
 	binDir := filepath.Join(baseDir, "bin")
@@ -146,8 +150,8 @@ func TestIsServerReady(t *testing.T) {
 				"postgres",
 				"postgres",
 				30,
-				pgctld.PostgresDataDir(baseDir),
-				pgctld.PostgresConfigFile(baseDir),
+				pgctld.PostgresDataDir(),
+				pgctld.PostgresConfigFile(),
 				baseDir,
 				"localhost",
 				pgctld.PostgresSocketDir(baseDir),
@@ -204,8 +208,8 @@ func TestGetServerVersion(t *testing.T) {
 				"postgres",
 				"postgres",
 				30,
-				pgctld.PostgresDataDir(baseDir),
-				pgctld.PostgresConfigFile(baseDir),
+				pgctld.PostgresDataDir(),
+				pgctld.PostgresConfigFile(),
 				baseDir,
 				"localhost",
 				pgctld.PostgresSocketDir(baseDir),

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -119,8 +119,8 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 			}
 
 			poolerDir := baseDir
-			pgDataDir := pgctld.PostgresDataDir(poolerDir)
-			pgConfigFile := pgctld.PostgresConfigFile(poolerDir)
+			pgDataDir := pgctld.PostgresDataDir()
+			pgConfigFile := pgctld.PostgresConfigFile()
 			config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
 			require.NoError(t, err)
 
@@ -275,6 +275,9 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 				defer os.Setenv("PATH", originalPath)
 			}
 
+			// Set PGDATA before generating config (GeneratePostgresServerConfig uses PostgresDataDir())
+			t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
+
 			// Create a mock PostgreSQL server config
 			pgConfig, err := pgctld.GeneratePostgresServerConfig(baseDir, 5432, "postgres")
 			require.NoError(t, err)
@@ -288,8 +291,8 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 			}
 
 			poolerDir := baseDir
-			pgDataDir := pgctld.PostgresDataDir(poolerDir)
-			pgConfigFile := pgctld.PostgresConfigFile(poolerDir)
+			pgDataDir := pgctld.PostgresDataDir()
+			pgConfigFile := pgctld.PostgresConfigFile()
 
 			config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, poolerDir, "localhost", pgctld.PostgresSocketDir(poolerDir))
 			require.NoError(t, err)
@@ -318,8 +321,8 @@ func TestTakeCheckpoint(t *testing.T) {
 			name:          "successful checkpoint",
 			setupBinaries: true,
 			config: func(baseDir string) *pgctld.PostgresCtlConfig {
-				pgDataDir := pgctld.PostgresDataDir(baseDir)
-				pgConfigFile := pgctld.PostgresConfigFile(baseDir)
+				pgDataDir := filepath.Join(baseDir, "pg_data")
+				pgConfigFile := filepath.Join(pgDataDir, "postgresql.conf")
 				config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
 				require.NoError(t, err)
 				return config
@@ -330,8 +333,8 @@ func TestTakeCheckpoint(t *testing.T) {
 			name:          "checkpoint failure - psql command fails",
 			setupBinaries: true, // Create failing psql binary
 			config: func(baseDir string) *pgctld.PostgresCtlConfig {
-				pgDataDir := pgctld.PostgresDataDir(baseDir)
-				pgConfigFile := pgctld.PostgresConfigFile(baseDir)
+				pgDataDir := filepath.Join(baseDir, "pg_data")
+				pgConfigFile := filepath.Join(pgDataDir, "postgresql.conf")
 				config, err := pgctld.NewPostgresCtlConfig(5432, constants.DefaultPostgresUser, constants.DefaultPostgresDatabase, 30, pgDataDir, pgConfigFile, baseDir, "localhost", pgctld.PostgresSocketDir(baseDir))
 				require.NoError(t, err)
 				return config

--- a/go/cmd/pgctld/testutil/temp_dirs.go
+++ b/go/cmd/pgctld/testutil/temp_dirs.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/services/pgctld"
 )
 
@@ -46,12 +47,13 @@ func TempDir(t *testing.T, prefix string) (string, func()) {
 	return dir, cleanup
 }
 
-// CreateDataDir creates a PostgreSQL-like data directory structure for testing
+// CreateDataDir creates a PostgreSQL-like data directory structure for testing.
+// It sets the PGDATA environment variable to baseDir/pg_data for the duration of the test.
 func CreateDataDir(t *testing.T, baseDir string, initialized bool) string {
 	t.Helper()
 
-	// This is the base location where multigres expects postgres data
-	dataDir := pgctld.PostgresDataDir(baseDir)
+	dataDir := filepath.Join(baseDir, "pg_data")
+	t.Setenv(constants.PgDataDirEnvVar, dataDir)
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		t.Fatalf("Failed to create data dir: %v", err)
 	}

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -34,12 +34,22 @@ const (
 	// PgDatabaseEnvVar is the environment variable for the PostgreSQL database name.
 	PgDatabaseEnvVar = "POSTGRES_DB"
 
+	// PgDataDirEnvVar is the environment variable for the PostgreSQL data directory.
+	PgDataDirEnvVar = "PGDATA"
+
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.
 	DefaultPostgresDatabase = "postgres"
 
 	// PostgresExecutable is the name of the PostgreSQL server binary.
 	PostgresExecutable = "postgres"
+
+	// MultigresMarkerDirectory is the name of the directory used by pgctld to
+	// mark a PostgreSQL data directory as managed by pgctld. This is also where
+	// all marker files are stored, such as the file indicating that the cluster
+	// is in the process of being initialized. This directory is created inside
+	// the PostgreSQL data directory.
+	MultigresMarkerDirectory = "multigres"
 
 	// DefaultSlowQueryThreshold is the duration after which a query is logged at WARN level.
 	DefaultSlowQueryThreshold = 1 * time.Second

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -786,7 +786,10 @@ type MultiPooler struct {
 	// Map of named ports. These are ports that the pooler exposes. Initially, this will only be gRPC
 	PortMap map[string]int32 `protobuf:"bytes,9,rep,name=port_map,json=portMap,proto3" json:"port_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	// PoolerDir is used by pgBackRest to compute the primary's data directory.
-	PoolerDir     string `protobuf:"bytes,10,opt,name=pooler_dir,json=poolerDir,proto3" json:"pooler_dir,omitempty"`
+	PoolerDir string `protobuf:"bytes,10,opt,name=pooler_dir,json=poolerDir,proto3" json:"pooler_dir,omitempty"`
+	// PgDataDir is the PostgreSQL data directory path (from the PGDATA environment variable).
+	// Used by multiadmin to compute the primary's data directory for pgBackRest.
+	PgDataDir     string `protobuf:"bytes,11,opt,name=pg_data_dir,json=pgDataDir,proto3" json:"pg_data_dir,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -887,6 +890,13 @@ func (x *MultiPooler) GetPortMap() map[string]int32 {
 func (x *MultiPooler) GetPoolerDir() string {
 	if x != nil {
 		return x.PoolerDir
+	}
+	return ""
+}
+
+func (x *MultiPooler) GetPgDataDir() string {
+	if x != nil {
+		return x.PgDataDir
 	}
 	return ""
 }
@@ -1351,7 +1361,7 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bendpoint\x18\x03 \x01(\tR\bendpoint\x12\x1d\n" +
 	"\n" +
 	"key_prefix\x18\x04 \x01(\tR\tkeyPrefix\x12.\n" +
-	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\xf8\x03\n" +
+	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\x98\x04\n" +
 	"\vMultiPooler\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x1a\n" +
 	"\bdatabase\x18\x02 \x01(\tR\bdatabase\x12\x1f\n" +
@@ -1365,7 +1375,8 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bport_map\x18\t \x03(\v2).clustermetadata.MultiPooler.PortMapEntryR\aportMap\x12\x1d\n" +
 	"\n" +
 	"pooler_dir\x18\n" +
-	" \x01(\tR\tpoolerDir\x1a:\n" +
+	" \x01(\tR\tpoolerDir\x12\x1e\n" +
+	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf1\x01\n" +

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -811,6 +811,9 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 	}
 	multipoolerCmd.Env = append(os.Environ(), "POSTGRES_PASSWORD="+pgPassword)
 
+	// Set PGDATA so multipooler knows where the PostgreSQL data directory is.
+	multipoolerCmd.Env = append(os.Environ(), constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"))
+
 	fmt.Printf("▶️  - Launching multipooler (HTTP:%d, gRPC:%d)...", httpPort, grpcPort)
 
 	if err := telemetry.StartCmd(ctx, multipoolerCmd); err != nil {

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -297,6 +298,9 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	if runtime.GOOS == "darwin" && os.Getenv("LC_ALL") == "" && os.Getenv("LANG") == "" {
 		pgctldCmd.Env = append(pgctldCmd.Env, "LC_ALL=C")
 	}
+
+	// Set PGDATA so pgctld knows where the PostgreSQL data directory is.
+	pgctldCmd.Env = append(pgctldCmd.Env, constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"))
 
 	// Pass the PostgreSQL password so pgctld can use it during init (--pwfile)
 	// and pg_hba.conf setup.

--- a/go/services/multiadmin/backup.go
+++ b/go/services/multiadmin/backup.go
@@ -93,9 +93,8 @@ func (s *MultiAdminServer) executeBackup(ctx context.Context, jobID string, pool
 			s.logger.WarnContext(ctx, "Failed to find primary pooler for pg2_path override",
 				"error", err)
 			// Continue without override - will work in TLS mode, fail in local mode
-		} else if primary.PoolerDir != "" {
-			// Construct primary's PGDATA path: ${pooler_dir}/pg_data
-			overrides["pg2_path"] = primary.PoolerDir + "/pg_data"
+		} else if primary.PgDataDir != "" {
+			overrides["pg2_path"] = primary.PgDataDir
 			s.logger.DebugContext(ctx, "Added pg2_path override for replica backup",
 				"pg2_path", overrides["pg2_path"])
 		}

--- a/go/services/multipooler/grpcconsensusservice/service_test.go
+++ b/go/services/multipooler/grpcconsensusservice/service_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -98,7 +99,9 @@ func TestConsensusService_BeginTerm(t *testing.T) {
 	pgDataDir := tmpDir + "/pg_data"
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("16\n"), 0o644))
-	require.NoError(t, os.WriteFile(pgDataDir+"/MULTIGRES_INITIALIZED", []byte("initialized\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory, "MULTIGRES_INITIALIZED"), []byte("initialized\n"), 0o644))
 	defer pm.Shutdown()
 
 	// Start the async loader
@@ -189,7 +192,9 @@ func TestConsensusService_Status(t *testing.T) {
 	pgDataDir := tmpDir + "/pg_data"
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("16\n"), 0o644))
-	require.NoError(t, os.WriteFile(pgDataDir+"/MULTIGRES_INITIALIZED", []byte("initialized\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory, "MULTIGRES_INITIALIZED"), []byte("initialized\n"), 0o644))
 	defer pm.Shutdown()
 
 	// Start the async loader
@@ -273,7 +278,9 @@ func TestConsensusService_GetLeadershipView(t *testing.T) {
 	pgDataDir := tmpDir + "/pg_data"
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("16\n"), 0o644))
-	require.NoError(t, os.WriteFile(pgDataDir+"/MULTIGRES_INITIALIZED", []byte("initialized\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory, "MULTIGRES_INITIALIZED"), []byte("initialized\n"), 0o644))
 	defer pm.Shutdown()
 
 	// Start the async loader
@@ -352,7 +359,9 @@ func TestConsensusService_CanReachPrimary(t *testing.T) {
 	pgDataDir := tmpDir + "/pg_data"
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("16\n"), 0o644))
-	require.NoError(t, os.WriteFile(pgDataDir+"/MULTIGRES_INITIALIZED", []byte("initialized\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory, "MULTIGRES_INITIALIZED"), []byte("initialized\n"), 0o644))
 	defer pm.Shutdown()
 
 	// Start the async loader
@@ -433,7 +442,9 @@ func TestConsensusService_AllMethods(t *testing.T) {
 	pgDataDir := tmpDir + "/pg_data"
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("16\n"), 0o644))
-	require.NoError(t, os.WriteFile(pgDataDir+"/MULTIGRES_INITIALIZED", []byte("initialized\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, constants.MultigresMarkerDirectory, "MULTIGRES_INITIALIZED"), []byte("initialized\n"), 0o644))
 	defer pm.Shutdown()
 
 	// Start the async loader

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -272,6 +273,10 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 		return errors.New("shard is required")
 	}
 
+	if os.Getenv(constants.PgDataDirEnvVar) == "" {
+		return errors.New("PGDATA environment variable is required")
+	}
+
 	// Create multipooler record with all fields now that servenv.Init() has set them up
 	multipooler := topoclient.NewMultiPooler(serviceID, cell, mp.senv.GetHostname(), mp.tableGroup.Get())
 	multipooler.PortMap["grpc"] = int32(mp.grpcServer.Port())
@@ -283,6 +288,7 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 	multipooler.Shard = mp.shard.Get()
 	multipooler.ServingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
 	multipooler.PoolerDir = mp.poolerDir.Get()
+	multipooler.PgDataDir = os.Getenv(constants.PgDataDirEnvVar)
 	// For now, all poolers start as REPLICA
 	multipooler.Type = clustermetadatapb.PoolerType_REPLICA
 

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -729,7 +729,7 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 			PoolerDir:     pm.multipooler.PoolerDir,
 			Pg1Port:       pgPort,
 			Pg1SocketPath: socketDir,
-			Pg1Path:       filepath.Join(pm.multipooler.PoolerDir, "pg_data"),
+			Pg1Path:       postgresDataDir(),
 		}, backupConfig)
 		if err != nil {
 			pm.setStateError(fmt.Errorf("failed to generate pgbackrest client config: %w", err))

--- a/go/services/multipooler/manager/manager_test.go
+++ b/go/services/multipooler/manager/manager_test.go
@@ -320,7 +320,8 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 			poolerDir := t.TempDir()
 
 			// Create a minimal data directory structure to satisfy IsDataDirInitialized check
-			dataDir := postgresDataDir(poolerDir)
+			dataDir := filepath.Join(poolerDir, "pg_data")
+			t.Setenv(constants.PgDataDirEnvVar, dataDir)
 			require.NoError(t, os.MkdirAll(dataDir, 0o755))
 			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("15\n"), 0o644))
 

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -257,8 +257,7 @@ func (pm *MultiPoolerManager) isInitialized(ctx context.Context) bool {
 		// This marker is created after full initialization completes (schema created, backup done).
 		// It's more reliable than checking for PG_VERSION/global because those exist after initdb
 		// but before the full initialization process completes.
-		dataDir := filepath.Join(pm.multipooler.PoolerDir, "pg_data")
-		markerFile := filepath.Join(dataDir, multigresInitMarker)
+		markerFile := filepath.Join(multigresDataDir(), multigresInitMarker)
 		_, err := os.Stat(markerFile)
 		initialized = err == nil
 	}
@@ -292,22 +291,18 @@ func (pm *MultiPoolerManager) setInitialized() error {
 // initialized, because replica initialization is not done until the restore
 // from backup completes. There is no other persistent way to determine this.
 func (pm *MultiPoolerManager) writeInitializationMarker() error {
-	dataDir := filepath.Join(pm.multipooler.PoolerDir, "pg_data")
-	markerFile := filepath.Join(dataDir, multigresInitMarker)
+	if err := os.MkdirAll(multigresDataDir(), 0o755); err != nil {
+		return fmt.Errorf("failed to create multigres directory: %w", err)
+	}
+	markerFile := filepath.Join(multigresDataDir(), multigresInitMarker)
 	return os.WriteFile(markerFile, []byte("initialized\n"), 0o644)
 }
 
 // hasDataDirectory checks if the PostgreSQL data directory exists
 func (pm *MultiPoolerManager) hasDataDirectory() bool {
-	poolerDir := pm.multipooler.PoolerDir
-	if poolerDir == "" {
-		return false
-	}
-
 	// Check if PG_VERSION file exists to confirm the data directory is properly initialized.
 	// This prevents treating an empty directory (e.g., left behind by a failed initdb) as initialized.
-	dataDir := filepath.Join(poolerDir, "pg_data")
-	pgVersionFile := filepath.Join(dataDir, "PG_VERSION")
+	pgVersionFile := filepath.Join(postgresDataDir(), "PG_VERSION")
 	_, err := os.Stat(pgVersionFile)
 	return err == nil
 }
@@ -373,12 +368,10 @@ func (pm *MultiPoolerManager) getShardID() string {
 
 // removeDataDirectory removes the PostgreSQL data directory
 func (pm *MultiPoolerManager) removeDataDirectory() error {
-	poolerDir := pm.multipooler.PoolerDir
-	if poolerDir == "" {
-		return errors.New("pooler directory path not configured")
+	dataDir := postgresDataDir()
+	if dataDir == "" {
+		return errors.New("PGDATA environment variable not set")
 	}
-
-	dataDir := filepath.Join(poolerDir, "pg_data")
 
 	// Safety check: ensure we're not deleting root or home directory
 	absDataDir, err := filepath.Abs(dataDir)
@@ -457,7 +450,7 @@ func (pm *MultiPoolerManager) waitForDatabaseConnection(ctx context.Context) err
 // removeArchiveConfigFromAutoConf removes archive configuration lines from postgresql.auto.conf
 // This is used after restore to remove the primary's archive config before applying the standby's config
 func (pm *MultiPoolerManager) removeArchiveConfigFromAutoConf() error {
-	autoConfPath := filepath.Join(pm.multipooler.PoolerDir, "pg_data", "postgresql.auto.conf")
+	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
 
 	content, err := os.ReadFile(autoConfPath)
 	if err != nil {
@@ -496,7 +489,7 @@ func (pm *MultiPoolerManager) configureArchiveMode(ctx context.Context) error {
 			fmt.Sprintf("pgbackrest config file not found at %s - ensure pgctld generated the config successfully", configPath))
 	}
 
-	autoConfPath := filepath.Join(pm.multipooler.PoolerDir, "pg_data", "postgresql.auto.conf")
+	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
 
 	// Check if archive_mode is already configured to avoid duplicates
 	if _, err := os.Stat(autoConfPath); err == nil {

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -63,9 +63,10 @@ func TestInitializeEmptyPrimary(t *testing.T) {
 			name: "idempotent - already has a backup",
 			setupFunc: func(t *testing.T, pm *MultiPoolerManager, poolerDir string) {
 				dataDir := filepath.Join(poolerDir, "pg_data")
-				require.NoError(t, os.MkdirAll(dataDir, 0o755))
+				markerDir := filepath.Join(dataDir, constants.MultigresMarkerDirectory)
+				require.NoError(t, os.MkdirAll(markerDir, 0o755))
 				require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("16"), 0o644))
-				require.NoError(t, os.WriteFile(filepath.Join(dataDir, multigresInitMarker), []byte("initialized\n"), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(markerDir, multigresInitMarker), []byte("initialized\n"), 0o644))
 			},
 			term:          1,
 			expectSuccess: true,
@@ -93,6 +94,7 @@ func TestInitializeEmptyPrimary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
 			poolerDir := t.TempDir()
+			t.Setenv(constants.PgDataDirEnvVar, filepath.Join(poolerDir, "pg_data"))
 
 			// Create test config with topology store that has backup location
 			database := "postgres"
@@ -201,9 +203,11 @@ func TestIsInitialized(t *testing.T) {
 		ctx := t.Context()
 		poolerDir := t.TempDir()
 		dataDir := filepath.Join(poolerDir, "pg_data")
-		require.NoError(t, os.MkdirAll(dataDir, 0o755))
+		markerDir := filepath.Join(dataDir, constants.MultigresMarkerDirectory)
+		require.NoError(t, os.MkdirAll(markerDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("16"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dataDir, multigresInitMarker), []byte("initialized\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(markerDir, multigresInitMarker), []byte("initialized\n"), 0o644))
+		t.Setenv(constants.PgDataDirEnvVar, dataDir)
 
 		pm := &MultiPoolerManager{
 			config:      &Config{},
@@ -232,6 +236,9 @@ func TestIsInitialized(t *testing.T) {
 func TestHelperMethods(t *testing.T) {
 	t.Run("hasDataDirectory", func(t *testing.T) {
 		poolerDir := t.TempDir()
+		dataDir := filepath.Join(poolerDir, "pg_data")
+		t.Setenv(constants.PgDataDirEnvVar, dataDir)
+
 		multiPooler := &clustermetadatapb.MultiPooler{PoolerDir: poolerDir}
 		pm := &MultiPoolerManager{config: &Config{}, multipooler: multiPooler}
 
@@ -239,7 +246,6 @@ func TestHelperMethods(t *testing.T) {
 		assert.False(t, pm.hasDataDirectory())
 
 		// Create data directory with PG_VERSION file (simulating initialized postgres)
-		dataDir := filepath.Join(poolerDir, "pg_data")
 		require.NoError(t, os.MkdirAll(dataDir, 0o755))
 		pgVersionFile := filepath.Join(dataDir, "PG_VERSION")
 		require.NoError(t, os.WriteFile(pgVersionFile, []byte("16"), 0o644))
@@ -277,6 +283,7 @@ func TestHelperMethods(t *testing.T) {
 		// Create data directory
 		dataDir := filepath.Join(poolerDir, "pg_data")
 		require.NoError(t, os.MkdirAll(dataDir, 0o755))
+		t.Setenv(constants.PgDataDirEnvVar, dataDir)
 
 		// Should succeed with valid directory
 		err := pm.removeDataDirectory()
@@ -294,6 +301,7 @@ func TestHelperMethods(t *testing.T) {
 func TestInitializeEmptyPrimary_EventPoolerName(t *testing.T) {
 	ctx := t.Context()
 	poolerDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, filepath.Join(poolerDir, "pg_data"))
 
 	database := "postgres"
 	backupLocation := t.TempDir()

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -1699,7 +1699,7 @@ func (pm *MultiPoolerManager) fixPgBackRestPaths(ctx context.Context) error {
 		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pooler directory not set")
 	}
 
-	autoConfPath := filepath.Join(poolerDir, "pg_data", "postgresql.auto.conf")
+	autoConfPath := filepath.Join(postgresDataDir(), "postgresql.auto.conf")
 
 	pm.logger.InfoContext(ctx, "Fixing pgbackrest paths in postgresql.auto.conf", "file", autoConfPath)
 

--- a/go/services/multipooler/manager/term_storage.go
+++ b/go/services/multipooler/manager/term_storage.go
@@ -21,26 +21,23 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/multigres/multigres/go/common/constants"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
-// postgresDataDir returns the PostgreSQL data directory path
-func postgresDataDir(poolerDir string) string {
-	return filepath.Join(poolerDir, "pg_data")
+// postgresDataDir returns the PostgreSQL data directory path from PGDATA env var
+func postgresDataDir() string {
+	return os.Getenv(constants.PgDataDirEnvVar)
 }
 
-// isDataDirInitialized checks if the PostgreSQL data directory is initialized
-func isDataDirInitialized(poolerDir string) bool {
-	dataDir := postgresDataDir(poolerDir)
-	pgVersionFile := filepath.Join(dataDir, "PG_VERSION")
-	_, err := os.Stat(pgVersionFile)
-	return err == nil
+// multigresDataDir returns the multigres-specific subdirectory within PGDATA
+func multigresDataDir() string {
+	return filepath.Join(postgresDataDir(), constants.MultigresMarkerDirectory)
 }
 
 // consensusTermPath returns the path to the consensus term file
 func consensusTermPath(poolerDir string) string {
-	dataDir := postgresDataDir(poolerDir)
-	return filepath.Join(dataDir, "consensus", "consensus_term.json")
+	return filepath.Join(poolerDir, "pg_data", "consensus", "consensus_term.json")
 }
 
 // getConsensusTerm retrieves the current consensus term information from disk
@@ -70,17 +67,10 @@ func getConsensusTerm(poolerDir string) (*multipoolermanagerdatapb.ConsensusTerm
 
 // setConsensusTerm saves the consensus term information to disk
 func setConsensusTerm(poolerDir string, term *multipoolermanagerdatapb.ConsensusTerm) error {
-	// Check if data directory is initialized
-	if !isDataDirInitialized(poolerDir) {
-		dataDir := postgresDataDir(poolerDir)
-		return fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
-	}
-
 	termPath := consensusTermPath(poolerDir)
 	consensusDir := filepath.Dir(termPath)
 
-	// Ensure consensus directory exists (data directory should already exist since we checked above)
-	// Note: This will only create the consensus subdirectory, not the pg_data parent
+	// Ensure consensus directory exists
 	if err := os.MkdirAll(consensusDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create consensus directory: %w", err)
 	}

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 
 	"github.com/multigres/multigres/config"
+	"github.com/multigres/multigres/go/common/constants"
 )
 
 // ExpandToAbsolutePath converts a relative path to an absolute path.
@@ -64,10 +65,10 @@ func GeneratePostgresServerConfig(poolerDir string, port int, pgUser string) (*P
 		return nil, fmt.Errorf("failed to expand pooler directory path: %w", err)
 	}
 	cnf := &PostgresServerConfig{}
-	cnf.Path = PostgresConfigFile(absPoolerDir)
-	cnf.DataDir = PostgresDataDir(absPoolerDir)
-	cnf.HbaFile = path.Join(PostgresDataDir(absPoolerDir), "pg_hba.conf")
-	cnf.IdentFile = path.Join(PostgresDataDir(absPoolerDir), "pg_ident.conf")
+	cnf.Path = PostgresConfigFile()
+	cnf.DataDir = PostgresDataDir()
+	cnf.HbaFile = path.Join(PostgresDataDir(), "pg_hba.conf")
+	cnf.IdentFile = path.Join(PostgresDataDir(), "pg_ident.conf")
 	cnf.Port = port
 	cnf.ListenAddresses = "localhost"
 	cnf.UnixSocketDirectories = PostgresSocketDir(absPoolerDir)
@@ -128,7 +129,7 @@ func LoadOrCreatePostgresServerConfig(poolerDir string, port int, pgUser string)
 		return nil, fmt.Errorf("failed to expand pooler directory path: %w", err)
 	}
 
-	configPath := PostgresConfigFile(absPoolerDir)
+	configPath := PostgresConfigFile()
 
 	// Check if config file already exists
 	if _, err := os.Stat(configPath); err == nil {
@@ -170,9 +171,9 @@ func (cnf *PostgresServerConfig) generateHbaFile() error {
 	return os.WriteFile(cnf.HbaFile, []byte(content), 0o644)
 }
 
-// PostgresDataDir returns the default location of the postgresql.conf file.
-func PostgresDataDir(poolerDir string) string {
-	return path.Join(poolerDir, "pg_data")
+// PostgresDataDir returns the PostgreSQL data directory from the PGDATA environment variable.
+func PostgresDataDir() string {
+	return os.Getenv(constants.PgDataDirEnvVar)
 }
 
 // PostgresSocketDir returns the default location of the PostgreSQL Unix sockets.
@@ -180,9 +181,9 @@ func PostgresSocketDir(poolerDir string) string {
 	return path.Join(poolerDir, "pg_sockets")
 }
 
-// PostgresConfigFile returns the default location of the postgresql.conf file.
-func PostgresConfigFile(poolerDir string) string {
-	return path.Join(PostgresDataDir(poolerDir), "postgresql.conf")
+// PostgresConfigFile returns the location of the postgresql.conf file within PGDATA.
+func PostgresConfigFile() string {
+	return path.Join(PostgresDataDir(), "postgresql.conf")
 }
 
 // MakePostgresConf will substitute values in the template

--- a/go/services/pgctld/postgresconfig_gen_test.go
+++ b/go/services/pgctld/postgresconfig_gen_test.go
@@ -19,10 +19,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
 )
 
 func TestNewPostgresServerConfig(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
 	tests := []struct {
 		name          string
@@ -73,24 +76,27 @@ func TestNewPostgresServerConfig(t *testing.T) {
 
 func TestPostgresBaseDir(t *testing.T) {
 	tempDir := t.TempDir()
-
 	expected := tempDir + "/pg_data"
-	result := PostgresDataDir(tempDir)
+	t.Setenv(constants.PgDataDirEnvVar, expected)
+
+	result := PostgresDataDir()
 
 	assert.Equal(t, expected, result, "PostgresDataDir should return expected path")
 }
 
 func TestPostgresConfigFile(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
 	expected := tempDir + "/pg_data/postgresql.conf"
-	result := PostgresConfigFile(tempDir)
+	result := PostgresConfigFile()
 
 	assert.Equal(t, expected, result, "PostgresConfigFile should return expected path")
 }
 
 func TestMakePostgresConf(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
 	config, err := GeneratePostgresServerConfig(tempDir, 5432, "postgres")
 	require.NoError(t, err, "GeneratePostgresServerConfig should not return error")

--- a/go/services/pgctld/postgresctl_config.go
+++ b/go/services/pgctld/postgresctl_config.go
@@ -65,11 +65,10 @@ func NewPostgresCtlConfig(port int, user string, database string, timeout int, p
 	}, nil
 }
 
-// IsDataDirInitialized checks if a PostgreSQL data directory has been initialized
-func IsDataDirInitialized(poolerDir string) bool {
+// IsDataDirInitialized checks if the PostgreSQL data directory (PGDATA) has been initialized
+func IsDataDirInitialized() bool {
 	// Check if PG_VERSION file exists (indicates initialized data directory)
-	dataDir := PostgresDataDir(poolerDir)
-	pgVersionFile := filepath.Join(dataDir, "PG_VERSION")
+	pgVersionFile := filepath.Join(PostgresDataDir(), "PG_VERSION")
 	_, err := os.Stat(pgVersionFile)
 	return err == nil
 }

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -407,7 +407,7 @@ func TestBootstrapInitialization(t *testing.T) {
 		standbyInst.Pgctld.StopPostgres(t)
 
 		// Remove pg_data directory to simulate complete data loss
-		pgDataDir := filepath.Join(standbyInst.Pgctld.DataDir, "pg_data")
+		pgDataDir := filepath.Join(standbyInst.Pgctld.PoolerDir, "pg_data")
 		err := os.RemoveAll(pgDataDir)
 		require.NoError(t, err, "Should remove pg_data directory")
 		t.Logf("Removed pg_data directory: %s", pgDataDir)
@@ -459,7 +459,7 @@ func TestBootstrapInitialization(t *testing.T) {
 		// Verify each pooler has archive_command pointing to its own local pgbackrest.conf
 		for name, inst := range setup.Multipoolers {
 			// Read postgresql.auto.conf
-			autoConfPath := filepath.Join(inst.Pgctld.DataDir, "pg_data", "postgresql.auto.conf")
+			autoConfPath := filepath.Join(inst.Pgctld.PoolerDir, "pg_data", "postgresql.auto.conf")
 			content, err := os.ReadFile(autoConfPath)
 			require.NoError(t, err, "Should read postgresql.auto.conf on %s", name)
 
@@ -470,7 +470,7 @@ func TestBootstrapInitialization(t *testing.T) {
 				"Node %s should have archive_mode enabled", name)
 
 			// Verify archive_command points to this pooler's local pgbackrest.conf
-			expectedConfigPath := filepath.Join(inst.Pgctld.DataDir, "pgbackrest", "pgbackrest.conf")
+			expectedConfigPath := filepath.Join(inst.Pgctld.PoolerDir, "pgbackrest", "pgbackrest.conf")
 			assert.Contains(t, autoConfStr, "--config="+expectedConfigPath,
 				"Node %s should have archive_command pointing to local pgbackrest.conf at %s", name, expectedConfigPath)
 		}

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -324,7 +324,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		require.Equal(t, clustermetadatapb.PoolerType_PRIMARY, resp.Status.PoolerType, "Final leader should have PRIMARY pooler type")
 
 		// Verify we can connect and query
-		socketDir := filepath.Join(finalPrimaryInst.Pgctld.DataDir, "pg_sockets")
+		socketDir := filepath.Join(finalPrimaryInst.Pgctld.PoolerDir, "pg_sockets")
 		db := connectToPostgres(t, socketDir, finalPrimaryInst.Pgctld.PgPort)
 		defer db.Close()
 
@@ -340,7 +340,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		finalPrimaryInst := setup.GetMultipoolerInstance(finalPrimaryName)
 		require.NotNil(t, finalPrimaryInst, "final primary instance should exist")
 
-		socketDir := filepath.Join(finalPrimaryInst.Pgctld.DataDir, "pg_sockets")
+		socketDir := filepath.Join(finalPrimaryInst.Pgctld.PoolerDir, "pg_sockets")
 		db := connectToPostgres(t, socketDir, finalPrimaryInst.Pgctld.PgPort)
 		defer db.Close()
 
@@ -361,7 +361,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		finalPrimaryInst := setup.GetMultipoolerInstance(finalPrimaryName)
 		require.NotNil(t, finalPrimaryInst, "final primary instance should exist")
 
-		socketDir := filepath.Join(finalPrimaryInst.Pgctld.DataDir, "pg_sockets")
+		socketDir := filepath.Join(finalPrimaryInst.Pgctld.PoolerDir, "pg_sockets")
 		db := connectToPostgres(t, socketDir, finalPrimaryInst.Pgctld.PgPort)
 		defer db.Close()
 
@@ -469,7 +469,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		require.NotNil(t, finalPrimaryInst)
 
 		// Connect to primary and get row count and checksum
-		primarySocketDir := filepath.Join(finalPrimaryInst.Pgctld.DataDir, "pg_sockets")
+		primarySocketDir := filepath.Join(finalPrimaryInst.Pgctld.PoolerDir, "pg_sockets")
 		primaryDB := connectToPostgres(t, primarySocketDir, finalPrimaryInst.Pgctld.PgPort)
 		defer primaryDB.Close()
 
@@ -500,7 +500,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 // verifyStandbyDataConsistency checks that a standby has the same data as the primary.
 func verifyStandbyDataConsistency(t *testing.T, name string, inst *shardsetup.MultipoolerInstance, countQuery, checksumQuery string, expectedRowCount int, expectedChecksum string) {
 	t.Helper()
-	standbySocketDir := filepath.Join(inst.Pgctld.DataDir, "pg_sockets")
+	standbySocketDir := filepath.Join(inst.Pgctld.PoolerDir, "pg_sockets")
 	standbyDB := connectToPostgres(t, standbySocketDir, inst.Pgctld.PgPort)
 	defer standbyDB.Close()
 
@@ -793,7 +793,7 @@ func TestPoolerDownNoFailover(t *testing.T) {
 
 	// Verify we can still query postgres on the primary directly (it's still running)
 	t.Run("verify primary postgres is still running", func(t *testing.T) {
-		socketDir := filepath.Join(primary.Pgctld.DataDir, "pg_sockets")
+		socketDir := filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets")
 		db := connectToPostgres(t, socketDir, primary.Pgctld.PgPort)
 		defer db.Close()
 
@@ -819,7 +819,7 @@ func TestPoolerDownNoFailover(t *testing.T) {
 // verifyStandbyIsQueryable checks that a standby postgres is queryable.
 func verifyStandbyIsQueryable(t *testing.T, name string, inst *shardsetup.MultipoolerInstance) {
 	t.Helper()
-	socketDir := filepath.Join(inst.Pgctld.DataDir, "pg_sockets")
+	socketDir := filepath.Join(inst.Pgctld.PoolerDir, "pg_sockets")
 	db := connectToPostgres(t, socketDir, inst.Pgctld.PgPort)
 	defer db.Close()
 

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -244,7 +244,7 @@ func writeDataToNewPrimary(t *testing.T, setup *shardsetup.ShardSetup, primaryNa
 	primary := setup.GetMultipoolerInstance(primaryName)
 	require.NotNil(t, primary, "primary instance should exist")
 
-	socketDir := filepath.Join(primary.Pgctld.DataDir, "pg_sockets")
+	socketDir := filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets")
 	db := connectToPostgres(t, socketDir, primary.Pgctld.PgPort)
 	require.NotNil(t, db, "should connect to new primary")
 	defer db.Close()

--- a/go/test/endtoend/multipooler/backup_failover_test.go
+++ b/go/test/endtoend/multipooler/backup_failover_test.go
@@ -130,7 +130,7 @@ func TestBackup_FailsDuringPrimaryFailover(t *testing.T) {
 
 	// pg2-path is required even in TLS mode (pgBackRest 2.58+).
 	// Pass the primary's pg_data directory so pgBackRest can connect to it remotely.
-	primaryPg2Path := filepath.Join(primary.Pgctld.DataDir, "pg_data")
+	primaryPg2Path := filepath.Join(primary.Pgctld.PoolerDir, "pg_data")
 
 	// Start a full backup from the standby in a goroutine (it will block inside s3mock).
 	// The standby connects to the primary's pgBackRest TLS server (pg2-host-type=tls).

--- a/go/test/endtoend/multipooler/backup_test.go
+++ b/go/test/endtoend/multipooler/backup_test.go
@@ -101,7 +101,7 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 			// Connect to primary PostgreSQL database using Unix socket
 			var err error
 			db := connectToPostgresViaSocket(t,
-				getPostgresSocketPath(setup.PrimaryPgctld.DataDir),
+				getPostgresSocketPath(setup.PrimaryPgctld.PoolerDir),
 				setup.PrimaryPgctld.PgPort)
 			defer db.Close()
 
@@ -217,7 +217,7 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 					require.NoError(t, err, "Should be able to stop PostgreSQL on standby")
 
 					// Remove pg_data directory
-					removeDataDirectory(t, setup.StandbyPgctld.DataDir)
+					removeDataDirectory(t, setup.StandbyPgctld.PoolerDir)
 
 					restoreReq := &multipoolermanagerdata.RestoreFromBackupRequest{
 						BackupId: fullBackupID,
@@ -266,7 +266,7 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 
 					// Connect to the standby database after restore
 					standbyDB := connectToPostgresViaSocket(t,
-						getPostgresSocketPath(setup.StandbyPgctld.DataDir),
+						getPostgresSocketPath(setup.StandbyPgctld.PoolerDir),
 						setup.StandbyPgctld.PgPort)
 					defer standbyDB.Close()
 
@@ -292,7 +292,7 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 					}, 10*time.Second, 100*time.Millisecond, "New row should replicate to standby after restore")
 
 					// Check if standby.signal exists
-					standbySignalPath := filepath.Join(setup.StandbyPgctld.DataDir, "pg_data", "standby.signal")
+					standbySignalPath := filepath.Join(setup.StandbyPgctld.PoolerDir, "pg_data", "standby.signal")
 					_, statErr := os.Stat(standbySignalPath)
 					assert.Nil(t, statErr, "standby signal should exist")
 
@@ -460,7 +460,7 @@ func TestBackup_FromStandby(t *testing.T) {
 
 			// For local mode (tests without TLS), we need to pass pg2_path override
 			// so pgBackRest can connect to the primary's postgres to get WAL files
-			primaryDataPath := filepath.Join(setup.PrimaryPgctld.DataDir, "pg_data")
+			primaryDataPath := filepath.Join(setup.PrimaryPgctld.PoolerDir, "pg_data")
 			overrides := map[string]string{
 				"pg2_path": primaryDataPath,
 			}
@@ -596,7 +596,7 @@ func TestBackup_MultiAdminAPIs(t *testing.T) {
 				t.Log("PostgreSQL stopped on standby")
 
 				t.Log("Step 3: Removing standby pg_data directory...")
-				removeDataDirectory(t, setup.StandbyPgctld.DataDir)
+				removeDataDirectory(t, setup.StandbyPgctld.PoolerDir)
 
 				t.Log("Step 4: Restoring backup to standby via MultiAdmin API...")
 
@@ -658,7 +658,7 @@ func TestBackup_MultiAdminAPIs(t *testing.T) {
 
 				// Connect to standby and verify it's in recovery mode
 				standbyDB := connectToPostgresViaSocket(t,
-					getPostgresSocketPath(setup.StandbyPgctld.DataDir),
+					getPostgresSocketPath(setup.StandbyPgctld.PoolerDir),
 					setup.StandbyPgctld.PgPort)
 				defer standbyDB.Close()
 

--- a/go/test/endtoend/multipooler/rpc_manager_promotion_demotion_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_promotion_demotion_test.go
@@ -131,7 +131,7 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Verify standby.signal exists after demotion and replication config
 		t.Log("Verifying standby.signal exists after demotion...")
-		primaryStandbySignalPath := filepath.Join(setup.PrimaryPgctld.DataDir, "pg_data", "standby.signal")
+		primaryStandbySignalPath := filepath.Join(setup.PrimaryPgctld.PoolerDir, "pg_data", "standby.signal")
 		_, statErr := os.Stat(primaryStandbySignalPath)
 		assert.NoError(t, statErr, "standby.signal should exist after demotion")
 
@@ -170,8 +170,8 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Verify signal files are removed after promotion
 		t.Log("Verifying signal files removed from newly promoted primary...")
-		standbySignalPath := filepath.Join(setup.StandbyPgctld.DataDir, "pg_data", "standby.signal")
-		recoverySignalPath := filepath.Join(setup.StandbyPgctld.DataDir, "pg_data", "recovery.signal")
+		standbySignalPath := filepath.Join(setup.StandbyPgctld.PoolerDir, "pg_data", "standby.signal")
+		recoverySignalPath := filepath.Join(setup.StandbyPgctld.PoolerDir, "pg_data", "recovery.signal")
 
 		_, standbyStatErr := os.Stat(standbySignalPath)
 		assert.True(t, os.IsNotExist(standbyStatErr), "standby.signal should not exist after promotion")
@@ -204,7 +204,7 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Verify standby.signal exists after second demotion
 		t.Log("Verifying standby.signal exists after second demotion...")
-		standbyStandbySignalPath := filepath.Join(setup.StandbyPgctld.DataDir, "pg_data", "standby.signal")
+		standbyStandbySignalPath := filepath.Join(setup.StandbyPgctld.PoolerDir, "pg_data", "standby.signal")
 		_, statErr2 := os.Stat(standbyStandbySignalPath)
 		assert.NoError(t, statErr2, "standby.signal should exist after demotion")
 
@@ -233,8 +233,8 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Verify signal files are removed after restoring original primary
 		t.Log("Verifying signal files removed from restored primary...")
-		primaryStandbySignalPath = filepath.Join(setup.PrimaryPgctld.DataDir, "pg_data", "standby.signal")
-		primaryRecoverySignalPath := filepath.Join(setup.PrimaryPgctld.DataDir, "pg_data", "recovery.signal")
+		primaryStandbySignalPath = filepath.Join(setup.PrimaryPgctld.PoolerDir, "pg_data", "standby.signal")
+		primaryRecoverySignalPath := filepath.Join(setup.PrimaryPgctld.PoolerDir, "pg_data", "recovery.signal")
 
 		_, primaryStandbyStatErr := os.Stat(primaryStandbySignalPath)
 		assert.True(t, os.IsNotExist(primaryStandbyStatErr), "standby.signal should not exist after promotion")

--- a/go/test/endtoend/pgctld/health_test.go
+++ b/go/test/endtoend/pgctld/health_test.go
@@ -56,7 +56,7 @@ func TestPgctldLiveEndpoint(t *testing.T) {
 		"--pg-port", strconv.Itoa(pgPort),
 		"--timeout", "30",
 	)
-	setupTestEnv(cmd)
+	setupTestEnv(cmd, tempDir)
 
 	err := cmd.Start()
 	require.NoError(t, err, "pgctld should start")

--- a/go/test/endtoend/pgctld/pgbackrest_server_test.go
+++ b/go/test/endtoend/pgctld/pgbackrest_server_test.go
@@ -51,7 +51,7 @@ func TestPgBackRestServer_Lifecycle(t *testing.T) {
 	initAndStartPostgreSQL(t, client)
 
 	// Verify pgbackrest-server.conf was generated
-	configPath := filepath.Join(setup.DataDir, "pgbackrest", "pgbackrest-server.conf")
+	configPath := filepath.Join(setup.PoolerDir, "pgbackrest", "pgbackrest-server.conf")
 	assert.FileExists(t, configPath, "pgbackrest-server.conf should be generated")
 
 	// Verify TLS server is running via socket connection
@@ -120,7 +120,7 @@ func TestPgBackRestServer_CrashRecovery(t *testing.T) {
 	require.Equal(t, int32(0), status1.RestartCount, "Should have zero restarts initially")
 
 	// Get the PID of the running pgBackRest process for this specific test
-	configPath := filepath.Join(setup.DataDir, "pgbackrest", "pgbackrest-server.conf")
+	configPath := filepath.Join(setup.PoolerDir, "pgbackrest", "pgbackrest-server.conf")
 	pid1 := getPgBackRestPID(t, configPath)
 	require.Greater(t, pid1, 0, "Should find running pgBackRest process")
 	t.Logf("Initial pgBackRest PID: %d", pid1)

--- a/go/test/endtoend/pgctld/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld/pgctld_grpc_test.go
@@ -421,6 +421,10 @@ func TestGRPCPortableConfig(t *testing.T) {
 	testutil.CreateMockPostgreSQLBinaries(t, binDir)
 
 	t.Run("portable_config_with_different_ports", func(t *testing.T) {
+		// Set environment variables before creating service (NewPgCtldService reads PGDATA)
+		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(dataDir, "pg_data"))
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
 		// First, create a service with port 5432 and initialize
 		initialPort := 5432
 		service, err := command.NewPgCtldService(
@@ -436,10 +440,6 @@ func TestGRPCPortableConfig(t *testing.T) {
 			"", // pgbackrestCertDir
 		)
 		require.NoError(t, err)
-
-		// Set environment variables for the initialization
-		t.Setenv("PGDATA", dataDir)
-		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 		// Initialize the data directory with the initial port
 		ctx := context.Background()
@@ -478,6 +478,10 @@ func createTestGRPCServer(t *testing.T, dataDir, binDir string) (net.Listener, f
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
 
+	// Set environment variables before creating service (NewPgCtldService reads PGDATA)
+	t.Setenv(constants.PgDataDirEnvVar, filepath.Join(dataDir, "pg_data"))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
 	// Create the pgctld service with mock environment
 	service, err := command.NewPgCtldService(
 		slog.Default(),
@@ -493,9 +497,6 @@ func createTestGRPCServer(t *testing.T, dataDir, binDir string) (net.Listener, f
 	)
 
 	require.NoError(t, err)
-	// Set environment variables for the service
-	t.Setenv("PGDATA", dataDir)
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	// Register the service
 	pb.RegisterPgCtldServer(grpcServer, service)

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	"github.com/multigres/multigres/go/common/constants"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/test/utils"
 	"github.com/multigres/multigres/go/tools/pathutil"
@@ -51,10 +52,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run()) //nolint:forbidigo
 }
 
-// setupTestEnv sets up environment variables for PostgreSQL tests
-func setupTestEnv(cmd *exec.Cmd) {
+// setupTestEnv sets up environment variables for PostgreSQL tests.
+// poolerDir is the pooler directory; PGDATA is set to poolerDir/pg_data.
+func setupTestEnv(cmd *exec.Cmd, poolerDir string) {
 	cmd.Env = append(os.Environ(),
 		"PGCONNECT_TIMEOUT=5", // Shorter timeout for tests
+		constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"),
 	)
 	if runtime.GOOS == "darwin" {
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
@@ -63,8 +66,8 @@ func setupTestEnv(cmd *exec.Cmd) {
 }
 
 // setupTestEnvWithPassword sets up environment variables for PostgreSQL tests, including the password.
-func setupTestEnvWithPassword(cmd *exec.Cmd, password string) {
-	setupTestEnv(cmd)
+func setupTestEnvWithPassword(cmd *exec.Cmd, poolerDir, password string) {
+	setupTestEnv(cmd, poolerDir)
 	cmd.Env = append(cmd.Env, "POSTGRES_PASSWORD="+password)
 }
 
@@ -97,7 +100,7 @@ timeout: 30
 	t.Run("basic_commands_with_real_postgresql", func(t *testing.T) {
 		// Step 1: Initialize the database first
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
-		setupTestEnv(initCmd)
+		setupTestEnv(initCmd, dataDir)
 		initOutput, err := initCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld init failed with output: %s", string(initOutput))
@@ -118,7 +121,7 @@ timeout: 30
 
 		// Step 2: Check status - should show stopped after init
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
-		setupTestEnv(statusCmd)
+		setupTestEnv(statusCmd, dataDir)
 		output, err := statusCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld status failed with output: %s", string(output))
@@ -191,6 +194,7 @@ timeout: 30
 		serverCmd.Env = append(os.Environ(),
 			"MULTIGRES_TESTDATA_DIR="+tempDir,
 			"PGCONNECT_TIMEOUT=5",
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"),
 		)
 
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
@@ -269,7 +273,7 @@ timeout: 30
 		// Measure time to start PostgreSQL
 		startTime := time.Now()
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(perfTestPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(initCmd)
+		setupTestEnv(initCmd, dataDir)
 		startOutput, err := initCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld start failed with output: %s", string(startOutput))
@@ -278,7 +282,7 @@ timeout: 30
 		require.NoError(t, err)
 
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(perfTestPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(startCmd)
+		setupTestEnv(startCmd, dataDir)
 		startOutput, err = startCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld start failed with output: %s", string(startOutput))
@@ -293,7 +297,7 @@ timeout: 30
 
 		// Clean shutdown
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(perfTestPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(stopCmd)
+		setupTestEnv(stopCmd, dataDir)
 		err = stopCmd.Run()
 		require.NoError(t, err)
 	})
@@ -305,7 +309,7 @@ timeout: 30
 
 			// Start
 			startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(perfTestPort), "--config-file", pgctldConfigFile)
-			setupTestEnv(startCmd)
+			setupTestEnv(startCmd, dataDir)
 			startOutput, err := startCmd.CombinedOutput()
 			if err != nil {
 				t.Logf("pgctld start failed with error: %v, output: %s", err, string(startOutput))
@@ -317,7 +321,7 @@ timeout: 30
 
 			// Stop
 			stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(perfTestPort), "--mode", "fast", "--config-file", pgctldConfigFile)
-			setupTestEnv(stopCmd)
+			setupTestEnv(stopCmd, dataDir)
 			err = stopCmd.Run()
 			require.NoError(t, err)
 
@@ -366,7 +370,7 @@ timeout: 30
 		t.Logf("PostgreSQL version: %s", string(output))
 
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile, "--pg-port", strconv.Itoa(testPort))
-		setupTestEnv(initCmd)
+		setupTestEnv(initCmd, dataDir)
 		initOutput, err := initCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld init failed with output: %s", string(initOutput))
@@ -375,7 +379,7 @@ timeout: 30
 
 		// Start PostgreSQL to test compatibility
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(startCmd)
+		setupTestEnv(startCmd, dataDir)
 		startOutput, err := startCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("pgctld start failed with output: %s", string(startOutput))
@@ -384,14 +388,14 @@ timeout: 30
 
 		// Get version info through pgctld
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(statusCmd)
+		setupTestEnv(statusCmd, dataDir)
 		output, err = statusCmd.Output()
 		require.NoError(t, err)
 		t.Logf("pgctld status output: %s", string(output))
 
 		// Clean shutdown
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-		setupTestEnv(stopCmd)
+		setupTestEnv(stopCmd, dataDir)
 		err = stopCmd.Run()
 		require.NoError(t, err)
 	})
@@ -428,7 +432,7 @@ timeout: 30
 
 	// Initialize database
 	initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(initCmd)
+	setupTestEnv(initCmd, dataDir)
 	initOutput, err := initCmd.CombinedOutput()
 	if err != nil {
 		t.Logf("pgctld init failed with output: %s", string(initOutput))
@@ -437,7 +441,7 @@ timeout: 30
 
 	// Start PostgreSQL
 	startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(startCmd)
+	setupTestEnv(startCmd, dataDir)
 	startOutput, err := startCmd.CombinedOutput()
 	if err != nil {
 		t.Logf("pgctld start failed with output: %s", string(startOutput))
@@ -446,14 +450,14 @@ timeout: 30
 
 	// Verify it's running
 	statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(statusCmd)
+	setupTestEnv(statusCmd, dataDir)
 	output, err := statusCmd.Output()
 	require.NoError(t, err)
 	assert.Contains(t, string(output), "Running")
 
 	// Restart as standby
 	restartCmd := exec.Command("pgctld", "restart", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--as-standby", "--config-file", pgctldConfigFile)
-	setupTestEnv(restartCmd)
+	setupTestEnv(restartCmd, dataDir)
 	output, err = restartCmd.CombinedOutput()
 	if err != nil {
 		t.Logf("restart --as-standby output: %s", string(output))
@@ -468,7 +472,7 @@ timeout: 30
 
 	// Verify server is still running
 	statusCmd = exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(statusCmd)
+	setupTestEnv(statusCmd, dataDir)
 	output, err = statusCmd.Output()
 	require.NoError(t, err)
 	assert.Contains(t, string(output), "Running")
@@ -483,7 +487,7 @@ timeout: 30
 		"-d", "postgres",
 		"-t", "-c", "SELECT pg_is_in_recovery();",
 	)
-	setupTestEnv(recoveryCheckCmd)
+	setupTestEnv(recoveryCheckCmd, dataDir)
 	output, err = recoveryCheckCmd.CombinedOutput()
 	require.NoError(t, err, "Recovery check should succeed, output: %s", string(output))
 	t.Logf("Recovery mode check result: %s", string(output))
@@ -492,7 +496,7 @@ timeout: 30
 
 	// Clean stop
 	stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(stopCmd)
+	setupTestEnv(stopCmd, dataDir)
 	err = stopCmd.Run()
 	require.NoError(t, err)
 }
@@ -532,6 +536,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		initCmd.Env = append(os.Environ(),
 			"PGCONNECT_TIMEOUT=5",
 			"POSTGRES_PASSWORD="+testPassword,
+			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
 		)
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
 		if runtime.GOOS == "darwin" {
@@ -548,6 +553,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		startCmd.Env = append(os.Environ(),
 			"PGCONNECT_TIMEOUT=5",
 			"POSTGRES_PASSWORD="+testPassword,
+			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
 		)
 
 		// Required to avoid "postmaster became multithreaded during startup" on macOS
@@ -581,6 +587,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 
 		// Get the actual port from the status output
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", baseDir)
+		statusCmd.Env = append(os.Environ(), constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"))
 		statusOutput, err := statusCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld status should succeed")
 		t.Logf("Status output: %s", string(statusOutput))
@@ -655,7 +662,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		// Clean shutdown
 		t.Logf("Shutting down PostgreSQL")
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", baseDir)
-		stopCmd.Env = append(os.Environ(), "PGCONNECT_TIMEOUT=5")
+		stopCmd.Env = append(os.Environ(), "PGCONNECT_TIMEOUT=5", constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"))
 		err = stopCmd.Run()
 		require.NoError(t, err, "pgctld stop should succeed")
 	})
@@ -685,7 +692,7 @@ func TestCustomDatabaseCreation(t *testing.T) {
 		port := utils.GetFreePort(t)
 		socketDir := filepath.Join(baseDir, "pg_sockets")
 
-		baseEnv := append(os.Environ(), "PGCONNECT_TIMEOUT=5")
+		baseEnv := append(os.Environ(), "PGCONNECT_TIMEOUT=5", constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"))
 		if runtime.GOOS == "darwin" {
 			baseEnv = append(baseEnv, "LC_ALL=en_US.UTF-8")
 		}
@@ -796,7 +803,8 @@ timeout: 30
 		// Step 1: Initialize the database first
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		initCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		initOutput, err := initCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("initCmd.Output() error: %v, output: %s", err, string(initOutput))
@@ -806,7 +814,8 @@ timeout: 30
 		// Step 2: Check status - should be stopped after init
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		statusCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err := statusCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("statusCmd.Output() error: %v, output: %s", err, string(output))
@@ -817,14 +826,16 @@ timeout: 30
 		// Step 3: Start PostgreSQL
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		startCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = startCmd.Run()
 		require.NoError(t, err)
 
 		// Step 4: Check status - should be running
 		statusCmd = exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		statusCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err = statusCmd.Output()
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "Running")
@@ -832,21 +843,24 @@ timeout: 30
 		// Step 5: Reload configuration
 		reloadCmd := exec.Command("pgctld", "reload-config", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		reloadCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = reloadCmd.Run()
 		require.NoError(t, err)
 
 		// Step 6: Restart PostgreSQL
 		restartCmd := exec.Command("pgctld", "restart", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		restartCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = restartCmd.Run()
 		require.NoError(t, err)
 
 		// Step 7: Check status again - should still be running
 		statusCmd = exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		statusCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err = statusCmd.Output()
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "Running")
@@ -854,14 +868,16 @@ timeout: 30
 		// Step 8: Stop PostgreSQL
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		stopCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = stopCmd.Run()
 		require.NoError(t, err)
 
 		// Step 9: Final status check - should be stopped
 		statusCmd = exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		statusCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err = statusCmd.Output()
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "Stopped")
@@ -897,21 +913,24 @@ timeout: 30
 	// Initialize database first
 	initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 	initCmd.Env = append(os.Environ(),
-		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 	err = initCmd.Run()
 	require.NoError(t, err)
 
 	// Start PostgreSQL for the first time
 	startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 	startCmd.Env = append(os.Environ(),
-		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 	err = startCmd.Run()
 	require.NoError(t, err)
 
 	// Stop initial start
 	stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 	stopCmd.Env = append(os.Environ(),
-		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 	err = stopCmd.Run()
 	require.NoError(t, err)
 
@@ -921,14 +940,16 @@ timeout: 30
 			// Start PostgreSQL
 			startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 			startCmd.Env = append(os.Environ(),
-				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+				constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 			err := startCmd.Run()
 			require.NoError(t, err)
 
 			// Verify running
 			statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 			statusCmd.Env = append(os.Environ(),
-				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+				constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 			output, err := statusCmd.Output()
 			require.NoError(t, err)
 			assert.Contains(t, string(output), "Running")
@@ -936,14 +957,16 @@ timeout: 30
 			// Stop PostgreSQL
 			stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--mode", "fast", "--config-file", pgctldConfigFile)
 			stopCmd.Env = append(os.Environ(),
-				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+				constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 			err = stopCmd.Run()
 			require.NoError(t, err)
 
 			// Verify stopped
 			statusCmd = exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 			statusCmd.Env = append(os.Environ(),
-				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+				"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+				constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 			output, err = statusCmd.Output()
 			require.NoError(t, err)
 			assert.Contains(t, string(output), "Stopped")
@@ -981,21 +1004,24 @@ timeout: 30
 	// Initialize database first
 	initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 	initCmd.Env = append(os.Environ(),
-		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 	err = initCmd.Run()
 	require.NoError(t, err)
 
 	// Start PostgreSQL
 	startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 	startCmd.Env = append(os.Environ(),
-		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+		"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 	err = startCmd.Run()
 	require.NoError(t, err)
 
 	defer func() {
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--mode", "fast", "--config-file", pgctldConfigFile)
 		stopCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		_ = stopCmd.Run()
 	}()
 
@@ -1012,14 +1038,16 @@ log_min_messages = info
 		// Reload configuration
 		reloadCmd := exec.Command("pgctld", "reload-config", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		reloadCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = reloadCmd.Run()
 		require.NoError(t, err)
 
 		// Server should still be running
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		statusCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err := statusCmd.Output()
 		require.NoError(t, err)
 		assert.Contains(t, string(output), "Running")
@@ -1058,28 +1086,32 @@ timeout: 30
 		// Try to start with non-existent directory - should fail requiring init first
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", nonexistentDir, "--config-file", pgctldConfigFile)
 		startCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(nonexistentDir, "pg_data"))
 		err := startCmd.Run()
 		require.Error(t, err, "Start should fail when data directory is not initialized")
 
 		// Initialize first, then start should work
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", nonexistentDir, "--config-file", pgctldConfigFile)
 		initCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(nonexistentDir, "pg_data"))
 		err = initCmd.Run()
 		require.NoError(t, err)
 
 		// Now start should work
 		startCmd = exec.Command("pgctld", "start", "--pooler-dir", nonexistentDir, "--config-file", pgctldConfigFile)
 		startCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(nonexistentDir, "pg_data"))
 		err = startCmd.Run()
 		require.NoError(t, err)
 
 		// Clean stop
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", nonexistentDir, "--mode", "immediate", "--config-file", pgctldConfigFile)
 		stopCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(nonexistentDir, "pg_data"))
 		_ = stopCmd.Run()
 	})
 
@@ -1087,21 +1119,24 @@ timeout: 30
 		// Initialize data directory first
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		initCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err := initCmd.Run()
 		require.NoError(t, err)
 
 		// Start PostgreSQL
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		startCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		err = startCmd.Run()
 		require.NoError(t, err)
 
 		// Try to start again - should handle gracefully
 		startCmd2 := exec.Command("pgctld", "start", "--pooler-dir", dataDir, "--config-file", pgctldConfigFile)
 		startCmd2.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		output, err := startCmd2.CombinedOutput()
 		// Should either succeed or fail gracefully with appropriate message
 		if err != nil {
@@ -1111,7 +1146,8 @@ timeout: 30
 		// Clean stop
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", dataDir, "--mode", "immediate", "--config-file", pgctldConfigFile)
 		stopCmd.Env = append(os.Environ(),
-			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"))
+			"PATH="+filepath.Join(tempDir, "bin")+":"+os.Getenv("PATH"),
+			constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"))
 		_ = stopCmd.Run()
 	})
 }
@@ -1140,7 +1176,7 @@ func TestOrphanDetectionWithRealPostgreSQL(t *testing.T) {
 
 	// Initialize data directory
 	initCmd := exec.Command("pgctld", "init", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(pgPort), "--config-file", pgctldConfigFile)
-	setupTestEnv(initCmd)
+	setupTestEnv(initCmd, dataDir)
 	require.NoError(t, initCmd.Run())
 
 	// Start pgctld server subprocess with orphan detection enabled
@@ -1157,6 +1193,7 @@ func TestOrphanDetectionWithRealPostgreSQL(t *testing.T) {
 	serverCmd.Env = append(os.Environ(),
 		"MULTIGRES_TESTDATA_DIR="+dataDir,
 		"PGCONNECT_TIMEOUT=5",
+		constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data"),
 		"PATH="+endtoendDir+":"+os.Getenv("PATH"))
 
 	// Required to avoid "postmaster became multithreaded during startup" on macOS
@@ -1274,7 +1311,7 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		"--grpc-port", strconv.Itoa(primaryGrpcPort),
 		"--pg-port", strconv.Itoa(primaryPgPort),
 		"--config-file", primaryConfigFile)
-	setupTestEnvWithPassword(primaryServerCmd, testPassword)
+	setupTestEnvWithPassword(primaryServerCmd, primaryDir, testPassword)
 	require.NoError(t, primaryServerCmd.Start())
 	defer func() {
 		if primaryServerCmd.Process != nil {
@@ -1318,7 +1355,7 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		"--grpc-port", strconv.Itoa(standbyGrpcPort),
 		"--pg-port", strconv.Itoa(standbyPgPort),
 		"--config-file", standbyConfigFile)
-	setupTestEnvWithPassword(standbyServerCmd, testPassword)
+	setupTestEnvWithPassword(standbyServerCmd, standbyDir, testPassword)
 	require.NoError(t, standbyServerCmd.Start())
 	defer func() {
 		if standbyServerCmd.Process != nil {

--- a/go/test/endtoend/pgctld/test_helpers.go
+++ b/go/test/endtoend/pgctld/test_helpers.go
@@ -42,7 +42,7 @@ import (
 // TestSetup holds all configuration for pgBackRest server tests
 type TestSetup struct {
 	TempDir        string
-	DataDir        string
+	PoolerDir      string
 	CertDir        string
 	PgPort         int
 	PgBackRestPort int
@@ -68,7 +68,7 @@ func setupPgBackRestTest(t *testing.T) *TestSetup {
 	testutil.CreateMockPostgreSQLBinaries(t, binDir)
 
 	// Set PATH for PostgreSQL binaries
-	t.Setenv("PGDATA", dataDir)
+	t.Setenv(constants.PgDataDirEnvVar, filepath.Join(dataDir, "pg_data"))
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	// Generate TLS certificates
@@ -92,7 +92,7 @@ func setupPgBackRestTest(t *testing.T) *TestSetup {
 
 	return &TestSetup{
 		TempDir:        tempDir,
-		DataDir:        dataDir,
+		PoolerDir:      dataDir,
 		CertDir:        certDir,
 		PgPort:         pgPort,
 		PgBackRestPort: pgbackrestPort,
@@ -218,7 +218,7 @@ func createTestGRPCServerWithPgBackRest(t *testing.T, setup *TestSetup) (net.Lis
 		constants.DefaultPostgresDatabase,
 		shardsetup.TestPostgresPassword,
 		30,
-		setup.DataDir,
+		setup.PoolerDir,
 		"localhost",
 		setup.PgBackRestPort,
 		setup.CertDir,

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -219,7 +220,7 @@ func (s *ShardSetup) CreateMultipoolerInstance(t *testing.T, name string, grpcPo
 	// Create multipooler instance with pgBackRest cert paths and port
 	// The name (e.g., "primary") is used as the service-id, combined with cell in the topology
 	multipooler := CreateMultipoolerProcessInstance(t, name, s.TempDir, multipoolerPort,
-		"localhost:"+strconv.Itoa(grpcPort), pgctld.DataDir, pgPort, s.EtcdClientAddr, s.CellName,
+		"localhost:"+strconv.Itoa(grpcPort), pgctld.PoolerDir, pgPort, s.EtcdClientAddr, s.CellName,
 		s.PgBackRestCertPaths, pgbackrestPort)
 
 	inst := &MultipoolerInstance{
@@ -246,7 +247,7 @@ func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, 
 
 	return &ProcessInstance{
 		Name:              name,
-		DataDir:           dataDir,
+		PoolerDir:         dataDir,
 		LogFile:           logFile,
 		GrpcPort:          grpcPort,
 		HttpPort:          httpPort,
@@ -255,7 +256,7 @@ func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, 
 		PgBackRestPort:    pgbackrestPort,
 		PgBackRestCertDir: pgbackrestCertDir,
 		BackupLocation:    backupLocation,
-		Environment:       append(os.Environ(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "POSTGRES_PASSWORD="+TestPostgresPassword),
+		Environment:       append(os.Environ(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data")),
 	}
 }
 
@@ -276,10 +277,10 @@ func CreateMultipoolerProcessInstance(t *testing.T, name, baseDir string, grpcPo
 		GrpcPort:    grpcPort,
 		PgPort:      pgPort,
 		PgctldAddr:  pgctldAddr,
-		DataDir:     pgctldDataDir,
+		PoolerDir:   pgctldDataDir,
 		EtcdAddr:    etcdAddr,
 		Binary:      "multipooler",
-		Environment: append(os.Environ(), "PGCONNECT_TIMEOUT=5", "POSTGRES_PASSWORD="+TestPostgresPassword),
+		Environment: append(os.Environ(), "PGCONNECT_TIMEOUT=5", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(pgctldDataDir, "pg_data")),
 	}
 
 	// Store pgBackRest cert paths struct and port for later use when starting multipooler
@@ -311,7 +312,7 @@ func (s *ShardSetup) CreateMultiOrchInstance(t *testing.T, name string, watchTar
 
 	instance := &ProcessInstance{
 		Name:                                name,
-		DataDir:                             orchDataDir,
+		PoolerDir:                           orchDataDir,
 		LogFile:                             logFile,
 		GrpcPort:                            grpcPort,
 		HttpPort:                            httpPort,

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -43,7 +43,7 @@ import (
 // This struct is extracted from multipooler/setup_test.go and extended for multiorch support.
 type ProcessInstance struct {
 	Name        string
-	DataDir     string // Used by pgctld, multipooler
+	PoolerDir   string // Used by pgctld, multipooler
 	ConfigFile  string // Used by pgctld
 	LogFile     string
 	GrpcPort    int
@@ -100,12 +100,12 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 	t.Helper()
 
 	t.Logf("Starting %s with binary '%s'", p.Name, p.Binary)
-	t.Logf("Data dir: %s, gRPC port: %d, PG port: %d", p.DataDir, p.GrpcPort, p.PgPort)
+	t.Logf("Data dir: %s, gRPC port: %d, PG port: %d", p.PoolerDir, p.GrpcPort, p.PgPort)
 
 	// Build pgctld server command with pgBackRest configuration
 	args := []string{
 		"server",
-		"--pooler-dir", p.DataDir,
+		"--pooler-dir", p.PoolerDir,
 		"--grpc-port", strconv.Itoa(p.GrpcPort),
 		"--pg-port", strconv.Itoa(p.PgPort),
 		"--timeout", "60",
@@ -129,7 +129,7 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	p.Process.Env = append(p.Environment,
-		"MULTIGRES_TESTDATA_DIR="+filepath.Dir(p.DataDir),
+		"MULTIGRES_TESTDATA_DIR="+filepath.Dir(p.PoolerDir),
 	)
 
 	t.Logf("Running server command: %v", p.Process.Args)
@@ -149,14 +149,14 @@ func (p *ProcessInstance) startMultipooler(ctx context.Context, t *testing.T) er
 
 	// Build command arguments
 	// Socket file path for Unix socket connection (uses trust auth per pg_hba.conf)
-	socketFile := filepath.Join(p.DataDir, "pg_sockets", fmt.Sprintf(".s.PGSQL.%d", p.PgPort))
+	socketFile := filepath.Join(p.PoolerDir, "pg_sockets", fmt.Sprintf(".s.PGSQL.%d", p.PgPort))
 	args := []string{
 		"--grpc-port", strconv.Itoa(p.GrpcPort),
 		"--database", "postgres", // Required parameter
 		"--table-group", "default", // Required parameter (MVP only supports "default")
 		"--shard", "0-inf", // Required parameter (MVP only supports "0-inf")
 		"--pgctld-addr", p.PgctldAddr,
-		"--pooler-dir", p.DataDir, // Use the same pooler dir as pgctld
+		"--pooler-dir", p.PoolerDir, // Use the same pooler dir as pgctld
 		"--pg-port", strconv.Itoa(p.PgPort),
 		"--socket-file", socketFile, // Unix socket for trust authentication
 		"--service-map", "grpc-pooler,grpc-poolermanager,grpc-consensus,grpc-backup",
@@ -186,7 +186,7 @@ func (p *ProcessInstance) startMultipooler(ctx context.Context, t *testing.T) er
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	p.Process.Env = append(p.Environment,
-		"MULTIGRES_TESTDATA_DIR="+filepath.Dir(p.DataDir),
+		"MULTIGRES_TESTDATA_DIR="+filepath.Dir(p.PoolerDir),
 	)
 
 	t.Logf("Running multipooler command: %v", p.Process.Args)
@@ -230,8 +230,8 @@ func (p *ProcessInstance) startMultiOrch(ctx context.Context, t *testing.T) erro
 	}
 
 	p.Process = exec.Command(p.Binary, args...)
-	if p.DataDir != "" {
-		p.Process.Dir = p.DataDir
+	if p.PoolerDir != "" {
+		p.Process.Dir = p.PoolerDir
 	}
 
 	// Set up logging like multiorch_helpers.go does

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1062,7 +1062,7 @@ func (s *ShardSetup) ReinitializeCluster(t *testing.T) {
 		// completely fresh. This clears pg_data (PostgreSQL data),
 		// pg_sockets (stale Unix sockets), pgbackrest (backup state),
 		// and any other state files.
-		dataDir := inst.Pgctld.DataDir
+		dataDir := inst.Pgctld.PoolerDir
 		entries, err := os.ReadDir(dataDir)
 		if err != nil {
 			t.Logf("ReinitializeCluster: warning: failed to read %s: %v", dataDir, err)
@@ -1437,7 +1437,7 @@ func (s *ShardSetup) KillPostgres(t *testing.T, name string) {
 	}
 
 	// Read the PID from postmaster.pid file
-	pgDataDir := filepath.Join(inst.Pgctld.DataDir, "pg_data")
+	pgDataDir := filepath.Join(inst.Pgctld.PoolerDir, "pg_data")
 	pidFile := filepath.Join(pgDataDir, "postmaster.pid")
 
 	pidBytes, err := os.ReadFile(pidFile)

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -149,6 +149,10 @@ message MultiPooler {
   // PoolerDir is used by pgBackRest to compute the primary's data directory.
   string pooler_dir = 10;
 
+  // PgDataDir is the PostgreSQL data directory path (from the PGDATA environment variable).
+  // Used by multiadmin to compute the primary's data directory for pgBackRest.
+  string pg_data_dir = 11;
+
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.


### PR DESCRIPTION
- Add `PgDataDirEnvVar` and `ConsensusTermFile` constants; replace all hardcoded strings
- Add `pg_data_dir` field to MultiPooler proto for `multiadmin` backup path
- Require `PGDATA` to be set at `pgctld` and multipooler startup
- Multigres-specific marker files move to `$PGDATA/multigres/`
- Add `PGDATA` to k8s manifest and local provisioner subprocess env
- Fix e2e tests: inject `PGDATA` into subprocess environments and correct pg_data subdirectory paths
- Rename `ProcessInstance.DataDir` to `PoolerDir` in e2e test infrastructure

poolerDir is still required for three purposes unrelated to PostgreSQL data:
- Unix socket directory (poolerDir/pg_sockets)
- pgBackRest operational files (server config, client config, logs) under poolerDir/pgbackrest/

Fixes MUL-228
