### PR TITLE
fix(etcd): use /health instead of /readyz for etcd health checks

### DIFF
--- a/go/common/topoclient/etcdtopo/test_helpers.go
+++ b/go/common/topoclient/etcdtopo/test_helpers.go
@@ -43,7 +43,7 @@ func checkPortAvailable(port int) error {
 	return nil
 }
 
-// WaitForReady waits for etcd to be ready by querying its /readyz endpoint in a loop.
+// WaitForReady waits for etcd to be ready by querying its /health endpoint in a loop.
 // The loop will retry until the endpoint returns 200 OK or the context is cancelled.
 // Callers should pass a context with an appropriate timeout.
 func WaitForReady(ctx context.Context, clientAddr string) error {
@@ -71,7 +71,7 @@ func WaitForReady(ctx context.Context, clientAddr string) error {
 			return fmt.Errorf("etcd failed to become ready: %w", err)
 		}
 
-		url := clientAddr + "/readyz"
+		url := clientAddr + "/health"
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create request: %w", err)

--- a/go/common/topoclient/etcdtopo/waitforready_test.go
+++ b/go/common/topoclient/etcdtopo/waitforready_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdtopo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+func TestWaitForReady(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping etcd integration tests in short mode")
+	}
+	ctx := utils.LeakCheckContext(t)
+
+	t.Run("healthy etcd returns nil", func(t *testing.T) {
+		clientAddr, _ := StartEtcd(t)
+		// StartEtcd already called WaitForReady internally, but call it again
+		// explicitly to confirm the /health endpoint continues to return 200.
+		readyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		err := WaitForReady(readyCtx, clientAddr)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong address times out", func(t *testing.T) {
+		freePort := utils.GetFreePort(t)
+		badAddr := fmt.Sprintf("http://localhost:%d", freePort)
+		readyCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+		err := WaitForReady(readyCtx, badAddr)
+		require.Error(t, err)
+	})
+
+	t.Run("already-cancelled context returns error immediately", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := WaitForReady(cancelledCtx, "http://localhost:1")
+		require.Error(t, err)
+	})
+}

--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -111,13 +111,14 @@ func (p *localProvisioner) checkMultigresServiceHealth(ctx context.Context, serv
 	return nil
 }
 
-// checkEtcdHealth checks if etcd is ready by querying its /readyz endpoint.
-// This matches the Kubernetes readiness probe behavior.
+// checkEtcdHealth checks if etcd is ready by querying its /health endpoint.
+// Note: /readyz is only available when etcd is started with --listen-metrics-urls,
+// but /health is always served on the client listener.
 func (p *localProvisioner) checkEtcdHealth(ctx context.Context, address string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	url := fmt.Sprintf("http://%s/readyz", address)
+	url := fmt.Sprintf("http://%s/health", address)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -125,12 +126,12 @@ func (p *localProvisioner) checkEtcdHealth(ctx context.Context, address string) 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to reach etcd readyz endpoint: %w", err)
+		return fmt.Errorf("failed to reach etcd health endpoint: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("etcd readyz endpoint returned status %d", resp.StatusCode)
+		return fmt.Errorf("etcd health endpoint returned status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/go/provisioner/local/healthcheck_test.go
+++ b/go/provisioner/local/healthcheck_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient/etcdtopo"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/pathutil"
+)
+
+func TestMain(m *testing.M) {
+	if err := pathutil.PrependBinToPath(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add directories to PATH: %v\n", err)
+		os.Exit(1) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+	}
+	os.Setenv("MULTIGRES_TEST_PARENT_PID", strconv.Itoa(os.Getpid()))
+	exitCode := m.Run()
+	os.Unsetenv("MULTIGRES_TEST_PARENT_PID")
+	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+}
+
+// TestCheckEtcdHealth verifies that checkEtcdHealth works against a real etcd instance.
+// This is the only test coverage for checkEtcdHealth — without it, a regression like
+// accidentally reverting /health back to /readyz would go undetected. (/readyz returns
+// 404 on etcd 3.5+ without a dedicated metrics listener, causing waitForServiceReady
+// to time out.)
+func TestCheckEtcdHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping etcd integration tests in short mode")
+	}
+	ctx := utils.LeakCheckContext(t)
+
+	clientAddr, _ := etcdtopo.StartEtcd(t)
+
+	// Strip the "http://" prefix — checkEtcdHealth expects a bare host:port address.
+	address := clientAddr[len("http://"):]
+
+	p := &localProvisioner{}
+
+	t.Run("healthy etcd returns nil", func(t *testing.T) {
+		err := p.checkEtcdHealth(ctx, address)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong address returns error", func(t *testing.T) {
+		freePort := utils.GetFreePort(t)
+		err := p.checkEtcdHealth(ctx, fmt.Sprintf("localhost:%d", freePort))
+		require.Error(t, err)
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := p.checkEtcdHealth(cancelledCtx, address)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
/readyz is only served on etcd's metrics listener (--listen-metrics-urls), which is not configured in local/test setups. This caused waitForServiceReady to time out after 60 attempts with 404 responses. /health is always available on the client listener in etcd 3.x.

Also adds explicit tests for checkEtcdHealth and WaitForReady. checkEtcdHealth had zero test coverage; without it a regression like reverting /health back to /readyz would go undetected. WaitForReady was only exercised implicitly via StartEtcd

Fixes MUL-272