### PR TITLE
fix(multiorch): pick highest-PrimaryTerm primary in populatePrimaryInfo

### DIFF
--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -341,21 +341,30 @@ func (g *AnalysisGenerator) populatePrimaryInfo(
 		return
 	}
 
-	// Find the primary in the same shard
+	// Find the primary with the highest PrimaryTerm in the same shard.
+	// During a failover, two primaries may transiently coexist: the stale old primary
+	// (postgres dead) and the newly elected one (postgres running). Selecting by
+	// PrimaryTerm ensures we always use the most recently elected primary, preventing
+	// PrimaryIsDeadAnalyzer from falsely triggering on the stale one.
 	var primary *multiorchdatapb.PoolerHealthState
+	var highestPrimaryTerm int64
 	for _, pooler := range poolers {
 		if pooler == nil || pooler.MultiPooler == nil || pooler.MultiPooler.Id == nil {
 			continue
 		}
 
-		// Look for primary in same shard - check health check type
-		// Nodes are never created with topology type PRIMARY
 		if pooler.PoolerType != clustermetadatapb.PoolerType_PRIMARY {
 			continue
 		}
 
-		primary = pooler
-		break
+		var primaryTerm int64
+		if pooler.ConsensusTerm != nil {
+			primaryTerm = pooler.ConsensusTerm.PrimaryTerm
+		}
+		if primary == nil || primaryTerm > highestPrimaryTerm {
+			primary = pooler
+			highestPrimaryTerm = primaryTerm
+		}
 	}
 
 	if primary == nil {

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -1101,6 +1101,82 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 	})
 }
 
+// TestPopulatePrimaryInfo_PicksHighestPrimaryTerm verifies that when two primaries transiently
+// coexist (e.g. during failover), the replica's analysis references the one with the higher
+// PrimaryTerm — not an arbitrary one from non-deterministic map iteration.
+func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
+	ps := store.NewPoolerStore(nil, slog.Default())
+
+	newPrimaryID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      "new-primary",
+	}
+	stalePrimaryID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      "stale-primary",
+	}
+	replicaID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      "replica-1",
+	}
+
+	shardConfig := func(id *clustermetadatapb.ID) *clustermetadatapb.MultiPooler {
+		return &clustermetadatapb.MultiPooler{
+			Id: id, Database: "testdb", TableGroup: "default", Shard: "0",
+			Type: clustermetadatapb.PoolerType_PRIMARY,
+		}
+	}
+
+	// New (correct) primary: higher PrimaryTerm, postgres running.
+	ps.Set("multipooler-cell1-new-primary", &multiorchdatapb.PoolerHealthState{
+		MultiPooler:       shardConfig(newPrimaryID),
+		PoolerType:        clustermetadatapb.PoolerType_PRIMARY,
+		IsLastCheckValid:  true,
+		IsPostgresRunning: true,
+		LastSeen:          timestamppb.Now(),
+		ConsensusTerm:     &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 11, PrimaryTerm: 6},
+		ConsensusStatus:   &consensusdatapb.StatusResponse{CurrentTerm: 11},
+	})
+
+	// Stale primary: lower PrimaryTerm, postgres NOT running (just came back after being killed).
+	ps.Set("multipooler-cell1-stale-primary", &multiorchdatapb.PoolerHealthState{
+		MultiPooler:       shardConfig(stalePrimaryID),
+		PoolerType:        clustermetadatapb.PoolerType_PRIMARY,
+		IsLastCheckValid:  true,
+		IsPostgresRunning: false,
+		LastSeen:          timestamppb.Now(),
+		ConsensusTerm:     &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10, PrimaryTerm: 5},
+		ConsensusStatus:   &consensusdatapb.StatusResponse{CurrentTerm: 10},
+	})
+
+	// Replica.
+	ps.Set("multipooler-cell1-replica-1", &multiorchdatapb.PoolerHealthState{
+		MultiPooler: &clustermetadatapb.MultiPooler{
+			Id: replicaID, Database: "testdb", TableGroup: "default", Shard: "0",
+			Type: clustermetadatapb.PoolerType_REPLICA,
+		},
+		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
+		IsLastCheckValid: true,
+		LastSeen:         timestamppb.Now(),
+	})
+
+	generator := NewAnalysisGenerator(ps)
+	analysis, err := generator.GenerateAnalysisForPooler("multipooler-cell1-replica-1")
+	require.NoError(t, err)
+
+	// The replica's analysis must point to the new (correct) primary, not the stale one.
+	// If it pointed to the stale primary (postgres dead), PrimaryReachable would be false
+	// and PrimaryIsDeadAnalyzer would falsely trigger a new election.
+	require.NotNil(t, analysis.PrimaryPoolerID)
+	assert.Equal(t, "new-primary", analysis.PrimaryPoolerID.Name,
+		"should pick primary with highest PrimaryTerm")
+	assert.True(t, analysis.PrimaryReachable,
+		"primary must appear reachable when new primary has postgres running")
+}
+
 func TestDetectOtherPrimary(t *testing.T) {
 	// Test the multiple primaries detection logic
 	t.Run("single other primary detected", func(t *testing.T) {


### PR DESCRIPTION
There was a bug here that a stale primary could get demoted so that postgres is not running, bug multiorch could incorrectly identify the demoted stale primary as the shard primary even though a working primary exists. The "high priority" issue of a dead primary would keep triggering leader appointment, which would determine that no problem exists and do nothing. Meanwhile the "lower priority" issue of a stale demoted primary that needs replication fixed would never be dealt with.

The fix is to trust the primary with a higher ConsensusTerm.PrimaryTerm, not just trust a random primary's claim that it's the current primary.