### PR TITLE
ci(coverage): fix flaky Coveralls parallel upload and check permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,41 +11,34 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 name: Code Coverage
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions: {}
-
 jobs:
   coverage-direct:
     name: Direct test coverage
     runs-on: ubuntu-24.04
-
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
-
       - name: Set up test environment
         run: .github/scripts/setup-test-environment.sh
-
       - name: Build
         run: make build
-
       - name: Run tests with direct coverage
         run: go test -json -v -skip TestPostgreSQLRegression -cover -covermode=atomic -coverprofile=coverage-direct.txt -coverpkg=./... ./... | tee coverage-direct-test-results.jsonl | go tool tparse -follow
-
       - name: Upload direct coverage artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
@@ -53,7 +46,6 @@ jobs:
           name: coverage-direct
           path: coverage-direct.txt
           retention-days: 7
-
       - name: Test Report
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
         if: ${{ !cancelled() }}
@@ -61,36 +53,31 @@ jobs:
           name: Direct Coverage Tests
           path: coverage-direct-test-results.jsonl
           reporter: golang-json
-
   coverage-subprocess:
     name: Subprocess coverage
     runs-on: ubuntu-24.04
-
+    permissions:
+      checks: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
-
       - name: Set up test environment
         run: .github/scripts/setup-test-environment.sh
-
       - name: Build coverage binaries
         run: make build-coverage
-
       - name: Run tests with subprocess coverage
         run: |
           mkdir -p coverage-subprocess-raw
           export GOCOVERDIR="$PWD/coverage-subprocess-raw"
           go test -json -v -skip TestPostgreSQLRegression ./... | tee coverage-subprocess-test-results.jsonl | go tool tparse -follow
-
       - name: Convert subprocess coverage to text format
         run: go tool covdata textfmt -i=coverage-subprocess-raw -o=coverage-subprocess.txt
-
       - name: Upload subprocess coverage artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
@@ -98,7 +85,6 @@ jobs:
           name: coverage-subprocess
           path: coverage-subprocess.txt
           retention-days: 7
-
       - name: Test Report
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637 # v2.5.0
         if: ${{ !cancelled() }}
@@ -106,35 +92,31 @@ jobs:
           name: Subprocess Coverage Tests
           path: coverage-subprocess-test-results.jsonl
           reporter: golang-json
-
   merge-and-upload:
     name: Merge coverage and upload
     runs-on: ubuntu-24.04
     needs: [coverage-direct, coverage-subprocess]
     if: always()
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
-
       - name: Download direct coverage artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: coverage-direct
           path: ./coverage-artifacts/direct
-
       - name: Download subprocess coverage artifact
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: coverage-subprocess
           path: ./coverage-artifacts/subprocess
-
       - name: Merge coverage files
         run: |
           ./scripts/merge-coverage.sh \
@@ -145,7 +127,6 @@ jobs:
           echo ""
           echo "Final coverage summary:"
           go tool cover -func=coverage-merged.txt | tail -1
-
       - name: Upload merged coverage artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
@@ -153,7 +134,6 @@ jobs:
           name: coverage-merged
           path: coverage-merged.txt
           retention-days: 7
-
       - name: Upload coverage to Coveralls
         if: success() || failure()
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
@@ -162,13 +142,12 @@ jobs:
           format: golang
           parallel: true
           flag-name: merged
-
   coveralls-finish:
     name: Finish Coveralls upload
     runs-on: ubuntu-24.04
     needs: [coverage-direct, coverage-subprocess, merge-and-upload]
-    if: success()
-
+    if: always()
+    permissions: {}
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6


### PR DESCRIPTION
The `dorny/test-reporter need to add report to the check runs, hence require  `checks: write` privileges, while `action/checkout` needs `contents:read` privileges to work reliably.

The job `coveralls-finish` used `if: success()`, so any upstream job failure  would skip it. As a result, Coverall would keep current partial runs uploaded, and on the next run these old runs would interfere with data from the new runs. To handle this, use `if: always()` to trigger the finish signal to always be sent.

However, the workflow permissons were `permissions: {}`, which prevented dorny/test-reporter from creating check runs (since this requires `checks:  write`), causing coverage jobs to fail even when tests passed. Fixed by adding `checks: write` and `contents: read` permissions to the workflow.

Also remove some whitespace to make "prettier" YAML file checker happy and permissions are on a per-job basis to make `zizmor` GitHub workflow linter happy.
