### PR TITLE
refactor(pgctld): always start postgres in recovery mode

### DIFF
--- a/.claude/skills/mt-local-cluster/SKILL.md
+++ b/.claude/skills/mt-local-cluster/SKILL.md
@@ -298,10 +298,10 @@ demo/local/multigres-with-otel.sh cluster start --config-path <config-path>  # t
 ./bin/pgctld start --pooler-dir <pooler-dir-from-config>
 ```
 
-**Restart pgctld (as standby)**:
+**Restart pgctld**:
 
 ```bash
-./bin/pgctld restart --pooler-dir <pooler-dir-from-config> --as-standby
+./bin/pgctld restart --pooler-dir <pooler-dir-from-config>
 ```
 
 **Check pgctld status**:
@@ -421,10 +421,10 @@ User: "stop pgctld"
 - Ask user which one to stop (zone1, zone2, or zone3)
 - Execute stop command with selected pooler-dir
 
-User: "restart pgctld xf42rpl6 as standby"
+User: "restart pgctld xf42rpl6"
 
 - Look up pooler-dir for xf42rpl6 in config
-- Execute: `./bin/pgctld restart --pooler-dir /path/to/pooler_xf42rpl6 --as-standby`
+- Execute: `./bin/pgctld restart --pooler-dir /path/to/pooler_xf42rpl6`
 
 User: "logs multipooler hm9hmxzm"
 

--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -31,27 +31,9 @@ import (
 // Pattern: FATAL: lock file "<filename>" already exists
 var postgresAlreadyRunningPattern = regexp.MustCompile(`lock file ".*" already exists`)
 
-// isPostgresCleanlyStopped checks if PostgreSQL is in a clean shutdown state.
-// Returns true if state is "shut down" or "shut down in recovery", false otherwise.
-func isPostgresCleanlyStopped(ctx context.Context) (bool, error) {
-	cmd := executil.Command(ctx, "pg_controldata", pgctld.PostgresDataDir())
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("pg_controldata failed: %w (output: %s)", err, string(output))
-	}
-
-	outputStr := string(output)
-	clusterStateStr := extractClusterState(outputStr)
-
-	// Clean states: "shut down", "shut down in recovery"
-	// Anything else means we should try crash recovery
-	cleanlyStopped := clusterStateStr == "shut down" || clusterStateStr == "shut down in recovery"
-
-	return cleanlyStopped, nil
-}
-
-// extractClusterState extracts the cluster state from pg_controldata output
-func extractClusterState(output string) string {
+// ExtractClusterState extracts the cluster state from pg_controldata output.
+// The returned string is the trimmed value after "Database cluster state:".
+func ExtractClusterState(output string) string {
 	for line := range strings.SplitSeq(output, "\n") {
 		if strings.Contains(line, "Database cluster state:") {
 			// Format: "Database cluster state:               in production"
@@ -62,6 +44,26 @@ func extractClusterState(output string) string {
 		}
 	}
 	return "unknown"
+}
+
+// IsCleanClusterState reports whether the pg_controldata cluster state indicates
+// a clean shutdown. The clean states are "shut down" and "shut down in recovery".
+// Any other state (e.g. "in production", "in archive recovery") requires crash recovery
+// before pg_rewind can run.
+func IsCleanClusterState(state string) bool {
+	return state == "shut down" || state == "shut down in recovery"
+}
+
+// isPostgresCleanlyStopped checks if PostgreSQL is in a clean shutdown state.
+// Returns true if state is "shut down" or "shut down in recovery", false otherwise.
+func isPostgresCleanlyStopped(ctx context.Context) (bool, error) {
+	cmd := executil.Command(ctx, "pg_controldata", pgctld.PostgresDataDir())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("pg_controldata failed: %w (output: %s)", err, string(output))
+	}
+
+	return IsCleanClusterState(ExtractClusterState(string(output))), nil
 }
 
 // runCrashRecovery performs crash recovery in single-user mode.
@@ -76,10 +78,10 @@ func runCrashRecovery(ctx context.Context, logger *slog.Logger) error {
 	// previously started node will have this file. The caller re-creates it
 	// via StartAsStandby after crash recovery completes.
 	standbySignalPath := filepath.Join(pgctld.PostgresDataDir(), "standby.signal")
-	if err := os.Remove(standbySignalPath); err != nil && !os.IsNotExist(err) {
-		logger.WarnContext(ctx, "Failed to remove standby.signal before crash recovery (continuing)", "error", err)
-	} else if err == nil {
+	if err := os.Remove(standbySignalPath); err == nil {
 		logger.InfoContext(ctx, "Removed standby.signal before crash recovery", "path", standbySignalPath)
+	} else if !os.IsNotExist(err) {
+		logger.WarnContext(ctx, "Failed to remove standby.signal before crash recovery (continuing)", "error", err)
 	}
 
 	// Run postgres in single-user mode to perform crash recovery

--- a/go/cmd/pgctld/command/crash_recovery.go
+++ b/go/cmd/pgctld/command/crash_recovery.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -67,6 +68,19 @@ func extractClusterState(output string) string {
 // This runs postgres --single to complete crash recovery, then exits cleanly.
 func runCrashRecovery(ctx context.Context, logger *slog.Logger) error {
 	logger.InfoContext(ctx, "Starting single-user crash recovery")
+
+	// Remove standby.signal if present. Single-user mode (postgres --single)
+	// does not support standby mode — PostgreSQL exits with FATAL if
+	// standby.signal exists when running as a standalone backend. Since
+	// StartAsStandby always writes standby.signal before starting, any
+	// previously started node will have this file. The caller re-creates it
+	// via StartAsStandby after crash recovery completes.
+	standbySignalPath := filepath.Join(pgctld.PostgresDataDir(), "standby.signal")
+	if err := os.Remove(standbySignalPath); err != nil && !os.IsNotExist(err) {
+		logger.WarnContext(ctx, "Failed to remove standby.signal before crash recovery (continuing)", "error", err)
+	} else if err == nil {
+		logger.InfoContext(ctx, "Removed standby.signal before crash recovery", "path", standbySignalPath)
+	}
 
 	// Run postgres in single-user mode to perform crash recovery
 	// postgres --single starts in single-user mode, performs recovery, and exits on EOF

--- a/go/cmd/pgctld/command/crash_recovery_test.go
+++ b/go/cmd/pgctld/command/crash_recovery_test.go
@@ -15,7 +15,12 @@
 package command
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPostgresAlreadyRunningPattern verifies the regex pattern matches the actual error
@@ -61,4 +66,128 @@ func TestPostgresAlreadyRunningPattern(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExtractClusterState verifies parsing of pg_controldata output.
+func TestExtractClusterState(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected string
+	}{
+		{
+			name: "in production",
+			output: `pg_control version number:            1300
+Database cluster state:               in production
+pg_control last modified:             Thu Apr  9 22:40:51 2026`,
+			expected: "in production",
+		},
+		{
+			name: "shut down",
+			output: `pg_control version number:            1300
+Database cluster state:               shut down
+pg_control last modified:             Thu Apr  9 22:40:51 2026`,
+			expected: "shut down",
+		},
+		{
+			name: "shut down in recovery",
+			output: `pg_control version number:            1300
+Database cluster state:               shut down in recovery
+pg_control last modified:             Thu Apr  9 22:40:51 2026`,
+			expected: "shut down in recovery",
+		},
+		{
+			name: "in archive recovery",
+			output: `pg_control version number:            1300
+Database cluster state:               in archive recovery
+pg_control last modified:             Thu Apr  9 22:40:51 2026`,
+			expected: "in archive recovery",
+		},
+		{
+			name:     "missing state line",
+			output:   `pg_control version number:            1300`,
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractClusterState(tt.output)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestIsCleanClusterState verifies the clean/unclean classification.
+func TestIsCleanClusterState(t *testing.T) {
+	tests := []struct {
+		state   string
+		isClean bool
+	}{
+		{"shut down", true},
+		{"shut down in recovery", true},
+		{"in production", false},
+		{"in archive recovery", false},
+		{"in crash recovery", false},
+		{"unknown", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			assert.Equal(t, tt.isClean, IsCleanClusterState(tt.state))
+		})
+	}
+}
+
+// TestRunCrashRecovery_RemovesStandbySignal verifies that runCrashRecovery removes
+// standby.signal before starting single-user mode.
+func TestRunCrashRecovery_RemovesStandbySignal(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("PGDATA", dataDir)
+
+	// Create standby.signal to simulate a previously started standby node.
+	standbySignalPath := filepath.Join(dataDir, "standby.signal")
+	require.NoError(t, os.WriteFile(standbySignalPath, []byte(""), 0o644))
+
+	// Set up a mock postgres binary that immediately fails (exits non-zero) so
+	// runCrashRecovery returns an error, but standby.signal removal is the first step.
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "postgres"),
+		[]byte("#!/bin/bash\nexit 1\n"),
+		0o755,
+	))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	// Run crash recovery — it will fail because our mock postgres exits 1,
+	// but standby.signal must be removed before postgres is called.
+	_ = runCrashRecovery(t.Context(), testLogger())
+
+	assert.NoFileExists(t, standbySignalPath, "standby.signal should be removed before crash recovery")
+}
+
+// TestRunCrashRecovery_NoStandbySignal verifies that runCrashRecovery works correctly
+// when standby.signal does not exist (e.g., after a primary crash).
+func TestRunCrashRecovery_NoStandbySignal(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("PGDATA", dataDir)
+
+	// No standby.signal present.
+	standbySignalPath := filepath.Join(dataDir, "standby.signal")
+
+	// Set up a mock postgres that exits successfully (simulates completed crash recovery).
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "postgres"),
+		[]byte("#!/bin/bash\nexit 0\n"),
+		0o755,
+	))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	err := runCrashRecovery(t.Context(), testLogger())
+	require.NoError(t, err)
+
+	// standby.signal should still not exist.
+	assert.NoFileExists(t, standbySignalPath)
 }

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -110,12 +110,14 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 		return nil, fmt.Errorf("failed to create postgres config: %w", err)
 	}
 
-	// If the target database is not the default "postgres" (always created by initdb),
-	// start PostgreSQL transiently and create it — same as docker-library/postgres does.
-	if cfg.Database != constants.DefaultPostgresDatabase {
-		if err := setupDatabase(logger, cfg); err != nil {
-			return nil, fmt.Errorf("failed to create database %q: %w", cfg.Database, err)
-		}
+	// Start PostgreSQL transiently and stop it. This updates pg_control with GUC values from
+	// our postgresql.conf (e.g. max_connections, max_worker_processes). initdb initializes
+	// pg_control with PostgreSQL's built-in defaults, but StartAsStandby (recovery mode)
+	// requires these GUCs to be >= the values recorded in pg_control. Running postgres once
+	// here ensures pg_control reflects our config before we switch to standby-only operation.
+	// This also creates cfg.Database if it doesn't already exist (initdb always creates "postgres").
+	if err := setupDatabase(logger, cfg); err != nil {
+		return nil, fmt.Errorf("failed to setup database %q: %w", cfg.Database, err)
 	}
 
 	result.AlreadyInitialized = false

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -86,8 +86,10 @@ Examples:
 }
 
 // InitDataDirWithResult initializes PostgreSQL data directory and returns detailed result information.
-// When pgDatabase differs from the default "postgres" database, it starts PostgreSQL transiently
-// and creates the target database — mirroring docker-library/postgres's docker_setup_db behaviour.
+// After initdb it starts PostgreSQL transiently to update pg_control with GUC values from our
+// postgresql.conf, then stops it. This must happen before any StartAsStandby call because
+// PostgreSQL's recovery mode requires that configured GUC values (e.g. max_connections) are ≥
+// the values recorded in pg_control by initdb. Also creates cfg.Database if it does not already exist.
 func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServiceConfig) (*InitResult, error) {
 	result := &InitResult{}
 	dataDir := pgctld.PostgresDataDir()

--- a/go/cmd/pgctld/command/init_test.go
+++ b/go/cmd/pgctld/command/init_test.go
@@ -52,3 +52,34 @@ func TestInitDataDirWithResult_AlreadyInitialized(t *testing.T) {
 	assert.True(t, result.AlreadyInitialized)
 	assert.Contains(t, result.Message, "already initialized")
 }
+
+// TestInitDataDirWithResult_InitdbFailure verifies that InitDataDirWithResult returns
+// an error (and does not proceed to setupDatabase) when initdb fails.
+func TestInitDataDirWithResult_InitdbFailure(t *testing.T) {
+	poolerDir := t.TempDir()
+
+	// Point PGDATA at an uninitialized directory so we attempt initdb.
+	dataDir := filepath.Join(poolerDir, "pg_data")
+	t.Setenv(constants.PgDataDirEnvVar, dataDir)
+
+	// Mock initdb that always fails.
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "initdb"),
+		[]byte("#!/bin/bash\necho 'initdb: fatal error' >&2\nexit 1\n"),
+		0o755,
+	))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	logger := slog.New(slog.DiscardHandler)
+	cfg := PgCtldServiceConfig{
+		Port:     5432,
+		User:     constants.DefaultPostgresUser,
+		Database: constants.DefaultPostgresDatabase,
+	}
+
+	_, err := InitDataDirWithResult(logger, poolerDir, cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize data directory")
+}

--- a/go/cmd/pgctld/command/init_test.go
+++ b/go/cmd/pgctld/command/init_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+)
+
+// TestInitDataDirWithResult_AlreadyInitialized verifies that InitDataDirWithResult
+// returns early without calling initdb or setupDatabase when the data directory
+// is already initialized.
+func TestInitDataDirWithResult_AlreadyInitialized(t *testing.T) {
+	poolerDir := t.TempDir()
+
+	// Create an initialized data directory (PG_VERSION is the marker)
+	dataDir := filepath.Join(poolerDir, "pg_data")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("17\n"), 0o644))
+	t.Setenv(constants.PgDataDirEnvVar, dataDir)
+
+	logger := slog.New(slog.DiscardHandler)
+	cfg := PgCtldServiceConfig{
+		Port:     5432,
+		User:     constants.DefaultPostgresUser,
+		Database: constants.DefaultPostgresDatabase,
+	}
+
+	result, err := InitDataDirWithResult(logger, poolerDir, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.AlreadyInitialized)
+	assert.Contains(t, result.Message, "already initialized")
+}

--- a/go/cmd/pgctld/command/restart.go
+++ b/go/cmd/pgctld/command/restart.go
@@ -35,9 +35,8 @@ type RestartResult struct {
 
 // PgCtlRestartCmd holds the restart command configuration
 type PgCtlRestartCmd struct {
-	pgCtlCmd  *PgCtlCommand
-	mode      viperutil.Value[string]
-	asStandby viperutil.Value[bool]
+	pgCtlCmd *PgCtlCommand
+	mode     viperutil.Value[string]
 }
 
 // AddRestartCommand adds the restart subcommand to the root command
@@ -49,11 +48,6 @@ func AddRestartCommand(root *cobra.Command, pc *PgCtlCommand) {
 			FlagName: "mode",
 			Dynamic:  false,
 		}),
-		asStandby: viperutil.Configure(pc.reg, "as-standby", viperutil.Options[bool]{
-			Default:  false,
-			FlagName: "as-standby",
-			Dynamic:  false,
-		}),
 	}
 	root.AddCommand(restartCmd.createCommand())
 }
@@ -62,11 +56,13 @@ func (r *PgCtlRestartCmd) createCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "Restart PostgreSQL server",
-		Long: `Restart the PostgreSQL server by stopping it and then starting it again.
+		Long: `Restart the PostgreSQL server by stopping it and then starting it again as a standby.
 
 The restart command performs a stop followed by start operation in sequence.
-Configuration can be provided via config file, environment variables, or CLI flags.
-CLI flags take precedence over config file and environment variable settings.
+PostgreSQL always starts in standby (recovery) mode, ensuring it never becomes
+a primary unexpectedly. Configuration can be provided via config file, environment
+variables, or CLI flags. CLI flags take precedence over config file and environment
+variable settings.
 
 Examples:
   # Restart with default settings
@@ -76,13 +72,7 @@ Examples:
   pgctld restart --pg-data-dir /var/lib/postgresql/data --port 5433 --mode smart
 
   # Restart with custom config and timeout
-  pgctld restart -d /var/lib/postgresql/data -c /etc/multigres/pgctld.yaml --timeout 60 --pg-config-file /etc/postgresql/custom.conf
-
-  # Restart with immediate stop and custom socket directory
-  pgctld restart -d /data --mode immediate -s /var/run/postgresql
-
-  # Restart as standby (for demotion)
-  pgctld restart --pg-data-dir /var/lib/postgresql/data --as-standby`,
+  pgctld restart -d /var/lib/postgresql/data -c /etc/multigres/pgctld.yaml --timeout 60 --pg-config-file /etc/postgresql/custom.conf`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return r.pgCtlCmd.validateInitialized(cmd, args)
 		},
@@ -90,21 +80,18 @@ Examples:
 	}
 
 	cmd.Flags().String("mode", r.mode.Default(), "Shutdown mode for stop phase: smart, fast, or immediate")
-	cmd.Flags().Bool("as-standby", r.asStandby.Default(), "Create standby.signal to restart as standby (for demotion)")
-	viperutil.BindFlags(cmd.Flags(), r.mode, r.asStandby)
+	viperutil.BindFlags(cmd.Flags(), r.mode)
 
 	return cmd
 }
 
-// RestartPostgreSQLWithResult restarts PostgreSQL with the given configuration and returns detailed result information
-func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string, asStandby bool) (*RestartResult, error) {
+// RestartPostgreSQLWithResult restarts PostgreSQL and returns detailed result information.
+// PostgreSQL always restarts in standby (recovery) mode — standby.signal is written
+// before the new process starts, so it never enters primary mode unexpectedly.
+func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlConfig, mode string) (*RestartResult, error) {
 	result := &RestartResult{}
 
-	if asStandby {
-		logger.Info("Restarting PostgreSQL server as standby", "data_dir", config.PostgresDataDir, "mode", mode)
-	} else {
-		logger.Info("Restarting PostgreSQL server", "data_dir", config.PostgresDataDir, "mode", mode)
-	}
+	logger.Info("Restarting PostgreSQL server", "data_dir", config.PostgresDataDir, "mode", mode)
 
 	// Stop the server if it's running
 	if isPostgreSQLRunning(config.PostgresDataDir) {
@@ -116,51 +103,22 @@ func RestartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtl
 		result.StoppedFirst = stopResult.WasRunning
 	} else {
 		logger.Info("PostgreSQL is not running, proceeding with start")
-		result.StoppedFirst = false
 	}
 
-	// Create standby.signal if restarting as standby
-	if asStandby {
-		standbySignalPath := filepath.Join(config.PostgresDataDir, "standby.signal")
-		logger.Info("Creating standby.signal file", "path", standbySignalPath)
-		if err := os.WriteFile(standbySignalPath, []byte(""), 0o644); err != nil {
-			return nil, fmt.Errorf("failed to create standby.signal: %w", err)
-		}
-		logger.Info("standby.signal created successfully", "path", standbySignalPath)
-	}
-
-	// Start the server with detailed context
-	if asStandby {
-		logger.Info("Starting PostgreSQL server as standby",
-			"data_dir", config.PostgresDataDir,
-			"port", config.Port,
-			"timeout", config.Timeout,
-		)
-	} else {
-		logger.Info("Starting PostgreSQL server")
+	// Always write standby.signal so postgres starts in recovery mode, never as primary.
+	standbySignalPath := filepath.Join(config.PostgresDataDir, "standby.signal")
+	if err := os.WriteFile(standbySignalPath, []byte(""), 0o644); err != nil {
+		return nil, fmt.Errorf("failed to create standby.signal: %w", err)
 	}
 
 	startResult, err := StartPostgreSQLWithResult(logger, config)
 	if err != nil {
-		// Enhanced error logging for standby mode
-		if asStandby {
-			logger.Error("Failed to start PostgreSQL as standby",
-				"error", err,
-				"data_dir", config.PostgresDataDir,
-				"port", config.Port,
-			)
-		}
 		return nil, fmt.Errorf("failed to start PostgreSQL during restart: %w", err)
 	}
 
 	result.PID = startResult.PID
-	if asStandby {
-		result.Message = "PostgreSQL server restarted as standby successfully"
-		logger.Info("PostgreSQL server restarted as standby successfully", "pid", result.PID)
-	} else {
-		result.Message = "PostgreSQL server restarted successfully"
-		logger.Info("PostgreSQL server restarted successfully")
-	}
+	result.Message = "PostgreSQL server restarted successfully"
+	logger.Info("PostgreSQL server restarted successfully", "pid", result.PID)
 
 	return result, nil
 }
@@ -170,15 +128,12 @@ func (r *PgCtlRestartCmd) runRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	result, err := RestartPostgreSQLWithResult(r.pgCtlCmd.lg.GetLogger(), config, r.mode.Get(), r.asStandby.Get())
+	result, err := RestartPostgreSQLWithResult(r.pgCtlCmd.lg.GetLogger(), config, r.mode.Get())
 	if err != nil {
 		return err
 	}
 
-	// Display appropriate message for CLI users
-	if r.asStandby.Get() {
-		fmt.Printf("PostgreSQL server restarted as standby successfully (PID: %d, mode: %s)\n", result.PID, r.mode.Get())
-	} else if result.StoppedFirst {
+	if result.StoppedFirst {
 		fmt.Printf("PostgreSQL server restarted successfully (PID: %d, mode: %s)\n", result.PID, r.mode.Get())
 	} else {
 		fmt.Printf("PostgreSQL server started successfully (PID: %d) - was not previously running\n", result.PID)

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -492,30 +492,15 @@ func (s *PgCtldService) StartPgBackRestManagement() {
 	})
 }
 
-func (s *PgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.StartResponse, error) {
-	s.logger.InfoContext(ctx, "gRPC Start request", "port", req.Port)
+func (s *PgCtldService) StartAsStandby(ctx context.Context, req *pb.StartAsStandbyRequest) (*pb.StartAsStandbyResponse, error) {
+	s.logger.InfoContext(ctx, "gRPC StartAsStandby request", "port", req.Port)
 
-	// Check if data directory is initialized
 	if !pgctld.IsDataDirInitialized() {
 		dataDir := pgctld.PostgresDataDir()
 		return nil, fmt.Errorf("data directory not initialized: %s. Run 'pgctld init' first", dataDir)
 	}
 
-	// Use the pre-configured PostgreSQL config for start operation
-	result, err := StartPostgreSQLWithResult(s.logger, s.pgConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start PostgreSQL: %w", err)
-	}
-
-	pid, err := intToInt32(result.PID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid PID: %w", err)
-	}
-
-	return &pb.StartResponse{
-		Pid:     pid,
-		Message: result.Message,
-	}, nil
+	return StartAsStandbyWithResult(ctx, s.logger, s.pgConfig)
 }
 
 func (s *PgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.StopResponse, error) {

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -524,7 +524,7 @@ func (s *PgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.Stop
 }
 
 func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*pb.RestartResponse, error) {
-	s.logger.InfoContext(ctx, "gRPC Restart request", "mode", req.Mode, "port", req.Port, "as_standby", req.AsStandby)
+	s.logger.InfoContext(ctx, "gRPC Restart request", "mode", req.Mode, "port", req.Port)
 
 	// Check if data directory is initialized
 	if !pgctld.IsDataDirInitialized() {
@@ -533,7 +533,7 @@ func (s *PgCtldService) Restart(ctx context.Context, req *pb.RestartRequest) (*p
 	}
 
 	// Use the pre-configured PostgreSQL config for restart operation
-	result, err := RestartPostgreSQLWithResult(s.logger, s.pgConfig, req.Mode, req.AsStandby)
+	result, err := RestartPostgreSQLWithResult(s.logger, s.pgConfig, req.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restart PostgreSQL: %w", err)
 	}

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -143,9 +143,32 @@ func TestPgCtldServiceStartAsStandby(t *testing.T) {
 		// The mock postgres checks for standby.signal in the data dir and exits 0.
 		// If standby.signal is missing, it exits 1.
 		pgDataDir := filepath.Join(baseDir, "pg_data")
-		testutil.MockBinary(t, binDir, "postgres", `
-[ -f "`+pgDataDir+`/standby.signal" ] && exit 0
-exit 1
+
+		// pg_ctl start creates a postmaster.pid and exits 0.
+		// The code writes standby.signal before calling pg_ctl start, so
+		// standby.signal will be present when pg_ctl runs. We verify this
+		// ordering by asserting standby.signal still exists after the call.
+		testutil.MockBinary(t, binDir, "pg_ctl", `
+case "$1" in
+    "start")
+        DATADIR=""
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+                -D) DATADIR="$2"; shift 2 ;;
+                -D*) DATADIR="${1#-D}"; shift ;;
+                *) shift ;;
+            esac
+        done
+        if [ -n "$DATADIR" ]; then
+            sleep 3600 >/dev/null 2>&1 &
+            MOCK_PID=$!
+            printf '%s\n%s\n%s\n5432\n/tmp\nlocalhost\n*\nready\n' \
+                "$MOCK_PID" "$DATADIR" "$(date +%s)" > "$DATADIR/postmaster.pid"
+        fi
+        echo "server started"
+        ;;
+    *) exit 1 ;;
+esac
 `)
 		testutil.MockBinary(t, binDir, "pg_isready", "exit 0")
 		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -87,19 +87,19 @@ func TestIntToInt32(t *testing.T) {
 	}
 }
 
