### PR TITLE
test(shardsetup): improve checkBootstrapStatus log readability

### DIFF
--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -985,8 +985,17 @@ func checkBootstrapStatus(ctx context.Context, t *testing.T, setup *ShardSetup) 
 		attribute.StringSlice("pooler.statuses", poolerStatuses),
 	)
 
-	t.Logf("checkBootstrapStatus: SUMMARY primary=%s initialized=%d/%d latest_backup=%q [%s]",
-		primaryName, initializedCount, len(setup.Multipoolers), latestBackupID, strings.Join(poolerStatuses, " | "))
+	primaryDisplay := primaryName
+	if primaryDisplay == "" {
+		primaryDisplay = "<unknown>"
+	}
+	backupDisplay := latestBackupID
+	if backupDisplay == "" {
+		backupDisplay = "<none>"
+	}
+	t.Logf("checkBootstrapStatus:\n  primary:       %s\n  initialized:   %d/%d\n  latest_backup: %s\n  poolers:\n    %s",
+		primaryDisplay, initializedCount, len(setup.Multipoolers), backupDisplay,
+		strings.Join(poolerStatuses, "\n    "))
 
 	// Query multiorch instances for status (best-effort diagnostic logging)
 	logMultiOrchStatus(ctx, t, setup, "checkBootstrapStatus")


### PR DESCRIPTION
## Summary

- Reformats the `checkBootstrapStatus` log from a dense single-line summary into a labelled multi-line block
- Shows `<unknown>` when no primary has been identified yet, and `<none>` when no backup exists
- Each pooler status appears on its own indented line instead of being pipe-delimited inline

## Before
```
checkBootstrapStatus: SUMMARY primary=pooler-1 initialized=1/3 latest_backup="20260416-150038F" [pooler-1: queryable, type=PRIMARY, sync_replication_configured [...] | pooler-2: not_queryable | pooler-3: not_queryable]
```

## After
```
checkBootstrapStatus:
  primary:       pooler-1
  initialized:   1/3
  latest_backup: 20260416-150038F
  poolers:
    pooler-1: queryable, type=PRIMARY, sync_replication_configured [...]
    pooler-2: not_queryable
    pooler-3: not_queryable
```