### PR TITLE
fix(multipooler): reject backups with empty table_group or shard

### DIFF
--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -175,10 +175,10 @@ func (pm *MultiPoolerManager) backupLockedInner(ctx context.Context, forcePrimar
 	// Backups missing these annotations would be silently skipped by replicas
 	// during restore, causing them to fall back to older backups.
 	if tableGroup == "" {
-		return "", mterrors.New(mtrpcpb.Code_INTERNAL, "table_group is missing")
+		return "", mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "table_group is missing")
 	}
 	if shard == "" {
-		return "", mterrors.New(mtrpcpb.Code_INTERNAL, "shard is missing")
+		return "", mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, "shard is missing")
 	}
 	args = append(args, "--annotation=table_group="+tableGroup)
 	args = append(args, "--annotation=shard="+shard)

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -171,13 +171,17 @@ func (pm *MultiPoolerManager) backupLockedInner(ctx context.Context, forcePrimar
 	}
 	args = append(args, pg2Args...)
 
-	// Add annotations if table_group and shard are provided
-	if tableGroup != "" {
-		args = append(args, "--annotation=table_group="+tableGroup)
+	// Reject backups with empty table_group or shard to prevent corrupt metadata.
+	// Backups missing these annotations would be silently skipped by replicas
+	// during restore, causing them to fall back to older backups.
+	if tableGroup == "" {
+		return "", mterrors.New(mtrpcpb.Code_INTERNAL, "table_group is missing")
 	}
-	if shard != "" {
-		args = append(args, "--annotation=shard="+shard)
+	if shard == "" {
+		return "", mterrors.New(mtrpcpb.Code_INTERNAL, "shard is missing")
 	}
+	args = append(args, "--annotation=table_group="+tableGroup)
+	args = append(args, "--annotation=shard="+shard)
 
 	// Add multipooler_id, pooler_type, and job_id annotations for unique identification
 	args = append(args, "--annotation=multipooler_id="+multipoolerName)

--- a/go/services/multipooler/manager/rpc_backup_test.go
+++ b/go/services/multipooler/manager/rpc_backup_test.go
@@ -1134,6 +1134,112 @@ pg1-path=/tmp/pg_data
 	}
 }
 
+func TestBackup_RejectsEmptyTableGroup(t *testing.T) {
+	// Regression test for MUL-223: backups with empty table_group produce
+	// corrupt metadata that causes replicas to skip valid backups.
+	// The backup must be rejected loudly rather than silently omitting
+	// the table_group annotation.
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// Create mock pgbackrest binary that succeeds for both backup and info.
+	// After the fix, pgbackrest should never be reached because the backup
+	// is rejected early due to empty table_group/shard.
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	mockScript := `#!/bin/bash
+if [[ "$*" == *"info"* ]]; then
+    cat << 'JSONEOF'
+[{
+    "backup": [{
+        "label": "20250104-100000F",
+        "type": "full",
+        "error": false,
+        "timestamp": {"start": 1735970400, "stop": 1735970500},
+        "annotation": {
+            "multipooler_id": "test-multipooler",
+            "job_id": "test-job-id"
+        }
+    }]
+}]
+JSONEOF
+fi
+exit 0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "pgbackrest"), []byte(mockScript), 0o755))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	poolerDir := filepath.Join(tmpDir, "pooler")
+	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
+
+	configPath := setupMockPgBackRestConfig(t, poolerDir)
+
+	tests := []struct {
+		name       string
+		tableGroup string
+		shard      string
+		wantErr    string
+	}{
+		{
+			name:       "empty table_group",
+			tableGroup: "",
+			shard:      "0-inf",
+			wantErr:    "table_group",
+		},
+		{
+			name:       "empty shard",
+			tableGroup: "default",
+			shard:      "",
+			wantErr:    "shard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build the manager directly to bypass createTestManager's
+			// default-substitution for empty table_group/shard.
+			multipoolerID := &clustermetadatapb.ID{
+				Component: clustermetadatapb.ID_MULTIPOOLER,
+				Cell:      "zone1",
+				Name:      "test-multipooler",
+			}
+			ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+			_ = ts.CreateDatabase(ctx, "test-database", &clustermetadatapb.Database{
+				Name:           "test-database",
+				BackupLocation: utils.FilesystemBackupLocation(tmpDir),
+			})
+			backupConfig, _ := backup.NewConfig(
+				utils.FilesystemBackupLocation(tmpDir),
+			)
+
+			pm := &MultiPoolerManager{
+				config:     &Config{},
+				serviceID:  multipoolerID,
+				topoClient: ts,
+				multipooler: &clustermetadatapb.MultiPooler{
+					Id:         multipoolerID,
+					Type:       clustermetadatapb.PoolerType_PRIMARY,
+					TableGroup: tt.tableGroup,
+					Shard:      tt.shard,
+					Database:   "test-database",
+					PoolerDir:  poolerDir,
+				},
+				state:                ManagerStateReady,
+				backupConfig:         backupConfig,
+				actionLock:           NewActionLock(),
+				logger:               slog.Default(),
+				pgMonitor:            timer.NewPeriodicRunner(context.TODO(), 10*time.Second),
+				pgBackRestConfigPath: configPath,
+			}
+
+			_, err := pm.Backup(ctx, true, "full", "test-job-id", nil)
+			require.Error(t, err, "backup with empty %s should be rejected", tt.name)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestGetPrimaryAsPg2Args(t *testing.T) {
 	tests := []struct {
 		name                    string


### PR DESCRIPTION
Backups with empty table_group or shard annotations produce corrupt metadata that causes replicas to skip valid backups during restore, falling back to older ones.

Replace the silent `if tableGroup != ""` guards with explicit validation that returns an error, preventing corrupt metadata from being written.

This doesn't fix MUL-223, because I can't repro it. However, this will make it impossible to create backups with missing `table_group` or `shard`, which makes them unusable.

Mitigates MUL-223