### PR TITLE
feat(multipooler): publish topology state asynchronously

### DIFF
--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1065,10 +1065,9 @@ func (pm *MultiPoolerManager) setNotServing(ctx context.Context, state *demotion
 		return mterrors.Wrap(err, "failed to transition to NOT_SERVING")
 	}
 
-	// Sync to topology
-	pm.mu.Lock()
+	// Notify the topology publisher of the new state. The write to etcd happens
+	// asynchronously so that a temporarily unreachable etcd does not block demotion.
 	pm.topoPublisher.Notify(pm.multipooler)
-	pm.mu.Unlock()
 
 	pm.logger.InfoContext(ctx, "Transitioned to NOT_SERVING successfully")
 	return nil
@@ -1398,10 +1397,9 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 		return mterrors.Wrap(err, "failed to set serving state for promotion")
 	}
 
-	// Sync to topology
-	pm.mu.Lock()
+	// Notify the topology publisher of the new state. The write to etcd happens
+	// asynchronously so that a temporarily unreachable etcd does not block promotion.
 	pm.topoPublisher.Notify(pm.multipooler)
-	pm.mu.Unlock()
 
 	return nil
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1067,7 +1067,9 @@ func (pm *MultiPoolerManager) setNotServing(ctx context.Context, state *demotion
 
 	// Notify the topology publisher of the new state. The write to etcd happens
 	// asynchronously so that a temporarily unreachable etcd does not block demotion.
-	pm.topoPublisher.Notify(pm.multipooler)
+	if err := pm.topoPublisher.Notify(ctx, pm.multipooler); err != nil {
+		pm.logger.ErrorContext(ctx, "topoPublisher.Notify called without action lock", "error", err)
+	}
 
 	pm.logger.InfoContext(ctx, "Transitioned to NOT_SERVING successfully")
 	return nil
@@ -1399,7 +1401,9 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 
 	// Notify the topology publisher of the new state. The write to etcd happens
 	// asynchronously so that a temporarily unreachable etcd does not block promotion.
-	pm.topoPublisher.Notify(pm.multipooler)
+	if err := pm.topoPublisher.Notify(ctx, pm.multipooler); err != nil {
+		pm.logger.ErrorContext(ctx, "topoPublisher.Notify called without action lock", "error", err)
+	}
 
 	return nil
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -42,7 +42,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/proto"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -155,6 +154,9 @@ type MultiPoolerManager struct {
 	// healthStreamer streams health state to subscribers.
 	// Owns all health-related state and provides typed update methods.
 	healthStreamer *healthStreamer
+
+	// topoPublisher asynchronously reflects in-memory state to etcd.
+	topoPublisher *topoPublisher
 }
 
 // promotionState tracks which parts of the promotion are complete
@@ -278,6 +280,8 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		logger.Warn("failed to register pgBackRest metrics", "error", metricsErr)
 	}
 
+	pm.topoPublisher = newTopoPublisher(logger, config.TopoClient)
+
 	return pm, nil
 }
 
