### PR TITLE
feat(consensus): select promotion candidate by leadership_term then LSN

### DIFF
--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -105,7 +105,23 @@ type WALPosition struct {
 	// For primary: empty
 	LastReplayLsn string `protobuf:"bytes,3,opt,name=last_replay_lsn,json=lastReplayLsn,proto3" json:"last_replay_lsn,omitempty"`
 	// Timestamp when this position was recorded
-	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// PostgreSQL timeline ID from pg_control_checkpoint().
+	// Retained for observability and as a secondary safety check during candidate
+	// selection (see leadership_term).
+	TimelineId int64 `protobuf:"varint,5,opt,name=timeline_id,json=timelineId,proto3" json:"timeline_id,omitempty"`
+	// Term number from the most recent multigres.leadership_history record, read
+	// after WAL replay stabilizes during revoke. Used as the primary criterion for
+	// candidate selection: a node that has replicated a higher consensus term has
+	// applied more of the agreed WAL history, regardless of LSN.
+	// LSN is used as a tiebreaker only when both term and timeline are equal.
+	// 0 if the leadership_history table is empty (e.g. pre-bootstrap).
+	LeadershipTerm int64 `protobuf:"varint,6,opt,name=leadership_term,json=leadershipTerm,proto3" json:"leadership_term,omitempty"`
+	// Cohort members from the most recent multigres.leadership_history record
+	// (application-name strings, same encoding as the table's cohort_members JSONB
+	// column). Empty if the table is empty. Allows the coordinator to see which
+	// cohort was active on each standby at the time of its last leadership event.
+	CohortMembers []string `protobuf:"bytes,7,rep,name=cohort_members,json=cohortMembers,proto3" json:"cohort_members,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -164,6 +180,27 @@ func (x *WALPosition) GetLastReplayLsn() string {
 func (x *WALPosition) GetTimestamp() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *WALPosition) GetTimelineId() int64 {
+	if x != nil {
+		return x.TimelineId
+	}
+	return 0
+}
+
+func (x *WALPosition) GetLeadershipTerm() int64 {
+	if x != nil {
+		return x.LeadershipTerm
+	}
+	return 0
+}
+
+func (x *WALPosition) GetCohortMembers() []string {
+	if x != nil {
+		return x.CohortMembers
 	}
 	return nil
 }
@@ -767,13 +804,17 @@ var File_consensusdata_proto protoreflect.FileDescriptor
 
 const file_consensusdata_proto_rawDesc = "" +
 	"\n" +
-	"\x13consensusdata.proto\x12\rconsensusdata\x1a\x15clustermetadata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xba\x01\n" +
+	"\x13consensusdata.proto\x12\rconsensusdata\x1a\x15clustermetadata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xab\x02\n" +
 	"\vWALPosition\x12\x1f\n" +
 	"\vcurrent_lsn\x18\x01 \x01(\tR\n" +
 	"currentLsn\x12(\n" +
 	"\x10last_receive_lsn\x18\x02 \x01(\tR\x0elastReceiveLsn\x12&\n" +
 	"\x0flast_replay_lsn\x18\x03 \x01(\tR\rlastReplayLsn\x128\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xd8\x01\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x1f\n" +
+	"\vtimeline_id\x18\x05 \x01(\x03R\n" +
+	"timelineId\x12'\n" +
+	"\x0fleadership_term\x18\x06 \x01(\x03R\x0eleadershipTerm\x12%\n" +
+	"\x0ecohort_members\x18\a \x03(\tR\rcohortMembers\"\xd8\x01\n" +
 	"\x10BeginTermRequest\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x03R\x04term\x126\n" +
 	"\fcandidate_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\vcandidateId\x12\x19\n" +

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -125,103 +125,133 @@ func (c *Coordinator) discoverMaxTerm(cohort []*multiorchdatapb.PoolerHealthStat
 	return maxTerm, nil
 }
 
+// walPositionLSN extracts and parses the most relevant LSN from a WALPosition.
+// For a primary node CurrentLsn is used; for a standby, LastReceiveLsn.
+// Returns (0, false) when pos is nil, both LSN fields are empty, or the string
+// cannot be parsed.
+func walPositionLSN(pos *consensusdatapb.WALPosition) (pglogrepl.LSN, bool) {
+	if pos == nil {
+		return 0, false
+	}
+
+	// Get either the CurrentLsn (for primaries) or LastReceiveLsn (for
+	// standbys). Both field may be empty if the server is not a primary or
+	// standby, or if the pooler hasn't fully initialized and fetched WAL
+	// position yet.
+	lsnStr := pos.CurrentLsn
+	if lsnStr == "" {
+		lsnStr = pos.LastReceiveLsn
+	}
+
+	// If both LSN fields are empty, we consider the WAL position invalid for
+	// selection purposes.
+	if lsnStr == "" {
+		return 0, false
+	}
+
+	lsn, err := pglogrepl.ParseLSN(lsnStr)
+	if err != nil {
+		return 0, false
+	}
+
+	return lsn, true
+}
+
 // selectCandidate chooses the best candidate from recruited poolers.
 //
-// WAL positions are captured after REVOKE (demote/pause), so they reflect
-// the final state and won't advance further.
+// WAL positions are captured after REVOKE (demote/pause), so they reflect the
+// final state and won't advance further.
 //
 // Selection Strategy (per generalized consensus):
 //
-// The framework (https://multigres.com/blog/generalized-consensus-part7) requires
-// choosing the timeline with the "latest decision" - meaning the most recent
-// term/coordinator that wrote to it.
+// Two-level ordering: leadership_term → LSN.
 //
-// Current Implementation (INCORRECT for multiple failures):
-//   - We currently select based on highest LSN. This works for simple failover
-//     scenarios with a single timeline.
-//   - However, when there are CONFLICTING TIMELINES from multiple failures,
-//     LSN alone cannot determine which timeline is most recent.
-//   - Problem: LSN measures bytes written, not logical progression.
-//     Example: Term 5 writes a large transaction (LSN 1000), Term 6 writes
-//     a small transaction (LSN 500). LSN would incorrectly choose Term 5's
-//     abandoned timeline over Term 6's. It will incorrectly propagate LSN from Term 5.
+// 1. Highest leadership_term (primary criterion).
 //
-// Why use Timestamps? (Next Steps)
-//   - We follow the "timestamp way" proposal from the blogpost (Part 7).
-//   - We use the timestamp of the most recent transaction commit to
-//     disambiguate conflicting timelines.
-//   - This provides logical ordering across conflicting timelines.
-//   - Limitation: Relies on clock synchronization (we accept theoretical
-//     clock skew for now).
-//   - TODO: Update selectCandidate to use timestamps
+//	Each promotion and replication-config change writes a record to
+//	multigres.leadership_history with the current consensus term, using
+//	RemoteOperationTimeout so synchronous standbys acknowledge the write
+//	before the primary returns. The most recent term_number in a standby's
+//	local leadership_history therefore reflects how far through the agreed
+//	consensus history that standby has replicated. A standby with a higher
+//	leadership_term has definitively applied more of the cluster's
+//	committed WAL history than one with a lower term.
 //
-// Why *NOT* use PrimaryTerm?
-//   - We track PrimaryTerm at the pooler/coordinator level (which term the
-//     coordinator is operating in).
-//   - But we DON'T track which term each individual WAL transaction belongs to.
-//   - Without per-transaction term numbers embedded in WAL, we can't determine
-//     which transactions came from which term when comparing conflicting logs.
+//	A stranded standby that diverged before a term-N promotion write was
+//	replicated may accumulate a numerically larger LSN (e.g. a large
+//	transaction written just before its primary crashed), but its
+//	leadership_term will be lower, correctly excluding it.
 //
-// Future Enhancement:
-//   - Once we implement two-phase sync, our API will be able to infer
-//     which term was associated with a WAL transaction.
-//   - Then we can use: highest term first, then highest LSN within that term
-//   - This eliminates reliance on timestamps and clock assumptions
+//	Falls back to 0 when leadership_history is empty (pre-bootstrap), in
+//	which case the secondary criteria (LSN) determine the winner.
+//
+// 2. Highest LSN (secondary tiebreaker).
+//
+//	When terms are identical, LSN measures genuine progress
+//	within the same history, so the node with the highest LSN is selected.
+//
+// Example (why LSN-only is wrong):
+//
+//	mp1: term=1, LSN=0/5000000  ← stranded, high LSN, old term
+//	mp2: term=2, LSN=0/3000000  ← current term
+//
+// LSN-only would incorrectly elect mp1. Term-first correctly elects mp2.
 func (c *Coordinator) selectCandidate(ctx context.Context, recruited []recruitmentResult) (*multiorchdatapb.PoolerHealthState, error) {
 	if len(recruited) == 0 {
 		return nil, mterrors.New(mtrpcpb.Code_UNAVAILABLE,
 			"no recruited poolers available for candidate selection")
 	}
 
-	var bestCandidate *multiorchdatapb.PoolerHealthState
+	var bestRecruit *recruitmentResult
 	var bestLSN pglogrepl.LSN
 
-	for _, r := range recruited {
-		// Extract LSN from WAL position
-		// For primary: use current_lsn, for standby: use last_receive_lsn
-		lsnStr := ""
-		if r.walPosition != nil {
-			if r.walPosition.CurrentLsn != "" {
-				lsnStr = r.walPosition.CurrentLsn
-			} else if r.walPosition.LastReceiveLsn != "" {
-				lsnStr = r.walPosition.LastReceiveLsn
-			}
-		}
+	for i := range recruited {
+		r := &recruited[i]
 
-		// Skip poolers with no WAL position data
-		if lsnStr == "" {
-			c.logger.InfoContext(ctx, "Skipping recruited pooler with empty WAL position",
+		lsn, ok := walPositionLSN(r.walPosition)
+		if !ok {
+			c.logger.WarnContext(ctx, "Skipping recruited pooler with missing or invalid WAL position",
 				"pooler", r.pooler.MultiPooler.Id.Name)
 			continue
 		}
 
-		// Parse and validate LSN
-		lsn, err := pglogrepl.ParseLSN(lsnStr)
-		if err != nil {
-			c.logger.WarnContext(ctx, "Invalid LSN format for recruited pooler, skipping",
-				"pooler", r.pooler.MultiPooler.Id.Name,
-				"lsn", lsnStr,
-				"error", err)
-			continue
+		var leadershipTerm int64
+		if r.walPosition != nil {
+			leadershipTerm = r.walPosition.LeadershipTerm
 		}
 
-		// Select node with highest LSN
-		if bestCandidate == nil || lsn > bestLSN {
-			bestCandidate = r.pooler
+		var bestLeadershipTerm int64
+		if bestRecruit != nil && bestRecruit.walPosition != nil {
+			bestLeadershipTerm = bestRecruit.walPosition.LeadershipTerm
+		}
+
+		// Select by: highest leadership_term, then highest LSN.
+		if bestRecruit == nil ||
+			leadershipTerm > bestLeadershipTerm ||
+			(leadershipTerm == bestLeadershipTerm && lsn > bestLSN) {
+			bestRecruit = r
 			bestLSN = lsn
 		}
 	}
 
-	if bestCandidate == nil {
+	if bestRecruit == nil {
 		return nil, mterrors.New(mtrpcpb.Code_UNAVAILABLE,
 			"no valid candidate found among recruited poolers - all have empty or invalid WAL positions")
 	}
 
+	// Log candidate selection details for observability. timeline_id is printed
+	// for debugging purposes but does not factor into selection criteria.
+	var timelineID int64
+	if bestRecruit.walPosition != nil {
+		timelineID = bestRecruit.walPosition.TimelineId
+	}
 	c.logger.InfoContext(ctx, "Selected candidate from recruited nodes",
-		"pooler", bestCandidate.MultiPooler.Id.Name,
+		"pooler", bestRecruit.pooler.MultiPooler.Id.Name,
+		"leadership_term", bestRecruit.walPosition.GetLeadershipTerm(),
+		"timeline_id", timelineID,
 		"lsn", bestLSN)
 
-	return bestCandidate, nil
+	return bestRecruit.pooler, nil
 }
 
 // selectCandidateFromRecruited chooses the best candidate from recruited nodes based on WAL position.

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -470,6 +470,170 @@ func TestSelectCandidate(t *testing.T) {
 			"should select standby with highest LSN even though others are primaries")
 	})
 
+	// -----------------------------------------------------------------------
+	// Leadership-term-first selection tests
+	//
+	// These tests encode the failure mode where a standby stranded on an older
+	// consensus term has a numerically higher LSN than standbys on the current
+	// term. Promoting it would discard committed transactions and resurrect ones
+	// clients never received acknowledgement for.
+	//
+	// Selection order: leadership_term → LSN.
+	// -----------------------------------------------------------------------
+
+	t.Run("leadership term takes precedence over LSN - naive LSN selection would be wrong", func(t *testing.T) {
+		// Scenario: after two failovers the cluster has nodes on different terms.
+		//
+		//   mp1 (term=1, TLI=1, LSN=0/5000000): stranded on the original term after
+		//       a large transaction was written just before the first crash. LSN is
+		//       high but the term is stale — promoting mp1 would resurrect those
+		//       transactions and discard everything committed on term 2.
+		//
+		//   mp2 (term=2, TLI=2, LSN=0/3000000): on the current term and timeline.
+		//       Lower LSN but the correct choice.
+		//
+		//   mp3 (term=2, TLI=2, LSN=0/2500000): also on the current term.
+		//
+		// A naive highest-LSN selector would pick mp1. Term-first must pick mp2.
+		c := &Coordinator{
+			coordinatorID: coordID,
+			logger:        logger,
+		}
+
+		recruited := []recruitmentResult{
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp1"},
+					},
+				},
+				// Old term, high LSN — the "naive" choice that would be WRONG
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/5000000",
+					TimelineId:     1,
+					LeadershipTerm: 1,
+				},
+			},
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp2"},
+					},
+				},
+				// Current term, lower LSN — the CORRECT choice
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/3000000",
+					TimelineId:     2,
+					LeadershipTerm: 2,
+				},
+			},
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp3"},
+					},
+				},
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/2500000",
+					TimelineId:     2,
+					LeadershipTerm: 2,
+				},
+			},
+		}
+
+		candidate, err := c.selectCandidate(ctx, recruited)
+		require.NoError(t, err)
+		require.Equal(t, "mp2", candidate.MultiPooler.Id.Name,
+			"must select the node on the highest leadership term (term 2), not the one with the highest LSN (term 1)")
+	})
+
+	t.Run("ties on leadership term resolved by LSN", func(t *testing.T) {
+		// When multiple nodes share the highest term, LSN is the tiebreaker.
+		c := &Coordinator{
+			coordinatorID: coordID,
+			logger:        logger,
+		}
+
+		recruited := []recruitmentResult{
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp1"},
+					},
+				},
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/2000000",
+					TimelineId:     3,
+					LeadershipTerm: 3,
+				},
+			},
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp2"},
+					},
+				},
+				// Same term, highest LSN — should win
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/5000000",
+					TimelineId:     3,
+					LeadershipTerm: 3,
+				},
+			},
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp3"},
+					},
+				},
+				// Lower term entirely
+				walPosition: &consensusdatapb.WALPosition{
+					LastReceiveLsn: "0/9000000",
+					TimelineId:     1,
+					LeadershipTerm: 1,
+				},
+			},
+		}
+
+		candidate, err := c.selectCandidate(ctx, recruited)
+		require.NoError(t, err)
+		require.Equal(t, "mp2", candidate.MultiPooler.Id.Name,
+			"among nodes on the same (highest) term, must select the one with the highest LSN")
+	})
+
+	t.Run("nodes without leadership term fall back to LSN", func(t *testing.T) {
+		// If leadership_term is 0 (empty leadership_history, e.g. pre-bootstrap),
+		// all nodes compare as equal on term, so LSN alone determines the winner.
+		c := &Coordinator{
+			coordinatorID: coordID,
+			logger:        logger,
+		}
+
+		recruited := []recruitmentResult{
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp1"},
+					},
+				},
+				walPosition: &consensusdatapb.WALPosition{LastReceiveLsn: "0/1000000"}, // no term, no timeline
+			},
+			{
+				pooler: &multiorchdatapb.PoolerHealthState{
+					MultiPooler: &clustermetadatapb.MultiPooler{
+						Id: &clustermetadatapb.ID{Name: "mp2"},
+					},
+				},
+				walPosition: &consensusdatapb.WALPosition{LastReceiveLsn: "0/4000000"}, // highest LSN
+			},
+		}
+
+		candidate, err := c.selectCandidate(ctx, recruited)
+		require.NoError(t, err)
+		require.Equal(t, "mp2", candidate.MultiPooler.Id.Name,
+			"without leadership term, highest LSN wins")
+	})
+
 	t.Run("handles multi-segment LSN comparison correctly", func(t *testing.T) {
 		c := &Coordinator{
 			coordinatorID: coordID,
@@ -822,6 +986,86 @@ func TestBeginTerm(t *testing.T) {
 		require.Equal(t, "mp2", candidate.MultiPooler.Id.Name,
 			"should select mp2, not mp1 which failed revoke")
 		require.Len(t, standbys, 1) // Only mp3
+		require.Equal(t, int64(6), term)
+	})
+
+	t.Run("selects candidate by leadership term first not LSN - end-to-end through BeginTerm", func(t *testing.T) {
+		// End-to-end scenario proving the naive-LSN selection would produce the wrong
+		// result and that leadership-term-first ordering corrects it.
+		//
+		// Cluster state after two failovers:
+		//
+		//   mp1 (term=1, TLI=1, LSN=0/5000000): stranded standby. Received a large
+		//       batch of WAL on term 1 before the primary crashed. Never promoted.
+		//       Its LSN is higher than any node on term 2, but its data diverges
+		//       from the current consensus history at the term-1 branch point.
+		//
+		//   mp2 (term=2, TLI=2, LSN=0/3000000): promoted during the first failover.
+		//       Has the correct term and timeline. Lower LSN but must win.
+		//
+		//   mp3 (term=2, TLI=2, LSN=0/2000000): also on the current term.
+		//
+		// Naive highest-LSN: mp1 (WRONG — would discard all term-2 commits)
+		// Term-first:        mp2 (CORRECT)
+		fakeClient := rpcclient.NewFakeClient()
+		c := &Coordinator{
+			coordinatorID: coordID,
+			logger:        logger,
+			rpcClient:     fakeClient,
+		}
+
+		mp1 := createMockNode(fakeClient, "mp1", 5, "0/5000000", true, "standby")
+		mp2 := createMockNode(fakeClient, "mp2", 5, "0/3000000", true, "standby")
+		mp3 := createMockNode(fakeClient, "mp3", 5, "0/2000000", true, "standby")
+		cohort := []*multiorchdatapb.PoolerHealthState{mp1, mp2, mp3}
+
+		// Inject leadership terms into the BeginTermResponses to simulate what the
+		// multipooler returns after the executeRevoke change. Timeline IDs are set
+		// for realism but do not affect selection.
+		mp1Key := topoclient.MultiPoolerIDString(mp1.MultiPooler.Id)
+		mp2Key := topoclient.MultiPoolerIDString(mp2.MultiPooler.Id)
+		mp3Key := topoclient.MultiPoolerIDString(mp3.MultiPooler.Id)
+		fakeClient.BeginTermResponses[mp1Key] = &consensusdatapb.BeginTermResponse{
+			Accepted: true,
+			PoolerId: "mp1",
+			WalPosition: &consensusdatapb.WALPosition{
+				LastReceiveLsn: "0/5000000",
+				TimelineId:     1,
+				LeadershipTerm: 1, // stranded on the old term
+			},
+		}
+		fakeClient.BeginTermResponses[mp2Key] = &consensusdatapb.BeginTermResponse{
+			Accepted: true,
+			PoolerId: "mp2",
+			WalPosition: &consensusdatapb.WALPosition{
+				LastReceiveLsn: "0/3000000",
+				TimelineId:     2,
+				LeadershipTerm: 2, // current term
+			},
+		}
+		fakeClient.BeginTermResponses[mp3Key] = &consensusdatapb.BeginTermResponse{
+			Accepted: true,
+			PoolerId: "mp3",
+			WalPosition: &consensusdatapb.WALPosition{
+				LastReceiveLsn: "0/2000000",
+				TimelineId:     2,
+				LeadershipTerm: 2, // current term
+			},
+		}
+
+		quorumRule := &clustermetadatapb.QuorumRule{
+			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+			RequiredCount: 2,
+		}
+
+		candidate, standbys, term, err := c.BeginTerm(ctx, "shard0", cohort, quorumRule, int64(6))
+		require.NoError(t, err)
+		require.NotNil(t, candidate)
+
+		// The critical assertion: mp2 (term=2, lower LSN) must win over mp1 (term=1, higher LSN).
+		require.Equal(t, "mp2", candidate.MultiPooler.Id.Name,
+			"must promote the standby on the highest leadership term (term 2), not the one with the highest LSN (term 1)")
+		require.Len(t, standbys, 2)
 		require.Equal(t, int64(6), term)
 	})
 

--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -333,6 +333,88 @@ func (pm *MultiPoolerManager) insertDurabilityPolicy(ctx context.Context, policy
 	return nil
 }
 
+// LeadershipHistoryRecord represents a row in the multigres.leadership_history table.
+type LeadershipHistoryRecord struct {
+	ID              int64
+	TermNumber      int64
+	EventType       string
+	LeaderID        *string
+	CoordinatorID   *string
+	WALPosition     *string
+	Operation       *string
+	Reason          string
+	CohortMembers   []string
+	AcceptedMembers []string
+	CreatedAt       time.Time
+}
+
+// queryLeadershipHistory returns the most recent leadership history records ordered
+// by term number descending (newest first). limit controls the maximum number of
+// records returned.
+func (pm *MultiPoolerManager) queryLeadershipHistory(ctx context.Context, limit int) ([]LeadershipHistoryRecord, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	result, err := pm.queryArgs(queryCtx, `
+		SELECT id, term_number, event_type, leader_id, coordinator_id,
+		       wal_position, operation, reason, cohort_members, accepted_members, created_at
+		FROM multigres.leadership_history
+		ORDER BY term_number DESC, id DESC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to query leadership history")
+	}
+
+	records := make([]LeadershipHistoryRecord, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		var rec LeadershipHistoryRecord
+		var cohortJSON string
+		var acceptedJSONPtr *string
+		if err := executor.ScanRow(row,
+			&rec.ID,
+			&rec.TermNumber,
+			&rec.EventType,
+			&rec.LeaderID,
+			&rec.CoordinatorID,
+			&rec.WALPosition,
+			&rec.Operation,
+			&rec.Reason,
+			&cohortJSON,
+			&acceptedJSONPtr,
+			&rec.CreatedAt,
+		); err != nil {
+			return nil, mterrors.Wrap(err, "failed to scan leadership history row")
+		}
+
+		if err := json.Unmarshal([]byte(cohortJSON), &rec.CohortMembers); err != nil {
+			return nil, mterrors.Wrap(err, "failed to unmarshal cohort_members")
+		}
+		if acceptedJSONPtr != nil {
+			if err := json.Unmarshal([]byte(*acceptedJSONPtr), &rec.AcceptedMembers); err != nil {
+				return nil, mterrors.Wrap(err, "failed to unmarshal accepted_members")
+			}
+		}
+
+		records = append(records, rec)
+	}
+
+	return records, nil
+}
+
+// currentLeadershipRecord returns the single most recent record in
+// multigres.leadership_history, determined by the highest term_number.
+// Returns nil if the table is empty.
+func (pm *MultiPoolerManager) currentLeadershipRecord(ctx context.Context) (*LeadershipHistoryRecord, error) {
+	records, err := pm.queryLeadershipHistory(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	return &records[0], nil
+}
+
 // insertHistoryRecord inserts a record into the leadership_history table.
 // This is used for both promotion events and replication config changes.
 // This operation uses the remote-operation-timeout and will fail if it cannot complete within

--- a/go/services/multipooler/manager/pg_multischema_test.go
+++ b/go/services/multipooler/manager/pg_multischema_test.go
@@ -497,6 +497,168 @@ func TestInsertLeadershipHistory(t *testing.T) {
 	}
 }
 
