### PR TITLE
feat(multiorch): fix Get+Set races in watcher and health check queue

### DIFF
--- a/go/services/multiorch/recovery/healthcheck.go
+++ b/go/services/multiorch/recovery/healthcheck.go
@@ -337,48 +337,32 @@ func (re *Engine) queuePoolersHealthCheck() {
 	pollInterval := re.config.GetPoolerHealthCheckInterval()
 	cutoff := time.Now().Add(-pollInterval)
 
-	pushedCount := 0
-
-	// Collect poolers to queue and poolers that need IsUpToDate reset
+	// DoUpdateRange holds the store lock for the entire iteration, resetting
+	// IsUpToDate atomically for poolers that need re-checking.
+	// Without this reset, pollPooler skips if IsUpToDate && IsLastCheckValid are both true.
+	// Queue pushes are collected and done after the lock is released.
 	var poolersToQueue []string
-	var poolersToReset []struct {
-		id   string
-		info *multiorchdatapb.PoolerHealthState
-	}
-
-	// Iterate over poolers using Range() - do NOT call Set inside Range (deadlock!)
-	re.poolerStore.Range(func(poolerID string, poolerInfo *multiorchdatapb.PoolerHealthState) bool {
-		// Skip if recently attempted (either never attempted or older than interval)
+	re.poolerStore.DoUpdateRange(func(poolerID string, poolerInfo *multiorchdatapb.PoolerHealthState) (*multiorchdatapb.PoolerHealthState, bool) {
 		lastCheckAttempted := time.Time{}
 		if poolerInfo.LastCheckAttempted != nil {
 			lastCheckAttempted = poolerInfo.LastCheckAttempted.AsTime()
 		}
+
 		if !lastCheckAttempted.IsZero() && lastCheckAttempted.After(cutoff) {
-			return true // continue iteration
+			return nil, true // recently checked, skip and continue
 		}
 
-		// Collect pooler for queueing
 		poolersToQueue = append(poolersToQueue, poolerID)
 
-		// If IsUpToDate is true, collect for reset (will be done after Range completes)
-		// Without this reset, pollPooler skips if IsUpToDate && IsLastCheckValid are both true.
 		if poolerInfo.IsUpToDate {
 			poolerInfo.IsUpToDate = false
-			poolersToReset = append(poolersToReset, struct {
-				id   string
-				info *multiorchdatapb.PoolerHealthState
-			}{poolerID, poolerInfo})
+			return poolerInfo, true // write reset back atomically and continue
 		}
-
-		return true // continue iteration
+		return nil, true // already false, no write needed, continue
 	})
 
-	// Now safe to call Set (Range lock is released)
-	for _, p := range poolersToReset {
-		re.poolerStore.Set(p.id, p.info)
-	}
-
-	// Push collected poolers to queue
+	// Push collected poolers to queue (outside the store lock)
+	pushedCount := 0
 	for _, poolerID := range poolersToQueue {
 		re.healthCheckQueue.Push(poolerID)
 		pushedCount++

--- a/go/services/multiorch/recovery/pooler_watcher.go
+++ b/go/services/multiorch/recovery/pooler_watcher.go
@@ -397,10 +397,18 @@ func (cw *cellPoolerWatcher) handlePoolerEvent(wd *topoclient.WatchDataRecursive
 
 	poolerID := topoclient.MultiPoolerIDString(pooler.Id)
 
-	if existing, ok := cw.store.Get(poolerID); ok {
-		// Update the MultiPooler metadata but preserve all health-check timestamps.
-		existing.MultiPooler = pooler
-		cw.store.Set(poolerID, existing)
+	// Use DoUpdate to atomically update only the topology metadata, preserving all
+	// health-check fields (timestamps, IsUpToDate, IsLastCheckValid, etc.) that may
+	// be written concurrently by the health check worker. A closure variable tracks
+	// whether the key existed so we know whether to treat this as a new pooler.
+	existing := false
+	cw.store.DoUpdate(poolerID, func(state *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
+		existing = true
+		state.MultiPooler = pooler
+		return state
+	})
+
+	if existing {
 		cw.logger.Debug("pooler metadata updated from topology", "pooler_id", poolerID)
 	} else {
 		// New pooler — add to store and queue for immediate health check.

--- a/go/services/multiorch/store/pooler_health_state.go
+++ b/go/services/multiorch/store/pooler_health_state.go
@@ -58,7 +58,14 @@ func (s *poolerHealthStore) rangeHealth(fn func(key string, value *multiorchdata
 	s.proto.Range(fn)
 }
 
+// doUpdateRange iterates over all poolers while holding the lock and allows
+// in-place updates. See ProtoStore.DoUpdateRange for full semantics.
+func (s *poolerHealthStore) doUpdateRange(fn func(key string, value *multiorchdata.PoolerHealthState) (*multiorchdata.PoolerHealthState, bool)) {
+	s.proto.DoUpdateRange(fn)
+}
+
 // doUpdate performs an atomic read-modify-write on a pooler's health state.
+// See ProtoStore.DoUpdate for full semantics.
 func (s *poolerHealthStore) doUpdate(key string, fn func(value *multiorchdata.PoolerHealthState) *multiorchdata.PoolerHealthState) {
 	s.proto.DoUpdate(key, fn)
 }

--- a/go/services/multiorch/store/pooler_store.go
+++ b/go/services/multiorch/store/pooler_store.go
@@ -85,6 +85,25 @@ func (s *PoolerStore) DoUpdate(key string, fn func(*multiorchdatapb.PoolerHealth
 	s.health.doUpdate(key, fn)
 }
 
+// DoUpdateRange iterates over all poolers while holding the lock and allows
+// in-place updates.
+//
+// Each value passed to the callback is the raw internal value (not a clone).
+// Return the updated value to write it back, or nil to leave it unchanged.
+// Return false to stop iteration early, consistent with Range. The callback
+// must not retain the pointer after it returns, and must not perform any
+// expensive or blocking operations since it runs while holding the store lock.
+//
+// Example:
+//
+//	store.DoUpdateRange(func(key string, value *PoolerHealthState) (*PoolerHealthState, bool) {
+//	    value.LastSeen = timestamppb.Now()
+//	    return value, true // write and continue
+//	})
+func (s *PoolerStore) DoUpdateRange(fn func(key string, value *multiorchdatapb.PoolerHealthState) (*multiorchdatapb.PoolerHealthState, bool)) {
+	s.health.doUpdateRange(fn)
+}
+
 // IsInitialized returns true if the pooler has been initialized.
 // FindPoolersInShard returns all poolers belonging to the given shard.
 func (s *PoolerStore) FindPoolersInShard(shardKey commontypes.ShardKey) []*multiorchdatapb.PoolerHealthState {

--- a/go/services/multiorch/store/pooler_store_test.go
+++ b/go/services/multiorch/store/pooler_store_test.go
@@ -301,3 +301,46 @@ func TestPoolerStore_FindHealthyPrimary(t *testing.T) {
 		assert.Contains(t, err.Error(), "multiple primaries found")
 	})
 }
+
+// TestPoolerStore_DoUpdateRange verifies that DoUpdateRange atomically resets fields
+// on qualifying poolers while leaving others unchanged — mirroring the
+// queuePoolersHealthCheck use case.
+func TestPoolerStore_DoUpdateRange(t *testing.T) {
+	store := NewPoolerStore(nil, slog.Default())
+
+	// pooler1: IsUpToDate=true — should be reset to false
+	store.Set("pooler1", &multiorchdatapb.PoolerHealthState{
+		MultiPooler: &clustermetadatapb.MultiPooler{
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		},
+		IsUpToDate: true,
+	})
+	// pooler2: IsUpToDate=false — should remain false and not be written back
+	store.Set("pooler2", &multiorchdatapb.PoolerHealthState{
+		MultiPooler: &clustermetadatapb.MultiPooler{
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		},
+		IsUpToDate: false,
+	})
+
+	writeCount := 0
+	store.DoUpdateRange(func(key string, value *multiorchdatapb.PoolerHealthState) (*multiorchdatapb.PoolerHealthState, bool) {
+		if value.IsUpToDate {
+			value.IsUpToDate = false
+			writeCount++
+			return value, true // write and continue
+		}
+		return nil, true // no write, continue
+	})
+
+	// Only pooler1 should have triggered a write-back
+	require.Equal(t, 1, writeCount)
+
+	p1, ok := store.Get("pooler1")
+	require.True(t, ok)
+	require.False(t, p1.IsUpToDate, "pooler1 IsUpToDate should have been reset to false")
+
+	p2, ok := store.Get("pooler2")
+	require.True(t, ok)
+	require.False(t, p2.IsUpToDate, "pooler2 IsUpToDate should remain false")
+}

--- a/go/services/multiorch/store/store.go
+++ b/go/services/multiorch/store/store.go
@@ -127,6 +127,42 @@ func (s *ProtoStore[K, V]) Range(fn func(key K, value V) bool) {
 	}
 }
 
+// DoUpdateRange iterates over all key-value pairs while holding the lock and
+// allows in-place updates.
+//
+// Each value passed to the callback is the raw internal value (not a clone).
+// The callback may mutate it in place. Return the updated value to write it
+// back to the store, or nil to leave the entry unchanged. Return false to stop
+// iteration early — consistent with Range.
+//
+// The callback must not retain the pointer after it returns, and must not
+// perform any expensive or blocking operations since it runs while holding the
+// store lock.
+//
+// Example:
+//
+//	store.DoUpdateRange(func(key string, value *PoolerHealthState) (*PoolerHealthState, bool) {
+//	    value.LastSeen = timestamppb.Now()
+//	    return value, true  // write updated value and continue
+//	    return nil, true    // no update, continue
+//	    return value, false // write updated value and stop
+//	})
+func (s *ProtoStore[K, V]) DoUpdateRange(fn func(key K, value V) (V, bool)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for k, v := range s.items {
+		var zero V
+		newValue, cont := fn(k, v)
+		if any(newValue) != any(zero) {
+			s.items[k] = newValue
+		}
+		if !cont {
+			return
+		}
+	}
+}
+
 // DoUpdate performs an atomic read-modify-write operation for a given key.
 //
 // The provided function receives a pointer to the current value and can modify
@@ -140,14 +176,10 @@ func (s *ProtoStore[K, V]) Range(fn func(key K, value V) bool) {
 // Example:
 //
 //	store.DoUpdate("pooler1", func(value *PoolerHealthState) *PoolerHealthState {
-//	    // Update value based on current state (value is a pointer to the current or zero value)
 //	    value.LastSeen = timestamppb.Now()
-//	    return value  // return the updated value to store it back in the map
+//	    return value // write updated value
+//	    return nil   // no update
 //	})
-//
-// Note: The update function should return the new value to be stored. If the
-// function does not modify the value, it should return the original value to
-// ensure it remains in the store.
 //
 // Right now we are holding a lock on the entire store for the duration of the
 // update function, but an improvement for the future could be to implement
@@ -159,6 +191,9 @@ func (s *ProtoStore[K, V]) DoUpdate(key K, fn func(value V) V) {
 	// Skip the update if the key doesn't exist to avoid accidentally creating
 	// new entries.
 	if v, ok := s.items[key]; ok {
-		s.items[key] = fn(v)
+		var zero V
+		if newValue := fn(v); any(newValue) != any(zero) {
+			s.items[key] = newValue
+		}
 	}
 }

--- a/go/test/endtoend/multiorch/fix_replication_test.go
+++ b/go/test/endtoend/multiorch/fix_replication_test.go
@@ -214,7 +214,7 @@ func TestFixReplication(t *testing.T) {
 	t.Log("Verifying replica was removed from standby list...")
 	require.Eventually(t, func() bool {
 		return !isReplicaInStandbyList(t, primaryClient, replicaName)
-	}, 2*time.Second, 100*time.Millisecond, "replica should not be in standby list after removal")
+	}, 5*time.Second, 200*time.Millisecond, "replica should not be in standby list after removal")
 
 	// Verify replication is still working (primary_conninfo should still be configured)
 	t.Log("Verifying replication is still working after standby list removal...")


### PR DESCRIPTION
Add `DoUpdateRange` to `ProtoStore`, `poolerHealthStore`, and `PoolerStore` for atomic read-modify-write across all entries and use it in queuePoolersHealthCheck to collapse the previous three-phase `Range` + collect + `Set` loop into a single atomic pass, resetting `IsUpToDate` without releasing the lock between reads and writes.

Fix the Get+Set race in `PoolerWatcher.handlePoolerEvent` by replacing it with `DoUpdate`, so concurrent health check writes to timestamps and validity flags are no longer overwritten by topology updates from etcd.

Modify `DoUpdate` and `DoUpdateRange` to treat a nil return as a no-op, preventing accidental nil entries from being stored.