### PR TITLE
fix(etcd): configure metrics port for provisioner to support /readyz

### DIFF
--- a/demo/k8s/k8s-etcd.yaml
+++ b/demo/k8s/k8s-etcd.yaml
@@ -12,6 +12,9 @@ spec:
     - name: peer
       port: 2380
       targetPort: 2380
+    - name: metrics
+      port: 2381
+      targetPort: 2381
   selector:
     app: etcd
   clusterIP: None
@@ -44,11 +47,26 @@ spec:
             - --initial-advertise-peer-urls=http://etcd-0.etcd:2380
             - --initial-cluster=etcd-0=http://etcd-0.etcd:2380
             - --initial-cluster-state=new
+            - --listen-metrics-urls=http://0.0.0.0:2381
           ports:
             - containerPort: 2379
               name: client
             - containerPort: 2380
               name: peer
+            - containerPort: 2381
+              name: metrics
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 2381
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 2381
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: etcd-data
               mountPath: /var/lib/etcd

--- a/go/common/topoclient/etcdtopo/test_helpers.go
+++ b/go/common/topoclient/etcdtopo/test_helpers.go
@@ -44,9 +44,11 @@ func checkPortAvailable(port int) error {
 }
 
 // WaitForReady waits for etcd to be ready by querying its /readyz endpoint in a loop.
-// The loop will retry until the endpoint returns 200 OK or the context is cancelled.
+// metricsAddr must be the HTTP address of etcd's metrics listener (the address passed
+// to --listen-metrics-urls), e.g. "http://localhost:2381". /readyz is not served on
+// the client listener, so passing the client address here will always return 404.
 // Callers should pass a context with an appropriate timeout.
