### PR TITLE
fix(executil): add context cancellation monitoring to Run/Output/CombinedOutput

### DIFF
--- a/go/tools/executil/command.go
+++ b/go/tools/executil/command.go
@@ -76,7 +76,9 @@
 package executil
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"sync"
@@ -218,25 +220,20 @@ func (c *Cmd) finalizeEnv() {
 	c.Cmd.Env = append(c.Cmd.Env, c.extraEnv...)
 }
 
-// Start starts the command without waiting for it to complete.
+// watchContext starts a background goroutine that monitors the parent context
+// for cancellation and gracefully terminates the process if it is cancelled.
 //
-// If the parent context is cancelled, the process will be terminated with
-// SIGTERM followed by SIGKILL after the default grace period.
-//
-// Note: WithClientSpan() has no effect on Start() since the span cannot be
-// ended until Wait() is called. Use Run() for client span support.
-func (c *Cmd) Start() error {
-	c.finalizeEnv()
-	if err := c.Cmd.Start(); err != nil {
-		return err
-	}
-
+// Must be called after c.Cmd.Start() succeeds. If called before, a
+// cancelled context fires Terminate() while c.Process is still nil, so
+// SIGTERM is a no-op and c.terminated is closed — the process then starts
+// and runs indefinitely with no watcher.
+func (c *Cmd) watchContext() {
 	// Watch for parent context cancellation
 	go func() {
 		select {
 		case <-c.parentCtx.Done():
-			// Parent context cancelled - terminate with default grace period
-			// Fresh context needed; parent context is cancelled
+			// Parent context cancelled - terminate with default grace period.
+			// Fresh context needed; parent context is cancelled.
 			termCtx, termCancel := context.WithTimeout(ctxutil.Detach(c.parentCtx), c.defaultGracePeriod)
 			_, exited := c.Terminate(termCtx)
 			termCancel()
@@ -252,7 +249,21 @@ func (c *Cmd) Start() error {
 			// Process exited naturally, nothing to do
 		}
 	}()
+}
 
+// Start starts the command without waiting for it to complete.
+//
+// If the parent context is cancelled, the process will be terminated with
+// SIGTERM followed by SIGKILL after the default grace period.
+//
+// Note: WithClientSpan() has no effect on Start() since the span cannot be
+// ended until Wait() is called. Use Run() for client span support.
+func (c *Cmd) Start() error {
+	c.finalizeEnv()
+	if err := c.Cmd.Start(); err != nil {
+		return err
+	}
+	c.watchContext()
 	return nil
 }
 
@@ -378,8 +389,10 @@ func (c *Cmd) Run() error {
 		_, span := tracer.Start(c.parentCtx, c.Cmd.Path)
 		defer span.End()
 	}
-	c.finalizeEnv()
-	return c.Cmd.Run()
+	if err := c.Start(); err != nil {
+		return err
+	}
+	return c.Wait()
 }
 
 // Output runs the command and returns its stdout.
@@ -390,8 +403,27 @@ func (c *Cmd) Output() ([]byte, error) {
 		_, span := tracer.Start(c.parentCtx, c.Cmd.Path)
 		defer span.End()
 	}
-	c.finalizeEnv()
-	return c.Cmd.Output()
+	if c.Cmd.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	c.Cmd.Stdout = &stdout
+	captureStderr := c.Cmd.Stderr == nil
+	var stderr bytes.Buffer
+	if captureStderr {
+		c.Cmd.Stderr = &stderr
+	}
+	err := c.Start()
+	if err == nil {
+		err = c.Wait()
+	}
+	if err != nil && captureStderr {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			ee.Stderr = stderr.Bytes()
+		}
+	}
+	return stdout.Bytes(), err
 }
 
 // CombinedOutput runs the command and returns its combined stdout and stderr.
@@ -402,6 +434,18 @@ func (c *Cmd) CombinedOutput() ([]byte, error) {
 		_, span := tracer.Start(c.parentCtx, c.Cmd.Path)
 		defer span.End()
 	}
-	c.finalizeEnv()
-	return c.Cmd.CombinedOutput()
+	if c.Cmd.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	if c.Cmd.Stderr != nil {
+		return nil, errors.New("exec: Stderr already set")
+	}
+	var buf bytes.Buffer
+	c.Cmd.Stdout = &buf
+	c.Cmd.Stderr = &buf
+	err := c.Start()
+	if err == nil {
+		err = c.Wait()
+	}
+	return buf.Bytes(), err
 }

--- a/go/tools/executil/executil_test.go
+++ b/go/tools/executil/executil_test.go
@@ -16,7 +16,9 @@ package executil
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -384,5 +386,120 @@ func TestCommand_CombinedOutput(t *testing.T) {
 	}
 	if !strings.Contains(out, "stderr") {
 		t.Error("expected stderr in combined output")
+	}
+}
+
+func TestCommand_Output_StderrInExitError(t *testing.T) {
+	ctx := context.Background()
+
+	// Command that writes to stderr then exits non-zero
+	cmd := Command(ctx, "sh", "-c", "echo error_output >&2; exit 1")
+	_, err := cmd.Output()
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	if !strings.Contains(string(exitErr.Stderr), "error_output") {
+		t.Errorf("expected stderr in ExitError.Stderr, got: %q", exitErr.Stderr)
+	}
+}
+
+func TestCommand_Run_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := CommandWithGracePeriod(ctx, 100*time.Millisecond, "sleep", "10")
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Run() }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected error from terminated process")
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Run() did not return after context cancellation")
+	}
+}
+
+func TestCommand_Output_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// "exec sleep" replaces the shell with sleep so no child process keeps
+	// the stdout pipe open after SIGTERM, which would block Wait().
+	cmd := CommandWithGracePeriod(ctx, 100*time.Millisecond, "sh", "-c", "echo out; echo err >&2; exec sleep 10")
+
+	type result struct {
+		out []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, err := cmd.Output()
+		done <- result{out, err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Error("expected error from terminated process")
+		}
+		// echo completes before exec sleep, so its output should be in the pipe buffer
+		if !strings.Contains(string(r.out), "out") {
+			t.Errorf("expected stdout in output, got: %q", r.out)
+		}
+		// Output() only captures stdout, not stderr
+		if strings.Contains(string(r.out), "err") {
+			t.Errorf("expected no stderr in output, got: %q", r.out)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Output() did not return after context cancellation")
+	}
+}
+
+func TestCommand_CombinedOutput_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// "exec sleep" replaces the shell with sleep so no child process keeps
+	// the stdout/stderr pipe open after SIGTERM, which would block Wait().
+	cmd := CommandWithGracePeriod(ctx, 100*time.Millisecond, "sh", "-c", "echo out; echo err >&2; exec sleep 10")
+
+	type result struct {
+		out []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, err := cmd.CombinedOutput()
+		done <- result{out, err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Error("expected error from terminated process")
+		}
+		// echo completes before exec sleep, so its output should be in the pipe buffer
+		if !strings.Contains(string(r.out), "out") {
+			t.Errorf("expected stdout in combined output, got: %q", r.out)
+		}
+		if !strings.Contains(string(r.out), "err") {
+			t.Errorf("expected stderr in combined output, got: %q", r.out)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("CombinedOutput() did not return after context cancellation")
 	}
 }


### PR DESCRIPTION
These methods previously delegated to exec.Cmd directly, bypassing the watchContext goroutine that handles graceful SIGTERM→SIGKILL termination on parent context cancellation. Extract watchContext() from Start() and restructure Run/Output/CombinedOutput to go through our Start()+Wait() so all execution paths honour the parent context.