-func TestPgCtldServiceStart(t *testing.T) {
+func TestPgCtldServiceStartAsStandby(t *testing.T) {
 	tests := []struct {
 		name          string
-		request       *pb.StartRequest
+		request       *pb.StartAsStandbyRequest
 		setupDataDir  func(string) string
 		setupBinaries bool
 		expectError   bool
 		errorContains string
-		checkResponse func(*testing.T, *pb.StartResponse)
+		checkResponse func(*testing.T, *pb.StartAsStandbyResponse)
 	}{
 		{
 			name: "start with uninitialized data dir should fail",
-			request: &pb.StartRequest{
+			request: &pb.StartAsStandbyRequest{
 				Port:      5432,
 				ExtraArgs: []string{},
 			},
@@ -112,7 +112,7 @@ func TestPgCtldServiceStart(t *testing.T) {
 		},
 		{
 			name: "start already running server",
-			request: &pb.StartRequest{
+			request: &pb.StartAsStandbyRequest{
 				Port: 5432,
 			},
 			setupDataDir: func(baseDir string) string {
@@ -122,11 +122,44 @@ func TestPgCtldServiceStart(t *testing.T) {
 			},
 			setupBinaries: true,
 			expectError:   false,
-			checkResponse: func(t *testing.T, resp *pb.StartResponse) {
-				assert.Contains(t, resp.Message, "already running")
+			checkResponse: func(t *testing.T, resp *pb.StartAsStandbyResponse) {
+				assert.Equal(t, pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING, resp.GetResult())
 			},
 		},
 	}
+
+	t.Run("writes standby.signal before starting postgres", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_standby_signal_test")
+		defer cleanup()
+
+		dataDir := testutil.CreateDataDir(t, baseDir, true)
+		_ = dataDir
+
+		// Mock postgres binary that records what files exist at startup time.
+		// We verify standby.signal is present when postgres is called.
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+		// The mock postgres checks for standby.signal in the data dir and exits 0.
+		// If standby.signal is missing, it exits 1.
+		pgDataDir := filepath.Join(baseDir, "pg_data")
+		testutil.MockBinary(t, binDir, "postgres", `
+[ -f "`+pgDataDir+`/standby.signal" ] && exit 0
+exit 1
+`)
+		testutil.MockBinary(t, binDir, "pg_isready", "exit 0")
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		service, err := NewPgCtldService(testLogger(), testServiceConfig, 30, baseDir, "localhost", 0, "")
+		require.NoError(t, err)
+
+		resp, err := service.StartAsStandby(context.Background(), &pb.StartAsStandbyRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED, resp.GetResult())
+
+		// standby.signal should still be present after startup
+		assert.FileExists(t, filepath.Join(pgDataDir, "standby.signal"))
+	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,7 +182,7 @@ func TestPgCtldServiceStart(t *testing.T) {
 			service, err := NewPgCtldService(testLogger(), testServiceConfig, 30, poolerDir, "localhost", 0, "")
 			require.NoError(t, err)
 
-			resp, err := service.Start(context.Background(), tt.request)
+			resp, err := service.StartAsStandby(context.Background(), tt.request)
 
 			if tt.expectError {
 				fmt.Println(resp)

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -29,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/multigres/multigres/go/common/servenv"
+	pb "github.com/multigres/multigres/go/pb/pgctldservice"
 	"github.com/multigres/multigres/go/services/pgctld"
 )
 
@@ -170,6 +172,44 @@ func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCo
 	result.Message = "PostgreSQL server started successfully"
 	logger.Info("PostgreSQL server started successfully")
 	return result, nil
+}
+
+// StartAsStandbyWithResult starts PostgreSQL in standby (recovery) mode.
+// It always writes standby.signal before starting, ensuring postgres never starts as primary.
+// If the data directory was not cleanly stopped, PostgreSQL performs crash recovery
+// automatically during startup (before accepting connections).
+func StartAsStandbyWithResult(ctx context.Context, logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*pb.StartAsStandbyResponse, error) {
+	if isPostgreSQLRunning(config.PostgresDataDir) {
+		pid, _ := readPostmasterPID(config.PostgresDataDir)
+		pid32, _ := intToInt32(pid)
+		return &pb.StartAsStandbyResponse{
+			Result: pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING,
+			Pid:    pid32,
+		}, nil
+	}
+
+	// Write standby.signal so postgres starts in recovery mode, never as primary.
+	// If the data directory was not cleanly stopped, postgres will apply crash recovery
+	// automatically before accepting connections.
+	standbySignalPath := filepath.Join(config.PostgresDataDir, "standby.signal")
+	if err := os.WriteFile(standbySignalPath, []byte(""), 0o644); err != nil {
+		return nil, fmt.Errorf("failed to create standby.signal: %w", err)
+	}
+
+	if err := startPostgreSQLWithConfig(logger, config); err != nil {
+		return nil, fmt.Errorf("failed to start PostgreSQL as standby: %w", err)
+	}
+	if err := waitForPostgreSQLWithConfig(logger, config); err != nil {
+		return nil, fmt.Errorf("PostgreSQL failed to become ready: %w", err)
+	}
+
+	pid, _ := readPostmasterPID(config.PostgresDataDir)
+	pid32, _ := intToInt32(pid)
+	logger.InfoContext(ctx, "PostgreSQL started successfully as standby", "pid", pid32)
+	return &pb.StartAsStandbyResponse{
+		Result: pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED,
+		Pid:    pid32,
+	}, nil
 }
 
 // StartPostgreSQLWithConfig starts PostgreSQL with the given configuration

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -104,16 +104,16 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := StartPostgreSQLWithResult(s.pgCtlCmd.lg.GetLogger(), config)
+	resp, err := StartAsStandbyWithResult(cmd.Context(), s.pgCtlCmd.lg.GetLogger(), config)
 	if err != nil {
 		return err
 	}
 
 	// Display appropriate message for CLI users
-	if result.AlreadyRunning {
-		fmt.Printf("PostgreSQL is already running (PID: %d)\n", result.PID)
+	if resp.GetResult() == pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING {
+		fmt.Printf("PostgreSQL is already running (PID: %d)\n", resp.GetPid())
 	} else {
-		fmt.Printf("PostgreSQL server started successfully (PID: %d)\n", result.PID)
+		fmt.Printf("PostgreSQL server started successfully (PID: %d)\n", resp.GetPid())
 	}
 
 	return nil
@@ -180,12 +180,32 @@ func StartPostgreSQLWithResult(logger *slog.Logger, config *pgctld.PostgresCtlCo
 // automatically during startup (before accepting connections).
 func StartAsStandbyWithResult(ctx context.Context, logger *slog.Logger, config *pgctld.PostgresCtlConfig) (*pb.StartAsStandbyResponse, error) {
 	if isPostgreSQLRunning(config.PostgresDataDir) {
-		pid, _ := readPostmasterPID(config.PostgresDataDir)
+		// Postgres is already running — it was started with standby.signal so it is
+		// already in recovery mode. Return the current PID without restarting.
+		pid, err := readPostmasterPID(config.PostgresDataDir)
+		if err != nil {
+			logger.DebugContext(ctx, "Failed to read postmaster.pid for already-running postgres", "error", err)
+		}
 		pid32, _ := intToInt32(pid)
 		return &pb.StartAsStandbyResponse{
 			Result: pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING,
 			Pid:    pid32,
 		}, nil
+	}
+
+	// Ensure Unix socket directory exists before starting PostgreSQL.
+	// This is necessary after restores, where pgBackRest only restores pg_data
+	// but not external directories like pg_sockets.
+	if config.UnixSocketDirectories != "" {
+		if err := os.MkdirAll(config.UnixSocketDirectories, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create Unix socket directory %s: %w", config.UnixSocketDirectories, err)
+		}
+		logger.InfoContext(ctx, "Ensured Unix socket directory exists", "socket_dir", config.UnixSocketDirectories)
+	}
+
+	// Enforce PGDATA permission invariant before pg_ctl start.
+	if err := ensurePGDATAPermissions(logger, config.PostgresDataDir); err != nil {
+		return nil, fmt.Errorf("PGDATA permission check failed: %w", err)
 	}
 
 	// Write standby.signal so postgres starts in recovery mode, never as primary.
@@ -196,6 +216,7 @@ func StartAsStandbyWithResult(ctx context.Context, logger *slog.Logger, config *
 		return nil, fmt.Errorf("failed to create standby.signal: %w", err)
 	}
 
+	logger.InfoContext(ctx, "Starting PostgreSQL server as standby", "data_dir", config.PostgresDataDir)
 	if err := startPostgreSQLWithConfig(logger, config); err != nil {
 		return nil, fmt.Errorf("failed to start PostgreSQL as standby: %w", err)
 	}
@@ -203,28 +224,16 @@ func StartAsStandbyWithResult(ctx context.Context, logger *slog.Logger, config *
 		return nil, fmt.Errorf("PostgreSQL failed to become ready: %w", err)
 	}
 
-	pid, _ := readPostmasterPID(config.PostgresDataDir)
+	pid, err := readPostmasterPID(config.PostgresDataDir)
+	if err != nil {
+		logger.DebugContext(ctx, "Failed to read postmaster.pid after starting postgres", "error", err)
+	}
 	pid32, _ := intToInt32(pid)
 	logger.InfoContext(ctx, "PostgreSQL started successfully as standby", "pid", pid32)
 	return &pb.StartAsStandbyResponse{
 		Result: pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED,
 		Pid:    pid32,
 	}, nil
-}
-
-// StartPostgreSQLWithConfig starts PostgreSQL with the given configuration
-func StartPostgreSQLWithConfig(logger *slog.Logger, config *pgctld.PostgresCtlConfig) error {
-	result, err := StartPostgreSQLWithResult(logger, config)
-	if err != nil {
-		return err
-	}
-
-	// For backward compatibility, log the message if provided
-	if result.Message != "" && !result.AlreadyRunning {
-		logger.Info(result.Message)
-	}
-
-	return nil
 }
 
 // ensurePGDATAPermissions ensures PGDATA is owned by the effective UID and set to 0700 before pg_ctl start.

--- a/go/cmd/pgctld/testutil/grpc_helpers.go
+++ b/go/cmd/pgctld/testutil/grpc_helpers.go
@@ -32,48 +32,48 @@ import (
 // MockPgCtldService implements a mock version of the PgCtld gRPC service for testing
 type MockPgCtldService struct {
 	pb.UnimplementedPgCtldServer
-	mu            sync.Mutex
-	StartCalls    []*pb.StartRequest
-	StopCalls     []*pb.StopRequest
-	RestartCalls  []*pb.RestartRequest
-	ReloadCalls   []*pb.ReloadConfigRequest
-	StatusCalls   []*pb.StatusRequest
-	VersionCalls  []*pb.VersionRequest
-	InitDirCalls  []*pb.InitDataDirRequest
-	PgRewindCalls []*pb.PgRewindRequest
+	mu                  sync.Mutex
+	StartAsStandbyCalls []*pb.StartAsStandbyRequest
+	StopCalls           []*pb.StopRequest
+	RestartCalls        []*pb.RestartRequest
+	ReloadCalls         []*pb.ReloadConfigRequest
+	StatusCalls         []*pb.StatusRequest
+	VersionCalls        []*pb.VersionRequest
+	InitDirCalls        []*pb.InitDataDirRequest
+	PgRewindCalls       []*pb.PgRewindRequest
 
 	// Response configurations
-	StartResponse    *pb.StartResponse
-	StopResponse     *pb.StopResponse
-	RestartResponse  *pb.RestartResponse
-	ReloadResponse   *pb.ReloadConfigResponse
-	StatusResponse   *pb.StatusResponse
-	VersionResponse  *pb.VersionResponse
-	InitDirResponse  *pb.InitDataDirResponse
-	PgRewindResponse *pb.PgRewindResponse
+	StartAsStandbyResponse *pb.StartAsStandbyResponse
+	StopResponse           *pb.StopResponse
+	RestartResponse        *pb.RestartResponse
+	ReloadResponse         *pb.ReloadConfigResponse
+	StatusResponse         *pb.StatusResponse
+	VersionResponse        *pb.VersionResponse
+	InitDirResponse        *pb.InitDataDirResponse
+	PgRewindResponse       *pb.PgRewindResponse
 
 	// Error configurations
-	StartError    error
-	StopError     error
-	RestartError  error
-	ReloadError   error
-	StatusError   error
-	VersionError  error
-	InitDirError  error
-	PgRewindError error
+	StartAsStandbyError error
+	StopError           error
+	RestartError        error
+	ReloadError         error
+	StatusError         error
+	VersionError        error
+	InitDirError        error
+	PgRewindError       error
 }
 
-func (m *MockPgCtldService) Start(ctx context.Context, req *pb.StartRequest) (*pb.StartResponse, error) {
+func (m *MockPgCtldService) StartAsStandby(ctx context.Context, req *pb.StartAsStandbyRequest) (*pb.StartAsStandbyResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.StartCalls = append(m.StartCalls, req)
-	if m.StartError != nil {
-		return nil, m.StartError
+	m.StartAsStandbyCalls = append(m.StartAsStandbyCalls, req)
+	if m.StartAsStandbyError != nil {
+		return nil, m.StartAsStandbyError
 	}
-	if m.StartResponse != nil {
-		return m.StartResponse, nil
+	if m.StartAsStandbyResponse != nil {
+		return m.StartAsStandbyResponse, nil
 	}
-	return &pb.StartResponse{Pid: 12345, Message: "Mock server started"}, nil
+	return &pb.StartAsStandbyResponse{Result: pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED, Pid: 12345}, nil
 }
 
 func (m *MockPgCtldService) Stop(ctx context.Context, req *pb.StopRequest) (*pb.StopResponse, error) {

--- a/go/cmd/pgctld/testutil/mock_postgres.go
+++ b/go/cmd/pgctld/testutil/mock_postgres.go
@@ -194,8 +194,11 @@ case "$1" in
         done
         
         if [ -n "$DATADIR" ]; then
-            # Start a background process to pass isProcessRunning check
-            sleep 3600 &
+            # Start a background process to pass isProcessRunning check.
+            # Redirect stdout/stderr to /dev/null so the pipe Go uses for
+            # CombinedOutput() reaches EOF when this script exits, not when
+            # sleep exits.
+            sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"
             echo "$DATADIR" >> "$DATADIR/postmaster.pid"
@@ -238,8 +241,8 @@ case "$1" in
             echo "waiting for server to shut down.... done"
             echo "server stopped"
 
-            # Start a new background process
-            sleep 3600 &
+            # Start a new background process (redirect so pipe closes on script exit).
+            sleep 3600 >/dev/null 2>&1 &
             MOCK_PID=$!
             echo "$MOCK_PID" > "$DATADIR/postmaster.pid"
             echo "$DATADIR" >> "$DATADIR/postmaster.pid"

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -37,6 +37,59 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// StartAsStandbyResult describes the outcome of a StartAsStandby call.
+type StartAsStandbyResult int32
+
+const (
+	StartAsStandbyResult_START_AS_STANDBY_RESULT_UNSPECIFIED StartAsStandbyResult = 0
+	// PostgreSQL was started successfully in standby mode. Crash recovery may
+	// have been performed automatically if the data directory was not cleanly stopped.
+	StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED StartAsStandbyResult = 1
+	// PostgreSQL was already running (no action taken).
+	StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING StartAsStandbyResult = 2
+)
+
+// Enum value maps for StartAsStandbyResult.
+var (
+	StartAsStandbyResult_name = map[int32]string{
+		0: "START_AS_STANDBY_RESULT_UNSPECIFIED",
+		1: "START_AS_STANDBY_RESULT_STARTED",
+		2: "START_AS_STANDBY_RESULT_ALREADY_RUNNING",
+	}
+	StartAsStandbyResult_value = map[string]int32{
+		"START_AS_STANDBY_RESULT_UNSPECIFIED":     0,
+		"START_AS_STANDBY_RESULT_STARTED":         1,
+		"START_AS_STANDBY_RESULT_ALREADY_RUNNING": 2,
+	}
+)
+
+func (x StartAsStandbyResult) Enum() *StartAsStandbyResult {
+	p := new(StartAsStandbyResult)
+	*p = x
+	return p
+}
+
+func (x StartAsStandbyResult) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (StartAsStandbyResult) Descriptor() protoreflect.EnumDescriptor {
+	return file_pgctldservice_proto_enumTypes[0].Descriptor()
+}
+
+func (StartAsStandbyResult) Type() protoreflect.EnumType {
+	return &file_pgctldservice_proto_enumTypes[0]
+}
+
+func (x StartAsStandbyResult) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use StartAsStandbyResult.Descriptor instead.
+func (StartAsStandbyResult) EnumDescriptor() ([]byte, []int) {
+	return file_pgctldservice_proto_rawDescGZIP(), []int{0}
+}
+
 // Server status enumeration
 type ServerStatus int32
 
@@ -80,11 +133,11 @@ func (x ServerStatus) String() string {
 }
 
 func (ServerStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_pgctldservice_proto_enumTypes[0].Descriptor()
+	return file_pgctldservice_proto_enumTypes[1].Descriptor()
 }
 
 func (ServerStatus) Type() protoreflect.EnumType {
-	return &file_pgctldservice_proto_enumTypes[0]
+	return &file_pgctldservice_proto_enumTypes[1]
 }
 
 func (x ServerStatus) Number() protoreflect.EnumNumber {
@@ -93,34 +146,34 @@ func (x ServerStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ServerStatus.Descriptor instead.
 func (ServerStatus) EnumDescriptor() ([]byte, []int) {
-	return file_pgctldservice_proto_rawDescGZIP(), []int{0}
+	return file_pgctldservice_proto_rawDescGZIP(), []int{1}
 }
 
-// Start PostgreSQL server
-type StartRequest struct {
+// StartAsStandby starts PostgreSQL in standby (recovery) mode.
+type StartAsStandbyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Override the default port
+	// Override the default port.
 	Port int32 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
-	// Additional postgres command line arguments
+	// Additional postgres command line arguments.
 	ExtraArgs     []string `protobuf:"bytes,2,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *StartRequest) Reset() {
-	*x = StartRequest{}
+func (x *StartAsStandbyRequest) Reset() {
+	*x = StartAsStandbyRequest{}
 	mi := &file_pgctldservice_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *StartRequest) String() string {
+func (x *StartAsStandbyRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StartRequest) ProtoMessage() {}
+func (*StartAsStandbyRequest) ProtoMessage() {}
 
-func (x *StartRequest) ProtoReflect() protoreflect.Message {
+func (x *StartAsStandbyRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_pgctldservice_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -132,49 +185,49 @@ func (x *StartRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StartRequest.ProtoReflect.Descriptor instead.
-func (*StartRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use StartAsStandbyRequest.ProtoReflect.Descriptor instead.
+func (*StartAsStandbyRequest) Descriptor() ([]byte, []int) {
 	return file_pgctldservice_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *StartRequest) GetPort() int32 {
+func (x *StartAsStandbyRequest) GetPort() int32 {
 	if x != nil {
 		return x.Port
 	}
 	return 0
 }
 
-func (x *StartRequest) GetExtraArgs() []string {
+func (x *StartAsStandbyRequest) GetExtraArgs() []string {
 	if x != nil {
 		return x.ExtraArgs
 	}
 	return nil
 }
 
-type StartResponse struct {
+type StartAsStandbyResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Process ID of started PostgreSQL server
-	Pid int32 `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
-	// Status message
-	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Outcome of the start attempt.
+	Result StartAsStandbyResult `protobuf:"varint,1,opt,name=result,proto3,enum=pgctldservice.StartAsStandbyResult" json:"result,omitempty"`
+	// Process ID of the running PostgreSQL server.
+	Pid           int32 `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *StartResponse) Reset() {
-	*x = StartResponse{}
+func (x *StartAsStandbyResponse) Reset() {
+	*x = StartAsStandbyResponse{}
 	mi := &file_pgctldservice_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *StartResponse) String() string {
+func (x *StartAsStandbyResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*StartResponse) ProtoMessage() {}
+func (*StartAsStandbyResponse) ProtoMessage() {}
 
-func (x *StartResponse) ProtoReflect() protoreflect.Message {
+func (x *StartAsStandbyResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_pgctldservice_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -186,23 +239,23 @@ func (x *StartResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StartResponse.ProtoReflect.Descriptor instead.
-func (*StartResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use StartAsStandbyResponse.ProtoReflect.Descriptor instead.
+func (*StartAsStandbyResponse) Descriptor() ([]byte, []int) {
 	return file_pgctldservice_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *StartResponse) GetPid() int32 {
+func (x *StartAsStandbyResponse) GetResult() StartAsStandbyResult {
+	if x != nil {
+		return x.Result
+	}
+	return StartAsStandbyResult_START_AS_STANDBY_RESULT_UNSPECIFIED
+}
+
+func (x *StartAsStandbyResponse) GetPid() int32 {
 	if x != nil {
 		return x.Pid
 	}
 	return 0
-}
-
-func (x *StartResponse) GetMessage() string {
-	if x != nil {
-		return x.Message
-	}
-	return ""
 }
 
 // Stop PostgreSQL server
@@ -1131,14 +1184,14 @@ var File_pgctldservice_proto protoreflect.FileDescriptor
 
 const file_pgctldservice_proto_rawDesc = "" +
 	"\n" +
-	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"A\n" +
-	"\fStartRequest\x12\x12\n" +
+	"\x13pgctldservice.proto\x12\rpgctldservice\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"J\n" +
+	"\x15StartAsStandbyRequest\x12\x12\n" +
 	"\x04port\x18\x01 \x01(\x05R\x04port\x12\x1d\n" +
 	"\n" +
-	"extra_args\x18\x02 \x03(\tR\textraArgs\";\n" +
-	"\rStartResponse\x12\x10\n" +
-	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"V\n" +
+	"extra_args\x18\x02 \x03(\tR\textraArgs\"g\n" +
+	"\x16StartAsStandbyResponse\x12;\n" +
+	"\x06result\x18\x01 \x01(\x0e2#.pgctldservice.StartAsStandbyResultR\x06result\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\"V\n" +
 	"\vStopRequest\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"(\n" +
@@ -1203,16 +1256,20 @@ const file_pgctldservice_proto_rawDesc = "" +
 	"\x10application_name\x18\x05 \x01(\tR\x0fapplicationName\"D\n" +
 	"\x10PgRewindResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x16\n" +
-	"\x06output\x18\x02 \x01(\tR\x06output*f\n" +
+	"\x06output\x18\x02 \x01(\tR\x06output*\x91\x01\n" +
+	"\x14StartAsStandbyResult\x12'\n" +
+	"#START_AS_STANDBY_RESULT_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fSTART_AS_STANDBY_RESULT_STARTED\x10\x01\x12+\n" +
+	"'START_AS_STANDBY_RESULT_ALREADY_RUNNING\x10\x02*f\n" +
 	"\fServerStatus\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aSTOPPED\x10\x01\x12\f\n" +
 	"\bSTARTING\x10\x02\x12\v\n" +
 	"\aRUNNING\x10\x03\x12\f\n" +
 	"\bSTOPPING\x10\x04\x12\x13\n" +
-	"\x0fNOT_INITIALIZED\x10\x052\xe4\x04\n" +
-	"\x06PgCtld\x12B\n" +
-	"\x05Start\x12\x1b.pgctldservice.StartRequest\x1a\x1c.pgctldservice.StartResponse\x12?\n" +
+	"\x0fNOT_INITIALIZED\x10\x052\xff\x04\n" +
+	"\x06PgCtld\x12]\n" +
+	"\x0eStartAsStandby\x12$.pgctldservice.StartAsStandbyRequest\x1a%.pgctldservice.StartAsStandbyResponse\x12?\n" +
 	"\x04Stop\x12\x1a.pgctldservice.StopRequest\x1a\x1b.pgctldservice.StopResponse\x12H\n" +
 	"\aRestart\x12\x1d.pgctldservice.RestartRequest\x1a\x1e.pgctldservice.RestartResponse\x12W\n" +
 	"\fReloadConfig\x12\".pgctldservice.ReloadConfigRequest\x1a#.pgctldservice.ReloadConfigResponse\x12E\n" +
@@ -1233,58 +1290,60 @@ func file_pgctldservice_proto_rawDescGZIP() []byte {
 	return file_pgctldservice_proto_rawDescData
 }
 
-var file_pgctldservice_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_pgctldservice_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_pgctldservice_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_pgctldservice_proto_goTypes = []any{
-	(ServerStatus)(0),             // 0: pgctldservice.ServerStatus
-	(*StartRequest)(nil),          // 1: pgctldservice.StartRequest
-	(*StartResponse)(nil),         // 2: pgctldservice.StartResponse
-	(*StopRequest)(nil),           // 3: pgctldservice.StopRequest
-	(*StopResponse)(nil),          // 4: pgctldservice.StopResponse
-	(*RestartRequest)(nil),        // 5: pgctldservice.RestartRequest
-	(*RestartResponse)(nil),       // 6: pgctldservice.RestartResponse
-	(*ReloadConfigRequest)(nil),   // 7: pgctldservice.ReloadConfigRequest
-	(*ReloadConfigResponse)(nil),  // 8: pgctldservice.ReloadConfigResponse
-	(*StatusRequest)(nil),         // 9: pgctldservice.StatusRequest
-	(*StatusResponse)(nil),        // 10: pgctldservice.StatusResponse
-	(*PgBackRestStatus)(nil),      // 11: pgctldservice.PgBackRestStatus
-	(*VersionRequest)(nil),        // 12: pgctldservice.VersionRequest
-	(*VersionResponse)(nil),       // 13: pgctldservice.VersionResponse
-	(*InitDataDirRequest)(nil),    // 14: pgctldservice.InitDataDirRequest
-	(*InitDataDirResponse)(nil),   // 15: pgctldservice.InitDataDirResponse
-	(*PgRewindRequest)(nil),       // 16: pgctldservice.PgRewindRequest
-	(*PgRewindResponse)(nil),      // 17: pgctldservice.PgRewindResponse
-	(*durationpb.Duration)(nil),   // 18: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil), // 19: google.protobuf.Timestamp
+	(StartAsStandbyResult)(0),      // 0: pgctldservice.StartAsStandbyResult
+	(ServerStatus)(0),              // 1: pgctldservice.ServerStatus
+	(*StartAsStandbyRequest)(nil),  // 2: pgctldservice.StartAsStandbyRequest
+	(*StartAsStandbyResponse)(nil), // 3: pgctldservice.StartAsStandbyResponse
+	(*StopRequest)(nil),            // 4: pgctldservice.StopRequest
+	(*StopResponse)(nil),           // 5: pgctldservice.StopResponse
+	(*RestartRequest)(nil),         // 6: pgctldservice.RestartRequest
+	(*RestartResponse)(nil),        // 7: pgctldservice.RestartResponse
+	(*ReloadConfigRequest)(nil),    // 8: pgctldservice.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),   // 9: pgctldservice.ReloadConfigResponse
+	(*StatusRequest)(nil),          // 10: pgctldservice.StatusRequest
+	(*StatusResponse)(nil),         // 11: pgctldservice.StatusResponse
+	(*PgBackRestStatus)(nil),       // 12: pgctldservice.PgBackRestStatus
+	(*VersionRequest)(nil),         // 13: pgctldservice.VersionRequest
+	(*VersionResponse)(nil),        // 14: pgctldservice.VersionResponse
+	(*InitDataDirRequest)(nil),     // 15: pgctldservice.InitDataDirRequest
+	(*InitDataDirResponse)(nil),    // 16: pgctldservice.InitDataDirResponse
+	(*PgRewindRequest)(nil),        // 17: pgctldservice.PgRewindRequest
+	(*PgRewindResponse)(nil),       // 18: pgctldservice.PgRewindResponse
+	(*durationpb.Duration)(nil),    // 19: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),  // 20: google.protobuf.Timestamp
 }
 var file_pgctldservice_proto_depIdxs = []int32{
-	18, // 0: pgctldservice.StopRequest.timeout:type_name -> google.protobuf.Duration
-	18, // 1: pgctldservice.RestartRequest.timeout:type_name -> google.protobuf.Duration
-	0,  // 2: pgctldservice.StatusResponse.status:type_name -> pgctldservice.ServerStatus
-	18, // 3: pgctldservice.StatusResponse.uptime:type_name -> google.protobuf.Duration
-	11, // 4: pgctldservice.StatusResponse.pgbackrest_status:type_name -> pgctldservice.PgBackRestStatus
-	19, // 5: pgctldservice.PgBackRestStatus.last_started:type_name -> google.protobuf.Timestamp
-	1,  // 6: pgctldservice.PgCtld.Start:input_type -> pgctldservice.StartRequest
-	3,  // 7: pgctldservice.PgCtld.Stop:input_type -> pgctldservice.StopRequest
-	5,  // 8: pgctldservice.PgCtld.Restart:input_type -> pgctldservice.RestartRequest
-	7,  // 9: pgctldservice.PgCtld.ReloadConfig:input_type -> pgctldservice.ReloadConfigRequest
-	9,  // 10: pgctldservice.PgCtld.Status:input_type -> pgctldservice.StatusRequest
-	12, // 11: pgctldservice.PgCtld.Version:input_type -> pgctldservice.VersionRequest
-	14, // 12: pgctldservice.PgCtld.InitDataDir:input_type -> pgctldservice.InitDataDirRequest
-	16, // 13: pgctldservice.PgCtld.PgRewind:input_type -> pgctldservice.PgRewindRequest
-	2,  // 14: pgctldservice.PgCtld.Start:output_type -> pgctldservice.StartResponse
-	4,  // 15: pgctldservice.PgCtld.Stop:output_type -> pgctldservice.StopResponse
-	6,  // 16: pgctldservice.PgCtld.Restart:output_type -> pgctldservice.RestartResponse
-	8,  // 17: pgctldservice.PgCtld.ReloadConfig:output_type -> pgctldservice.ReloadConfigResponse
-	10, // 18: pgctldservice.PgCtld.Status:output_type -> pgctldservice.StatusResponse
-	13, // 19: pgctldservice.PgCtld.Version:output_type -> pgctldservice.VersionResponse
-	15, // 20: pgctldservice.PgCtld.InitDataDir:output_type -> pgctldservice.InitDataDirResponse
-	17, // 21: pgctldservice.PgCtld.PgRewind:output_type -> pgctldservice.PgRewindResponse
-	14, // [14:22] is the sub-list for method output_type
-	6,  // [6:14] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	0,  // 0: pgctldservice.StartAsStandbyResponse.result:type_name -> pgctldservice.StartAsStandbyResult
+	19, // 1: pgctldservice.StopRequest.timeout:type_name -> google.protobuf.Duration
+	19, // 2: pgctldservice.RestartRequest.timeout:type_name -> google.protobuf.Duration
+	1,  // 3: pgctldservice.StatusResponse.status:type_name -> pgctldservice.ServerStatus
+	19, // 4: pgctldservice.StatusResponse.uptime:type_name -> google.protobuf.Duration
+	12, // 5: pgctldservice.StatusResponse.pgbackrest_status:type_name -> pgctldservice.PgBackRestStatus
+	20, // 6: pgctldservice.PgBackRestStatus.last_started:type_name -> google.protobuf.Timestamp
+	2,  // 7: pgctldservice.PgCtld.StartAsStandby:input_type -> pgctldservice.StartAsStandbyRequest
+	4,  // 8: pgctldservice.PgCtld.Stop:input_type -> pgctldservice.StopRequest
+	6,  // 9: pgctldservice.PgCtld.Restart:input_type -> pgctldservice.RestartRequest
+	8,  // 10: pgctldservice.PgCtld.ReloadConfig:input_type -> pgctldservice.ReloadConfigRequest
+	10, // 11: pgctldservice.PgCtld.Status:input_type -> pgctldservice.StatusRequest
+	13, // 12: pgctldservice.PgCtld.Version:input_type -> pgctldservice.VersionRequest
+	15, // 13: pgctldservice.PgCtld.InitDataDir:input_type -> pgctldservice.InitDataDirRequest
+	17, // 14: pgctldservice.PgCtld.PgRewind:input_type -> pgctldservice.PgRewindRequest
+	3,  // 15: pgctldservice.PgCtld.StartAsStandby:output_type -> pgctldservice.StartAsStandbyResponse
+	5,  // 16: pgctldservice.PgCtld.Stop:output_type -> pgctldservice.StopResponse
+	7,  // 17: pgctldservice.PgCtld.Restart:output_type -> pgctldservice.RestartResponse
+	9,  // 18: pgctldservice.PgCtld.ReloadConfig:output_type -> pgctldservice.ReloadConfigResponse
+	11, // 19: pgctldservice.PgCtld.Status:output_type -> pgctldservice.StatusResponse
+	14, // 20: pgctldservice.PgCtld.Version:output_type -> pgctldservice.VersionResponse
+	16, // 21: pgctldservice.PgCtld.InitDataDir:output_type -> pgctldservice.InitDataDirResponse
+	18, // 22: pgctldservice.PgCtld.PgRewind:output_type -> pgctldservice.PgRewindResponse
+	15, // [15:23] is the sub-list for method output_type
+	7,  // [7:15] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_pgctldservice_proto_init() }
@@ -1297,7 +1356,7 @@ func file_pgctldservice_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pgctldservice_proto_rawDesc), len(file_pgctldservice_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -366,10 +366,8 @@ type RestartRequest struct {
 	// Timeout for stop phase
 	Timeout *durationpb.Duration `protobuf:"bytes,2,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// Override default port for start phase
-	Port      int32    `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
-	ExtraArgs []string `protobuf:"bytes,4,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
-	// If true, creates standby.signal before restart (for demotion to standby)
-	AsStandby     bool `protobuf:"varint,5,opt,name=as_standby,json=asStandby,proto3" json:"as_standby,omitempty"`
+	Port          int32    `protobuf:"varint,3,opt,name=port,proto3" json:"port,omitempty"`
+	ExtraArgs     []string `protobuf:"bytes,4,rep,name=extra_args,json=extraArgs,proto3" json:"extra_args,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -430,13 +428,6 @@ func (x *RestartRequest) GetExtraArgs() []string {
 		return x.ExtraArgs
 	}
 	return nil
-}
-
-func (x *RestartRequest) GetAsStandby() bool {
-	if x != nil {
-		return x.AsStandby
-	}
-	return false
 }
 
 type RestartResponse struct {
@@ -1196,15 +1187,13 @@ const file_pgctldservice_proto_rawDesc = "" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\"(\n" +
 	"\fStopResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"\xab\x01\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\x8c\x01\n" +
 	"\x0eRestartRequest\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12\x12\n" +
 	"\x04port\x18\x03 \x01(\x05R\x04port\x12\x1d\n" +
 	"\n" +
-	"extra_args\x18\x04 \x03(\tR\textraArgs\x12\x1d\n" +
-	"\n" +
-	"as_standby\x18\x05 \x01(\bR\tasStandby\"=\n" +
+	"extra_args\x18\x04 \x03(\tR\textraArgs\"=\n" +
 	"\x0fRestartResponse\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"\x15\n" +

--- a/go/pb/pgctldservice/pgctldservice.pb.gw.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.gw.go
@@ -35,9 +35,9 @@ var (
 	_ = metadata.Join
 )
 
-func request_PgCtld_Start_0(ctx context.Context, marshaler runtime.Marshaler, client PgCtldClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_PgCtld_StartAsStandby_0(ctx context.Context, marshaler runtime.Marshaler, client PgCtldClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq StartRequest
+		protoReq StartAsStandbyRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -46,19 +46,19 @@ func request_PgCtld_Start_0(ctx context.Context, marshaler runtime.Marshaler, cl
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	msg, err := client.Start(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.StartAsStandby(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_PgCtld_Start_0(ctx context.Context, marshaler runtime.Marshaler, server PgCtldServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_PgCtld_StartAsStandby_0(ctx context.Context, marshaler runtime.Marshaler, server PgCtldServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq StartRequest
+		protoReq StartAsStandbyRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.Start(ctx, &protoReq)
+	msg, err := server.StartAsStandby(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -257,25 +257,25 @@ func local_request_PgCtld_PgRewind_0(ctx context.Context, marshaler runtime.Mars
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterPgCtldHandlerFromEndpoint instead.
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterPgCtldHandlerServer(ctx context.Context, mux *runtime.ServeMux, server PgCtldServer) error {
-	mux.Handle(http.MethodPost, pattern_PgCtld_Start_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_PgCtld_StartAsStandby_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/pgctldservice.PgCtld/Start", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/Start"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/pgctldservice.PgCtld/StartAsStandby", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/StartAsStandby"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_PgCtld_Start_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_PgCtld_StartAsStandby_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_PgCtld_Start_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_PgCtld_StartAsStandby_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_PgCtld_Stop_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -457,22 +457,22 @@ func RegisterPgCtldHandler(ctx context.Context, mux *runtime.ServeMux, conn *grp
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "PgCtldClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterPgCtldHandlerClient(ctx context.Context, mux *runtime.ServeMux, client PgCtldClient) error {
-	mux.Handle(http.MethodPost, pattern_PgCtld_Start_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_PgCtld_StartAsStandby_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/pgctldservice.PgCtld/Start", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/Start"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/pgctldservice.PgCtld/StartAsStandby", runtime.WithHTTPPathPattern("/pgctldservice.PgCtld/StartAsStandby"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_PgCtld_Start_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_PgCtld_StartAsStandby_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_PgCtld_Start_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_PgCtld_StartAsStandby_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_PgCtld_Stop_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -597,23 +597,23 @@ func RegisterPgCtldHandlerClient(ctx context.Context, mux *runtime.ServeMux, cli
 }
 
 var (
-	pattern_PgCtld_Start_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Start"}, ""))
-	pattern_PgCtld_Stop_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Stop"}, ""))
-	pattern_PgCtld_Restart_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Restart"}, ""))
-	pattern_PgCtld_ReloadConfig_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "ReloadConfig"}, ""))
-	pattern_PgCtld_Status_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Status"}, ""))
-	pattern_PgCtld_Version_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Version"}, ""))
-	pattern_PgCtld_InitDataDir_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "InitDataDir"}, ""))
-	pattern_PgCtld_PgRewind_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "PgRewind"}, ""))
+	pattern_PgCtld_StartAsStandby_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "StartAsStandby"}, ""))
+	pattern_PgCtld_Stop_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Stop"}, ""))
+	pattern_PgCtld_Restart_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Restart"}, ""))
+	pattern_PgCtld_ReloadConfig_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "ReloadConfig"}, ""))
+	pattern_PgCtld_Status_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Status"}, ""))
+	pattern_PgCtld_Version_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "Version"}, ""))
+	pattern_PgCtld_InitDataDir_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "InitDataDir"}, ""))
+	pattern_PgCtld_PgRewind_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"pgctldservice.PgCtld", "PgRewind"}, ""))
 )
 
 var (
-	forward_PgCtld_Start_0        = runtime.ForwardResponseMessage
-	forward_PgCtld_Stop_0         = runtime.ForwardResponseMessage
-	forward_PgCtld_Restart_0      = runtime.ForwardResponseMessage
-	forward_PgCtld_ReloadConfig_0 = runtime.ForwardResponseMessage
-	forward_PgCtld_Status_0       = runtime.ForwardResponseMessage
-	forward_PgCtld_Version_0      = runtime.ForwardResponseMessage
-	forward_PgCtld_InitDataDir_0  = runtime.ForwardResponseMessage
-	forward_PgCtld_PgRewind_0     = runtime.ForwardResponseMessage
+	forward_PgCtld_StartAsStandby_0 = runtime.ForwardResponseMessage
+	forward_PgCtld_Stop_0           = runtime.ForwardResponseMessage
+	forward_PgCtld_Restart_0        = runtime.ForwardResponseMessage
+	forward_PgCtld_ReloadConfig_0   = runtime.ForwardResponseMessage
+	forward_PgCtld_Status_0         = runtime.ForwardResponseMessage
+	forward_PgCtld_Version_0        = runtime.ForwardResponseMessage
+	forward_PgCtld_InitDataDir_0    = runtime.ForwardResponseMessage
+	forward_PgCtld_PgRewind_0       = runtime.ForwardResponseMessage
 )

--- a/go/pb/pgctldservice/pgctldservice_grpc.pb.go
+++ b/go/pb/pgctldservice/pgctldservice_grpc.pb.go
@@ -33,14 +33,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	PgCtld_Start_FullMethodName        = "/pgctldservice.PgCtld/Start"
-	PgCtld_Stop_FullMethodName         = "/pgctldservice.PgCtld/Stop"
-	PgCtld_Restart_FullMethodName      = "/pgctldservice.PgCtld/Restart"
-	PgCtld_ReloadConfig_FullMethodName = "/pgctldservice.PgCtld/ReloadConfig"
-	PgCtld_Status_FullMethodName       = "/pgctldservice.PgCtld/Status"
-	PgCtld_Version_FullMethodName      = "/pgctldservice.PgCtld/Version"
-	PgCtld_InitDataDir_FullMethodName  = "/pgctldservice.PgCtld/InitDataDir"
-	PgCtld_PgRewind_FullMethodName     = "/pgctldservice.PgCtld/PgRewind"
+	PgCtld_StartAsStandby_FullMethodName = "/pgctldservice.PgCtld/StartAsStandby"
+	PgCtld_Stop_FullMethodName           = "/pgctldservice.PgCtld/Stop"
+	PgCtld_Restart_FullMethodName        = "/pgctldservice.PgCtld/Restart"
+	PgCtld_ReloadConfig_FullMethodName   = "/pgctldservice.PgCtld/ReloadConfig"
+	PgCtld_Status_FullMethodName         = "/pgctldservice.PgCtld/Status"
+	PgCtld_Version_FullMethodName        = "/pgctldservice.PgCtld/Version"
+	PgCtld_InitDataDir_FullMethodName    = "/pgctldservice.PgCtld/InitDataDir"
+	PgCtld_PgRewind_FullMethodName       = "/pgctldservice.PgCtld/PgRewind"
 )
 
 // PgCtldClient is the client API for PgCtld service.
@@ -49,8 +49,11 @@ const (
 //
 // PostgreSQL Control Service
 type PgCtldClient interface {
-	// Start PostgreSQL server
-	Start(ctx context.Context, in *StartRequest, opts ...grpc.CallOption) (*StartResponse, error)
+	// StartAsStandby starts PostgreSQL in standby (recovery) mode.
+	// Always writes standby.signal before starting, ensuring postgres never starts as primary.
+	// If the data directory was not cleanly shut down, PostgreSQL performs crash recovery
+	// automatically as part of startup (before accepting connections).
+	StartAsStandby(ctx context.Context, in *StartAsStandbyRequest, opts ...grpc.CallOption) (*StartAsStandbyResponse, error)
 	// Stop PostgreSQL server
 	Stop(ctx context.Context, in *StopRequest, opts ...grpc.CallOption) (*StopResponse, error)
 	// Restart PostgreSQL server
@@ -76,10 +79,10 @@ func NewPgCtldClient(cc grpc.ClientConnInterface) PgCtldClient {
 	return &pgCtldClient{cc}
 }
 
-func (c *pgCtldClient) Start(ctx context.Context, in *StartRequest, opts ...grpc.CallOption) (*StartResponse, error) {
+func (c *pgCtldClient) StartAsStandby(ctx context.Context, in *StartAsStandbyRequest, opts ...grpc.CallOption) (*StartAsStandbyResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(StartResponse)
-	err := c.cc.Invoke(ctx, PgCtld_Start_FullMethodName, in, out, cOpts...)
+	out := new(StartAsStandbyResponse)
+	err := c.cc.Invoke(ctx, PgCtld_StartAsStandby_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -162,8 +165,11 @@ func (c *pgCtldClient) PgRewind(ctx context.Context, in *PgRewindRequest, opts .
 //
 // PostgreSQL Control Service
 type PgCtldServer interface {
-	// Start PostgreSQL server
-	Start(context.Context, *StartRequest) (*StartResponse, error)
+	// StartAsStandby starts PostgreSQL in standby (recovery) mode.
+	// Always writes standby.signal before starting, ensuring postgres never starts as primary.
+	// If the data directory was not cleanly shut down, PostgreSQL performs crash recovery
+	// automatically as part of startup (before accepting connections).
+	StartAsStandby(context.Context, *StartAsStandbyRequest) (*StartAsStandbyResponse, error)
 	// Stop PostgreSQL server
 	Stop(context.Context, *StopRequest) (*StopResponse, error)
 	// Restart PostgreSQL server
@@ -189,8 +195,8 @@ type PgCtldServer interface {
 // pointer dereference when methods are called.
 type UnimplementedPgCtldServer struct{}
 
-func (UnimplementedPgCtldServer) Start(context.Context, *StartRequest) (*StartResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Start not implemented")
+func (UnimplementedPgCtldServer) StartAsStandby(context.Context, *StartAsStandbyRequest) (*StartAsStandbyResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StartAsStandby not implemented")
 }
 func (UnimplementedPgCtldServer) Stop(context.Context, *StopRequest) (*StopResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Stop not implemented")
@@ -234,20 +240,20 @@ func RegisterPgCtldServer(s grpc.ServiceRegistrar, srv PgCtldServer) {
 	s.RegisterService(&PgCtld_ServiceDesc, srv)
 }
 
-func _PgCtld_Start_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(StartRequest)
+func _PgCtld_StartAsStandby_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartAsStandbyRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(PgCtldServer).Start(ctx, in)
+		return srv.(PgCtldServer).StartAsStandby(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: PgCtld_Start_FullMethodName,
+		FullMethod: PgCtld_StartAsStandby_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PgCtldServer).Start(ctx, req.(*StartRequest))
+		return srv.(PgCtldServer).StartAsStandby(ctx, req.(*StartAsStandbyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -386,8 +392,8 @@ var PgCtld_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*PgCtldServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Start",
-			Handler:    _PgCtld_Start_Handler,
+			MethodName: "StartAsStandby",
+			Handler:    _PgCtld_StartAsStandby_Handler,
 		},
 		{
 			MethodName: "Stop",

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -65,28 +65,15 @@ func (p *localProvisioner) startPostgreSQLViaPgctld(ctx context.Context, address
 		return nil
 	}
 
-	// Data directory exists but PostgreSQL is not running - start it
+	// Data directory exists but PostgreSQL is not running - start it as standby.
+	// Crash recovery is permitted: this is resuming a previously initialized node,
+	// not a consensus-aware operation.
 	fmt.Printf(" starting PostgreSQL...")
-	startResp, err := client.Start(ctx, &pb.StartRequest{})
+	resp, err := client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 	if err != nil {
 		return fmt.Errorf("failed to start PostgreSQL: %w", err)
 	}
-
-	// Verify PostgreSQL is now running
-	statusResp, err = client.Status(ctx, &pb.StatusRequest{})
-	if err != nil {
-		return fmt.Errorf("failed to verify PostgreSQL status after start: %w", err)
-	}
-
-	if statusResp.GetStatus() != pb.ServerStatus_RUNNING {
-		return fmt.Errorf("PostgreSQL failed to start - status: %s, message: %s",
-			statusResp.GetStatus().String(), statusResp.GetMessage())
-	}
-
-	fmt.Printf(" PostgreSQL started (PID: %d) ✓\n", statusResp.GetPid())
-	if startResp.GetMessage() != "" {
-		fmt.Printf(" - %s", startResp.GetMessage())
-	}
+	fmt.Printf(" PostgreSQL started (PID: %d) ✓\n", resp.GetPid())
 
 	return nil
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1112,7 +1112,6 @@ func (pm *MultiPoolerManager) restartPostgresAsStandby(ctx context.Context, stat
 		Timeout:   nil, // Use default timeout
 		Port:      0,   // Use default port
 		ExtraArgs: nil,
-		AsStandby: true, // Create standby.signal before restart
 	}
 
 	resp, err := pm.pgctldClient.Restart(ctx, req)
@@ -1526,6 +1525,10 @@ type postgresState struct {
 	postgresRunning  bool
 	backupsAvailable bool
 	isPrimary        bool
+	// hasPrimaryTerm is true when the local consensus state records a non-zero primary term,
+	// meaning this node was promoted as primary and has not been explicitly demoted.
+	// A zero primary term indicates the node was gracefully demoted.
+	hasPrimaryTerm bool
 }
 
 // remedialAction represents actions the postgres monitor can take
@@ -1537,6 +1540,7 @@ const (
 	remedialActionRestoreFromBackup
 	remedialActionAdjustTypeToPrimary
 	remedialActionAdjustTypeToReplica
+	remedialActionPromoteToPrimary
 )
 
 // monitorPostgresIteration performs one iteration of PostgreSQL monitoring.
@@ -1627,6 +1631,14 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) postgre
 		state.backupsAvailable = pm.hasCompleteBackups(ctx)
 	}
 
+	// Check if this node has an active primary term (non-zero primary term means it was
+	// promoted as primary and not explicitly demoted via SetPrimaryTerm(0)).
+	if pm.consensusState != nil {
+		if term, _ := pm.consensusState.GetInconsistentTerm(); term != nil {
+			state.hasPrimaryTerm = term.GetPrimaryTerm() > 0
+		}
+	}
+
 	return state
 }
 
@@ -1652,8 +1664,18 @@ func (pm *MultiPoolerManager) determineRemedialAction(currentState postgresState
 		if currentState.isPrimary && pm.getPoolerType() != clustermetadatapb.PoolerType_PRIMARY {
 			return remedialActionAdjustTypeToPrimary
 		}
-		if !currentState.isPrimary && pm.getPoolerType() == clustermetadatapb.PoolerType_PRIMARY {
-			return remedialActionAdjustTypeToReplica
+		if !currentState.isPrimary {
+			// Postgres started as standby. If we have an active primary term (non-zero),
+			// we crashed before being explicitly demoted — promote back to primary.
+			// A zero primary term means we were demoted gracefully; adjust topology if needed.
+			// TODO: Consider publishing degraded health and requesting failover from multiorch instead,
+			// to guard against serving non-durable transactions under read-committed isolation.
+			if currentState.hasPrimaryTerm {
+				return remedialActionPromoteToPrimary
+			}
+			if pm.getPoolerType() == clustermetadatapb.PoolerType_PRIMARY {
+				return remedialActionAdjustTypeToReplica
+			}
 		}
 		return remedialActionNone // Pooler type already matches
 	}
@@ -1723,6 +1745,17 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		if err := pm.restoreAndStartPostgres(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to restore from backup, will retry", "error", err)
+		}
+
+	case remedialActionPromoteToPrimary:
+		pm.setMonitorReason(ctx, reasonPostgresRunning, "MonitorPostgres: PostgreSQL is running as standby but primary term is set")
+		pm.logger.InfoContext(ctx, "MonitorPostgres: promoting PostgreSQL to primary")
+		if err := pm.exec(ctx, "SELECT pg_promote()"); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to promote PostgreSQL, will retry", "error", err)
+			return
+		}
+		if err := pm.waitForPromotionComplete(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: promotion did not complete, will retry", "error", err)
 		}
 	}
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1745,15 +1745,17 @@ func (pm *MultiPoolerManager) hasCompleteBackups(ctx context.Context) bool {
 	return false
 }
 
-// startPostgres starts PostgreSQL via pgctld
+// startPostgres starts PostgreSQL as a standby via pgctld.
+// Crash recovery is not permitted — it requires consensus awareness and must be
+// explicitly requested. If crash recovery is needed, an error is returned and
+// MonitorPostgres will log it and retry next cycle.
 func (pm *MultiPoolerManager) startPostgres(ctx context.Context) error {
-	pm.logger.InfoContext(ctx, "MonitorPostgres: Attempting to restart PostgreSQL")
+	pm.logger.InfoContext(ctx, "MonitorPostgres: Attempting to start PostgreSQL as standby")
 	if pm.pgctldClient == nil {
 		return errors.New("pgctld client not available")
 	}
 
-	_, err := pm.pgctldClient.Start(ctx, &pgctldpb.StartRequest{})
-	if err != nil {
+	if _, err := pm.pgctldClient.StartAsStandby(ctx, &pgctldpb.StartAsStandbyRequest{}); err != nil {
 		return fmt.Errorf("MonitorPostgres: failed to start PostgreSQL: %w", err)
 	}
 

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1756,6 +1756,11 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		}
 		if err := pm.waitForPromotionComplete(ctx); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: promotion did not complete, will retry", "error", err)
+			return
+		}
+		pm.logger.InfoContext(ctx, "MonitorPostgres: promotion complete, updating pooler type to primary")
+		if err := pm.changeTypeLocked(ctx, clustermetadatapb.PoolerType_PRIMARY); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to change pooler type to primary after promotion", "error", err)
 		}
 	}
 }

--- a/go/services/multipooler/manager/pgctld_client.go
+++ b/go/services/multipooler/manager/pgctld_client.go
@@ -44,12 +44,12 @@ func NewProtectedPgctldClient(client pgctldpb.PgCtldClient) pgctldpb.PgCtldClien
 	}
 }
 
-// Start starts PostgreSQL. Requires action lock to be held by caller.
-func (p *protectedPgctldClient) Start(ctx context.Context, req *pgctldpb.StartRequest, opts ...grpc.CallOption) (*pgctldpb.StartResponse, error) {
+// StartAsStandby starts PostgreSQL in standby (recovery) mode. Requires action lock to be held by caller.
+func (p *protectedPgctldClient) StartAsStandby(ctx context.Context, req *pgctldpb.StartAsStandbyRequest, opts ...grpc.CallOption) (*pgctldpb.StartAsStandbyResponse, error) {
 	if err := AssertActionLockHeld(ctx); err != nil {
-		return nil, fmt.Errorf("Start requires action lock to be held: %w", err)
+		return nil, fmt.Errorf("StartAsStandby requires action lock to be held: %w", err)
 	}
-	return p.client.Start(ctx, req, opts...)
+	return p.client.StartAsStandby(ctx, req, opts...)
 }
 
 // Stop stops PostgreSQL. Requires action lock to be held by caller.

--- a/go/services/multipooler/manager/pgctld_client_test.go
+++ b/go/services/multipooler/manager/pgctld_client_test.go
@@ -36,8 +36,8 @@ func TestProtectedPgctldClient_StateChangingOperationsRequireLock(t *testing.T) 
 	}
 	protected := NewProtectedPgctldClient(mockClient)
 
-	t.Run("Start requires lock", func(t *testing.T) {
-		_, err := protected.Start(ctx, &pgctldpb.StartRequest{})
+	t.Run("StartAsStandby requires lock", func(t *testing.T) {
+		_, err := protected.StartAsStandby(ctx, &pgctldpb.StartAsStandbyRequest{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "action lock")
 	})
@@ -109,11 +109,11 @@ func TestProtectedPgctldClient_WithLockHeld(t *testing.T) {
 	}
 	protected := NewProtectedPgctldClient(mockClient)
 
-	t.Run("Start succeeds with lock", func(t *testing.T) {
-		resp, err := protected.Start(lockCtx, &pgctldpb.StartRequest{})
+	t.Run("StartAsStandby succeeds with lock", func(t *testing.T) {
+		resp, err := protected.StartAsStandby(lockCtx, &pgctldpb.StartAsStandbyRequest{})
 		require.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.True(t, mockClient.startCalled)
+		assert.True(t, mockClient.startAsStandbyCalled)
 	})
 
 	t.Run("Restart succeeds with lock", func(t *testing.T) {

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -415,9 +415,7 @@ func (pm *MultiPoolerManager) startPostgreSQLAfterRestore(ctx context.Context, b
 	slog.InfoContext(ctx, "Starting PostgreSQL after restore",
 		"backup_id", backupID)
 
-	_, err := pgctldClient.Restart(restartCtx, &pgctldpb.RestartRequest{
-		AsStandby: true,
-	})
+	_, err := pgctldClient.Restart(restartCtx, &pgctldpb.RestartRequest{})
 	if err != nil {
 		return mterrors.New(mtrpcpb.Code_INTERNAL,
 			fmt.Sprintf("failed to start PostgreSQL after restore: %v", err))

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -116,9 +116,20 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 		}
 	}
 
-	// Wait for database connection
+	// Wait for database connection. PostgreSQL is in recovery mode (started via
+	// StartAsStandby), which accepts read-only connections, so SELECT 1 succeeds.
 	if err := pm.waitForDatabaseConnection(ctx); err != nil {
 		return nil, mterrors.Wrap(err, "failed to connect to database")
+	}
+
+	// Promote PostgreSQL from recovery mode to a writable primary. This is
+	// required before any DDL (schema creation) can be executed.
+	pm.logger.InfoContext(ctx, "Promoting PostgreSQL from recovery mode to primary", "shard", pm.getShardID())
+	if err := pm.exec(ctx, "SELECT pg_promote()"); err != nil {
+		return nil, mterrors.Wrap(err, "failed to promote PostgreSQL to primary")
+	}
+	if err := pm.waitForPromotionComplete(ctx); err != nil {
+		return nil, mterrors.Wrap(err, "failed to wait for PostgreSQL promotion")
 	}
 
 	// Create multigres schema and tables (heartbeat, durability_policy, tablegroup, table, shard)

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -111,8 +111,7 @@ func (pm *MultiPoolerManager) InitializeEmptyPrimary(ctx context.Context, req *m
 			return nil, mterrors.New(mtrpcpb.Code_UNAVAILABLE, "pgctld client not available")
 		}
 
-		startReq := &pgctldpb.StartRequest{}
-		if _, err := pm.pgctldClient.Start(ctx, startReq); err != nil {
+		if _, err := pm.pgctldClient.StartAsStandby(ctx, &pgctldpb.StartAsStandbyRequest{}); err != nil {
 			return nil, mterrors.Wrap(err, "failed to start PostgreSQL")
 		}
 	}

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -507,11 +507,34 @@ func TestDetermineRemedialAction(t *testing.T) {
 			expectedAction: remedialActionAdjustTypeToPrimary,
 		},
 		{
+			name: "postgres_running_standby_with_primary_term_promotes",
+			state: postgresState{
+				pgctldAvailable: true,
+				postgresRunning: true,
+				isPrimary:       false,
+				hasPrimaryTerm:  true,
+			},
+			poolerType:     clustermetadatapb.PoolerType_PRIMARY,
+			expectedAction: remedialActionPromoteToPrimary,
+		},
+		{
+			name: "postgres_running_standby_with_primary_term_promotes_regardless_of_topology",
+			state: postgresState{
+				pgctldAvailable: true,
+				postgresRunning: true,
+				isPrimary:       false,
+				hasPrimaryTerm:  true,
+			},
+			poolerType:     clustermetadatapb.PoolerType_REPLICA,
+			expectedAction: remedialActionPromoteToPrimary,
+		},
+		{
 			name: "postgres_running_demote_to_replica",
 			state: postgresState{
 				pgctldAvailable: true,
 				postgresRunning: true,
 				isPrimary:       false,
+				hasPrimaryTerm:  false,
 			},
 			poolerType:     clustermetadatapb.PoolerType_PRIMARY,
 			expectedAction: remedialActionAdjustTypeToReplica,

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -82,7 +82,8 @@ func TestInitializeEmptyPrimary(t *testing.T) {
 			// A fresh (uninitialized) pooler passes term and idempotency checks,
 			// then reaches the first pgctld call (InitDataDir). Unit tests stop
 			// here because real pgctld/postgres are not available; the full success
-			// path is covered by the integration test.
+			// path (InitDataDir → StartAsStandby → pg_promote() → schema creation)
+			// is covered by the shardsetup integration test.
 			name:          "initialize fresh pooler",
 			term:          1,
 			expectSuccess: false,

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -636,14 +636,14 @@ func TestTakeRemedialAction_StartPostgres(t *testing.T) {
 	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
 
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
-	assert.True(t, mockPgctld.startCalled, "Should have called Start()")
+	assert.True(t, mockPgctld.startAsStandbyCalled, "Should have called Start()")
 }
 
 func TestTakeRemedialAction_StartPostgresFails(t *testing.T) {
 	ctx := t.Context()
 
 	mockPgctld := &mockPgctldClient{
-		startError: assert.AnError,
+		startAsStandbyError: assert.AnError,
 	}
 
 	pm := &MultiPoolerManager{
@@ -662,7 +662,7 @@ func TestTakeRemedialAction_StartPostgresFails(t *testing.T) {
 	// Should handle error gracefully
 	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
 
-	assert.True(t, mockPgctld.startCalled, "Should have attempted to call Start()")
+	assert.True(t, mockPgctld.startAsStandbyCalled, "Should have attempted to call Start()")
 	// Reason stays the same since we're retrying
 }
 
@@ -800,7 +800,7 @@ func TestStartPostgres_Success(t *testing.T) {
 	err := pm.startPostgres(ctx)
 
 	require.NoError(t, err)
-	assert.True(t, mockPgctld.startCalled)
+	assert.True(t, mockPgctld.startAsStandbyCalled)
 }
 
 func TestStartPostgres_PgctldUnavailable(t *testing.T) {
@@ -821,7 +821,7 @@ func TestStartPostgres_StartFails(t *testing.T) {
 	ctx := t.Context()
 
 	mockPgctld := &mockPgctldClient{
-		startError: assert.AnError,
+		startAsStandbyError: assert.AnError,
 	}
 
 	pm := &MultiPoolerManager{
@@ -833,7 +833,7 @@ func TestStartPostgres_StartFails(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to start PostgreSQL")
-	assert.True(t, mockPgctld.startCalled)
+	assert.True(t, mockPgctld.startAsStandbyCalled)
 }
 
 // Integration Tests for MonitorPostgres
@@ -859,7 +859,7 @@ func TestMonitorPostgres_WaitsForReady(t *testing.T) {
 
 	// Call iteration when not ready - should return early without calling pgctld
 	pm.monitorPostgresIteration(ctx)
-	assert.False(t, mockPgctld.startCalled, "Should not attempt to start when not ready")
+	assert.False(t, mockPgctld.startAsStandbyCalled, "Should not attempt to start when not ready")
 
 	// Set state to ready
 	pm.mu.Lock()
@@ -869,7 +869,7 @@ func TestMonitorPostgres_WaitsForReady(t *testing.T) {
 
 	// Call iteration again when ready - should proceed and attempt to start
 	pm.monitorPostgresIteration(ctx)
-	assert.True(t, mockPgctld.startCalled, "Should attempt to start when ready")
+	assert.True(t, mockPgctld.startAsStandbyCalled, "Should attempt to start when ready")
 }
 
 func TestMonitorPostgres_HandlesRunningPostgres(t *testing.T) {
@@ -899,7 +899,7 @@ func TestMonitorPostgres_HandlesRunningPostgres(t *testing.T) {
 	pm.monitorPostgresIteration(ctx)
 
 	// Should not have called Start (postgres already running)
-	assert.False(t, mockPgctld.startCalled, "Should not call Start when postgres is already running")
+	assert.False(t, mockPgctld.startAsStandbyCalled, "Should not call Start when postgres is already running")
 }
 
 func TestMonitorPostgres_StartsStoppedPostgres(t *testing.T) {
@@ -926,7 +926,7 @@ func TestMonitorPostgres_StartsStoppedPostgres(t *testing.T) {
 	pm.monitorPostgresIteration(ctx)
 
 	// Should have attempted to start postgres
-	assert.True(t, mockPgctld.startCalled, "Should attempt to start stopped postgres")
+	assert.True(t, mockPgctld.startAsStandbyCalled, "Should attempt to start stopped postgres")
 }
 
 func TestMonitorPostgres_RetriesOnStartFailure(t *testing.T) {
@@ -940,7 +940,7 @@ func TestMonitorPostgres_RetriesOnStartFailure(t *testing.T) {
 			statusResponse: &pgctldpb.StatusResponse{
 				Status: pgctldpb.ServerStatus_STOPPED,
 			},
-			startError: assert.AnError,
+			startAsStandbyError: assert.AnError,
 		},
 	}
 
@@ -963,12 +963,12 @@ func TestMonitorPostgres_RetriesOnStartFailure(t *testing.T) {
 
 // Mock pgctld client for testing
 type mockPgctldClient struct {
-	statusResponse *pgctldpb.StatusResponse
-	statusError    error
-	startCalled    bool
-	startError     error
-	restartCalled  bool
-	restartError   error
+	statusResponse        *pgctldpb.StatusResponse
+	statusError           error
+	startAsStandbyCalled  bool
+	startAsStandbyError   error
+	restartCalled         bool
+	restartAsStandbyError error
 }
 
 func (m *mockPgctldClient) Status(ctx context.Context, req *pgctldpb.StatusRequest, opts ...grpc.CallOption) (*pgctldpb.StatusResponse, error) {
@@ -983,12 +983,14 @@ func (m *mockPgctldClient) Status(ctx context.Context, req *pgctldpb.StatusReque
 	}, nil
 }
 
-func (m *mockPgctldClient) Start(ctx context.Context, req *pgctldpb.StartRequest, opts ...grpc.CallOption) (*pgctldpb.StartResponse, error) {
-	m.startCalled = true
-	if m.startError != nil {
-		return nil, m.startError
+func (m *mockPgctldClient) StartAsStandby(ctx context.Context, req *pgctldpb.StartAsStandbyRequest, opts ...grpc.CallOption) (*pgctldpb.StartAsStandbyResponse, error) {
+	m.startAsStandbyCalled = true
+	if m.startAsStandbyError != nil {
+		return nil, m.startAsStandbyError
 	}
-	return &pgctldpb.StartResponse{}, nil
+	return &pgctldpb.StartAsStandbyResponse{
+		Result: pgctldpb.StartAsStandbyResult_START_AS_STANDBY_RESULT_STARTED,
+	}, nil
 }
 
 func (m *mockPgctldClient) Stop(ctx context.Context, req *pgctldpb.StopRequest, opts ...grpc.CallOption) (*pgctldpb.StopResponse, error) {
@@ -997,8 +999,8 @@ func (m *mockPgctldClient) Stop(ctx context.Context, req *pgctldpb.StopRequest, 
 
 func (m *mockPgctldClient) Restart(ctx context.Context, req *pgctldpb.RestartRequest, opts ...grpc.CallOption) (*pgctldpb.RestartResponse, error) {
 	m.restartCalled = true
-	if m.restartError != nil {
-		return nil, m.restartError
+	if m.restartAsStandbyError != nil {
+		return nil, m.restartAsStandbyError
 	}
 	return &pgctldpb.RestartResponse{}, nil
 }
@@ -1025,7 +1027,7 @@ type mockPgctldClientWithCounter struct {
 	startCallCount int
 }
 
-func (m *mockPgctldClientWithCounter) Start(ctx context.Context, req *pgctldpb.StartRequest, opts ...grpc.CallOption) (*pgctldpb.StartResponse, error) {
+func (m *mockPgctldClientWithCounter) StartAsStandby(ctx context.Context, req *pgctldpb.StartAsStandbyRequest, opts ...grpc.CallOption) (*pgctldpb.StartAsStandbyResponse, error) {
 	m.startCallCount++
-	return m.mockPgctldClient.Start(ctx, req, opts...)
+	return m.mockPgctldClient.StartAsStandby(ctx, req, opts...)
 }

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -1436,12 +1436,11 @@ func (pm *MultiPoolerManager) RewindToSource(ctx context.Context, source *cluste
 	}
 
 	// Step 4: Start PostgreSQL as standby
-	// Use Restart with as_standby=true to create standby.signal and start postgres
-	// Note: postgres is already stopped, so the stop phase will be a no-op
+	// Use Restart to start postgres as standby (standby.signal is always written).
+	// Note: postgres is already stopped, so the stop phase will be a no-op.
 	pm.logger.InfoContext(ctx, "Starting PostgreSQL as standby after pg_rewind")
 	restartReq := &pgctldpb.RestartRequest{
-		Mode:      "fast",
-		AsStandby: true,
+		Mode: "fast",
 	}
 	if _, err := pm.pgctldClient.Restart(ctx, restartReq); err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to restart PostgreSQL as standby", "error", err)

--- a/go/test/endtoend/multipooler/main_test.go
+++ b/go/test/endtoend/multipooler/main_test.go
@@ -151,8 +151,7 @@ func restoreAfterEmergencyDemotion(t *testing.T, setup *MultipoolerTestSetup, pg
 	restartCtx, restartCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer restartCancel()
 	_, err = pgctldClient.Restart(restartCtx, &pgctldpb.RestartRequest{
-		Mode:      "fast",
-		AsStandby: true,
+		Mode: "fast",
 	})
 	require.NoError(t, err, "Restart as standby should succeed on pooler: %s", multipoolerName)
 

--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -393,7 +393,7 @@ func TestConsensus_GetLeadershipView(t *testing.T) {
 	waitForManagerReady(t, setup, setup.PrimaryMultipooler)
 	waitForManagerReady(t, setup, setup.StandbyMultipooler)
 
-	setupPoolerTest(t, setup, WithoutReplication())
+	setupPoolerTest(t, setup, WithoutReplication(), WithEnabledMonitor())
 
 	t.Log("Manager primary-multipooler is ready")
 	t.Log("Manager standby-multipooler is ready")

--- a/go/test/endtoend/pgctld/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld/pgctld_grpc_test.go
@@ -77,9 +77,9 @@ func TestGRPCServerIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		// Step 3: Start PostgreSQL
-		startResp, err := client.Start(ctx, &pb.StartRequest{})
+		startResp, err := client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 		require.NoError(t, err)
-		assert.NotEmpty(t, startResp.Message)
+		assert.NotZero(t, startResp.GetPid())
 
 		// Step 4: Check status - should be running
 		statusResp, err = client.Status(ctx, &pb.StatusRequest{})
@@ -154,18 +154,13 @@ func TestGRPCErrorHandling(t *testing.T) {
 		_, err := client.InitDataDir(ctx, &pb.InitDataDirRequest{})
 		require.NoError(t, err)
 
-		_, err = client.Start(ctx, &pb.StartRequest{})
+		_, err = client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 		require.NoError(t, err)
 
-		// Try to start again - should handle gracefully
-		startResp, err := client.Start(ctx, &pb.StartRequest{})
-		if err != nil {
-			// Error is acceptable
-			t.Logf("Expected error on duplicate start: %v", err)
-		} else {
-			// Or success with appropriate message
-			assert.Contains(t, startResp.Message, "already")
-		}
+		// Try to start again - should handle gracefully (already running)
+		startResp, err := client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, pb.StartAsStandbyResult_START_AS_STANDBY_RESULT_ALREADY_RUNNING, startResp.GetResult())
 
 		// Clean up
 		_, _ = client.Stop(ctx, &pb.StopRequest{Mode: "fast"})
@@ -366,7 +361,7 @@ func TestGRPCUninitializedDatabase(t *testing.T) {
 		assert.Equal(t, "Data directory is not initialized", statusResp.GetMessage())
 
 		// Step 2: Try to start without initialization - should fail with proper error
-		_, err = client.Start(ctx, &pb.StartRequest{})
+		_, err = client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "data directory not initialized")
 		assert.Contains(t, err.Error(), "Run 'pgctld init' first")

--- a/go/test/endtoend/pgctld/pgctld_helpers.go
+++ b/go/test/endtoend/pgctld/pgctld_helpers.go
@@ -55,12 +55,12 @@ func InitAndStartPostgreSQL(t *testing.T, grpcAddr string) error {
 
 	// Start PostgreSQL
 	t.Logf("Starting PostgreSQL via gRPC at %s", grpcAddr)
-	startResp, err := client.Start(ctx, &pb.StartRequest{})
+	startResp, err := client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 	if err != nil {
-		return fmt.Errorf("call to Start RPC failed: %w", err)
+		return fmt.Errorf("call to StartAsStandby RPC failed: %w", err)
 	}
 
-	t.Logf("PostgreSQL started: PID=%d, Message=%s", startResp.Pid, startResp.Message)
+	t.Logf("PostgreSQL started: PID=%d", startResp.GetPid())
 	return nil
 }
 
@@ -112,11 +112,11 @@ func StartPostgreSQL(t *testing.T, grpcAddr string) error {
 
 	// Start PostgreSQL
 	t.Logf("Starting PostgreSQL via gRPC at %s", grpcAddr)
-	startResp, err := client.Start(ctx, &pb.StartRequest{})
+	startResp, err := client.StartAsStandby(ctx, &pb.StartAsStandbyRequest{})
 	if err != nil {
-		return fmt.Errorf("call to Start RPC failed: %w", err)
+		return fmt.Errorf("call to StartAsStandby RPC failed: %w", err)
 	}
 
-	t.Logf("PostgreSQL started: PID=%d, Message=%s", startResp.Pid, startResp.Message)
+	t.Logf("PostgreSQL started: PID=%d", startResp.GetPid())
 	return nil
 }

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -332,8 +332,8 @@ timeout: 30
 	})
 }
 
-// TestRestartAsStandbyWithRealPostgreSQL tests restart --as-standby with real PostgreSQL
-func TestRestartAsStandbyWithRealPostgreSQL(t *testing.T) {
+// TestRestartWithRealPostgreSQL tests that restart always writes standby.signal
+func TestRestartWithRealPostgreSQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -386,20 +386,20 @@ timeout: 30
 	require.NoError(t, err)
 	assert.Contains(t, string(output), "Running")
 
-	// Restart as standby
-	restartCmd := executil.Command(t.Context(), "pgctld", "restart", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--as-standby", "--config-file", pgctldConfigFile)
+	// Restart — always writes standby.signal
+	restartCmd := executil.Command(t.Context(), "pgctld", "restart", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
 	setupTestEnv(restartCmd, dataDir)
 	output, err = restartCmd.CombinedOutput()
 	if err != nil {
-		t.Logf("restart --as-standby output: %s", string(output))
+		t.Logf("restart output: %s", string(output))
 	}
 	require.NoError(t, err)
-	assert.Contains(t, string(output), "restarted as standby successfully")
+	assert.Contains(t, string(output), "restarted successfully")
 
-	// Verify standby.signal was created
+	// Verify standby.signal was created (restart always writes it)
 	standbySignalPath := filepath.Join(dataDir, "pg_data", "standby.signal")
 	_, err = os.Stat(standbySignalPath)
-	assert.NoError(t, err, "standby.signal file should exist after restart --as-standby")
+	assert.NoError(t, err, "standby.signal file should exist after restart")
 
 	// Verify server is still running
 	statusCmd = executil.Command(t.Context(), "pgctld", "status", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)
@@ -423,7 +423,7 @@ timeout: 30
 	require.NoError(t, err, "Recovery check should succeed, output: %s", string(output))
 	t.Logf("Recovery mode check result: %s", string(output))
 	// The output should contain 't' for true indicating recovery mode
-	assert.Contains(t, strings.TrimSpace(string(output)), "t", "PostgreSQL should be in recovery mode after restart --as-standby")
+	assert.Contains(t, strings.TrimSpace(string(output)), "t", "PostgreSQL should be in recovery mode after restart")
 
 	// Clean stop
 	stopCmd := executil.Command(t.Context(), "pgctld", "stop", "--pooler-dir", dataDir, "--pg-port", strconv.Itoa(testPort), "--config-file", pgctldConfigFile)

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/cmd/pgctld/command"
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/constants"
 	pb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -1176,7 +1177,7 @@ func readPostmasterPID(dataDir string) (int, error) {
 }
 
 // TestPgRewind_AfterCrash tests that PgRewind RPC automatically handles crash recovery
-// when PostgreSQL was killed ungracefully (SIGKILL) and left in "in production" state
+// when PostgreSQL was killed ungracefully (SIGKILL) and left in an unclean state
 func TestPgRewind_AfterCrash(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
@@ -1255,15 +1256,19 @@ func TestPgRewind_AfterCrash(t *testing.T) {
 		return err != nil
 	}, 5*time.Second, 100*time.Millisecond, "Standby postgres should terminate after SIGKILL")
 
-	// Verify standby is in "in production" state (not cleanly stopped)
-	t.Log("Verifying standby is in 'in production' state after crash")
+	// Verify standby is in an unclean state (not a clean shutdown) so crash recovery is needed.
+	// Since postgres always starts as standby, the cluster state after SIGKILL is
+	// "in archive recovery" rather than "in production".
+	t.Log("Verifying standby is in an unclean state after crash")
 	controldataCmd := exec.Command("pg_controldata", standbyPgDataDir)
 	output, err := controldataCmd.CombinedOutput()
 	require.NoError(t, err)
 	outputStr := string(output)
 	assert.Contains(t, outputStr, "Database cluster state:", "Should show cluster state")
-	assert.Contains(t, outputStr, "in production", "Should be 'in production' after SIGKILL")
-	t.Log("Confirmed: standby is in 'in production' state")
+	clusterState := command.ExtractClusterState(outputStr)
+	assert.False(t, command.IsCleanClusterState(clusterState),
+		"Cluster state should be unclean after SIGKILL (crash recovery needed), got: %q", clusterState)
+	t.Logf("Confirmed: standby is in state %q after SIGKILL (unclean, crash recovery needed)", clusterState)
 
 	// ===== CALL PGREWIND RPC =====
 	// Connect to standby gRPC and call PgRewind with dry_run=true

--- a/go/test/endtoend/pgctld/test_helpers.go
+++ b/go/test/endtoend/pgctld/test_helpers.go
@@ -280,8 +280,9 @@ func initAndStartPostgreSQL(t *testing.T, client pgctldservice.PgCtldClient) {
 	require.NoError(t, err, "InitDataDir should succeed")
 
 	// Start PostgreSQL
-	_, err = client.Start(ctx, &pgctldservice.StartRequest{})
-	require.NoError(t, err, "Start should succeed")
+	startResp, err := client.StartAsStandby(ctx, &pgctldservice.StartAsStandbyRequest{})
+	require.NoError(t, err, "StartAsStandby should succeed")
+	require.NotNil(t, startResp)
 
 	// Wait for PostgreSQL to be ready
 	deadline := time.Now().Add(30 * time.Second)

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1517,16 +1517,18 @@ func (s *ShardSetup) SetupTest(t *testing.T, opts ...SetupTestOption) {
 			client.Close()
 		}
 
-		// Ensure monitor is disabled (in case something during test re-enabled it)
-		s.disableMonitorOnAll(t, cleanupCtx)
-
 		// Validate cleanup worked.
 		// Use a generous timeout: GUC values written by RestoreGUCs are already
 		// waited on inside that function, so this is a final sanity check that
 		// should pass quickly. The extra headroom guards against slow CI runners.
+		// Note: monitor is intentionally left running here so it can complete any
+		// in-progress promotion (e.g., after a crash restart) before validation.
 		require.Eventually(t, func() bool {
 			return s.ValidateCleanState() == nil
 		}, 15*time.Second, 50*time.Millisecond, "Test cleanup failed: state did not return to clean state")
+
+		// Ensure monitor is disabled after validation (in case something during test re-enabled it)
+		s.disableMonitorOnAll(t, cleanupCtx)
 	})
 }
 

--- a/proto/pgctldservice.proto
+++ b/proto/pgctldservice.proto
@@ -110,9 +110,6 @@ message RestartRequest {
   int32 port = 3;
 
   repeated string extra_args = 4;
-
-  // If true, creates standby.signal before restart (for demotion to standby)
-  bool as_standby = 5;
 }
 
 message RestartResponse {

--- a/proto/pgctldservice.proto
+++ b/proto/pgctldservice.proto
@@ -26,8 +26,11 @@ service PgCtld {
 
   // Bootstrap and lifecycle Methods
 
-  // Start PostgreSQL server
-  rpc Start(StartRequest) returns (StartResponse);
+  // StartAsStandby starts PostgreSQL in standby (recovery) mode.
+  // Always writes standby.signal before starting, ensuring postgres never starts as primary.
+  // If the data directory was not cleanly shut down, PostgreSQL performs crash recovery
+  // automatically as part of startup (before accepting connections).
+  rpc StartAsStandby(StartAsStandbyRequest) returns (StartAsStandbyResponse);
 
   // Stop PostgreSQL server
   rpc Stop(StopRequest) returns (StopResponse);
@@ -52,21 +55,33 @@ service PgCtld {
   rpc PgRewind(PgRewindRequest) returns (PgRewindResponse);
 }
 
-// Start PostgreSQL server
-message StartRequest {
-  // Override the default port
+// StartAsStandby starts PostgreSQL in standby (recovery) mode.
+message StartAsStandbyRequest {
+  // Override the default port.
   int32 port = 1;
 
-  // Additional postgres command line arguments
+  // Additional postgres command line arguments.
   repeated string extra_args = 2;
 }
 
-message StartResponse {
-  // Process ID of started PostgreSQL server
-  int32 pid = 1;
+// StartAsStandbyResult describes the outcome of a StartAsStandby call.
+enum StartAsStandbyResult {
+  START_AS_STANDBY_RESULT_UNSPECIFIED = 0;
 
-  // Status message
-  string message = 2;
+  // PostgreSQL was started successfully in standby mode. Crash recovery may
+  // have been performed automatically if the data directory was not cleanly stopped.
+  START_AS_STANDBY_RESULT_STARTED = 1;
+
+  // PostgreSQL was already running (no action taken).
+  START_AS_STANDBY_RESULT_ALREADY_RUNNING = 2;
+}
+
+message StartAsStandbyResponse {
+  // Outcome of the start attempt.
+  StartAsStandbyResult result = 1;
+
+  // Process ID of the running PostgreSQL server.
+  int32 pid = 2;
 }
 
 // Stop PostgreSQL server


### PR DESCRIPTION
Note: this is not a critical change. We can wait on it

Replace the Start RPC (which could allow postgres to start as primary) with StartAsStandby, which always writes standby.signal before starting so postgres never enters primary mode unexpectedly.

In any situation where we want Postgres to be writable, we start as a standby and then `pg_promote()` explicitly.