@@ -344,6 +348,9 @@ func (pm *MultiPoolerManager) Open() {
 	pm.logger.InfoContext(pm.ctx, "MonitorPostgres enabled successfully")
 
 	pm.isOpen = true
+
+	// Start topology publisher goroutine to eventually-consistently sync state to etcd.
+	go pm.topoPublisher.Run(pm.ctx)
 
 	// Start health heartbeat goroutine and transition to SERVING.
 	// SetState notifies all components (query service, heartbeat, health streamer).
@@ -1060,13 +1067,8 @@ func (pm *MultiPoolerManager) setNotServing(ctx context.Context, state *demotion
 
 	// Sync to topology
 	pm.mu.Lock()
-	multiPoolerToSync := proto.Clone(pm.multipooler).(*clustermetadatapb.MultiPooler)
+	pm.topoPublisher.Notify(pm.multipooler)
 	pm.mu.Unlock()
-
-	if err := pm.topoClient.RegisterMultiPooler(ctx, multiPoolerToSync, true); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to update serving status in topology", "error", err)
-		return mterrors.Wrap(err, "failed to sync NOT_SERVING to topology")
-	}
 
 	pm.logger.InfoContext(ctx, "Transitioned to NOT_SERVING successfully")
 	return nil
@@ -1398,13 +1400,8 @@ func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, 
 
 	// Sync to topology
 	pm.mu.Lock()
-	multiPoolerToSync := proto.Clone(pm.multipooler).(*clustermetadatapb.MultiPooler)
+	pm.topoPublisher.Notify(pm.multipooler)
 	pm.mu.Unlock()
-
-	if err := pm.topoClient.RegisterMultiPooler(ctx, multiPoolerToSync, true); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to update pooler type in topology", "error", err)
-		return mterrors.Wrap(err, "promotion succeeded but failed to update topology")
-	}
 
 	return nil
 }

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -1333,12 +1333,13 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			assert.Equal(t, tt.expectedPrimaryTerm, persistedTerm.PrimaryTerm,
 				"Primary term should be %d but got %d", tt.expectedPrimaryTerm, persistedTerm.PrimaryTerm)
 
