### PR TITLE
fix(multigateway): allow ROLLBACK TO SAVEPOINT in aborted transaction state

### DIFF
--- a/go/common/parser/ast/helper.go
+++ b/go/common/parser/ast/helper.go
@@ -42,6 +42,23 @@ func IsRollbackStatement(stmt Stmt) bool {
 	return txStmt.Kind == TRANS_STMT_ROLLBACK
 }
 
+// IsAllowedInAbortedTransaction returns true if the statement may proceed when
+// the transaction is in the aborted (failed) state. PostgreSQL allows ROLLBACK,
+// ROLLBACK TO SAVEPOINT, and COMMIT (which it converts to ROLLBACK with a
+// WARNING) in this state. All other statements are rejected with SQLSTATE 25P02.
+func IsAllowedInAbortedTransaction(stmt Stmt) bool {
+	txStmt, ok := stmt.(*TransactionStmt)
+	if !ok {
+		return false
+	}
+	switch txStmt.Kind {
+	case TRANS_STMT_ROLLBACK, TRANS_STMT_ROLLBACK_TO, TRANS_STMT_COMMIT:
+		return true
+	default:
+		return false
+	}
+}
+
 // ExtractTablesUsed walks the AST and returns deduplicated, schema-qualified
 // table names from all RangeVar nodes. CTE names are excluded since they are
 // virtual tables, not real ones. Returns nil for statements that don't

--- a/go/services/multigateway/engine/transaction_primitive.go
+++ b/go/services/multigateway/engine/transaction_primitive.go
@@ -83,8 +83,11 @@ func (t *TransactionPrimitive) StreamExecute(
 	case ast.TRANS_STMT_ROLLBACK:
 		return t.executeRollback(ctx, exec, conn, state, callback)
 
+	case ast.TRANS_STMT_ROLLBACK_TO:
+		return t.executeRollbackToSavepoint(ctx, exec, conn, state, callback)
+
 	default:
-		// For other transaction statements (SAVEPOINT, etc.), pass through to backend
+		// For other transaction statements (SAVEPOINT, RELEASE SAVEPOINT), pass through to backend
 		return exec.StreamExecute(ctx, conn, t.TableGroup, constants.DefaultShard, t.Query, state, callback)
 	}
 }
