### PR TITLE
fix(multigateway): downgrade EOF log levels from ERROR to DEBUG

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -413,6 +413,10 @@ func (c *Conn) serve() error {
 
 	// First, handle the startup phase.
 	if err := c.handleStartup(); err != nil {
+		if errors.Is(err, io.EOF) {
+			c.logger.Debug("client disconnected before startup")
+			return nil
+		}
 		c.logger.Error("startup failed", "error", err)
 		// Try to send an error response before closing.
 		// If the error is already a PgDiagnostic (e.g., duplicate SSLRequest
@@ -448,6 +452,10 @@ func (c *Conn) serve() error {
 
 		// Process the message based on type.
 		if err := c.handleMessage(msgType); err != nil {
+			if errors.Is(err, io.EOF) {
+				c.logger.Debug("client closed connection")
+				return nil
+			}
 			c.logger.Error("error handling message", "type", string(msgType), "error", err)
 			// Send error response and continue (unless it's a fatal error).
 			_ = c.writeError(mterrors.MTD03.NewWithDetail(err.Error()))


### PR DESCRIPTION
## Summary

- Downgrade "startup failed: EOF" from ERROR to DEBUG — caused by TCP health checks (K8s probes, load balancers) connecting and disconnecting without sending a startup message
- Downgrade "error handling message: EOF" from ERROR to DEBUG — caused by normal client disconnects via the PostgreSQL Terminate message
- Skip sending error responses to already-disconnected clients in the startup EOF path

## Problem

Multigateway logs two expected, non-error events at ERROR level: TCP health check disconnects during startup, and clean client terminations. In production, this creates hundreds of false ERROR entries per hour, triggers monitoring alerts, and masks real issues. See #718 for full analysis.

## Solution

Add `errors.Is(err, io.EOF)` guards in `serve()` before the ERROR log calls, following the pattern already established at the `ReadMessageType` call site (line 441). EOF returns `nil` instead of the error, so the listener-level handler also treats these as clean closes.

Fixes #718 