### PR TITLE
feat(multipooler): add backup lifecycle state reporting contracts

### DIFF
--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2858,7 +2858,15 @@ type StateResponse struct {
 	// Manager state (starting, ready, error)
 	State string `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
 	// Error message if state is error
-	ErrorMessage  string `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	ErrorMessage string `protobuf:"bytes,2,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	// Whether a backup is currently running on this pooler.
+	BackupInProgress bool `protobuf:"varint,3,opt,name=backup_in_progress,json=backupInProgress,proto3" json:"backup_in_progress,omitempty"`
+	// Whether the most recent pgbackrest check passed.
+	LastIntegrityCheckPassed *bool `protobuf:"varint,4,opt,name=last_integrity_check_passed,json=lastIntegrityCheckPassed,proto3,oneof" json:"last_integrity_check_passed,omitempty"`
+	// Error from the most recent failed pgbackrest check.
+	LastIntegrityCheckError string `protobuf:"bytes,5,opt,name=last_integrity_check_error,json=lastIntegrityCheckError,proto3" json:"last_integrity_check_error,omitempty"`
+	// Error code from the most recent stanza-create attempt.
+	StanzaError   string `protobuf:"bytes,6,opt,name=stanza_error,json=stanzaError,proto3" json:"stanza_error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2903,6 +2911,34 @@ func (x *StateResponse) GetState() string {
 func (x *StateResponse) GetErrorMessage() string {
 	if x != nil {
 		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *StateResponse) GetBackupInProgress() bool {
+	if x != nil {
+		return x.BackupInProgress
+	}
+	return false
+}
+
+func (x *StateResponse) GetLastIntegrityCheckPassed() bool {
+	if x != nil && x.LastIntegrityCheckPassed != nil {
+		return *x.LastIntegrityCheckPassed
+	}
+	return false
+}
+
+func (x *StateResponse) GetLastIntegrityCheckError() string {
+	if x != nil {
+		return x.LastIntegrityCheckError
+	}
+	return ""
+}
+
+func (x *StateResponse) GetStanzaError() string {
+	if x != nil {
+		return x.StanzaError
 	}
 	return ""
 }
@@ -4309,10 +4345,15 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\rreload_config\x18\x05 \x01(\bR\freloadConfig\x12\x14\n" +
 	"\x05force\x18\x06 \x01(\bR\x05force\")\n" +
 	"'ConfigureSynchronousReplicationResponse\"\x0e\n" +
-	"\fStateRequest\"J\n" +
+	"\fStateRequest\"\xbc\x02\n" +
 	"\rStateResponse\x12\x14\n" +
 	"\x05state\x18\x01 \x01(\tR\x05state\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"\xc7\x02\n" +
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12,\n" +
+	"\x12backup_in_progress\x18\x03 \x01(\bR\x10backupInProgress\x12B\n" +
+	"\x1blast_integrity_check_passed\x18\x04 \x01(\bH\x00R\x18lastIntegrityCheckPassed\x88\x01\x01\x12;\n" +
+	"\x1alast_integrity_check_error\x18\x05 \x01(\tR\x17lastIntegrityCheckError\x12!\n" +
+	"\fstanza_error\x18\x06 \x01(\tR\vstanzaErrorB\x1e\n" +
+	"\x1c_last_integrity_check_passed\"\xc7\x02\n" +
 	"#UpdateSynchronousStandbyListRequest\x12L\n" +
 	"\toperation\x18\x01 \x01(\x0e2..multipoolermanagerdata.StandbyUpdateOperationR\toperation\x124\n" +
 	"\vstandby_ids\x18\x02 \x03(\v2\x13.clustermetadata.IDR\n" +
@@ -4585,6 +4626,7 @@ func file_multipoolermanagerdata_proto_init() {
 	if File_multipoolermanagerdata_proto != nil {
 		return
 	}
+	file_multipoolermanagerdata_proto_msgTypes[42].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/go/services/multipooler/manager/config.go
+++ b/go/services/multipooler/manager/config.go
@@ -32,4 +32,7 @@ type Config struct {
 	PgBackRestCertFile string // TLS client certificate file path
 	PgBackRestKeyFile  string // TLS client key file path
 	PgBackRestCAFile   string // TLS CA certificate file path
+
+	// OperatorManaged disables pooler-managed backup scheduling.
+	OperatorManaged bool
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -154,6 +154,17 @@ type MultiPoolerManager struct {
 	// healthStreamer streams health state to subscribers.
 	// Owns all health-related state and provides typed update methods.
 	healthStreamer *healthStreamer
+
+	// lastIntegrityCheckPassed stores the most recent pgbackrest check result.
+	lastIntegrityCheckPassed *bool
+	// lastIntegrityCheckError stores the most recent pgbackrest check error.
+	lastIntegrityCheckError string
+
+	// backupInProgress indicates whether a backup is currently running.
+	backupInProgress bool
+
+	// lastStanzaError stores the most recent stanza-create error code.
+	lastStanzaError string
 }
 
 // promotionState tracks which parts of the promotion are complete

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -82,6 +82,15 @@ func (pm *MultiPoolerManager) Backup(ctx context.Context, forcePrimary bool, bac
 
 // backupLocked performs a backup. Caller must hold the action lock and backup lease.
 func (pm *MultiPoolerManager) backupLocked(ctx context.Context, forcePrimary bool, backupType string, jobID string, overrides map[string]string) (retBackupID string, retErr error) {
+	pm.mu.Lock()
+	pm.backupInProgress = true
+	pm.mu.Unlock()
+	defer func() {
+		pm.mu.Lock()
+		pm.backupInProgress = false
+		pm.mu.Unlock()
+	}()
+
 	retErr = telemetry.WithSpan(ctx, "backup", func(ctx context.Context) error {
 		var err error
 		retBackupID, err = pm.backupLockedInner(ctx, forcePrimary, backupType, jobID, overrides)
@@ -234,6 +243,36 @@ func (pm *MultiPoolerManager) backupLockedInner(ctx context.Context, forcePrimar
 	}
 	// TODO: use `pgbackrest info` to verify that the database pages from the backed up
 	// Postgres cluster pass checksum validation.
+
+	// Record the latest pgbackrest check result for State().
+	checkCtx, checkCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer checkCancel()
+
+	checkCmd := executil.Command(checkCtx, "pgbackrest",
+		"--stanza="+pm.stanzaName(),
+		"--config="+configPath,
+		"check")
+
+	checkPassed := true
+	var checkError string
+	checkErr := telemetry.WithSpan(checkCtx, "backup/check", func(ctx context.Context) error {
+		checkOutput, runErr := pm.runLongCommand(ctx, checkCmd, "pgbackrest check")
+		if runErr != nil {
+			checkPassed = false
+			checkError = fmt.Sprintf("pgbackrest check failed: %v\nOutput: %s", runErr, string(checkOutput))
+			pm.logger.WarnContext(ctx, "Post-backup integrity check failed",
+				"backup_id", foundBackupID, "error", checkError)
+		}
+		return nil // Don't fail the backup because of a check failure
+	})
+	if checkErr != nil {
+		pm.logger.WarnContext(ctx, "Post-backup integrity check span error", "error", checkErr)
+	}
+
+	pm.mu.Lock()
+	pm.lastIntegrityCheckPassed = &checkPassed
+	pm.lastIntegrityCheckError = checkError
+	pm.mu.Unlock()
 
 	return foundBackupID, nil
 }

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -545,12 +545,8 @@ func (pm *MultiPoolerManager) initializePgBackRestStanza(ctx context.Context) er
 		output, err := safeCombinedOutput(cmd)
 		if err != nil {
 			// Record the latest stanza-create error code for State().
-			stanzaErr := "unknown"
-			if strings.Contains(output, "[028]") {
-				stanzaErr = "028"
-			}
 			pm.mu.Lock()
-			pm.lastStanzaError = stanzaErr
+			pm.lastStanzaError = classifyStanzaError(output)
 			pm.mu.Unlock()
 
 			return mterrors.New(mtrpcpb.Code_INTERNAL,
@@ -558,11 +554,32 @@ func (pm *MultiPoolerManager) initializePgBackRestStanza(ctx context.Context) er
 		}
 
 		// Clear any previous stanza error on success.
-		pm.mu.Lock()
-		pm.lastStanzaError = ""
-		pm.mu.Unlock()
+		pm.clearStanzaError()
 
 		pm.logger.InfoContext(ctx, "pgbackrest stanza initialized successfully", "stanza", pm.stanzaName(), "config", configPath)
 		return nil
 	})
+}
+
+// classifyStanzaError maps pgbackrest stanza-create output to a stanza error code.
+// Returns:
+//   - "028" if the output contains [028] (system identifier mismatch)
+//   - "unknown" for any other failure
+//
+// The return value is stored in lastStanzaError and surfaced via State().
+// Empty string means no error (set on success via clearStanzaError, not by this function).
+func classifyStanzaError(output string) string {
+	if strings.Contains(output, "[028]") {
+		return "028"
+	}
+	return "unknown"
+}
+
+// clearStanzaError resets the stanza error state after a successful stanza-create.
+// This is the production path that clears lastStanzaError — callers should use this
+// rather than setting the field directly.
+func (pm *MultiPoolerManager) clearStanzaError() {
+	pm.mu.Lock()
+	pm.lastStanzaError = ""
+	pm.mu.Unlock()
 }

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -544,9 +544,23 @@ func (pm *MultiPoolerManager) initializePgBackRestStanza(ctx context.Context) er
 
 		output, err := safeCombinedOutput(cmd)
 		if err != nil {
+			// Record the latest stanza-create error code for State().
+			stanzaErr := "unknown"
+			if strings.Contains(output, "[028]") {
+				stanzaErr = "028"
+			}
+			pm.mu.Lock()
+			pm.lastStanzaError = stanzaErr
+			pm.mu.Unlock()
+
 			return mterrors.New(mtrpcpb.Code_INTERNAL,
 				fmt.Sprintf("failed to create pgbackrest stanza %s: %v\nOutput: %s", pm.stanzaName(), err, output))
 		}
+
+		// Clear any previous stanza error on success.
+		pm.mu.Lock()
+		pm.lastStanzaError = ""
+		pm.mu.Unlock()
 
 		pm.logger.InfoContext(ctx, "pgbackrest stanza initialized successfully", "stanza", pm.stanzaName(), "config", configPath)
 		return nil

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -787,10 +787,19 @@ func (pm *MultiPoolerManager) State(ctx context.Context) (*multipoolermanagerdat
 		errorMessage = pm.stateError.Error()
 	}
 
-	return &multipoolermanagerdatapb.StateResponse{
-		State:        state,
-		ErrorMessage: errorMessage,
-	}, nil
+	resp := &multipoolermanagerdatapb.StateResponse{
+		State:            state,
+		ErrorMessage:     errorMessage,
+		BackupInProgress: pm.backupInProgress,
+		StanzaError:      pm.lastStanzaError,
+	}
+
+	if pm.lastIntegrityCheckPassed != nil {
+		resp.LastIntegrityCheckPassed = pm.lastIntegrityCheckPassed
+		resp.LastIntegrityCheckError = pm.lastIntegrityCheckError
+	}
+
+	return resp, nil
 }
 
 // GetFollowers gets the list of follower servers with detailed replication status

--- a/go/services/multipooler/manager/state_fields_test.go
+++ b/go/services/multipooler/manager/state_fields_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMinimalManager() *MultiPoolerManager {
+	return &MultiPoolerManager{
+		state: ManagerStateReady,
+	}
+}
+
+func TestState_DefaultFields(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, string(ManagerStateReady), resp.State)
+	assert.False(t, resp.BackupInProgress, "backup_in_progress should default to false")
+	assert.Nil(t, resp.LastIntegrityCheckPassed, "last_integrity_check_passed should be nil by default")
+	assert.Empty(t, resp.LastIntegrityCheckError, "last_integrity_check_error should be empty by default")
+	assert.Empty(t, resp.StanzaError, "stanza_error should be empty by default")
+}
+
+func TestState_BackupInProgress(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	pm.mu.Lock()
+	pm.backupInProgress = true
+	pm.mu.Unlock()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.BackupInProgress)
+}
+
+func TestState_IntegrityCheckFields(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	passed := true
+	pm.mu.Lock()
+	pm.lastIntegrityCheckPassed = &passed
+	pm.lastIntegrityCheckError = ""
+	pm.mu.Unlock()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp.LastIntegrityCheckPassed)
+	assert.True(t, *resp.LastIntegrityCheckPassed)
+	assert.Empty(t, resp.LastIntegrityCheckError)
+}
+
+func TestState_IntegrityCheckFailed(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	failed := false
+	pm.mu.Lock()
+	pm.lastIntegrityCheckPassed = &failed
+	pm.lastIntegrityCheckError = "stanza mismatch"
+	pm.mu.Unlock()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp.LastIntegrityCheckPassed)
+	assert.False(t, *resp.LastIntegrityCheckPassed)
+	assert.Equal(t, "stanza mismatch", resp.LastIntegrityCheckError)
+}
+
+func TestState_StanzaError(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	pm.mu.Lock()
+	pm.lastStanzaError = "028"
+	pm.mu.Unlock()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "028", resp.StanzaError)
+}
+
+func TestState_StanzaErrorUnknown(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	pm.mu.Lock()
+	pm.lastStanzaError = "unknown"
+	pm.mu.Unlock()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", resp.StanzaError)
+}
+
+// TestStanzaErrorMapping tests the production classifyStanzaError helper
+// that maps pgbackrest output to the stanza_error field value.
+func TestStanzaErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		output      string
+		expectError string
+	}{
+		{
+			name:        "028 system identifier mismatch",
+			output:      "ERROR: [028]: stanza 'multigres' already exists on repo1 with a different system-id",
+			expectError: "028",
+		},
+		{
+			name:        "other stanza error",
+			output:      "ERROR: [056]: unable to find stanza 'multigres'",
+			expectError: "unknown",
+		},
+		{
+			name:        "generic failure without error code",
+			output:      "connection refused",
+			expectError: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := classifyStanzaError(tt.output)
+			assert.Equal(t, tt.expectError, result)
+		})
+	}
+}
+
+// TestStanzaErrorClearedOnSuccess verifies that the production clearStanzaError()
+// method clears a previously recorded stanza error.
+func TestStanzaErrorClearedOnSuccess(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	// Set a previous error (simulating a prior failed stanza-create)
+	pm.mu.Lock()
+	pm.lastStanzaError = "028"
+	pm.mu.Unlock()
+
+	// Call the production success path
+	pm.clearStanzaError()
+
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, resp.StanzaError)
+}
+
+// TestIntegrityCheckStateTransitions verifies that integrity check results
+// are correctly stored and surfaced through State().
+func TestIntegrityCheckStateTransitions(t *testing.T) {
+	t.Parallel()
+	pm := newMinimalManager()
+
+	// Initially nil
+	resp, err := pm.State(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, resp.LastIntegrityCheckPassed)
+
+	// After a passing check
+	passed := true
+	pm.mu.Lock()
+	pm.lastIntegrityCheckPassed = &passed
+	pm.lastIntegrityCheckError = ""
+	pm.mu.Unlock()
+
+	resp, err = pm.State(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp.LastIntegrityCheckPassed)
+	assert.True(t, *resp.LastIntegrityCheckPassed)
+
+	// After a failing check
+	failed := false
+	pm.mu.Lock()
+	pm.lastIntegrityCheckPassed = &failed
+	pm.lastIntegrityCheckError = "WAL archive check failed"
+	pm.mu.Unlock()
+
+	resp, err = pm.State(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, resp.LastIntegrityCheckPassed)
+	assert.False(t, *resp.LastIntegrityCheckPassed)
+	assert.Equal(t, "WAL archive check failed", resp.LastIntegrityCheckError)
+}