@@ -230,6 +233,35 @@ func (t *TransactionPrimitive) executeRollback(
 	conn.SetTxnStatus(protocol.TxnStatusIdle)
 
 	return err
+}
+
+// executeRollbackToSavepoint handles ROLLBACK TO SAVEPOINT by passing through
+// to the backend. On success, transitions TxnStatus from Failed back to InBlock
+// so subsequent statements can execute normally. This matches PostgreSQL's
+// behavior where ROLLBACK TO SAVEPOINT is the primary mechanism for recovering
+// from errors within a transaction.
+func (t *TransactionPrimitive) executeRollbackToSavepoint(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	wasFailed := conn.TxnStatus() == protocol.TxnStatusFailed
+
+	err := exec.StreamExecute(ctx, conn, t.TableGroup, constants.DefaultShard, t.Query, state, callback)
+	if err != nil {
+		return err
+	}
+
+	// On success, restore transaction state if we were in the aborted state.
+	// The backend has rolled back to the savepoint and is now in a normal
+	// in-transaction state.
+	if wasFailed {
+		conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	}
+
+	return nil
 }
 
 // recordTxnMetrics records transaction duration and count if TxnStartTime

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -152,13 +152,12 @@ func (h *MultiGatewayHandler) HandleQuery(ctx context.Context, conn *server.Conn
 	st := h.getConnectionState(conn)
 
 	// If the transaction is in an aborted state, reject all queries unless the
-	// first statement is ROLLBACK. This matches PostgreSQL's behavior: after an
-	// error in a transaction block, commands are rejected until ROLLBACK.
-	// Multi-statement batches starting with ROLLBACK are allowed (e.g.,
-	// "ROLLBACK; SELECT 1;") — ROLLBACK clears the aborted state and the
-	// remaining statements execute normally.
+	// first statement can recover from the aborted state. PostgreSQL allows
+	// ROLLBACK, ROLLBACK TO SAVEPOINT, and COMMIT (converted to ROLLBACK) in
+	// this state. Multi-statement batches are permitted as long as the first
+	// statement is one of these (e.g., "ROLLBACK TO sp1; SELECT 1;").
 	if conn.TxnStatus() == protocol.TxnStatusFailed {
-		if !h.startsWithRollback(asts) {
+		if !h.startsWithAbortRecovery(asts) {
 			h.recordQueryCompletion(ctx, conn, operationName, "simple", parseDuration, 0, time.Since(queryStart), 0, nil, errAbortedTransaction)
 			recordSpanError(span, errAbortedTransaction, mterrors.ExtractSQLSTATE(errAbortedTransaction))
 			return errAbortedTransaction
@@ -240,12 +239,11 @@ func (h *MultiGatewayHandler) HandleQuery(ctx context.Context, conn *server.Conn
 	return err
 }
 
-// startsWithRollback returns true if the first statement is ROLLBACK,
-// allowing the client to exit an aborted transaction. Multi-statement
-// batches are permitted as long as the first statement is ROLLBACK
-// (matching PostgreSQL behavior).
-func (h *MultiGatewayHandler) startsWithRollback(asts []ast.Stmt) bool {
-	return len(asts) > 0 && ast.IsRollbackStatement(asts[0])
+// startsWithAbortRecovery returns true if the first statement can recover
+// from an aborted transaction. PostgreSQL allows ROLLBACK, ROLLBACK TO
+// SAVEPOINT, and COMMIT in aborted state.
+func (h *MultiGatewayHandler) startsWithAbortRecovery(asts []ast.Stmt) bool {
+	return len(asts) > 0 && ast.IsAllowedInAbortedTransaction(asts[0])
 }
 
 // getConnectionState retrieves and typecasts the connection state for this handler.
@@ -342,10 +340,10 @@ func (h *MultiGatewayHandler) HandleExecute(ctx context.Context, conn *server.Co
 	ctx, span := startQuerySpan(ctx, operationName, "extended", conn.Database(), conn.User())
 	defer span.End()
 
-	// Reject queries in aborted transaction state, except ROLLBACK which is the
-	// only statement that can recover from an aborted transaction.
+	// Reject queries in aborted transaction state, except statements that can
+	// recover: ROLLBACK, ROLLBACK TO SAVEPOINT, and COMMIT (converted to ROLLBACK).
 	if conn.TxnStatus() == protocol.TxnStatusFailed {
-		if !ast.IsRollbackStatement(portalInfo.AstStmt()) {
+		if !ast.IsAllowedInAbortedTransaction(portalInfo.AstStmt()) {
 			h.recordQueryCompletion(ctx, conn, operationName, "extended", 0, 0, time.Since(queryStart), 0, nil, errAbortedTransaction)
 			recordSpanError(span, errAbortedTransaction, mterrors.ExtractSQLSTATE(errAbortedTransaction))
 			return errAbortedTransaction

--- a/go/test/endtoend/queryserving/transaction_test.go
+++ b/go/test/endtoend/queryserving/transaction_test.go
@@ -575,6 +575,116 @@ func explicitTransactionTestCases() []transactionTestCase {
 			},
 		},
 		{
+			// ROLLBACK TO SAVEPOINT recovers from an error in a transaction
+			name: "SavepointErrorRecovery",
+			testFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) error {
+				_, err := conn.Query(ctx, "DROP TABLE IF EXISTS txn_sp_recovery_test")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "CREATE TABLE txn_sp_recovery_test (id INT PRIMARY KEY, name TEXT)")
+				require.NoError(t, err)
+
+				_, err = conn.Query(ctx, "BEGIN")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_recovery_test VALUES (1, 'Alice')")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "SAVEPOINT sp1")
+				require.NoError(t, err)
+
+				// Cause an error — transaction enters aborted state
+				_, err = conn.Query(ctx, "SELECT 1/0")
+				require.Error(t, err, "Expected division by zero error")
+
+				// ROLLBACK TO SAVEPOINT should recover from the aborted state
+				_, err = conn.Query(ctx, "ROLLBACK TO SAVEPOINT sp1")
+				require.NoError(t, err, "ROLLBACK TO SAVEPOINT should succeed in aborted state")
+
+				// Subsequent statements should work normally
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_recovery_test VALUES (2, 'Bob')")
+				require.NoError(t, err, "INSERT should succeed after savepoint recovery")
+
+				_, err = conn.Query(ctx, "COMMIT")
+				require.NoError(t, err)
+				return nil
+			},
+			verifyFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) {
+				results, err := conn.Query(ctx, "SELECT id, name FROM txn_sp_recovery_test ORDER BY id")
+				require.NoError(t, err)
+				require.Len(t, results[0].Rows, 2, "Alice and Bob should exist")
+				assert.Equal(t, "Alice", string(results[0].Rows[0].Values[1]))
+				assert.Equal(t, "Bob", string(results[0].Rows[1].Values[1]))
+			},
+		},
+		{
+			// ROLLBACK TO nonexistent savepoint stays in aborted state
+			name: "SavepointErrorRecoveryNonexistent",
+			testFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) error {
+				_, err := conn.Query(ctx, "BEGIN")
+				require.NoError(t, err)
+
+				// Cause an error
+				_, err = conn.Query(ctx, "SELECT 1/0")
+				require.Error(t, err)
+
+				// ROLLBACK TO nonexistent savepoint should fail
+				_, err = conn.Query(ctx, "ROLLBACK TO SAVEPOINT nonexistent")
+				require.Error(t, err, "ROLLBACK TO nonexistent savepoint should fail")
+
+				// Still in aborted state — ROLLBACK to exit
+				_, err = conn.Query(ctx, "ROLLBACK")
+				require.NoError(t, err)
+				return nil
+			},
+		},
+		{
+			// Multiple savepoint recovery cycles within one transaction
+			name: "SavepointMultipleRecoveries",
+			testFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) error {
+				_, err := conn.Query(ctx, "DROP TABLE IF EXISTS txn_sp_multi_test")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "CREATE TABLE txn_sp_multi_test (id INT PRIMARY KEY, name TEXT)")
+				require.NoError(t, err)
+
+				_, err = conn.Query(ctx, "BEGIN")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_multi_test VALUES (1, 'Alice')")
+				require.NoError(t, err)
+
+				// First error + recovery cycle
+				_, err = conn.Query(ctx, "SAVEPOINT sp1")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "SELECT 1/0")
+				require.Error(t, err)
+				_, err = conn.Query(ctx, "ROLLBACK TO SAVEPOINT sp1")
+				require.NoError(t, err, "First savepoint recovery should succeed")
+
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_multi_test VALUES (2, 'Bob')")
+				require.NoError(t, err)
+
+				// Second error + recovery cycle
+				_, err = conn.Query(ctx, "SAVEPOINT sp2")
+				require.NoError(t, err)
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_multi_test VALUES (2, 'Duplicate')")
+				require.Error(t, err, "Expected duplicate key error")
+				_, err = conn.Query(ctx, "ROLLBACK TO SAVEPOINT sp2")
+				require.NoError(t, err, "Second savepoint recovery should succeed")
+
+				_, err = conn.Query(ctx, "INSERT INTO txn_sp_multi_test VALUES (3, 'Charlie')")
+				require.NoError(t, err)
+
+				_, err = conn.Query(ctx, "COMMIT")
+				require.NoError(t, err)
+				return nil
+			},
+			verifyFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) {
+				results, err := conn.Query(ctx, "SELECT id, name FROM txn_sp_multi_test ORDER BY id")
+				require.NoError(t, err)
+				require.Len(t, results[0].Rows, 3, "Alice, Bob, Charlie should exist")
+				assert.Equal(t, "Alice", string(results[0].Rows[0].Values[1]))
+				assert.Equal(t, "Bob", string(results[0].Rows[1].Values[1]))
+				assert.Equal(t, "Charlie", string(results[0].Rows[2].Values[1]))
+			},
+		},
+		{
 			// Error causes transaction to enter aborted state
 			name: "AbortedTransactionState",
 			testFunc: func(ctx context.Context, t *testing.T, conn *client.Conn) error {


### PR DESCRIPTION
## Summary

- Allow `ROLLBACK TO SAVEPOINT`, `COMMIT`, and `ROLLBACK` to proceed when a transaction is in the aborted (failed) state, matching PostgreSQL behavior
- Transition `TxnStatus` from `Failed` back to `InBlock` after a successful `ROLLBACK TO SAVEPOINT`
- Add e2e tests for savepoint error recovery, nonexistent savepoint, and multiple recovery cycles

## Problem

When a statement fails inside an explicit transaction, multigres correctly enters the aborted state but rejects `ROLLBACK TO SAVEPOINT` with "current transaction is aborted, commands ignored until end of transaction block". PostgreSQL allows `ROLLBACK TO SAVEPOINT` in aborted state — this is the primary mechanism for error recovery within transactions.

```sql
BEGIN;
SAVEPOINT sp1;
SELECT 1/0;          -- error: division by zero
ROLLBACK TO sp1;     -- ERROR: current transaction is aborted (should succeed)
```

This is one of the largest source of cascading failures in the pgregress compatibility tests.

## Solution

- Add `IsAllowedInAbortedTransaction()` AST helper that returns true for `ROLLBACK`, `ROLLBACK TO SAVEPOINT`, and `COMMIT` (the three statements PostgreSQL permits in aborted state)
- Update both simple query (`HandleQuery`) and extended query (`HandleExecute`) gates to use the new helper instead of `IsRollbackStatement`
- Add explicit `TRANS_STMT_ROLLBACK_TO` case in `TransactionPrimitive.StreamExecute` that passes through to the backend and transitions `TxnStatus` from `Failed` to `InBlock` on success