### PR TITLE
fix(pgctld): stale postmaster pid

### DIFF
--- a/go/cmd/pgctld/command/reload.go
+++ b/go/cmd/pgctld/command/reload.go
@@ -76,7 +76,7 @@ func ReloadPostgreSQLConfigWithResult(logger *slog.Logger, config *pgctld.Postgr
 	result := &ReloadResult{}
 
 	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
+	if !isPostgreSQLRunning(config) {
 		result.WasRunning = false
 		result.Message = "PostgreSQL is not running"
 		return result, errors.New("PostgreSQL is not running")

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -107,7 +107,7 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 	}
 
 	// Stop the server if it's running
-	if isPostgreSQLRunning(config.PostgresDataDir) {
+	if isPostgreSQLRunning(config) {
 		logger.Info("Stopping PostgreSQL server")
 		stopResult, err := StopPostgreSQLWithResult(logger, config, mode)
 		if err != nil {

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -122,7 +122,7 @@ func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCo
 	result := &StartResult{}
 
 	// Check if PostgreSQL is already running
-	if isPostgreSQLRunning(config.PostgresDataDir) {
+	if isPostgreSQLRunning(config) {
 		logger.Info("PostgreSQL is already running")
 		result.AlreadyRunning = true
 		result.Message = "PostgreSQL is already running"
@@ -133,6 +133,19 @@ func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCo
 		}
 
 		return result, nil
+	}
+
+	// Clean up stale postmaster.pid before starting PostgreSQL.
+	// This is critical for issue #723 (PID reuse vulnerability in K8s with PVC).
+	// When a container restarts with PVC retention, the old postmaster.pid persists.
+	// If the stale PID gets reused by another process, pg_ctl will fail with "lock file already exists".
+	err := removePostmasterFile(config)
+	if err != nil {
+		// If removal fails, it's typically because the file doesn't exist (already removed or never created)
+		// which is harmless, so we log and continue. pg_ctl will handle any actual lock issues.
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Warn("Failed to remove stale postmaster.pid, proceeding anyway", "error", err)
+		}
 	}
 
 	// Ensure Unix socket directory exists before starting PostgreSQL
@@ -227,20 +240,20 @@ func ensurePGDATAPermissions(logger *slog.Logger, dataDir string) error {
 	return nil
 }
 
-func isPostgreSQLRunning(dataDir string) bool {
+// removePostmasterFile removes the PostgreSQL lock file (postmaster.pid) from PGDATA.
+func removePostmasterFile(config *pgctld.PostgresCtlConfig) error {
+	pidFile := filepath.Join(config.PostgresDataDir, "postmaster.pid")
+	return os.Remove(pidFile)
+}
+
+func isPostgreSQLRunning(config *pgctld.PostgresCtlConfig) bool {
 	// Check if postmaster.pid file exists and process is running
-	pidFile := filepath.Join(dataDir, "postmaster.pid")
+	pidFile := filepath.Join(config.PostgresDataDir, "postmaster.pid")
 	if _, err := os.Stat(pidFile); err != nil {
 		return false
 	}
 
-	// Read PID from file and check if process is actually running
-	pid, err := readPostmasterPID(dataDir)
-	if err != nil {
-		return false
-	}
-
-	return isProcessRunning(pid)
+	return IsPostmasterProcessRunning(config)
 }
 
 func startPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig) error {
@@ -414,6 +427,20 @@ func readPostmasterPID(dataDir string) (int, error) {
 	}
 
 	return pid, nil
+}
+
+func IsPostmasterProcessRunning(config *pgctld.PostgresCtlConfig) bool {
+	socketDir := pgctld.PostgresSocketDir(config.PoolerDir)
+
+	cmd := exec.Command("pg_isready",
+		"-h", socketDir,
+		"-p", strconv.Itoa(config.Port),
+		"-U", config.User,
+		"-d", config.Database,
+	)
+
+	_, err := cmd.CombinedOutput()
+	return err == nil
 }
 
 func isProcessRunning(pid int) bool {

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -189,7 +189,31 @@ func TestIsPostgreSQLRunning(t *testing.T) {
 			defer cleanup()
 
 			dataDir := tt.setupDir(baseDir)
-			result := isPostgreSQLRunning(dataDir)
+
+			// Setup mock binaries for pg_isready
+			binDir := filepath.Join(baseDir, "bin")
+			require.NoError(t, os.MkdirAll(binDir, 0o755))
+			testutil.CreateMockPostgreSQLBinaries(t, binDir)
+
+			originalPath := os.Getenv("PATH")
+			os.Setenv("PATH", binDir+":"+originalPath)
+			defer os.Setenv("PATH", originalPath)
+
+			// Create config object
+			config, err := pgctld.NewPostgresCtlConfig(
+				5432,
+				constants.DefaultPostgresUser,
+				constants.DefaultPostgresDatabase,
+				30,
+				dataDir,
+				pgctld.PostgresConfigFile(),
+				baseDir,
+				"localhost",
+				pgctld.PostgresSocketDir(baseDir),
+			)
+			require.NoError(t, err)
+
+			result := isPostgreSQLRunning(config)
 			assert.Equal(t, tt.isRunning, result)
 		})
 	}

--- a/go/cmd/pgctld/command/status.go
+++ b/go/cmd/pgctld/command/status.go
@@ -115,7 +115,7 @@ func GetStatusWithResult(ctx context.Context, logger *slog.Logger, config *pgctl
 	}
 
 	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
+	if !isPostgreSQLRunning(config) {
 		result.Status = statusStopped
 		result.Message = "PostgreSQL server is stopped"
 		return result, nil

--- a/go/cmd/pgctld/command/stop.go
+++ b/go/cmd/pgctld/command/stop.go
@@ -122,7 +122,7 @@ func StopPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCon
 	}
 
 	// Check if PostgreSQL is running
-	if !isPostgreSQLRunning(config.PostgresDataDir) {
+	if !isPostgreSQLRunning(config) {
 		logger.Info("PostgreSQL is not running")
 		result.WasRunning = false
 		result.Message = "PostgreSQL is not running"

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -21,12 +21,13 @@
 package clustermetadata
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (

--- a/go/pb/consensus/consensusservice.pb.go
+++ b/go/pb/consensus/consensusservice.pb.go
@@ -21,12 +21,13 @@
 package consensus
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	consensusdata "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -22,6 +22,7 @@ package consensus
 
 import (
 	context "context"
+
 	consensusdata "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	grpc "google.golang.org/grpc"

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -21,13 +21,14 @@
 package consensusdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/mtrpc/mtrpc.pb.go
+++ b/go/pb/mtrpc/mtrpc.pb.go
@@ -24,12 +24,13 @@
 package mtrpc
 
 import (
-	query "github.com/multigres/multigres/go/pb/query"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	query "github.com/multigres/multigres/go/pb/query"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -21,6 +21,10 @@
 package multiadmin
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	multigatewaymanagerdata "github.com/multigres/multigres/go/pb/multigatewaymanagerdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -28,9 +32,6 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multiadmin/multiadminservice_grpc.pb.go
+++ b/go/pb/multiadmin/multiadminservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multiadmin
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multigatewayservice/multigatewayservice.pb.go
+++ b/go/pb/multigatewayservice/multigatewayservice.pb.go
@@ -24,11 +24,12 @@
 package multigatewayservice
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/pb/multigatewayservice/multigatewayservice_grpc.pb.go
+++ b/go/pb/multigatewayservice/multigatewayservice_grpc.pb.go
@@ -25,6 +25,7 @@ package multigatewayservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multiorch/multiorchservice.pb.go
+++ b/go/pb/multiorch/multiorchservice.pb.go
@@ -21,13 +21,14 @@
 package multiorch
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multiorch/multiorchservice_grpc.pb.go
+++ b/go/pb/multiorch/multiorchservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multiorch
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multiorchdata/multiorchdata.pb.go
+++ b/go/pb/multiorchdata/multiorchdata.pb.go
@@ -21,14 +21,15 @@
 package multiorchdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -21,11 +21,12 @@
 package multipoolermanager
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multipoolermanager
 
 import (
 	context "context"
+
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -21,14 +21,15 @@
 package multipoolermanagerdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -24,15 +24,16 @@
 package multipoolerservice
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpc "github.com/multigres/multigres/go/pb/mtrpc"
 	query "github.com/multigres/multigres/go/pb/query"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolerservice/multipoolerservice_grpc.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice_grpc.pb.go
@@ -25,6 +25,7 @@ package multipoolerservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -21,13 +21,14 @@
 package pgctldservice
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/pgctldservice/pgctldservice_grpc.pb.go
+++ b/go/pb/pgctldservice/pgctldservice_grpc.pb.go
@@ -22,6 +22,7 @@ package pgctldservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -24,12 +24,13 @@
 package query
 
 import (
-	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (


### PR DESCRIPTION
### Fixes
- https://github.com/multigres/multigres/issues/723

### Changes
- Previously, we checked whether a stale process (mentioned in `postmaster.pid`) was still running by sending signal 0 and assuming the process existed if no error occurred. Now, instead of relying on that approach, we verify whether PostgreSQL is actually running using `pg_isready`.

### Reproduce

```shell
➜ /Users/bhautik/workspace/src/multigres/bin/pgctld start \
    --pooler-dir /tmp/local-test \
    --pg-port 5433

...
PostgreSQL server started successfully (PID: 58207)

➜ kill -9 58207

➜ echo $$
75110

# Write obtained process ID of current shell in postmaster.pid

# Start again
➜ /Users/bhautik/workspace/src/multigres/bin/pgctld start \
    --pooler-dir /tmp/local-test \
    --pg-port 5433
# Instead of saying postgresql is running, It should remove pid and start postgres
```