-			// Verify topology was updated to REPLICA (only on success)
+			// Verify topology was updated to REPLICA (only on success).
+			// The write is asynchronous so we poll until the publisher catches up.
 			if !tt.expectedError {
-				updatedPooler, err := ts.GetMultiPooler(ctx, serviceID)
-				require.NoError(t, err)
-				assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, updatedPooler.Type,
-					"Pooler type should be updated to REPLICA in topology")
+				require.Eventually(t, func() bool {
+					updatedPooler, err := ts.GetMultiPooler(ctx, serviceID)
+					return err == nil && updatedPooler.Type == clustermetadatapb.PoolerType_REPLICA
+				}, 500*time.Millisecond, 50*time.Millisecond, "Pooler type should be updated to REPLICA in topology")
 
 				// Verify health streamer reports the new primary (source)
 				healthState := pm.healthStreamer.getState()

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -743,7 +743,9 @@ func (pm *MultiPoolerManager) changeTypeLocked(ctx context.Context, poolerType c
 
 	// Notify the topology publisher of the new state. The write to etcd happens
 	// asynchronously so that a temporarily unreachable etcd does not block type changes.
-	pm.topoPublisher.Notify(pm.multipooler)
+	if err := pm.topoPublisher.Notify(ctx, pm.multipooler); err != nil {
+		pm.logger.ErrorContext(ctx, "topoPublisher.Notify called without action lock", "error", err)
+	}
 
 	pm.logger.InfoContext(ctx, "Pooler type updated successfully", "new_type", poolerType.String(), "service_id", pm.serviceID.String())
 	return nil

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/multigres/multigres/go/common/eventlog"
@@ -744,13 +743,8 @@ func (pm *MultiPoolerManager) changeTypeLocked(ctx context.Context, poolerType c
 
 	// Sync to topology
 	pm.mu.Lock()
-	multiPoolerToSync := proto.Clone(pm.multipooler).(*clustermetadatapb.MultiPooler)
+	pm.topoPublisher.Notify(pm.multipooler)
 	pm.mu.Unlock()
-
-	if err := pm.topoClient.RegisterMultiPooler(ctx, multiPoolerToSync, true); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to update pooler type in topology", "error", err, "service_id", pm.serviceID.String())
-		return mterrors.Wrap(err, "failed to update pooler type in topology")
-	}
 
 	pm.logger.InfoContext(ctx, "Pooler type updated successfully", "new_type", poolerType.String(), "service_id", pm.serviceID.String())
 	return nil

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -741,10 +741,9 @@ func (pm *MultiPoolerManager) changeTypeLocked(ctx context.Context, poolerType c
 		return mterrors.Wrap(err, "failed to set serving state")
 	}
 
-	// Sync to topology
-	pm.mu.Lock()
+	// Notify the topology publisher of the new state. The write to etcd happens
+	// asynchronously so that a temporarily unreachable etcd does not block type changes.
 	pm.topoPublisher.Notify(pm.multipooler)
-	pm.mu.Unlock()
 
 	pm.logger.InfoContext(ctx, "Pooler type updated successfully", "new_type", poolerType.String(), "service_id", pm.serviceID.String())
 	return nil

--- a/go/services/multipooler/manager/topo_publisher.go
+++ b/go/services/multipooler/manager/topo_publisher.go
@@ -59,7 +59,15 @@ func newTopoPublisher(logger *slog.Logger, topoClient topoRegistrar) *topoPublis
 
 // Notify records mp as the desired topology state and schedules an immediate
 // publish attempt. mp is cloned so the caller may reuse the original.
-func (tp *topoPublisher) Notify(mp *clustermetadatapb.MultiPooler) {
+//
+// ctx must carry an action lock (see AssertActionLockHeld). The action lock
+// serialises state transitions, preventing concurrent calls from racing to
+// overwrite each other's desired state.
+func (tp *topoPublisher) Notify(ctx context.Context, mp *clustermetadatapb.MultiPooler) error {
+	if err := AssertActionLockHeld(ctx); err != nil {
+		return err
+	}
+
 	tp.mu.Lock()
 	tp.desired = proto.Clone(mp).(*clustermetadatapb.MultiPooler)
 	tp.mu.Unlock()
@@ -70,6 +78,7 @@ func (tp *topoPublisher) Notify(mp *clustermetadatapb.MultiPooler) {
 	case tp.wakeup <- struct{}{}:
 	default:
 	}
+	return nil
 }
 
 // Run is the background loop. It blocks until ctx is cancelled. Call it in a

--- a/go/services/multipooler/manager/topo_publisher.go
+++ b/go/services/multipooler/manager/topo_publisher.go
@@ -40,10 +40,6 @@ type topoPublisher struct {
 	logger     *slog.Logger
 	topoClient topoRegistrar
 
-	// retryInterval controls how often the background loop polls for missed writes.
-	// Defaults to topoPublisherRetryInterval. May be overridden in tests.
-	retryInterval time.Duration
-
 	// wakeup is a size-1 buffered channel. A non-blocking send schedules a
 	// publish without accumulating multiple pending signals.
 	wakeup chan struct{}
@@ -55,10 +51,9 @@ type topoPublisher struct {
 
 func newTopoPublisher(logger *slog.Logger, topoClient topoRegistrar) *topoPublisher {
 	return &topoPublisher{
-		logger:        logger,
-		topoClient:    topoClient,
-		retryInterval: topoPublisherRetryInterval,
-		wakeup:        make(chan struct{}, 1),
+		logger:     logger,
+		topoClient: topoClient,
+		wakeup:     make(chan struct{}, 1),
 	}
 }
 
@@ -80,16 +75,21 @@ func (tp *topoPublisher) Notify(mp *clustermetadatapb.MultiPooler) {
 // Run is the background loop. It blocks until ctx is cancelled. Call it in a
 // goroutine: go tp.Run(ctx).
 func (tp *topoPublisher) Run(ctx context.Context) {
-	ticker := time.NewTicker(tp.retryInterval)
+	ticker := time.NewTicker(topoPublisherRetryInterval)
 	defer ticker.Stop()
+	tp.run(ctx, ticker.C)
+}
 
+// run is the internal loop, accepting an injectable ticker channel so tests can
+// drive retries without real clock time.
+func (tp *topoPublisher) run(ctx context.Context, tickC <-chan time.Time) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-tp.wakeup:
 			tp.publishIfNeeded(ctx)
-		case <-ticker.C:
+		case <-tickC:
 			tp.publishIfNeeded(ctx)
 		}
 	}

--- a/go/services/multipooler/manager/topo_publisher.go
+++ b/go/services/multipooler/manager/topo_publisher.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+const topoPublisherRetryInterval = 30 * time.Second
+
+// topoRegistrar is the subset of topoclient.Store used by topoPublisher.
+type topoRegistrar interface {
+	RegisterMultiPooler(ctx context.Context, multipooler *clustermetadatapb.MultiPooler, allowUpdate bool) error
+}
+
+// topoPublisher eventually-consistently reflects the multipooler's in-memory state
+// to etcd. Callers invoke Notify with the current state whenever it changes; a
+// background goroutine wakes immediately to write it and also retries periodically
+// so that writes missed during an etcd outage are recovered automatically.
+type topoPublisher struct {
+	logger     *slog.Logger
+	topoClient topoRegistrar
+
+	// retryInterval controls how often the background loop polls for missed writes.
+	// Defaults to topoPublisherRetryInterval. May be overridden in tests.
+	retryInterval time.Duration
+
+	// wakeup is a size-1 buffered channel. A non-blocking send schedules a
+	// publish without accumulating multiple pending signals.
+	wakeup chan struct{}
+
+	mu            sync.Mutex
+	desired       *clustermetadatapb.MultiPooler // latest state that should be in etcd
+	lastPublished *clustermetadatapb.MultiPooler // last state successfully written; nil if never written
+}
+
+func newTopoPublisher(logger *slog.Logger, topoClient topoRegistrar) *topoPublisher {
+	return &topoPublisher{
+		logger:        logger,
+		topoClient:    topoClient,
+		retryInterval: topoPublisherRetryInterval,
+		wakeup:        make(chan struct{}, 1),
+	}
+}
+
+// Notify records mp as the desired topology state and schedules an immediate
+// publish attempt. mp is cloned so the caller may reuse the original.
+func (tp *topoPublisher) Notify(mp *clustermetadatapb.MultiPooler) {
+	tp.mu.Lock()
+	tp.desired = proto.Clone(mp).(*clustermetadatapb.MultiPooler)
+	tp.mu.Unlock()
+
+	// Non-blocking send: if the channel is already full, a publish is already
+	// pending and will pick up the latest desired state.
+	select {
+	case tp.wakeup <- struct{}{}:
+	default:
+	}
+}
+
+// Run is the background loop. It blocks until ctx is cancelled. Call it in a
+// goroutine: go tp.Run(ctx).
+func (tp *topoPublisher) Run(ctx context.Context) {
+	ticker := time.NewTicker(tp.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tp.wakeup:
+			tp.publishIfNeeded(ctx)
+		case <-ticker.C:
+			tp.publishIfNeeded(ctx)
+		}
+	}
+}
+
+// publishIfNeeded writes the desired state to etcd if it differs from the last
+// successfully published state. A no-op when state is already current.
+func (tp *topoPublisher) publishIfNeeded(ctx context.Context) {
+	tp.mu.Lock()
+	desired := tp.desired
+	lastPublished := tp.lastPublished
+	tp.mu.Unlock()
+
+	if desired == nil {
+		return
+	}
+
+	if proto.Equal(desired, lastPublished) {
+		return
+	}
+
+	tp.logger.InfoContext(ctx, "Publishing multipooler state to topology",
+		"type", desired.Type,
+		"serving_status", desired.ServingStatus)
+
+	publishCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := tp.topoClient.RegisterMultiPooler(publishCtx, desired, true); err != nil {
+		tp.logger.ErrorContext(ctx, "Failed to publish multipooler state to topology; will retry",
+			"error", err,
+			"type", desired.Type,
+			"serving_status", desired.ServingStatus)
+		return
+	}
+
+	tp.mu.Lock()
+	tp.lastPublished = proto.Clone(desired).(*clustermetadatapb.MultiPooler)
+	tp.mu.Unlock()
+
+	tp.logger.InfoContext(ctx, "Published multipooler state to topology",
+		"type", desired.Type,
+		"serving_status", desired.ServingStatus)
+}

--- a/go/services/multipooler/manager/topo_publisher_test.go
+++ b/go/services/multipooler/manager/topo_publisher_test.go
@@ -29,12 +29,14 @@ import (
 
 // fakeRegistrar is a minimal topoRegistrar for testing.
 type fakeRegistrar struct {
-	calls    atomic.Int32
+	attempts atomic.Int32 // incremented on every RegisterMultiPooler call, success or failure
+	calls    atomic.Int32 // incremented only on successful calls
 	err      atomic.Pointer[error]
 	lastSeen atomic.Pointer[clustermetadatapb.MultiPooler]
 }
 
 func (f *fakeRegistrar) RegisterMultiPooler(_ context.Context, mp *clustermetadatapb.MultiPooler, _ bool) error {
+	f.attempts.Add(1)
 	if ep := f.err.Load(); ep != nil {
 		return *ep
 	}
@@ -63,20 +65,97 @@ func newTestPooler(poolerType clustermetadatapb.PoolerType, status clustermetada
 	}
 }
 
-func TestTopoPublisher_NotifyTriggersWrite(t *testing.T) {
+// --- publishIfNeeded unit tests (no goroutines, fully deterministic) ---
+
+func TestTopoPublisher_PublishIfNeeded_WritesOnFirstCall(t *testing.T) {
 	reg := &fakeRegistrar{}
 	tp := newTopoPublisher(newTestLogger(), reg)
 
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	tp.publishIfNeeded(t.Context())
+
+	assert.Equal(t, int32(1), reg.calls.Load())
+	seen := reg.lastSeen.Load()
+	require.NotNil(t, seen)
+	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
+	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, seen.ServingStatus)
+}
+
+func TestTopoPublisher_PublishIfNeeded_NoopWhenStateUnchanged(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	tp.publishIfNeeded(t.Context())
+	require.Equal(t, int32(1), reg.calls.Load())
+
+	// Same state again: should not write.
+	tp.publishIfNeeded(t.Context())
+	assert.Equal(t, int32(1), reg.calls.Load(), "duplicate publish for unchanged state")
+}
+
+func TestTopoPublisher_PublishIfNeeded_WritesOnStateChange(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
+	tp.publishIfNeeded(t.Context())
+	require.Equal(t, int32(1), reg.calls.Load())
+
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	tp.publishIfNeeded(t.Context())
+	assert.Equal(t, int32(2), reg.calls.Load())
+
+	seen := reg.lastSeen.Load()
+	require.NotNil(t, seen)
+	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
+}
+
+func TestTopoPublisher_PublishIfNeeded_RetriesAfterFailure(t *testing.T) {
+	reg := &fakeRegistrar{}
+	reg.setError(errors.New("etcd unavailable"))
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+
+	// First attempt fails.
+	tp.publishIfNeeded(t.Context())
+	assert.Equal(t, int32(0), reg.calls.Load())
+
+	// After the error clears, next attempt succeeds.
+	reg.clearError()
+	tp.publishIfNeeded(t.Context())
+	assert.Equal(t, int32(1), reg.calls.Load())
+}
+
+func TestTopoPublisher_PublishIfNeeded_NoopWhenNoDesiredState(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	tp.publishIfNeeded(t.Context())
+	assert.Equal(t, int32(0), reg.calls.Load())
+	assert.Equal(t, int32(0), reg.attempts.Load())
+}
+
+// --- Goroutine integration tests (wakeup channel and ticker wiring) ---
+
+// TestTopoPublisher_NotifyWakesGoroutine verifies that Notify triggers an
+// immediate write without waiting for a ticker tick.
+func TestTopoPublisher_NotifyWakesGoroutine(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	// tickC is never sent to in this test — the wakeup channel does all the work.
+	tickC := make(chan time.Time)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go tp.Run(ctx)
+	go tp.run(ctx, tickC)
 
-	mp := newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
-	tp.Notify(mp)
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 
 	require.Eventually(t, func() bool {
 		return reg.calls.Load() == 1
-	}, time.Second, 5*time.Millisecond)
+	}, time.Second, time.Millisecond)
 
 	seen := reg.lastSeen.Load()
 	require.NotNil(t, seen)
@@ -84,84 +163,44 @@ func TestTopoPublisher_NotifyTriggersWrite(t *testing.T) {
 	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, seen.ServingStatus)
 }
 
-func TestTopoPublisher_RetriesAfterFailure(t *testing.T) {
+// TestTopoPublisher_TickerDrivesRetry verifies that a ticker signal retries a
+// previously failed write without needing Notify to be called again.
+func TestTopoPublisher_TickerDrivesRetry(t *testing.T) {
 	reg := &fakeRegistrar{}
 	reg.setError(errors.New("etcd unavailable"))
-
 	tp := newTopoPublisher(newTestLogger(), reg)
-	// Use a short retry interval so the test doesn't wait 30 seconds.
-	tp.retryInterval = 20 * time.Millisecond
 
+	tickC := make(chan time.Time)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	go tp.Run(ctx)
+	go tp.run(ctx, tickC)
 
-	mp := newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING)
-	tp.Notify(mp)
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
 
-	// Allow some time for at least one failed attempt.
-	time.Sleep(30 * time.Millisecond)
-	assert.Equal(t, int32(0), reg.calls.Load(), "expected no successful writes while erroring")
+	// Wait for the goroutine to attempt (and fail) the wakeup-triggered write.
+	require.Eventually(t, func() bool {
+		return reg.attempts.Load() >= 1
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, int32(0), reg.calls.Load())
 
-	// Clear the error; the periodic ticker should now succeed.
+	// Clear the error and fire a ticker tick; the retry should succeed.
 	reg.clearError()
+	tickC <- time.Time{}
 
 	require.Eventually(t, func() bool {
 		return reg.calls.Load() >= 1
-	}, time.Second, 5*time.Millisecond)
-}
-
-func TestTopoPublisher_NoDuplicateWrites(t *testing.T) {
-	reg := &fakeRegistrar{}
-	tp := newTopoPublisher(newTestLogger(), reg)
-	tp.retryInterval = 20 * time.Millisecond
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go tp.Run(ctx)
-
-	mp := newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
-	tp.Notify(mp)
-
-	// Wait for the first write to succeed.
-	require.Eventually(t, func() bool {
-		return reg.calls.Load() == 1
-	}, time.Second, 5*time.Millisecond)
-
-	// Let a few ticker intervals pass — state hasn't changed, so no more writes.
-	time.Sleep(60 * time.Millisecond)
-	assert.Equal(t, int32(1), reg.calls.Load(), "expected no additional writes for unchanged state")
-}
-
-func TestTopoPublisher_SecondNotifyWritesNewState(t *testing.T) {
-	reg := &fakeRegistrar{}
-	tp := newTopoPublisher(newTestLogger(), reg)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go tp.Run(ctx)
-
-	// First transition: REPLICA SERVING
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
-	require.Eventually(t, func() bool { return reg.calls.Load() == 1 }, time.Second, 5*time.Millisecond)
-
-	// Second transition: PRIMARY SERVING
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
-	require.Eventually(t, func() bool { return reg.calls.Load() == 2 }, time.Second, 5*time.Millisecond)
-
-	seen := reg.lastSeen.Load()
-	require.NotNil(t, seen)
-	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
+	}, time.Second, time.Millisecond)
 }
 
 func TestTopoPublisher_RunExitsOnContextCancel(t *testing.T) {
 	reg := &fakeRegistrar{}
 	tp := newTopoPublisher(newTestLogger(), reg)
 
+	tickC := make(chan time.Time)
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
 	go func() {
-		tp.Run(ctx)
+		tp.run(ctx, tickC)
 		close(done)
 	}()
 
@@ -170,6 +209,6 @@ func TestTopoPublisher_RunExitsOnContextCancel(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("Run did not exit after context cancellation")
+		t.Fatal("run did not exit after context cancellation")
 	}
 }