-func WaitForReady(ctx context.Context, clientAddr string) error {
+func WaitForReady(ctx context.Context, metricsAddr string) error {
 	var lastErr error
 	var lastStatusCode int
 
@@ -71,7 +73,7 @@ func WaitForReady(ctx context.Context, clientAddr string) error {
 			return fmt.Errorf("etcd failed to become ready: %w", err)
 		}
 
-		url := clientAddr + "/readyz"
+		url := metricsAddr + "/readyz"
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create request: %w", err)
@@ -104,24 +106,33 @@ type EtcdOptions struct {
 	// If 0 and ClientPort is specified, defaults to ClientPort+1 for backwards compatibility.
 	PeerPort int
 
+	// MetricsPort is the port for etcd's metrics/health listener (--listen-metrics-urls).
+	// /readyz is only served on this listener, not on the client listener.
+	// If 0, a port will be automatically assigned.
+	MetricsPort int
+
 	// DataDir is the directory for etcd data storage.
 	// If empty, a temporary directory will be created and cleaned up after the test.
 	DataDir string
 }
 
 // StartEtcd starts an etcd subprocess with automatically allocated ports.
-// Returns the client address (which includes the port) and the process handle.
-func StartEtcd(t *testing.T) (string, *executil.Cmd) {
+// Returns the client address, the metrics address (to pass to WaitForReady),
+// and the process handle.
+func StartEtcd(t *testing.T) (clientAddr, metricsAddr string, cmd *executil.Cmd) {
 	clientPort := utils.GetFreePort(t)
 	peerPort := utils.GetFreePort(t)
+	metricsPort := utils.GetFreePort(t)
 	return StartEtcdWithOptions(t, EtcdOptions{
-		ClientPort: clientPort,
-		PeerPort:   peerPort,
+		ClientPort:  clientPort,
+		PeerPort:    peerPort,
+		MetricsPort: metricsPort,
 	})
 }
 
 // StartEtcdWithOptions starts an etcd subprocess with custom options, and waits for it to be ready.
-func StartEtcdWithOptions(t *testing.T, opts EtcdOptions) (string, *executil.Cmd) {
+// Returns the client address, the metrics address (to pass to WaitForReady), and the process handle.
+func StartEtcdWithOptions(t *testing.T, opts EtcdOptions) (clientAddr, metricsAddr string, cmd *executil.Cmd) {
 	// Check if etcd is available in PATH
 	_, err := exec.LookPath("etcd")
 	require.NoError(t, err, "etcd not found in PATH")
@@ -132,9 +143,13 @@ func StartEtcdWithOptions(t *testing.T, opts EtcdOptions) (string, *executil.Cmd
 		dataDir = t.TempDir()
 	}
 
-	// Get our two ports to listen to - both must be specified
+	// Get our ports to listen to - client and peer must be specified; metrics is auto-allocated if unset.
 	clientPort := opts.ClientPort
 	peerPort := opts.PeerPort
+	metricsPort := opts.MetricsPort
+	if metricsPort == 0 {
+		metricsPort = utils.GetFreePort(t)
+	}
 
 	require.NotZero(t, clientPort, "EtcdOptions.ClientPort must be set to a non-zero value")
 	require.NotZero(t, peerPort, "EtcdOptions.PeerPort must be set to a non-zero value")
@@ -144,20 +159,24 @@ func StartEtcdWithOptions(t *testing.T, opts EtcdOptions) (string, *executil.Cmd
 	require.NoError(t, err, "Port check failed")
 	err = checkPortAvailable(peerPort)
 	require.NoError(t, err, "Peer port check failed")
+	err = checkPortAvailable(metricsPort)
+	require.NoError(t, err, "Metrics port check failed")
 
 	name := "multigres_unit_test"
-	clientAddr := fmt.Sprintf("http://localhost:%v", clientPort)
+	clientAddr = fmt.Sprintf("http://localhost:%v", clientPort)
 	peerAddr := fmt.Sprintf("http://localhost:%v", peerPort)
+	metricsAddr = fmt.Sprintf("http://localhost:%v", metricsPort)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 
 	// Wrap etcd with run_in_test.sh for orphan protection. Stops gracefully when
 	// the test context is cancelled so run_in_test.sh can terminate etcd cleanly.
-	cmd := utils.CommandWithOrphanProtection(t.Context(), "etcd",
+	cmd = utils.CommandWithOrphanProtection(t.Context(), "etcd",
 		"-name", name,
 		"-advertise-client-urls", clientAddr,
 		"-initial-advertise-peer-urls", peerAddr,
 		"-listen-client-urls", clientAddr,
 		"-listen-peer-urls", peerAddr,
+		"-listen-metrics-urls", metricsAddr,
 		"-initial-cluster", initialCluster,
 		"-data-dir", dataDir)
 
@@ -169,11 +188,11 @@ func StartEtcdWithOptions(t *testing.T, opts EtcdOptions) (string, *executil.Cmd
 	err = cmd.Start()
 	require.NoError(t, err, "failed to start etcd")
 
-	// Wait for etcd to be ready
+	// Wait for etcd to be ready via the metrics listener (/readyz requires --listen-metrics-urls)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	err = WaitForReady(ctx, clientAddr)
+	err = WaitForReady(ctx, metricsAddr)
 	require.NoError(t, err, "etcd failed to become ready")
 
-	return clientAddr, cmd
+	return clientAddr, metricsAddr, cmd
 }

--- a/go/common/topoclient/etcdtopo/waitforready_test.go
+++ b/go/common/topoclient/etcdtopo/waitforready_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdtopo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+func TestWaitForReady(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping etcd integration tests in short mode")
+	}
+	ctx := utils.LeakCheckContext(t)
+
+	t.Run("healthy etcd returns nil", func(t *testing.T) {
+		_, metricsAddr, _ := StartEtcd(t)
+		// StartEtcd already called WaitForReady internally, but call it again
+		// explicitly to confirm the /readyz endpoint on the metrics listener
+		// continues to return 200.
+		readyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		err := WaitForReady(readyCtx, metricsAddr)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong address times out", func(t *testing.T) {
+		freePort := utils.GetFreePort(t)
+		badAddr := fmt.Sprintf("http://localhost:%d", freePort)
+		readyCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+		err := WaitForReady(readyCtx, badAddr)
+		require.Error(t, err)
+	})
+
+	t.Run("already-cancelled context returns error immediately", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := WaitForReady(cancelledCtx, "http://localhost:1")
+		require.Error(t, err)
+	})
+}

--- a/go/common/topoclient/etcdtopo/watch_test.go
+++ b/go/common/topoclient/etcdtopo/watch_test.go
@@ -66,7 +66,7 @@ func TestWatchTopoVersion(t *testing.T) {
 		t.Skip("Skipping etcd integration tests in short mode")
 	}
 	ctx := utils.LeakCheckContext(t)
-	etcdServerAddr, _ := StartEtcd(t)
+	etcdServerAddr, _, _ := StartEtcd(t)
 	root := "/vitess/test"
 	name := "testkey"
 	path := path.Join(root, name)
@@ -202,7 +202,7 @@ func TestWatchRecursiveReconnection(t *testing.T) {
 	peerPort := utils.GetFreePort(t)
 
 	// Start first etcd server with persistent data
-	etcdServerAddr, etcdServer := StartEtcdWithOptions(t, EtcdOptions{
+	etcdServerAddr, _, etcdServer := StartEtcdWithOptions(t, EtcdOptions{
 		ClientPort: clientPort,
 		PeerPort:   peerPort,
 		DataDir:    dataDir,
@@ -269,7 +269,7 @@ func TestWatchRecursiveReconnection(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond, "ports should be released after etcd shutdown")
 
 	// Restart etcd with SAME data directory (simulates cluster recovery)
-	_, newEtcdServer := StartEtcdWithOptions(t, EtcdOptions{
+	_, _, newEtcdServer := StartEtcdWithOptions(t, EtcdOptions{
 		ClientPort: clientPort,
 		PeerPort:   peerPort,
 		DataDir:    dataDir,
@@ -308,7 +308,7 @@ func TestWatchRecursiveCompaction(t *testing.T) {
 	}
 	ctx := utils.LeakCheckContext(t)
 
-	etcdServerAddr, _ := StartEtcd(t)
+	etcdServerAddr, _, _ := StartEtcd(t)
 	root := "/vitess/test"
 
 	client, err := clientv3.New(clientv3.Config{

--- a/go/provisioner/local/healthcheck.go
+++ b/go/provisioner/local/healthcheck.go
@@ -95,10 +95,13 @@ func (p *localProvisioner) checkMultigresServiceHealth(ctx context.Context, serv
 				}
 			}
 		case "etcd_port":
-			// Run etcd health check
+			// TCP connectivity is already verified above; no HTTP check on the client port.
+			// /readyz is only available on the metrics listener (etcd_metrics_port).
+		case "etcd_metrics_port":
+			// Run etcd readiness check via /readyz on the dedicated metrics listener.
 			if serviceName == "etcd" {
-				etcdAddress := net.JoinHostPort(host, strconv.Itoa(port))
-				if err := p.checkEtcdHealth(ctx, etcdAddress); err != nil {
+				etcdMetricsAddress := net.JoinHostPort(host, strconv.Itoa(port))
+				if err := p.checkEtcdHealth(ctx, etcdMetricsAddress); err != nil {
 					return err
 				}
 			}
@@ -112,7 +115,8 @@ func (p *localProvisioner) checkMultigresServiceHealth(ctx context.Context, serv
 }
 
 // checkEtcdHealth checks if etcd is ready by querying its /readyz endpoint.
-// This matches the Kubernetes readiness probe behavior.
+// address must be the host:port of etcd's metrics listener (--listen-metrics-urls),
+// not the client listener. /readyz returns 404 on the client port.
 func (p *localProvisioner) checkEtcdHealth(ctx context.Context, address string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/go/provisioner/local/healthcheck_test.go
+++ b/go/provisioner/local/healthcheck_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/topoclient/etcdtopo"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/pathutil"
+)
+
+func TestMain(m *testing.M) {
+	if err := pathutil.PrependBinToPath(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add directories to PATH: %v\n", err)
+		os.Exit(1) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+	}
+	os.Setenv("MULTIGRES_TEST_PARENT_PID", strconv.Itoa(os.Getpid()))
+	exitCode := m.Run()
+	os.Unsetenv("MULTIGRES_TEST_PARENT_PID")
+	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+}
+
+// TestCheckEtcdHealth verifies that checkEtcdHealth works against a real etcd instance.
+// This is the only test coverage for checkEtcdHealth — without it, a regression like
+// accidentally removing --listen-metrics-urls (which would cause /readyz to return 404
+// on the client port and make waitForServiceReady time out after 60 attempts) would go
+// undetected.
+func TestCheckEtcdHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping etcd integration tests in short mode")
+	}
+	ctx := utils.LeakCheckContext(t)
+
+	_, metricsAddr, _ := etcdtopo.StartEtcd(t)
+
+	// Strip the "http://" prefix — checkEtcdHealth expects a bare host:port address.
+	address := metricsAddr[len("http://"):]
+
+	p := &localProvisioner{}
+
+	t.Run("healthy etcd returns nil", func(t *testing.T) {
+		err := p.checkEtcdHealth(ctx, address)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong address returns error", func(t *testing.T) {
+		freePort := utils.GetFreePort(t)
+		err := p.checkEtcdHealth(ctx, fmt.Sprintf("localhost:%d", freePort))
+		require.Error(t, err)
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := p.checkEtcdHealth(cancelledCtx, address)
+		require.Error(t, err)
+	})
+}

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -132,6 +132,13 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 		peerPort = pp
 	}
 
+	// Get metrics port from config, or default to port + 2.
+	// The metrics listener is required for /readyz health checks.
+	metricsPort := port + 2
+	if mp, ok := etcdConfig["metrics-port"].(int); ok && mp > 0 {
+		metricsPort = mp
+	}
+
 	// Find etcd binary (PATH or configured path)
 	etcdBinary, err := p.findBinary("etcd", etcdConfig)
 	if err != nil {
@@ -176,6 +183,7 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 		"--initial-advertise-peer-urls", fmt.Sprintf("http://localhost:%d", peerPort),
 		"--initial-cluster", fmt.Sprintf("default=http://localhost:%d", peerPort),
 		"--initial-cluster-state", "new",
+		"--listen-metrics-urls", fmt.Sprintf("http://0.0.0.0:%d", metricsPort),
 		"--log-outputs", logFile,
 	}
 
@@ -194,7 +202,7 @@ func (p *localProvisioner) provisionEtcd(ctx context.Context, req *provisioner.P
 	}
 
 	// Wait for etcd to be ready
-	servicePorts := map[string]int{"etcd_port": port}
+	servicePorts := map[string]int{"etcd_port": port, "etcd_metrics_port": metricsPort}
 	if err := p.waitForServiceReady(ctx, "etcd", "localhost", servicePorts, 10*time.Second); err != nil {
 		logs := p.readServiceLogs(logFile, 20)
 		return nil, fmt.Errorf("etcd readiness check failed: %w\n\nLast 20 lines from etcd logs:\n%s", err, logs)

--- a/go/test/endtoend/etcd_topo_test.go
+++ b/go/test/endtoend/etcd_topo_test.go
@@ -38,7 +38,7 @@ func TestEtcd2Topo(t *testing.T) {
 		t.Skip("Skipping topology etcd integration test in short mode")
 	}
 	// Start a single etcd in the background.
-	clientAddr, _ := etcdtopo.StartEtcd(t)
+	clientAddr, _, _ := etcdtopo.StartEtcd(t)
 
 	testIndex := 0
 	newServer := func() topoclient.Store {

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1025,18 +1025,21 @@ func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *exec
 		return "", nil, fmt.Errorf("etcd not found in PATH: %w", err)
 	}
 
-	// Get ports for etcd (client and peer)
+	// Get ports for etcd (client, peer, and metrics)
 	clientPort := utils.GetFreePort(t)
 	peerPort := utils.GetFreePort(t)
+	metricsPort := utils.GetFreePort(t)
 
 	span.SetAttributes(
 		attribute.Int("etcd.client_port", clientPort),
 		attribute.Int("etcd.peer_port", peerPort),
+		attribute.Int("etcd.metrics_port", metricsPort),
 	)
 
 	name := "shardsetup_test"
 	clientAddr := fmt.Sprintf("http://localhost:%v", clientPort)
 	peerAddr := fmt.Sprintf("http://localhost:%v", peerPort)
+	metricsAddr := fmt.Sprintf("http://localhost:%v", metricsPort)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 
 	// Wrap etcd with run_in_test.sh for orphan protection. Stops gracefully when
@@ -1047,6 +1050,7 @@ func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *exec
 		"-initial-advertise-peer-urls", peerAddr,
 		"-listen-client-urls", clientAddr,
 		"-listen-peer-urls", peerAddr,
+		"-listen-metrics-urls", metricsAddr,
 		"-initial-cluster", initialCluster,
 		"-data-dir", dataDir)
 
@@ -1061,7 +1065,7 @@ func startEtcd(ctx context.Context, t *testing.T, dataDir string) (string, *exec
 
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if err := etcdtopo.WaitForReady(waitCtx, clientAddr); err != nil {
+	if err := etcdtopo.WaitForReady(waitCtx, metricsAddr); err != nil {
 		// Stop the etcd process if it's not ready
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		_, _ = cmd.Stop(stopCtx)


### PR DESCRIPTION
Provisioner previously used `/health` which is served on the client port and  switched to `/readyz` in commit cbaa5cd.  However, `/readyz` is only served on etcd's metrics listener (`--listen-metrics-urls`), which means that when `/readyz` was sent to the  client port, it returns 404. This causes `waitForServiceReady` to time out after 60 attempts even though etcd has elected a leader and is fully functional.

This commit fixes this by adding `--listen-metrics-urls` to every place etcd is started (local provisioner, shardsetup end-to-end tests, etcdtopo test helpers) and route the `/readyz` health check to the metrics listener instead of the client listener.

- EtcdOptions gains MetricsPort (auto-allocated when 0)
- StartEtcd / StartEtcdWithOptions now return (clientAddr, metricsAddr, cmd)
- WaitForReady parameter renamed to metricsAddr to make the intent clear
- checkMultigresServiceHealth routes etcd_metrics_port to checkEtcdHealth; etcd_port is TCP-only (no HTTP check on the client listener)
- Adds explicit tests for WaitForReady and checkEtcdHealth so a regression (e.g. removing --listen-metrics-urls) is caught immediately

Fixes MUL-272