### PR TITLE
fix(provisioner): skip pgbackrest config when backup is disabled

### DIFF
--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -203,6 +203,8 @@ func buildBackupConfig(backupConfig map[string]string, baseDir string) BackupCon
 	config := BackupConfig{Type: backupType}
 
 	switch backupType {
+	case "none":
+		// No backup configured
 	case "local":
 		path := backupConfig["path"]
 		if path == "" {

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -789,23 +789,25 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 	// Add service map configuration to enable grpc-pooler service
 	args = append(args, "--service-map", "grpc-pooler")
 
-	// Get pgbackrest port from pgctld config (pgbackrest is now managed by pgctld)
-	pgctldConfig, err := p.getCellServiceConfig(cell, constants.ServicePgctld)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pgctld config for cell %s: %w", cell, err)
-	}
-	pgbackrestPort := ports.DefaultPgbackRestPort
-	if port, ok := pgctldConfig["pgbackrest_port"].(int); ok && port > 0 {
-		pgbackrestPort = port
-	}
+	// Add pgbackrest TLS certificate paths and port (only when backup is configured)
+	if p.pgBackRestCertPaths != nil {
+		if pgctldConfig, err := p.getCellServiceConfig(cell, constants.ServicePgctld); err == nil {
+			pgbackrestPort := ports.DefaultPgbackRestPort
+			if port, ok := pgctldConfig["pgbackrest_port"].(int); ok && port > 0 {
+				pgbackrestPort = port
+			}
 
-	// Add pgbackrest TLS certificate paths and port
-	args = append(args,
-		"--pgbackrest-cert-file", p.pgBackRestCertPaths.ServerCertFile,
-		"--pgbackrest-key-file", p.pgBackRestCertPaths.ServerKeyFile,
-		"--pgbackrest-ca-file", p.pgBackRestCertPaths.CACertFile,
-		"--pgbackrest-port", strconv.Itoa(pgbackrestPort),
-	)
+			// Add pgbackrest TLS certificate paths and port
+			args = append(args,
+				"--pgbackrest-cert-file", p.pgBackRestCertPaths.ServerCertFile,
+				"--pgbackrest-key-file", p.pgBackRestCertPaths.ServerKeyFile,
+				"--pgbackrest-ca-file", p.pgBackRestCertPaths.CACertFile,
+				"--pgbackrest-port", strconv.Itoa(pgbackrestPort),
+			)
+		} else {
+			return nil, fmt.Errorf("failed to get pgctld config for cell %s: %w", cell, err)
+		}
+	}
 
 	// Start multipooler process
 	multipoolerCmd := executil.Command(ctx, multipoolerBinary, args...)
@@ -1541,9 +1543,11 @@ func (p *localProvisioner) ProvisionDatabase(ctx context.Context, databaseName s
 	}
 	fmt.Println("")
 
-	// Generate pgBackRest certificates before starting services
-	if err := p.generatePgBackRestCertsOnce(ctx); err != nil {
-		return nil, err
+	// Generate pgBackRest certificates before starting services (skip when backup is disabled)
+	if p.config.Backup.Type != "none" {
+		if err := p.generatePgBackRestCertsOnce(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	// Provision all services in parallel across all cells.
@@ -1651,6 +1655,10 @@ func (p *localProvisioner) ProvisionDatabase(ctx context.Context, databaseName s
 // buildBackupLocation creates a BackupLocation proto from config
 func (p *localProvisioner) buildBackupLocation() (*clustermetadatapb.BackupLocation, error) {
 	switch p.config.Backup.Type {
+	case "none":
+		// Backup disabled - no backup location configured
+		return nil, nil
+
 	case "":
 		// No backup type configured - use default filesystem backup location
 		defaultPath := filepath.Join(p.config.RootWorkingDir, "data", "backups")


### PR DESCRIPTION
In a minimal local setup with backup.type: none, provisionMultipooler was unconditionally passing pgbackrest TLS cert paths to the multipooler process and fetching pgctld config solely to get the pgbackrest port. This fails when pgbackrest is not provisioned.

- Guard the pgbackrest args block in provisionMultipooler with `if p.pgBackRestCertPaths != nil`, matching the existing pattern in pgctld.go
- Skip generatePgBackRestCertsOnce in ProvisionDatabase when backup.type is "none"
- Add "none" as a valid backup type in buildBackupLocation and buildBackupConfig

Fixes MUL-275