--- a/go/services/multipooler/manager/topo_publisher_test.go
+++ b/go/services/multipooler/manager/topo_publisher_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+// fakeRegistrar is a minimal topoRegistrar for testing.
+type fakeRegistrar struct {
+	calls    atomic.Int32
+	err      atomic.Pointer[error]
+	lastSeen atomic.Pointer[clustermetadatapb.MultiPooler]
+}
+
+func (f *fakeRegistrar) RegisterMultiPooler(_ context.Context, mp *clustermetadatapb.MultiPooler, _ bool) error {
+	if ep := f.err.Load(); ep != nil {
+		return *ep
+	}
+	f.calls.Add(1)
+	f.lastSeen.Store(mp)
+	return nil
+}
+
+func (f *fakeRegistrar) setError(err error) {
+	f.err.Store(&err)
+}
+
+func (f *fakeRegistrar) clearError() {
+	f.err.Store(nil)
+}
+
+func newTestPooler(poolerType clustermetadatapb.PoolerType, status clustermetadatapb.PoolerServingStatus) *clustermetadatapb.MultiPooler {
+	return &clustermetadatapb.MultiPooler{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Name:      "test-pooler",
+		},
+		Type:          poolerType,
+		ServingStatus: status,
+	}
+}
+
+func TestTopoPublisher_NotifyTriggersWrite(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go tp.Run(ctx)
+
+	mp := newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
+	tp.Notify(mp)
+
+	require.Eventually(t, func() bool {
+		return reg.calls.Load() == 1
+	}, time.Second, 5*time.Millisecond)
+
+	seen := reg.lastSeen.Load()
+	require.NotNil(t, seen)
+	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
+	assert.Equal(t, clustermetadatapb.PoolerServingStatus_SERVING, seen.ServingStatus)
+}
+
+func TestTopoPublisher_RetriesAfterFailure(t *testing.T) {
+	reg := &fakeRegistrar{}
+	reg.setError(errors.New("etcd unavailable"))
+
+	tp := newTopoPublisher(newTestLogger(), reg)
+	// Use a short retry interval so the test doesn't wait 30 seconds.
+	tp.retryInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go tp.Run(ctx)
+
+	mp := newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING)
+	tp.Notify(mp)
+
+	// Allow some time for at least one failed attempt.
+	time.Sleep(30 * time.Millisecond)
+	assert.Equal(t, int32(0), reg.calls.Load(), "expected no successful writes while erroring")
+
+	// Clear the error; the periodic ticker should now succeed.
+	reg.clearError()
+
+	require.Eventually(t, func() bool {
+		return reg.calls.Load() >= 1
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestTopoPublisher_NoDuplicateWrites(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+	tp.retryInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go tp.Run(ctx)
+
+	mp := newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)
+	tp.Notify(mp)
+
+	// Wait for the first write to succeed.
+	require.Eventually(t, func() bool {
+		return reg.calls.Load() == 1
+	}, time.Second, 5*time.Millisecond)
+
+	// Let a few ticker intervals pass — state hasn't changed, so no more writes.
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, int32(1), reg.calls.Load(), "expected no additional writes for unchanged state")
+}
+
+func TestTopoPublisher_SecondNotifyWritesNewState(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go tp.Run(ctx)
+
+	// First transition: REPLICA SERVING
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.Eventually(t, func() bool { return reg.calls.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// Second transition: PRIMARY SERVING
+	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.Eventually(t, func() bool { return reg.calls.Load() == 2 }, time.Second, 5*time.Millisecond)
+
+	seen := reg.lastSeen.Load()
+	require.NotNil(t, seen)
+	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, seen.Type)
+}
+
+func TestTopoPublisher_RunExitsOnContextCancel(t *testing.T) {
+	reg := &fakeRegistrar{}
+	tp := newTopoPublisher(newTestLogger(), reg)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		tp.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after context cancellation")
+	}
+}

