### PR TITLE
refactor(multipooler): move consensus term file out of PGDATA

### DIFF
--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -54,6 +54,10 @@ const (
 	// the PostgreSQL data directory.
 	MultigresMarkerDirectory = "multigres"
 
+	// ConsensusTermFile is the name of the file used to persist the consensus term
+	// for a multipooler instance. It is stored under the pooler directory.
+	ConsensusTermFile = "consensus_term.json"
+
 	// DefaultSlowQueryThreshold is the duration after which a query is logged at WARN level.
 	DefaultSlowQueryThreshold = 1 * time.Second
 )

--- a/go/services/multipooler/manager/consensus_state.go
+++ b/go/services/multipooler/manager/consensus_state.go
@@ -55,7 +55,7 @@ func NewConsensusState(poolerDir string, serviceID *clustermetadatapb.ID) *Conse
 // If the file doesn't exist, initializes with default values (term 0, no accepted coordinator).
 // This method is idempotent - subsequent calls will reload from disk.
 func (cs *ConsensusState) Load() (int64, error) {
-	term, err := getConsensusTerm(cs.poolerDir)
+	term, err := cs.getConsensusTerm()
 	if err != nil {
 		return 0, fmt.Errorf("failed to load consensus term: %w", err)
 	}
@@ -339,7 +339,7 @@ func (cs *ConsensusState) SetPrimaryTerm(ctx context.Context, primaryTerm int64,
 // If the save fails, memory remains unchanged and the error is returned.
 func (cs *ConsensusState) saveAndUpdateLocked(newTerm *multipoolermanagerdatapb.ConsensusTerm) error {
 	// Save to disk (lock still held)
-	if err := setConsensusTerm(cs.poolerDir, newTerm); err != nil {
+	if err := cs.setConsensusTerm(newTerm); err != nil {
 		// Save failed - don't update memory, propagate error
 		return fmt.Errorf("failed to save consensus term: %w", err)
 	}

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -765,14 +765,6 @@ func (pm *MultiPoolerManager) validateAndUpdateTerm(ctx context.Context, request
 		return fmt.Errorf("failed to get current term: %w", err)
 	}
 
-	// Check if consensus term has been initialized (term 0 means uninitialized)
-	if currentTerm == 0 {
-		pm.logger.ErrorContext(ctx, "Consensus term not initialized",
-			"service_id", pm.serviceID.String())
-		return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			"consensus term not initialized, must be set via BeginTerm (use force=true to bypass)")
-	}
-
 	// If request term == current term: ACCEPT (same term, execute)
 	// If request term < current term: REJECT (stale request)
 	// If request term > current term: UPDATE term and ACCEPT (new term discovered)

--- a/go/services/multipooler/manager/manager_test.go
+++ b/go/services/multipooler/manager/manager_test.go
@@ -301,13 +301,14 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:          "Zero cached term rejects (uninitialized)",
-			currentTerm:   0,
-			requestTerm:   5,
-			force:         false,
-			expectError:   true,
-			expectedCode:  mtrpcpb.Code_FAILED_PRECONDITION,
-			errorContains: "not initialized",
+			// Term 0 means uninitialized (consensus_term.json not yet written, e.g. on a fresh
+			// standby after poolerDir was wiped by a restore). A positive request term is
+			// accepted and initializes the local term.
+			name:        "Zero cached term accepts higher request term (initializes standby)",
+			currentTerm: 0,
+			requestTerm: 5,
+			force:       false,
+			expectError: false,
 		},
 	}
 
@@ -330,7 +331,8 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 				initialTerm := &multipoolermanagerdatapb.ConsensusTerm{
 					TermNumber: tt.currentTerm,
 				}
-				require.NoError(t, setConsensusTerm(poolerDir, initialTerm))
+				setupCS := NewConsensusState(poolerDir, nil)
+				require.NoError(t, setupCS.setConsensusTerm(initialTerm))
 			}
 
 			// Create the database in topology with backup location

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -322,31 +322,26 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 		return err
 	}
 