+func TestQueryLeadershipHistory(t *testing.T) {
+	t.Run("returns records ordered newest first", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		leaderID := "zone1_leader-1"
+		coordID := "zone1_coordinator-1"
+		walPos := "0/1234567"
+		operation := "promotion"
+		createdAt := "2026-03-24 09:00:17.000000+00"
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT id, term_number, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"id", "term_number", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
+				},
+				[][]any{
+					{
+						int64(2), int64(2), "promotion", leaderID, coordID, walPos, operation,
+						"manual failover", `["zone1_pooler-2","zone1_pooler-3"]`, `["zone1_pooler-2"]`, createdAt,
+					},
+					{
+						int64(1), int64(1), "replication_config", leaderID, coordID, nil, "configure",
+						"initial bootstrap", `["zone1_pooler-1","zone1_pooler-2"]`, nil, createdAt,
+					},
+				},
+			),
+		)
+
+		records, err := pm.queryLeadershipHistory(t.Context(), 10)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+
+		// First record: term 2 (newest)
+		assert.Equal(t, int64(2), records[0].ID)
+		assert.Equal(t, int64(2), records[0].TermNumber)
+		assert.Equal(t, "promotion", records[0].EventType)
+		require.NotNil(t, records[0].LeaderID)
+		assert.Equal(t, leaderID, *records[0].LeaderID)
+		require.NotNil(t, records[0].WALPosition)
+		assert.Equal(t, walPos, *records[0].WALPosition)
+		require.NotNil(t, records[0].Operation)
+		assert.Equal(t, operation, *records[0].Operation)
+		assert.Equal(t, "manual failover", records[0].Reason)
+		assert.Equal(t, []string{"zone1_pooler-2", "zone1_pooler-3"}, records[0].CohortMembers)
+		assert.Equal(t, []string{"zone1_pooler-2"}, records[0].AcceptedMembers)
+
+		// Second record: term 1, nullable fields are nil
+		assert.Equal(t, int64(1), records[1].TermNumber)
+		assert.Nil(t, records[1].WALPosition)
+		assert.Nil(t, records[1].AcceptedMembers)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("returns empty slice when no records exist", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT id, term_number, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"id", "term_number", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
+				},
+				[][]any{},
+			),
+		)
+
+		records, err := pm.queryLeadershipHistory(t.Context(), 10)
+		require.NoError(t, err)
+		assert.Empty(t, records)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		mockQueryService.AddQueryPatternOnceWithError(
+			"SELECT id, term_number, event_type",
+			errors.New("connection refused"),
+		)
+
+		_, err := pm.queryLeadershipHistory(t.Context(), 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to query leadership history")
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+}
+
+func TestCurrentLeadershipRecord(t *testing.T) {
+	t.Run("returns the record with the highest term_number", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		leaderID := "zone1_leader-2"
+		coordID := "zone1_coordinator-1"
+		walPos := "0/5000000"
+		operation := "promotion"
+		createdAt := "2026-03-24 09:00:17.000000+00"
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT id, term_number, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"id", "term_number", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
+				},
+				[][]any{
+					{
+						int64(5), int64(3), "promotion", leaderID, coordID, walPos, operation,
+						"failover", `["zone1_pooler-2","zone1_pooler-3"]`, `["zone1_pooler-2"]`, createdAt,
+					},
+				},
+			),
+		)
+
+		record, err := pm.currentLeadershipRecord(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, int64(5), record.ID)
+		assert.Equal(t, int64(3), record.TermNumber)
+		assert.Equal(t, "promotion", record.EventType)
+		require.NotNil(t, record.LeaderID)
+		assert.Equal(t, leaderID, *record.LeaderID)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("returns nil when table is empty", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT id, term_number, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"id", "term_number", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
+				},
+				[][]any{},
+			),
+		)
+
+		record, err := pm.currentLeadershipRecord(t.Context())
+		require.NoError(t, err)
+		assert.Nil(t, record)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
+
+		mockQueryService.AddQueryPatternOnceWithError(
+			"SELECT id, term_number, event_type",
+			errors.New("connection refused"),
+		)
+
+		_, err := pm.currentLeadershipRecord(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to query leadership history")
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+}
+
 func TestInsertReplicationConfigHistory(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -225,6 +225,33 @@ func (pm *MultiPoolerManager) executeRevoke(ctx context.Context, term int64, res
 			"last_replay_lsn", status.LastReplayLsn)
 	}
 