--- a/go/services/multipooler/manager/topo_publisher_test.go
+++ b/go/services/multipooler/manager/topo_publisher_test.go
@@ -53,6 +53,17 @@ func (f *fakeRegistrar) clearError() {
 	f.err.Store(nil)
 }
 
+// newActionLockedCtx returns a context that satisfies AssertActionLockHeld,
+// and releases the lock automatically when the test ends.
+func newActionLockedCtx(t *testing.T) context.Context {
+	t.Helper()
+	al := NewActionLock()
+	ctx, err := al.Acquire(t.Context(), "test")
+	require.NoError(t, err)
+	t.Cleanup(func() { al.Release(ctx) })
+	return ctx
+}
+
 func newTestPooler(poolerType clustermetadatapb.PoolerType, status clustermetadatapb.PoolerServingStatus) *clustermetadatapb.MultiPooler {
 	return &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
@@ -71,7 +82,7 @@ func TestTopoPublisher_PublishIfNeeded_WritesOnFirstCall(t *testing.T) {
 	reg := &fakeRegistrar{}
 	tp := newTopoPublisher(newTestLogger(), reg)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)))
 	tp.publishIfNeeded(t.Context())
 
 	assert.Equal(t, int32(1), reg.calls.Load())
@@ -85,7 +96,7 @@ func TestTopoPublisher_PublishIfNeeded_NoopWhenStateUnchanged(t *testing.T) {
 	reg := &fakeRegistrar{}
 	tp := newTopoPublisher(newTestLogger(), reg)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)))
 	tp.publishIfNeeded(t.Context())
 	require.Equal(t, int32(1), reg.calls.Load())
 
