### PR TITLE
refactor(multipooler): introduce ruleStore for shard rule management

### DIFF
--- a/go/common/consensus/rulenumber.go
+++ b/go/common/consensus/rulenumber.go
@@ -27,14 +27,14 @@ func CompareRuleNumbers(a, b *clustermetadatapb.RuleNumber) int {
 	aSubterm := int64(0)
 	if a != nil {
 		aTerm = a.GetCoordinatorTerm()
-		aSubterm = a.GetRuleSubterm()
+		aSubterm = a.GetLeaderSubterm()
 	}
 
 	bTerm := int64(0)
 	bSubterm := int64(0)
 	if b != nil {
 		bTerm = b.GetCoordinatorTerm()
-		bSubterm = b.GetRuleSubterm()
+		bSubterm = b.GetLeaderSubterm()
 	}
 
 	if aTerm != bTerm {

--- a/go/common/consensus/rulenumber_test.go
+++ b/go/common/consensus/rulenumber_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func rn(term, subterm int64) *clustermetadatapb.RuleNumber {
-	return &clustermetadatapb.RuleNumber{CoordinatorTerm: term, RuleSubterm: subterm}
+	return &clustermetadatapb.RuleNumber{CoordinatorTerm: term, LeaderSubterm: subterm}
 }
 
 func TestCompareRuleNumbers(t *testing.T) {

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -369,9 +369,9 @@ func argToParam(arg any) ([]byte, error) {
 	}
 }
 
-// encodeStringArray encodes a []string as a PostgreSQL text-format array literal (e.g. {foo,bar}).
-// Elements that require quoting (containing braces, commas, backslashes, double-quotes, or whitespace)
-// are enclosed in double-quotes with internal double-quotes and backslashes escaped.
+// encodeStringArray encodes a []string as a PostgreSQL text-format array literal (e.g. {"foo","bar"}).
+// All elements are double-quoted with internal double-quotes and backslashes escaped.
+// Always quoting avoids edge cases (empty strings, NULL, whitespace, unicode) without loss of correctness.
 func encodeStringArray(elems []string) string {
 	if len(elems) == 0 {
 		return "{}"
@@ -382,33 +382,17 @@ func encodeStringArray(elems []string) string {
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		if needsQuoting(e) {
-			b.WriteByte('"')
-			for _, c := range e {
-				if c == '"' || c == '\\' {
-					b.WriteByte('\\')
-				}
-				b.WriteRune(c)
+		b.WriteByte('"')
+		for _, c := range e {
+			if c == '"' || c == '\\' {
+				b.WriteByte('\\')
 			}
-			b.WriteByte('"')
-		} else {
-			b.WriteString(e)
+			b.WriteRune(c)
 		}
+		b.WriteByte('"')
 	}
 	b.WriteByte('}')
 	return b.String()
-}
-
-func needsQuoting(s string) bool {
-	if s == "" {
-		return true
-	}
-	for _, c := range s {
-		if c == '{' || c == '}' || c == ',' || c == '"' || c == '\\' || c == ' ' || c == '\t' || c == '\n' {
-			return true
-		}
-	}
-	return false
 }
 
 // processExecuteResponses processes responses to an Execute command.

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -354,9 +355,55 @@ func argToParam(arg any) ([]byte, error) {
 	case time.Time:
 		// Use RFC3339 format which PostgreSQL understands.
 		return []byte(v.Format(time.RFC3339Nano)), nil
+	case []string:
+		// Encode as PostgreSQL array literal: {elem1,elem2,...}
+		// Elements containing commas, braces, backslashes, or whitespace are double-quoted.
+		return []byte(encodeStringArray(v)), nil
 	default:
 		return nil, fmt.Errorf("unsupported type: %T", arg)
 	}
+}
+
+// encodeStringArray encodes a []string as a PostgreSQL text-format array literal (e.g. {foo,bar}).
+// Elements that require quoting (containing braces, commas, backslashes, double-quotes, or whitespace)
+// are enclosed in double-quotes with internal double-quotes and backslashes escaped.
+func encodeStringArray(elems []string) string {
+	if len(elems) == 0 {
+		return "{}"
+	}
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, e := range elems {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		if needsQuoting(e) {
+			b.WriteByte('"')
+			for _, c := range e {
+				if c == '"' || c == '\\' {
+					b.WriteByte('\\')
+				}
+				b.WriteRune(c)
+			}
+			b.WriteByte('"')
+		} else {
+			b.WriteString(e)
+		}
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, c := range s {
+		if c == '{' || c == '}' || c == ',' || c == '"' || c == '\\' || c == ' ' || c == '\t' || c == '\n' {
+			return true
+		}
+	}
+	return false
 }
 
 // processExecuteResponses processes responses to an Execute command.

--- a/go/common/pgprotocol/client/extended.go
+++ b/go/common/pgprotocol/client/extended.go
@@ -240,7 +240,7 @@ func (c *Conn) PrepareAndExecute(ctx context.Context, name, queryStr string, par
 // QueryArgs executes a parameterized query using the extended query protocol.
 // This is a convenience method that accepts Go values as arguments and converts
 // them to the appropriate text format for PostgreSQL.
-// Supported argument types: nil, string, []byte, int, int32, int64, uint32, uint64,
+// Supported argument types: nil, string, []byte, int, int32, int64, *int64, uint32, uint64,
 // float32, float64, bool, and time.Time.
 func (c *Conn) QueryArgs(ctx context.Context, queryStr string, args ...any) ([]*sqltypes.Result, error) {
 	// Convert args to [][]byte
@@ -339,6 +339,11 @@ func argToParam(arg any) ([]byte, error) {
 		return []byte(strconv.FormatInt(int64(v), 10)), nil
 	case int64:
 		return []byte(strconv.FormatInt(v, 10)), nil
+	case *int64:
+		if v == nil {
+			return nil, nil // NULL
+		}
+		return []byte(strconv.FormatInt(*v, 10)), nil
 	case uint32:
 		return []byte(strconv.FormatUint(uint64(v), 10)), nil
 	case uint64:

--- a/go/common/pgprotocol/client/extended_test.go
+++ b/go/common/pgprotocol/client/extended_test.go
@@ -414,3 +414,39 @@ func TestWriteBindWithNullParams(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), p3)
 }
+
+func TestEncodeStringArray(t *testing.T) {
+	t.Run("empty slice", func(t *testing.T) {
+		assert.Equal(t, "{}", encodeStringArray([]string{}))
+	})
+
+	t.Run("single plain element", func(t *testing.T) {
+		assert.Equal(t, "{foo}", encodeStringArray([]string{"foo"}))
+	})
+
+	t.Run("multiple plain elements", func(t *testing.T) {
+		assert.Equal(t, "{foo,bar,baz}", encodeStringArray([]string{"foo", "bar", "baz"}))
+	})
+
+	t.Run("element with space is quoted", func(t *testing.T) {
+		assert.Equal(t, `{"foo bar"}`, encodeStringArray([]string{"foo bar"}))
+	})
+
+	t.Run("element with comma is quoted", func(t *testing.T) {
+		assert.Equal(t, `{"foo,bar"}`, encodeStringArray([]string{"foo,bar"}))
+	})
+
+	t.Run("element with double quote is quoted and escaped", func(t *testing.T) {
+		assert.Equal(t, `{"foo\"bar"}`, encodeStringArray([]string{`foo"bar`}))
+	})
+
+	t.Run("element with backslash is quoted and escaped", func(t *testing.T) {
+		assert.Equal(t, `{"foo\\bar"}`, encodeStringArray([]string{`foo\bar`}))
+	})
+
+	t.Run("pooler ID format round-trips through ParseTextArray", func(t *testing.T) {
+		elems := []string{"zone1_pooler-1", "zone1_pooler-2", "zone1_pooler-3"}
+		encoded := encodeStringArray(elems)
+		assert.Equal(t, "{zone1_pooler-1,zone1_pooler-2,zone1_pooler-3}", encoded)
+	})
+}

--- a/go/common/pgprotocol/client/extended_test.go
+++ b/go/common/pgprotocol/client/extended_test.go
@@ -421,11 +421,11 @@ func TestEncodeStringArray(t *testing.T) {
 	})
 
 	t.Run("single plain element", func(t *testing.T) {
-		assert.Equal(t, "{foo}", encodeStringArray([]string{"foo"}))
+		assert.Equal(t, `{"foo"}`, encodeStringArray([]string{"foo"}))
 	})
 
 	t.Run("multiple plain elements", func(t *testing.T) {
-		assert.Equal(t, "{foo,bar,baz}", encodeStringArray([]string{"foo", "bar", "baz"}))
+		assert.Equal(t, `{"foo","bar","baz"}`, encodeStringArray([]string{"foo", "bar", "baz"}))
 	})
 
 	t.Run("element with space is quoted", func(t *testing.T) {
@@ -447,6 +447,14 @@ func TestEncodeStringArray(t *testing.T) {
 	t.Run("pooler ID format round-trips through ParseTextArray", func(t *testing.T) {
 		elems := []string{"zone1_pooler-1", "zone1_pooler-2", "zone1_pooler-3"}
 		encoded := encodeStringArray(elems)
-		assert.Equal(t, "{zone1_pooler-1,zone1_pooler-2,zone1_pooler-3}", encoded)
+		assert.Equal(t, `{"zone1_pooler-1","zone1_pooler-2","zone1_pooler-3"}`, encoded)
+	})
+
+	t.Run("unicode elements are encoded correctly", func(t *testing.T) {
+		assert.Equal(t, `{"ᚼᛅᛁᛚ","ᚼᛅᛁᛗᚱ"}`, encodeStringArray([]string{"ᚼᛅᛁᛚ", "ᚼᛅᛁᛗᚱ"}))
+	})
+
+	t.Run("null string is quoted to avoid SQL NULL interpretation", func(t *testing.T) {
+		assert.Equal(t, `{"NULL"}`, encodeStringArray([]string{"NULL"}))
 	})
 }

--- a/go/common/sqltypes/arrays.go
+++ b/go/common/sqltypes/arrays.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqltypes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseTextArray parses a PostgreSQL text-format array literal (e.g. {foo,bar}) into a []string.
+// Quoted elements (e.g. {"foo bar","baz,qux"}) and backslash escapes within quoted elements
+// are handled. Returns an error if the input is not a valid PostgreSQL array literal.
+func ParseTextArray(s string) ([]string, error) {
+	if len(s) < 2 || s[0] != '{' || s[len(s)-1] != '}' {
+		return nil, fmt.Errorf("not a PostgreSQL array literal: %q", s)
+	}
+	inner := s[1 : len(s)-1]
+	if inner == "" {
+		return []string{}, nil
+	}
+	var result []string
+	var cur strings.Builder
+	quoted := false
+	i := 0
+	for i < len(inner) {
+		c := inner[i]
+		switch {
+		case c == '"' && !quoted:
+			quoted = true
+		case c == '"' && quoted:
+			quoted = false
+		case c == '\\' && quoted && i+1 < len(inner):
+			i++
+			cur.WriteByte(inner[i])
+		case c == ',' && !quoted:
+			result = append(result, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+		i++
+	}
+	result = append(result, cur.String())
+	return result, nil
+}

--- a/go/common/sqltypes/arrays.go
+++ b/go/common/sqltypes/arrays.go
@@ -20,8 +20,13 @@ import (
 )
 
 // ParseTextArray parses a PostgreSQL text-format array literal (e.g. {foo,bar}) into a []string.
-// Quoted elements (e.g. {"foo bar","baz,qux"}) and backslash escapes within quoted elements
-// are handled. Returns an error if the input is not a valid PostgreSQL array literal.
+// Follows the PostgreSQL specification:
+//   - Quoted elements preserve all content; backslash escapes apply inside quotes.
+//   - Unquoted elements have leading/trailing whitespace trimmed; backslash escapes apply.
+//   - Unquoted NULL (any case, no escapes) is SQL NULL — an error since it cannot be a string.
+//   - Backslash-escaped values (e.g. \null) are never treated as NULL.
+//
+// Multi-dimensional arrays return an error. Malformed input returns an error.
 func ParseTextArray(s string) ([]string, error) {
 	if len(s) < 2 || s[0] != '{' || s[len(s)-1] != '}' {
 		return nil, fmt.Errorf("not a PostgreSQL array literal: %q", s)
@@ -30,28 +35,139 @@ func ParseTextArray(s string) ([]string, error) {
 	if inner == "" {
 		return []string{}, nil
 	}
+
 	var result []string
-	var cur strings.Builder
-	quoted := false
 	i := 0
+
+	for {
+		// Skip leading whitespace before the element.
+		for i < len(inner) && isArraySpace(inner[i]) {
+			i++
+		}
+		if i >= len(inner) {
+			// Reached end after a comma: trailing delimiter.
+			return nil, fmt.Errorf("trailing delimiter in PostgreSQL array: %q", s)
+		}
+		if inner[i] == '{' {
+			return nil, fmt.Errorf("multi-dimensional arrays are not supported: %q", s)
+		}
+
+		var (
+			elem       string
+			hasEscapes bool
+			wasQuoted  bool
+			err        error
+		)
+
+		if inner[i] == '"' {
+			elem, i, err = readQuotedArrayElem(inner, i, s)
+			wasQuoted = true
+		} else {
+			elem, hasEscapes, i, err = readUnquotedArrayElem(inner, i, s)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Consecutive or trailing delimiters produce an empty unquoted element.
+		if !wasQuoted && elem == "" {
+			return nil, fmt.Errorf("unexpected empty element in PostgreSQL array: %q", s)
+		}
+		// Unquoted NULL without backslash escapes is SQL NULL, which has no string representation.
+		if !wasQuoted && !hasEscapes && strings.EqualFold(elem, "null") {
+			return nil, fmt.Errorf("NULL element in PostgreSQL array is not supported: %q", s)
+		}
+
+		result = append(result, elem)
+
+		if i >= len(inner) {
+			break
+		}
+		if inner[i] != ',' {
+			return nil, fmt.Errorf("unexpected character %q in PostgreSQL array: %q", inner[i], s)
+		}
+		i++ // skip comma
+	}
+
+	return result, nil
+}
+
+// readQuotedArrayElem reads a double-quoted element starting at inner[i] (the opening `"`).
+// Returns the element value and the position pointing at `,` or end of inner.
+func readQuotedArrayElem(inner string, i int, orig string) (string, int, error) {
+	i++ // skip opening `"`
+	var cur strings.Builder
 	for i < len(inner) {
 		c := inner[i]
-		switch {
-		case c == '"' && !quoted:
-			quoted = true
-		case c == '"' && quoted:
-			quoted = false
-		case c == '\\' && quoted && i+1 < len(inner):
+		if c == '\\' {
 			i++
+			if i >= len(inner) {
+				return "", i, fmt.Errorf("unterminated escape sequence in PostgreSQL array: %q", orig)
+			}
 			cur.WriteByte(inner[i])
-		case c == ',' && !quoted:
-			result = append(result, cur.String())
-			cur.Reset()
+			i++
+			continue
+		}
+		if c == '"' {
+			i++ // skip closing `"`
+			// After the closing quote only whitespace and then `,` or end is valid.
+			for i < len(inner) && isArraySpace(inner[i]) {
+				i++
+			}
+			if i < len(inner) && inner[i] != ',' {
+				return "", i, fmt.Errorf("incorrectly quoted array element in PostgreSQL array: %q", orig)
+			}
+			return cur.String(), i, nil
+		}
+		cur.WriteByte(c)
+		i++
+	}
+	return "", i, fmt.Errorf("unterminated quoted element in PostgreSQL array: %q", orig)
+}
+
+// readUnquotedArrayElem reads an unquoted element starting at inner[i].
+// Processes backslash escapes and trims trailing whitespace (leading whitespace is
+// consumed by the caller before invoking this function).
+// Returns (element, hasEscapes, newPos, error) where newPos points at `,` or end of inner.
+func readUnquotedArrayElem(inner string, i int, orig string) (string, bool, int, error) {
+	var cur strings.Builder
+	hasEscapes := false
+	lastNonSpace := 0 // length of cur up to and including the last non-whitespace byte
+
+	for i < len(inner) {
+		c := inner[i]
+		switch c {
+		case ',':
+			return cur.String()[:lastNonSpace], hasEscapes, i, nil
+		case '{':
+			return "", false, i, fmt.Errorf("multi-dimensional arrays are not supported: %q", orig)
+		case '}':
+			return "", false, i, fmt.Errorf("unexpected '}' in PostgreSQL array: %q", orig)
+		case '"':
+			return "", false, i, fmt.Errorf("incorrectly quoted array element in PostgreSQL array: %q", orig)
+		case '\\':
+			i++
+			if i >= len(inner) {
+				return "", false, i, fmt.Errorf("unterminated escape sequence in PostgreSQL array: %q", orig)
+			}
+			cur.WriteByte(inner[i])
+			hasEscapes = true
+			lastNonSpace = cur.Len()
+			i++
+			continue
 		default:
 			cur.WriteByte(c)
+			if !isArraySpace(c) {
+				lastNonSpace = cur.Len()
+			}
 		}
 		i++
 	}
-	result = append(result, cur.String())
-	return result, nil
+	return cur.String()[:lastNonSpace], hasEscapes, i, nil
+}
+
+// isArraySpace reports whether c is whitespace per PostgreSQL's scanner_isspace:
+// space, tab, newline, carriage return, form feed, vertical tab.
+func isArraySpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
 }

--- a/go/common/sqltypes/arrays_test.go
+++ b/go/common/sqltypes/arrays_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqltypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTextArray(t *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
+		result, err := ParseTextArray("{}")
+		require.NoError(t, err)
+		assert.Equal(t, []string{}, result)
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		result, err := ParseTextArray("{foo}")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo"}, result)
+	})
+
+	t.Run("multiple elements", func(t *testing.T) {
+		result, err := ParseTextArray("{foo,bar,baz}")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz"}, result)
+	})
+
+	t.Run("quoted element with spaces", func(t *testing.T) {
+		result, err := ParseTextArray(`{"foo bar",baz}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo bar", "baz"}, result)
+	})
+
+	t.Run("quoted element with comma", func(t *testing.T) {
+		result, err := ParseTextArray(`{"foo,bar","baz"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo,bar", "baz"}, result)
+	})
+
+	t.Run("quoted element with backslash escape", func(t *testing.T) {
+		result, err := ParseTextArray(`{"foo\"bar"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`foo"bar`}, result)
+	})
+
+	t.Run("quoted element with backslash", func(t *testing.T) {
+		result, err := ParseTextArray(`{"foo\\bar"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{`foo\bar`}, result)
+	})
+
+	t.Run("pooler ID format", func(t *testing.T) {
+		result, err := ParseTextArray("{zone1_pooler-1,zone1_pooler-2,zone1_pooler-3}")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"zone1_pooler-1", "zone1_pooler-2", "zone1_pooler-3"}, result)
+	})
+
+	t.Run("not an array literal - missing braces", func(t *testing.T) {
+		_, err := ParseTextArray("foo,bar")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+
+	t.Run("not an array literal - empty string", func(t *testing.T) {
+		_, err := ParseTextArray("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+
+	t.Run("not an array literal - only open brace", func(t *testing.T) {
+		_, err := ParseTextArray("{")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+}

--- a/go/common/sqltypes/arrays_test.go
+++ b/go/common/sqltypes/arrays_test.go
@@ -101,6 +101,13 @@ func TestParseTextArray(t *testing.T) {
 		assert.Equal(t, []string{"abc"}, result)
 	})
 
+	t.Run("backslash escapes comma delimiter in unquoted element", func(t *testing.T) {
+		// {foo\,bar} is a single element "foo,bar", not two elements.
+		result, err := ParseTextArray(`{foo\,bar}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo,bar"}, result)
+	})
+
 	t.Run("backslash-escaped null is not treated as SQL NULL", func(t *testing.T) {
 		// \null has a backslash escape so it is the string "null", not SQL NULL.
 		result, err := ParseTextArray(`{n\ull}`)

--- a/go/common/sqltypes/arrays_test.go
+++ b/go/common/sqltypes/arrays_test.go
@@ -176,6 +176,12 @@ func TestParseTextArray(t *testing.T) {
 		assert.Contains(t, err.Error(), "unterminated escape sequence")
 	})
 
+	t.Run("trailing backslash in unquoted element", func(t *testing.T) {
+		_, err := ParseTextArray(`{foo\}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated escape sequence")
+	})
+
 	t.Run("unterminated quoted element", func(t *testing.T) {
 		// {"foo} has valid outer braces but the closing quote is missing.
 		_, err := ParseTextArray(`{"foo}`)

--- a/go/common/sqltypes/arrays_test.go
+++ b/go/common/sqltypes/arrays_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestParseTextArray(t *testing.T) {
+	// ── Happy path ───────────────────────────────────────────────────────────
+
 	t.Run("empty array", func(t *testing.T) {
 		result, err := ParseTextArray("{}")
 		require.NoError(t, err)
@@ -52,13 +54,13 @@ func TestParseTextArray(t *testing.T) {
 		assert.Equal(t, []string{"foo,bar", "baz"}, result)
 	})
 
-	t.Run("quoted element with backslash escape", func(t *testing.T) {
+	t.Run("quoted element with escaped double quote", func(t *testing.T) {
 		result, err := ParseTextArray(`{"foo\"bar"}`)
 		require.NoError(t, err)
 		assert.Equal(t, []string{`foo"bar`}, result)
 	})
 
-	t.Run("quoted element with backslash", func(t *testing.T) {
+	t.Run("quoted element with escaped backslash", func(t *testing.T) {
 		result, err := ParseTextArray(`{"foo\\bar"}`)
 		require.NoError(t, err)
 		assert.Equal(t, []string{`foo\bar`}, result)
@@ -69,6 +71,72 @@ func TestParseTextArray(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"zone1_pooler-1", "zone1_pooler-2", "zone1_pooler-3"}, result)
 	})
+
+	// ── Whitespace handling (PostgreSQL spec: trim around unquoted elements) ─
+
+	t.Run("whitespace around elements is trimmed", func(t *testing.T) {
+		result, err := ParseTextArray("{ foo , bar }")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, result)
+	})
+
+	t.Run("internal whitespace in unquoted element is preserved", func(t *testing.T) {
+		// PostgreSQL preserves whitespace surrounded by non-whitespace chars.
+		result, err := ParseTextArray("{0 second  ,0 second}")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"0 second", "0 second"}, result)
+	})
+
+	t.Run("whitespace inside quoted element is preserved", func(t *testing.T) {
+		result, err := ParseTextArray(`{"  0 second  ","0 second"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"  0 second  ", "0 second"}, result)
+	})
+
+	// ── Backslash escaping outside of quotes ─────────────────────────────────
+
+	t.Run("backslash escapes special char in unquoted element", func(t *testing.T) {
+		result, err := ParseTextArray(`{ab\c}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"abc"}, result)
+	})
+
+	t.Run("backslash-escaped null is not treated as SQL NULL", func(t *testing.T) {
+		// \null has a backslash escape so it is the string "null", not SQL NULL.
+		result, err := ParseTextArray(`{n\ull}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"null"}, result)
+	})
+
+	// ── NULL handling ─────────────────────────────────────────────────────────
+
+	t.Run("unquoted NULL element returns error", func(t *testing.T) {
+		_, err := ParseTextArray(`{NULL}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NULL element")
+	})
+
+	t.Run("unquoted null is case-insensitive", func(t *testing.T) {
+		_, err := ParseTextArray(`{foo,null,bar}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NULL element")
+	})
+
+	t.Run("quoted NULL string is valid", func(t *testing.T) {
+		result, err := ParseTextArray(`{"NULL"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"NULL"}, result)
+	})
+
+	// ── Unicode ───────────────────────────────────────────────────────────────
+
+	t.Run("unicode elements", func(t *testing.T) {
+		result, err := ParseTextArray(`{"ᚼᛅᛁᛚ","ᚼᛅᛁᛗᚱ"}`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ᚼᛅᛁᛚ", "ᚼᛅᛁᛗᚱ"}, result)
+	})
+
+	// ── Structural errors ─────────────────────────────────────────────────────
 
 	t.Run("not an array literal - missing braces", func(t *testing.T) {
 		_, err := ParseTextArray("foo,bar")
@@ -86,5 +154,61 @@ func TestParseTextArray(t *testing.T) {
 		_, err := ParseTextArray("{")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+
+	t.Run("missing closing brace", func(t *testing.T) {
+		_, err := ParseTextArray(`{"foo","bar"`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+
+	t.Run("trailing backslash in quoted element", func(t *testing.T) {
+		// {"foo\} has valid outer braces but a backslash at end of inner content.
+		_, err := ParseTextArray(`{"foo\}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated escape sequence")
+	})
+
+	t.Run("unterminated quoted element", func(t *testing.T) {
+		// {"foo} has valid outer braces but the closing quote is missing.
+		_, err := ParseTextArray(`{"foo}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unterminated quoted element")
+	})
+
+	t.Run("junk after quoted element", func(t *testing.T) {
+		_, err := ParseTextArray(`{"a"b}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incorrectly quoted")
+	})
+
+	t.Run("quote in middle of unquoted element", func(t *testing.T) {
+		_, err := ParseTextArray(`{a"b"}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "incorrectly quoted")
+	})
+
+	t.Run("consecutive delimiters", func(t *testing.T) {
+		_, err := ParseTextArray(`{1,,3}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected empty element")
+	})
+
+	t.Run("trailing delimiter", func(t *testing.T) {
+		_, err := ParseTextArray(`{1,}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trailing delimiter")
+	})
+
+	t.Run("stray closing brace inside element", func(t *testing.T) {
+		_, err := ParseTextArray(`{foo}bar}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected '}'")
+	})
+
+	t.Run("multi-dimensional array", func(t *testing.T) {
+		_, err := ParseTextArray(`{{a,b},{c,d}}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multi-dimensional")
 	})
 }

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1248,13 +1248,13 @@ func (x *DurabilityPolicy) GetAsyncFallback() AsyncReplicationFallbackMode {
 // cohort membership, durability policy) produces a new RuleNumber.
 //
 // Compared lexicographically: higher coordinator_term takes precedence; within
-// the same coordinator_term, higher rule_subterm takes precedence. rule_subterm
+// the same coordinator_term, higher leader_subterm takes precedence. leader_subterm
 // resets to 0 when coordinator_term increases, so subterms alone are not
 // globally unique.
 type RuleNumber struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	CoordinatorTerm int64                  `protobuf:"varint,1,opt,name=coordinator_term,json=coordinatorTerm,proto3" json:"coordinator_term,omitempty"`
-	RuleSubterm     int64                  `protobuf:"varint,2,opt,name=rule_subterm,json=ruleSubterm,proto3" json:"rule_subterm,omitempty"`
+	LeaderSubterm   int64                  `protobuf:"varint,2,opt,name=leader_subterm,json=leaderSubterm,proto3" json:"leader_subterm,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1296,9 +1296,9 @@ func (x *RuleNumber) GetCoordinatorTerm() int64 {
 	return 0
 }
 
-func (x *RuleNumber) GetRuleSubterm() int64 {
+func (x *RuleNumber) GetLeaderSubterm() int64 {
 	if x != nil {
-		return x.RuleSubterm
+		return x.LeaderSubterm
 	}
 	return 0
 }
@@ -1406,7 +1406,7 @@ func (x *ShardRule) GetCreationTime() *timestamppb.Timestamp {
 // promotion candidate.
 //
 // Comparison: prefer the node with the higher rule (coordinator_term first,
-// then rule_subterm). Break ties by LSN.
+// then leader_subterm). Break ties by LSN.
 type NodePosition struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The highest shard rule this node has committed to local WAL.
@@ -1756,11 +1756,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"quorumType\x12%\n" +
 	"\x0erequired_count\x18\x04 \x01(\x05R\rrequiredCount\x12 \n" +
 	"\vdescription\x18\x05 \x01(\tR\vdescription\x12T\n" +
-	"\x0easync_fallback\x18\x06 \x01(\x0e2-.clustermetadata.AsyncReplicationFallbackModeR\rasyncFallback\"Z\n" +
+	"\x0easync_fallback\x18\x06 \x01(\x0e2-.clustermetadata.AsyncReplicationFallbackModeR\rasyncFallback\"^\n" +
 	"\n" +
 	"RuleNumber\x12)\n" +
-	"\x10coordinator_term\x18\x01 \x01(\x03R\x0fcoordinatorTerm\x12!\n" +
-	"\frule_subterm\x18\x02 \x01(\x03R\vruleSubterm\"\x86\x03\n" +
+	"\x10coordinator_term\x18\x01 \x01(\x03R\x0fcoordinatorTerm\x12%\n" +
+	"\x0eleader_subterm\x18\x02 \x01(\x03R\rleaderSubterm\"\x86\x03\n" +
 	"\tShardRule\x12<\n" +
 	"\vrule_number\x18\x01 \x01(\v2\x1b.clustermetadata.RuleNumberR\n" +
 	"ruleNumber\x122\n" +

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -168,10 +168,10 @@ func walPositionLSN(pos *consensusdatapb.WALPosition) (pgutil.LSN, bool) {
 // 1. Highest leadership_term (primary criterion).
 //
 //	Each promotion and replication-config change writes a record to
-//	multigres.leadership_history with the current consensus term, using
+//	multigres.rule_history with the current consensus term, using
 //	RemoteOperationTimeout so synchronous standbys acknowledge the write
-//	before the primary returns. The most recent term_number in a standby's
-//	local leadership_history therefore reflects how far through the agreed
+//	before the primary returns. The most recent coordinator_term in a standby's
+//	local rule_history therefore reflects how far through the agreed
 //	consensus history that standby has replicated. A standby with a higher
 //	leadership_term has definitively applied more of the cluster's
 //	committed WAL history than one with a lower term.
@@ -181,7 +181,7 @@ func walPositionLSN(pos *consensusdatapb.WALPosition) (pgutil.LSN, bool) {
 //	transaction written just before its primary crashed), but its
 //	leadership_term will be lower, correctly excluding it.
 //
-//	Falls back to 0 when leadership_history is empty (pre-bootstrap), in
+//	Falls back to 0 when rule_history is empty (pre-bootstrap), in
 //	which case the secondary criteria (LSN) determine the winner.
 //
 // 2. Highest LSN (secondary tiebreaker).
@@ -353,22 +353,22 @@ func (c *Coordinator) recruitNodes(ctx context.Context, cohort []*multiorchdatap
 // This is accomplished by:
 //  1. Configuring standbys to replicate from the candidate (before promotion)
 //  2. Promoting the candidate to primary with synchronous replication configured.
-//  3. Writing leadership history under the new timeline. This write blocks until
+//  3. Writing rule history under the new timeline. This write blocks until
 //     acknowledged by the quorum, which proves:
 //     a) The quorum has replicated the candidate's entire timeline (up to promotion point).
-//     b) The quorum has replicated the leadership history write itself.
+//     b) The quorum has replicated the rule history write itself.
 //     c) The timeline is now durable under the new term.
 //
-// Once the leadership history write succeeds, the new leader has successfully
-// propagated its timeline and established leadership. The leadership table serves
+// Once the rule history write succeeds, the new leader has successfully
+// propagated its timeline and established leadership. The rule_history table serves
 // as the canonical source of truth for when the new term began.
 //
 // Critical ordering: Standbys MUST be configured BEFORE promotion (step 1) to avoid
-// deadlock. Promotion configures sync replication and writes leadership history, which
+// deadlock. Promotion configures sync replication and writes rule history, which
 // blocks waiting for acknowledgments. If standbys aren't replicating yet, the write
 // blocks forever.
 //
-// If we fail to write leadership history, leadership couldn't be established.
+// If we fail to write rule history, leadership couldn't be established.
 // A future coordinator will need to re-discover the most advanced timeline and re-propagate.
 func (c *Coordinator) EstablishLeadership(
 	ctx context.Context,
@@ -434,7 +434,7 @@ func (c *Coordinator) EstablishLeadership(
 	// Configure standbys to replicate from the candidate BEFORE promoting.
 	// This ensures standbys are ready to connect when sync replication is configured.
 	// Without this, the Promote call can deadlock: it configures sync replication and
-	// tries to write leadership history, but blocks waiting for standby acknowledgment.
+	// tries to write rule history, but blocks waiting for standby acknowledgment.
 	// The standbys can't acknowledge because they haven't been told to replicate yet.
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(standbys))

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -602,7 +602,7 @@ func TestSelectCandidate(t *testing.T) {
 	})
 
 	t.Run("nodes without leadership term fall back to LSN", func(t *testing.T) {
-		// If leadership_term is 0 (empty leadership_history, e.g. pre-bootstrap),
+		// If leadership_term is 0 (empty rule_history, e.g. pre-bootstrap),
 		// all nodes compare as equal on term, so LSN alone determines the winner.
 		c := &Coordinator{
 			coordinatorID: coordID,

--- a/go/services/multipooler/executor/internal_query.go
+++ b/go/services/multipooler/executor/internal_query.go
@@ -32,7 +32,7 @@ type InternalQueryService interface {
 	// QueryArgs executes a query with arguments and returns the result.
 	// This is a convenience method that accepts Go values as arguments and converts
 	// them to the appropriate text format for PostgreSQL.
-	// Supported argument types: nil, string, []byte, int, int32, int64, uint32, uint64,
+	// Supported argument types: nil, string, []byte, int, int32, int64, *int64, uint32, uint64,
 	// float32, float64, bool, and time.Time.
 	QueryArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error)
 
@@ -94,7 +94,7 @@ func (e *Executor) QueryMultiStatement(ctx context.Context, queryStr string) err
 // QueryArgs implements InternalQueryService for simple internal queries.
 // This is a convenience method that accepts Go values as arguments and converts
 // them to the appropriate text format for PostgreSQL.
-// Supported argument types: nil, string, []byte, int, int32, int64, uint32, uint64,
+// Supported argument types: nil, string, []byte, int, int32, int64, *int64, uint32, uint64,
 // float32, float64, bool, and time.Time.
 // Internal queries include SQL text in trace spans since they use system functions.
 func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {

--- a/go/services/multipooler/executor/result.go
+++ b/go/services/multipooler/executor/result.go
@@ -199,6 +199,12 @@ func scanValue(val []byte, dest any) error {
 		return fmt.Errorf("cannot parse %q as time.Time", s)
 	case *[]byte:
 		*d = val
+	case *[]string:
+		parsed, err := sqltypes.ParseTextArray(s)
+		if err != nil {
+			return err
+		}
+		*d = parsed
 	default:
 		return fmt.Errorf("unsupported destination type: %T", dest)
 	}

--- a/go/services/multipooler/executor/result_test.go
+++ b/go/services/multipooler/executor/result_test.go
@@ -603,3 +603,45 @@ func TestScanRowAllowNils(t *testing.T) {
 		assert.Equal(t, 42, i)
 	})
 }
+
+func TestScanValue_StringSlice(t *testing.T) {
+	t.Run("plain elements", func(t *testing.T) {
+		row := makeRow("{foo,bar,baz}")
+		var result []string
+		err := ScanRow(row, &result)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz"}, result)
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		row := makeRow("{}")
+		var result []string
+		err := ScanRow(row, &result)
+		require.NoError(t, err)
+		assert.Equal(t, []string{}, result)
+	})
+
+	t.Run("quoted element with spaces", func(t *testing.T) {
+		row := makeRow(`{"foo bar","baz"}`)
+		var result []string
+		err := ScanRow(row, &result)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo bar", "baz"}, result)
+	})
+
+	t.Run("invalid array literal returns error", func(t *testing.T) {
+		row := makeRow("foo,bar")
+		var result []string
+		err := ScanRow(row, &result)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a PostgreSQL array literal")
+	})
+
+	t.Run("NULL value leaves slice unchanged", func(t *testing.T) {
+		row := makeRow(nil)
+		result := []string{"existing"}
+		err := ScanRow(row, &result)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"existing"}, result) // unchanged
+	})
+}

--- a/go/services/multipooler/manager/fake_rule_store_test.go
+++ b/go/services/multipooler/manager/fake_rule_store_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// fakeRuleStore is a test double for ruleStorer that returns a preset position
+// without hitting postgres. Both observePosition and updateRule return pos
+// (or observeErr/updateErr when set). updateRule records all calls in updates.
+type fakeRuleStore struct {
+	mu         sync.Mutex
+	pos        *clustermetadatapb.NodePosition
+	observeErr error
+	updateErr  error
+	updates    []*ruleUpdateBuilder
+}
+
+func (f *fakeRuleStore) observePosition(_ context.Context) (*clustermetadatapb.NodePosition, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pos, f.observeErr
+}
+
+func (f *fakeRuleStore) updateRule(_ context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, update)
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	return f.pos, nil
+}
+
+// assertPromoteRecorded asserts that exactly one updateRule call was made with
+// eventType "promotion" and returns the update so callers can inspect its fields.
+func (f *fakeRuleStore) assertPromoteRecorded(t *testing.T) *ruleUpdateBuilder {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.Len(t, f.updates, 1, "expected exactly one updateRule call for promotion")
+	assert.Equal(t, "promotion", f.updates[0].eventType)
+	return f.updates[0]
+}

--- a/go/services/multipooler/manager/fake_rule_store_test.go
+++ b/go/services/multipooler/manager/fake_rule_store_test.go
@@ -42,6 +42,10 @@ func (f *fakeRuleStore) observePosition(_ context.Context) (*clustermetadatapb.N
 	return f.pos, f.observeErr
 }
 
+func (f *fakeRuleStore) createRuleTables(_ context.Context) error {
+	return nil
+}
+
 func (f *fakeRuleStore) updateRule(_ context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -108,6 +108,7 @@ type MultiPoolerManager struct {
 	consensusState  *ConsensusState
 	topoLoaded      bool
 	consensusLoaded bool
+	rules           ruleStorer
 	ctx             context.Context
 	cancel          context.CancelFunc
 	loadTimeout     time.Duration
@@ -259,6 +260,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
 	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.TableGroup, multiPooler.Shard, pm, drainGracePeriod)
+	pm.rules = newRuleStore(pm.logger, pm.qsc.InternalQueryService())
 
 	// The health streamer must wait for the query server to update its type before
 	// broadcasting SERVING transitions, so the gateway doesn't discover the new

--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -54,15 +54,7 @@ func (pm *MultiPoolerManager) createSidecarSchema(ctx context.Context) error {
 		return err
 	}
 
-	if err := pm.createCurrentRuleTable(ctx); err != nil {
-		return err
-	}
-
-	if err := pm.initializeCurrentRule(ctx); err != nil {
-		return err
-	}
-
-	if err := pm.createRuleHistoryTable(ctx); err != nil {
+	if err := pm.rules.createRuleTables(ctx); err != nil {
 		return err
 	}
 

--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -16,16 +16,10 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
-	"github.com/multigres/multigres/go/common/parser/ast"
-	"github.com/multigres/multigres/go/common/timeouts"
-	"github.com/multigres/multigres/go/common/topoclient"
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multipooler/executor"
 )
 
@@ -60,7 +54,15 @@ func (pm *MultiPoolerManager) createSidecarSchema(ctx context.Context) error {
 		return err
 	}
 
-	if err := pm.createLeadershipHistoryTable(ctx); err != nil {
+	if err := pm.createCurrentRuleTable(ctx); err != nil {
+		return err
+	}
+
+	if err := pm.initializeCurrentRule(ctx); err != nil {
+		return err
+	}
+
+	if err := pm.createRuleHistoryTable(ctx); err != nil {
 		return err
 	}
 
@@ -145,36 +147,6 @@ func (pm *MultiPoolerManager) createHeartbeatTable(ctx context.Context) error {
 	)`); err != nil {
 		return mterrors.Wrap(err, "failed to create heartbeat table")
 	}
-	return nil
-}
-
-// createLeadershipHistoryTable creates the leadership_history table and its indexes
-func (pm *MultiPoolerManager) createLeadershipHistoryTable(ctx context.Context) error {
-	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.leadership_history (
-		id BIGSERIAL PRIMARY KEY,
-		term_number BIGINT NOT NULL,
-		event_type TEXT NOT NULL,
-		leader_id TEXT,
-		coordinator_id TEXT,
-		wal_position TEXT,
-		accepted_members JSONB,
-		reason TEXT NOT NULL,
-		cohort_members JSONB NOT NULL,
-		operation TEXT,
-		created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-	)`); err != nil {
-		return mterrors.Wrap(err, "failed to create leadership_history table")
-	}
-
-	execCtx, cancel = context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	if err := pm.exec(execCtx, `CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event
-		ON multigres.leadership_history(term_number DESC, event_type)`); err != nil {
-		return mterrors.Wrap(err, "failed to create leadership_history index")
-	}
-
 	return nil
 }
 
@@ -275,141 +247,6 @@ func (pm *MultiPoolerManager) insertShard(ctx context.Context, tablegroupName st
 		ON CONFLICT (tablegroup_oid, shard_name) DO NOTHING`, tablegroupOid, shardName)
 	if err != nil {
 		return mterrors.Wrap(err, "failed to insert shard")
-	}
-
-	return nil
-}
-
-// LeadershipHistoryRecord represents a row in the multigres.leadership_history table.
-type LeadershipHistoryRecord struct {
-	ID              int64
-	TermNumber      int64
-	EventType       string
-	LeaderID        *string
-	CoordinatorID   *string
-	WALPosition     *string
-	Operation       *string
-	Reason          string
-	CohortMembers   []string
-	AcceptedMembers []string
-	CreatedAt       time.Time
-}
-
-// queryLeadershipHistory returns the most recent leadership history records ordered
-// by term number descending (newest first). limit controls the maximum number of
-// records returned.
-func (pm *MultiPoolerManager) queryLeadershipHistory(ctx context.Context, limit int) ([]LeadershipHistoryRecord, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	result, err := pm.queryArgs(queryCtx, `
-		SELECT id, term_number, event_type, leader_id, coordinator_id,
-		       wal_position, operation, reason, cohort_members, accepted_members, created_at
-		FROM multigres.leadership_history
-		ORDER BY term_number DESC, id DESC
-		LIMIT $1`, limit)
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to query leadership history")
-	}
-
-	records := make([]LeadershipHistoryRecord, 0, len(result.Rows))
-	for _, row := range result.Rows {
-		var rec LeadershipHistoryRecord
-		var cohortJSON string
-		var acceptedJSONPtr *string
-		if err := executor.ScanRow(row,
-			&rec.ID,
-			&rec.TermNumber,
-			&rec.EventType,
-			&rec.LeaderID,
-			&rec.CoordinatorID,
-			&rec.WALPosition,
-			&rec.Operation,
-			&rec.Reason,
-			&cohortJSON,
-			&acceptedJSONPtr,
-			&rec.CreatedAt,
-		); err != nil {
-			return nil, mterrors.Wrap(err, "failed to scan leadership history row")
-		}
-
-		if err := json.Unmarshal([]byte(cohortJSON), &rec.CohortMembers); err != nil {
-			return nil, mterrors.Wrap(err, "failed to unmarshal cohort_members")
-		}
-		if acceptedJSONPtr != nil {
-			if err := json.Unmarshal([]byte(*acceptedJSONPtr), &rec.AcceptedMembers); err != nil {
-				return nil, mterrors.Wrap(err, "failed to unmarshal accepted_members")
-			}
-		}
-
-		records = append(records, rec)
-	}
-
-	return records, nil
-}
-
-// currentLeadershipRecord returns the single most recent record in
-// multigres.leadership_history, determined by the highest term_number.
-// Returns nil if the table is empty.
-func (pm *MultiPoolerManager) currentLeadershipRecord(ctx context.Context) (*LeadershipHistoryRecord, error) {
-	records, err := pm.queryLeadershipHistory(ctx, 1)
-	if err != nil {
-		return nil, err
-	}
-	if len(records) == 0 {
-		return nil, nil
-	}
-	return &records[0], nil
-}
-
-// insertHistoryRecord inserts a record into the leadership_history table.
-// This is used for both promotion events and replication config changes.
-// This operation uses the remote-operation-timeout and will fail if it cannot complete within
-// that time. A timeout typically indicates that synchronous replication is not functioning.
-func (pm *MultiPoolerManager) insertHistoryRecord(ctx context.Context, termNumber int64, eventType string, leaderID poolerID, coordinatorID *clustermetadatapb.ID, walPosition, operation, reason string, cohortMembers, acceptedMembers []poolerID, force bool) error {
-	if force {
-		// Force mode skips history recording entirely. Force operations are emergency
-		// operations that must configure replication GUCs regardless. The INSERT would
-		// block on sync replication with unreachable standbys, consuming the parent
-		// context's deadline and causing subsequent GUC changes to fail.
-		pm.logger.InfoContext(ctx, "Skipping history record in force mode",
-			"term_number", termNumber,
-			"event_type", eventType,
-			"operation", operation)
-		return nil
-	}
-
-	cohortJSON, err := json.Marshal(poolerIDsToAppNames(cohortMembers))
-	if err != nil {
-		return mterrors.Wrap(err, "failed to marshal cohort_members")
-	}
-
-	acceptedJSON, err := json.Marshal(poolerIDsToAppNames(acceptedMembers))
-	if err != nil {
-		return mterrors.Wrap(err, "failed to marshal accepted_members")
-	}
-
-	// Use the remote operation timeout for history writes. This write validates that synchronous
-	// replication is functioning - it must wait long enough for standbys to connect and acknowledge.
-	execCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)
-	defer cancel()
-
-	insert := fmt.Sprintf(`INSERT INTO multigres.leadership_history
-	(term_number, event_type, leader_id, coordinator_id, wal_position, operation, reason, cohort_members, accepted_members)
-	VALUES (%d, %s, NULLIF(%s, ''), NULLIF(%s, ''), NULLIF(%s, ''), NULLIF(%s, ''), %s, %s::jsonb, %s::jsonb)`,
-		termNumber,
-		ast.QuoteStringLiteral(eventType),
-		ast.QuoteStringLiteral(leaderID.appName),
-		ast.QuoteStringLiteral(topoclient.ClusterIDString(coordinatorID)),
-		ast.QuoteStringLiteral(walPosition),
-		ast.QuoteStringLiteral(operation),
-		ast.QuoteStringLiteral(reason),
-		ast.QuoteStringLiteral(string(cohortJSON)),
-		ast.QuoteStringLiteral(string(acceptedJSON)),
-	)
-
-	if err := pm.exec(execCtx, insert); err != nil {
-		return mterrors.Wrap(err, "failed to insert history record")
 	}
 
 	return nil

--- a/go/services/multipooler/manager/pg_multischema_test.go
+++ b/go/services/multipooler/manager/pg_multischema_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/pubsub"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // mockPoolerController implements poolerserver.PoolerController for testing.
@@ -89,6 +88,7 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 		serviceID:       svcID,
 		servicePoolerID: svcPoolerID,
 	}
+	pm.rules = newRuleStore(logger, mockQueryService)
 
 	return pm, mockQueryService
 }
@@ -107,8 +107,9 @@ func TestCreateSidecarSchema(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("INSERT INTO multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.rule_history", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.tablegroup", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.tablegroup_table", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.shard", mock.MakeQueryResult(nil, nil))
@@ -135,27 +136,40 @@ func TestCreateSidecarSchema(t *testing.T) {
 			errorContains: "failed to create heartbeat table",
 		},
 		{
-			name:       "leadership_history table creation fails",
+			name:       "current_rule table creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.leadership_history", errors.New("table creation failed"))
+				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.current_rule", errors.New("table creation failed"))
 			},
 			expectError:   true,
-			errorContains: "failed to create leadership_history table",
+			errorContains: "failed to create current_rule table",
 		},
 		{
-			name:       "leadership_history index creation fails",
+			name:       "current_rule initialization fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event", errors.New("index creation failed"))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("INSERT INTO multigres.current_rule", errors.New("insert failed"))
 			},
 			expectError:   true,
-			errorContains: "failed to create leadership_history index",
+			errorContains: "failed to initialize current_rule",
+		},
+		{
+			name:       "rule_history table creation fails",
+			tableGroup: constants.DefaultTableGroup,
+			setupMock: func(m *mock.QueryService) {
+				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("INSERT INTO multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.rule_history", errors.New("table creation failed"))
+			},
+			expectError:   true,
+			errorContains: "failed to create rule_history table",
 		},
 		{
 			name:       "tablegroup table creation fails",
@@ -163,8 +177,9 @@ func TestCreateSidecarSchema(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE INDEX IF NOT EXISTS idx_leadership_history_term", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("INSERT INTO multigres.current_rule", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.rule_history", mock.MakeQueryResult(nil, nil))
 				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.tablegroup", errors.New("table creation failed"))
 			},
 			expectError:   true,
@@ -274,370 +289,6 @@ func TestInitializeMultischemaData(t *testing.T) {
 
 			ctx := context.Background()
 			err := pm.initializeMultischemaData(ctx)
-
-			if tt.expectError {
-				assert.Error(t, err)
-				if tt.errorContains != "" {
-					assert.Contains(t, err.Error(), tt.errorContains)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.NoError(t, mockQueryService.ExpectationsWereMet())
-		})
-	}
-}
-
-func mustPoolerID(cell, name string) poolerID {
-	pid, err := newPoolerID(&clustermetadatapb.ID{Cell: cell, Name: name})
-	if err != nil {
-		panic(err)
-	}
-	return pid
-}
-
-func TestInsertLeadershipHistory(t *testing.T) {
-	tests := []struct {
-		name            string
-		termNumber      int64
-		leaderID        poolerID
-		coordinatorID   *clustermetadatapb.ID
-		walPosition     string
-		operation       string
-		reason          string
-		cohortMembers   []poolerID
-		acceptedMembers []poolerID
-		force           bool
-		setupMock       func(m *mock.QueryService)
-		expectError     bool
-		errorContains   string
-	}{
-		{
-			name:            "successful insert",
-			termNumber:      1,
-			leaderID:        mustPoolerID("zone1", "leader-1"),
-			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-1"},
-			walPosition:     "0/1234567",
-			operation:       "promotion",
-			reason:          "Leadership changed due to manual promotion",
-			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2"), mustPoolerID("zone1", "member-3")},
-			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-			},
-			expectError: false,
-		},
-		{
-			name:            "insert fails with database error",
-			termNumber:      2,
-			leaderID:        mustPoolerID("zone1", "leader-2"),
-			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-2"},
-			walPosition:     "0/2345678",
-			operation:       "failover",
-			reason:          "Leadership changed due to failover",
-			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
-			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1")},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnceWithError("INSERT INTO multigres.leadership_history", errors.New("connection refused"))
-			},
-			expectError:   true,
-			errorContains: "failed to insert history record",
-		},
-		{
-			name:            "force mode skips insert entirely",
-			termNumber:      2,
-			leaderID:        mustPoolerID("zone1", "leader-2"),
-			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-2"},
-			walPosition:     "0/2345678",
-			operation:       "configure",
-			reason:          "Emergency replication GUC change",
-			cohortMembers:   []poolerID{mustPoolerID("zone1", "member-1"), mustPoolerID("zone1", "member-2")},
-			acceptedMembers: []poolerID{mustPoolerID("zone1", "member-1")},
-			force:           true,
-			setupMock: func(m *mock.QueryService) {
-				// No mock needed - force mode skips the insert entirely
-			},
-			expectError: false,
-		},
-		{
-			name:            "insert with empty cohort and accepted members arrays",
-			termNumber:      3,
-			leaderID:        mustPoolerID("zone1", "leader-3"),
-			coordinatorID:   &clustermetadatapb.ID{Cell: "zone1", Name: "coordinator-3"},
-			walPosition:     "0/3456789",
-			operation:       "bootstrap",
-			reason:          "Initial cluster bootstrap",
-			cohortMembers:   []poolerID{},
-			acceptedMembers: []poolerID{},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-			},
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-			tt.setupMock(mockQueryService)
-
-			err := pm.insertHistoryRecord(t.Context(), tt.termNumber, "promotion", tt.leaderID, tt.coordinatorID,
-				tt.walPosition, tt.operation, tt.reason, tt.cohortMembers, tt.acceptedMembers, tt.force)
-
-			if tt.expectError {
-				assert.Error(t, err)
-				if tt.errorContains != "" {
-					assert.Contains(t, err.Error(), tt.errorContains)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.NoError(t, mockQueryService.ExpectationsWereMet())
-		})
-	}
-}
-
-func TestQueryLeadershipHistory(t *testing.T) {
-	t.Run("returns records ordered newest first", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		leaderID := "zone1_leader-1"
-		coordID := "zone1_coordinator-1"
-		walPos := "0/1234567"
-		operation := "promotion"
-		createdAt := "2026-03-24 09:00:17.000000+00"
-
-		mockQueryService.AddQueryPatternOnce(
-			"SELECT id, term_number, event_type",
-			mock.MakeQueryResult(
-				[]string{
-					"id", "term_number", "event_type", "leader_id", "coordinator_id",
-					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
-				},
-				[][]any{
-					{
-						int64(2), int64(2), "promotion", leaderID, coordID, walPos, operation,
-						"manual failover", `["zone1_pooler-2","zone1_pooler-3"]`, `["zone1_pooler-2"]`, createdAt,
-					},
-					{
-						int64(1), int64(1), "replication_config", leaderID, coordID, nil, "configure",
-						"initial bootstrap", `["zone1_pooler-1","zone1_pooler-2"]`, nil, createdAt,
-					},
-				},
-			),
-		)
-
-		records, err := pm.queryLeadershipHistory(t.Context(), 10)
-		require.NoError(t, err)
-		require.Len(t, records, 2)
-
-		// First record: term 2 (newest)
-		assert.Equal(t, int64(2), records[0].ID)
-		assert.Equal(t, int64(2), records[0].TermNumber)
-		assert.Equal(t, "promotion", records[0].EventType)
-		require.NotNil(t, records[0].LeaderID)
-		assert.Equal(t, leaderID, *records[0].LeaderID)
-		require.NotNil(t, records[0].WALPosition)
-		assert.Equal(t, walPos, *records[0].WALPosition)
-		require.NotNil(t, records[0].Operation)
-		assert.Equal(t, operation, *records[0].Operation)
-		assert.Equal(t, "manual failover", records[0].Reason)
-		assert.Equal(t, []string{"zone1_pooler-2", "zone1_pooler-3"}, records[0].CohortMembers)
-		assert.Equal(t, []string{"zone1_pooler-2"}, records[0].AcceptedMembers)
-
-		// Second record: term 1, nullable fields are nil
-		assert.Equal(t, int64(1), records[1].TermNumber)
-		assert.Nil(t, records[1].WALPosition)
-		assert.Nil(t, records[1].AcceptedMembers)
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-
-	t.Run("returns empty slice when no records exist", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		mockQueryService.AddQueryPatternOnce(
-			"SELECT id, term_number, event_type",
-			mock.MakeQueryResult(
-				[]string{
-					"id", "term_number", "event_type", "leader_id", "coordinator_id",
-					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
-				},
-				[][]any{},
-			),
-		)
-
-		records, err := pm.queryLeadershipHistory(t.Context(), 10)
-		require.NoError(t, err)
-		assert.Empty(t, records)
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-
-	t.Run("propagates query error", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		mockQueryService.AddQueryPatternOnceWithError(
-			"SELECT id, term_number, event_type",
-			errors.New("connection refused"),
-		)
-
-		_, err := pm.queryLeadershipHistory(t.Context(), 10)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to query leadership history")
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-}
-
-func TestCurrentLeadershipRecord(t *testing.T) {
-	t.Run("returns the record with the highest term_number", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		leaderID := "zone1_leader-2"
-		coordID := "zone1_coordinator-1"
-		walPos := "0/5000000"
-		operation := "promotion"
-		createdAt := "2026-03-24 09:00:17.000000+00"
-
-		mockQueryService.AddQueryPatternOnce(
-			"SELECT id, term_number, event_type",
-			mock.MakeQueryResult(
-				[]string{
-					"id", "term_number", "event_type", "leader_id", "coordinator_id",
-					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
-				},
-				[][]any{
-					{
-						int64(5), int64(3), "promotion", leaderID, coordID, walPos, operation,
-						"failover", `["zone1_pooler-2","zone1_pooler-3"]`, `["zone1_pooler-2"]`, createdAt,
-					},
-				},
-			),
-		)
-
-		record, err := pm.currentLeadershipRecord(t.Context())
-		require.NoError(t, err)
-		require.NotNil(t, record)
-		assert.Equal(t, int64(5), record.ID)
-		assert.Equal(t, int64(3), record.TermNumber)
-		assert.Equal(t, "promotion", record.EventType)
-		require.NotNil(t, record.LeaderID)
-		assert.Equal(t, leaderID, *record.LeaderID)
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-
-	t.Run("returns nil when table is empty", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		mockQueryService.AddQueryPatternOnce(
-			"SELECT id, term_number, event_type",
-			mock.MakeQueryResult(
-				[]string{
-					"id", "term_number", "event_type", "leader_id", "coordinator_id",
-					"wal_position", "operation", "reason", "cohort_members", "accepted_members", "created_at",
-				},
-				[][]any{},
-			),
-		)
-
-		record, err := pm.currentLeadershipRecord(t.Context())
-		require.NoError(t, err)
-		assert.Nil(t, record)
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-
-	t.Run("propagates query error", func(t *testing.T) {
-		pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-		mockQueryService.AddQueryPatternOnceWithError(
-			"SELECT id, term_number, event_type",
-			errors.New("connection refused"),
-		)
-
-		_, err := pm.currentLeadershipRecord(t.Context())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to query leadership history")
-		assert.NoError(t, mockQueryService.ExpectationsWereMet())
-	})
-}
-
-func TestInsertReplicationConfigHistory(t *testing.T) {
-	tests := []struct {
-		name          string
-		termNumber    int64
-		operation     string
-		reason        string
-		standbyIDs    []*clustermetadatapb.ID
-		setupMock     func(m *mock.QueryService)
-		expectError   bool
-		errorContains string
-	}{
-		{
-			name:       "successful insert with configure operation",
-			termNumber: 1,
-			operation:  "configure",
-			reason:     "ConfigureSynchronousReplication called",
-			standbyIDs: []*clustermetadatapb.ID{
-				{Cell: "us-west", Name: "replica-1"},
-				{Cell: "us-west", Name: "replica-2"},
-			},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-			},
-			expectError: false,
-		},
-		{
-			name:       "successful insert with add operation",
-			termNumber: 2,
-			operation:  "add",
-			reason:     "UpdateSynchronousStandbyList: add",
-			standbyIDs: []*clustermetadatapb.ID{
-				{Cell: "us-west", Name: "replica-3"},
-			},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-			},
-			expectError: false,
-		},
-		{
-			name:       "insert fails with database error",
-			termNumber: 3,
-			operation:  "remove",
-			reason:     "UpdateSynchronousStandbyList: remove",
-			standbyIDs: []*clustermetadatapb.ID{
-				{Cell: "us-west", Name: "replica-1"},
-			},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnceWithError("INSERT INTO multigres.leadership_history", errors.New("timeout waiting for sync replication"))
-			},
-			expectError:   true,
-			errorContains: "failed to insert history record",
-		},
-		{
-			name:       "insert with empty standby list",
-			termNumber: 4,
-			operation:  "configure",
-			reason:     "ConfigureSynchronousReplication called",
-			standbyIDs: []*clustermetadatapb.ID{},
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-			},
-			expectError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock(constants.DefaultTableGroup, constants.DefaultShard)
-
-			tt.setupMock(mockQueryService)
-
-			ctx := context.Background()
-
-			// Convert standby IDs to pooler IDs
-			standbyPoolerIDs, err := toPoolerIDs(tt.standbyIDs)
-			require.NoError(t, err)
-
-			err = pm.insertHistoryRecord(ctx, tt.termNumber, "replication_config", pm.servicePoolerID, nil, "", tt.operation, tt.reason, standbyPoolerIDs, nil, false /* force */)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -64,32 +64,49 @@ type poolerID struct {
 // This is used consistently for:
 // - SetPrimaryConnInfo: standby's application_name when connecting to primary
 // - ConfigureSynchronousReplication: standby names in synchronous_standby_names
+//
+// On validation failure an approximate poolerID is returned alongside the error.
+// The approximate appName is "{cell}_{name}" with missing fields replaced by
+// "<unknown>". For overlong names the full (invalid) string is returned as-is.
+// Callers that require a strictly valid appName must check the error. Callers that
+// can tolerate an approximate name (e.g. for logging or informational responses)
+// may use the returned value regardless.
 func newPoolerID(id *clustermetadatapb.ID) (poolerID, error) {
 	if id == nil {
-		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "nil")
+		return poolerID{appName: "<nil>"}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "nil ID")
 	}
+
+	cell := id.Cell
+	if cell == "" {
+		cell = "<unknown>"
+	}
+	name := id.Name
+	if name == "" {
+		name = "<unknown>"
+	}
+	appName := fmt.Sprintf("%s_%s", cell, name)
+
 	if id.Cell == "" {
-		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty cell")
+		return poolerID{id: id, appName: appName}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty cell")
 	}
 	if id.Name == "" {
-		return poolerID{}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty name")
+		return poolerID{id: id, appName: appName}, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "empty name")
 	}
 	// Underscores are not allowed in Cell or Name because they are used as delimiters
 	// in the application_name format (cell_name). Allowing underscores would break parsing.
 	if strings.Contains(id.Cell, "_") {
-		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+		return poolerID{id: id, appName: appName}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"cell contains underscore: %q (underscores not allowed)", id.Cell)
 	}
 	if strings.Contains(id.Name, "_") {
-		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+		return poolerID{id: id, appName: appName}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
 			"name contains underscore: %q (underscores not allowed)", id.Name)
 	}
-	name := fmt.Sprintf("%s_%s", id.Cell, id.Name)
-	if len(name) > maxApplicationNameLength {
-		return poolerID{}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
-			"application name %q exceeds maximum length of %d characters", name, maxApplicationNameLength)
+	if len(appName) > maxApplicationNameLength {
+		return poolerID{id: id, appName: appName}, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+			"application name %q exceeds maximum length of %d characters", appName, maxApplicationNameLength)
 	}
-	return poolerID{id: id, appName: name}, nil
+	return poolerID{id: id, appName: appName}, nil
 }
 
 // poolerIDsToAppNames converts a slice of poolerID to their application name strings for use in APIs
@@ -111,17 +128,23 @@ func formatStandbyList(ids []poolerID) string {
 	return strings.Join(quoted, ", ")
 }
 
-// toPoolerIDs converts a slice of standby IDs to their poolerID representations.
+// toPoolerIDs converts a slice of IDs to their poolerID representations.
+// If any ID fails strict validation the corresponding poolerID contains an
+// approximate appName and the first error is returned alongside the full slice.
+// Callers that require strict validity must check the error. Callers that can
+// tolerate approximate names (e.g. for logging or informational responses) may
+// use the returned slice regardless.
 func toPoolerIDs(ids []*clustermetadatapb.ID) ([]poolerID, error) {
 	result := make([]poolerID, len(ids))
+	var firstErr error
 	for i, id := range ids {
 		pid, err := newPoolerID(id)
-		if err != nil {
-			return nil, mterrors.Wrapf(err, "standby_ids[%d]", i)
-		}
 		result[i] = pid
+		if err != nil && firstErr == nil {
+			firstErr = mterrors.Wrapf(err, "ids[%d]", i)
+		}
 	}
-	return result, nil
+	return result, firstErr
 }
 
 // ----------------------------------------------------------------------------
@@ -963,7 +986,11 @@ func validateStandbyIDs(standbyIDs []*clustermetadatapb.ID) ([]poolerID, error) 
 	if len(standbyIDs) == 0 {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "standby_ids cannot be empty")
 	}
-	return toPoolerIDs(standbyIDs)
+	pids, err := toPoolerIDs(standbyIDs)
+	if err != nil {
+		return pids, mterrors.Wrap(err, "invalid standby_ids")
+	}
+	return pids, nil
 }
 
 // validateSyncReplicationParams validates the parameters for ConfigureSynchronousReplication

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -51,56 +51,70 @@ func TestNewPoolerID(t *testing.T) {
 	tests := []struct {
 		name            string
 		id              *clustermetadatapb.ID
-		expectedAppName string
+		expectedAppName string // always asserted, including error cases
 		expectError     bool
 	}{
 		{
-			name: "standard ID",
-			id: &clustermetadatapb.ID{
-				Cell: "us-west",
-				Name: "replica-1",
-			},
+			name:            "standard ID",
+			id:              &clustermetadatapb.ID{Cell: "us-west", Name: "replica-1"},
 			expectedAppName: "us-west_replica-1",
 		},
 		{
-			name: "single character values",
-			id: &clustermetadatapb.ID{
-				Cell: "a",
-				Name: "b",
-			},
+			name:            "single character values",
+			id:              &clustermetadatapb.ID{Cell: "a", Name: "b"},
 			expectedAppName: "a_b",
 		},
 		{
-			name: "hyphenated names",
-			id: &clustermetadatapb.ID{
-				Cell: "us-east-1a",
-				Name: "primary-db-001",
-			},
+			name:            "hyphenated names",
+			id:              &clustermetadatapb.ID{Cell: "us-east-1a", Name: "primary-db-001"},
 			expectedAppName: "us-east-1a_primary-db-001",
 		},
 		{
-			name: "numeric values",
-			id: &clustermetadatapb.ID{
-				Cell: "zone1",
-				Name: "pooler-001",
-			},
+			name:            "numeric values",
+			id:              &clustermetadatapb.ID{Cell: "zone1", Name: "pooler-001"},
 			expectedAppName: "zone1_pooler-001",
 		},
 		{
-			name: "exactly 63 characters",
-			id: &clustermetadatapb.ID{
-				Cell: "us-east-1a",
-				Name: strings.Repeat("x", 52), // "us-east-1a_" (11) + 52 = 63
-			},
+			name:            "exactly 63 characters",
+			id:              &clustermetadatapb.ID{Cell: "us-east-1a", Name: strings.Repeat("x", 52)}, // 11+52=63
 			expectedAppName: "us-east-1a_" + strings.Repeat("x", 52),
 		},
+		// Error cases: approximate appName returned alongside the error.
 		{
-			name: "exceeds 63 characters",
-			id: &clustermetadatapb.ID{
-				Cell: "us-east-1a",
-				Name: strings.Repeat("x", 53), // "us-east-1a_" (11) + 53 = 64
-			},
-			expectError: true,
+			name:            "nil ID",
+			id:              nil,
+			expectError:     true,
+			expectedAppName: "<nil>",
+		},
+		{
+			name:            "empty cell",
+			id:              &clustermetadatapb.ID{Name: "replica-1"},
+			expectError:     true,
+			expectedAppName: "<unknown>_replica-1",
+		},
+		{
+			name:            "empty name",
+			id:              &clustermetadatapb.ID{Cell: "zone1"},
+			expectError:     true,
+			expectedAppName: "zone1_<unknown>",
+		},
+		{
+			name:            "cell contains underscore",
+			id:              &clustermetadatapb.ID{Cell: "us_west", Name: "replica-1"},
+			expectError:     true,
+			expectedAppName: "us_west_replica-1",
+		},
+		{
+			name:            "name contains underscore",
+			id:              &clustermetadatapb.ID{Cell: "zone1", Name: "replica_1"},
+			expectError:     true,
+			expectedAppName: "zone1_replica_1",
+		},
+		{
+			name:            "exceeds 63 characters",
+			id:              &clustermetadatapb.ID{Cell: "us-east-1a", Name: strings.Repeat("x", 53)}, // 11+53=64
+			expectError:     true,
+			expectedAppName: "us-east-1a_" + strings.Repeat("x", 53), // full string returned, not truncated
 		},
 	}
 
@@ -112,11 +126,60 @@ func TestNewPoolerID(t *testing.T) {
 				assert.Equal(t, mtrpcpb.Code_INVALID_ARGUMENT, mterrors.Code(err))
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.expectedAppName, result.appName)
 				assert.Equal(t, tt.id, result.id)
 			}
+			assert.Equal(t, tt.expectedAppName, result.appName)
 		})
 	}
+}
+
+func TestToPoolerIDs(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		ids := []*clustermetadatapb.ID{
+			{Cell: "zone1", Name: "replica-1"},
+			{Cell: "zone2", Name: "replica-2"},
+		}
+		result, err := toPoolerIDs(ids)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		assert.Equal(t, "zone1_replica-1", result[0].appName)
+		assert.Equal(t, "zone2_replica-2", result[1].appName)
+	})
+
+	t.Run("nil slice", func(t *testing.T) {
+		result, err := toPoolerIDs(nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("invalid entry returns approximate value and error", func(t *testing.T) {
+		ids := []*clustermetadatapb.ID{
+			{Cell: "zone1", Name: "replica-1"},
+			nil,
+		}
+		result, err := toPoolerIDs(ids)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ids[1]")
+		// Full slice returned despite the error.
+		require.Len(t, result, 2)
+		assert.Equal(t, "zone1_replica-1", result[0].appName)
+		assert.Equal(t, "<nil>", result[1].appName)
+	})
+
+	t.Run("first error is reported when multiple entries are invalid", func(t *testing.T) {
+		ids := []*clustermetadatapb.ID{
+			nil,
+			{Cell: "zone1", Name: "replica-1"},
+			nil,
+		}
+		result, err := toPoolerIDs(ids)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ids[0]") // first error, not ids[2]
+		require.Len(t, result, 3)
+		assert.Equal(t, "<nil>", result[0].appName)
+		assert.Equal(t, "zone1_replica-1", result[1].appName)
+		assert.Equal(t, "<nil>", result[2].appName)
+	})
 }
 
 func TestFormatStandbyList(t *testing.T) {
@@ -272,7 +335,7 @@ func TestValidateStandbyIDs(t *testing.T) {
 				nil,
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[1]: nil",
+			errorMsg:    "ids[1]: nil ID",
 		},
 		{
 			name: "empty cell returns error",
@@ -280,7 +343,7 @@ func TestValidateStandbyIDs(t *testing.T) {
 				{Cell: "", Name: "replica-1"},
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[0]: empty cell",
+			errorMsg:    "ids[0]: empty cell",
 		},
 		{
 			name: "empty name returns error",
@@ -288,7 +351,7 @@ func TestValidateStandbyIDs(t *testing.T) {
 				{Cell: "zone1", Name: ""},
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[0]: empty name",
+			errorMsg:    "ids[0]: empty name",
 		},
 		{
 			name: "underscore in cell returns error",
@@ -329,7 +392,7 @@ func TestValidateStandbyIDs(t *testing.T) {
 				{Cell: "zone2", Name: "replica_2"},
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[1]: name contains underscore",
+			errorMsg:    "ids[1]: name contains underscore",
 		},
 		{
 			name: "exceeds 63 character limit",
@@ -337,7 +400,7 @@ func TestValidateStandbyIDs(t *testing.T) {
 				{Cell: "us-east-1a", Name: strings.Repeat("x", 53)}, // "us-east-1a_" (11) + 53 = 64
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[0]: application name",
+			errorMsg:    "ids[0]: application name",
 		},
 	}
 
@@ -1182,7 +1245,7 @@ func TestValidateSyncReplicationParams(t *testing.T) {
 				nil,
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[1]: nil",
+			errorMsg:    "ids[1]: nil ID",
 		},
 		{
 			name:    "Invalid empty cell",
@@ -1195,7 +1258,7 @@ func TestValidateSyncReplicationParams(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[0]: empty cell",
+			errorMsg:    "ids[0]: empty cell",
 		},
 		{
 			name:    "Invalid empty name",
@@ -1208,7 +1271,7 @@ func TestValidateSyncReplicationParams(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorMsg:    "standby_ids[0]: empty name",
+			errorMsg:    "ids[0]: empty name",
 		},
 	}
 

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -242,14 +242,19 @@ func (pm *MultiPoolerManager) executeRevoke(ctx context.Context, term int64, res
 	// the primary criterion: a node that has seen a higher term has applied more
 	// of the agreed WAL history (the history write uses RemoteOperationTimeout,
 	// so sync standbys are guaranteed to have acknowledged it).
-	if rec, err := pm.currentLeadershipRecord(ctx); err != nil {
-		pm.logger.WarnContext(ctx, "Failed to get leadership term during revoke; candidate selection may be suboptimal",
+	if nodePosition, err := pm.rules.observePosition(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "Failed to get rule history during revoke; candidate selection may be suboptimal",
 			"term", term, "error", err)
-	} else if rec != nil {
-		response.WalPosition.LeadershipTerm = rec.TermNumber
-		response.WalPosition.CohortMembers = rec.CohortMembers
-		pm.logger.InfoContext(ctx, "Captured leadership term for candidate selection",
-			"term", term, "leadership_term", rec.TermNumber)
+	} else if nodePosition != nil {
+		response.WalPosition.LeadershipTerm = nodePosition.GetRule().GetRuleNumber().GetCoordinatorTerm()
+		pids, pidErr := toPoolerIDs(nodePosition.GetRule().GetCohortMembers())
+		if pidErr != nil {
+			pm.logger.WarnContext(ctx, "Some cohort member IDs have invalid format; using approximate names for candidate selection",
+				"term", term, "error", pidErr)
+		}
+		response.WalPosition.CohortMembers = poolerIDsToAppNames(pids)
+		pm.logger.InfoContext(ctx, "Captured coordinator term for candidate selection",
+			"term", term, "coordinator_term", nodePosition.GetRule().GetRuleNumber().GetCoordinatorTerm())
 	}
 
 	return nil

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -69,7 +69,7 @@ func expectStandbyRevokeMocks(m *mock.QueryService, lsn string) {
 	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
 }
 
-func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService) (*MultiPoolerManager, string) {
+func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, rules ruleStorer) (*MultiPoolerManager, string) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
@@ -109,8 +109,10 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService) (
 	require.NoError(t, err)
 	t.Cleanup(func() { pm.Shutdown() })
 
-	// Assign mock pooler controller BEFORE starting the manager to avoid race conditions
+	// Assign mock pooler controller and rule store BEFORE starting the manager
+	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = rules
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	pm.Start(senv)
@@ -488,7 +490,7 @@ func TestBeginTerm(t *testing.T) {
 
 			tt.setupMocks(mockQueryService)
 
-			pm, _ := setupManagerWithMockDB(t, mockQueryService)
+			pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{})
 
 			// Initialize term on disk
 			err := pm.consensusState.setConsensusTerm(tt.initialTerm)
@@ -545,7 +547,7 @@ func TestBeginTerm(t *testing.T) {
 
 			tt.setupMocks(mockQueryService)
 
-			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService)
+			pm, tmpDir := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{})
 
 			// Initialize term on disk
 			err := pm.consensusState.setConsensusTerm(tt.initialTerm)
@@ -884,7 +886,7 @@ func TestCanReachPrimary(t *testing.T) {
 
 			tt.setupMock(mockQueryService)
 
-			pm, _ := setupManagerWithMockDB(t, mockQueryService)
+			pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{})
 
 			// Handle nil qsc case
 			if tt.nilQsc {
@@ -1023,7 +1025,7 @@ func TestConsensusStatus(t *testing.T) {
 			mockQueryService := mock.NewQueryService()
 			tt.setupMock(mockQueryService)
 
-			pm, _ := setupManagerWithMockDB(t, mockQueryService)
+			pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{})
 
 			// Initialize term on disk
 			err := pm.consensusState.setConsensusTerm(tt.initialTerm)

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -162,31 +162,27 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 		PrimaryTerm: req.ConsensusTerm,
 	})
 
-	// Get final LSN position for leadership history
+	// Get final LSN position for rule history
 	finalLSN, err := pm.getPrimaryLSN(ctx)
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to get final LSN", "error", err)
 		return nil, err
 	}
 
-	// Write leadership history record for bootstrap
-	reason := "ShardNeedsBootstrap"
-	cohortMembers := []poolerID{leaderID} // Only the initial primary during bootstrap
-	acceptedMembers := []poolerID{leaderID}
-
-	if err := pm.insertHistoryRecord(ctx,
+	// Write rule history record for bootstrap
+	if _, err := pm.rules.updateRule(ctx, newRuleUpdate(
 		req.ConsensusTerm,
-		"promotion",
-		leaderID,
 		req.CoordinatorId,
-		finalLSN,
-		"bootstrap", // operation
-		reason,
-		cohortMembers,
-		acceptedMembers,
-		false /* force */); err != nil {
+		"promotion",
+		"ShardNeedsBootstrap",
+		time.Now()).
+		withLeader(leaderID.id).
+		withCohort([]*clustermetadatapb.ID{leaderID.id}).
+		withAcceptedMembers([]*clustermetadatapb.ID{leaderID.id}).
+		withOperation("bootstrap").
+		withWALPosition(finalLSN)); err != nil {
 		// Log but don't fail - history is for audit, not correctness
-		pm.logger.WarnContext(ctx, "Failed to insert leadership history",
+		pm.logger.WarnContext(ctx, "Failed to write rule history",
 			"term", req.ConsensusTerm,
 			"error", err)
 	}

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -412,15 +412,18 @@ func (pm *MultiPoolerManager) configureSynchronousReplicationLocked(ctx context.
 	if err != nil {
 		return mterrors.Wrap(err, "failed to get consensus term")
 	}
-	if err := pm.insertHistoryRecord(ctx,
-		term.GetPrimaryTerm(),
+	update := newRuleUpdate(
+		term.GetTermNumber(),
+		pm.serviceID,
 		"replication_config",
-		pm.servicePoolerID, nil, "", // leaderID, coordinatorID, walPosition
-		"configure",
 		"ConfigureSynchronousReplication called",
-		standbyNames,
-		nil, // acceptedMembers
-		force); err != nil {
+		time.Now()).
+		withCohort(standbyIDs).
+		withOperation("configure")
+	if force {
+		update.withForce()
+	}
+	if _, err := pm.rules.updateRule(ctx, update); err != nil {
 		return mterrors.Wrap(err, "failed to record replication config history")
 	}
 
@@ -562,17 +565,27 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 	// before this primary can accept ACKs from it.
 	// This is for safe replica joining of the cluster.
 	// It will ensure multiorch can discover the new cohort during a failure.
-	if err := pm.insertHistoryRecord(ctx,
+	coordID := coordinatorID
+	if coordID == nil {
+		coordID = pm.serviceID
+	}
+	updatedStandbyIDs := make([]*clustermetadatapb.ID, len(updatedStandbys))
+	for i, p := range updatedStandbys {
+		updatedStandbyIDs[i] = p.id
+	}
+	standbyUpdate := newRuleUpdate(
 		consensusTerm,
+		coordID,
 		"replication_config",
-		leaderID,
-		coordinatorID,
-		"", // walPosition (not applicable for replication config changes)
-		operationName,
 		"UpdateSynchronousStandbyList: "+operationName,
-		updatedStandbys, // This is what we care in this update
-		nil,             // acceptedMembers
-		force); err != nil {
+		time.Now()).
+		withLeader(leaderID.id).
+		withCohort(updatedStandbyIDs).
+		withOperation(operationName)
+	if force {
+		standbyUpdate.withForce()
+	}
+	if _, err := pm.rules.updateRule(ctx, standbyUpdate); err != nil {
 		return mterrors.Wrap(err, "failed to record replication config history")
 	}
 
@@ -1180,19 +1193,8 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 		return nil, err
 	}
 
-	// Pre-compute names before acquiring the lock, so we fail fast on bad arguments.
-	leaderID := pm.servicePoolerID
-	cohortMembers, err := toPoolerIDs(cohortMemberIDs)
-	if err != nil {
-		return nil, err
-	}
-	acceptedMembers, err := toPoolerIDs(acceptedMemberIDs)
-	if err != nil {
-		return nil, err
-	}
-
 	// Acquire the action lock to ensure only one mutation runs at a time
-	ctx, err = pm.actionLock.Acquire(ctx, "Promote")
+	ctx, err := pm.actionLock.Acquire(ctx, "Promote")
 	if err != nil {
 		return nil, err
 	}
@@ -1201,7 +1203,7 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 	// Validation & Readiness
 
 	// Validate term - strict equality, no automatic updates
-	if err = pm.validateTermExactMatch(ctx, consensusTerm, force); err != nil {
+	if err := pm.validateTermExactMatch(ctx, consensusTerm, force); err != nil {
 		return nil, err
 	}
 
@@ -1288,27 +1290,34 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 		PrimaryTerm: consensusTerm,
 	})
 
-	// Write leadership history record - this validates that sync replication is working.
+	// Write rule history record - this validates that sync replication is working.
 	// If this fails (typically due to timeout waiting for standby acknowledgment), we fail
 	// the promotion. It's better to have no primary than one that can't satisfy durability.
 	if reason == "" {
 		reason = "unknown"
 	}
-	if err := pm.insertHistoryRecord(ctx,
+	promoteCoordID := coordinatorID
+	if promoteCoordID == nil {
+		promoteCoordID = pm.serviceID
+	}
+	promoteUpdate := newRuleUpdate(
 		consensusTerm,
+		promoteCoordID,
 		"promotion",
-		leaderID,
-		coordinatorID,
-		finalLSN,
-		"", // operation
 		reason,
-		cohortMembers,
-		acceptedMembers,
-		force); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to insert leadership history - promotion failed",
+		time.Now()).
+		withLeader(pm.serviceID).
+		withCohort(cohortMemberIDs).
+		withAcceptedMembers(acceptedMemberIDs).
+		withWALPosition(finalLSN)
+	if force {
+		promoteUpdate.withForce()
+	}
+	if _, err = pm.rules.updateRule(ctx, promoteUpdate); err != nil {
+		pm.logger.ErrorContext(ctx, "Failed to write rule history - promotion failed",
 			"term", consensusTerm,
 			"error", err)
-		return nil, mterrors.Wrap(err, "promotion failed: could not write leadership history (sync replication may not be functioning)")
+		return nil, mterrors.Wrap(err, "promotion failed: could not write rule history (sync replication may not be functioning)")
 	}
 
 	// Update topology and notify all components (best-effort, don't fail promotion)

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	"github.com/multigres/multigres/go/services/multipooler/executor/mock"
 	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/prototest"
 	"github.com/multigres/multigres/go/tools/viperutil"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -359,12 +360,6 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	}
 }
 
-// expectLeadershipHistoryInsert adds a mock expectation for successful leadership history insertion.
-// This is required for Promote to succeed since leadership history insertion failure now fails the promotion.
-func expectLeadershipHistoryInsert(m *mock.QueryService) {
-	m.AddQueryPatternOnce("INSERT INTO multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-}
-
 // createPgDataDir creates the pg_data directory with PG_VERSION file.
 // This is needed for setInitialized() to work since it writes a marker file to pg_data.
 func createPgDataDir(t *testing.T, poolerDir string) {
@@ -376,7 +371,7 @@ func createPgDataDir(t *testing.T, poolerDir string) {
 }
 
 // setupPromoteTestManager creates a manager configured as a REPLICA for promotion tests.
-func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService) (*MultiPoolerManager, string) {
+func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService, rules ruleStorer) (*MultiPoolerManager, string) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
@@ -431,8 +426,10 @@ func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService) 
 	err = pm.setInitialized()
 	require.NoError(t, err)
 
-	// Assign mock pooler controller BEFORE starting the manager to avoid race conditions
+	// Assign mock pooler controller and rule store BEFORE starting the manager
+	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = rules
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	go pm.Start(senv)
@@ -481,10 +478,8 @@ func TestPromoteIdempotency_PostgreSQLPromotedButTopologyNotUpdated(t *testing.T
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/ABCDEF0"}}))
 
-	// Mock: insertLeadershipHistory - required for promotion success
-	expectLeadershipHistoryInsert(mockQueryService)
-
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	fakeRules := &fakeRuleStore{}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	// Topology is still REPLICA (this is what the guard rail checks)
 	pm.mu.Lock()
@@ -504,6 +499,7 @@ func TestPromoteIdempotency_PostgreSQLPromotedButTopologyNotUpdated(t *testing.T
 	pm.mu.Lock()
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.multipooler.Type, "Topology should be updated to PRIMARY")
 	pm.mu.Unlock()
+	fakeRules.assertPromoteRecorded(t)
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
@@ -528,7 +524,7 @@ func TestPromoteIdempotency_FullyCompleteTopologyPrimary(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/FEDCBA0"}}))
 
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	pm, _ := setupPromoteTestManager(t, mockQueryService, &fakeRuleStore{})
 
 	// Topology is already PRIMARY
 	pm.mu.Lock()
@@ -562,7 +558,7 @@ func TestPromoteIdempotency_InconsistentStateTopologyPrimaryPgNotPrimary(t *test
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	pm, _ := setupPromoteTestManager(t, mockQueryService, &fakeRuleStore{})
 
 	// Topology shows PRIMARY (inconsistent!)
 	pm.mu.Lock()
@@ -616,7 +612,7 @@ func TestPromoteIdempotency_InconsistentStateFixedWithForce(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/FEDCBA0"}}))
 
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	pm, _ := setupPromoteTestManager(t, mockQueryService, &fakeRuleStore{})
 
 	// Topology shows PRIMARY (inconsistent!)
 	pm.mu.Lock()
@@ -674,10 +670,8 @@ func TestPromoteIdempotency_NothingCompleteYet(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/5678ABC"}}))
 
-	// Mock: insertLeadershipHistory - required for promotion success
-	expectLeadershipHistoryInsert(mockQueryService)
-
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	fakeRules := &fakeRuleStore{}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	// Topology is REPLICA
 	pm.mu.Lock()
@@ -696,6 +690,7 @@ func TestPromoteIdempotency_NothingCompleteYet(t *testing.T) {
 	pm.mu.Lock()
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.multipooler.Type)
 	pm.mu.Unlock()
+	fakeRules.assertPromoteRecorded(t)
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
@@ -714,7 +709,7 @@ func TestPromoteIdempotency_LSNMismatchBeforePromotion(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_last_wal_replay_lsn",
 		mock.MakeQueryResult([]string{"pg_last_wal_replay_lsn", "pg_is_wal_replay_paused"}, [][]any{{"0/9999999", "t"}}))
 
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	pm, _ := setupPromoteTestManager(t, mockQueryService, &fakeRuleStore{})
 
 	pm.mu.Lock()
 	pm.multipooler.Type = clustermetadatapb.PoolerType_REPLICA
@@ -734,7 +729,7 @@ func TestPromoteIdempotency_TermMismatch(t *testing.T) {
 	// Create mock - only startup expectations needed because term validation happens before test DB queries
 	mockQueryService := mock.NewQueryService()
 
-	pm, tmpDir := setupPromoteTestManager(t, mockQueryService)
+	pm, tmpDir := setupPromoteTestManager(t, mockQueryService, &fakeRuleStore{})
 
 	// Explicitly set the term to 10 to ensure we have the expected value via direct file write
 	term := &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10}
@@ -787,11 +782,8 @@ func TestPromoteIdempotency_SecondCallSucceedsAfterCompletion(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/AAA1111"}}))
 
-	// Mock: insertLeadershipHistory - required for first promotion call success
-	// Note: second call returns early (WasAlreadyPrimary) so doesn't need this
-	expectLeadershipHistoryInsert(mockQueryService)
-
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	fakeRules := &fakeRuleStore{}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	pm.mu.Lock()
 	pm.multipooler.Type = clustermetadatapb.PoolerType_REPLICA
@@ -806,6 +798,7 @@ func TestPromoteIdempotency_SecondCallSucceedsAfterCompletion(t *testing.T) {
 	pm.mu.Lock()
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.multipooler.Type)
 	pm.mu.Unlock()
+	fakeRules.assertPromoteRecorded(t)
 
 	// Second call should SUCCEED - topology is PRIMARY and everything is consistent (idempotent)
 	// The pg_is_in_recovery pattern already returns "f" (false) since the first call consumed the "t" patterns
@@ -846,10 +839,8 @@ func TestPromoteIdempotency_EmptyExpectedLSNSkipsValidation(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/BBBBBBB"}}))
 
-	// Mock: insertLeadershipHistory - required for promotion success
-	expectLeadershipHistoryInsert(mockQueryService)
-
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	fakeRules := &fakeRuleStore{}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	pm.mu.Lock()
 	pm.multipooler.Type = clustermetadatapb.PoolerType_REPLICA
@@ -862,6 +853,7 @@ func TestPromoteIdempotency_EmptyExpectedLSNSkipsValidation(t *testing.T) {
 
 	assert.False(t, resp.WasAlreadyPrimary)
 	assert.Equal(t, "0/BBBBBBB", resp.LsnPosition)
+	fakeRules.assertPromoteRecorded(t)
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
@@ -891,16 +883,14 @@ func TestPromote_WithElectionMetadata(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/1234567"}}))
 
-	// Mock: insertLeadershipHistory - required for promotion success
-	expectLeadershipHistoryInsert(mockQueryService)
-
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
 	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
 		mock.MakeQueryResult(nil, nil))
 
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	fakeRules := &fakeRuleStore{}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	// Topology is REPLICA
 	pm.mu.Lock()
@@ -932,18 +922,19 @@ func TestPromote_WithElectionMetadata(t *testing.T) {
 	pm.mu.Lock()
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, pm.multipooler.Type)
 	pm.mu.Unlock()
-	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 
-	// Note: We don't directly test that insertLeadershipHistory is called with the correct metadata
-	// because that would require mocking the database layer. The leadership history functionality
-	// will be tested by the actual implementation. This test verifies that the Promote method
-	// accepts the new parameters without error and completes successfully.
+	update := fakeRules.assertPromoteRecorded(t)
+	assert.Equal(t, "dead_primary", update.reason)
+	prototest.AssertEqual(t, coordinatorID, update.coordinatorID)
+	prototest.RequireElementsMatch(t, cohortMembers, update.cohortMembers)
+	prototest.RequireElementsMatch(t, acceptedMembers, update.acceptedMembers)
+	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
-// TestPromote_LeadershipHistoryErrorFailsPromotion tests that an error in insertLeadershipHistory
+// TestPromote_RuleHistoryErrorFailsPromotion tests that an error in updateRule
 // fails the entire Promote operation. This ensures sync replication is functioning before
 // accepting the promotion - better to have no primary than one that violates durability policy.
-func TestPromote_LeadershipHistoryErrorFailsPromotion(t *testing.T) {
+func TestPromote_RuleHistoryErrorFailsPromotion(t *testing.T) {
 	ctx := context.Background()
 
 	// Create mock and set ALL expectations BEFORE starting the manager
@@ -968,17 +959,15 @@ func TestPromote_LeadershipHistoryErrorFailsPromotion(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/9876543"}}))
 
-	// Mock: Clear primary_conninfo after promotion (executed before insertLeadershipHistory)
+	// Mock: Clear primary_conninfo after promotion (executed before updateRule)
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
 	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
 		mock.MakeQueryResult(nil, nil))
 
-	// Mock: insertLeadershipHistory fails with database error (e.g., sync replication timeout)
-	mockQueryService.AddQueryPatternOnceWithError("INSERT INTO multigres.leadership_history",
-		mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for synchronous replication"))
-
-	pm, _ := setupPromoteTestManager(t, mockQueryService)
+	// updateRule fails (e.g., sync replication timeout)
+	fakeRules := &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for synchronous replication")}
+	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
 
 	// Topology is REPLICA
 	pm.mu.Lock()
@@ -990,13 +979,13 @@ func TestPromote_LeadershipHistoryErrorFailsPromotion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), term.GetPrimaryTerm(), "primary_term should be 0 before promotion")
 
-	// Call Promote - should FAIL because leadership history insertion fails
+	// Call Promote - should FAIL because rule history write fails
 	resp, err := pm.Promote(ctx, 10, "0/9876543", nil, false /* force */, "test_reason", nil, nil, nil)
-	require.Error(t, err, "Promote should fail when leadership history insertion fails")
+	require.Error(t, err, "Promote should fail when rule history write fails")
 	require.Nil(t, resp)
 
-	// Error message should indicate the leadership history failure
-	assert.Contains(t, err.Error(), "leadership history")
+	// Error message should indicate the rule history failure
+	assert.Contains(t, err.Error(), "rule history")
 
 	// CRITICAL: Verify that primary_term WAS set even though promotion failed.
 	// This is intentional - we set primary_term (local state) before writing to history table
@@ -1010,7 +999,6 @@ func TestPromote_LeadershipHistoryErrorFailsPromotion(t *testing.T) {
 
 	// Note: PostgreSQL was promoted but we return error to indicate the promotion is incomplete.
 	// The coordinator should handle this partial promotion state (e.g., retry or repair).
-	// The mock expectations should still be met (all queries were executed).
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
@@ -1045,9 +1033,6 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	// Get final LSN
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/ABCDEF0"}}))
-
-	// insertLeadershipHistory
-	expectLeadershipHistoryInsert(mockQueryService)
 
 	// Inline setup (like setupPromoteTestManager but capturing factory)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -1096,7 +1081,9 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	err = pm.setInitialized()
 	require.NoError(t, err)
 
+	fakeRules := &fakeRuleStore{}
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = fakeRules
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	go pm.Start(senv)
@@ -1138,6 +1125,7 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	assert.Equal(t, serviceID, healthState.PrimaryObservation.PrimaryID, "primary observation should point to self")
 	assert.Equal(t, int64(10), healthState.PrimaryObservation.PrimaryTerm, "primary observation term should match consensus term")
 
+	fakeRules.assertPromoteRecorded(t)
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
@@ -2150,9 +2138,9 @@ func TestSetMonitorRPCDisable(t *testing.T) {
 }
 
 func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *testing.T) {
-	// This test verifies that if insertReplicationConfigHistory fails,
+	// This test verifies that if updateRule fails,
 	// the synchronous_commit and synchronous_standby_names GUCs are NOT updated.
-	// This ensures, that we only update the GUC, if the insert succeeds
+	// This ensures that we only update GUCs if the rule update succeeds.
 
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -2215,6 +2203,7 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication")}
 
 	// Mark as initialized
 	err = manager.setInitialized()
@@ -2226,12 +2215,6 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 	require.Eventually(t, func() bool {
 		return manager.GetState() == ManagerStateReady
 	}, 5*time.Second, 100*time.Millisecond)
-
-	// CRITICAL: Mock the INSERT INTO leadership_history to FAIL
-	// This should prevent any subsequent GUC updates from happening
-	mockQueryService.AddQueryPatternOnceWithError(
-		"INSERT INTO multigres.leadership_history",
-		mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication"))
 
 	// We do NOT add expectations for ALTER SYSTEM SET queries
 	// If they get called, ExpectationsWereMet() will fail
@@ -2263,7 +2246,7 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 }
 
 func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing.T) {
-	// This test verifies that if insertReplicationConfigHistory fails during
+	// This test verifies that if updateRule fails during
 	// UpdateSynchronousStandbyList, the synchronous_standby_names GUC is NOT updated.
 
 	ctx := context.Background()
@@ -2327,6 +2310,7 @@ func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication")}
 
 	err = manager.setInitialized()
 	require.NoError(t, err)
@@ -2343,11 +2327,6 @@ func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing
 		mock.MakeQueryResult([]string{"synchronous_standby_names"}, [][]any{{"FIRST 1 (zone1_replica-1, zone1_replica-2)"}}))
 	mockQueryService.AddQueryPattern("SHOW synchronous_commit",
 		mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"remote_write"}}))
-
-	// CRITICAL: Mock the INSERT INTO leadership_history to FAIL
-	mockQueryService.AddQueryPatternOnceWithError(
-		"INSERT INTO multigres.leadership_history",
-		mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication"))
 
 	// We do NOT add expectations for ALTER SYSTEM SET synchronous_standby_names
 	// If it gets called, ExpectationsWereMet() will fail

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -66,7 +66,7 @@ func newRuleStore(
 // ruleNumber identifies a specific rule version by coordinator term and subterm.
 type ruleNumber struct {
 	coordinatorTerm int64
-	ruleSubterm     int64
+	leaderSubterm   int64
 }
 
 // ruleUpdateBuilder constructs the parameters for updateRule.
@@ -135,8 +135,8 @@ func (b *ruleUpdateBuilder) withForce() *ruleUpdateBuilder {
 
 // withPreviousRule adds a compare-and-swap check: the update only proceeds if the
 // current rule matches the given coordinator term and subterm.
-func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, ruleSubterm int64) *ruleUpdateBuilder {
-	b.previousRule = &ruleNumber{coordinatorTerm: coordinatorTerm, ruleSubterm: ruleSubterm}
+func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, leaderSubterm int64) *ruleUpdateBuilder {
+	b.previousRule = &ruleNumber{coordinatorTerm: coordinatorTerm, leaderSubterm: leaderSubterm}
 	return b
 }
 
@@ -160,7 +160,7 @@ func (rs *ruleStore) createRuleTables(ctx context.Context) error {
 	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE IF NOT EXISTS multigres.current_rule (
 		shard_id                  BYTEA PRIMARY KEY,
 		coordinator_term          BIGINT NOT NULL,
-		rule_subterm              BIGINT NOT NULL,
+		leader_subterm            BIGINT NOT NULL,
 		leader_id                 TEXT,
 		coordinator_id            TEXT,
 		cohort_members            TEXT[] NOT NULL,
@@ -175,7 +175,7 @@ func (rs *ruleStore) createRuleTables(ctx context.Context) error {
 
 	if _, err := rs.queryService.QueryArgs(execCtx, `
 		INSERT INTO multigres.current_rule
-		  (shard_id, coordinator_term, rule_subterm, cohort_members, created_at)
+		  (shard_id, coordinator_term, leader_subterm, cohort_members, created_at)
 		VALUES ($1, 0, 0, '{}', now())
 		ON CONFLICT (shard_id) DO NOTHING`,
 		[]byte("0")); err != nil {
@@ -183,11 +183,11 @@ func (rs *ruleStore) createRuleTables(ctx context.Context) error {
 	}
 
 	// Each row records a cluster state change (promotion, cohort membership, durability policy).
-	// The composite primary key (coordinator_term, rule_subterm) uniquely identifies each rule;
-	// rule_subterm is assigned by the application as MAX(rule_subterm)+1 within a coordinator_term.
+	// The composite primary key (coordinator_term, leader_subterm) uniquely identifies each rule;
+	// leader_subterm is assigned by the application as MAX(leader_subterm)+1 within a coordinator_term.
 	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE IF NOT EXISTS multigres.rule_history (
 		coordinator_term          BIGINT NOT NULL,
-		rule_subterm              BIGINT NOT NULL,
+		leader_subterm              BIGINT NOT NULL,
 		event_type                TEXT NOT NULL,
 		leader_id                 TEXT,
 		coordinator_id            TEXT,
@@ -201,7 +201,7 @@ func (rs *ruleStore) createRuleTables(ctx context.Context) error {
 		durability_async_fallback TEXT,
 		operation                 TEXT,
 		created_at                TIMESTAMPTZ NOT NULL,
-		PRIMARY KEY (coordinator_term, rule_subterm)
+		PRIMARY KEY (coordinator_term, leader_subterm)
 	)`); err != nil {
 		return mterrors.Wrap(err, "failed to create rule_history table")
 	}
@@ -227,7 +227,7 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.No
 	defer cancel()
 
 	result, err := rs.queryService.QueryArgs(queryCtx, `
-		SELECT coordinator_term, rule_subterm, leader_id, coordinator_id, cohort_members,
+		SELECT coordinator_term, leader_subterm, leader_id, coordinator_id, cohort_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
 		       durability_async_fallback,
 		       CASE
@@ -244,7 +244,7 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.No
 		return nil, nil
 	}
 
-	var coordinatorTerm, ruleSubterm int64
+	var coordinatorTerm, leaderSubterm int64
 	var leaderIDStr, coordinatorIDStr *string
 	var cohortNames []string
 	var durabilityPolicyName, durabilityQuorumType, durabilityAsyncFallback *string
@@ -252,7 +252,7 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.No
 	var lsn string
 	if err := executor.ScanRow(result.Rows[0],
 		&coordinatorTerm,
-		&ruleSubterm,
+		&leaderSubterm,
 		&leaderIDStr,
 		&coordinatorIDStr,
 		&cohortNames,
@@ -275,7 +275,7 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.No
 		coordinatorIDStrVal = *coordinatorIDStr
 	}
 	pos, err := buildNodePosition(
-		coordinatorTerm, ruleSubterm,
+		coordinatorTerm, leaderSubterm,
 		leaderIDStr, coordinatorIDStrVal, cohortNames,
 		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount, durabilityAsyncFallback,
 		lsn,
@@ -289,9 +289,9 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.No
 // updateRule atomically writes a new rule by updating multigres.current_rule and
 // appending to multigres.rule_history in a single CTE statement.
 //
-// The rule_subterm is assigned as:
+// The leader_subterm is assigned as:
 //   - 0 if termNumber is greater than the current coordinator_term (new term)
-//   - current rule_subterm + 1 if termNumber equals the current coordinator_term
+//   - current leader_subterm + 1 if termNumber equals the current coordinator_term
 //
 // Fields not set via the builder (leaderID, cohortMembers) retain their current
 // values in current_rule. All provided values are written to rule_history.
@@ -353,7 +353,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 	var previousTerm, previousSubterm *int64
 	if update.previousRule != nil {
 		previousTerm = &update.previousRule.coordinatorTerm
-		previousSubterm = &update.previousRule.ruleSubterm
+		previousSubterm = &update.previousRule.leaderSubterm
 	}
 
 	// Use the remote operation timeout for history writes. This write validates that synchronous
@@ -375,31 +375,31 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		           $9::text[]       AS cohort_members,
 		           $10::text[]      AS accepted_members,
 		           $11::bigint      AS cas_coordinator_term,
-		           $12::bigint      AS cas_rule_subterm,
+		           $12::bigint      AS cas_leader_subterm,
 		           $13::timestamptz AS created_at
 		  ),
 		  locked AS (
 		    -- FOR UPDATE serializes concurrent writes at the database level, complementing
 		    -- the action lock held by the caller.
 		    -- Returns zero rows (causing a no-op write and error return) when any condition fails.
-		    -- next_sub: 0 when starting a new coordinator term, otherwise increment within term.
-		    SELECT current_rule.coordinator_term, current_rule.rule_subterm,
+		    -- next_leader_subterm: 0 when starting a new coordinator term, otherwise increment within term.
+		    SELECT current_rule.coordinator_term, current_rule.leader_subterm,
 		           current_rule.leader_id, current_rule.cohort_members,
 		           CASE WHEN params.coordinator_term > current_rule.coordinator_term THEN 0
-		                ELSE current_rule.rule_subterm + 1
-		           END AS next_sub
+		                ELSE current_rule.leader_subterm + 1
+		           END AS next_leader_subterm
 		    FROM multigres.current_rule, params
 		    WHERE current_rule.shard_id = params.shard_id                   -- target shard
 		      AND params.coordinator_term >= current_rule.coordinator_term  -- reject stale writes
 		      AND (params.cas_coordinator_term IS NULL                      -- optimistic CAS check
 		           OR (current_rule.coordinator_term = params.cas_coordinator_term
-		               AND current_rule.rule_subterm = params.cas_rule_subterm))
+		               AND current_rule.leader_subterm = params.cas_leader_subterm))
 		    FOR UPDATE
 		  ),
 		  updated AS (
 		    UPDATE multigres.current_rule
 		    SET coordinator_term = params.coordinator_term,
-		        rule_subterm     = locked.next_sub,
+		        leader_subterm     = locked.next_leader_subterm,
 		        leader_id        = COALESCE(NULLIF(params.leader_id, ''), locked.leader_id),
 		        coordinator_id   = NULLIF(params.coordinator_id, ''),
 		        cohort_members   = COALESCE(params.cohort_members, locked.cohort_members),
@@ -408,16 +408,16 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		    -- Correlates the update target to the specific shard row. If locked is empty
 		    -- (any condition above failed), the cross-join produces zero rows here too.
 		    WHERE current_rule.shard_id = params.shard_id
-		    RETURNING current_rule.coordinator_term, current_rule.rule_subterm,
+		    RETURNING current_rule.coordinator_term, current_rule.leader_subterm,
 		              current_rule.leader_id, current_rule.coordinator_id, current_rule.cohort_members,
 		              current_rule.durability_policy_name, current_rule.durability_quorum_type,
 		              current_rule.durability_required_count, current_rule.durability_async_fallback
 		  ),
 		  inserted AS (
 		    INSERT INTO multigres.rule_history
-		      (coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
+		      (coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members, created_at)
-		    SELECT updated.coordinator_term, updated.rule_subterm,
+		    SELECT updated.coordinator_term, updated.leader_subterm,
 		           params.event_type,
 		           updated.leader_id,
 		           updated.coordinator_id,
@@ -430,7 +430,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		  )
 		-- Cross-joining inserted ensures a zero-row history insert (a bug) also returns zero
 		-- rows here, causing the caller to surface an error rather than silently succeeding.
-		SELECT updated.coordinator_term, updated.rule_subterm,
+		SELECT updated.coordinator_term, updated.leader_subterm,
 		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
 		       updated.durability_policy_name, updated.durability_quorum_type,
 		       updated.durability_required_count, updated.durability_async_fallback,
@@ -471,7 +471,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 			update.termNumber)
 	}
 
-	var coordinatorTerm, ruleSubterm int64
+	var coordinatorTerm, leaderSubterm int64
 	var leaderIDStr *string
 	var coordinatorIDStrResult string
 	var cohortNames []string
@@ -480,7 +480,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 	var lsn string
 	if err := executor.ScanSingleRow(result,
 		&coordinatorTerm,
-		&ruleSubterm,
+		&leaderSubterm,
 		&leaderIDStr,
 		&coordinatorIDStrResult,
 		&cohortNames,
@@ -494,7 +494,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 	}
 
 	pos, err := buildNodePosition(
-		coordinatorTerm, ruleSubterm,
+		coordinatorTerm, leaderSubterm,
 		leaderIDStr, coordinatorIDStrResult, cohortNames,
 		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount, durabilityAsyncFallback,
 		lsn,
@@ -506,18 +506,18 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 }
 
 // queryRuleHistory returns the most recent rule history records in descending
-// order by (coordinator_term, rule_subterm). Returns at most limit records.
+// order by (coordinator_term, leader_subterm). Returns at most limit records.
 func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHistoryRecord, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
 
 	result, err := rs.queryService.QueryArgs(queryCtx, `
-		SELECT coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
+		SELECT coordinator_term, leader_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members,
 		       durability_policy_name, durability_quorum_type, durability_required_count,
 		       durability_async_fallback, created_at
 		FROM multigres.rule_history
-		ORDER BY coordinator_term DESC, rule_subterm DESC
+		ORDER BY coordinator_term DESC, leader_subterm DESC
 		LIMIT $1`, limit)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to query rule_history")
@@ -531,7 +531,7 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 		var durabilityRequiredCount *int64
 		if err := executor.ScanRow(row,
 			&rec.CoordinatorTerm,
-			&rec.RuleSubterm,
+			&rec.LeaderSubterm,
 			&rec.EventType,
 			&leaderIDStr,
 			&rec.CoordinatorID,
@@ -568,7 +568,7 @@ func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHis
 // leaderIDStr and coordinatorIDStr are app-name formatted strings (e.g. "zone1_pooler-name").
 // durability fields are nil when not set in the DB.
 func buildNodePosition(
-	coordinatorTerm, ruleSubterm int64,
+	coordinatorTerm, leaderSubterm int64,
 	leaderIDStr *string,
 	coordinatorIDStr string,
 	cohortNames []string,
@@ -580,7 +580,7 @@ func buildNodePosition(
 	rule := &clustermetadatapb.ShardRule{
 		RuleNumber: &clustermetadatapb.RuleNumber{
 			CoordinatorTerm: coordinatorTerm,
-			RuleSubterm:     ruleSubterm,
+			LeaderSubterm:   leaderSubterm,
 		},
 	}
 
@@ -653,7 +653,7 @@ func appNamesToIDs(names []string) ([]*clustermetadatapb.ID, error) {
 // ruleHistoryRecord represents a row from multigres.rule_history or multigres.current_rule.
 type ruleHistoryRecord struct {
 	CoordinatorTerm         int64
-	RuleSubterm             int64
+	LeaderSubterm           int64
 	EventType               string
 	LeaderID                *poolerID // nil if not set
 	CoordinatorID           *string   // informational only; component type is not stored

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -28,28 +28,36 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/executor"
 )
 
-// errRuleConflict is returned by updateRule when a withPreviousRule compare-and-swap
-// check fails: the current rule's term/subterm did not match the expected values.
-var errRuleConflict = errors.New("rule conflict: current rule version mismatch")
-
-// ruleHistoryRecord represents a row from multigres.rule_history or multigres.current_rule.
-type ruleHistoryRecord struct {
-	CoordinatorTerm         int64
-	RuleSubterm             int64
-	EventType               string
-	LeaderID                *poolerID // nil if not set
-	CoordinatorID           *string   // informational only; component type is not stored
-	WALPosition             *string
-	Operation               *string
-	Reason                  string
-	CohortMembers           []poolerID
-	AcceptedMembers         []poolerID
-	DurabilityPolicyName    *string
-	DurabilityQuorumType    *string
-	DurabilityRequiredCount *int32
-	DurabilityAsyncFallback *string
-	CreatedAt               time.Time
+// ruleStorer is the interface for reading and writing the current shard rule.
+// *ruleStore implements this; tests use fakeRuleStore.
+type ruleStorer interface {
+	observePosition(ctx context.Context) (*clustermetadatapb.NodePosition, error)
+	updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error)
 }
+
+// ruleStore manages the current shard rule in postgres.
+//
+// All DB operations that write or read the current rule go through ruleStore,
+// ensuring consistent access to rule state.
+type ruleStore struct {
+	logger       *slog.Logger
+	queryService executor.InternalQueryService
+}
+
+// newRuleStore creates a ruleStore.
+func newRuleStore(
+	logger *slog.Logger,
+	qs executor.InternalQueryService,
+) *ruleStore {
+	return &ruleStore{
+		logger:       logger,
+		queryService: qs,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Rule Update Builder
+// ----------------------------------------------------------------------------
 
 // ruleNumber identifies a specific rule version by coordinator term and subterm.
 type ruleNumber struct {
@@ -128,76 +136,6 @@ func (b *ruleUpdateBuilder) withForce() *ruleUpdateBuilder {
 func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, ruleSubterm int64) *ruleUpdateBuilder {
 	b.previousRule = &ruleNumber{coordinatorTerm: coordinatorTerm, ruleSubterm: ruleSubterm}
 	return b
-}
-
-// parsePoolerIDStrings converts a slice of "cell_name" app name strings into poolerIDs.
-// Returns nil for nil input, preserving the distinction between "not set" and "empty".
-func parsePoolerIDStrings(names []string) ([]poolerID, error) {
-	if names == nil {
-		return nil, nil
-	}
-	result := make([]poolerID, 0, len(names))
-	for _, s := range names {
-		id, err := parseApplicationName(s)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, poolerID{id: id, appName: s})
-	}
-	return result, nil
-}
-
-// scanRuleHistoryRow scans string-typed DB columns into a ruleHistoryRecord,
-// parsing leader_id, cohort_members, and accepted_members into poolerIDs.
-// leaderIDStr, cohortNames, and acceptedNames are intermediary scan targets.
-func scanRuleHistoryRow(rec *ruleHistoryRecord, leaderIDStr *string, cohortNames, acceptedNames []string) error {
-	if leaderIDStr != nil {
-		id, err := parseApplicationName(*leaderIDStr)
-		if err != nil {
-			return mterrors.Wrapf(err, "failed to parse leader_id %q", *leaderIDStr)
-		}
-		p := poolerID{id: id, appName: *leaderIDStr}
-		rec.LeaderID = &p
-	}
-	cohort, err := parsePoolerIDStrings(cohortNames)
-	if err != nil {
-		return mterrors.Wrap(err, "failed to parse cohort_members")
-	}
-	rec.CohortMembers = cohort
-
-	accepted, err := parsePoolerIDStrings(acceptedNames)
-	if err != nil {
-		return mterrors.Wrap(err, "failed to parse accepted_members")
-	}
-	rec.AcceptedMembers = accepted
-	return nil
-}
-
-// ruleStorer is the interface for reading and writing the current shard rule.
-// *ruleStore implements this; tests use fakeRuleStore.
-type ruleStorer interface {
-	observePosition(ctx context.Context) (*clustermetadatapb.NodePosition, error)
-	updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error)
-}
-
-// ruleStore manages the current shard rule in postgres.
-//
-// All DB operations that write or read the current rule go through ruleStore,
-// ensuring consistent access to rule state.
-type ruleStore struct {
-	logger       *slog.Logger
-	queryService executor.InternalQueryService
-}
-
-// newRuleStore creates a ruleStore.
-func newRuleStore(
-	logger *slog.Logger,
-	qs executor.InternalQueryService,
-) *ruleStore {
-	return &ruleStore{
-		logger:       logger,
-		queryService: qs,
-	}
 }
 
 // ----------------------------------------------------------------------------
@@ -290,6 +228,10 @@ func (pm *MultiPoolerManager) createRuleHistoryTable(ctx context.Context) error 
 // ----------------------------------------------------------------------------
 // Read/Write Operations
 // ----------------------------------------------------------------------------
+
+// errRuleConflict is returned by updateRule when a withPreviousRule compare-and-swap
+// check fails: the current rule's term/subterm did not match the expected values.
+var errRuleConflict = errors.New("rule conflict: current rule version mismatch")
 
 // observePosition reads the current rule and WAL LSN from postgres and returns
 // the observed position. Returns nil if no rule has been applied yet
@@ -559,6 +501,65 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 	return pos, nil
 }
 
+// queryRuleHistory returns the most recent rule history records in descending
+// order by (coordinator_term, rule_subterm). Returns at most limit records.
+func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHistoryRecord, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(queryCtx, `
+		SELECT coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
+		       wal_position, operation, reason, cohort_members, accepted_members,
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       durability_async_fallback, created_at
+		FROM multigres.rule_history
+		ORDER BY coordinator_term DESC, rule_subterm DESC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to query rule_history")
+	}
+
+	records := make([]ruleHistoryRecord, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		var rec ruleHistoryRecord
+		var leaderIDStr *string
+		var cohortNames, acceptedNames []string
+		var durabilityRequiredCount *int64
+		if err := executor.ScanRow(row,
+			&rec.CoordinatorTerm,
+			&rec.RuleSubterm,
+			&rec.EventType,
+			&leaderIDStr,
+			&rec.CoordinatorID,
+			&rec.WALPosition,
+			&rec.Operation,
+			&rec.Reason,
+			&cohortNames,
+			&acceptedNames,
+			&rec.DurabilityPolicyName,
+			&rec.DurabilityQuorumType,
+			&durabilityRequiredCount,
+			&rec.DurabilityAsyncFallback,
+			&rec.CreatedAt,
+		); err != nil {
+			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
+		}
+		if durabilityRequiredCount != nil {
+			v := int32(*durabilityRequiredCount)
+			rec.DurabilityRequiredCount = &v
+		}
+		if err := scanRuleHistoryRow(&rec, leaderIDStr, cohortNames, acceptedNames); err != nil {
+			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
 // buildNodePosition constructs a *clustermetadatapb.NodePosition from raw DB column values.
 // leaderIDStr and coordinatorIDStr are app-name formatted strings (e.g. "zone1_pooler-name").
 // durability fields are nil when not set in the DB.
@@ -632,61 +633,6 @@ func buildNodePosition(
 	}, nil
 }
 
-// queryRuleHistory returns the most recent rule history records in descending
-// order by (coordinator_term, rule_subterm). Returns at most limit records.
-func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHistoryRecord, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	result, err := rs.queryService.QueryArgs(queryCtx, `
-		SELECT coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
-		       wal_position, operation, reason, cohort_members, accepted_members,
-		       durability_policy_name, durability_quorum_type, durability_required_count,
-		       durability_async_fallback, created_at
-		FROM multigres.rule_history
-		ORDER BY coordinator_term DESC, rule_subterm DESC
-		LIMIT $1`, limit)
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to query rule_history")
-	}
-
-	records := make([]ruleHistoryRecord, 0, len(result.Rows))
-	for _, row := range result.Rows {
-		var rec ruleHistoryRecord
-		var leaderIDStr *string
-		var cohortNames, acceptedNames []string
-		var durabilityRequiredCount *int64
-		if err := executor.ScanRow(row,
-			&rec.CoordinatorTerm,
-			&rec.RuleSubterm,
-			&rec.EventType,
-			&leaderIDStr,
-			&rec.CoordinatorID,
-			&rec.WALPosition,
-			&rec.Operation,
-			&rec.Reason,
-			&cohortNames,
-			&acceptedNames,
-			&rec.DurabilityPolicyName,
-			&rec.DurabilityQuorumType,
-			&durabilityRequiredCount,
-			&rec.DurabilityAsyncFallback,
-			&rec.CreatedAt,
-		); err != nil {
-			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
-		}
-		if durabilityRequiredCount != nil {
-			v := int32(*durabilityRequiredCount)
-			rec.DurabilityRequiredCount = &v
-		}
-		if err := scanRuleHistoryRow(&rec, leaderIDStr, cohortNames, acceptedNames); err != nil {
-			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
-		}
-		records = append(records, rec)
-	}
-	return records, nil
-}
-
 // appNamesToIDs converts a slice of app-name formatted strings to proto IDs.
 func appNamesToIDs(names []string) ([]*clustermetadatapb.ID, error) {
 	ids := make([]*clustermetadatapb.ID, 0, len(names))
@@ -698,4 +644,66 @@ func appNamesToIDs(names []string) ([]*clustermetadatapb.ID, error) {
 		ids = append(ids, id)
 	}
 	return ids, nil
+}
+
+// ruleHistoryRecord represents a row from multigres.rule_history or multigres.current_rule.
+type ruleHistoryRecord struct {
+	CoordinatorTerm         int64
+	RuleSubterm             int64
+	EventType               string
+	LeaderID                *poolerID // nil if not set
+	CoordinatorID           *string   // informational only; component type is not stored
+	WALPosition             *string
+	Operation               *string
+	Reason                  string
+	CohortMembers           []poolerID
+	AcceptedMembers         []poolerID
+	DurabilityPolicyName    *string
+	DurabilityQuorumType    *string
+	DurabilityRequiredCount *int32
+	DurabilityAsyncFallback *string
+	CreatedAt               time.Time
+}
+
+// parsePoolerIDStrings converts a slice of "cell_name" app name strings into poolerIDs.
+// Returns nil for nil input, preserving the distinction between "not set" and "empty".
+func parsePoolerIDStrings(names []string) ([]poolerID, error) {
+	if names == nil {
+		return nil, nil
+	}
+	result := make([]poolerID, 0, len(names))
+	for _, s := range names {
+		id, err := parseApplicationName(s)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, poolerID{id: id, appName: s})
+	}
+	return result, nil
+}
+
+// scanRuleHistoryRow scans string-typed DB columns into a ruleHistoryRecord,
+// parsing leader_id, cohort_members, and accepted_members into poolerIDs.
+// leaderIDStr, cohortNames, and acceptedNames are intermediary scan targets.
+func scanRuleHistoryRow(rec *ruleHistoryRecord, leaderIDStr *string, cohortNames, acceptedNames []string) error {
+	if leaderIDStr != nil {
+		id, err := parseApplicationName(*leaderIDStr)
+		if err != nil {
+			return mterrors.Wrapf(err, "failed to parse leader_id %q", *leaderIDStr)
+		}
+		p := poolerID{id: id, appName: *leaderIDStr}
+		rec.LeaderID = &p
+	}
+	cohort, err := parsePoolerIDStrings(cohortNames)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to parse cohort_members")
+	}
+	rec.CohortMembers = cohort
+
+	accepted, err := parsePoolerIDStrings(acceptedNames)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to parse accepted_members")
+	}
+	rec.AcceptedMembers = accepted
+	return nil
 }

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -1,0 +1,701 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	"github.com/multigres/multigres/go/services/multipooler/executor"
+)
+
+// errRuleConflict is returned by updateRule when a withPreviousRule compare-and-swap
+// check fails: the current rule's term/subterm did not match the expected values.
+var errRuleConflict = errors.New("rule conflict: current rule version mismatch")
+
+// ruleHistoryRecord represents a row from multigres.rule_history or multigres.current_rule.
+type ruleHistoryRecord struct {
+	CoordinatorTerm         int64
+	RuleSubterm             int64
+	EventType               string
+	LeaderID                *poolerID // nil if not set
+	CoordinatorID           *string   // informational only; component type is not stored
+	WALPosition             *string
+	Operation               *string
+	Reason                  string
+	CohortMembers           []poolerID
+	AcceptedMembers         []poolerID
+	DurabilityPolicyName    *string
+	DurabilityQuorumType    *string
+	DurabilityRequiredCount *int32
+	DurabilityAsyncFallback *string
+	CreatedAt               time.Time
+}
+
+// ruleNumber identifies a specific rule version by coordinator term and subterm.
+type ruleNumber struct {
+	coordinatorTerm int64
+	ruleSubterm     int64
+}
+
+// ruleUpdateBuilder constructs the parameters for updateRule.
+// coordinatorID, eventType, reason, and createdAt are always required.
+// Fields not set via builder methods retain their current value in current_rule.
+type ruleUpdateBuilder struct {
+	// required
+	termNumber    int64
+	coordinatorID *clustermetadatapb.ID
+	eventType     string
+	reason        string
+	createdAt     time.Time
+
+	// optional; nil means keep the existing value in current_rule
+	leaderID      *clustermetadatapb.ID
+	cohortMembers []*clustermetadatapb.ID
+
+	// history-only optional fields
+	walPosition     string
+	operation       string
+	acceptedMembers []*clustermetadatapb.ID
+
+	force        bool
+	previousRule *ruleNumber // for compare-and-swap; nil means no check
+}
+
+func newRuleUpdate(termNumber int64, coordinatorID *clustermetadatapb.ID, eventType, reason string, createdAt time.Time) *ruleUpdateBuilder {
+	return &ruleUpdateBuilder{
+		termNumber:    termNumber,
+		coordinatorID: coordinatorID,
+		eventType:     eventType,
+		reason:        reason,
+		createdAt:     createdAt,
+	}
+}
+
+func (b *ruleUpdateBuilder) withLeader(id *clustermetadatapb.ID) *ruleUpdateBuilder {
+	b.leaderID = id
+	return b
+}
+
+func (b *ruleUpdateBuilder) withCohort(members []*clustermetadatapb.ID) *ruleUpdateBuilder {
+	b.cohortMembers = members
+	return b
+}
+
+func (b *ruleUpdateBuilder) withWALPosition(pos string) *ruleUpdateBuilder {
+	b.walPosition = pos
+	return b
+}
+
+func (b *ruleUpdateBuilder) withOperation(op string) *ruleUpdateBuilder {
+	b.operation = op
+	return b
+}
+
+func (b *ruleUpdateBuilder) withAcceptedMembers(members []*clustermetadatapb.ID) *ruleUpdateBuilder {
+	b.acceptedMembers = members
+	return b
+}
+
+func (b *ruleUpdateBuilder) withForce() *ruleUpdateBuilder {
+	b.force = true
+	return b
+}
+
+// withPreviousRule adds a compare-and-swap check: the update only proceeds if the
+// current rule matches the given coordinator term and subterm.
+//
+//nolint:unused // CAS support is wired into the SQL query; callers will be added soon.
+func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, ruleSubterm int64) *ruleUpdateBuilder {
+	b.previousRule = &ruleNumber{coordinatorTerm: coordinatorTerm, ruleSubterm: ruleSubterm}
+	return b
+}
+
+// parsePoolerIDStrings converts a slice of "cell_name" app name strings into poolerIDs.
+// Returns nil for nil input, preserving the distinction between "not set" and "empty".
+func parsePoolerIDStrings(names []string) ([]poolerID, error) {
+	if names == nil {
+		return nil, nil
+	}
+	result := make([]poolerID, 0, len(names))
+	for _, s := range names {
+		id, err := parseApplicationName(s)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, poolerID{id: id, appName: s})
+	}
+	return result, nil
+}
+
+// scanRuleHistoryRow scans string-typed DB columns into a ruleHistoryRecord,
+// parsing leader_id, cohort_members, and accepted_members into poolerIDs.
+// leaderIDStr, cohortNames, and acceptedNames are intermediary scan targets.
+func scanRuleHistoryRow(rec *ruleHistoryRecord, leaderIDStr *string, cohortNames, acceptedNames []string) error {
+	if leaderIDStr != nil {
+		id, err := parseApplicationName(*leaderIDStr)
+		if err != nil {
+			return mterrors.Wrapf(err, "failed to parse leader_id %q", *leaderIDStr)
+		}
+		p := poolerID{id: id, appName: *leaderIDStr}
+		rec.LeaderID = &p
+	}
+	cohort, err := parsePoolerIDStrings(cohortNames)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to parse cohort_members")
+	}
+	rec.CohortMembers = cohort
+
+	accepted, err := parsePoolerIDStrings(acceptedNames)
+	if err != nil {
+		return mterrors.Wrap(err, "failed to parse accepted_members")
+	}
+	rec.AcceptedMembers = accepted
+	return nil
+}
+
+// ruleStorer is the interface for reading and writing the current shard rule.
+// *ruleStore implements this; tests use fakeRuleStore.
+type ruleStorer interface {
+	observePosition(ctx context.Context) (*clustermetadatapb.NodePosition, error)
+	updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error)
+}
+
+// ruleStore manages the current shard rule in postgres.
+//
+// All DB operations that write or read the current rule go through ruleStore,
+// ensuring consistent access to rule state.
+type ruleStore struct {
+	logger       *slog.Logger
+	queryService executor.InternalQueryService
+}
+
+// newRuleStore creates a ruleStore.
+func newRuleStore(
+	logger *slog.Logger,
+	qs executor.InternalQueryService,
+) *ruleStore {
+	return &ruleStore{
+		logger:       logger,
+		queryService: qs,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Schema Operations
+// ----------------------------------------------------------------------------
+
+// createCurrentRuleTable creates the current_rule table.
+// This table holds a single row per shard representing the current cluster rule.
+// It is used as a locking target (SELECT FOR UPDATE) and a fast read path for
+// current state, while rule_history provides the append-only audit log.
+//
+// Non-essential audit fields (event_type, wal_position, accepted_members, reason,
+// operation) are stored only in rule_history to keep this table focused on
+// operational state.
+//
+// created_at records when this particular rule was written, matching the
+// corresponding rule_history.created_at for the same (coordinator_term, rule_subterm).
+func (pm *MultiPoolerManager) createCurrentRuleTable(ctx context.Context) error {
+	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.current_rule (
+		shard_id                  BYTEA PRIMARY KEY,
+		coordinator_term          BIGINT NOT NULL,
+		rule_subterm              BIGINT NOT NULL,
+		leader_id                 TEXT,
+		coordinator_id            TEXT,
+		cohort_members            TEXT[] NOT NULL,
+		durability_policy_name    TEXT,
+		durability_quorum_type    TEXT,
+		durability_required_count INT,
+		durability_async_fallback TEXT,
+		created_at                TIMESTAMPTZ NOT NULL
+	)`); err != nil {
+		return mterrors.Wrap(err, "failed to create current_rule table")
+	}
+	return nil
+}
+
+// initializeCurrentRule inserts the zero-state sentinel row for the default shard.
+// This row must exist before any rule is written so that updateRule can SELECT FOR
+// UPDATE on it to serialise concurrent writes.
+// coordinator_term=0 means no rule has been applied yet.
+// Uses ON CONFLICT DO NOTHING so it is safe to call multiple times.
+func (pm *MultiPoolerManager) initializeCurrentRule(ctx context.Context) error {
+	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	err := pm.execArgs(execCtx, `
+		INSERT INTO multigres.current_rule
+		  (shard_id, coordinator_term, rule_subterm, cohort_members, created_at)
+		VALUES ($1, 0, 0, '{}', now())
+		ON CONFLICT (shard_id) DO NOTHING`,
+		[]byte("0"))
+	if err != nil {
+		return mterrors.Wrap(err, "failed to initialize current_rule")
+	}
+	return nil
+}
+
+// createRuleHistoryTable creates the rule_history table.
+// Each row records a cluster state change (promotion, cohort membership, durability policy).
+// The composite primary key (coordinator_term, rule_subterm) uniquely identifies each rule;
+// rule_subterm is assigned by the application as MAX(rule_subterm)+1 within a coordinator_term.
+func (pm *MultiPoolerManager) createRuleHistoryTable(ctx context.Context) error {
+	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.rule_history (
+		coordinator_term          BIGINT NOT NULL,
+		rule_subterm              BIGINT NOT NULL,
+		event_type                TEXT NOT NULL,
+		leader_id                 TEXT,
+		coordinator_id            TEXT,
+		wal_position              TEXT,
+		accepted_members          TEXT[],
+		reason                    TEXT NOT NULL,
+		cohort_members            TEXT[] NOT NULL,
+		durability_policy_name    TEXT,
+		durability_quorum_type    TEXT,
+		durability_required_count INT,
+		durability_async_fallback TEXT,
+		operation                 TEXT,
+		created_at                TIMESTAMPTZ NOT NULL,
+		PRIMARY KEY (coordinator_term, rule_subterm)
+	)`); err != nil {
+		return mterrors.Wrap(err, "failed to create rule_history table")
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Read/Write Operations
+// ----------------------------------------------------------------------------
+
+// observePosition reads the current rule and WAL LSN from postgres and returns
+// the observed position. Returns nil if no rule has been applied yet
+// (coordinator_term = 0).
+//
+// Returns an error if postgres is unreachable.
+func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.NodePosition, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(queryCtx, `
+		SELECT coordinator_term, rule_subterm, leader_id, coordinator_id, cohort_members,
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       durability_async_fallback,
+		       CASE
+		         WHEN pg_is_in_recovery()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())
+		         ELSE pg_current_wal_lsn()
+		       END::text AS current_lsn
+		FROM multigres.current_rule
+		WHERE shard_id = $1`, []byte("0"))
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to query current position")
+	}
+	if len(result.Rows) == 0 {
+		return nil, nil
+	}
+
+	var coordinatorTerm, ruleSubterm int64
+	var leaderIDStr, coordinatorIDStr *string
+	var cohortNames []string
+	var durabilityPolicyName, durabilityQuorumType, durabilityAsyncFallback *string
+	var durabilityRequiredCount *int64
+	var lsn string
+	if err := executor.ScanRow(result.Rows[0],
+		&coordinatorTerm,
+		&ruleSubterm,
+		&leaderIDStr,
+		&coordinatorIDStr,
+		&cohortNames,
+		&durabilityPolicyName,
+		&durabilityQuorumType,
+		&durabilityRequiredCount,
+		&durabilityAsyncFallback,
+		&lsn,
+	); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan current position")
+	}
+
+	// coordinator_term=0 is the sentinel initial state; no rule has been applied yet.
+	if coordinatorTerm == 0 {
+		return nil, nil
+	}
+
+	var coordinatorIDStrVal string
+	if coordinatorIDStr != nil {
+		coordinatorIDStrVal = *coordinatorIDStr
+	}
+	pos, err := buildNodePosition(
+		coordinatorTerm, ruleSubterm,
+		leaderIDStr, coordinatorIDStrVal, cohortNames,
+		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount, durabilityAsyncFallback,
+		lsn,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse current position")
+	}
+	return pos, nil
+}
+
+// updateRule atomically writes a new rule by updating multigres.current_rule and
+// appending to multigres.rule_history in a single CTE statement.
+//
+// The rule_subterm is assigned as:
+//   - 0 if termNumber is greater than the current coordinator_term (new term)
+//   - current rule_subterm + 1 if termNumber equals the current coordinator_term
+//
+// Fields not set via the builder (leaderID, cohortMembers) retain their current
+// values in current_rule. All provided values are written to rule_history.
+//
+// current_rule is locked with SELECT FOR UPDATE before the update, serialising
+// concurrent writes at the database level in addition to the caller's action lock.
+//
+// Returns the node's position (rule + WAL LSN) at the time of the write,
+// or nil if force mode skipped the write.
+//
+// This operation uses the remote-operation-timeout and will fail if it cannot
+// complete within that time. A timeout typically indicates that synchronous
+// replication is not functioning.
+func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error) {
+	if update.force {
+		// Force mode skips history recording entirely. Force operations are emergency
+		// operations that must configure replication GUCs regardless. The write would
+		// block on sync replication with unreachable standbys, consuming the parent
+		// context's deadline and causing subsequent GUC changes to fail.
+		rs.logger.InfoContext(ctx, "Skipping rule update in force mode",
+			"coordinator_term", update.termNumber,
+			"event_type", update.eventType)
+		return nil, nil
+	}
+
+	// Convert optional leader ID; empty string causes NULLIF→COALESCE to keep existing.
+	var leaderStr string
+	if update.leaderID != nil {
+		pid, err := newPoolerID(update.leaderID)
+		if err != nil {
+			return nil, mterrors.Wrap(err, "invalid leader ID")
+		}
+		leaderStr = pid.appName
+	}
+
+	// Convert optional cohort; nil slice becomes SQL NULL, triggering COALESCE to keep existing.
+	var cohortParam []string
+	if update.cohortMembers != nil {
+		pids, err := toPoolerIDs(update.cohortMembers)
+		if err != nil {
+			return nil, mterrors.Wrap(err, "invalid cohort member ID")
+		}
+		cohortParam = poolerIDsToAppNames(pids)
+	}
+
+	var acceptedParam []string
+	if len(update.acceptedMembers) > 0 {
+		pids, err := toPoolerIDs(update.acceptedMembers)
+		if err != nil {
+			return nil, mterrors.Wrap(err, "invalid accepted member ID")
+		}
+		acceptedParam = poolerIDsToAppNames(pids)
+	}
+
+	coordinatorIDStr := topoclient.ClusterIDString(update.coordinatorID)
+
+	// For compare-and-swap: pass the expected term/subterm as SQL parameters.
+	// NULL causes the WHERE clause to skip the check, allowing any current state.
+	var previousTerm, previousSubterm *int64
+	if update.previousRule != nil {
+		previousTerm = &update.previousRule.coordinatorTerm
+		previousSubterm = &update.previousRule.ruleSubterm
+	}
+
+	// Use the remote operation timeout for history writes. This write validates that synchronous
+	// replication is functioning - it must wait long enough for standbys to connect and acknowledge.
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(execCtx, `
+		WITH
+		  locked AS (
+		    SELECT coordinator_term, rule_subterm, leader_id, coordinator_id, cohort_members,
+		           durability_policy_name, durability_quorum_type, durability_required_count,
+		           durability_async_fallback
+		    FROM multigres.current_rule
+		    WHERE shard_id = $1
+		      AND ($11::bigint IS NULL OR (coordinator_term = $11 AND rule_subterm = $12))
+		    FOR UPDATE
+		  ),
+		  next_sub AS (
+		    SELECT CASE
+		      WHEN $2 > locked.coordinator_term THEN 0
+		      ELSE locked.rule_subterm + 1
+		    END AS value
+		    FROM locked
+		  ),
+		  updated AS (
+		    UPDATE multigres.current_rule
+		    SET coordinator_term = $2,
+		        rule_subterm     = next_sub.value,
+		        leader_id        = COALESCE(NULLIF($4, ''), locked.leader_id),
+		        coordinator_id   = NULLIF($5, ''),
+		        cohort_members   = COALESCE($9, locked.cohort_members),
+		        created_at       = $13
+		    FROM next_sub, locked
+		    WHERE shard_id = $1
+		      AND ($2 > locked.coordinator_term OR ($2 = locked.coordinator_term AND next_sub.value > locked.rule_subterm))
+		    RETURNING current_rule.coordinator_term, current_rule.rule_subterm,
+		              current_rule.leader_id, current_rule.coordinator_id, current_rule.cohort_members,
+		              current_rule.durability_policy_name, current_rule.durability_quorum_type,
+		              current_rule.durability_required_count, current_rule.durability_async_fallback
+		  ),
+		  inserted AS (
+		    INSERT INTO multigres.rule_history
+		      (coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
+		       wal_position, operation, reason, cohort_members, accepted_members, created_at)
+		    SELECT updated.coordinator_term, updated.rule_subterm,
+		           $3,
+		           updated.leader_id,
+		           updated.coordinator_id,
+		           NULLIF($6, ''), NULLIF($7, ''), $8,
+		           updated.cohort_members,
+		           $10,
+		           $13
+		    FROM updated
+		    RETURNING coordinator_term
+		  )
+		SELECT updated.coordinator_term, updated.rule_subterm,
+		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
+		       updated.durability_policy_name, updated.durability_quorum_type,
+		       updated.durability_required_count, updated.durability_async_fallback,
+		       CASE
+		         WHEN pg_is_in_recovery()
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())
+		         ELSE pg_current_wal_lsn()
+		       END::text AS current_lsn
+		FROM updated, inserted`,
+		[]byte("0"),
+		update.termNumber,
+		update.eventType,
+		leaderStr,
+		coordinatorIDStr,
+		update.walPosition,
+		update.operation,
+		update.reason,
+		cohortParam,
+		acceptedParam,
+		previousTerm,
+		previousSubterm,
+		update.createdAt,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to write rule history record")
+	}
+
+	// Zero rows means either:
+	//   - CAS check failed (expectedPreviousRule didn't match)
+	//   - advancement check failed (term/subterm would not advance current state — bug)
+	//   - shard row missing from current_rule (should never happen after initialisation)
+	if len(result.Rows) == 0 {
+		if update.previousRule != nil {
+			return nil, errRuleConflict
+		}
+		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL,
+			"rule update rejected for term %d: current_rule already at equal or higher position",
+			update.termNumber)
+	}
+
+	var coordinatorTerm, ruleSubterm int64
+	var leaderIDStr *string
+	var coordinatorIDStrResult string
+	var cohortNames []string
+	var durabilityPolicyName, durabilityQuorumType, durabilityAsyncFallback *string
+	var durabilityRequiredCount *int64
+	var lsn string
+	if err := executor.ScanSingleRow(result,
+		&coordinatorTerm,
+		&ruleSubterm,
+		&leaderIDStr,
+		&coordinatorIDStrResult,
+		&cohortNames,
+		&durabilityPolicyName,
+		&durabilityQuorumType,
+		&durabilityRequiredCount,
+		&durabilityAsyncFallback,
+		&lsn,
+	); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan written rule position")
+	}
+
+	pos, err := buildNodePosition(
+		coordinatorTerm, ruleSubterm,
+		leaderIDStr, coordinatorIDStrResult, cohortNames,
+		durabilityPolicyName, durabilityQuorumType, durabilityRequiredCount, durabilityAsyncFallback,
+		lsn,
+	)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse written rule position")
+	}
+	return pos, nil
+}
+
+// buildNodePosition constructs a *clustermetadatapb.NodePosition from raw DB column values.
+// leaderIDStr and coordinatorIDStr are app-name formatted strings (e.g. "zone1_pooler-name").
+// durability fields are nil when not set in the DB.
+func buildNodePosition(
+	coordinatorTerm, ruleSubterm int64,
+	leaderIDStr *string,
+	coordinatorIDStr string,
+	cohortNames []string,
+	durabilityPolicyName, durabilityQuorumType *string,
+	durabilityRequiredCount *int64,
+	durabilityAsyncFallback *string,
+	lsn string,
+) (*clustermetadatapb.NodePosition, error) {
+	rule := &clustermetadatapb.ShardRule{
+		RuleNumber: &clustermetadatapb.RuleNumber{
+			CoordinatorTerm: coordinatorTerm,
+			RuleSubterm:     ruleSubterm,
+		},
+	}
+
+	if leaderIDStr != nil {
+		id, err := parseApplicationName(*leaderIDStr)
+		if err != nil {
+			return nil, mterrors.Wrapf(err, "failed to parse leader_id %q", *leaderIDStr)
+		}
+		rule.PrimaryId = id
+	}
+
+	if coordinatorIDStr != "" {
+		id, err := parseApplicationName(coordinatorIDStr)
+		if err != nil {
+			return nil, mterrors.Wrapf(err, "failed to parse coordinator_id %q", coordinatorIDStr)
+		}
+		rule.CoordinatorId = id
+	}
+
+	cohortIDs, err := appNamesToIDs(cohortNames)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to parse cohort_members")
+	}
+	rule.CohortMembers = cohortIDs
+
+	if durabilityPolicyName != nil || durabilityQuorumType != nil || durabilityRequiredCount != nil || durabilityAsyncFallback != nil {
+		dp := &clustermetadatapb.DurabilityPolicy{}
+		if durabilityPolicyName != nil {
+			dp.PolicyName = *durabilityPolicyName
+		}
+		if durabilityQuorumType != nil {
+			v, ok := clustermetadatapb.QuorumType_value[*durabilityQuorumType]
+			if !ok {
+				return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "unknown quorum_type %q", *durabilityQuorumType)
+			}
+			dp.QuorumType = clustermetadatapb.QuorumType(v)
+		}
+		if durabilityRequiredCount != nil {
+			dp.RequiredCount = int32(*durabilityRequiredCount)
+		}
+		if durabilityAsyncFallback != nil {
+			v, ok := clustermetadatapb.AsyncReplicationFallbackMode_value[*durabilityAsyncFallback]
+			if !ok {
+				return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "unknown async_fallback %q", *durabilityAsyncFallback)
+			}
+			dp.AsyncFallback = clustermetadatapb.AsyncReplicationFallbackMode(v)
+		}
+		rule.DurabilityPolicy = dp
+	}
+
+	return &clustermetadatapb.NodePosition{
+		Rule: rule,
+		Lsn:  lsn,
+	}, nil
+}
+
+// queryRuleHistory returns the most recent rule history records in descending
+// order by (coordinator_term, rule_subterm). Returns at most limit records.
+func (rs *ruleStore) queryRuleHistory(ctx context.Context, limit int) ([]ruleHistoryRecord, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	result, err := rs.queryService.QueryArgs(queryCtx, `
+		SELECT coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
+		       wal_position, operation, reason, cohort_members, accepted_members,
+		       durability_policy_name, durability_quorum_type, durability_required_count,
+		       durability_async_fallback, created_at
+		FROM multigres.rule_history
+		ORDER BY coordinator_term DESC, rule_subterm DESC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to query rule_history")
+	}
+
+	records := make([]ruleHistoryRecord, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		var rec ruleHistoryRecord
+		var leaderIDStr *string
+		var cohortNames, acceptedNames []string
+		var durabilityRequiredCount *int64
+		if err := executor.ScanRow(row,
+			&rec.CoordinatorTerm,
+			&rec.RuleSubterm,
+			&rec.EventType,
+			&leaderIDStr,
+			&rec.CoordinatorID,
+			&rec.WALPosition,
+			&rec.Operation,
+			&rec.Reason,
+			&cohortNames,
+			&acceptedNames,
+			&rec.DurabilityPolicyName,
+			&rec.DurabilityQuorumType,
+			&durabilityRequiredCount,
+			&rec.DurabilityAsyncFallback,
+			&rec.CreatedAt,
+		); err != nil {
+			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
+		}
+		if durabilityRequiredCount != nil {
+			v := int32(*durabilityRequiredCount)
+			rec.DurabilityRequiredCount = &v
+		}
+		if err := scanRuleHistoryRow(&rec, leaderIDStr, cohortNames, acceptedNames); err != nil {
+			return nil, mterrors.Wrap(err, "failed to parse rule_history row")
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// appNamesToIDs converts a slice of app-name formatted strings to proto IDs.
+func appNamesToIDs(names []string) ([]*clustermetadatapb.ID, error) {
+	ids := make([]*clustermetadatapb.ID, 0, len(names))
+	for _, name := range names {
+		id, err := parseApplicationName(name)
+		if err != nil {
+			return nil, mterrors.Wrapf(err, "invalid ID %q", name)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -33,6 +33,10 @@ import (
 type ruleStorer interface {
 	observePosition(ctx context.Context) (*clustermetadatapb.NodePosition, error)
 	updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.NodePosition, error)
+	// createRuleTables creates multigres.current_rule and multigres.rule_history
+	// if they do not already exist, and inserts the zero-state sentinel row for
+	// the default shard. It is idempotent and safe to call multiple times.
+	createRuleTables(ctx context.Context) error
 }
 
 // ruleStore manages the current shard rule in postgres.
@@ -131,8 +135,6 @@ func (b *ruleUpdateBuilder) withForce() *ruleUpdateBuilder {
 
 // withPreviousRule adds a compare-and-swap check: the update only proceeds if the
 // current rule matches the given coordinator term and subterm.
-//
-//nolint:unused // CAS support is wired into the SQL query; callers will be added soon.
 func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, ruleSubterm int64) *ruleUpdateBuilder {
 	b.previousRule = &ruleNumber{coordinatorTerm: coordinatorTerm, ruleSubterm: ruleSubterm}
 	return b
@@ -142,21 +144,20 @@ func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, ruleSubterm int64)
 // Schema Operations
 // ----------------------------------------------------------------------------
 
-// createCurrentRuleTable creates the current_rule table.
-// This table holds a single row per shard representing the current cluster rule.
-// It is used as a locking target (SELECT FOR UPDATE) and a fast read path for
-// current state, while rule_history provides the append-only audit log.
+// createRuleTables creates multigres.current_rule and multigres.rule_history if
+// they do not already exist, then inserts the zero-state sentinel row for the
+// default shard. It is idempotent and safe to call multiple times.
 //
-// Non-essential audit fields (event_type, wal_position, accepted_members, reason,
-// operation) are stored only in rule_history to keep this table focused on
-// operational state.
+// current_rule holds a single row per shard representing the current cluster rule.
+// It is used as a locking target (SELECT FOR UPDATE) to serialise concurrent
+// writes; rule_history provides the append-only audit log.
 //
-// created_at records when this particular rule was written, matching the
-// corresponding rule_history.created_at for the same (coordinator_term, rule_subterm).
-func (pm *MultiPoolerManager) createCurrentRuleTable(ctx context.Context) error {
+// coordinator_term=0 in the sentinel row means no rule has been applied yet.
+func (rs *ruleStore) createRuleTables(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.current_rule (
+
+	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE IF NOT EXISTS multigres.current_rule (
 		shard_id                  BYTEA PRIMARY KEY,
 		coordinator_term          BIGINT NOT NULL,
 		rule_subterm              BIGINT NOT NULL,
@@ -171,37 +172,20 @@ func (pm *MultiPoolerManager) createCurrentRuleTable(ctx context.Context) error 
 	)`); err != nil {
 		return mterrors.Wrap(err, "failed to create current_rule table")
 	}
-	return nil
-}
 
-// initializeCurrentRule inserts the zero-state sentinel row for the default shard.
-// This row must exist before any rule is written so that updateRule can SELECT FOR
-// UPDATE on it to serialise concurrent writes.
-// coordinator_term=0 means no rule has been applied yet.
-// Uses ON CONFLICT DO NOTHING so it is safe to call multiple times.
-func (pm *MultiPoolerManager) initializeCurrentRule(ctx context.Context) error {
-	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	err := pm.execArgs(execCtx, `
+	if _, err := rs.queryService.QueryArgs(execCtx, `
 		INSERT INTO multigres.current_rule
 		  (shard_id, coordinator_term, rule_subterm, cohort_members, created_at)
 		VALUES ($1, 0, 0, '{}', now())
 		ON CONFLICT (shard_id) DO NOTHING`,
-		[]byte("0"))
-	if err != nil {
+		[]byte("0")); err != nil {
 		return mterrors.Wrap(err, "failed to initialize current_rule")
 	}
-	return nil
-}
 
-// createRuleHistoryTable creates the rule_history table.
-// Each row records a cluster state change (promotion, cohort membership, durability policy).
-// The composite primary key (coordinator_term, rule_subterm) uniquely identifies each rule;
-// rule_subterm is assigned by the application as MAX(rule_subterm)+1 within a coordinator_term.
-func (pm *MultiPoolerManager) createRuleHistoryTable(ctx context.Context) error {
-	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.rule_history (
+	// Each row records a cluster state change (promotion, cohort membership, durability policy).
+	// The composite primary key (coordinator_term, rule_subterm) uniquely identifies each rule;
+	// rule_subterm is assigned by the application as MAX(rule_subterm)+1 within a coordinator_term.
+	if _, err := rs.queryService.Query(execCtx, `CREATE TABLE IF NOT EXISTS multigres.rule_history (
 		coordinator_term          BIGINT NOT NULL,
 		rule_subterm              BIGINT NOT NULL,
 		event_type                TEXT NOT NULL,
@@ -379,33 +363,51 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 
 	result, err := rs.queryService.QueryArgs(execCtx, `
 		WITH
-		  locked AS (
-		    SELECT coordinator_term, rule_subterm, leader_id, coordinator_id, cohort_members,
-		           durability_policy_name, durability_quorum_type, durability_required_count,
-		           durability_async_fallback
-		    FROM multigres.current_rule
-		    WHERE shard_id = $1
-		      AND ($11::bigint IS NULL OR (coordinator_term = $11 AND rule_subterm = $12))
-		    FOR UPDATE
+		  params AS (
+		    SELECT $1::bytea        AS shard_id,
+		           $2::bigint       AS coordinator_term,
+		           $3::text         AS event_type,
+		           $4::text         AS leader_id,
+		           $5::text         AS coordinator_id,
+		           $6::text         AS wal_position,
+		           $7::text         AS operation,
+		           $8::text         AS reason,
+		           $9::text[]       AS cohort_members,
+		           $10::text[]      AS accepted_members,
+		           $11::bigint      AS cas_coordinator_term,
+		           $12::bigint      AS cas_rule_subterm,
+		           $13::timestamptz AS created_at
 		  ),
-		  next_sub AS (
-		    SELECT CASE
-		      WHEN $2 > locked.coordinator_term THEN 0
-		      ELSE locked.rule_subterm + 1
-		    END AS value
-		    FROM locked
+		  locked AS (
+		    -- FOR UPDATE serializes concurrent writes at the database level, complementing
+		    -- the action lock held by the caller.
+		    -- Returns zero rows (causing a no-op write and error return) when any condition fails.
+		    -- next_sub: 0 when starting a new coordinator term, otherwise increment within term.
+		    SELECT current_rule.coordinator_term, current_rule.rule_subterm,
+		           current_rule.leader_id, current_rule.cohort_members,
+		           CASE WHEN params.coordinator_term > current_rule.coordinator_term THEN 0
+		                ELSE current_rule.rule_subterm + 1
+		           END AS next_sub
+		    FROM multigres.current_rule, params
+		    WHERE current_rule.shard_id = params.shard_id                   -- target shard
+		      AND params.coordinator_term >= current_rule.coordinator_term  -- reject stale writes
+		      AND (params.cas_coordinator_term IS NULL                      -- optimistic CAS check
+		           OR (current_rule.coordinator_term = params.cas_coordinator_term
+		               AND current_rule.rule_subterm = params.cas_rule_subterm))
+		    FOR UPDATE
 		  ),
 		  updated AS (
 		    UPDATE multigres.current_rule
-		    SET coordinator_term = $2,
-		        rule_subterm     = next_sub.value,
-		        leader_id        = COALESCE(NULLIF($4, ''), locked.leader_id),
-		        coordinator_id   = NULLIF($5, ''),
-		        cohort_members   = COALESCE($9, locked.cohort_members),
-		        created_at       = $13
-		    FROM next_sub, locked
-		    WHERE shard_id = $1
-		      AND ($2 > locked.coordinator_term OR ($2 = locked.coordinator_term AND next_sub.value > locked.rule_subterm))
+		    SET coordinator_term = params.coordinator_term,
+		        rule_subterm     = locked.next_sub,
+		        leader_id        = COALESCE(NULLIF(params.leader_id, ''), locked.leader_id),
+		        coordinator_id   = NULLIF(params.coordinator_id, ''),
+		        cohort_members   = COALESCE(params.cohort_members, locked.cohort_members),
+		        created_at       = params.created_at
+		    FROM locked, params
+		    -- Correlates the update target to the specific shard row. If locked is empty
+		    -- (any condition above failed), the cross-join produces zero rows here too.
+		    WHERE current_rule.shard_id = params.shard_id
 		    RETURNING current_rule.coordinator_term, current_rule.rule_subterm,
 		              current_rule.leader_id, current_rule.coordinator_id, current_rule.cohort_members,
 		              current_rule.durability_policy_name, current_rule.durability_quorum_type,
@@ -416,16 +418,18 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		      (coordinator_term, rule_subterm, event_type, leader_id, coordinator_id,
 		       wal_position, operation, reason, cohort_members, accepted_members, created_at)
 		    SELECT updated.coordinator_term, updated.rule_subterm,
-		           $3,
+		           params.event_type,
 		           updated.leader_id,
 		           updated.coordinator_id,
-		           NULLIF($6, ''), NULLIF($7, ''), $8,
+		           NULLIF(params.wal_position, ''), NULLIF(params.operation, ''), params.reason,
 		           updated.cohort_members,
-		           $10,
-		           $13
-		    FROM updated
+		           params.accepted_members,
+		           params.created_at
+		    FROM updated, params
 		    RETURNING coordinator_term
 		  )
+		-- Cross-joining inserted ensures a zero-row history insert (a bug) also returns zero
+		-- rows here, causing the caller to surface an error rather than silently succeeding.
 		SELECT updated.coordinator_term, updated.rule_subterm,
 		       updated.leader_id, updated.coordinator_id, updated.cohort_members,
 		       updated.durability_policy_name, updated.durability_quorum_type,

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -319,7 +319,7 @@ func TestRuleStorePG_UpdateRule_FirstWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 	assert.Equal(t, int64(1), pos.Rule.RuleNumber.CoordinatorTerm)
-	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm, "first write in a new term starts at subterm 0")
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.LeaderSubterm, "first write in a new term starts at subterm 0")
 }
 
 func TestRuleStorePG_UpdateRule_SameTermIncrementsSubterm(t *testing.T) {
@@ -335,11 +335,11 @@ func TestRuleStorePG_UpdateRule_SameTermIncrementsSubterm(t *testing.T) {
 
 	pos1, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), pos1.Rule.RuleNumber.RuleSubterm)
+	assert.Equal(t, int64(0), pos1.Rule.RuleNumber.LeaderSubterm)
 
 	pos2, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "config_change", "second", now))
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.RuleSubterm, "second write in same term increments subterm")
+	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.LeaderSubterm, "second write in same term increments subterm")
 }
 
 func TestRuleStorePG_UpdateRule_NewTermResetsSubterm(t *testing.T) {
@@ -363,7 +363,7 @@ func TestRuleStorePG_UpdateRule_NewTermResetsSubterm(t *testing.T) {
 	pos, err := rs.updateRule(ctx, newRuleUpdate(2, coordinatorID, "promotion", "new coordinator", now))
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), pos.Rule.RuleNumber.CoordinatorTerm)
-	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm, "new term resets subterm to 0")
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.LeaderSubterm, "new term resets subterm to 0")
 }
 
 func TestRuleStorePG_UpdateRule_StaleTermRejected(t *testing.T) {
@@ -414,7 +414,7 @@ func TestRuleStorePG_UpdateRule_ObserveAfterWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 	assert.Equal(t, int64(3), pos.Rule.RuleNumber.CoordinatorTerm)
-	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm)
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.LeaderSubterm)
 
 	require.NotNil(t, pos.Rule.PrimaryId)
 	assert.Equal(t, "zone1", pos.Rule.PrimaryId.Cell)
@@ -468,7 +468,7 @@ func TestRuleStorePG_UpdateRule_HistoryFields(t *testing.T) {
 
 	rec := records[0]
 	assert.Equal(t, int64(5), rec.CoordinatorTerm)
-	assert.Equal(t, int64(0), rec.RuleSubterm)
+	assert.Equal(t, int64(0), rec.LeaderSubterm)
 	assert.Equal(t, "promotion", rec.EventType)
 	assert.Equal(t, "bootstrap failover", rec.Reason)
 
@@ -511,8 +511,8 @@ func TestRuleStorePG_UpdateRule_CASSuccess(t *testing.T) {
 	// Write the first rule so we know the exact term/subterm.
 	pos1, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
 	require.NoError(t, err)
-	term := pos1.Rule.RuleNumber.CoordinatorTerm // 1
-	subterm := pos1.Rule.RuleNumber.RuleSubterm  // 0
+	term := pos1.Rule.RuleNumber.CoordinatorTerm  // 1
+	subterm := pos1.Rule.RuleNumber.LeaderSubterm // 0
 
 	// CAS: only proceed if current rule is still (term=1, subterm=0).
 	pos2, err := rs.updateRule(ctx,
@@ -520,7 +520,7 @@ func TestRuleStorePG_UpdateRule_CASSuccess(t *testing.T) {
 			withPreviousRule(term, subterm),
 	)
 	require.NoError(t, err, "CAS should succeed when term/subterm match")
-	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.RuleSubterm, "subterm should advance to 1")
+	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.LeaderSubterm, "subterm should advance to 1")
 }
 
 func TestRuleStorePG_UpdateRule_CASConflict(t *testing.T) {
@@ -618,7 +618,7 @@ func TestRuleStorePG_UpdateRule_Concurrent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pos)
 	assert.Equal(t, int64(1), pos.Rule.RuleNumber.CoordinatorTerm)
-	assert.Equal(t, int64(goroutines-1), pos.Rule.RuleNumber.RuleSubterm,
+	assert.Equal(t, int64(goroutines-1), pos.Rule.RuleNumber.LeaderSubterm,
 		"final subterm should equal goroutines-1 after %d serialized writes", goroutines)
 }
 

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -1,0 +1,633 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/executor"
+	testutils "github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/pathutil"
+)
+
+// pgTestFixture is the lazily-started postgres instance shared by all PG tests.
+// It is nil until the first PG test triggers initialisation via skipIfNoPG.
+var (
+	pgTestFixture *pgPostgresFixture
+	pgTestOnce    sync.Once
+	pgTestErr     error
+)
+
+// pgPostgresFixture holds a running postgres instance.
+type pgPostgresFixture struct {
+	dataDir   string // root temp directory
+	pgDataDir string // postgres data directory (dataDir/pg_data)
+	socketDir string // unix socket directory (dataDir/pg_sockets)
+}
+
+// socketFile returns the path to the postgres unix domain socket.
+// With listen_addresses=” postgres never binds TCP, so 5432 here is purely
+// the filename convention (.s.PGSQL.<port>).  Isolation between concurrent
+// test binaries comes from each fixture having its own unique socketDir, not
+// from the port number.
+func (f *pgPostgresFixture) socketFile() string {
+	return filepath.Join(f.socketDir, ".s.PGSQL.5432")
+}
+
+// newClientConn opens a new postgres connection via the unix socket.
+// The returned Conn must be closed by the caller.
+func (f *pgPostgresFixture) newClientConn(ctx context.Context) (*client.Conn, error) {
+	return client.Connect(ctx, ctx, &client.Config{
+		SocketFile: f.socketFile(),
+		User:       "postgres",
+		Database:   "postgres",
+	})
+}
+
+// connQueryService wraps a *client.Conn to implement executor.InternalQueryService.
+// Each instance is single-threaded; callers must not share across goroutines.
+type connQueryService struct {
+	conn *client.Conn
+}
+
+var _ executor.InternalQueryService = (*connQueryService)(nil)
+
+func (s *connQueryService) Query(ctx context.Context, query string) (*sqltypes.Result, error) {
+	results, err := s.conn.QueryArgs(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return &sqltypes.Result{}, nil
+	}
+	return results[0], nil
+}
+
+func (s *connQueryService) QueryArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
+	results, err := s.conn.QueryArgs(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return &sqltypes.Result{}, nil
+	}
+	return results[0], nil
+}
+
+func (s *connQueryService) QueryMultiStatement(ctx context.Context, query string) error {
+	_, err := s.conn.Query(ctx, query)
+	return err
+}
+
+// TestMain sets up the PATH for PG binaries and the orphan-detection watchdog,
+// runs the tests, and tears down the postgres instance if it was started.
+// Postgres is started lazily by the first PG test (via skipIfNoPG) so that
+// tests without PG dependencies are unaffected.
+func TestMain(m *testing.M) {
+	// Add bin/ and go/test/endtoend/ to PATH so run_command_if_parent_dies.sh
+	// and PostgreSQL binaries are found.
+	if err := pathutil.PrependBinToPath(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to prepend bin to PATH: %v\n", err)
+		os.Exit(1) //nolint:forbidigo
+	}
+
+	// Record our PID so orphan-detection watchdogs know which process to monitor.
+	os.Setenv("MULTIGRES_TEST_PARENT_PID", strconv.Itoa(os.Getpid()))
+
+	code := m.Run()
+
+	if pgTestFixture != nil {
+		stopSharedPostgres(pgTestFixture)
+		os.RemoveAll(pgTestFixture.dataDir)
+	}
+
+	os.Exit(code) //nolint:forbidigo
+}
+
+// startSharedPostgres initialises and starts a dedicated postgres instance.
+// It sets up the multigres schema via createRuleTables so tests do not need to.
+func startSharedPostgres(t *testing.T) (*pgPostgresFixture, error) {
+	t.Helper()
+	// Use /tmp explicitly so the unix socket path stays under the 104-byte macOS limit.
+	dataDir, err := os.MkdirTemp("/tmp", "rule_store_pg_test-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	pgDataDir := filepath.Join(dataDir, "pg_data")
+	socketDir := filepath.Join(dataDir, "pg_sockets")
+
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create socket dir: %w", err)
+	}
+
+	// LC_ALL=C avoids locale-library issues on macOS with Homebrew postgres.
+	pgEnv := append(os.Environ(), "LC_ALL=C")
+
+	// Initialise the data directory.
+	initdb := exec.Command(
+		"initdb",
+		"-D", pgDataDir,
+		"-U", "postgres",
+		"--no-instructions",
+		"-A", "trust",
+	)
+	initdb.Env = pgEnv
+	if out, err := initdb.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("initdb failed: %w\nOutput: %s", err, out)
+	}
+
+	f := &pgPostgresFixture{
+		dataDir:   dataDir,
+		pgDataDir: pgDataDir,
+		socketDir: socketDir,
+	}
+
+	logFile := filepath.Join(dataDir, "postgres.log")
+	// listen_addresses= disables TCP entirely; postgres only creates a unix socket.
+	// The socket filename uses the default port (5432) by convention.
+	opts := fmt.Sprintf(
+		"-c listen_addresses= -c unix_socket_directories=%s -c logging_collector=off",
+		socketDir,
+	)
+
+	// Start postgres and wait up to 30 seconds for it to be ready.
+	pgStart := exec.Command(
+		"pg_ctl", "start",
+		"-D", pgDataDir,
+		"-o", opts,
+		"-l", logFile,
+		"-w", "-t", "30",
+	)
+	pgStart.Env = pgEnv
+	if out, err := pgStart.CombinedOutput(); err != nil {
+		pgLog, _ := os.ReadFile(logFile)
+		return nil, fmt.Errorf("pg_ctl start failed: %w\nOutput: %s\nPostgres log:\n%s", err, out, pgLog)
+	}
+
+	// Spawn an orphan-detection watchdog so postgres is stopped even if the test
+	// process is killed unexpectedly.  The watchdog runs in its own process group
+	// so signals delivered to the test process group do not terminate it early.
+	watchdog := exec.Command(
+		"run_command_if_parent_dies.sh",
+		"pg_ctl", "stop", "-D", pgDataDir, "-m", "fast",
+	)
+	watchdog.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	watchdog.Env = append(os.Environ(), "MULTIGRES_TESTDATA_DIR="+dataDir)
+	if err := watchdog.Start(); err != nil {
+		// Non-fatal: the deferred stopSharedPostgres call handles normal teardown.
+		fmt.Fprintf(os.Stderr, "Warning: failed to start watchdog: %v\n", err)
+	}
+
+	// Create the multigres schema and rule tables so all tests start with a
+	// clean, initialised state.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := f.newClientConn(ctx)
+	if err != nil {
+		_ = exec.Command("pg_ctl", "stop", "-D", pgDataDir, "-m", "fast").Run()
+		return nil, fmt.Errorf("connect to postgres: %w", err)
+	}
+	defer conn.Close()
+
+	qs := &connQueryService{conn: conn}
+	if _, err := qs.conn.Query(ctx, "CREATE SCHEMA IF NOT EXISTS multigres"); err != nil {
+		_ = exec.Command("pg_ctl", "stop", "-D", pgDataDir, "-m", "fast").Run()
+		return nil, fmt.Errorf("create schema: %w", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rs := newRuleStore(logger, qs)
+	if err := rs.createRuleTables(ctx); err != nil {
+		_ = exec.Command("pg_ctl", "stop", "-D", pgDataDir, "-m", "fast").Run()
+		return nil, fmt.Errorf("create rule tables: %w", err)
+	}
+
+	return f, nil
+}
+
+// stopSharedPostgres stops the shared postgres instance.
+func stopSharedPostgres(f *pgPostgresFixture) {
+	exec.Command("pg_ctl", "stop", "-D", f.pgDataDir, "-m", "fast").Run() //nolint:errcheck
+}
+
+// newTestRuleStore creates a ruleStore connected to the shared test postgres.
+// The returned conn must be closed when done; close it via t.Cleanup.
+func newTestRuleStore(ctx context.Context, t *testing.T) (*ruleStore, *client.Conn) {
+	t.Helper()
+	conn, err := pgTestFixture.newClientConn(ctx)
+	require.NoError(t, err)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rs := newRuleStore(logger, &connQueryService{conn: conn})
+	return rs, conn
+}
+
+// resetRuleStoreTables truncates and re-initialises the rule tables so each test
+// starts from the zero-state sentinel row.
+func resetRuleStoreTables(ctx context.Context, t *testing.T) {
+	t.Helper()
+	conn, err := pgTestFixture.newClientConn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	qs := &connQueryService{conn: conn}
+	_, err = qs.conn.Query(ctx, "TRUNCATE multigres.current_rule, multigres.rule_history")
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rs := newRuleStore(logger, qs)
+	require.NoError(t, rs.createRuleTables(ctx))
+}
+
+// skipIfNoPG lazily starts the shared postgres fixture on first call and skips
+// the test if PostgreSQL binaries are not available.
+func skipIfNoPG(t *testing.T) {
+	t.Helper()
+	pgTestOnce.Do(func() {
+		if !testutils.HasPostgreSQLBinaries() {
+			return // pgTestFixture stays nil; tests skip below
+		}
+		pgTestFixture, pgTestErr = startSharedPostgres(t)
+	})
+	if pgTestErr != nil {
+		t.Fatalf("postgres setup failed: %v", pgTestErr)
+	}
+	if pgTestFixture == nil {
+		t.Skip("PostgreSQL binaries not available")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+func TestRuleStorePG_ObservePosition_FreshState(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	pos, err := rs.observePosition(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, pos, "fresh sentinel row (coordinator_term=0) should return nil position")
+}
+
+func TestRuleStorePG_UpdateRule_FirstWrite(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	update := newRuleUpdate(1, coordinatorID, "promotion", "initial primary", time.Now())
+
+	pos, err := rs.updateRule(ctx, update)
+	require.NoError(t, err)
+	require.NotNil(t, pos)
+	assert.Equal(t, int64(1), pos.Rule.RuleNumber.CoordinatorTerm)
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm, "first write in a new term starts at subterm 0")
+}
+
+func TestRuleStorePG_UpdateRule_SameTermIncrementsSubterm(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	pos1, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pos1.Rule.RuleNumber.RuleSubterm)
+
+	pos2, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "config_change", "second", now))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.RuleSubterm, "second write in same term increments subterm")
+}
+
+func TestRuleStorePG_UpdateRule_NewTermResetsSubterm(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	// Establish term 1 with a few subterms.
+	for range 3 {
+		_, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "config_change", "setup", now))
+		require.NoError(t, err)
+	}
+
+	// Advance to term 2: subterm must reset to 0.
+	pos, err := rs.updateRule(ctx, newRuleUpdate(2, coordinatorID, "promotion", "new coordinator", now))
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), pos.Rule.RuleNumber.CoordinatorTerm)
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm, "new term resets subterm to 0")
+}
+
+func TestRuleStorePG_UpdateRule_StaleTermRejected(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	// Advance to term 2.
+	_, err := rs.updateRule(ctx, newRuleUpdate(2, coordinatorID, "promotion", "initial", now))
+	require.NoError(t, err)
+
+	// Attempt to write with stale term 1.
+	_, err = rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "config_change", "stale", now))
+	require.Error(t, err, "writing with a stale term must fail")
+	assert.Contains(t, err.Error(), "already at equal or higher position")
+}
+
+func TestRuleStorePG_UpdateRule_ObserveAfterWrite(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	now := time.Now()
+
+	_, err := rs.updateRule(ctx,
+		newRuleUpdate(3, coordinatorID, "promotion", "bootstrap", now).
+			withLeader(leaderID).
+			withCohort(cohort),
+	)
+	require.NoError(t, err)
+
+	pos, err := rs.observePosition(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, pos)
+	assert.Equal(t, int64(3), pos.Rule.RuleNumber.CoordinatorTerm)
+	assert.Equal(t, int64(0), pos.Rule.RuleNumber.RuleSubterm)
+
+	require.NotNil(t, pos.Rule.PrimaryId)
+	assert.Equal(t, "zone1", pos.Rule.PrimaryId.Cell)
+	assert.Equal(t, "leader-1", pos.Rule.PrimaryId.Name)
+
+	require.NotNil(t, pos.Rule.CoordinatorId)
+	assert.Equal(t, "zone1", pos.Rule.CoordinatorId.Cell)
+	assert.Equal(t, "coordinator-1", pos.Rule.CoordinatorId.Name)
+
+	require.Len(t, pos.Rule.CohortMembers, 2)
+	assert.Equal(t, "member-1", pos.Rule.CohortMembers[0].Name)
+	assert.Equal(t, "member-2", pos.Rule.CohortMembers[1].Name)
+
+	assert.NotEmpty(t, pos.Lsn, "LSN should be populated after a write")
+}
+
+func TestRuleStorePG_UpdateRule_HistoryFields(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	leaderID := testPoolerID(t, "zone1", "leader-1")
+	cohort := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+		testPoolerID(t, "zone1", "member-2"),
+	}
+	accepted := []*clustermetadatapb.ID{
+		testPoolerID(t, "zone1", "member-1"),
+	}
+	walPos := "0/1234ABCD"
+	op := "replication_config"
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	_, err := rs.updateRule(ctx,
+		newRuleUpdate(5, coordinatorID, "promotion", "bootstrap failover", now).
+			withLeader(leaderID).
+			withCohort(cohort).
+			withWALPosition(walPos).
+			withOperation(op).
+			withAcceptedMembers(accepted),
+	)
+	require.NoError(t, err)
+
+	records, err := rs.queryRuleHistory(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	assert.Equal(t, int64(5), rec.CoordinatorTerm)
+	assert.Equal(t, int64(0), rec.RuleSubterm)
+	assert.Equal(t, "promotion", rec.EventType)
+	assert.Equal(t, "bootstrap failover", rec.Reason)
+
+	require.NotNil(t, rec.LeaderID)
+	assert.Equal(t, "zone1", rec.LeaderID.id.Cell)
+	assert.Equal(t, "leader-1", rec.LeaderID.id.Name)
+
+	// coordinator_id is stored and returned as the "cell_name" app-name string.
+	require.NotNil(t, rec.CoordinatorID)
+	assert.Equal(t, "zone1_coordinator-1", *rec.CoordinatorID)
+
+	require.NotNil(t, rec.WALPosition)
+	assert.Equal(t, walPos, *rec.WALPosition)
+
+	require.NotNil(t, rec.Operation)
+	assert.Equal(t, op, *rec.Operation)
+
+	require.Len(t, rec.CohortMembers, 2)
+	assert.Equal(t, "zone1", rec.CohortMembers[0].id.Cell)
+	assert.Equal(t, "member-1", rec.CohortMembers[0].id.Name)
+	assert.Equal(t, "member-2", rec.CohortMembers[1].id.Name)
+
+	require.Len(t, rec.AcceptedMembers, 1)
+	assert.Equal(t, "member-1", rec.AcceptedMembers[0].id.Name)
+
+	assert.WithinDuration(t, now, rec.CreatedAt, time.Second)
+}
+
+func TestRuleStorePG_UpdateRule_CASSuccess(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	// Write the first rule so we know the exact term/subterm.
+	pos1, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
+	require.NoError(t, err)
+	term := pos1.Rule.RuleNumber.CoordinatorTerm // 1
+	subterm := pos1.Rule.RuleNumber.RuleSubterm  // 0
+
+	// CAS: only proceed if current rule is still (term=1, subterm=0).
+	pos2, err := rs.updateRule(ctx,
+		newRuleUpdate(1, coordinatorID, "config_change", "cas write", now).
+			withPreviousRule(term, subterm),
+	)
+	require.NoError(t, err, "CAS should succeed when term/subterm match")
+	assert.Equal(t, int64(1), pos2.Rule.RuleNumber.RuleSubterm, "subterm should advance to 1")
+}
+
+func TestRuleStorePG_UpdateRule_CASConflict(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	// Write once to advance past the sentinel.
+	_, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
+	require.NoError(t, err)
+
+	// CAS with stale coordinates should fail with errRuleConflict.
+	_, err = rs.updateRule(ctx,
+		newRuleUpdate(1, coordinatorID, "config_change", "stale cas", now).
+			withPreviousRule(0, 0), // sentinel coordinates no longer current
+	)
+	require.ErrorIs(t, err, errRuleConflict, "CAS with wrong term/subterm must return errRuleConflict")
+}
+
+func TestRuleStorePG_UpdateRule_HistoryRecorded(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	for i := range 5 {
+		_, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "config_change", fmt.Sprintf("write %d", i), now))
+		require.NoError(t, err)
+	}
+
+	records, err := rs.queryRuleHistory(ctx, 10)
+	require.NoError(t, err)
+	assert.Len(t, records, 5, "every updateRule call must append a rule_history row")
+}
+
+func TestRuleStorePG_UpdateRule_Concurrent(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	const goroutines = 100
+	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			conn, err := pgTestFixture.newClientConn(ctx)
+			if err != nil {
+				errs[idx] = fmt.Errorf("connect: %w", err)
+				return
+			}
+			defer conn.Close()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			rs := newRuleStore(logger, &connQueryService{conn: conn})
+			_, errs[idx] = rs.updateRule(ctx,
+				newRuleUpdate(1, coordinatorID, "config_change",
+					fmt.Sprintf("concurrent write %d", idx), now),
+			)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d failed", i)
+	}
+
+	// All goroutines serialized via SELECT FOR UPDATE; verify the full audit log.
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	records, err := rs.queryRuleHistory(ctx, goroutines+1)
+	require.NoError(t, err)
+	assert.Len(t, records, goroutines, "every concurrent write must produce a history row")
+
+	pos, err := rs.observePosition(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, pos)
+	assert.Equal(t, int64(1), pos.Rule.RuleNumber.CoordinatorTerm)
+	assert.Equal(t, int64(goroutines-1), pos.Rule.RuleNumber.RuleSubterm,
+		"final subterm should equal goroutines-1 after %d serialized writes", goroutines)
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+// testPoolerID builds a *clustermetadatapb.ID for use in test updates.
+func testPoolerID(t *testing.T, cell, name string) *clustermetadatapb.ID {
+	t.Helper()
+	return &clustermetadatapb.ID{Cell: cell, Name: name}
+}

--- a/go/services/multipooler/manager/rule_store_test.go
+++ b/go/services/multipooler/manager/rule_store_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/multigres/multigres/go/services/multipooler/executor/mock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryRuleHistory(t *testing.T) {
+	t.Run("returns records ordered newest first", func(t *testing.T) {
+		mockQueryService := mock.NewQueryService()
+		rs := newRuleStore(slog.New(slog.NewTextHandler(io.Discard, nil)), mockQueryService)
+
+		leaderAppName := "zone1_leader-1"
+		coordID := "zone1_coordinator-1"
+		walPos := "0/1234567"
+		operation := "promotion"
+		createdAt := "2026-03-24 09:00:17.000000+00"
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT coordinator_term, rule_subterm, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"coordinator_term", "rule_subterm", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
+					"durability_policy_name", "durability_quorum_type", "durability_required_count",
+					"durability_async_fallback", "created_at",
+				},
+				[][]any{
+					{
+						int64(2), int64(1), "promotion", leaderAppName, coordID, walPos, operation,
+						"manual failover", "{zone1_pooler-2,zone1_pooler-3}", "{zone1_pooler-2}",
+						nil, nil, nil, nil, createdAt,
+					},
+					{
+						int64(1), int64(0), "replication_config", leaderAppName, coordID, nil, nil,
+						"initial bootstrap", "{zone1_pooler-1,zone1_pooler-2}", nil,
+						nil, nil, nil, nil, createdAt,
+					},
+				},
+			),
+		)
+
+		records, err := rs.queryRuleHistory(t.Context(), 10)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+
+		// First record: term 2, subterm 1 (newest)
+		assert.Equal(t, int64(2), records[0].CoordinatorTerm)
+		assert.Equal(t, int64(1), records[0].RuleSubterm)
+		assert.Equal(t, "promotion", records[0].EventType)
+		require.NotNil(t, records[0].LeaderID)
+		assert.Equal(t, leaderAppName, records[0].LeaderID.appName)
+		require.NotNil(t, records[0].WALPosition)
+		assert.Equal(t, walPos, *records[0].WALPosition)
+		require.NotNil(t, records[0].Operation)
+		assert.Equal(t, operation, *records[0].Operation)
+		assert.Equal(t, "manual failover", records[0].Reason)
+		require.Len(t, records[0].CohortMembers, 2)
+		assert.Equal(t, "zone1_pooler-2", records[0].CohortMembers[0].appName)
+		assert.Equal(t, "zone1_pooler-3", records[0].CohortMembers[1].appName)
+		require.Len(t, records[0].AcceptedMembers, 1)
+		assert.Equal(t, "zone1_pooler-2", records[0].AcceptedMembers[0].appName)
+		assert.False(t, records[0].CreatedAt.IsZero())
+
+		// Second record: term 1, subterm 0; nullable fields are nil/empty
+		assert.Equal(t, int64(1), records[1].CoordinatorTerm)
+		assert.Nil(t, records[1].WALPosition)
+		assert.Nil(t, records[1].Operation)
+		assert.Empty(t, records[1].AcceptedMembers)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("returns empty slice when no records exist", func(t *testing.T) {
+		mockQueryService := mock.NewQueryService()
+		rs := newRuleStore(slog.New(slog.NewTextHandler(io.Discard, nil)), mockQueryService)
+
+		mockQueryService.AddQueryPatternOnce(
+			"SELECT coordinator_term, rule_subterm, event_type",
+			mock.MakeQueryResult(
+				[]string{
+					"coordinator_term", "rule_subterm", "event_type", "leader_id", "coordinator_id",
+					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
+					"durability_policy_name", "durability_quorum_type", "durability_required_count",
+					"durability_async_fallback", "created_at",
+				},
+				[][]any{},
+			),
+		)
+
+		records, err := rs.queryRuleHistory(t.Context(), 10)
+		require.NoError(t, err)
+		assert.Empty(t, records)
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		mockQueryService := mock.NewQueryService()
+		rs := newRuleStore(slog.New(slog.NewTextHandler(io.Discard, nil)), mockQueryService)
+
+		mockQueryService.AddQueryPatternOnceWithError(
+			"SELECT coordinator_term, rule_subterm, event_type",
+			errors.New("connection refused"),
+		)
+
+		_, err := rs.queryRuleHistory(t.Context(), 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to query rule_history")
+		assert.Contains(t, err.Error(), "connection refused")
+		assert.NoError(t, mockQueryService.ExpectationsWereMet())
+	})
+}

--- a/go/services/multipooler/manager/rule_store_test.go
+++ b/go/services/multipooler/manager/rule_store_test.go
@@ -38,10 +38,10 @@ func TestQueryRuleHistory(t *testing.T) {
 		createdAt := "2026-03-24 09:00:17.000000+00"
 
 		mockQueryService.AddQueryPatternOnce(
-			"SELECT coordinator_term, rule_subterm, event_type",
+			"SELECT coordinator_term, leader_subterm, event_type",
 			mock.MakeQueryResult(
 				[]string{
-					"coordinator_term", "rule_subterm", "event_type", "leader_id", "coordinator_id",
+					"coordinator_term", "leader_subterm", "event_type", "leader_id", "coordinator_id",
 					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
 					"durability_policy_name", "durability_quorum_type", "durability_required_count",
 					"durability_async_fallback", "created_at",
@@ -67,7 +67,7 @@ func TestQueryRuleHistory(t *testing.T) {
 
 		// First record: term 2, subterm 1 (newest)
 		assert.Equal(t, int64(2), records[0].CoordinatorTerm)
-		assert.Equal(t, int64(1), records[0].RuleSubterm)
+		assert.Equal(t, int64(1), records[0].LeaderSubterm)
 		assert.Equal(t, "promotion", records[0].EventType)
 		require.NotNil(t, records[0].LeaderID)
 		assert.Equal(t, leaderAppName, records[0].LeaderID.appName)
@@ -96,10 +96,10 @@ func TestQueryRuleHistory(t *testing.T) {
 		rs := newRuleStore(slog.New(slog.NewTextHandler(io.Discard, nil)), mockQueryService)
 
 		mockQueryService.AddQueryPatternOnce(
-			"SELECT coordinator_term, rule_subterm, event_type",
+			"SELECT coordinator_term, leader_subterm, event_type",
 			mock.MakeQueryResult(
 				[]string{
-					"coordinator_term", "rule_subterm", "event_type", "leader_id", "coordinator_id",
+					"coordinator_term", "leader_subterm", "event_type", "leader_id", "coordinator_id",
 					"wal_position", "operation", "reason", "cohort_members", "accepted_members",
 					"durability_policy_name", "durability_quorum_type", "durability_required_count",
 					"durability_async_fallback", "created_at",
@@ -119,7 +119,7 @@ func TestQueryRuleHistory(t *testing.T) {
 		rs := newRuleStore(slog.New(slog.NewTextHandler(io.Discard, nil)), mockQueryService)
 
 		mockQueryService.AddQueryPatternOnceWithError(
-			"SELECT coordinator_term, rule_subterm, event_type",
+			"SELECT coordinator_term, leader_subterm, event_type",
 			errors.New("connection refused"),
 		)
 

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -234,7 +234,7 @@ func TestBootstrapInitialization(t *testing.T) {
 			       array_to_json(cohort_members)::text, array_to_json(accepted_members)::text
 			FROM multigres.rule_history
 			WHERE event_type = 'promotion'
-			ORDER BY coordinator_term DESC, rule_subterm DESC
+			ORDER BY coordinator_term DESC, leader_subterm DESC
 			LIMIT 1
 		`, 7)
 		require.NoError(t, err, "should query rule_history")

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -220,22 +220,25 @@ func TestBootstrapInitialization(t *testing.T) {
 		)
 	})
 
-	t.Run("verify leadership history", func(t *testing.T) {
+	t.Run("verify rule history", func(t *testing.T) {
 		primaryClient := setup.NewPrimaryClient(t)
 		defer primaryClient.Close()
 
 		ctx := t.Context()
 
-		// Query leadership_history table
+		// Query rule_history table for the bootstrap promotion record.
+		// TODO: Switch to requesting consensus status from the multipooler RPC once
+		// ConsensusStatus is hooked up to RPCs; that will avoid the direct SQL query.
 		resp, err := primaryClient.Pooler.ExecuteQuery(ctx, `
-			SELECT term_number, leader_id, coordinator_id, wal_position, reason,
-			       cohort_members, accepted_members
-			FROM multigres.leadership_history
-			ORDER BY term_number DESC
+			SELECT coordinator_term, leader_id, coordinator_id, wal_position, reason,
+			       array_to_json(cohort_members)::text, array_to_json(accepted_members)::text
+			FROM multigres.rule_history
+			WHERE event_type = 'promotion'
+			ORDER BY coordinator_term DESC, rule_subterm DESC
 			LIMIT 1
 		`, 7)
-		require.NoError(t, err, "should query leadership_history")
-		require.Len(t, resp.Rows, 1, "should have exactly one leadership history record")
+		require.NoError(t, err, "should query rule_history")
+		require.Len(t, resp.Rows, 1, "should have exactly one rule history promotion record")
 
 		row := resp.Rows[0]
 		termNumber := string(row.Values[0])
@@ -246,8 +249,8 @@ func TestBootstrapInitialization(t *testing.T) {
 		cohortMembersJSON := string(row.Values[5])
 		acceptedMembersJSON := string(row.Values[6])
 
-		// Verify term_number is 1
-		assert.Equal(t, "1", termNumber, "term_number should be 1 for initial bootstrap")
+		// Verify coordinator_term is 1
+		assert.Equal(t, "1", termNumber, "coordinator_term should be 1 for initial bootstrap")
 
 		// Verify leader_id matches primary name (format: cell_name)
 		expectedLeaderID := fmt.Sprintf("%s_%s", setup.CellName, setup.PrimaryName)
@@ -276,7 +279,7 @@ func TestBootstrapInitialization(t *testing.T) {
 		require.NoError(t, err, "accepted_members should be valid JSON array")
 		assert.Contains(t, acceptedMembers, expectedLeaderID, "accepted_members should contain leader")
 
-		t.Logf("Leadership history verified: term=%s, leader=%s, coordinator=%s, reason=%s",
+		t.Logf("Rule history verified: term=%s, leader=%s, coordinator=%s, reason=%s",
 			termNumber, leaderID, coordinatorID, reason)
 	})
 

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -338,8 +338,10 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		assert.Equal(t, "on", syncCommit, "synchronous_commit should be 'on' after failover")
 	})
 
-	// Verify leadership_history records all failovers
-	t.Run("verify leadership_history after failovers", func(t *testing.T) {
+	// Verify rule_history records all failovers.
+	// TODO: Switch to requesting consensus status from the multipooler RPC once
+	// ConsensusStatus is hooked up to RPCs; that will avoid the direct SQL query.
+	t.Run("verify rule_history after failovers", func(t *testing.T) {
 		finalPrimaryName := setup.PrimaryName
 		finalPrimaryInst := setup.GetMultipoolerInstance(finalPrimaryName)
 		require.NotNil(t, finalPrimaryInst, "final primary instance should exist")
@@ -348,11 +350,12 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		db := connectToPostgres(t, socketDir, finalPrimaryInst.Pgctld.PgPort)
 		defer db.Close()
 
-		// Query the leadership_history table for the latest record
-		query := `SELECT term_number, leader_id, coordinator_id, wal_position, reason,
-				  cohort_members, accepted_members, created_at
-				  FROM multigres.leadership_history
-				  ORDER BY term_number DESC
+		// Query the rule_history table for the latest promotion record
+		query := `SELECT coordinator_term, leader_id, coordinator_id, wal_position, reason,
+				  array_to_json(cohort_members)::text, array_to_json(accepted_members)::text, created_at
+				  FROM multigres.rule_history
+				  WHERE event_type = 'promotion'
+				  ORDER BY coordinator_term DESC, rule_subterm DESC
 				  LIMIT 1`
 
 		var termNumber int64
@@ -362,10 +365,10 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 
 		err := db.QueryRow(query).Scan(&termNumber, &leaderID, &coordinatorID, &walPosition,
 			&reason, &cohortMembersJSON, &acceptedMembersJSON, &createdAt)
-		require.NoError(t, err, "Should be able to query leadership_history")
+		require.NoError(t, err, "Should be able to query rule_history")
 
-		// Assertions - after 3 failovers, term_number should be >= 3
-		assert.GreaterOrEqual(t, termNumber, int64(3), "term_number should be >= 3 after 3 failovers")
+		// Assertions - after 3 failovers, coordinator_term should be >= 3
+		assert.GreaterOrEqual(t, termNumber, int64(3), "coordinator_term should be >= 3 after 3 failovers")
 		assert.Contains(t, leaderID, finalPrimaryName, "leader_id should contain final primary name")
 		// Verify coordinator_id matches the multiorch's cell_name format (with multiple multiorchs, any could be coordinator)
 		expectedCoordinatorPrefix := setup.CellName + "_multiorch"
@@ -385,7 +388,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		assert.LessOrEqual(t, len(acceptedMembers), len(cohortMembers),
 			"accepted_members should not exceed cohort_members")
 
-		t.Logf("Leadership history verified: term=%d, leader=%s, coordinator=%s, reason=%s",
+		t.Logf("Rule history verified: term=%d, leader=%s, coordinator=%s, reason=%s",
 			termNumber, leaderID, coordinatorID, reason)
 	})
 

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -355,7 +355,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 				  array_to_json(cohort_members)::text, array_to_json(accepted_members)::text, created_at
 				  FROM multigres.rule_history
 				  WHERE event_type = 'promotion'
-				  ORDER BY coordinator_term DESC, rule_subterm DESC
+				  ORDER BY coordinator_term DESC, leader_subterm DESC
 				  LIMIT 1`
 
 		var termNumber int64

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -329,12 +329,12 @@ enum AsyncReplicationFallbackMode {
 // cohort membership, durability policy) produces a new RuleNumber.
 //
 // Compared lexicographically: higher coordinator_term takes precedence; within
-// the same coordinator_term, higher rule_subterm takes precedence. rule_subterm
+// the same coordinator_term, higher leader_subterm takes precedence. leader_subterm
 // resets to 0 when coordinator_term increases, so subterms alone are not
 // globally unique.
 message RuleNumber {
   int64 coordinator_term = 1;
-  int64 rule_subterm = 2;
+  int64 leader_subterm = 2;
 }
 
 // ShardRule is the complete, authoritative description of shard state at a
@@ -367,7 +367,7 @@ message ShardRule {
 // promotion candidate.
 //
 // Comparison: prefer the node with the higher rule (coordinator_term first,
-// then rule_subterm). Break ties by LSN.
+// then leader_subterm). Break ties by LSN.
 message NodePosition {
   // The highest shard rule this node has committed to local WAL.
   ShardRule rule = 1;


### PR DESCRIPTION
Replace the insertHistoryRecord approach with a typed ruleStore
abstraction that owns the current_rule and rule_history tables.

- New ruleStorer interface (observePosition, updateRule) enables test
  isolation via fakeRuleStore, replacing direct DB mocks in manager tests
- ruleUpdateBuilder provides a builder API for constructing rule updates
  with optional fields (leader, cohort, WAL position, operation, etc.)
- buildNodePosition consolidates row-to-proto parsing shared by both the
  read (observePosition) and write (updateRule) paths
- newPoolerID/toPoolerIDs now return approximate values alongside errors,
  letting best-effort callers (e.g. BeginTerm revoke) use the result
  while strict callers (e.g. validateStandbyIDs) check the error
- Schema operations move from pg_multischema into rule_store where they
  logically belong