+	// Always capture timeline ID after WAL positions are frozen.
+	// Retained for observability only; does not affect candidate selection.
+	timelineID, err := pm.getTimelineID(ctx)
+	if err != nil {
+		pm.logger.WarnContext(ctx, "Failed to get timeline ID during revoke; observability data will be incomplete",
+			"term", term, "error", err)
+	} else {
+		response.WalPosition.TimelineId = timelineID
+		pm.logger.InfoContext(ctx, "Captured timeline ID for observability",
+			"term", term, "timeline_id", timelineID)
+	}
+
+	// Capture the highest consensus term replicated to this node, plus the cohort
+	// that was active at that point. The coordinator uses leadership_term as
+	// the primary criterion: a node that has seen a higher term has applied more
+	// of the agreed WAL history (the history write uses RemoteOperationTimeout,
+	// so sync standbys are guaranteed to have acknowledged it).
+	if rec, err := pm.currentLeadershipRecord(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "Failed to get leadership term during revoke; candidate selection may be suboptimal",
+			"term", term, "error", err)
+	} else if rec != nil {
+		response.WalPosition.LeadershipTerm = rec.TermNumber
+		response.WalPosition.CohortMembers = rec.CohortMembers
+		pm.logger.InfoContext(ctx, "Captured leadership term for candidate selection",
+			"term", term, "leadership_term", rec.TermNumber)
+	}
+
 	return nil
 }
 

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -37,6 +37,25 @@ message WALPosition {
 
   // Timestamp when this position was recorded
   google.protobuf.Timestamp timestamp = 4;
+
+  // PostgreSQL timeline ID from pg_control_checkpoint().
+  // Retained for observability and as a secondary safety check during candidate
+  // selection (see leadership_term).
+  int64 timeline_id = 5;
+
+  // Term number from the most recent multigres.leadership_history record, read
+  // after WAL replay stabilizes during revoke. Used as the primary criterion for
+  // candidate selection: a node that has replicated a higher consensus term has
+  // applied more of the agreed WAL history, regardless of LSN.
+  // LSN is used as a tiebreaker only when both term and timeline are equal.
+  // 0 if the leadership_history table is empty (e.g. pre-bootstrap).
+  int64 leadership_term = 6;
+
+  // Cohort members from the most recent multigres.leadership_history record
+  // (application-name strings, same encoding as the table's cohort_members JSONB
+  // column). Empty if the table is empty. Allows the coordinator to see which
+  // cohort was active on each standby at the time of its last leadership event.
+  repeated string cohort_members = 7;
 }
 
 // Action type for BeginTerm operations


### PR DESCRIPTION
Add read functions for multigres.leadership_history and use the highest replicated consensus term (leadership_term) as the primary criterion when selecting which standby to promote, with LSN as the tiebreaker.

Using leadership_term instead of raw LSN makes candidate selection protocol-native: a standby with a higher term has definitively applied more of the agreed consensus history, regardless of raw WAL position. leadership_history writes use RemoteOperationTimeout so synchronous standbys are guaranteed to have acknowledged them before a write returns.

Two-level ordering in selectCandidate:
1. leadership_term — highest consensus term replicated locally (primary)
2. lsn             — tiebreaker when terms are equal

timeline_id is still captured in WALPosition and included in the post-selection log message for observability, but does not affect which candidate is chosen.

When leadership_term is 0 for all candidates (empty leadership_history, e.g. a freshly bootstrapped cluster), LSN is the sole tiebreaker — identical to the previous behaviour.

Add queryLeadershipHistory and currentLeadershipRecord to pg_multischema.go, and populate LeadershipTerm / CohortMembers in executeRevoke after WAL replay stabilizes.

Fixes MUL-263