### PR TITLE
refactor(multipooler): remove IF NOT EXISTS from schema creation DDL

### DIFF
--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -124,7 +124,7 @@ func (pm *MultiPoolerManager) initializeMultischemaData(ctx context.Context) err
 func (pm *MultiPoolerManager) createSchema(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, "CREATE SCHEMA IF NOT EXISTS multigres"); err != nil {
+	if err := pm.exec(execCtx, "CREATE SCHEMA multigres"); err != nil {
 		return mterrors.Wrap(err, "failed to create multigres schema")
 	}
 	return nil
@@ -138,7 +138,7 @@ func (pm *MultiPoolerManager) createSchema(ctx context.Context) error {
 func (pm *MultiPoolerManager) createHeartbeatTable(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.heartbeat (
+	if err := pm.exec(execCtx, `CREATE TABLE multigres.heartbeat (
 		shard_id BYTEA PRIMARY KEY,
 		leader_id TEXT NOT NULL,
 		ts BIGINT NOT NULL
@@ -152,7 +152,7 @@ func (pm *MultiPoolerManager) createHeartbeatTable(ctx context.Context) error {
 func (pm *MultiPoolerManager) createLeadershipHistoryTable(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.leadership_history (
+	if err := pm.exec(execCtx, `CREATE TABLE multigres.leadership_history (
 		id BIGSERIAL PRIMARY KEY,
 		term_number BIGINT NOT NULL,
 		event_type TEXT NOT NULL,
@@ -170,7 +170,7 @@ func (pm *MultiPoolerManager) createLeadershipHistoryTable(ctx context.Context) 
 
 	execCtx, cancel = context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event
+	if err := pm.exec(execCtx, `CREATE INDEX idx_leadership_history_term_event
 		ON multigres.leadership_history(term_number DESC, event_type)`); err != nil {
 		return mterrors.Wrap(err, "failed to create leadership_history index")
 	}
@@ -186,7 +186,7 @@ func (pm *MultiPoolerManager) createLeadershipHistoryTable(ctx context.Context) 
 func (pm *MultiPoolerManager) createTablegroup(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.tablegroup (
+	if err := pm.exec(execCtx, `CREATE TABLE multigres.tablegroup (
 		oid BIGSERIAL PRIMARY KEY,
 		name TEXT NOT NULL UNIQUE,
 		type TEXT NOT NULL
@@ -200,7 +200,7 @@ func (pm *MultiPoolerManager) createTablegroup(ctx context.Context) error {
 func (pm *MultiPoolerManager) createTablegroupTable(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.tablegroup_table (
+	if err := pm.exec(execCtx, `CREATE TABLE multigres.tablegroup_table (
 		oid BIGSERIAL PRIMARY KEY,
 		tablegroup_oid BIGINT NOT NULL REFERENCES multigres.tablegroup(oid),
 		name TEXT NOT NULL,
@@ -215,7 +215,7 @@ func (pm *MultiPoolerManager) createTablegroupTable(ctx context.Context) error {
 func (pm *MultiPoolerManager) createShard(ctx context.Context) error {
 	execCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	if err := pm.exec(execCtx, `CREATE TABLE IF NOT EXISTS multigres.shard (
+	if err := pm.exec(execCtx, `CREATE TABLE multigres.shard (
 		oid BIGSERIAL PRIMARY KEY,
 		tablegroup_oid BIGINT NOT NULL REFERENCES multigres.tablegroup(oid),
 		shard_name TEXT NOT NULL,

--- a/go/services/multipooler/manager/pg_multischema_test.go
+++ b/go/services/multipooler/manager/pg_multischema_test.go
@@ -105,13 +105,13 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "successful schema creation for default tablegroup",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.tablegroup", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.tablegroup_table", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.shard", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE SCHEMA multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.heartbeat", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.leadership_history", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE INDEX idx_leadership_history_term_event", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.tablegroup", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.tablegroup_table", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.shard", mock.MakeQueryResult(nil, nil))
 			},
 			expectError: false,
 		},
@@ -119,7 +119,7 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "schema creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnceWithError("CREATE SCHEMA IF NOT EXISTS multigres", errors.New("permission denied"))
+				m.AddQueryPatternOnceWithError("CREATE SCHEMA multigres", errors.New("permission denied"))
 			},
 			expectError:   true,
 			errorContains: "failed to create multigres schema",
@@ -128,8 +128,8 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "heartbeat table creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.heartbeat", errors.New("table creation failed"))
+				m.AddQueryPatternOnce("CREATE SCHEMA multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("CREATE TABLE multigres.heartbeat", errors.New("table creation failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to create heartbeat table",
@@ -138,9 +138,9 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "leadership_history table creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.leadership_history", errors.New("table creation failed"))
+				m.AddQueryPatternOnce("CREATE SCHEMA multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.heartbeat", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("CREATE TABLE multigres.leadership_history", errors.New("table creation failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to create leadership_history table",
@@ -149,10 +149,10 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "leadership_history index creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE INDEX IF NOT EXISTS idx_leadership_history_term_event", errors.New("index creation failed"))
+				m.AddQueryPatternOnce("CREATE SCHEMA multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.heartbeat", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.leadership_history", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("CREATE INDEX idx_leadership_history_term_event", errors.New("index creation failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to create leadership_history index",
@@ -161,11 +161,11 @@ func TestCreateSidecarSchema(t *testing.T) {
 			name:       "tablegroup table creation fails",
 			tableGroup: constants.DefaultTableGroup,
 			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("CREATE SCHEMA IF NOT EXISTS multigres", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.heartbeat", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE TABLE IF NOT EXISTS multigres.leadership_history", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("CREATE INDEX IF NOT EXISTS idx_leadership_history_term", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("CREATE TABLE IF NOT EXISTS multigres.tablegroup", errors.New("table creation failed"))
+				m.AddQueryPatternOnce("CREATE SCHEMA multigres", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.heartbeat", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE TABLE multigres.leadership_history", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnce("CREATE INDEX idx_leadership_history_term", mock.MakeQueryResult(nil, nil))
+				m.AddQueryPatternOnceWithError("CREATE TABLE multigres.tablegroup", errors.New("table creation failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to create tablegroup table",

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -261,7 +261,7 @@ func resetRuleStoreTables(ctx context.Context, t *testing.T) {
 	defer conn.Close()
 
 	qs := &connQueryService{conn: conn}
-	_, err = qs.conn.Query(ctx, "TRUNCATE multigres.current_rule, multigres.rule_history")
+	_, err = qs.conn.Query(ctx, "DROP TABLE multigres.current_rule, multigres.rule_history")
 	require.NoError(t, err)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))


### PR DESCRIPTION
Schema creation runs only once on a fresh database, so the IF NOT EXISTS guards are unnecessary and can mask errors if objects already exist unexpectedly.