### PR TITLE
test(multiorch): cover the quorum loss gap in HA validation

### DIFF
--- a/go/test/endtoend/multiorch/quorum_loss_test.go
+++ b/go/test/endtoend/multiorch/quorum_loss_test.go
@@ -91,7 +91,7 @@ func TestQuorumLoss(t *testing.T) {
 
 	preKillSuccess, preKillFailed := validator.Stats()
 	t.Logf("Pre-kill writes: %d successful, %d failed", preKillSuccess, preKillFailed)
-	require.Greater(t, preKillSuccess, int64(0), "should have some successful writes before killing standbys")
+	require.Greater(t, preKillSuccess, 0, "should have some successful writes before killing standbys")
 
 	// Kill both standbys to break quorum
 	t.Logf("Killing postgres on both standbys: %s, %s", standbyNames[0], standbyNames[1])


### PR DESCRIPTION
## Description
this PR adds a quorum loss test to the multiorch tests. It introduces the case where the primary is healthy but can't commit because all sync standbys are gone.

With AT_LEAST_2, the primary needs at least one sync standby to ack before a commit goes through. If both standbys are killed, the primary can't get any sync acks, so every write just hangs, adhering to the durability policy. 

## How it Works

the test starts continuous writes through multigateway, kills both standbys, then tries a direct INSERT on the primary with a 2s `statement_timeout` to confirm it hangs, with no sync standby to ack. After that, it waits for multiorch to bring a standby back to streaming, confirms writes go through again, and checks that exactly one primary exists. At the end it verifies all successful writes landed on all 3 nodes using `WriterValidator.Verify` and md5 checksums.

It follows the same patterns as TestDeadPrimaryRecovery (shardsetup, WriterValidator, disableMonitoringOnAllNodes, etc).