-	// Set consensus term after restore.
-	// If the cluster is at a higher term,
-	// validateAndUpdateTerm will automatically update our term when multiorch fixes replication.
-	var term int64 = 0
-	if err := telemetry.WithSpan(ctx, "restore/reload-consensus-term", func(ctx context.Context) error {
+	// Delete the consensus term file after restore.
+	//
+	// The term file lives outside PGDATA and is not included in the backup, so
+	// its on-disk value may be ahead of what the restored PGDATA participated in.
+	// Deleting it resets the node to term 0; multiorch will advance the term to
+	// the current cluster value on first contact via BeginTerm.
+	//
+	// TODO: Revisit this when we restore backups for other reasons than to
+	// bootstrap a new node, e.g. point-in-time recovery for an existing node.
+	if err := telemetry.WithSpan(ctx, "restore/reset-consensus-term", func(ctx context.Context) error {
 		if pm.consensusState != nil {
-			pm.logger.InfoContext(ctx, "Loading consensus term that was restored from backup")
-			pm.loadConsensusTermFromDisk()
-			term = pm.consensusState.term.TermNumber
-
-			// Clear primary_term from backup since this is a standby restore
-			// The backup may contain a non-zero primary_term if it was taken from a primary
-			if err := pm.consensusState.SetPrimaryTerm(ctx, 0, false /* force */); err != nil {
-				return mterrors.Wrap(err, "failed to clear primary_term after restore")
+			pm.logger.InfoContext(ctx, "Deleting consensus term file after restore; node will re-join consensus from term 0")
+			if err := pm.consensusState.DeleteTermFile(); err != nil {
+				return mterrors.Wrap(err, "failed to delete consensus term file after restore")
 			}
 		}
 		pm.healthStreamer.UpdatePrimaryObservation(nil)
-
 		return nil
 	}); err != nil {
 		return err
-	}
-
-	if term == 0 {
-		pm.logger.ErrorContext(ctx, "MonitorPostgres: term is uninitialized even after restore")
 	}
 
 	if err := telemetry.WithSpan(ctx, "restore/reopen-pooler", func(ctx context.Context) error {

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -126,6 +126,7 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService) (
 	// Create PG_VERSION file to mark it as initialized
 	err = os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644)
 	require.NoError(t, err)
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 
 	// Initialize consensus state
 	pm.mu.Lock()
@@ -487,10 +488,10 @@ func TestBeginTerm(t *testing.T) {
 
 			tt.setupMocks(mockQueryService)
 
-			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService)
+			pm, _ := setupManagerWithMockDB(t, mockQueryService)
 
 			// Initialize term on disk
-			err := setConsensusTerm(tmpDir, tt.initialTerm)
+			err := pm.consensusState.setConsensusTerm(tt.initialTerm)
 			require.NoError(t, err)
 
 			// Load into consensus state
@@ -526,7 +527,7 @@ func TestBeginTerm(t *testing.T) {
 			}
 
 			// Verify persisted state (acceptance should be persisted even if revoke fails)
-			persistedTerm, err := getConsensusTerm(tmpDir)
+			persistedTerm, err := pm.consensusState.getConsensusTerm()
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedTerm, persistedTerm.TermNumber)
 			assert.Equal(t, tt.expectedAcceptedTermFromCoordinator, persistedTerm.AcceptedTermFromCoordinatorId.GetName())
@@ -547,7 +548,7 @@ func TestBeginTerm(t *testing.T) {
 			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService)
 
 			// Initialize term on disk
-			err := setConsensusTerm(tmpDir, tt.initialTerm)
+			err := pm.consensusState.setConsensusTerm(tt.initialTerm)
 			require.NoError(t, err)
 
 			// Load into consensus state
@@ -557,13 +558,11 @@ func TestBeginTerm(t *testing.T) {
 
 			// Make filesystem read-only to simulate save failure
 			if tt.makeFilesystemReadOnly {
-				pgDataDir := tmpDir + "/pg_data"
-				consensusDir := pgDataDir + "/consensus"
-				err := os.Chmod(consensusDir, 0o555)
+				err := os.Chmod(tmpDir, 0o555)
 				require.NoError(t, err)
 				// Restore permissions after test
 				t.Cleanup(func() {
-					_ = os.Chmod(consensusDir, 0o755)
+					_ = os.Chmod(tmpDir, 0o755)
 				})
 			}
 
@@ -603,7 +602,7 @@ func TestBeginTerm(t *testing.T) {
 				assert.Equal(t, tt.expectedMemoryLeader, memoryLeader, "Memory leader should be unchanged after save failure")
 
 				// Verify disk is unchanged
-				loadedTerm, loadErr := getConsensusTerm(tmpDir)
+				loadedTerm, loadErr := pm.consensusState.getConsensusTerm()
 				require.NoError(t, loadErr)
 				assert.Equal(t, tt.expectedMemoryTerm, loadedTerm.TermNumber, "Disk term should match initial state after save failure")
 				if tt.expectedMemoryLeader != "" {
@@ -736,6 +735,7 @@ func TestUpdateTermAndAcceptCandidate(t *testing.T) {
 			// Create PG_VERSION file to mark it as initialized
 			err = os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644)
 			require.NoError(t, err)
+			t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 
 			cs := NewConsensusState(poolerDir, serviceID)
 			_, err = cs.Load()
@@ -1023,10 +1023,10 @@ func TestConsensusStatus(t *testing.T) {
 			mockQueryService := mock.NewQueryService()
 			tt.setupMock(mockQueryService)
 
-			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService)
+			pm, _ := setupManagerWithMockDB(t, mockQueryService)
 
 			// Initialize term on disk
-			err := setConsensusTerm(tmpDir, tt.initialTerm)
+			err := pm.consensusState.setConsensusTerm(tt.initialTerm)
 			require.NoError(t, err)
 
 			// Load term into consensus state if term should be in memory
@@ -1262,6 +1262,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			require.NoError(t, err)
 			err = os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644)
 			require.NoError(t, err)
+			t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 
 			config := &Config{
 				TopoClient: ts,
@@ -1288,7 +1289,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			pm.consensusState = NewConsensusState(tmpDir, serviceID)
 			pm.mu.Unlock()
 
-			err = setConsensusTerm(tmpDir, tt.initialTerm)
+			err = pm.consensusState.setConsensusTerm(tt.initialTerm)
 			require.NoError(t, err)
 			_, err = pm.consensusState.Load()
 			require.NoError(t, err)
@@ -1320,7 +1321,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			}
 
 			// Verify consensus term was updated correctly
-			persistedTerm, err := getConsensusTerm(tmpDir)
+			persistedTerm, err := pm.consensusState.getConsensusTerm()
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedFinalConsensusTerm, persistedTerm.TermNumber,
 				"Consensus term should be %d but got %d", tt.expectedFinalConsensusTerm, persistedTerm.TermNumber)

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/constants"
@@ -45,13 +44,8 @@ import (
 // setTermForTest writes the consensus term file directly for testing.
 func setTermForTest(t *testing.T, poolerDir string, term *multipoolermanagerdatapb.ConsensusTerm) {
 	t.Helper()
-	data, err := protojson.Marshal(term)
-	require.NoError(t, err, "failed to marshal term")
-	// Write to the correct path: {poolerDir}/pg_data/consensus/consensus_term.json
-	consensusDir := filepath.Join(poolerDir, "pg_data", "consensus")
-	require.NoError(t, os.MkdirAll(consensusDir, 0o755), "failed to create consensus dir")
-	termPath := filepath.Join(consensusDir, "consensus_term.json")
-	require.NoError(t, os.WriteFile(termPath, data, 0o644), "failed to write term file")
+	cs := NewConsensusState(poolerDir, nil)
+	require.NoError(t, cs.setConsensusTerm(term), "failed to write term file")
 }
 
 // addDatabaseToTopo creates a database in the topology with a backup location
@@ -379,6 +373,7 @@ func createPgDataDir(t *testing.T, poolerDir string) {
 	pgDataDir := filepath.Join(poolerDir, "pg_data")
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, "PG_VERSION"), []byte("16"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 }
 
 // setupPromoteTestManager creates a manager configured as a REPLICA for promotion tests.
@@ -421,6 +416,7 @@ func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService) 
 	pgDataDir := filepath.Join(tmpDir, "pg_data")
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, "PG_VERSION"), []byte("16"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 
 	multipooler.PoolerDir = tmpDir
 
@@ -1087,6 +1083,7 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	pgDataDir := filepath.Join(tmpDir, "pg_data")
 	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(pgDataDir, "PG_VERSION"), []byte("16"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 	multipooler.PoolerDir = tmpDir
 
 	config := &Config{

--- a/go/services/multipooler/manager/term_storage.go
+++ b/go/services/multipooler/manager/term_storage.go
@@ -36,13 +36,13 @@ func multigresDataDir() string {
 }
 
 // consensusTermPath returns the path to the consensus term file
-func consensusTermPath(poolerDir string) string {
-	return filepath.Join(poolerDir, "pg_data", "consensus", "consensus_term.json")
+func (cs *ConsensusState) consensusTermPath() string {
+	return filepath.Join(cs.poolerDir, constants.ConsensusTermFile)
 }
 
 // getConsensusTerm retrieves the current consensus term information from disk
-func getConsensusTerm(poolerDir string) (*multipoolermanagerdatapb.ConsensusTerm, error) {
-	termPath := consensusTermPath(poolerDir)
+func (cs *ConsensusState) getConsensusTerm() (*multipoolermanagerdatapb.ConsensusTerm, error) {
+	termPath := cs.consensusTermPath()
 
 	// Check if consensus term file exists
 	if _, err := os.Stat(termPath); os.IsNotExist(err) {
@@ -66,14 +66,8 @@ func getConsensusTerm(poolerDir string) (*multipoolermanagerdatapb.ConsensusTerm
 }
 
 // setConsensusTerm saves the consensus term information to disk
-func setConsensusTerm(poolerDir string, term *multipoolermanagerdatapb.ConsensusTerm) error {
-	termPath := consensusTermPath(poolerDir)
-	consensusDir := filepath.Dir(termPath)
-
-	// Ensure consensus directory exists
-	if err := os.MkdirAll(consensusDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create consensus directory: %w", err)
-	}
+func (cs *ConsensusState) setConsensusTerm(term *multipoolermanagerdatapb.ConsensusTerm) error {
+	termPath := cs.consensusTermPath()
 
 	// Marshal protobuf to JSON
 	data, err := protojson.MarshalOptions{
@@ -95,5 +89,24 @@ func setConsensusTerm(poolerDir string, term *multipoolermanagerdatapb.Consensus
 		return fmt.Errorf("failed to rename consensus term file: %w", err)
 	}
 
+	return nil
+}
+
+// DeleteTermFile removes the consensus term file from disk and resets the
+// in-memory state to uninitialized (term 0, no accepted coordinator).
+// Called after a pgBackRest restore so the node re-joins consensus from
+// scratch; the cluster's current term will be propagated by multiorch on
+// first contact via BeginTerm.
+// If the file does not exist this is a no-op. Returns an error only if
+// the file exists but cannot be removed.
+func (cs *ConsensusState) DeleteTermFile() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if err := os.Remove(cs.consensusTermPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete consensus term file after restore: %w", err)
+	}
+
+	cs.term = &multipoolermanagerdatapb.ConsensusTerm{}
 	return nil
 }

--- a/go/services/multipooler/manager/term_storage_test.go
+++ b/go/services/multipooler/manager/term_storage_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+func newTestConsensusState(t *testing.T) (*ConsensusState, string) {
+	t.Helper()
+	poolerDir := t.TempDir()
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test-pooler",
+	}
+	return NewConsensusState(poolerDir, id), poolerDir
+}
+
+func TestDeleteTermFile_FileExists(t *testing.T) {
+	cs, poolerDir := newTestConsensusState(t)
+
+	// Write a term file with a non-zero term
+	term := &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 42}
+	cs.mu.Lock()
+	cs.term = term
+	require.NoError(t, cs.setConsensusTerm(term))
+	cs.mu.Unlock()
+
+	termPath := filepath.Join(poolerDir, constants.ConsensusTermFile)
+	_, err := os.Stat(termPath)
+	require.NoError(t, err, "term file should exist before deletion")
+
+	require.NoError(t, cs.DeleteTermFile())
+
+	// File must be gone
+	_, err = os.Stat(termPath)
+	assert.True(t, os.IsNotExist(err), "term file should be deleted")
+
+	// In-memory term must be reset to 0
+	n, err := cs.GetInconsistentCurrentTermNumber()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+func TestDeleteTermFile_FileDoesNotExist(t *testing.T) {
+	cs, poolerDir := newTestConsensusState(t)
+
+	// Prime in-memory state to a non-zero term without writing to disk
+	cs.mu.Lock()
+	cs.term = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 7}
+	cs.mu.Unlock()
+
+	termPath := filepath.Join(poolerDir, constants.ConsensusTermFile)
+	_, err := os.Stat(termPath)
+	require.True(t, os.IsNotExist(err), "term file should not exist at start")
+
+	// Must succeed (idempotent)
+	require.NoError(t, cs.DeleteTermFile())
+
+	// In-memory term must still be reset to 0
+	n, err := cs.GetInconsistentCurrentTermNumber()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/go/test/endtoend/multipooler/backup_test.go
+++ b/go/test/endtoend/multipooler/backup_test.go
@@ -241,23 +241,23 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 						}
 						return statusResp.Status.PostgresRunning
 					}, 10*time.Second, 100*time.Millisecond, "PostgreSQL should be running after restore")
-					t.Logf("Term after restore: %d (expected: 1)", restoredTerm)
-					assert.Equal(t, int64(1), restoredTerm, "Term should be restored to backup's original value (1)")
+					t.Logf("Term after restore: %d (expected: 0)", restoredTerm)
+					assert.Equal(t, int64(0), restoredTerm, "Term should be reset to 0 after restore (stale term file is deleted)")
 
-					// Verify primary_term was cleared after restore
+					// Verify primary_term is 0 after restore
 					statusCtx = utils.WithShortDeadline(t)
 					statusResp, err = standbyBackupClient.Status(statusCtx, &multipoolermanagerdata.StatusRequest{})
 					require.NoError(t, err, "Should be able to get status after restore")
 					require.NotNil(t, statusResp.Status.ConsensusTerm, "ConsensusTerm should not be nil after restore")
 					assert.Equal(t, int64(0), statusResp.Status.ConsensusTerm.PrimaryTerm,
-						"primary_term should be cleared to 0 after restore (standby restore)")
+						"primary_term should be 0 after restore")
 
 					// Configure replication after restore
 					setPrimaryReq := &multipoolermanagerdata.SetPrimaryConnInfoRequest{
 						Primary:               primary,
 						StartReplicationAfter: true,
 						StopReplicationBefore: false,
-						CurrentTerm:           restoredTerm, // Use the term we just verified from backup
+						CurrentTerm:           restoredTerm, // Term is 0 after restore; Force allows multiorch to advance it
 						Force:                 true,         // Force reconfiguration after restore
 					}
 					setPrimaryCtx := utils.WithTimeout(t, 30*time.Second)


### PR DESCRIPTION
The consensus term was previously stored inside PGDATA (`pg_data/consensus/consensus_term.json`). This meant a pgBackRest restore — which replaces PGDATA — would also reset the term to whatever value was in the backup, forcing the node to re-join consensus at a stale lower term.

The term file is now stored at `poolerDir/consensus_term.json`, directly alongside other multipooler state, outside the PostgreSQL data directory. The file is intentionally not included in backups — the term only needs to be monotonically increasing, so the pre-restore value is the correct one to keep.

Because the term file is no longer backed up, a restored node could have a term file on disk that is ahead of the restored PGDATA. restoreFromBackupLocked now deletes the term file (and resets in-memory state to term 0) immediately after pgBackRest completes and before PostgreSQL starts. Multiorch advances the term to the current cluster value on the first BeginTerm RPC after the node rejoins.

To allow a post-restore node (term 0) to accept the first `BeginTerm` RPC without special-casing, the guard in validateAndUpdateTerm that rejected all RPCs when the local term was 0 is removed. A positive request term is now accepted and initializes the local term regardless of whether term 0 came from an uninitialized state or a just-deleted term file.

Changes:
- Term file path simplified from pg_data/consensus/consensus_term.json to poolerDir/consensus_term.json (no subdirectory)
- New ConsensusTermFile constant in go/common/constants/postgres.go
- Term storage functions (consensusTermPath, getConsensusTerm, setConsensusTerm) converted from package-level functions taking poolerDir to methods on ConsensusState
- New ConsensusState.DeleteTermFile() method, idempotent if file absent
- restoreFromBackupLocked calls DeleteTermFile() after restore completes
- validateAndUpdateTerm: remove zero-term rejection guard
- Tests updated to use the new ConsensusState method API and to set the PGDATA env var where term_storage needs it
- New term_storage_test.go with unit tests for DeleteTermFile
- backup_test.go: assert term resets to 0 after restore

Fixes MUL-257