--- a/go/services/pgctld/postgresctl_config.go
+++ b/go/services/pgctld/postgresctl_config.go
@@ -20,6 +20,11 @@ import (
 	"path/filepath"
 )
 
+const (
+	// ExitCodeCorruption is reserved for PostgreSQL data corruption signaling.
+	ExitCodeCorruption = 3
+)
+
 // PostgresCtlConfig holds all PostgreSQL control configuration parameters
 // It contains a PostgresServerConfig for all PostgreSQL-specific settings
 // plus additional connection parameters for control operations

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -563,6 +563,18 @@ message StateResponse {
 
   // Error message if state is error
   string error_message = 2;
+
+  // Whether a backup is currently running on this pooler.
+  bool backup_in_progress = 3;
+
+  // Whether the most recent pgbackrest check passed.
+  optional bool last_integrity_check_passed = 4;
+
+  // Error from the most recent failed pgbackrest check.
+  string last_integrity_check_error = 5;
+
+  // Error code from the most recent stanza-create attempt.
+  string stanza_error = 6;
 }
 
 // UpdateSynchronousStandbyList updates the synchronous standby list


### PR DESCRIPTION
## Description

this pr extends Multipooler and pgctld with the backup lifecycle signals needed by the operator-side backup work.

The goal is to make backup state observable to the operator without duplicating pgBackRest state in Kubernetes. Multipooler now reports whether a backup is running, the result of the most recent `pgbackrest check`, and the most recent stanza-create error code. pgctld also reserves a dedicated exit code for future corruption signaling.


## Changes

- add `backup_in_progress`, `last_integrity_check_passed`, `last_integrity_check_error`, and `stanza_error` to `StateResponse`
- track whether a backup is currently running in `MultiPoolerManager`
- run `pgbackrest check` after a successful backup and surface the latest result through `State()`
- surface the latest stanza-create error code through `State()`
- reserve `ExitCodeCorruption = 3` in `pgctld` for future corruption signaling


## Validation

Regenerated protobufs with `make proto` and verified that the generated `multipoolermanagerdata.pb.go` output matched the new `StateResponse` fields. Reviewed the final diff to confirm the change stayed limited to the backup lifecycle contract surface.

## Related Issues

This PR is paired with the operator-side retention, health, and metrics changes. It is also related to backup integrity validation and stale backup metadata handling.