@@ -98,11 +109,11 @@ func TestTopoPublisher_PublishIfNeeded_WritesOnStateChange(t *testing.T) {
 	reg := &fakeRegistrar{}
 	tp := newTopoPublisher(newTestLogger(), reg)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_SERVING)))
 	tp.publishIfNeeded(t.Context())
 	require.Equal(t, int32(1), reg.calls.Load())
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)))
 	tp.publishIfNeeded(t.Context())
 	assert.Equal(t, int32(2), reg.calls.Load())
 
@@ -116,7 +127,7 @@ func TestTopoPublisher_PublishIfNeeded_RetriesAfterFailure(t *testing.T) {
 	reg.setError(errors.New("etcd unavailable"))
 	tp := newTopoPublisher(newTestLogger(), reg)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING)))
 
 	// First attempt fails.
 	tp.publishIfNeeded(t.Context())
@@ -151,7 +162,7 @@ func TestTopoPublisher_NotifyWakesGoroutine(t *testing.T) {
 	defer cancel()
 	go tp.run(ctx, tickC)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING)))
 
 	require.Eventually(t, func() bool {
 		return reg.calls.Load() == 1
@@ -175,7 +186,7 @@ func TestTopoPublisher_TickerDrivesRetry(t *testing.T) {
 	defer cancel()
 	go tp.run(ctx, tickC)
 
-	tp.Notify(newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+	require.NoError(t, tp.Notify(newActionLockedCtx(t), newTestPooler(clustermetadatapb.PoolerType_REPLICA, clustermetadatapb.PoolerServingStatus_NOT_SERVING)))
 
 	// Wait for the goroutine to attempt (and fail) the wakeup-triggered write.
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
Discovery information (pooler type, serving status) is eventually-consistent by design — consumers like multigateway already tolerate stale reads. Making multipooler block on etcd writes during failovers or type changes means etcd availability issues can slow down or fail operations that have already succeeded locally in PostgreSQL.

Introduce topoPublisher: a background goroutine that reflects in-memory state to etcd as soon as practical. Callers invoke Notify after each state transition; the goroutine wakes immediately and also retries on a 30s ticker to recover from missed writes during etcd outages.