### PR TITLE
refactor(multipooler): replace applicationName with poolerID type

### DIFF
--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -62,12 +62,14 @@ const (
 
 // MultiPoolerManager manages the pooler lifecycle and PostgreSQL operations
 type MultiPoolerManager struct {
-	logger       *slog.Logger
-	config       *Config
-	topoClient   topoclient.Store
-	serviceID    *clustermetadatapb.ID
-	replTracker  *heartbeat.ReplTracker
-	pgctldClient pgctldpb.PgCtldClient
+	logger     *slog.Logger
+	config     *Config
+	topoClient topoclient.Store
+	// Deprecated: use servicePoolerID instead.
+	serviceID       *clustermetadatapb.ID
+	servicePoolerID poolerID
+	replTracker     *heartbeat.ReplTracker
+	pgctldClient    pgctldpb.PgCtldClient
 
 	// connPoolMgr manages all connection pools (admin, regular, reserved)
 	connPoolMgr connpoolmanager.PoolManager
@@ -187,7 +189,8 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	if multiPooler.Id == nil {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "MultiPooler.Id is required")
 	}
-	if _, err := generateApplicationName(multiPooler.Id); err != nil {
+	svcPoolerID, err := newPoolerID(multiPooler.Id)
+	if err != nil {
 		return nil, mterrors.Wrap(err, "invalid MultiPooler.Id")
 	}
 
@@ -226,6 +229,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		config:                 config,
 		topoClient:             config.TopoClient,
 		serviceID:              multiPooler.Id,
+		servicePoolerID:        svcPoolerID,
 		multipooler:            multiPooler,
 		actionLock:             NewActionLock(),
 		state:                  ManagerStateStarting,

--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -337,7 +337,7 @@ func (pm *MultiPoolerManager) insertDurabilityPolicy(ctx context.Context, policy
 // This is used for both promotion events and replication config changes.
 // This operation uses the remote-operation-timeout and will fail if it cannot complete within
 // that time. A timeout typically indicates that synchronous replication is not functioning.
-func (pm *MultiPoolerManager) insertHistoryRecord(ctx context.Context, termNumber int64, eventType string, leaderID applicationName, coordinatorID *clustermetadatapb.ID, walPosition, operation, reason string, cohortMembers, acceptedMembers []applicationName, force bool) error {
+func (pm *MultiPoolerManager) insertHistoryRecord(ctx context.Context, termNumber int64, eventType string, leaderID poolerID, coordinatorID *clustermetadatapb.ID, walPosition, operation, reason string, cohortMembers, acceptedMembers []poolerID, force bool) error {
 	if force {
 		// Force mode skips history recording entirely. Force operations are emergency
 		// operations that must configure replication GUCs regardless. The INSERT would
@@ -350,12 +350,12 @@ func (pm *MultiPoolerManager) insertHistoryRecord(ctx context.Context, termNumbe
 		return nil
 	}
 
-	cohortJSON, err := json.Marshal(applicationNamesToStrings(cohortMembers))
+	cohortJSON, err := json.Marshal(poolerIDsToAppNames(cohortMembers))
 	if err != nil {
 		return mterrors.Wrap(err, "failed to marshal cohort_members")
 	}
 
-	acceptedJSON, err := json.Marshal(applicationNamesToStrings(acceptedMembers))
+	acceptedJSON, err := json.Marshal(poolerIDsToAppNames(acceptedMembers))
 	if err != nil {
 		return mterrors.Wrap(err, "failed to marshal accepted_members")
 	}
@@ -370,7 +370,7 @@ func (pm *MultiPoolerManager) insertHistoryRecord(ctx context.Context, termNumbe
 	VALUES (%d, %s, NULLIF(%s, ''), NULLIF(%s, ''), NULLIF(%s, ''), NULLIF(%s, ''), %s, %s::jsonb, %s::jsonb)`,
 		termNumber,
 		ast.QuoteStringLiteral(eventType),
-		ast.QuoteStringLiteral(string(leaderID)),
+		ast.QuoteStringLiteral(leaderID.appName),
 		ast.QuoteStringLiteral(topoclient.ClusterIDString(coordinatorID)),
 		ast.QuoteStringLiteral(walPosition),
 		ast.QuoteStringLiteral(operation),

--- a/go/services/multipooler/manager/pg_multischema_test.go
+++ b/go/services/multipooler/manager/pg_multischema_test.go
@@ -68,13 +68,20 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 		Shard:      shard,
 	}
 
+	svcID := &clustermetadatapb.ID{Cell: "test-cell", Name: "test-pooler"}
+	svcPoolerID, err := newPoolerID(svcID)
+	if err != nil {
+		panic(err)
+	}
+
 	pm := &MultiPoolerManager{
-		logger:      logger,
-		qsc:         &mockPoolerController{queryService: mockQueryService},
-		topoClient:  topoStore,
-		config:      &Config{},
-		multipooler: multiPooler,
-		serviceID:   &clustermetadatapb.ID{Cell: "test-cell", Name: "test-pooler"},
+		logger:          logger,
+		qsc:             &mockPoolerController{queryService: mockQueryService},
+		topoClient:      topoStore,
+		config:          &Config{},
+		multipooler:     multiPooler,
+		serviceID:       svcID,
+		servicePoolerID: svcPoolerID,
 	}
 
 	return pm, mockQueryService
@@ -377,17 +384,25 @@ func TestInitializeMultischemaData(t *testing.T) {
 	}
 }
 
+func mustPoolerID(cell, name string) poolerID {
+	pid, err := newPoolerID(&clustermetadatapb.ID{Cell: cell, Name: name})
+	if err != nil {
+		panic(err)
+	}
+	return pid
+}
+
 func TestInsertLeadershipHistory(t *testing.T) {
 	tests := []struct {
 		name            string
 		termNumber      int64
-		leaderID        applicationName
+		leaderID        poolerID
 		coordinatorID   *clustermetadatapb.ID
 		walPosition     string
 		operation       string
 		reason          string
-		cohortMembers   []applicationName
-		acceptedMembers []applicationName
+		cohortMembers   []poolerID
+		acceptedMembers []poolerID
 		force           bool
 		setupMock       func(m *mock.QueryService)
 		expectError     bool
@@ -396,13 +411,13 @@ func TestInsertLeadershipHistory(t *testing.T) {
 		{
 			name:            "successful insert",
 			termNumber:      1,
-			leaderID:        "zone1_leader-1",
+			leaderID:        mustPoolerID("zone1", "leader-1"),
 			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"},
 			walPosition:     "0/1234567",
 			operation:       "promotion",
 			reason:          "Leadership changed due to manual promotion",
-			cohortMembers:   []applicationName{"zone1_member-1", "zone1_member-2", "zone1_member-3"},
-			acceptedMembers: []applicationName{"zone1_member-1", "zone1_member-2"},
+			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2"), mustPoolerID("zone1", "member-3")},
+			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
 			},
@@ -411,13 +426,13 @@ func TestInsertLeadershipHistory(t *testing.T) {
 		{
 			name:            "insert fails with database error",
 			termNumber:      2,
-			leaderID:        "zone1_leader-2",
+			leaderID:        mustPoolerID("zone1", "leader-2"),
 			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-2"},
 			walPosition:     "0/2345678",
 			operation:       "failover",
 			reason:          "Leadership changed due to failover",
-			cohortMembers:   []applicationName{"zone1_member-1", "zone1_member-2"},
-			acceptedMembers: []applicationName{"zone1_member-1"},
+			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
+			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1")},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnceWithError("INSERT INTO multigres.leadership_history", errors.New("connection refused"))
 			},
@@ -427,13 +442,13 @@ func TestInsertLeadershipHistory(t *testing.T) {
 		{
 			name:            "force mode skips insert entirely",
 			termNumber:      2,
-			leaderID:        "zone1_leader-2",
+			leaderID:        mustPoolerID("zone1", "leader-2"),
 			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-2"},
 			walPosition:     "0/2345678",
 			operation:       "configure",
 			reason:          "Emergency replication GUC change",
-			cohortMembers:   []applicationName{"zone1_member-1", "zone1_member-2"},
-			acceptedMembers: []applicationName{"zone1_member-1"},
+			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
+			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1")},
 			force:           true,
 			setupMock: func(m *mock.QueryService) {
 				// No mock needed - force mode skips the insert entirely
@@ -443,13 +458,13 @@ func TestInsertLeadershipHistory(t *testing.T) {
 		{
 			name:            "insert with empty cohort and accepted members arrays",
 			termNumber:      3,
-			leaderID:        "zone1_leader-3",
+			leaderID:        mustPoolerID("zone1", "leader-3"),
 			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-3"},
 			walPosition:     "0/3456789",
 			operation:       "bootstrap",
 			reason:          "Initial cluster bootstrap",
-			cohortMembers:   []applicationName{},
-			acceptedMembers: []applicationName{},
+			cohortMembers:   []poolerID{},
+			acceptedMembers: []poolerID{},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
 			},
@@ -552,13 +567,11 @@ func TestInsertReplicationConfigHistory(t *testing.T) {
 
 			ctx := context.Background()
 
-			// Convert standby IDs to application names
-			standbyAppNames, err := standbyIDsToAppNames(tt.standbyIDs)
+			// Convert standby IDs to pooler IDs
+			standbyPoolerIDs, err := toPoolerIDs(tt.standbyIDs)
 			require.NoError(t, err)
 
-			leaderID, err := generateApplicationName(pm.serviceID)
-			require.NoError(t, err)
-			err = pm.insertHistoryRecord(ctx, tt.termNumber, "replication_config", leaderID, nil, "", tt.operation, tt.reason, standbyAppNames, nil, false /* force */)
+			err = pm.insertHistoryRecord(ctx, tt.termNumber, "replication_config", pm.servicePoolerID, nil, "", tt.operation, tt.reason, standbyPoolerIDs, nil, false /* force */)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -50,73 +50,78 @@ import (
 // maxApplicationNameLength is the maximum length of a PostgreSQL application_name (NAMEDATALEN - 1).
 const maxApplicationNameLength = 63
 
-// applicationName is a validated PostgreSQL application_name string.
-// Use generateApplicationName to construct one from a cluster ID.
-type applicationName string
+// poolerID is a validated MULTIPOOLER identity for use in PostgreSQL replication.
+// Construct via newPoolerID(). Holds both the canonical cluster ID and its derived
+// PostgreSQL application_name. The appName field is the only serialization format
+// used internally; other formats (e.g., JSON, gRPC ID) are accessible via the id field.
+type poolerID struct {
+	id      *clustermetadatapb.ID
+	appName string
+}
 
-// generateApplicationName generates the application_name for a multipooler from its ID
+// newPoolerID generates the poolerID for a multipooler from its ID.
 // Format: {cell}_{name}
 // This is used consistently for:
 // - SetPrimaryConnInfo: standby's application_name when connecting to primary
 // - ConfigureSynchronousReplication: standby names in synchronous_standby_names
-func generateApplicationName(id *clustermetadatapb.ID) (applicationName, error) {
+func newPoolerID(id *clustermetadatapb.ID) (poolerID, error) {
 	if id == nil {
-		return "", mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "nil")
+		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "nil")
 	}
 	if id.Cell == "" {
-		return "", mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty cell")
+		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty cell")
 	}
 	if id.Name == "" {
-		return "", mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty name")
+		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty name")
 	}
 	// Underscores are not allowed in Cell or Name because they are used as delimiters
 	// in the application_name format (cell_name). Allowing underscores would break parsing.
 	if strings.Contains(id.Cell, "_") {
-		return "", mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"cell contains underscore: %q (underscores not allowed)", id.Cell)
 	}
 	if strings.Contains(id.Name, "_") {
-		return "", mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"name contains underscore: %q (underscores not allowed)", id.Name)
 	}
 	name := fmt.Sprintf("%s_%s", id.Cell, id.Name)
 	if len(name) > maxApplicationNameLength {
-		return "", mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"application name %q exceeds maximum length of %d characters", name, maxApplicationNameLength)
 	}
-	return applicationName(name), nil
+	return poolerID{id: id, appName: name}, nil
 }
 
-// applicationNamesToStrings converts a slice of applicationName to plain strings for use in APIs
+// poolerIDsToAppNames converts a slice of poolerID to their application name strings for use in APIs
 // that accept []string (e.g., history records).
-func applicationNamesToStrings(names []applicationName) []string {
-	strs := make([]string, len(names))
-	for i, n := range names {
-		strs[i] = string(n)
+func poolerIDsToAppNames(ids []poolerID) []string {
+	strs := make([]string, len(ids))
+	for i, n := range ids {
+		strs[i] = n.appName
 	}
 	return strs
 }
 
-// formatStandbyList formats a list of application names as a comma-separated list of quoted names.
-func formatStandbyList(names []applicationName) string {
-	quoted := make([]string, len(names))
-	for i, name := range names {
-		quoted[i] = fmt.Sprintf(`"%s"`, name)
+// formatStandbyList formats a list of pooler IDs as a comma-separated list of quoted application names.
+func formatStandbyList(ids []poolerID) string {
+	quoted := make([]string, len(ids))
+	for i, id := range ids {
+		quoted[i] = fmt.Sprintf(`"%s"`, id.appName)
 	}
 	return strings.Join(quoted, ", ")
 }
 
-// standbyIDsToAppNames converts a slice of standby IDs to their application names.
-func standbyIDsToAppNames(ids []*clustermetadatapb.ID) ([]applicationName, error) {
-	names := make([]applicationName, len(ids))
+// toPoolerIDs converts a slice of standby IDs to their poolerID representations.
+func toPoolerIDs(ids []*clustermetadatapb.ID) ([]poolerID, error) {
+	result := make([]poolerID, len(ids))
 	for i, id := range ids {
-		name, err := generateApplicationName(id)
+		pid, err := newPoolerID(id)
 		if err != nil {
 			return nil, mterrors.Wrapf(err, "standby_ids[%d]", i)
 		}
-		names[i] = name
+		result[i] = pid
 	}
-	return names, nil
+	return result, nil
 }
 
 // ----------------------------------------------------------------------------
@@ -705,7 +710,7 @@ func (pm *MultiPoolerManager) setSynchronousCommit(ctx context.Context, synchron
 
 // buildSynchronousStandbyNamesValue constructs the synchronous_standby_names value string
 // This produces values like: FIRST 1 ("standby-1", "standby-2") or ANY 1 ("standby-1", "standby-2")
-func buildSynchronousStandbyNamesValue(method multipoolermanagerdatapb.SynchronousMethod, numSync int32, names []applicationName) (string, error) {
+func buildSynchronousStandbyNamesValue(method multipoolermanagerdatapb.SynchronousMethod, numSync int32, names []poolerID) (string, error) {
 	if len(names) == 0 {
 		return "", nil
 	}
@@ -749,8 +754,8 @@ func (pm *MultiPoolerManager) applySynchronousStandbyNames(ctx context.Context, 
 //	ANY 1 (standby1, standby2)
 //
 // Note: Use '*' to match all connected standbys, or specify explicit standby application_name values
-// Application names are generated from multipooler IDs using the shared generateApplicationName helper
-func (pm *MultiPoolerManager) setSynchronousStandbyNames(ctx context.Context, synchronousMethod multipoolermanagerdatapb.SynchronousMethod, numSync int32, names []applicationName) error {
+// Application names are generated from multipooler IDs using the shared newPoolerID helper
+func (pm *MultiPoolerManager) setSynchronousStandbyNames(ctx context.Context, synchronousMethod multipoolermanagerdatapb.SynchronousMethod, numSync int32, names []poolerID) error {
 	// If standby list is empty, clear synchronous_standby_names
 	if len(names) == 0 {
 		execCtx, execCancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -807,11 +812,11 @@ func (pm *MultiPoolerManager) getSynchronousReplicationConfig(ctx context.Contex
 		config.SynchronousMethod = syncConfig.Method
 		config.NumSync = syncConfig.NumSync
 		config.StandbyIds = syncConfig.StandbyIDs
-		appNames, err := standbyIDsToAppNames(syncConfig.StandbyIDs)
+		appNames, err := toPoolerIDs(syncConfig.StandbyIDs)
 		if err != nil {
 			return nil, mterrors.Wrap(err, "failed to convert standby IDs to application names")
 		}
-		config.StandbyApplicationNames = applicationNamesToStrings(appNames)
+		config.StandbyApplicationNames = poolerIDsToAppNames(appNames)
 	}
 
 	// Query synchronous_commit
@@ -953,16 +958,16 @@ func (pm *MultiPoolerManager) syncReplicationConfigMatches(current *multipoolerm
 // ----------------------------------------------------------------------------
 // Validation Helpers
 // ----------------------------------------------------------------------------
-// validateStandbyIDs validates that the list is non-empty and converts each ID to its application name.
-func validateStandbyIDs(standbyIDs []*clustermetadatapb.ID) ([]applicationName, error) {
+// validateStandbyIDs validates that the list is non-empty and converts each ID to its poolerID.
+func validateStandbyIDs(standbyIDs []*clustermetadatapb.ID) ([]poolerID, error) {
 	if len(standbyIDs) == 0 {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "standby_ids cannot be empty")
 	}
-	return standbyIDsToAppNames(standbyIDs)
+	return toPoolerIDs(standbyIDs)
 }
 
 // validateSyncReplicationParams validates the parameters for ConfigureSynchronousReplication
-func validateSyncReplicationParams(numSync int32, standbyIDs []*clustermetadatapb.ID) ([]applicationName, error) {
+func validateSyncReplicationParams(numSync int32, standbyIDs []*clustermetadatapb.ID) ([]poolerID, error) {
 	// Validate numSync is non-negative
 	if numSync < 0 {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT,
@@ -1008,14 +1013,14 @@ func standbyUpdateOperationName(op multipoolermanagerdatapb.StandbyUpdateOperati
 // ----------------------------------------------------------------------------
 
 // applyAddOperation adds new standbys to the standby list (idempotent)
-func applyAddOperation(currentStandbys, newStandbys []applicationName) []applicationName {
-	updatedStandbys := append([]applicationName{}, currentStandbys...)
-	existingMap := make(map[applicationName]bool, len(currentStandbys))
+func applyAddOperation(currentStandbys, newStandbys []poolerID) []poolerID {
+	updatedStandbys := append([]poolerID{}, currentStandbys...)
+	existingMap := make(map[string]bool, len(currentStandbys))
 	for _, standby := range currentStandbys {
-		existingMap[standby] = true
+		existingMap[standby.appName] = true
 	}
 	for _, newStandby := range newStandbys {
-		if !existingMap[newStandby] {
+		if !existingMap[newStandby.appName] {
 			updatedStandbys = append(updatedStandbys, newStandby)
 		}
 	}
@@ -1023,14 +1028,14 @@ func applyAddOperation(currentStandbys, newStandbys []applicationName) []applica
 }
 
 // applyRemoveOperation removes standby names from the standby list (idempotent)
-func applyRemoveOperation(currentStandbys, standbysToRemove []applicationName) []applicationName {
-	removeMap := make(map[applicationName]bool, len(standbysToRemove))
+func applyRemoveOperation(currentStandbys, standbysToRemove []poolerID) []poolerID {
+	removeMap := make(map[string]bool, len(standbysToRemove))
 	for _, standby := range standbysToRemove {
-		removeMap[standby] = true
+		removeMap[standby.appName] = true
 	}
-	var updatedStandbys []applicationName
+	var updatedStandbys []poolerID
 	for _, standby := range currentStandbys {
-		if !removeMap[standby] {
+		if !removeMap[standby.appName] {
 			updatedStandbys = append(updatedStandbys, standby)
 		}
 	}
@@ -1038,7 +1043,7 @@ func applyRemoveOperation(currentStandbys, standbysToRemove []applicationName) [
 }
 
 // applyReplaceOperation replaces the entire standby list
-func applyReplaceOperation(newStandbys []applicationName) []applicationName {
+func applyReplaceOperation(newStandbys []poolerID) []poolerID {
 	return newStandbys
 }
 

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -33,12 +33,26 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
-func TestGenerateApplicationName(t *testing.T) {
+// mustPoolerIDFromAppName constructs a poolerID from a "cell_name" application name string.
+// Panics if parsing or construction fails; for use in tests only.
+func mustPoolerIDFromAppName(appName string) poolerID {
+	id, err := parseApplicationName(appName)
+	if err != nil {
+		panic(err)
+	}
+	pid, err := newPoolerID(id)
+	if err != nil {
+		panic(err)
+	}
+	return pid
+}
+
+func TestNewPoolerID(t *testing.T) {
 	tests := []struct {
-		name        string
-		id          *clustermetadatapb.ID
-		expected    applicationName
-		expectError bool
+		name            string
+		id              *clustermetadatapb.ID
+		expectedAppName string
+		expectError     bool
 	}{
 		{
 			name: "standard ID",
@@ -46,7 +60,7 @@ func TestGenerateApplicationName(t *testing.T) {
 				Cell: "us-west",
 				Name: "replica-1",
 			},
-			expected: applicationName("us-west_replica-1"),
+			expectedAppName: "us-west_replica-1",
 		},
 		{
 			name: "single character values",
@@ -54,7 +68,7 @@ func TestGenerateApplicationName(t *testing.T) {
 				Cell: "a",
 				Name: "b",
 			},
-			expected: applicationName("a_b"),
+			expectedAppName: "a_b",
 		},
 		{
 			name: "hyphenated names",
@@ -62,7 +76,7 @@ func TestGenerateApplicationName(t *testing.T) {
 				Cell: "us-east-1a",
 				Name: "primary-db-001",
 			},
-			expected: applicationName("us-east-1a_primary-db-001"),
+			expectedAppName: "us-east-1a_primary-db-001",
 		},
 		{
 			name: "numeric values",
@@ -70,7 +84,7 @@ func TestGenerateApplicationName(t *testing.T) {
 				Cell: "zone1",
 				Name: "pooler-001",
 			},
-			expected: applicationName("zone1_pooler-001"),
+			expectedAppName: "zone1_pooler-001",
 		},
 		{
 			name: "exactly 63 characters",
@@ -78,7 +92,7 @@ func TestGenerateApplicationName(t *testing.T) {
 				Cell: "us-east-1a",
 				Name: strings.Repeat("x", 52), // "us-east-1a_" (11) + 52 = 63
 			},
-			expected: applicationName("us-east-1a_" + strings.Repeat("x", 52)),
+			expectedAppName: "us-east-1a_" + strings.Repeat("x", 52),
 		},
 		{
 			name: "exceeds 63 characters",
@@ -92,13 +106,14 @@ func TestGenerateApplicationName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := generateApplicationName(tt.id)
+			result, err := newPoolerID(tt.id)
 			if tt.expectError {
 				require.Error(t, err)
 				assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err))
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				assert.Equal(t, tt.expectedAppName, result.appName)
+				assert.Equal(t, tt.id, result.id)
 			}
 		})
 	}
@@ -107,27 +122,27 @@ func TestGenerateApplicationName(t *testing.T) {
 func TestFormatStandbyList(t *testing.T) {
 	tests := []struct {
 		name     string
-		names    []applicationName
+		names    []poolerID
 		expected string
 	}{
 		{
 			name:     "empty list",
-			names:    []applicationName{},
+			names:    []poolerID{},
 			expected: "",
 		},
 		{
 			name:     "single standby",
-			names:    []applicationName{"zone1_replica-1"},
+			names:    []poolerID{mustPoolerIDFromAppName("zone1_replica-1")},
 			expected: `"zone1_replica-1"`,
 		},
 		{
 			name:     "multiple standbys",
-			names:    []applicationName{"zone1_replica-1", "zone2_replica-2", "zone3_replica-3"},
+			names:    []poolerID{mustPoolerIDFromAppName("zone1_replica-1"), mustPoolerIDFromAppName("zone2_replica-2"), mustPoolerIDFromAppName("zone3_replica-3")},
 			expected: `"zone1_replica-1", "zone2_replica-2", "zone3_replica-3"`,
 		},
 		{
 			name:     "two standbys",
-			names:    []applicationName{"east_standby-a", "west_standby-b"},
+			names:    []poolerID{mustPoolerIDFromAppName("east_standby-a"), mustPoolerIDFromAppName("west_standby-b")},
 			expected: `"east_standby-a", "west_standby-b"`,
 		},
 	}
@@ -144,7 +159,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 		name        string
 		method      multipoolermanagerdatapb.SynchronousMethod
 		numSync     int32
-		names       []applicationName
+		names       []poolerID
 		expected    string
 		expectError bool
 		errorMsg    string
@@ -153,7 +168,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "empty standby list returns empty string",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST,
 			numSync:     1,
-			names:       []applicationName{},
+			names:       []poolerID{},
 			expected:    "",
 			expectError: false,
 		},
@@ -161,7 +176,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "FIRST method with single standby",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST,
 			numSync:     1,
-			names:       []applicationName{"zone1_replica-1"},
+			names:       []poolerID{mustPoolerIDFromAppName("zone1_replica-1")},
 			expected:    `FIRST 1 ("zone1_replica-1")`,
 			expectError: false,
 		},
@@ -169,7 +184,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "FIRST method with multiple standbys",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST,
 			numSync:     2,
-			names:       []applicationName{"zone1_replica-1", "zone2_replica-2", "zone3_replica-3"},
+			names:       []poolerID{mustPoolerIDFromAppName("zone1_replica-1"), mustPoolerIDFromAppName("zone2_replica-2"), mustPoolerIDFromAppName("zone3_replica-3")},
 			expected:    `FIRST 2 ("zone1_replica-1", "zone2_replica-2", "zone3_replica-3")`,
 			expectError: false,
 		},
@@ -177,7 +192,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "ANY method with multiple standbys",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
 			numSync:     1,
-			names:       []applicationName{"zone1_replica-1", "zone2_replica-2"},
+			names:       []poolerID{mustPoolerIDFromAppName("zone1_replica-1"), mustPoolerIDFromAppName("zone2_replica-2")},
 			expected:    `ANY 1 ("zone1_replica-1", "zone2_replica-2")`,
 			expectError: false,
 		},
@@ -185,7 +200,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "ANY method with three standbys and numSync=2",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
 			numSync:     2,
-			names:       []applicationName{"a_1", "b_2", "c_3"},
+			names:       []poolerID{mustPoolerIDFromAppName("a_1"), mustPoolerIDFromAppName("b_2"), mustPoolerIDFromAppName("c_3")},
 			expected:    `ANY 2 ("a_1", "b_2", "c_3")`,
 			expectError: false,
 		},
@@ -193,7 +208,7 @@ func TestBuildSynchronousStandbyNamesValue(t *testing.T) {
 			name:        "invalid method returns error",
 			method:      multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_UNSPECIFIED,
 			numSync:     1,
-			names:       []applicationName{"zone1_replica-1"},
+			names:       []poolerID{mustPoolerIDFromAppName("zone1_replica-1")},
 			expected:    "",
 			expectError: true,
 			errorMsg:    "invalid synchronous method",
@@ -512,51 +527,51 @@ func TestSyncReplicationConfigMatches(t *testing.T) {
 }
 
 func TestApplyAddOperation(t *testing.T) {
-	s1 := applicationName("zone1_replica-1")
-	s2 := applicationName("zone2_replica-2")
-	s3 := applicationName("zone3_replica-3")
+	s1 := mustPoolerIDFromAppName("zone1_replica-1")
+	s2 := mustPoolerIDFromAppName("zone2_replica-2")
+	s3 := mustPoolerIDFromAppName("zone3_replica-3")
 
 	tests := []struct {
 		name     string
-		current  []applicationName
-		incoming []applicationName
-		expected []applicationName
+		current  []poolerID
+		incoming []poolerID
+		expected []poolerID
 	}{
 		{
 			name:     "add to empty list",
-			current:  []applicationName{},
-			incoming: []applicationName{s1},
-			expected: []applicationName{s1},
+			current:  []poolerID{},
+			incoming: []poolerID{s1},
+			expected: []poolerID{s1},
 		},
 		{
 			name:     "add new standby to existing list",
-			current:  []applicationName{s1},
-			incoming: []applicationName{s2},
-			expected: []applicationName{s1, s2},
+			current:  []poolerID{s1},
+			incoming: []poolerID{s2},
+			expected: []poolerID{s1, s2},
 		},
 		{
 			name:     "add multiple new standbys",
-			current:  []applicationName{s1},
-			incoming: []applicationName{s2, s3},
-			expected: []applicationName{s1, s2, s3},
+			current:  []poolerID{s1},
+			incoming: []poolerID{s2, s3},
+			expected: []poolerID{s1, s2, s3},
 		},
 		{
 			name:     "idempotent - add existing standby",
-			current:  []applicationName{s1, s2},
-			incoming: []applicationName{s1},
-			expected: []applicationName{s1, s2},
+			current:  []poolerID{s1, s2},
+			incoming: []poolerID{s1},
+			expected: []poolerID{s1, s2},
 		},
 		{
 			name:     "idempotent - add mix of existing and new",
-			current:  []applicationName{s1, s2},
-			incoming: []applicationName{s2, s3},
-			expected: []applicationName{s1, s2, s3},
+			current:  []poolerID{s1, s2},
+			incoming: []poolerID{s2, s3},
+			expected: []poolerID{s1, s2, s3},
 		},
 		{
 			name:     "add empty list does nothing",
-			current:  []applicationName{s1},
-			incoming: []applicationName{},
-			expected: []applicationName{s1},
+			current:  []poolerID{s1},
+			incoming: []poolerID{},
+			expected: []poolerID{s1},
 		},
 	}
 
@@ -569,57 +584,57 @@ func TestApplyAddOperation(t *testing.T) {
 }
 
 func TestApplyRemoveOperation(t *testing.T) {
-	s1 := applicationName("zone1_replica-1")
-	s2 := applicationName("zone2_replica-2")
-	s3 := applicationName("zone3_replica-3")
+	s1 := mustPoolerIDFromAppName("zone1_replica-1")
+	s2 := mustPoolerIDFromAppName("zone2_replica-2")
+	s3 := mustPoolerIDFromAppName("zone3_replica-3")
 
 	tests := []struct {
 		name     string
-		current  []applicationName
-		remove   []applicationName
-		expected []applicationName
+		current  []poolerID
+		remove   []poolerID
+		expected []poolerID
 	}{
 		{
 			name:     "remove from single item list",
-			current:  []applicationName{s1},
-			remove:   []applicationName{s1},
-			expected: []applicationName{},
+			current:  []poolerID{s1},
+			remove:   []poolerID{s1},
+			expected: []poolerID{},
 		},
 		{
 			name:     "remove one from multiple",
-			current:  []applicationName{s1, s2, s3},
-			remove:   []applicationName{s2},
-			expected: []applicationName{s1, s3},
+			current:  []poolerID{s1, s2, s3},
+			remove:   []poolerID{s2},
+			expected: []poolerID{s1, s3},
 		},
 		{
 			name:     "remove multiple standbys",
-			current:  []applicationName{s1, s2, s3},
-			remove:   []applicationName{s1, s3},
-			expected: []applicationName{s2},
+			current:  []poolerID{s1, s2, s3},
+			remove:   []poolerID{s1, s3},
+			expected: []poolerID{s2},
 		},
 		{
 			name:     "idempotent - remove non-existent standby",
-			current:  []applicationName{s1, s2},
-			remove:   []applicationName{s3},
-			expected: []applicationName{s1, s2},
+			current:  []poolerID{s1, s2},
+			remove:   []poolerID{s3},
+			expected: []poolerID{s1, s2},
 		},
 		{
 			name:     "idempotent - remove mix of existing and non-existent",
-			current:  []applicationName{s1, s2},
-			remove:   []applicationName{s2, s3},
-			expected: []applicationName{s1},
+			current:  []poolerID{s1, s2},
+			remove:   []poolerID{s2, s3},
+			expected: []poolerID{s1},
 		},
 		{
 			name:     "remove empty list does nothing",
-			current:  []applicationName{s1, s2},
-			remove:   []applicationName{},
-			expected: []applicationName{s1, s2},
+			current:  []poolerID{s1, s2},
+			remove:   []poolerID{},
+			expected: []poolerID{s1, s2},
 		},
 		{
 			name:     "remove from empty list",
-			current:  []applicationName{},
-			remove:   []applicationName{s1},
-			expected: []applicationName{},
+			current:  []poolerID{},
+			remove:   []poolerID{s1},
+			expected: []poolerID{},
 		},
 	}
 
@@ -634,23 +649,23 @@ func TestApplyRemoveOperation(t *testing.T) {
 func TestApplyReplaceOperation(t *testing.T) {
 	tests := []struct {
 		name     string
-		names    []applicationName
-		expected []applicationName
+		names    []poolerID
+		expected []poolerID
 	}{
 		{
 			name:     "replace with single standby",
-			names:    []applicationName{"zone1_replica-1"},
-			expected: []applicationName{"zone1_replica-1"},
+			names:    []poolerID{mustPoolerIDFromAppName("zone1_replica-1")},
+			expected: []poolerID{mustPoolerIDFromAppName("zone1_replica-1")},
 		},
 		{
 			name:     "replace with multiple standbys",
-			names:    []applicationName{"zone1_replica-1", "zone2_replica-2", "zone3_replica-3"},
-			expected: []applicationName{"zone1_replica-1", "zone2_replica-2", "zone3_replica-3"},
+			names:    []poolerID{mustPoolerIDFromAppName("zone1_replica-1"), mustPoolerIDFromAppName("zone2_replica-2"), mustPoolerIDFromAppName("zone3_replica-3")},
+			expected: []poolerID{mustPoolerIDFromAppName("zone1_replica-1"), mustPoolerIDFromAppName("zone2_replica-2"), mustPoolerIDFromAppName("zone3_replica-3")},
 		},
 		{
 			name:     "replace with empty list",
-			names:    []applicationName{},
-			expected: []applicationName{},
+			names:    []poolerID{},
+			expected: []poolerID{},
 		},
 	}
 
@@ -948,7 +963,7 @@ func TestSetSynchronousStandbyNames(t *testing.T) {
 		name              string
 		synchronousMethod multipoolermanagerdatapb.SynchronousMethod
 		numSync           int32
-		names             []applicationName
+		names             []poolerID
 		setupMock         func(*mock.QueryService)
 		expectError       bool
 	}{
@@ -956,7 +971,7 @@ func TestSetSynchronousStandbyNames(t *testing.T) {
 			name:              "FIRST method with multiple standbys",
 			synchronousMethod: multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST,
 			numSync:           1,
-			names:             []applicationName{"cell1_pooler1", "cell1_pooler2"},
+			names:             []poolerID{mustPoolerIDFromAppName("cell1_pooler1"), mustPoolerIDFromAppName("cell1_pooler2")},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 			},
@@ -966,7 +981,7 @@ func TestSetSynchronousStandbyNames(t *testing.T) {
 			name:              "ANY method with multiple standbys",
 			synchronousMethod: multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY,
 			numSync:           2,
-			names:             []applicationName{"cell1_pooler1", "cell2_pooler2", "cell2_pooler3"},
+			names:             []poolerID{mustPoolerIDFromAppName("cell1_pooler1"), mustPoolerIDFromAppName("cell2_pooler2"), mustPoolerIDFromAppName("cell2_pooler3")},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM SET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
 			},
@@ -976,7 +991,7 @@ func TestSetSynchronousStandbyNames(t *testing.T) {
 			name:              "db exec error",
 			synchronousMethod: multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST,
 			numSync:           1,
-			names:             []applicationName{"cell1_pooler1"},
+			names:             []poolerID{mustPoolerIDFromAppName("cell1_pooler1")},
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnceWithError("ALTER SYSTEM SET synchronous_standby_names", errors.New("exec error"))
 			},

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -45,13 +45,10 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 		return nil, err
 	}
 
-	// Pre-compute the leader's application name before acquiring the lock.
-	leaderID, err := generateApplicationName(pm.serviceID)
-	if err != nil {
-		return nil, err
-	}
+	leaderID := pm.servicePoolerID
 
 	// Acquire action lock
+	var err error
 	ctx, err = pm.actionLock.Acquire(ctx, "InitializeEmptyPrimary")
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to acquire action lock")
@@ -182,8 +179,8 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 
 	// Write leadership history record for bootstrap
 	reason := "ShardNeedsBootstrap"
-	cohortMembers := []applicationName{leaderID} // Only the initial primary during bootstrap
-	acceptedMembers := []applicationName{leaderID}
+	cohortMembers := []poolerID{leaderID} // Only the initial primary during bootstrap
+	acceptedMembers := []poolerID{leaderID}
 
 	if err := pm.insertHistoryRecord(ctx,
 		req.ConsensusTerm,

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -148,10 +148,7 @@ func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 			fmt.Sprintf("operation not allowed: the PostgreSQL instance is not in standby mode (service_id: %s)", pm.serviceID.String()))
 	}
 
-	appName, err := generateApplicationName(pm.serviceID)
-	if err != nil {
-		return err
-	}
+	appName := pm.servicePoolerID
 
 	// Optionally stop replication before making changes
 	if stopReplicationBefore {
@@ -168,7 +165,7 @@ func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 	database := pm.multipooler.Database
 	pm.mu.Unlock()
 	connInfo := fmt.Sprintf("host=%s port=%d user=%s application_name=%s",
-		host, port, database, string(appName))
+		host, port, database, appName.appName)
 
 	// Set primary_conninfo using ALTER SYSTEM
 	if err = pm.setPrimaryConnInfo(ctx, connInfo); err != nil {
@@ -419,7 +416,7 @@ func (pm *MultiPoolerManager) configureSynchronousReplicationLocked(ctx context.
 	if err := pm.insertHistoryRecord(ctx,
 		term.GetPrimaryTerm(),
 		"replication_config",
-		"", nil, "", // leaderID, coordinatorID, walPosition
+		pm.servicePoolerID, nil, "", // leaderID, coordinatorID, walPosition
 		"configure",
 		"ConfigureSynchronousReplication called",
 		standbyNames,
@@ -475,10 +472,7 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 	}
 
 	// Pre-compute history fields before acquiring the lock.
-	leaderID, err := generateApplicationName(pm.serviceID)
-	if err != nil {
-		return err
-	}
+	leaderID := pm.servicePoolerID
 
 	ctx, err = pm.actionLock.Acquire(ctx, "UpdateSynchronousStandbyList")
 	if err != nil {
@@ -514,7 +508,7 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 
 	// Convert current config IDs to application names for set operations.
 	// These IDs were previously validated and written by us, so this cannot fail in practice.
-	currentApplicationNames, err := standbyIDsToAppNames(syncConfig.StandbyIds)
+	currentApplicationNames, err := toPoolerIDs(syncConfig.StandbyIds)
 	if err != nil {
 		return err
 	}
@@ -527,7 +521,7 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 
 	// === Apply Operation ===
 
-	var updatedStandbys []applicationName
+	var updatedStandbys []poolerID
 	switch operation {
 	case multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_ADD:
 		updatedStandbys = applyAddOperation(currentApplicationNames, requestedApplicationNames)
@@ -825,20 +819,20 @@ func (pm *MultiPoolerManager) GetFollowers(ctx context.Context) (*multipoolerman
 	// Build the response with all configured standbys
 	followers := make([]*multipoolermanagerdatapb.FollowerInfo, 0, len(syncConfig.StandbyIds))
 	for _, standbyID := range syncConfig.StandbyIds {
-		appName, err := generateApplicationName(standbyID)
-		if err != nil {
+		pid, pidErr := newPoolerID(standbyID)
+		if pidErr != nil {
 			// We're in a suspicious state since this follower can't be represented in Postgres,
 			// but it seems better to return a blank ApplicationName than to fail this entire request.
-			pm.logger.WarnContext(ctx, "Could not generate application name for follower", "follower_id", standbyID, "error", err)
+			pm.logger.WarnContext(ctx, "Could not generate application name for follower", "follower_id", standbyID, "error", pidErr)
 		}
 
 		followerInfo := &multipoolermanagerdatapb.FollowerInfo{
 			FollowerId:      standbyID,
-			ApplicationName: string(appName),
+			ApplicationName: pid.appName,
 		}
 
 		// Check if this standby is currently connected
-		if stats, connected := connectedMap[string(appName)]; connected {
+		if stats, connected := connectedMap[pid.appName]; connected {
 			followerInfo.IsConnected = true
 			followerInfo.ReplicationStats = stats
 		} else {
@@ -1188,15 +1182,12 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 	}
 
 	// Pre-compute names before acquiring the lock, so we fail fast on bad arguments.
-	leaderID, err := generateApplicationName(pm.serviceID)
+	leaderID := pm.servicePoolerID
+	cohortMembers, err := toPoolerIDs(cohortMemberIDs)
 	if err != nil {
 		return nil, err
 	}
-	cohortMembers, err := standbyIDsToAppNames(cohortMemberIDs)
-	if err != nil {
-		return nil, err
-	}
-	acceptedMembers, err := standbyIDsToAppNames(acceptedMemberIDs)
+	acceptedMembers, err := toPoolerIDs(acceptedMemberIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1610,11 +1601,8 @@ func (pm *MultiPoolerManager) runPgRewind(ctx context.Context, sourceHost string
 		return false, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "pgctld client not initialized")
 	}
 
-	// Generate application name for replication connection
-	appName, err := generateApplicationName(pm.serviceID)
-	if err != nil {
-		return false, err
-	}
+	// Get application name for replication connection
+	pid := pm.servicePoolerID
 
 	pm.logger.InfoContext(ctx, "Running pg_rewind dry-run (may do crash recovery)",
 		"source_host", sourceHost, "source_port", sourcePort)
@@ -1624,7 +1612,7 @@ func (pm *MultiPoolerManager) runPgRewind(ctx context.Context, sourceHost string
 		SourceHost:      sourceHost,
 		SourcePort:      sourcePort,
 		DryRun:          true,
-		ApplicationName: string(appName),
+		ApplicationName: pid.appName,
 	}
 	dryRunResp, err := pm.pgctldClient.PgRewind(ctx, dryRunReq)
 	if err != nil {
@@ -1642,7 +1630,7 @@ func (pm *MultiPoolerManager) runPgRewind(ctx context.Context, sourceHost string
 			SourceHost:      sourceHost,
 			SourcePort:      sourcePort,
 			DryRun:          false,
-			ApplicationName: string(appName),
+			ApplicationName: pid.appName,
 			ExtraArgs:       []string{"-R"},
 		}
 		rewindResp, err := pm.pgctldClient.PgRewind(ctx, rewindReq)


### PR DESCRIPTION
Replace the applicationName string type with a poolerID struct that holds both the proto ID and its derived PostgreSQL application_name. This eliminates repeated back-and-forth conversions between application names and proto IDs, and provides a single validated identity type callers can pass around.