### PR TITLE
fix(pgctld): remove stale standby.signal before crash recovery in PgRewind

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -675,6 +675,18 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 	if err != nil {
 		s.logger.WarnContext(ctx, "Failed to check postgres state (continuing anyway)", "error", err)
 	} else if !cleanlyStopped {
+		// Remove standby.signal if present before crash recovery. Single-user crash
+		// recovery mode (postgres --single) does not support standby mode, so a
+		// leftover standby.signal from a previously failed rewind attempt would
+		// prevent crash recovery from completing. It is safe to remove it here
+		// because the caller will re-create it via Restart --as-standby after rewind.
+		standbySignalPath := filepath.Join(s.poolerDir, "pg_data", "standby.signal")
+		if err := os.Remove(standbySignalPath); err != nil && !os.IsNotExist(err) {
+			s.logger.WarnContext(ctx, "Failed to remove standby.signal before rewind", "error", err)
+		} else if err == nil {
+			s.logger.InfoContext(ctx, "Removed stale standby.signal before rewind", "path", standbySignalPath)
+		}
+
 		// Try to run crash recovery.
 		// It's not harmful to do this if postgres is already running.
 		if err := runCrashRecovery(ctx, s.logger, s.poolerDir); err != nil {


### PR DESCRIPTION
When a previous RewindToSource attempt failed during postgres startup (e.g. due to a timeline incompatibility), standby.signal was left in the data directory. On the next attempt, single-user crash recovery mode (postgres --single) would fail with "standby mode is not supported by single-user servers", preventing pg_rewind from recovering the dirty data dir and causing an infinite failure loop.

Remove standby.signal before crash recovery when postgres is not cleanly stopped. The caller re-creates it via Restart --as-standby after rewind.