### PR TITLE
feat(multiorch): add ManagerHealthStream bidirectional stream

### DIFF
--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -109,6 +109,22 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
+// ManagerHealthStream is the bidirectional health channel to a multipooler.
+//
+// The stream is established by calling ManagerHealthStream on the
+// MultiPoolerClient. The caller must send an init message before reading.
+//
+// Recv delivers full health snapshots whenever the pooler's health state
+// changes and as periodic heartbeats. Send is used to send poll requests
+// that trigger an immediate snapshot.
+//
+// The stream remains open until the context passed to ManagerHealthStream is
+// cancelled or the pooler closes it.
+type ManagerHealthStream interface {
+	Recv() (*multipoolermanagerdatapb.ManagerHealthStreamResponse, error)
+	Send(*multipoolermanagerdatapb.ManagerHealthStreamClientMessage) error
+}
+
 // MultiPoolerClient defines the unified interface for communicating with a multipooler node.
 // It provides methods for both consensus and manager services, maintaining a cache of
 // connections with LRU eviction for optimal performance in monitoring scenarios.
@@ -264,6 +280,21 @@ type MultiPoolerClient interface {
 
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 	SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error)
+
+	//
+	// Manager Service Methods - Health Streaming
+	//
+
+	// ManagerHealthStream opens a bidirectional health stream to a pooler.
+	//
+	// The caller must send an init message via stream.Send before reading.
+	// After that, the stream delivers full health snapshots on every state
+	// change, in response to poll requests, and as periodic heartbeats.
+	// Poll requests are sent via stream.Send with a poll message.
+	//
+	// The stream stays open until the context is cancelled or the pooler
+	// closes it. Recv blocks until a message arrives or an error occurs.
+	ManagerHealthStream(ctx context.Context, pooler *clustermetadatapb.MultiPooler) (ManagerHealthStream, error)
 
 	//
 	// Connection Management Methods

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -16,6 +16,7 @@ package rpcclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -95,6 +96,10 @@ type FakeClient struct {
 
 	// Request tracking for verification in tests
 	PromoteRequests map[string]*multipoolermanagerdatapb.PromoteRequest
+
+	// OnManagerHealthStream, if set, is called after each FakeManagerHealthStream
+	// is created. Tests use this to capture the stream and inject snapshots.
+	OnManagerHealthStream func(poolerID string, stream *FakeManagerHealthStream)
 }
 
 // NewFakeClient creates a new FakeClient with empty response maps.
@@ -769,6 +774,67 @@ func (f *FakeClient) SetPostgresRestartsEnabled(ctx context.Context, pooler *clu
 		return resp, nil
 	}
 	return &multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse{}, nil
+}
+
+//
+// Manager Service Methods - Health Streaming
+//
+
+// FakeManagerHealthStream implements ManagerHealthStream for testing.
+// Recv blocks until the context is cancelled or a response is injected via Ch.
+// Sent messages (init, poll) are recorded on the Sent channel.
+type FakeManagerHealthStream struct {
+	ctx  context.Context
+	Ch   chan *multipoolermanagerdatapb.ManagerHealthStreamResponse
+	Sent chan *multipoolermanagerdatapb.ManagerHealthStreamClientMessage
+}
+
+// Recv blocks until a response is available or the context is cancelled.
+func (f *FakeManagerHealthStream) Recv() (*multipoolermanagerdatapb.ManagerHealthStreamResponse, error) {
+	select {
+	case <-f.ctx.Done():
+		return nil, f.ctx.Err()
+	case resp, ok := <-f.Ch:
+		if !ok {
+			return nil, errors.New("stream closed")
+		}
+		return resp, nil
+	}
+}
+
+// Send records the outgoing message on the Sent channel.
+// Non-blocking: if Sent is full the message is dropped (tests should drain it).
+func (f *FakeManagerHealthStream) Send(msg *multipoolermanagerdatapb.ManagerHealthStreamClientMessage) error {
+	select {
+	case f.Sent <- msg:
+	default:
+	}
+	return nil
+}
+
+// ManagerHealthStream returns a FakeManagerHealthStream. Tests inject snapshots
+// by sending on stream.Ch or close it to simulate disconnection. Outgoing
+// messages (init/poll) are readable from stream.Sent.
+func (f *FakeClient) ManagerHealthStream(ctx context.Context, pooler *clustermetadatapb.MultiPooler) (ManagerHealthStream, error) {
+	poolerID := f.getPoolerID(pooler)
+	f.logCall("ManagerHealthStream", poolerID)
+
+	f.mu.RLock()
+	err := f.Errors[poolerID]
+	f.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
+	stream := &FakeManagerHealthStream{
+		ctx:  ctx,
+		Ch:   make(chan *multipoolermanagerdatapb.ManagerHealthStreamResponse),
+		Sent: make(chan *multipoolermanagerdatapb.ManagerHealthStreamClientMessage, 16),
+	}
+	if f.OnManagerHealthStream != nil {
+		f.OnManagerHealthStream(poolerID, stream)
+	}
+	return stream, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -16,6 +16,7 @@ package rpcclient
 
 import (
 	"context"
+	"sync"
 
 	"google.golang.org/grpc"
 
@@ -523,6 +524,59 @@ func (c *Client) SetPostgresRestartsEnabled(ctx context.Context, pooler *cluster
 	}()
 
 	return conn.managerClient.SetPostgresRestartsEnabled(ctx, request)
+}
+
+//
+// Manager Service Methods - Health Streaming
+//
+
+// managerHealthStream wraps the gRPC bidirectional stream and releases the
+// connection reference when the stream ends.
+type managerHealthStream struct {
+	stream grpc.BidiStreamingClient[multipoolermanagerdatapb.ManagerHealthStreamClientMessage, multipoolermanagerdatapb.ManagerHealthStreamResponse]
+	closer closeFunc
+	once   sync.Once
+}
+
+// ManagerHealthStream opens a bidirectional health stream to a pooler.
+//
+// The caller must send an init message via stream.Send before reading snapshots.
+// The connection reference is held for the stream's lifetime and released
+// automatically when Recv or Send returns a non-nil error.
+func (c *Client) ManagerHealthStream(ctx context.Context, pooler *clustermetadatapb.MultiPooler) (ManagerHealthStream, error) {
+	conn, closer, err := c.dialPersistent(ctx, pooler)
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := conn.managerClient.ManagerHealthStream(ctx)
+	if err != nil {
+		_ = closer()
+		return nil, err
+	}
+
+	return &managerHealthStream{stream: stream, closer: closer}, nil
+}
+
+// Recv receives the next health snapshot from the stream.
+// Returns a non-nil error on stream end or network failure, and releases the
+// connection reference.
+func (s *managerHealthStream) Recv() (*multipoolermanagerdatapb.ManagerHealthStreamResponse, error) {
+	resp, err := s.stream.Recv()
+	if err != nil {
+		s.once.Do(func() { _ = s.closer() })
+	}
+	return resp, err
+}
+
+// Send sends a message to the pooler (init or poll request).
+// Returns a non-nil error on failure and releases the connection reference.
+func (s *managerHealthStream) Send(msg *multipoolermanagerdatapb.ManagerHealthStreamClientMessage) error {
+	err := s.stream.Send(msg)
+	if err != nil {
+		s.once.Do(func() { _ = s.closer() })
+	}
+	return err
 }
 
 //

--- a/go/pb/multiorchdata/multiorchdata.pb.go
+++ b/go/pb/multiorchdata/multiorchdata.pb.go
@@ -97,8 +97,12 @@ type PoolerHealthState struct {
 	// it accepts connections. Mirrors multipoolermanagerdata.Status.postgres_running.
 	// Used to distinguish SIGSTOP (process alive but unresponsive) from SIGKILL (process dead).
 	IsPostgresRunning bool `protobuf:"varint,17,opt,name=is_postgres_running,json=isPostgresRunning,proto3" json:"is_postgres_running,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Whether a ManagerHealthStream stream is currently active for this pooler.
+	StreamConnected bool `protobuf:"varint,20,opt,name=stream_connected,json=streamConnected,proto3" json:"stream_connected,omitempty"`
+	// The time at which the current stream was established.
+	StreamConnectedSince *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=stream_connected_since,json=streamConnectedSince,proto3" json:"stream_connected_since,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PoolerHealthState) Reset() {
@@ -250,11 +254,25 @@ func (x *PoolerHealthState) GetIsPostgresRunning() bool {
 	return false
 }
 
+func (x *PoolerHealthState) GetStreamConnected() bool {
+	if x != nil {
+		return x.StreamConnected
+	}
+	return false
+}
+
+func (x *PoolerHealthState) GetStreamConnectedSince() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StreamConnectedSince
+	}
+	return nil
+}
+
 var File_multiorchdata_proto protoreflect.FileDescriptor
 
 const file_multiorchdata_proto_rawDesc = "" +
 	"\n" +
-	"\x13multiorchdata.proto\x12\rmultiorchdata\x1a\x15clustermetadata.proto\x1a\x13consensusdata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmultipoolermanagerdata.proto\"\xc4\b\n" +
+	"\x13multiorchdata.proto\x12\rmultiorchdata\x1a\x15clustermetadata.proto\x1a\x13consensusdata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmultipoolermanagerdata.proto\"\xc1\t\n" +
 	"\x11PoolerHealthState\x12?\n" +
 	"\fmulti_pooler\x18\x01 \x01(\v2\x1c.clustermetadata.MultiPoolerR\vmultiPooler\x12!\n" +
 	"\ris_up_to_date\x18\x02 \x01(\bR\n" +
@@ -275,7 +293,9 @@ const file_multiorchdata_proto_rawDesc = "" +
 	"\x10consensus_status\x18\x0e \x01(\v2\x1d.consensusdata.StatusResponseR\x0fconsensusStatus\x12:\n" +
 	"\x0ecohort_members\x18\x0f \x03(\v2\x13.clustermetadata.IDR\rcohortMembers\x12S\n" +
 	"\x18last_postgres_ready_time\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x15lastPostgresReadyTime\x12.\n" +
-	"\x13is_postgres_running\x18\x11 \x01(\bR\x11isPostgresRunningB4Z2github.com/multigres/multigres/go/pb/multiorchdatab\x06proto3"
+	"\x13is_postgres_running\x18\x11 \x01(\bR\x11isPostgresRunning\x12)\n" +
+	"\x10stream_connected\x18\x14 \x01(\bR\x0fstreamConnected\x12P\n" +
+	"\x16stream_connected_since\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\x14streamConnectedSinceB4Z2github.com/multigres/multigres/go/pb/multiorchdatab\x06proto3"
 
 var (
 	file_multiorchdata_proto_rawDescOnce sync.Once
@@ -313,11 +333,12 @@ var file_multiorchdata_proto_depIdxs = []int32{
 	7,  // 8: multiorchdata.PoolerHealthState.consensus_status:type_name -> consensusdata.StatusResponse
 	8,  // 9: multiorchdata.PoolerHealthState.cohort_members:type_name -> clustermetadata.ID
 	2,  // 10: multiorchdata.PoolerHealthState.last_postgres_ready_time:type_name -> google.protobuf.Timestamp
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	2,  // 11: multiorchdata.PoolerHealthState.stream_connected_since:type_name -> google.protobuf.Timestamp
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_multiorchdata_proto_init() }

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,7 +39,7 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\x83\x1a\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\x8e\x1b\n" +
 	"\x12MultiPoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12{\n" +
@@ -72,7 +72,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\x10GetBackupByJobId\x12/.multipoolermanagerdata.GetBackupByJobIdRequest\x1a0.multipoolermanagerdata.GetBackupByJobIdResponse\x12l\n" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12o\n" +
 	"\x0eRewindToSource\x12-.multipoolermanagerdata.RewindToSourceRequest\x1a..multipoolermanagerdata.RewindToSourceResponse\x12\x93\x01\n" +
-	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponseB9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
+	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12\x88\x01\n" +
+	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
 
 var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.WaitForLSNRequest)(nil),                       // 0: multipoolermanagerdata.WaitForLSNRequest
@@ -103,34 +104,36 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),                    // 25: multipoolermanagerdata.ExpireBackupsRequest
 	(*multipoolermanagerdata.RewindToSourceRequest)(nil),                   // 26: multipoolermanagerdata.RewindToSourceRequest
 	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),       // 27: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                      // 28: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.SetPrimaryConnInfoResponse)(nil),              // 29: multipoolermanagerdata.SetPrimaryConnInfoResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),                // 30: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),                 // 31: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StandbyReplicationStatusResponse)(nil),        // 32: multipoolermanagerdata.StandbyReplicationStatusResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                          // 33: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.ResetReplicationResponse)(nil),                // 34: multipoolermanagerdata.ResetReplicationResponse
-	(*multipoolermanagerdata.ConfigureSynchronousReplicationResponse)(nil), // 35: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
-	(*multipoolermanagerdata.UpdateSynchronousStandbyListResponse)(nil),    // 36: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	(*multipoolermanagerdata.PrimaryStatusResponse)(nil),                   // 37: multipoolermanagerdata.PrimaryStatusResponse
-	(*multipoolermanagerdata.PrimaryPositionResponse)(nil),                 // 38: multipoolermanagerdata.PrimaryPositionResponse
-	(*multipoolermanagerdata.StopReplicationAndGetStatusResponse)(nil),     // 39: multipoolermanagerdata.StopReplicationAndGetStatusResponse
-	(*multipoolermanagerdata.GetDurabilityPolicyResponse)(nil),             // 40: multipoolermanagerdata.GetDurabilityPolicyResponse
-	(*multipoolermanagerdata.CreateDurabilityPolicyResponse)(nil),          // 41: multipoolermanagerdata.CreateDurabilityPolicyResponse
-	(*multipoolermanagerdata.ChangeTypeResponse)(nil),                      // 42: multipoolermanagerdata.ChangeTypeResponse
-	(*multipoolermanagerdata.GetFollowersResponse)(nil),                    // 43: multipoolermanagerdata.GetFollowersResponse
-	(*multipoolermanagerdata.EmergencyDemoteResponse)(nil),                 // 44: multipoolermanagerdata.EmergencyDemoteResponse
-	(*multipoolermanagerdata.UndoDemoteResponse)(nil),                      // 45: multipoolermanagerdata.UndoDemoteResponse
-	(*multipoolermanagerdata.DemoteStalePrimaryResponse)(nil),              // 46: multipoolermanagerdata.DemoteStalePrimaryResponse
-	(*multipoolermanagerdata.PromoteResponse)(nil),                         // 47: multipoolermanagerdata.PromoteResponse
-	(*multipoolermanagerdata.StateResponse)(nil),                           // 48: multipoolermanagerdata.StateResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                          // 49: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),               // 50: multipoolermanagerdata.RestoreFromBackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                      // 51: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),                // 52: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),                   // 53: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.RewindToSourceResponse)(nil),                  // 54: multipoolermanagerdata.RewindToSourceResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil),      // 55: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),        // 28: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                      // 29: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.SetPrimaryConnInfoResponse)(nil),              // 30: multipoolermanagerdata.SetPrimaryConnInfoResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),                // 31: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),                 // 32: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StandbyReplicationStatusResponse)(nil),        // 33: multipoolermanagerdata.StandbyReplicationStatusResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                          // 34: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.ResetReplicationResponse)(nil),                // 35: multipoolermanagerdata.ResetReplicationResponse
+	(*multipoolermanagerdata.ConfigureSynchronousReplicationResponse)(nil), // 36: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
+	(*multipoolermanagerdata.UpdateSynchronousStandbyListResponse)(nil),    // 37: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	(*multipoolermanagerdata.PrimaryStatusResponse)(nil),                   // 38: multipoolermanagerdata.PrimaryStatusResponse
+	(*multipoolermanagerdata.PrimaryPositionResponse)(nil),                 // 39: multipoolermanagerdata.PrimaryPositionResponse
+	(*multipoolermanagerdata.StopReplicationAndGetStatusResponse)(nil),     // 40: multipoolermanagerdata.StopReplicationAndGetStatusResponse
+	(*multipoolermanagerdata.GetDurabilityPolicyResponse)(nil),             // 41: multipoolermanagerdata.GetDurabilityPolicyResponse
+	(*multipoolermanagerdata.CreateDurabilityPolicyResponse)(nil),          // 42: multipoolermanagerdata.CreateDurabilityPolicyResponse
+	(*multipoolermanagerdata.ChangeTypeResponse)(nil),                      // 43: multipoolermanagerdata.ChangeTypeResponse
+	(*multipoolermanagerdata.GetFollowersResponse)(nil),                    // 44: multipoolermanagerdata.GetFollowersResponse
+	(*multipoolermanagerdata.EmergencyDemoteResponse)(nil),                 // 45: multipoolermanagerdata.EmergencyDemoteResponse
+	(*multipoolermanagerdata.UndoDemoteResponse)(nil),                      // 46: multipoolermanagerdata.UndoDemoteResponse
+	(*multipoolermanagerdata.DemoteStalePrimaryResponse)(nil),              // 47: multipoolermanagerdata.DemoteStalePrimaryResponse
+	(*multipoolermanagerdata.PromoteResponse)(nil),                         // 48: multipoolermanagerdata.PromoteResponse
+	(*multipoolermanagerdata.StateResponse)(nil),                           // 49: multipoolermanagerdata.StateResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                          // 50: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),               // 51: multipoolermanagerdata.RestoreFromBackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                      // 52: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),                // 53: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),                   // 54: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.RewindToSourceResponse)(nil),                  // 55: multipoolermanagerdata.RewindToSourceResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil),      // 56: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),             // 57: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultiPoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -161,36 +164,38 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	25, // 25: multipoolermanager.MultiPoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
 	26, // 26: multipoolermanager.MultiPoolerManager.RewindToSource:input_type -> multipoolermanagerdata.RewindToSourceRequest
 	27, // 27: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	28, // 28: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	29, // 29: multipoolermanager.MultiPoolerManager.SetPrimaryConnInfo:output_type -> multipoolermanagerdata.SetPrimaryConnInfoResponse
-	30, // 30: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	31, // 31: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	32, // 32: multipoolermanager.MultiPoolerManager.StandbyReplicationStatus:output_type -> multipoolermanagerdata.StandbyReplicationStatusResponse
-	33, // 33: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	34, // 34: multipoolermanager.MultiPoolerManager.ResetReplication:output_type -> multipoolermanagerdata.ResetReplicationResponse
-	35, // 35: multipoolermanager.MultiPoolerManager.ConfigureSynchronousReplication:output_type -> multipoolermanagerdata.ConfigureSynchronousReplicationResponse
-	36, // 36: multipoolermanager.MultiPoolerManager.UpdateSynchronousStandbyList:output_type -> multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	37, // 37: multipoolermanager.MultiPoolerManager.PrimaryStatus:output_type -> multipoolermanagerdata.PrimaryStatusResponse
-	38, // 38: multipoolermanager.MultiPoolerManager.PrimaryPosition:output_type -> multipoolermanagerdata.PrimaryPositionResponse
-	39, // 39: multipoolermanager.MultiPoolerManager.StopReplicationAndGetStatus:output_type -> multipoolermanagerdata.StopReplicationAndGetStatusResponse
-	40, // 40: multipoolermanager.MultiPoolerManager.GetDurabilityPolicy:output_type -> multipoolermanagerdata.GetDurabilityPolicyResponse
-	41, // 41: multipoolermanager.MultiPoolerManager.CreateDurabilityPolicy:output_type -> multipoolermanagerdata.CreateDurabilityPolicyResponse
-	42, // 42: multipoolermanager.MultiPoolerManager.ChangeType:output_type -> multipoolermanagerdata.ChangeTypeResponse
-	43, // 43: multipoolermanager.MultiPoolerManager.GetFollowers:output_type -> multipoolermanagerdata.GetFollowersResponse
-	44, // 44: multipoolermanager.MultiPoolerManager.EmergencyDemote:output_type -> multipoolermanagerdata.EmergencyDemoteResponse
-	45, // 45: multipoolermanager.MultiPoolerManager.UndoDemote:output_type -> multipoolermanagerdata.UndoDemoteResponse
-	46, // 46: multipoolermanager.MultiPoolerManager.DemoteStalePrimary:output_type -> multipoolermanagerdata.DemoteStalePrimaryResponse
-	47, // 47: multipoolermanager.MultiPoolerManager.Promote:output_type -> multipoolermanagerdata.PromoteResponse
-	48, // 48: multipoolermanager.MultiPoolerManager.State:output_type -> multipoolermanagerdata.StateResponse
-	49, // 49: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	50, // 50: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
-	51, // 51: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	52, // 52: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	53, // 53: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	54, // 54: multipoolermanager.MultiPoolerManager.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
-	55, // 55: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	28, // [28:56] is the sub-list for method output_type
-	0,  // [0:28] is the sub-list for method input_type
+	28, // 28: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	29, // 29: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	30, // 30: multipoolermanager.MultiPoolerManager.SetPrimaryConnInfo:output_type -> multipoolermanagerdata.SetPrimaryConnInfoResponse
+	31, // 31: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	32, // 32: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	33, // 33: multipoolermanager.MultiPoolerManager.StandbyReplicationStatus:output_type -> multipoolermanagerdata.StandbyReplicationStatusResponse
+	34, // 34: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	35, // 35: multipoolermanager.MultiPoolerManager.ResetReplication:output_type -> multipoolermanagerdata.ResetReplicationResponse
+	36, // 36: multipoolermanager.MultiPoolerManager.ConfigureSynchronousReplication:output_type -> multipoolermanagerdata.ConfigureSynchronousReplicationResponse
+	37, // 37: multipoolermanager.MultiPoolerManager.UpdateSynchronousStandbyList:output_type -> multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	38, // 38: multipoolermanager.MultiPoolerManager.PrimaryStatus:output_type -> multipoolermanagerdata.PrimaryStatusResponse
+	39, // 39: multipoolermanager.MultiPoolerManager.PrimaryPosition:output_type -> multipoolermanagerdata.PrimaryPositionResponse
+	40, // 40: multipoolermanager.MultiPoolerManager.StopReplicationAndGetStatus:output_type -> multipoolermanagerdata.StopReplicationAndGetStatusResponse
+	41, // 41: multipoolermanager.MultiPoolerManager.GetDurabilityPolicy:output_type -> multipoolermanagerdata.GetDurabilityPolicyResponse
+	42, // 42: multipoolermanager.MultiPoolerManager.CreateDurabilityPolicy:output_type -> multipoolermanagerdata.CreateDurabilityPolicyResponse
+	43, // 43: multipoolermanager.MultiPoolerManager.ChangeType:output_type -> multipoolermanagerdata.ChangeTypeResponse
+	44, // 44: multipoolermanager.MultiPoolerManager.GetFollowers:output_type -> multipoolermanagerdata.GetFollowersResponse
+	45, // 45: multipoolermanager.MultiPoolerManager.EmergencyDemote:output_type -> multipoolermanagerdata.EmergencyDemoteResponse
+	46, // 46: multipoolermanager.MultiPoolerManager.UndoDemote:output_type -> multipoolermanagerdata.UndoDemoteResponse
+	47, // 47: multipoolermanager.MultiPoolerManager.DemoteStalePrimary:output_type -> multipoolermanagerdata.DemoteStalePrimaryResponse
+	48, // 48: multipoolermanager.MultiPoolerManager.Promote:output_type -> multipoolermanagerdata.PromoteResponse
+	49, // 49: multipoolermanager.MultiPoolerManager.State:output_type -> multipoolermanagerdata.StateResponse
+	50, // 50: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	51, // 51: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
+	52, // 52: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	53, // 53: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	54, // 54: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	55, // 55: multipoolermanager.MultiPoolerManager.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
+	56, // 56: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	57, // 57: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	29, // [29:58] is the sub-list for method output_type
+	0,  // [0:29] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -792,6 +792,49 @@ func local_request_MultiPoolerManager_SetPostgresRestartsEnabled_0(ctx context.C
 	return msg, metadata, err
 }
 
+func request_MultiPoolerManager_ManagerHealthStream_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (MultiPoolerManager_ManagerHealthStreamClient, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
+	stream, err := client.ManagerHealthStream(ctx)
+	if err != nil {
+		grpclog.Errorf("Failed to start streaming: %v", err)
+		return nil, metadata, err
+	}
+	dec := marshaler.NewDecoder(req.Body)
+	handleSend := func() error {
+		var protoReq multipoolermanagerdata.ManagerHealthStreamClientMessage
+		err := dec.Decode(&protoReq)
+		if errors.Is(err, io.EOF) {
+			return err
+		}
+		if err != nil {
+			grpclog.Errorf("Failed to decode request: %v", err)
+			return status.Errorf(codes.InvalidArgument, "Failed to decode request: %v", err)
+		}
+		if err := stream.Send(&protoReq); err != nil {
+			grpclog.Errorf("Failed to send request: %v", err)
+			return err
+		}
+		return nil
+	}
+	go func() {
+		for {
+			if err := handleSend(); err != nil {
+				break
+			}
+		}
+		if err := stream.CloseSend(); err != nil {
+			grpclog.Errorf("Failed to terminate client stream: %v", err)
+		}
+	}()
+	header, err := stream.Header()
+	if err != nil {
+		grpclog.Errorf("Failed to get header from client: %v", err)
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+}
+
 // RegisterMultiPoolerManagerHandlerServer registers the http handlers for service MultiPoolerManager to "mux".
 // UnaryRPC     :call MultiPoolerManagerServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1359,6 +1402,13 @@ func RegisterMultiPoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		forward_MultiPoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
+		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	})
+
 	return nil
 }
 
@@ -1874,6 +1924,23 @@ func RegisterMultiPoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/ManagerHealthStream", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/ManagerHealthStream"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerManager_ManagerHealthStream_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_ManagerHealthStream_0(annotatedContext, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1906,6 +1973,7 @@ var (
 	pattern_MultiPoolerManager_ExpireBackups_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ExpireBackups"}, ""))
 	pattern_MultiPoolerManager_RewindToSource_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "RewindToSource"}, ""))
 	pattern_MultiPoolerManager_SetPostgresRestartsEnabled_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "SetPostgresRestartsEnabled"}, ""))
+	pattern_MultiPoolerManager_ManagerHealthStream_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ManagerHealthStream"}, ""))
 )
 
 var (
@@ -1937,4 +2005,5 @@ var (
 	forward_MultiPoolerManager_ExpireBackups_0                   = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_RewindToSource_0                  = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_SetPostgresRestartsEnabled_0      = runtime.ForwardResponseMessage
+	forward_MultiPoolerManager_ManagerHealthStream_0             = runtime.ForwardResponseStream
 )

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -62,6 +62,7 @@ const (
 	MultiPoolerManager_ExpireBackups_FullMethodName                   = "/multipoolermanager.MultiPoolerManager/ExpireBackups"
 	MultiPoolerManager_RewindToSource_FullMethodName                  = "/multipoolermanager.MultiPoolerManager/RewindToSource"
 	MultiPoolerManager_SetPostgresRestartsEnabled_FullMethodName      = "/multipoolermanager.MultiPoolerManager/SetPostgresRestartsEnabled"
+	MultiPoolerManager_ManagerHealthStream_FullMethodName             = "/multipoolermanager.MultiPoolerManager/ManagerHealthStream"
 )
 
 // MultiPoolerManagerClient is the client API for MultiPoolerManager service.
@@ -142,6 +143,21 @@ type MultiPoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ManagerHealthStream is a bidirectional health stream between orchestrator
+	// and pooler.
+	//
+	// The orchestrator sends a start message (ManagerHealthStreamClientMessage
+	// with the start field set) to open the stream, then may send poll requests
+	// at any time to trigger an immediate snapshot.
+	//
+	// The pooler sends a full health snapshot on connection, on every state
+	// change, in response to poll requests, and periodically as a heartbeat.
+	// Every message is a complete snapshot — there are no incremental updates.
+	//
+	// The orchestrator MUST implement a staleness timeout. The recommended
+	// timeout is provided in the timeout field of each snapshot. If no message is
+	// received within this timeout, the pooler should be marked unhealthy.
+	ManagerHealthStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse], error)
 }
 
 type multiPoolerManagerClient struct {
@@ -432,6 +448,19 @@ func (c *multiPoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return out, nil
 }
 
+func (c *multiPoolerManagerClient) ManagerHealthStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &MultiPoolerManager_ServiceDesc.Streams[0], MultiPoolerManager_ManagerHealthStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type MultiPoolerManager_ManagerHealthStreamClient = grpc.BidiStreamingClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]
+
 // MultiPoolerManagerServer is the server API for MultiPoolerManager service.
 // All implementations must embed UnimplementedMultiPoolerManagerServer
 // for forward compatibility.
@@ -510,6 +539,21 @@ type MultiPoolerManagerServer interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// ManagerHealthStream is a bidirectional health stream between orchestrator
+	// and pooler.
+	//
+	// The orchestrator sends a start message (ManagerHealthStreamClientMessage
+	// with the start field set) to open the stream, then may send poll requests
+	// at any time to trigger an immediate snapshot.
+	//
+	// The pooler sends a full health snapshot on connection, on every state
+	// change, in response to poll requests, and periodically as a heartbeat.
+	// Every message is a complete snapshot — there are no incremental updates.
+	//
+	// The orchestrator MUST implement a staleness timeout. The recommended
+	// timeout is provided in the timeout field of each snapshot. If no message is
+	// received within this timeout, the pooler should be marked unhealthy.
+	ManagerHealthStream(grpc.BidiStreamingServer[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]) error
 	mustEmbedUnimplementedMultiPoolerManagerServer()
 }
 
@@ -603,6 +647,9 @@ func (UnimplementedMultiPoolerManagerServer) RewindToSource(context.Context, *mu
 }
 func (UnimplementedMultiPoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
+}
+func (UnimplementedMultiPoolerManagerServer) ManagerHealthStream(grpc.BidiStreamingServer[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ManagerHealthStream not implemented")
 }
 func (UnimplementedMultiPoolerManagerServer) mustEmbedUnimplementedMultiPoolerManagerServer() {}
 func (UnimplementedMultiPoolerManagerServer) testEmbeddedByValue()                            {}
@@ -1129,6 +1176,13 @@ func _MultiPoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiPoolerManager_ManagerHealthStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(MultiPoolerManagerServer).ManagerHealthStream(&grpc.GenericServerStream[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type MultiPoolerManager_ManagerHealthStreamServer = grpc.BidiStreamingServer[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]
+
 // MultiPoolerManager_ServiceDesc is the grpc.ServiceDesc for MultiPoolerManager service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1249,6 +1303,13 @@ var MultiPoolerManager_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _MultiPoolerManager_SetPostgresRestartsEnabled_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "ManagerHealthStream",
+			Handler:       _MultiPoolerManager_ManagerHealthStream_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "multipoolermanagerservice.proto",
 }

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -95,6 +95,67 @@ func (PostgresAction) EnumDescriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{0}
 }
 
+// SnapshotTrigger describes why a ManagerHealthSnapshot was sent.
+type SnapshotTrigger int32
+
+const (
+	// Default / unknown trigger. Not used by the server.
+	SnapshotTrigger_SNAPSHOT_TRIGGER_UNSPECIFIED SnapshotTrigger = 0
+	// Sent immediately when the stream is first opened.
+	SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL SnapshotTrigger = 1
+	// Triggered by a state-change broadcast (e.g. type change, SetPrimaryConnInfo).
+	SnapshotTrigger_SNAPSHOT_TRIGGER_BROADCAST SnapshotTrigger = 2
+	// Triggered by an explicit poll request from the orchestrator.
+	SnapshotTrigger_SNAPSHOT_TRIGGER_POLL SnapshotTrigger = 3
+	// Sent by the periodic heartbeat ticker.
+	SnapshotTrigger_SNAPSHOT_TRIGGER_HEARTBEAT SnapshotTrigger = 4
+)
+
+// Enum value maps for SnapshotTrigger.
+var (
+	SnapshotTrigger_name = map[int32]string{
+		0: "SNAPSHOT_TRIGGER_UNSPECIFIED",
+		1: "SNAPSHOT_TRIGGER_INITIAL",
+		2: "SNAPSHOT_TRIGGER_BROADCAST",
+		3: "SNAPSHOT_TRIGGER_POLL",
+		4: "SNAPSHOT_TRIGGER_HEARTBEAT",
+	}
+	SnapshotTrigger_value = map[string]int32{
+		"SNAPSHOT_TRIGGER_UNSPECIFIED": 0,
+		"SNAPSHOT_TRIGGER_INITIAL":     1,
+		"SNAPSHOT_TRIGGER_BROADCAST":   2,
+		"SNAPSHOT_TRIGGER_POLL":        3,
+		"SNAPSHOT_TRIGGER_HEARTBEAT":   4,
+	}
+)
+
+func (x SnapshotTrigger) Enum() *SnapshotTrigger {
+	p := new(SnapshotTrigger)
+	*p = x
+	return p
+}
+
+func (x SnapshotTrigger) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SnapshotTrigger) Descriptor() protoreflect.EnumDescriptor {
+	return file_multipoolermanagerdata_proto_enumTypes[1].Descriptor()
+}
+
+func (SnapshotTrigger) Type() protoreflect.EnumType {
+	return &file_multipoolermanagerdata_proto_enumTypes[1]
+}
+
+func (x SnapshotTrigger) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SnapshotTrigger.Descriptor instead.
+func (SnapshotTrigger) EnumDescriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{1}
+}
+
 // Replication pause mode - defines what aspect of replication to pause
 type ReplicationPauseMode int32
 
@@ -135,11 +196,11 @@ func (x ReplicationPauseMode) String() string {
 }
 
 func (ReplicationPauseMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolermanagerdata_proto_enumTypes[1].Descriptor()
+	return file_multipoolermanagerdata_proto_enumTypes[2].Descriptor()
 }
 
 func (ReplicationPauseMode) Type() protoreflect.EnumType {
-	return &file_multipoolermanagerdata_proto_enumTypes[1]
+	return &file_multipoolermanagerdata_proto_enumTypes[2]
 }
 
 func (x ReplicationPauseMode) Number() protoreflect.EnumNumber {
@@ -148,7 +209,7 @@ func (x ReplicationPauseMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ReplicationPauseMode.Descriptor instead.
 func (ReplicationPauseMode) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{1}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{2}
 }
 
 // Synchronization method for standby servers
@@ -188,11 +249,11 @@ func (x SynchronousMethod) String() string {
 }
 
 func (SynchronousMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolermanagerdata_proto_enumTypes[2].Descriptor()
+	return file_multipoolermanagerdata_proto_enumTypes[3].Descriptor()
 }
 
 func (SynchronousMethod) Type() protoreflect.EnumType {
-	return &file_multipoolermanagerdata_proto_enumTypes[2]
+	return &file_multipoolermanagerdata_proto_enumTypes[3]
 }
 
 func (x SynchronousMethod) Number() protoreflect.EnumNumber {
@@ -201,7 +262,7 @@ func (x SynchronousMethod) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SynchronousMethod.Descriptor instead.
 func (SynchronousMethod) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{2}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{3}
 }
 
 // Enum representing the type of standby list modification
@@ -241,11 +302,11 @@ func (x StandbyUpdateOperation) String() string {
 }
 
 func (StandbyUpdateOperation) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolermanagerdata_proto_enumTypes[3].Descriptor()
+	return file_multipoolermanagerdata_proto_enumTypes[4].Descriptor()
 }
 
 func (StandbyUpdateOperation) Type() protoreflect.EnumType {
-	return &file_multipoolermanagerdata_proto_enumTypes[3]
+	return &file_multipoolermanagerdata_proto_enumTypes[4]
 }
 
 func (x StandbyUpdateOperation) Number() protoreflect.EnumNumber {
@@ -254,7 +315,7 @@ func (x StandbyUpdateOperation) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use StandbyUpdateOperation.Descriptor instead.
 func (StandbyUpdateOperation) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{3}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{4}
 }
 
 // Synchronous commit level
@@ -302,11 +363,11 @@ func (x SynchronousCommitLevel) String() string {
 }
 
 func (SynchronousCommitLevel) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolermanagerdata_proto_enumTypes[4].Descriptor()
+	return file_multipoolermanagerdata_proto_enumTypes[5].Descriptor()
 }
 
 func (SynchronousCommitLevel) Type() protoreflect.EnumType {
-	return &file_multipoolermanagerdata_proto_enumTypes[4]
+	return &file_multipoolermanagerdata_proto_enumTypes[5]
 }
 
 func (x SynchronousCommitLevel) Number() protoreflect.EnumNumber {
@@ -315,7 +376,7 @@ func (x SynchronousCommitLevel) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SynchronousCommitLevel.Descriptor instead.
 func (SynchronousCommitLevel) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{4}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{5}
 }
 
 // Status represents the state of a backup
@@ -352,11 +413,11 @@ func (x BackupMetadata_Status) String() string {
 }
 
 func (BackupMetadata_Status) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolermanagerdata_proto_enumTypes[5].Descriptor()
+	return file_multipoolermanagerdata_proto_enumTypes[6].Descriptor()
 }
 
 func (BackupMetadata_Status) Type() protoreflect.EnumType {
-	return &file_multipoolermanagerdata_proto_enumTypes[5]
+	return &file_multipoolermanagerdata_proto_enumTypes[6]
 }
 
 func (x BackupMetadata_Status) Number() protoreflect.EnumNumber {
@@ -365,7 +426,7 @@ func (x BackupMetadata_Status) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use BackupMetadata_Status.Descriptor instead.
 func (BackupMetadata_Status) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{56, 0}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{61, 0}
 }
 
 // Primary connection information parsed from PostgreSQL's primary_conninfo setting
@@ -1653,6 +1714,287 @@ func (x *StatusResponse) GetStatus() *Status {
 	return nil
 }
 
+// ManagerHealthStreamClientMessage is sent from the orchestrator to the pooler.
+// The first message on a new stream must be a start message; subsequent messages
+// may be poll requests.
+type ManagerHealthStreamClientMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Message:
+	//
+	//	*ManagerHealthStreamClientMessage_Start
+	//	*ManagerHealthStreamClientMessage_Poll
+	Message       isManagerHealthStreamClientMessage_Message `protobuf_oneof:"message"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagerHealthStreamClientMessage) Reset() {
+	*x = ManagerHealthStreamClientMessage{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthStreamClientMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthStreamClientMessage) ProtoMessage() {}
+
+func (x *ManagerHealthStreamClientMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthStreamClientMessage.ProtoReflect.Descriptor instead.
+func (*ManagerHealthStreamClientMessage) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ManagerHealthStreamClientMessage) GetMessage() isManagerHealthStreamClientMessage_Message {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *ManagerHealthStreamClientMessage) GetStart() *ManagerHealthStreamStartRequest {
+	if x != nil {
+		if x, ok := x.Message.(*ManagerHealthStreamClientMessage_Start); ok {
+			return x.Start
+		}
+	}
+	return nil
+}
+
+func (x *ManagerHealthStreamClientMessage) GetPoll() *ManagerHealthStreamPollRequest {
+	if x != nil {
+		if x, ok := x.Message.(*ManagerHealthStreamClientMessage_Poll); ok {
+			return x.Poll
+		}
+	}
+	return nil
+}
+
+type isManagerHealthStreamClientMessage_Message interface {
+	isManagerHealthStreamClientMessage_Message()
+}
+
+type ManagerHealthStreamClientMessage_Start struct {
+	// Sent once at stream open to identify the orchestrator.
+	Start *ManagerHealthStreamStartRequest `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
+}
+
+type ManagerHealthStreamClientMessage_Poll struct {
+	// Requests an immediate health snapshot from the pooler.
+	// Used by the orchestrator to trigger fresh state on demand (e.g. in tests).
+	Poll *ManagerHealthStreamPollRequest `protobuf:"bytes,2,opt,name=poll,proto3,oneof"`
+}
+
+func (*ManagerHealthStreamClientMessage_Start) isManagerHealthStreamClientMessage_Message() {}
+
+func (*ManagerHealthStreamClientMessage_Poll) isManagerHealthStreamClientMessage_Message() {}
+
+// ManagerHealthStreamStartRequest is sent as the first message inside
+// ManagerHealthStreamClientMessage. There are no fields in this message; its
+// presence is the signal to start the stream.
+type ManagerHealthStreamStartRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagerHealthStreamStartRequest) Reset() {
+	*x = ManagerHealthStreamStartRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthStreamStartRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthStreamStartRequest) ProtoMessage() {}
+
+func (x *ManagerHealthStreamStartRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthStreamStartRequest.ProtoReflect.Descriptor instead.
+func (*ManagerHealthStreamStartRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
+}
+
+// ManagerHealthStreamPollRequest triggers an immediate health snapshot.
+// The message carries no payload; its presence on the stream is the signal.
+type ManagerHealthStreamPollRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagerHealthStreamPollRequest) Reset() {
+	*x = ManagerHealthStreamPollRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthStreamPollRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthStreamPollRequest) ProtoMessage() {}
+
+func (x *ManagerHealthStreamPollRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthStreamPollRequest.ProtoReflect.Descriptor instead.
+func (*ManagerHealthStreamPollRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
+}
+
+// ManagerHealthStreamResponse is sent by the pooler on connection, on every
+// state change, on poll request, and periodically as a heartbeat snapshot.
+// Every message is a full health snapshot — there are no incremental updates.
+type ManagerHealthStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The full health state of the pooler.
+	Snapshot      *ManagerHealthSnapshot `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagerHealthStreamResponse) Reset() {
+	*x = ManagerHealthStreamResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthStreamResponse) ProtoMessage() {}
+
+func (x *ManagerHealthStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthStreamResponse.ProtoReflect.Descriptor instead.
+func (*ManagerHealthStreamResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ManagerHealthStreamResponse) GetSnapshot() *ManagerHealthSnapshot {
+	if x != nil {
+		return x.Snapshot
+	}
+	return nil
+}
+
+// ManagerHealthSnapshot is a full health snapshot of the pooler.
+// Sent immediately on connection, on any state change, and periodically as a
+// heartbeat when no state change has occurred.
+type ManagerHealthSnapshot struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Full health state of the pooler.
+	Status *StatusResponse `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	// The duration the orchestrator should use to detect a stale or dead stream.
+	// If no message is received within this duration, the pooler should be marked
+	// unhealthy.
+	Timeout *durationpb.Duration `protobuf:"bytes,2,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// Why this snapshot was sent. Useful for diagnostics and testing.
+	Trigger       SnapshotTrigger `protobuf:"varint,3,opt,name=trigger,proto3,enum=multipoolermanagerdata.SnapshotTrigger" json:"trigger,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagerHealthSnapshot) Reset() {
+	*x = ManagerHealthSnapshot{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthSnapshot) ProtoMessage() {}
+
+func (x *ManagerHealthSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthSnapshot.ProtoReflect.Descriptor instead.
+func (*ManagerHealthSnapshot) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *ManagerHealthSnapshot) GetStatus() *StatusResponse {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *ManagerHealthSnapshot) GetTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.Timeout
+	}
+	return nil
+}
+
+func (x *ManagerHealthSnapshot) GetTrigger() SnapshotTrigger {
+	if x != nil {
+		return x.Trigger
+	}
+	return SnapshotTrigger_SNAPSHOT_TRIGGER_UNSPECIFIED
+}
+
 // Replication statistics for a connected follower from pg_stat_replication
 type ReplicationStats struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1684,7 +2026,7 @@ type ReplicationStats struct {
 
 func (x *ReplicationStats) Reset() {
 	*x = ReplicationStats{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1696,7 +2038,7 @@ func (x *ReplicationStats) String() string {
 func (*ReplicationStats) ProtoMessage() {}
 
 func (x *ReplicationStats) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1709,7 +2051,7 @@ func (x *ReplicationStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicationStats.ProtoReflect.Descriptor instead.
 func (*ReplicationStats) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{21}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ReplicationStats) GetPid() int32 {
@@ -1807,7 +2149,7 @@ type FollowerInfo struct {
 
 func (x *FollowerInfo) Reset() {
 	*x = FollowerInfo{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1819,7 +2161,7 @@ func (x *FollowerInfo) String() string {
 func (*FollowerInfo) ProtoMessage() {}
 
 func (x *FollowerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1832,7 +2174,7 @@ func (x *FollowerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FollowerInfo.ProtoReflect.Descriptor instead.
 func (*FollowerInfo) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *FollowerInfo) GetFollowerId() *clustermetadata.ID {
@@ -1872,7 +2214,7 @@ type GetFollowersRequest struct {
 
 func (x *GetFollowersRequest) Reset() {
 	*x = GetFollowersRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1884,7 +2226,7 @@ func (x *GetFollowersRequest) String() string {
 func (*GetFollowersRequest) ProtoMessage() {}
 
 func (x *GetFollowersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1897,7 +2239,7 @@ func (x *GetFollowersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFollowersRequest.ProtoReflect.Descriptor instead.
 func (*GetFollowersRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
 }
 
 type GetFollowersResponse struct {
@@ -1914,7 +2256,7 @@ type GetFollowersResponse struct {
 
 func (x *GetFollowersResponse) Reset() {
 	*x = GetFollowersResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1926,7 +2268,7 @@ func (x *GetFollowersResponse) String() string {
 func (*GetFollowersResponse) ProtoMessage() {}
 
 func (x *GetFollowersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1939,7 +2281,7 @@ func (x *GetFollowersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFollowersResponse.ProtoReflect.Descriptor instead.
 func (*GetFollowersResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetFollowersResponse) GetFollowers() []*FollowerInfo {
@@ -1974,7 +2316,7 @@ type EmergencyDemoteRequest struct {
 
 func (x *EmergencyDemoteRequest) Reset() {
 	*x = EmergencyDemoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1986,7 +2328,7 @@ func (x *EmergencyDemoteRequest) String() string {
 func (*EmergencyDemoteRequest) ProtoMessage() {}
 
 func (x *EmergencyDemoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1999,7 +2341,7 @@ func (x *EmergencyDemoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyDemoteRequest.ProtoReflect.Descriptor instead.
 func (*EmergencyDemoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *EmergencyDemoteRequest) GetConsensusTerm() int64 {
@@ -2039,7 +2381,7 @@ type EmergencyDemoteResponse struct {
 
 func (x *EmergencyDemoteResponse) Reset() {
 	*x = EmergencyDemoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2051,7 +2393,7 @@ func (x *EmergencyDemoteResponse) String() string {
 func (*EmergencyDemoteResponse) ProtoMessage() {}
 
 func (x *EmergencyDemoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2064,7 +2406,7 @@ func (x *EmergencyDemoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyDemoteResponse.ProtoReflect.Descriptor instead.
 func (*EmergencyDemoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *EmergencyDemoteResponse) GetWasAlreadyDemoted() bool {
@@ -2116,7 +2458,7 @@ type DemoteStalePrimaryRequest struct {
 
 func (x *DemoteStalePrimaryRequest) Reset() {
 	*x = DemoteStalePrimaryRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2128,7 +2470,7 @@ func (x *DemoteStalePrimaryRequest) String() string {
 func (*DemoteStalePrimaryRequest) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2141,7 +2483,7 @@ func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryRequest.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DemoteStalePrimaryRequest) GetSource() *clustermetadata.MultiPooler {
@@ -2179,7 +2521,7 @@ type DemoteStalePrimaryResponse struct {
 
 func (x *DemoteStalePrimaryResponse) Reset() {
 	*x = DemoteStalePrimaryResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2191,7 +2533,7 @@ func (x *DemoteStalePrimaryResponse) String() string {
 func (*DemoteStalePrimaryResponse) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2204,7 +2546,7 @@ func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryResponse.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DemoteStalePrimaryResponse) GetSuccess() bool {
@@ -2237,7 +2579,7 @@ type UndoDemoteRequest struct {
 
 func (x *UndoDemoteRequest) Reset() {
 	*x = UndoDemoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2249,7 +2591,7 @@ func (x *UndoDemoteRequest) String() string {
 func (*UndoDemoteRequest) ProtoMessage() {}
 
 func (x *UndoDemoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2262,7 +2604,7 @@ func (x *UndoDemoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDemoteRequest.ProtoReflect.Descriptor instead.
 func (*UndoDemoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
 }
 
 type UndoDemoteResponse struct {
@@ -2273,7 +2615,7 @@ type UndoDemoteResponse struct {
 
 func (x *UndoDemoteResponse) Reset() {
 	*x = UndoDemoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2285,7 +2627,7 @@ func (x *UndoDemoteResponse) String() string {
 func (*UndoDemoteResponse) ProtoMessage() {}
 
 func (x *UndoDemoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2298,7 +2640,7 @@ func (x *UndoDemoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UndoDemoteResponse.ProtoReflect.Descriptor instead.
 func (*UndoDemoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
 }
 
 // StopReplicationAndGetStatus stops PostgreSQL replication (replay and/or receiver based on mode)
@@ -2317,7 +2659,7 @@ type StopReplicationAndGetStatusRequest struct {
 
 func (x *StopReplicationAndGetStatusRequest) Reset() {
 	*x = StopReplicationAndGetStatusRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2329,7 +2671,7 @@ func (x *StopReplicationAndGetStatusRequest) String() string {
 func (*StopReplicationAndGetStatusRequest) ProtoMessage() {}
 
 func (x *StopReplicationAndGetStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2342,7 +2684,7 @@ func (x *StopReplicationAndGetStatusRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use StopReplicationAndGetStatusRequest.ProtoReflect.Descriptor instead.
 func (*StopReplicationAndGetStatusRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *StopReplicationAndGetStatusRequest) GetMode() ReplicationPauseMode {
@@ -2369,7 +2711,7 @@ type StopReplicationAndGetStatusResponse struct {
 
 func (x *StopReplicationAndGetStatusResponse) Reset() {
 	*x = StopReplicationAndGetStatusResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2381,7 +2723,7 @@ func (x *StopReplicationAndGetStatusResponse) String() string {
 func (*StopReplicationAndGetStatusResponse) ProtoMessage() {}
 
 func (x *StopReplicationAndGetStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2394,7 +2736,7 @@ func (x *StopReplicationAndGetStatusResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use StopReplicationAndGetStatusResponse.ProtoReflect.Descriptor instead.
 func (*StopReplicationAndGetStatusResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *StopReplicationAndGetStatusResponse) GetStatus() *StandbyReplicationStatus {
@@ -2415,7 +2757,7 @@ type ChangeTypeRequest struct {
 
 func (x *ChangeTypeRequest) Reset() {
 	*x = ChangeTypeRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2427,7 +2769,7 @@ func (x *ChangeTypeRequest) String() string {
 func (*ChangeTypeRequest) ProtoMessage() {}
 
 func (x *ChangeTypeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2440,7 +2782,7 @@ func (x *ChangeTypeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeTypeRequest.ProtoReflect.Descriptor instead.
 func (*ChangeTypeRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ChangeTypeRequest) GetPoolerType() clustermetadata.PoolerType {
@@ -2458,7 +2800,7 @@ type ChangeTypeResponse struct {
 
 func (x *ChangeTypeResponse) Reset() {
 	*x = ChangeTypeResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2470,7 +2812,7 @@ func (x *ChangeTypeResponse) String() string {
 func (*ChangeTypeResponse) ProtoMessage() {}
 
 func (x *ChangeTypeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2483,7 +2825,7 @@ func (x *ChangeTypeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeTypeResponse.ProtoReflect.Descriptor instead.
 func (*ChangeTypeResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
 }
 
 // Promote promotes a replica to leader (Multigres-level operation)
@@ -2521,7 +2863,7 @@ type PromoteRequest struct {
 
 func (x *PromoteRequest) Reset() {
 	*x = PromoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2533,7 +2875,7 @@ func (x *PromoteRequest) String() string {
 func (*PromoteRequest) ProtoMessage() {}
 
 func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2546,7 +2888,7 @@ func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteRequest.ProtoReflect.Descriptor instead.
 func (*PromoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PromoteRequest) GetConsensusTerm() int64 {
@@ -2619,7 +2961,7 @@ type PromoteResponse struct {
 
 func (x *PromoteResponse) Reset() {
 	*x = PromoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2631,7 +2973,7 @@ func (x *PromoteResponse) String() string {
 func (*PromoteResponse) ProtoMessage() {}
 
 func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2644,7 +2986,7 @@ func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteResponse.ProtoReflect.Descriptor instead.
 func (*PromoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PromoteResponse) GetLsnPosition() string {
@@ -2677,7 +3019,7 @@ type ResetReplicationRequest struct {
 
 func (x *ResetReplicationRequest) Reset() {
 	*x = ResetReplicationRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2689,7 +3031,7 @@ func (x *ResetReplicationRequest) String() string {
 func (*ResetReplicationRequest) ProtoMessage() {}
 
 func (x *ResetReplicationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2702,7 +3044,7 @@ func (x *ResetReplicationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetReplicationRequest.ProtoReflect.Descriptor instead.
 func (*ResetReplicationRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
 }
 
 type ResetReplicationResponse struct {
@@ -2715,7 +3057,7 @@ type ResetReplicationResponse struct {
 
 func (x *ResetReplicationResponse) Reset() {
 	*x = ResetReplicationResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2727,7 +3069,7 @@ func (x *ResetReplicationResponse) String() string {
 func (*ResetReplicationResponse) ProtoMessage() {}
 
 func (x *ResetReplicationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2740,7 +3082,7 @@ func (x *ResetReplicationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResetReplicationResponse.ProtoReflect.Descriptor instead.
 func (*ResetReplicationResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ResetReplicationResponse) GetStatus() *StandbyReplicationStatus {
@@ -2774,7 +3116,7 @@ type ConfigureSynchronousReplicationRequest struct {
 
 func (x *ConfigureSynchronousReplicationRequest) Reset() {
 	*x = ConfigureSynchronousReplicationRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2786,7 +3128,7 @@ func (x *ConfigureSynchronousReplicationRequest) String() string {
 func (*ConfigureSynchronousReplicationRequest) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2799,7 +3141,7 @@ func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ConfigureSynchronousReplicationRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ConfigureSynchronousReplicationRequest) GetSynchronousCommit() SynchronousCommitLevel {
@@ -2852,7 +3194,7 @@ type ConfigureSynchronousReplicationResponse struct {
 
 func (x *ConfigureSynchronousReplicationResponse) Reset() {
 	*x = ConfigureSynchronousReplicationResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2864,7 +3206,7 @@ func (x *ConfigureSynchronousReplicationResponse) String() string {
 func (*ConfigureSynchronousReplicationResponse) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2877,7 +3219,7 @@ func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use ConfigureSynchronousReplicationResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
 }
 
 // State gets the current status of the manager
@@ -2889,7 +3231,7 @@ type StateRequest struct {
 
 func (x *StateRequest) Reset() {
 	*x = StateRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2901,7 +3243,7 @@ func (x *StateRequest) String() string {
 func (*StateRequest) ProtoMessage() {}
 
 func (x *StateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2914,7 +3256,7 @@ func (x *StateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateRequest.ProtoReflect.Descriptor instead.
 func (*StateRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{46}
 }
 
 type StateResponse struct {
@@ -2929,7 +3271,7 @@ type StateResponse struct {
 
 func (x *StateResponse) Reset() {
 	*x = StateResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2941,7 +3283,7 @@ func (x *StateResponse) String() string {
 func (*StateResponse) ProtoMessage() {}
 
 func (x *StateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2954,7 +3296,7 @@ func (x *StateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StateResponse.ProtoReflect.Descriptor instead.
 func (*StateResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *StateResponse) GetState() string {
@@ -2993,7 +3335,7 @@ type UpdateSynchronousStandbyListRequest struct {
 
 func (x *UpdateSynchronousStandbyListRequest) Reset() {
 	*x = UpdateSynchronousStandbyListRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3005,7 +3347,7 @@ func (x *UpdateSynchronousStandbyListRequest) String() string {
 func (*UpdateSynchronousStandbyListRequest) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3018,7 +3360,7 @@ func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpdateSynchronousStandbyListRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *UpdateSynchronousStandbyListRequest) GetOperation() StandbyUpdateOperation {
@@ -3071,7 +3413,7 @@ type UpdateSynchronousStandbyListResponse struct {
 
 func (x *UpdateSynchronousStandbyListResponse) Reset() {
 	*x = UpdateSynchronousStandbyListResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3083,7 +3425,7 @@ func (x *UpdateSynchronousStandbyListResponse) String() string {
 func (*UpdateSynchronousStandbyListResponse) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3096,7 +3438,7 @@ func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateSynchronousStandbyListResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{49}
 }
 
 // ConsensusTerm represents the consensus term information for the pooler
@@ -3123,7 +3465,7 @@ type ConsensusTerm struct {
 
 func (x *ConsensusTerm) Reset() {
 	*x = ConsensusTerm{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3135,7 +3477,7 @@ func (x *ConsensusTerm) String() string {
 func (*ConsensusTerm) ProtoMessage() {}
 
 func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3148,7 +3490,7 @@ func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusTerm.ProtoReflect.Descriptor instead.
 func (*ConsensusTerm) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ConsensusTerm) GetTermNumber() int64 {
@@ -3209,7 +3551,7 @@ type BackupRequest struct {
 
 func (x *BackupRequest) Reset() {
 	*x = BackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3221,7 +3563,7 @@ func (x *BackupRequest) String() string {
 func (*BackupRequest) ProtoMessage() {}
 
 func (x *BackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3234,7 +3576,7 @@ func (x *BackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupRequest.ProtoReflect.Descriptor instead.
 func (*BackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{46}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *BackupRequest) GetForcePrimary() bool {
@@ -3277,7 +3619,7 @@ type BackupResponse struct {
 
 func (x *BackupResponse) Reset() {
 	*x = BackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3289,7 +3631,7 @@ func (x *BackupResponse) String() string {
 func (*BackupResponse) ProtoMessage() {}
 
 func (x *BackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3302,7 +3644,7 @@ func (x *BackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupResponse.ProtoReflect.Descriptor instead.
 func (*BackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{47}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *BackupResponse) GetBackupId() string {
@@ -3324,7 +3666,7 @@ type RestoreFromBackupRequest struct {
 
 func (x *RestoreFromBackupRequest) Reset() {
 	*x = RestoreFromBackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[48]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3336,7 +3678,7 @@ func (x *RestoreFromBackupRequest) String() string {
 func (*RestoreFromBackupRequest) ProtoMessage() {}
 
 func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[48]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3349,7 +3691,7 @@ func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{48}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *RestoreFromBackupRequest) GetBackupId() string {
@@ -3368,7 +3710,7 @@ type RestoreFromBackupResponse struct {
 
 func (x *RestoreFromBackupResponse) Reset() {
 	*x = RestoreFromBackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[49]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3380,7 +3722,7 @@ func (x *RestoreFromBackupResponse) String() string {
 func (*RestoreFromBackupResponse) ProtoMessage() {}
 
 func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[49]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3393,7 +3735,7 @@ func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupResponse.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{49}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{54}
 }
 
 // GetBackupsRequest requests backup information
@@ -3406,7 +3748,7 @@ type GetBackupsRequest struct {
 
 func (x *GetBackupsRequest) Reset() {
 	*x = GetBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[50]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3418,7 +3760,7 @@ func (x *GetBackupsRequest) String() string {
 func (*GetBackupsRequest) ProtoMessage() {}
 
 func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[50]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3431,7 +3773,7 @@ func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{50}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetBackupsRequest) GetLimit() uint32 {
@@ -3451,7 +3793,7 @@ type GetBackupsResponse struct {
 
 func (x *GetBackupsResponse) Reset() {
 	*x = GetBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[51]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3463,7 +3805,7 @@ func (x *GetBackupsResponse) String() string {
 func (*GetBackupsResponse) ProtoMessage() {}
 
 func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[51]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3476,7 +3818,7 @@ func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{51}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetBackupsResponse) GetBackups() []*BackupMetadata {
@@ -3497,7 +3839,7 @@ type GetBackupByJobIdRequest struct {
 
 func (x *GetBackupByJobIdRequest) Reset() {
 	*x = GetBackupByJobIdRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[52]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3851,7 @@ func (x *GetBackupByJobIdRequest) String() string {
 func (*GetBackupByJobIdRequest) ProtoMessage() {}
 
 func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[52]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3864,7 @@ func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{52}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetBackupByJobIdRequest) GetJobId() string {
@@ -3544,7 +3886,7 @@ type GetBackupByJobIdResponse struct {
 
 func (x *GetBackupByJobIdResponse) Reset() {
 	*x = GetBackupByJobIdResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[53]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3556,7 +3898,7 @@ func (x *GetBackupByJobIdResponse) String() string {
 func (*GetBackupByJobIdResponse) ProtoMessage() {}
 
 func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[53]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3569,7 +3911,7 @@ func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{53}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetBackupByJobIdResponse) GetBackup() *BackupMetadata {
@@ -3592,7 +3934,7 @@ type ExpireBackupsRequest struct {
 
 func (x *ExpireBackupsRequest) Reset() {
 	*x = ExpireBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[54]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3604,7 +3946,7 @@ func (x *ExpireBackupsRequest) String() string {
 func (*ExpireBackupsRequest) ProtoMessage() {}
 
 func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[54]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3617,7 +3959,7 @@ func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{54}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ExpireBackupsRequest) GetOverrides() map[string]string {
@@ -3638,7 +3980,7 @@ type ExpireBackupsResponse struct {
 
 func (x *ExpireBackupsResponse) Reset() {
 	*x = ExpireBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[55]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3650,7 +3992,7 @@ func (x *ExpireBackupsResponse) String() string {
 func (*ExpireBackupsResponse) ProtoMessage() {}
 
 func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[55]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3663,7 +4005,7 @@ func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{55}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ExpireBackupsResponse) GetExpiredBackupIds() []string {
@@ -3697,7 +4039,7 @@ type BackupMetadata struct {
 
 func (x *BackupMetadata) Reset() {
 	*x = BackupMetadata{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[56]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3709,7 +4051,7 @@ func (x *BackupMetadata) String() string {
 func (*BackupMetadata) ProtoMessage() {}
 
 func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[56]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3722,7 +4064,7 @@ func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupMetadata.ProtoReflect.Descriptor instead.
 func (*BackupMetadata) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{56}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *BackupMetadata) GetTableGroup() string {
@@ -3804,7 +4146,7 @@ type GetDurabilityPolicyRequest struct {
 
 func (x *GetDurabilityPolicyRequest) Reset() {
 	*x = GetDurabilityPolicyRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[57]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3816,7 +4158,7 @@ func (x *GetDurabilityPolicyRequest) String() string {
 func (*GetDurabilityPolicyRequest) ProtoMessage() {}
 
 func (x *GetDurabilityPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[57]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3829,7 +4171,7 @@ func (x *GetDurabilityPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDurabilityPolicyRequest.ProtoReflect.Descriptor instead.
 func (*GetDurabilityPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{57}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{62}
 }
 
 // GetDurabilityPolicyResponse returns the active durability policy
@@ -3843,7 +4185,7 @@ type GetDurabilityPolicyResponse struct {
 
 func (x *GetDurabilityPolicyResponse) Reset() {
 	*x = GetDurabilityPolicyResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[58]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3855,7 +4197,7 @@ func (x *GetDurabilityPolicyResponse) String() string {
 func (*GetDurabilityPolicyResponse) ProtoMessage() {}
 
 func (x *GetDurabilityPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[58]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3868,7 +4210,7 @@ func (x *GetDurabilityPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDurabilityPolicyResponse.ProtoReflect.Descriptor instead.
 func (*GetDurabilityPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{58}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetDurabilityPolicyResponse) GetPolicy() *clustermetadata.DurabilityPolicy {
@@ -3888,7 +4230,7 @@ type CreateDurabilityPolicyRequest struct {
 
 func (x *CreateDurabilityPolicyRequest) Reset() {
 	*x = CreateDurabilityPolicyRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[59]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3900,7 +4242,7 @@ func (x *CreateDurabilityPolicyRequest) String() string {
 func (*CreateDurabilityPolicyRequest) ProtoMessage() {}
 
 func (x *CreateDurabilityPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[59]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3913,7 +4255,7 @@ func (x *CreateDurabilityPolicyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDurabilityPolicyRequest.ProtoReflect.Descriptor instead.
 func (*CreateDurabilityPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{59}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *CreateDurabilityPolicyRequest) GetDurabilityPolicy() *clustermetadata.DurabilityPolicy {
@@ -3933,7 +4275,7 @@ type CreateDurabilityPolicyResponse struct {
 
 func (x *CreateDurabilityPolicyResponse) Reset() {
 	*x = CreateDurabilityPolicyResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[60]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3945,7 +4287,7 @@ func (x *CreateDurabilityPolicyResponse) String() string {
 func (*CreateDurabilityPolicyResponse) ProtoMessage() {}
 
 func (x *CreateDurabilityPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[60]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3958,7 +4300,7 @@ func (x *CreateDurabilityPolicyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDurabilityPolicyResponse.ProtoReflect.Descriptor instead.
 func (*CreateDurabilityPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{60}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{65}
 }
 
 // RewindToSourceRequest requests pg_rewind to synchronize with a source server.
@@ -3977,7 +4319,7 @@ type RewindToSourceRequest struct {
 
 func (x *RewindToSourceRequest) Reset() {
 	*x = RewindToSourceRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[61]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3989,7 +4331,7 @@ func (x *RewindToSourceRequest) String() string {
 func (*RewindToSourceRequest) ProtoMessage() {}
 
 func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[61]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4002,7 +4344,7 @@ func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceRequest.ProtoReflect.Descriptor instead.
 func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{61}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *RewindToSourceRequest) GetSource() *clustermetadata.MultiPooler {
@@ -4027,7 +4369,7 @@ type RewindToSourceResponse struct {
 
 func (x *RewindToSourceResponse) Reset() {
 	*x = RewindToSourceResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[62]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4039,7 +4381,7 @@ func (x *RewindToSourceResponse) String() string {
 func (*RewindToSourceResponse) ProtoMessage() {}
 
 func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[62]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4052,7 +4394,7 @@ func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceResponse.ProtoReflect.Descriptor instead.
 func (*RewindToSourceResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{62}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *RewindToSourceResponse) GetSuccess() bool {
@@ -4089,7 +4431,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[63]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4101,7 +4443,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[63]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4114,7 +4456,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{63}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -4134,7 +4476,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[64]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4146,7 +4488,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[64]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4159,7 +4501,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{64}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{69}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -4246,7 +4588,19 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x0epostgres_ready\x18\x0e \x01(\bR\rpostgresReady\"\x0f\n" +
 	"\rStatusRequest\"H\n" +
 	"\x0eStatusResponse\x126\n" +
-	"\x06status\x18\x01 \x01(\v2\x1e.multipoolermanagerdata.StatusR\x06status\"\x98\x03\n" +
+	"\x06status\x18\x01 \x01(\v2\x1e.multipoolermanagerdata.StatusR\x06status\"\xcc\x01\n" +
+	" ManagerHealthStreamClientMessage\x12O\n" +
+	"\x05start\x18\x01 \x01(\v27.multipoolermanagerdata.ManagerHealthStreamStartRequestH\x00R\x05start\x12L\n" +
+	"\x04poll\x18\x02 \x01(\v26.multipoolermanagerdata.ManagerHealthStreamPollRequestH\x00R\x04pollB\t\n" +
+	"\amessage\"!\n" +
+	"\x1fManagerHealthStreamStartRequest\" \n" +
+	"\x1eManagerHealthStreamPollRequest\"h\n" +
+	"\x1bManagerHealthStreamResponse\x12I\n" +
+	"\bsnapshot\x18\x01 \x01(\v2-.multipoolermanagerdata.ManagerHealthSnapshotR\bsnapshot\"\xcf\x01\n" +
+	"\x15ManagerHealthSnapshot\x12>\n" +
+	"\x06status\x18\x01 \x01(\v2&.multipoolermanagerdata.StatusResponseR\x06status\x123\n" +
+	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12A\n" +
+	"\atrigger\x18\x03 \x01(\x0e2'.multipoolermanagerdata.SnapshotTriggerR\atrigger\"\x98\x03\n" +
 	"\x10ReplicationStats\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x1f\n" +
 	"\vclient_addr\x18\x02 \x01(\tR\n" +
@@ -4415,7 +4769,13 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x1bPOSTGRES_ACTION_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18POSTGRES_ACTION_STARTING\x10\x01\x12)\n" +
 	"%POSTGRES_ACTION_RESTORING_FROM_BACKUP\x10\x02\x12)\n" +
-	"%POSTGRES_ACTION_CREATING_FIRST_BACKUP\x10\x03*\x98\x01\n" +
+	"%POSTGRES_ACTION_CREATING_FIRST_BACKUP\x10\x03*\xac\x01\n" +
+	"\x0fSnapshotTrigger\x12 \n" +
+	"\x1cSNAPSHOT_TRIGGER_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18SNAPSHOT_TRIGGER_INITIAL\x10\x01\x12\x1e\n" +
+	"\x1aSNAPSHOT_TRIGGER_BROADCAST\x10\x02\x12\x19\n" +
+	"\x15SNAPSHOT_TRIGGER_POLL\x10\x03\x12\x1e\n" +
+	"\x1aSNAPSHOT_TRIGGER_HEARTBEAT\x10\x04*\x98\x01\n" +
 	"\x14ReplicationPauseMode\x12&\n" +
 	"\"REPLICATION_PAUSE_MODE_REPLAY_ONLY\x10\x00\x12(\n" +
 	"$REPLICATION_PAUSE_MODE_RECEIVER_ONLY\x10\x01\x12.\n" +
@@ -4448,154 +4808,166 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 	return file_multipoolermanagerdata_proto_rawDescData
 }
 
-var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 72)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresAction)(0),                             // 0: multipoolermanagerdata.PostgresAction
-	(ReplicationPauseMode)(0),                       // 1: multipoolermanagerdata.ReplicationPauseMode
-	(SynchronousMethod)(0),                          // 2: multipoolermanagerdata.SynchronousMethod
-	(StandbyUpdateOperation)(0),                     // 3: multipoolermanagerdata.StandbyUpdateOperation
-	(SynchronousCommitLevel)(0),                     // 4: multipoolermanagerdata.SynchronousCommitLevel
-	(BackupMetadata_Status)(0),                      // 5: multipoolermanagerdata.BackupMetadata.Status
-	(*PrimaryConnInfo)(nil),                         // 6: multipoolermanagerdata.PrimaryConnInfo
-	(*StandbyReplicationStatus)(nil),                // 7: multipoolermanagerdata.StandbyReplicationStatus
-	(*WaitForLSNRequest)(nil),                       // 8: multipoolermanagerdata.WaitForLSNRequest
-	(*WaitForLSNResponse)(nil),                      // 9: multipoolermanagerdata.WaitForLSNResponse
-	(*StartReplicationRequest)(nil),                 // 10: multipoolermanagerdata.StartReplicationRequest
-	(*StartReplicationResponse)(nil),                // 11: multipoolermanagerdata.StartReplicationResponse
-	(*SetPrimaryConnInfoRequest)(nil),               // 12: multipoolermanagerdata.SetPrimaryConnInfoRequest
-	(*SetPrimaryConnInfoResponse)(nil),              // 13: multipoolermanagerdata.SetPrimaryConnInfoResponse
-	(*StopReplicationRequest)(nil),                  // 14: multipoolermanagerdata.StopReplicationRequest
-	(*StopReplicationResponse)(nil),                 // 15: multipoolermanagerdata.StopReplicationResponse
-	(*StandbyReplicationStatusRequest)(nil),         // 16: multipoolermanagerdata.StandbyReplicationStatusRequest
-	(*StandbyReplicationStatusResponse)(nil),        // 17: multipoolermanagerdata.StandbyReplicationStatusResponse
-	(*SynchronousReplicationConfiguration)(nil),     // 18: multipoolermanagerdata.SynchronousReplicationConfiguration
-	(*PrimaryStatus)(nil),                           // 19: multipoolermanagerdata.PrimaryStatus
-	(*PrimaryStatusRequest)(nil),                    // 20: multipoolermanagerdata.PrimaryStatusRequest
-	(*PrimaryStatusResponse)(nil),                   // 21: multipoolermanagerdata.PrimaryStatusResponse
-	(*PrimaryPositionRequest)(nil),                  // 22: multipoolermanagerdata.PrimaryPositionRequest
-	(*PrimaryPositionResponse)(nil),                 // 23: multipoolermanagerdata.PrimaryPositionResponse
-	(*Status)(nil),                                  // 24: multipoolermanagerdata.Status
-	(*StatusRequest)(nil),                           // 25: multipoolermanagerdata.StatusRequest
-	(*StatusResponse)(nil),                          // 26: multipoolermanagerdata.StatusResponse
-	(*ReplicationStats)(nil),                        // 27: multipoolermanagerdata.ReplicationStats
-	(*FollowerInfo)(nil),                            // 28: multipoolermanagerdata.FollowerInfo
-	(*GetFollowersRequest)(nil),                     // 29: multipoolermanagerdata.GetFollowersRequest
-	(*GetFollowersResponse)(nil),                    // 30: multipoolermanagerdata.GetFollowersResponse
-	(*EmergencyDemoteRequest)(nil),                  // 31: multipoolermanagerdata.EmergencyDemoteRequest
-	(*EmergencyDemoteResponse)(nil),                 // 32: multipoolermanagerdata.EmergencyDemoteResponse
-	(*DemoteStalePrimaryRequest)(nil),               // 33: multipoolermanagerdata.DemoteStalePrimaryRequest
-	(*DemoteStalePrimaryResponse)(nil),              // 34: multipoolermanagerdata.DemoteStalePrimaryResponse
-	(*UndoDemoteRequest)(nil),                       // 35: multipoolermanagerdata.UndoDemoteRequest
-	(*UndoDemoteResponse)(nil),                      // 36: multipoolermanagerdata.UndoDemoteResponse
-	(*StopReplicationAndGetStatusRequest)(nil),      // 37: multipoolermanagerdata.StopReplicationAndGetStatusRequest
-	(*StopReplicationAndGetStatusResponse)(nil),     // 38: multipoolermanagerdata.StopReplicationAndGetStatusResponse
-	(*ChangeTypeRequest)(nil),                       // 39: multipoolermanagerdata.ChangeTypeRequest
-	(*ChangeTypeResponse)(nil),                      // 40: multipoolermanagerdata.ChangeTypeResponse
-	(*PromoteRequest)(nil),                          // 41: multipoolermanagerdata.PromoteRequest
-	(*PromoteResponse)(nil),                         // 42: multipoolermanagerdata.PromoteResponse
-	(*ResetReplicationRequest)(nil),                 // 43: multipoolermanagerdata.ResetReplicationRequest
-	(*ResetReplicationResponse)(nil),                // 44: multipoolermanagerdata.ResetReplicationResponse
-	(*ConfigureSynchronousReplicationRequest)(nil),  // 45: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	(*ConfigureSynchronousReplicationResponse)(nil), // 46: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
-	(*StateRequest)(nil),                            // 47: multipoolermanagerdata.StateRequest
-	(*StateResponse)(nil),                           // 48: multipoolermanagerdata.StateResponse
-	(*UpdateSynchronousStandbyListRequest)(nil),     // 49: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
-	(*UpdateSynchronousStandbyListResponse)(nil),    // 50: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	(*ConsensusTerm)(nil),                           // 51: multipoolermanagerdata.ConsensusTerm
-	(*BackupRequest)(nil),                           // 52: multipoolermanagerdata.BackupRequest
-	(*BackupResponse)(nil),                          // 53: multipoolermanagerdata.BackupResponse
-	(*RestoreFromBackupRequest)(nil),                // 54: multipoolermanagerdata.RestoreFromBackupRequest
-	(*RestoreFromBackupResponse)(nil),               // 55: multipoolermanagerdata.RestoreFromBackupResponse
-	(*GetBackupsRequest)(nil),                       // 56: multipoolermanagerdata.GetBackupsRequest
-	(*GetBackupsResponse)(nil),                      // 57: multipoolermanagerdata.GetBackupsResponse
-	(*GetBackupByJobIdRequest)(nil),                 // 58: multipoolermanagerdata.GetBackupByJobIdRequest
-	(*GetBackupByJobIdResponse)(nil),                // 59: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*ExpireBackupsRequest)(nil),                    // 60: multipoolermanagerdata.ExpireBackupsRequest
-	(*ExpireBackupsResponse)(nil),                   // 61: multipoolermanagerdata.ExpireBackupsResponse
-	(*BackupMetadata)(nil),                          // 62: multipoolermanagerdata.BackupMetadata
-	(*GetDurabilityPolicyRequest)(nil),              // 63: multipoolermanagerdata.GetDurabilityPolicyRequest
-	(*GetDurabilityPolicyResponse)(nil),             // 64: multipoolermanagerdata.GetDurabilityPolicyResponse
-	(*CreateDurabilityPolicyRequest)(nil),           // 65: multipoolermanagerdata.CreateDurabilityPolicyRequest
-	(*CreateDurabilityPolicyResponse)(nil),          // 66: multipoolermanagerdata.CreateDurabilityPolicyResponse
-	(*RewindToSourceRequest)(nil),                   // 67: multipoolermanagerdata.RewindToSourceRequest
-	(*RewindToSourceResponse)(nil),                  // 68: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),       // 69: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),      // 70: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                                      // 71: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                      // 72: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),              // 73: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),            // 74: google.protobuf.Timestamp
-	(*clustermetadata.MultiPooler)(nil),      // 75: clustermetadata.MultiPooler
-	(*clustermetadata.ID)(nil),               // 76: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),          // 77: clustermetadata.PoolerType
-	(*clustermetadata.DurabilityPolicy)(nil), // 78: clustermetadata.DurabilityPolicy
+	(SnapshotTrigger)(0),                            // 1: multipoolermanagerdata.SnapshotTrigger
+	(ReplicationPauseMode)(0),                       // 2: multipoolermanagerdata.ReplicationPauseMode
+	(SynchronousMethod)(0),                          // 3: multipoolermanagerdata.SynchronousMethod
+	(StandbyUpdateOperation)(0),                     // 4: multipoolermanagerdata.StandbyUpdateOperation
+	(SynchronousCommitLevel)(0),                     // 5: multipoolermanagerdata.SynchronousCommitLevel
+	(BackupMetadata_Status)(0),                      // 6: multipoolermanagerdata.BackupMetadata.Status
+	(*PrimaryConnInfo)(nil),                         // 7: multipoolermanagerdata.PrimaryConnInfo
+	(*StandbyReplicationStatus)(nil),                // 8: multipoolermanagerdata.StandbyReplicationStatus
+	(*WaitForLSNRequest)(nil),                       // 9: multipoolermanagerdata.WaitForLSNRequest
+	(*WaitForLSNResponse)(nil),                      // 10: multipoolermanagerdata.WaitForLSNResponse
+	(*StartReplicationRequest)(nil),                 // 11: multipoolermanagerdata.StartReplicationRequest
+	(*StartReplicationResponse)(nil),                // 12: multipoolermanagerdata.StartReplicationResponse
+	(*SetPrimaryConnInfoRequest)(nil),               // 13: multipoolermanagerdata.SetPrimaryConnInfoRequest
+	(*SetPrimaryConnInfoResponse)(nil),              // 14: multipoolermanagerdata.SetPrimaryConnInfoResponse
+	(*StopReplicationRequest)(nil),                  // 15: multipoolermanagerdata.StopReplicationRequest
+	(*StopReplicationResponse)(nil),                 // 16: multipoolermanagerdata.StopReplicationResponse
+	(*StandbyReplicationStatusRequest)(nil),         // 17: multipoolermanagerdata.StandbyReplicationStatusRequest
+	(*StandbyReplicationStatusResponse)(nil),        // 18: multipoolermanagerdata.StandbyReplicationStatusResponse
+	(*SynchronousReplicationConfiguration)(nil),     // 19: multipoolermanagerdata.SynchronousReplicationConfiguration
+	(*PrimaryStatus)(nil),                           // 20: multipoolermanagerdata.PrimaryStatus
+	(*PrimaryStatusRequest)(nil),                    // 21: multipoolermanagerdata.PrimaryStatusRequest
+	(*PrimaryStatusResponse)(nil),                   // 22: multipoolermanagerdata.PrimaryStatusResponse
+	(*PrimaryPositionRequest)(nil),                  // 23: multipoolermanagerdata.PrimaryPositionRequest
+	(*PrimaryPositionResponse)(nil),                 // 24: multipoolermanagerdata.PrimaryPositionResponse
+	(*Status)(nil),                                  // 25: multipoolermanagerdata.Status
+	(*StatusRequest)(nil),                           // 26: multipoolermanagerdata.StatusRequest
+	(*StatusResponse)(nil),                          // 27: multipoolermanagerdata.StatusResponse
+	(*ManagerHealthStreamClientMessage)(nil),        // 28: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*ManagerHealthStreamStartRequest)(nil),         // 29: multipoolermanagerdata.ManagerHealthStreamStartRequest
+	(*ManagerHealthStreamPollRequest)(nil),          // 30: multipoolermanagerdata.ManagerHealthStreamPollRequest
+	(*ManagerHealthStreamResponse)(nil),             // 31: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*ManagerHealthSnapshot)(nil),                   // 32: multipoolermanagerdata.ManagerHealthSnapshot
+	(*ReplicationStats)(nil),                        // 33: multipoolermanagerdata.ReplicationStats
+	(*FollowerInfo)(nil),                            // 34: multipoolermanagerdata.FollowerInfo
+	(*GetFollowersRequest)(nil),                     // 35: multipoolermanagerdata.GetFollowersRequest
+	(*GetFollowersResponse)(nil),                    // 36: multipoolermanagerdata.GetFollowersResponse
+	(*EmergencyDemoteRequest)(nil),                  // 37: multipoolermanagerdata.EmergencyDemoteRequest
+	(*EmergencyDemoteResponse)(nil),                 // 38: multipoolermanagerdata.EmergencyDemoteResponse
+	(*DemoteStalePrimaryRequest)(nil),               // 39: multipoolermanagerdata.DemoteStalePrimaryRequest
+	(*DemoteStalePrimaryResponse)(nil),              // 40: multipoolermanagerdata.DemoteStalePrimaryResponse
+	(*UndoDemoteRequest)(nil),                       // 41: multipoolermanagerdata.UndoDemoteRequest
+	(*UndoDemoteResponse)(nil),                      // 42: multipoolermanagerdata.UndoDemoteResponse
+	(*StopReplicationAndGetStatusRequest)(nil),      // 43: multipoolermanagerdata.StopReplicationAndGetStatusRequest
+	(*StopReplicationAndGetStatusResponse)(nil),     // 44: multipoolermanagerdata.StopReplicationAndGetStatusResponse
+	(*ChangeTypeRequest)(nil),                       // 45: multipoolermanagerdata.ChangeTypeRequest
+	(*ChangeTypeResponse)(nil),                      // 46: multipoolermanagerdata.ChangeTypeResponse
+	(*PromoteRequest)(nil),                          // 47: multipoolermanagerdata.PromoteRequest
+	(*PromoteResponse)(nil),                         // 48: multipoolermanagerdata.PromoteResponse
+	(*ResetReplicationRequest)(nil),                 // 49: multipoolermanagerdata.ResetReplicationRequest
+	(*ResetReplicationResponse)(nil),                // 50: multipoolermanagerdata.ResetReplicationResponse
+	(*ConfigureSynchronousReplicationRequest)(nil),  // 51: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	(*ConfigureSynchronousReplicationResponse)(nil), // 52: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
+	(*StateRequest)(nil),                            // 53: multipoolermanagerdata.StateRequest
+	(*StateResponse)(nil),                           // 54: multipoolermanagerdata.StateResponse
+	(*UpdateSynchronousStandbyListRequest)(nil),     // 55: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
+	(*UpdateSynchronousStandbyListResponse)(nil),    // 56: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	(*ConsensusTerm)(nil),                           // 57: multipoolermanagerdata.ConsensusTerm
+	(*BackupRequest)(nil),                           // 58: multipoolermanagerdata.BackupRequest
+	(*BackupResponse)(nil),                          // 59: multipoolermanagerdata.BackupResponse
+	(*RestoreFromBackupRequest)(nil),                // 60: multipoolermanagerdata.RestoreFromBackupRequest
+	(*RestoreFromBackupResponse)(nil),               // 61: multipoolermanagerdata.RestoreFromBackupResponse
+	(*GetBackupsRequest)(nil),                       // 62: multipoolermanagerdata.GetBackupsRequest
+	(*GetBackupsResponse)(nil),                      // 63: multipoolermanagerdata.GetBackupsResponse
+	(*GetBackupByJobIdRequest)(nil),                 // 64: multipoolermanagerdata.GetBackupByJobIdRequest
+	(*GetBackupByJobIdResponse)(nil),                // 65: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*ExpireBackupsRequest)(nil),                    // 66: multipoolermanagerdata.ExpireBackupsRequest
+	(*ExpireBackupsResponse)(nil),                   // 67: multipoolermanagerdata.ExpireBackupsResponse
+	(*BackupMetadata)(nil),                          // 68: multipoolermanagerdata.BackupMetadata
+	(*GetDurabilityPolicyRequest)(nil),              // 69: multipoolermanagerdata.GetDurabilityPolicyRequest
+	(*GetDurabilityPolicyResponse)(nil),             // 70: multipoolermanagerdata.GetDurabilityPolicyResponse
+	(*CreateDurabilityPolicyRequest)(nil),           // 71: multipoolermanagerdata.CreateDurabilityPolicyRequest
+	(*CreateDurabilityPolicyResponse)(nil),          // 72: multipoolermanagerdata.CreateDurabilityPolicyResponse
+	(*RewindToSourceRequest)(nil),                   // 73: multipoolermanagerdata.RewindToSourceRequest
+	(*RewindToSourceResponse)(nil),                  // 74: multipoolermanagerdata.RewindToSourceResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),       // 75: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),      // 76: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                                      // 77: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                      // 78: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),              // 79: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),            // 80: google.protobuf.Timestamp
+	(*clustermetadata.MultiPooler)(nil),      // 81: clustermetadata.MultiPooler
+	(*clustermetadata.ID)(nil),               // 82: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),          // 83: clustermetadata.PoolerType
+	(*clustermetadata.DurabilityPolicy)(nil), // 84: clustermetadata.DurabilityPolicy
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	73, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
-	6,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	74, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	73, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	73, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	73, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
-	75, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
-	1,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
-	7,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	7,  // 9: multipoolermanagerdata.StandbyReplicationStatusResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
-	2,  // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	76, // 12: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	76, // 13: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
-	18, // 14: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	19, // 15: multipoolermanagerdata.PrimaryStatusResponse.status:type_name -> multipoolermanagerdata.PrimaryStatus
-	77, // 16: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
-	19, // 17: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
-	7,  // 18: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	51, // 19: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
+	79, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	7,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
+	80, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	79, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	79, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	79, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	81, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
+	2,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
+	8,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	8,  // 9: multipoolermanagerdata.StandbyReplicationStatusResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	5,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
+	3,  // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
+	82, // 12: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	82, // 13: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	19, // 14: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
+	20, // 15: multipoolermanagerdata.PrimaryStatusResponse.status:type_name -> multipoolermanagerdata.PrimaryStatus
+	83, // 16: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	20, // 17: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
+	8,  // 18: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	57, // 19: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
 	0,  // 20: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	73, // 21: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	76, // 22: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
-	24, // 23: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	73, // 24: multipoolermanagerdata.ReplicationStats.write_lag:type_name -> google.protobuf.Duration
-	73, // 25: multipoolermanagerdata.ReplicationStats.flush_lag:type_name -> google.protobuf.Duration
-	73, // 26: multipoolermanagerdata.ReplicationStats.replay_lag:type_name -> google.protobuf.Duration
-	76, // 27: multipoolermanagerdata.FollowerInfo.follower_id:type_name -> clustermetadata.ID
-	27, // 28: multipoolermanagerdata.FollowerInfo.replication_stats:type_name -> multipoolermanagerdata.ReplicationStats
-	28, // 29: multipoolermanagerdata.GetFollowersResponse.followers:type_name -> multipoolermanagerdata.FollowerInfo
-	18, // 30: multipoolermanagerdata.GetFollowersResponse.sync_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	73, // 31: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
-	75, // 32: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
-	1,  // 33: multipoolermanagerdata.StopReplicationAndGetStatusRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
-	7,  // 34: multipoolermanagerdata.StopReplicationAndGetStatusResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	77, // 35: multipoolermanagerdata.ChangeTypeRequest.pooler_type:type_name -> clustermetadata.PoolerType
-	45, // 36: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	76, // 37: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
-	76, // 38: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
-	76, // 39: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
-	7,  // 40: multipoolermanagerdata.ResetReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	4,  // 41: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
-	2,  // 42: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	76, // 43: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
-	3,  // 44: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
-	76, // 45: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
-	76, // 46: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
-	76, // 47: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
-	74, // 48: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
-	76, // 49: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
-	71, // 50: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
-	62, // 51: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
-	62, // 52: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	72, // 53: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	5,  // 54: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	77, // 55: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	78, // 56: multipoolermanagerdata.GetDurabilityPolicyResponse.policy:type_name -> clustermetadata.DurabilityPolicy
-	78, // 57: multipoolermanagerdata.CreateDurabilityPolicyRequest.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	75, // 58: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
-	59, // [59:59] is the sub-list for method output_type
-	59, // [59:59] is the sub-list for method input_type
-	59, // [59:59] is the sub-list for extension type_name
-	59, // [59:59] is the sub-list for extension extendee
-	0,  // [0:59] is the sub-list for field type_name
+	79, // 21: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	82, // 22: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
+	25, // 23: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
+	29, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
+	30, // 25: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
+	32, // 26: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
+	27, // 27: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
+	79, // 28: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	1,  // 29: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
+	79, // 30: multipoolermanagerdata.ReplicationStats.write_lag:type_name -> google.protobuf.Duration
+	79, // 31: multipoolermanagerdata.ReplicationStats.flush_lag:type_name -> google.protobuf.Duration
+	79, // 32: multipoolermanagerdata.ReplicationStats.replay_lag:type_name -> google.protobuf.Duration
+	82, // 33: multipoolermanagerdata.FollowerInfo.follower_id:type_name -> clustermetadata.ID
+	33, // 34: multipoolermanagerdata.FollowerInfo.replication_stats:type_name -> multipoolermanagerdata.ReplicationStats
+	34, // 35: multipoolermanagerdata.GetFollowersResponse.followers:type_name -> multipoolermanagerdata.FollowerInfo
+	19, // 36: multipoolermanagerdata.GetFollowersResponse.sync_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
+	79, // 37: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
+	81, // 38: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
+	2,  // 39: multipoolermanagerdata.StopReplicationAndGetStatusRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
+	8,  // 40: multipoolermanagerdata.StopReplicationAndGetStatusResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	83, // 41: multipoolermanagerdata.ChangeTypeRequest.pooler_type:type_name -> clustermetadata.PoolerType
+	51, // 42: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	82, // 43: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
+	82, // 44: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
+	82, // 45: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
+	8,  // 46: multipoolermanagerdata.ResetReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
+	5,  // 47: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
+	3,  // 48: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
+	82, // 49: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
+	4,  // 50: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
+	82, // 51: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
+	82, // 52: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
+	82, // 53: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
+	80, // 54: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
+	82, // 55: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
+	77, // 56: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	68, // 57: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
+	68, // 58: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
+	78, // 59: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	6,  // 60: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
+	83, // 61: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	84, // 62: multipoolermanagerdata.GetDurabilityPolicyResponse.policy:type_name -> clustermetadata.DurabilityPolicy
+	84, // 63: multipoolermanagerdata.CreateDurabilityPolicyRequest.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	81, // 64: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	65, // [65:65] is the sub-list for method output_type
+	65, // [65:65] is the sub-list for method input_type
+	65, // [65:65] is the sub-list for extension type_name
+	65, // [65:65] is the sub-list for extension extendee
+	0,  // [0:65] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -4603,13 +4975,17 @@ func file_multipoolermanagerdata_proto_init() {
 	if File_multipoolermanagerdata_proto != nil {
 		return
 	}
+	file_multipoolermanagerdata_proto_msgTypes[21].OneofWrappers = []any{
+		(*ManagerHealthStreamClientMessage_Start)(nil),
+		(*ManagerHealthStreamClientMessage_Poll)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   67,
+			NumEnums:      7,
+			NumMessages:   72,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -169,6 +169,7 @@ func (a *ShardInitAction) getInitializedPoolers(shardKey commontypes.ShardKey) (
 		}
 		if len(pooler.CohortMembers) > 0 {
 			cohortEstablished = true
+			initialized = nil
 			return false // stop iteration
 		}
 		if pooler.IsInitialized {

--- a/go/services/multiorch/recovery/health_stream.go
+++ b/go/services/multiorch/recovery/health_stream.go
@@ -1,0 +1,410 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+	"github.com/multigres/multigres/go/tools/retry"
+)
+
+const (
+	// streamReconnectInitialBackoff is the initial wait before retrying a
+	// failed ManagerHealthStream connection.
+	streamReconnectInitialBackoff = 1 * time.Second
+
+	// streamReconnectMaxBackoff caps the exponential backoff between retries.
+	streamReconnectMaxBackoff = 30 * time.Second
+
+	// streamStalenessTimeout is the default maximum time to wait for a health
+	// snapshot before treating the stream as stale and reconnecting.
+	//
+	// This is an application-level watchdog that catches the "server goroutine
+	// stuck but TCP alive" failure mode that gRPC keepalive does not cover.
+	// gRPC keepalive (10s ping / 10s timeout) handles dead TCP connections;
+	// this constant handles a live connection whose send loop has deadlocked.
+	//
+	// The server guarantees a snapshot at least every managerHealthPollingInterval
+	// (5s), so messages normally arrive far more frequently than this. The value
+	// is seeded from the server's recommended timeout in each snapshot.
+	streamStalenessTimeout = 90 * time.Second
+)
+
+// streamEntry holds the lifecycle handles for one active stream goroutine.
+type streamEntry struct {
+	cancel context.CancelFunc
+
+	// mu protects stream; set to the live gRPC stream after the start message
+	// is sent, and cleared on stream exit.
+	mu     sync.Mutex
+	stream rpcclient.ManagerHealthStream
+}
+
+// HealthStream maintains one HealthStream stream per pooler. It replaces the
+// polling loop: instead of periodically calling the Status RPC, each pooler
+// pushes health snapshots to multiorch via a long-lived gRPC stream.
+//
+// When a snapshot arrives the HealthStream writes the same health fields into
+// the pooler store that the old pollPooler function wrote on success. On stream
+// disconnect the pooler is marked unreachable and reconnection is attempted
+// with exponential backoff (1s → 2s → … → 30s cap).
+type HealthStream struct {
+	logger    *slog.Logger
+	rpcClient rpcclient.MultiPoolerClient
+	store     *store.PoolerStore
+
+	// stalenessTimeout overrides streamStalenessTimeout if positive.
+	// Set via WithStalenessTimeout; used in tests.
+	stalenessTimeout time.Duration
+
+	// Active stream goroutines, keyed by pooler ID string.
+	mu      sync.Mutex
+	streams map[string]*streamEntry
+
+	// Parent context; cancelled by Stop().
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// Option is a functional option for NewHealthStream.
+type Option func(*HealthStream)
+
+// WithStalenessTimeout overrides the default staleness timeout. Intended for tests.
+func WithStalenessTimeout(d time.Duration) Option {
+	return func(hs *HealthStream) {
+		hs.stalenessTimeout = d
+	}
+}
+
+// NewHealthStream creates a HealthStream.
+//
+// Call Start() for each pooler that should be monitored.
+func NewHealthStream(
+	ctx context.Context,
+	rpcClient rpcclient.MultiPoolerClient,
+	poolerStore *store.PoolerStore,
+	logger *slog.Logger,
+	options ...Option,
+) *HealthStream {
+	smCtx, cancel := context.WithCancel(ctx)
+	hs := &HealthStream{
+		logger:    logger,
+		rpcClient: rpcClient,
+		store:     poolerStore,
+		streams:   make(map[string]*streamEntry),
+		ctx:       smCtx,
+		cancel:    cancel,
+	}
+
+	for _, opt := range options {
+		opt(hs)
+	}
+
+	return hs
+}
+
+// Shutdown cancels all active streams and waits for their goroutines to exit.
+func (hs *HealthStream) Shutdown() {
+	hs.cancel()
+	hs.wg.Wait()
+}
+
+// Start starts a health stream for poolerID.
+// If a stream is already running for this pooler the call is a no-op.
+// The pooler's MultiPooler metadata is read from the store on each
+// reconnect attempt so topology updates are automatically picked up.
+func (hs *HealthStream) Start(poolerID string) {
+	hs.mu.Lock()
+	defer hs.mu.Unlock()
+
+	if _, exists := hs.streams[poolerID]; exists {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(hs.ctx)
+	entry := &streamEntry{cancel: cancel}
+	hs.streams[poolerID] = entry
+
+	hs.wg.Go(func() {
+		defer func() {
+			hs.mu.Lock()
+			delete(hs.streams, poolerID)
+			hs.mu.Unlock()
+		}()
+		hs.runStream(ctx, poolerID, entry)
+	})
+}
+
+// Stop the health stream for a pooler.
+//
+// The stream goroutine will exit and the pooler will be marked unreachable
+// until a new stream is started. The pooler's MultiPooler metadata must remain
+// in the store for the stream to reconnect if Start() is called again.
+//
+// If no stream is running for this pooler the call is a no-op.
+func (hs *HealthStream) Stop(poolerID string) {
+	hs.mu.Lock()
+	defer hs.mu.Unlock()
+
+	if entry, exists := hs.streams[poolerID]; exists {
+		entry.cancel()
+		// The goroutine removes itself from hs.streams via its defer.
+	}
+}
+
+// runStream manages the lifecycle of one stream, reconnecting with backoff on failure.
+// It reads the latest MultiPooler metadata from the store on each reconnect attempt
+// so hostname/port changes are picked up automatically.
+func (hs *HealthStream) runStream(ctx context.Context, poolerID string, entry *streamEntry) {
+	r := retry.New(streamReconnectInitialBackoff, streamReconnectMaxBackoff, retry.WithInitialDelay())
+	for _, err := range r.Attempts(ctx) {
+		if err != nil {
+			return
+		}
+
+		// Read current pooler metadata from store on every attempt.
+		poolerHealth, ok := hs.store.Get(poolerID)
+		if !ok || poolerHealth.MultiPooler == nil {
+			hs.logger.WarnContext(ctx, "pooler not found in store, stopping health stream",
+				"pooler_id", poolerID)
+			return
+		}
+
+		connected, streamErr := hs.streamOnce(ctx, poolerID, poolerHealth, entry)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if connected {
+			// Stream was successfully established before failing — reset backoff.
+			r.Reset()
+		}
+
+		hs.markDisconnected(poolerID)
+
+		if streamErr != nil {
+			hs.logger.WarnContext(ctx, "health stream disconnected",
+				"pooler_id", poolerID,
+				"error", streamErr,
+			)
+		}
+	}
+}
+
+// streamOnce opens one HealthStream stream and reads until the stream fails or
+// the context is cancelled. Returns (connected, err): connected is true if the
+// stream was established before any error occurred.
+func (hs *HealthStream) streamOnce(ctx context.Context, poolerID string, poolerHealth *multiorchdatapb.PoolerHealthState, entry *streamEntry) (connected bool, _ error) {
+	// Staleness watchdog: cancel the stream if no snapshot arrives within the
+	// timeout. This catches the "server goroutine stuck but TCP alive" failure
+	// mode that gRPC keepalive does not cover.
+	//
+	// The watchdog context is what we pass to ManagerHealthStream; cancelling it
+	// terminates the gRPC stream and causes stream.Recv() to return an error.
+	watchdogCtx, cancelWatchdog := context.WithCancel(ctx)
+	defer cancelWatchdog()
+
+	// Resolve the effective staleness timeout (WithStalenessTimeout overrides the default).
+	effectiveStalenessTimeout := streamStalenessTimeout
+	if hs.stalenessTimeout > 0 {
+		effectiveStalenessTimeout = hs.stalenessTimeout
+	}
+
+	// resetCh is used by the recv loop to reset the staleness timer. The
+	// duration is taken from each snapshot's recommended timeout.
+	resetCh := make(chan time.Duration, 1)
+	go func() {
+		timer := time.NewTimer(effectiveStalenessTimeout)
+		defer timer.Stop()
+		for {
+			select {
+			case d := <-resetCh:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(d)
+			case <-timer.C:
+				hs.logger.WarnContext(ctx, "health stream stale: no snapshot received within timeout, reconnecting",
+					"pooler_id", poolerID,
+					"timeout", effectiveStalenessTimeout,
+				)
+				cancelWatchdog()
+				return
+			case <-watchdogCtx.Done():
+				return
+			}
+		}
+	}()
+
+	stream, err := hs.rpcClient.ManagerHealthStream(watchdogCtx, poolerHealth.MultiPooler)
+	if err != nil {
+		return false, fmt.Errorf("open stream: %w", err)
+	}
+
+	// Send the start message so the server starts sending snapshots.
+	if err := stream.Send(&multipoolermanagerdatapb.ManagerHealthStreamClientMessage{
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamClientMessage_Start{
+			Start: &multipoolermanagerdatapb.ManagerHealthStreamStartRequest{},
+		},
+	}); err != nil {
+		return false, fmt.Errorf("send start: %w", err)
+	}
+
+	// Expose the live stream so Poll() can send requests.
+	entry.mu.Lock()
+	entry.stream = stream
+	entry.mu.Unlock()
+	defer func() {
+		entry.mu.Lock()
+		entry.stream = nil
+		entry.mu.Unlock()
+	}()
+
+	hs.markConnected(poolerID)
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			// Distinguish a staleness-triggered cancellation from an external one
+			// so the caller can log a useful error message.
+			if watchdogCtx.Err() != nil && ctx.Err() == nil {
+				return true, fmt.Errorf("staleness timeout: no snapshot received within %s", effectiveStalenessTimeout)
+			}
+			return true, fmt.Errorf("recv: %w", err)
+		}
+		if resp.Snapshot != nil {
+			// Reset the staleness watchdog using the server's recommended timeout.
+			timeout := resp.Snapshot.Timeout.AsDuration()
+			if timeout <= 0 {
+				timeout = effectiveStalenessTimeout
+			}
+			select {
+			case resetCh <- timeout:
+			default:
+				// A reset is already pending; the watchdog will pick it up.
+			}
+			hs.applySnapshot(ctx, poolerID, poolerHealth, resp.Snapshot)
+		}
+	}
+}
+
+// Poll sends a poll request on the active stream for poolerID, triggering an
+// immediate health snapshot from the pooler. Returns an error if no stream is
+// active or the send fails.
+func (hs *HealthStream) Poll(poolerID string) error {
+	hs.mu.Lock()
+	entry, exists := hs.streams[poolerID]
+	hs.mu.Unlock()
+	if !exists {
+		return fmt.Errorf("no active stream for pooler %s", poolerID)
+	}
+
+	entry.mu.Lock()
+	stream := entry.stream
+	entry.mu.Unlock()
+	if stream == nil {
+		return fmt.Errorf("stream not yet established for pooler %s", poolerID)
+	}
+
+	return stream.Send(&multipoolermanagerdatapb.ManagerHealthStreamClientMessage{
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamClientMessage_Poll{
+			Poll: &multipoolermanagerdatapb.ManagerHealthStreamPollRequest{},
+		},
+	})
+}
+
+// applySnapshot writes health fields from a snapshot into the pooler store.
+// This mirrors the field writes performed by the old pollPooler function on success.
+func (hs *HealthStream) applySnapshot(ctx context.Context, poolerID string, poolerHealth *multiorchdatapb.PoolerHealthState, snapshot *multipoolermanagerdatapb.ManagerHealthSnapshot) {
+	if snapshot.Status == nil || snapshot.Status.Status == nil {
+		hs.logger.WarnContext(ctx, "received snapshot with nil status, skipping",
+			"pooler_id", poolerID)
+		return
+	}
+
+	status := snapshot.Status.Status
+	now := timestamppb.Now()
+
+	poolerIDStr := topoclient.MultiPoolerIDString(poolerHealth.MultiPooler.Id)
+	update := func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
+		existing.LastCheckSuccessful = now
+		existing.LastSeen = now
+		existing.IsUpToDate = true
+		existing.IsLastCheckValid = true
+		existing.IsPostgresReady = status.PostgresReady
+		if status.PostgresReady {
+			existing.LastPostgresReadyTime = now
+		}
+		// NOTE: when PostgresReady is false, LastPostgresReadyTime is intentionally
+		// left at its previous value so callers can reason about "last known good" time.
+		existing.IsPostgresRunning = status.PostgresRunning
+		existing.PoolerType = status.PoolerType
+		existing.PrimaryStatus = status.PrimaryStatus
+		existing.ReplicationStatus = status.ReplicationStatus
+		existing.IsInitialized = status.IsInitialized
+		existing.HasDataDirectory = status.HasDataDirectory
+		existing.ConsensusTerm = status.ConsensusTerm
+		existing.CohortMembers = status.CohortMembers
+		return existing
+	}
+
+	hs.store.DoUpdate(poolerIDStr, update)
+
+	hs.logger.DebugContext(ctx, "health snapshot applied",
+		"pooler_id", poolerID,
+		"pooler_type", status.PoolerType,
+		"postgres_ready", status.PostgresReady,
+		"postgres_running", status.PostgresRunning,
+	)
+}
+
+// markConnected records that the stream is connected in the pooler store.
+func (hs *HealthStream) markConnected(poolerID string) {
+	now := timestamppb.Now()
+	cb := func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
+		existing.StreamConnected = true
+		existing.StreamConnectedSince = now
+		return existing
+	}
+	hs.store.DoUpdate(poolerID, cb)
+}
+
+// markDisconnected records that the stream is disconnected and the pooler
+// should be treated as unreachable.
+func (hs *HealthStream) markDisconnected(poolerID string) {
+	cb := func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
+		existing.IsLastCheckValid = false
+		existing.IsPostgresReady = false
+		existing.IsPostgresRunning = false
+		existing.StreamConnected = false
+		return existing
+	}
+	hs.store.DoUpdate(poolerID, cb)
+}

--- a/go/services/multiorch/recovery/health_stream_test.go
+++ b/go/services/multiorch/recovery/health_stream_test.go
@@ -1,0 +1,565 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/services/multiorch/store"
+)
+
+// makeSnapshot wraps a Status into a HealthStreamResponse snapshot.
+func makeSnapshot(status *multipoolermanagerdatapb.Status) *multipoolermanagerdatapb.ManagerHealthStreamResponse {
+	return &multipoolermanagerdatapb.ManagerHealthStreamResponse{
+		Snapshot: &multipoolermanagerdatapb.ManagerHealthSnapshot{
+			Status: &multipoolermanagerdatapb.StatusResponse{Status: status},
+		},
+	}
+}
+
+// newTestHealthStream creates a HealthStream wired to the given FakeClient and store.
+func newTestHealthStream(ctx context.Context, fakeClient *rpcclient.FakeClient, poolerStore *store.PoolerStore, opts ...Option) *HealthStream {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewHealthStream(ctx, fakeClient, poolerStore, logger, opts...)
+}
+
+// seedPooler adds a minimal pooler entry to the store and returns its key.
+func seedPooler(poolerStore *store.PoolerStore, poolerID *clustermetadata.ID, poolerType clustermetadata.PoolerType) string {
+	key := topoclient.MultiPoolerIDString(poolerID)
+	poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
+		MultiPooler: &clustermetadata.MultiPooler{
+			Id:         poolerID,
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+			Type:       poolerType,
+			Hostname:   "host1",
+			PortMap:    map[string]int32{"grpc": 5432},
+		},
+	})
+	return key
+}
+
+// waitForStart drains the Sent channel until a start message arrives.
+func waitForStart(t *testing.T, sent <-chan *multipoolermanagerdatapb.ManagerHealthStreamClientMessage) {
+	t.Helper()
+	select {
+	case msg := <-sent:
+		require.NotNil(t, msg.GetStart(), "first message should be a start message")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for start message")
+	}
+}
+
+// waitForPoll drains the Sent channel until a poll message arrives.
+func waitForPoll(t *testing.T, sent <-chan *multipoolermanagerdatapb.ManagerHealthStreamClientMessage) {
+	t.Helper()
+	select {
+	case msg := <-sent:
+		require.NotNil(t, msg.GetPoll(), "expected a poll message")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for poll message")
+	}
+}
+
+// TestHealthStream_UpdatesStore_Primary tests that a PRIMARY snapshot is applied to the store.
+func TestHealthStream_UpdatesStore_Primary(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType: clustermetadata.PoolerType_PRIMARY,
+		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+			Lsn:   "0/123ABC",
+			Ready: true,
+			ConnectedFollowers: []*clustermetadata.ID{
+				{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "replica1"},
+				{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "replica2"},
+			},
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond, "snapshot should be applied")
+
+	updated, _ := poolerStore.Get(key)
+	require.True(t, updated.IsUpToDate)
+	require.NotNil(t, updated.LastSeen)
+	require.NotNil(t, updated.LastCheckSuccessful)
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType)
+	require.NotNil(t, updated.PrimaryStatus)
+	require.Equal(t, "0/123ABC", updated.PrimaryStatus.Lsn)
+	require.True(t, updated.PrimaryStatus.Ready)
+	require.Len(t, updated.PrimaryStatus.ConnectedFollowers, 2)
+	require.Nil(t, updated.ReplicationStatus)
+}
+
+// TestHealthStream_UpdatesStore_Replica tests that a REPLICA snapshot is applied to the store.
+func TestHealthStream_UpdatesStore_Replica(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "replica1"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_REPLICA)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType: clustermetadata.PoolerType_REPLICA,
+		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+			LastReplayLsn:           "0/123ABC",
+			LastReceiveLsn:          "0/123DEF",
+			IsWalReplayPaused:       false,
+			WalReplayPauseState:     "not paused",
+			Lag:                     durationpb.New(500 * time.Millisecond),
+			LastXactReplayTimestamp: "2025-01-19 20:00:00.000000+00",
+			PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+				Host: "primary-host",
+				Port: 5432,
+			},
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond)
+
+	updated, _ := poolerStore.Get(key)
+	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.PoolerType)
+	require.NotNil(t, updated.ReplicationStatus)
+	require.Equal(t, "0/123ABC", updated.ReplicationStatus.LastReplayLsn)
+	require.Equal(t, "0/123DEF", updated.ReplicationStatus.LastReceiveLsn)
+	require.False(t, updated.ReplicationStatus.IsWalReplayPaused)
+	require.Equal(t, "not paused", updated.ReplicationStatus.WalReplayPauseState)
+	require.Equal(t, int64(500), updated.ReplicationStatus.Lag.AsDuration().Milliseconds())
+	require.Equal(t, "2025-01-19 20:00:00.000000+00", updated.ReplicationStatus.LastXactReplayTimestamp)
+	require.NotNil(t, updated.ReplicationStatus.PrimaryConnInfo)
+	require.Equal(t, "primary-host", updated.ReplicationStatus.PrimaryConnInfo.Host)
+	require.Equal(t, int32(5432), updated.ReplicationStatus.PrimaryConnInfo.Port)
+	require.Nil(t, updated.PrimaryStatus)
+}
+
+// TestHealthStream_Poll tests that Poll() sends a poll message and a subsequent snapshot is applied.
+func TestHealthStream_Poll(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Inject initial snapshot.
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:    clustermetadata.PoolerType_PRIMARY,
+		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{Lsn: "0/AAAAAA", Ready: true},
+	})
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.PrimaryStatus != nil && s.PrimaryStatus.Lsn == "0/AAAAAA"
+	}, 2*time.Second, 10*time.Millisecond, "initial snapshot should be applied")
+
+	// Trigger a poll.
+	require.NoError(t, sm.Poll(key))
+	waitForPoll(t, stream.Sent)
+
+	// Inject updated snapshot (as if pooler responded to the poll).
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:    clustermetadata.PoolerType_PRIMARY,
+		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{Lsn: "0/BBBBBB", Ready: true},
+	})
+
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.PrimaryStatus != nil && s.PrimaryStatus.Lsn == "0/BBBBBB"
+	}, 2*time.Second, 10*time.Millisecond, "polled snapshot should be applied")
+}
+
+// TestHealthStream_Disconnect tests that a stream disconnection marks the pooler unreachable.
+func TestHealthStream_Disconnect(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 2) // buffer for reconnect
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "failed-pooler"}
+	lastSeenTime := time.Now().Add(-1 * time.Hour)
+	key := topoclient.MultiPoolerIDString(poolerID)
+	poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
+		MultiPooler: &clustermetadata.MultiPooler{
+			Id: poolerID, Database: "mydb", TableGroup: "tg1", Shard: "0",
+			Type: clustermetadata.PoolerType_PRIMARY, Hostname: "host1",
+			PortMap: map[string]int32{"grpc": 5432},
+		},
+		IsLastCheckValid: true,
+		LastSeen:         timestamppb.New(lastSeenTime),
+	})
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Inject one snapshot so the stream is "connected" with valid data.
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:    clustermetadata.PoolerType_PRIMARY,
+		PostgresReady: true,
+	})
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Close the stream to simulate a disconnect.
+	close(stream.Ch)
+
+	// The store should be marked unreachable.
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && !s.IsLastCheckValid && !s.StreamConnected
+	}, 2*time.Second, 10*time.Millisecond, "pooler should be marked unreachable after disconnect")
+
+	// LastSeen should remain from the last successful snapshot, not cleared.
+	s, _ := poolerStore.Get(key)
+	require.NotNil(t, s.LastSeen)
+}
+
+// TestHealthStream_ConcurrentWatcherUpdate tests that a topology update written by the
+// PoolerWatcher while a snapshot is being applied is not overwritten (DoUpdate semantics).
+func TestHealthStream_ConcurrentWatcherUpdate(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_REPLICA)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Concurrently promote the pooler in the topology (simulates PoolerWatcher update)
+	// before the snapshot is applied.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		poolerStore.DoUpdate(key, func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
+			existing.MultiPooler.Type = clustermetadata.PoolerType_PRIMARY
+			return existing
+		})
+	}()
+
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:      clustermetadata.PoolerType_REPLICA,
+		PostgresRunning: true,
+	})
+
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond)
+
+	result, _ := poolerStore.Get(key)
+	// The watcher's topology promotion must be preserved.
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, result.MultiPooler.Type,
+		"watcher's topology update should not be overwritten by snapshot")
+	// Health fields from the snapshot should still be applied.
+	require.True(t, result.IsLastCheckValid)
+	require.True(t, result.IsUpToDate)
+}
+
+// TestHealthStream_DeletedDuringStream tests that a pooler deleted from the store while a
+// snapshot is in-flight is not resurrected by the apply.
+func TestHealthStream_DeletedDuringStream(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Delete the pooler from the store before the snapshot arrives.
+	poolerStore.Delete(key)
+
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:      clustermetadata.PoolerType_PRIMARY,
+		PostgresRunning: true,
+	})
+
+	// Give applySnapshot time to run.
+	time.Sleep(100 * time.Millisecond)
+
+	_, ok := poolerStore.Get(key)
+	require.False(t, ok, "deleted pooler should not be resurrected by a snapshot")
+}
+
+// TestHealthStream_LastPostgresReadyTime tests that LastPostgresReadyTime is set/preserved correctly.
+func TestHealthStream_LastPostgresReadyTime(t *testing.T) {
+	t.Run("sets LastPostgresReadyTime when PostgresReady is true", func(t *testing.T) {
+		ctx := t.Context()
+
+		fakeClient := rpcclient.NewFakeClient()
+		streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+		fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+			streamCh <- s
+		}
+
+		poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+		sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+		poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+		key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+		sm.Start(key)
+		stream := <-streamCh
+		waitForStart(t, stream.Sent)
+
+		before := time.Now()
+		stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadata.PoolerType_PRIMARY,
+			PostgresReady: true,
+		})
+
+		require.Eventually(t, func() bool {
+			s, ok := poolerStore.Get(key)
+			return ok && s.LastPostgresReadyTime != nil
+		}, 2*time.Second, 10*time.Millisecond)
+
+		updated, _ := poolerStore.Get(key)
+		require.True(t, updated.LastPostgresReadyTime.AsTime().After(before))
+	})
+
+	t.Run("preserves LastPostgresReadyTime when PostgresReady is false", func(t *testing.T) {
+		ctx := t.Context()
+
+		fakeClient := rpcclient.NewFakeClient()
+		streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+		fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+			streamCh <- s
+		}
+
+		poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+		sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+		poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"}
+		key := topoclient.MultiPoolerIDString(poolerID)
+		lastReadyTime := timestamppb.New(time.Now().Add(-10 * time.Second))
+		poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
+			MultiPooler: &clustermetadata.MultiPooler{
+				Id: poolerID, Database: "mydb", TableGroup: "tg1", Shard: "0",
+				Type: clustermetadata.PoolerType_PRIMARY, Hostname: "host2",
+				PortMap: map[string]int32{"grpc": 5432},
+			},
+			LastPostgresReadyTime: lastReadyTime,
+		})
+
+		sm.Start(key)
+		stream := <-streamCh
+		waitForStart(t, stream.Sent)
+
+		stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadata.PoolerType_PRIMARY,
+			PostgresReady: false,
+		})
+
+		require.Eventually(t, func() bool {
+			s, ok := poolerStore.Get(key)
+			return ok && s.IsLastCheckValid
+		}, 2*time.Second, 10*time.Millisecond)
+
+		updated, _ := poolerStore.Get(key)
+		require.NotNil(t, updated.LastPostgresReadyTime)
+		require.WithinDuration(t, lastReadyTime.AsTime(), updated.LastPostgresReadyTime.AsTime(), time.Second,
+			"LastPostgresReadyTime should not change when PostgresReady is false")
+	})
+}
+
+// TestHealthStream_StalenessTimeout verifies that a stream that stops sending messages
+// is detected and triggers a reconnect. This exercises the application-level watchdog
+// in streamOnce, which catches "live TCP but silent server goroutine" failures that
+// gRPC keepalive does not cover.
+func TestHealthStream_StalenessTimeout(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	// Buffer 2: first stream + reconnect stream.
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 2)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	// Use a very short staleness timeout so the test completes quickly.
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore, WithStalenessTimeout(100*time.Millisecond))
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "silent-pooler"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+	sm.Start(key)
+
+	// First stream connection.
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Send one snapshot so the stream is marked connected.
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:    clustermetadata.PoolerType_PRIMARY,
+		PostgresReady: true,
+	})
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond, "initial snapshot should be applied")
+
+	// Now let the stream go silent — don't close it, don't send anything.
+	// The staleness watchdog should fire after 100ms and trigger a reconnect.
+
+	// Wait for the pooler to be marked unreachable.
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && !s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond, "pooler should be marked unreachable after staleness timeout")
+
+	// The stream manager should reconnect — a second stream must be dialled.
+	select {
+	case <-streamCh:
+		// Reconnect stream arrived — staleness detection and reconnect work correctly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected reconnect after staleness timeout, but no second stream was opened")
+	}
+}
+
+// TestHealthStream_TypeMismatch tests that when a pooler reports a different type than topology,
+// both are preserved: MultiPooler.Type stays as topology, PoolerType reflects what the pooler reports.
+func TestHealthStream_TypeMismatch(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "confused-pooler"}
+	// Topology says REPLICA.
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_REPLICA)
+
+	sm.Start(key)
+	stream := <-streamCh
+	waitForStart(t, stream.Sent)
+
+	// Pooler reports PRIMARY (type mismatch).
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType: clustermetadata.PoolerType_PRIMARY,
+		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+			Lsn:   "0/FFFFFF",
+			Ready: true,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond)
+
+	updated, _ := poolerStore.Get(key)
+	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.MultiPooler.Type,
+		"topology type should remain REPLICA")
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType,
+		"reported type should be PRIMARY")
+	require.NotNil(t, updated.PrimaryStatus)
+	require.Equal(t, "0/FFFFFF", updated.PrimaryStatus.Lsn)
+	require.True(t, updated.PrimaryStatus.Ready)
+}

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -19,6 +19,10 @@ import (
 	"context"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
 	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
@@ -321,4 +325,137 @@ func (s *managerService) RewindToSource(ctx context.Context, req *multipoolerman
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor
 func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)
+}
+
+// managerHealthPollingInterval is how often ManagerHealthStream proactively
+// polls Status() even without a broadcast notification. This guarantees that
+// postgres state changes (e.g. process death) reach the orchestrator within
+// this interval even when the multipooler's local monitor is disabled.
+const managerHealthPollingInterval = 5 * time.Second
+
+// ManagerHealthStream is the bidirectional health stream implementation.
+//
+// The orchestrator sends a start message to open the stream, then may send poll
+// requests at any time to trigger an immediate snapshot.
+//
+// On each healthStreamer broadcast or poll request we call Status() to build a
+// full snapshot and send it. Every message is a complete snapshot — there are
+// no incremental updates or separate heartbeat message types.
+//
+// In addition to broadcast-driven snapshots, we also send a snapshot every
+// managerHealthPollingInterval (5s) regardless of broadcasts. This ensures that
+// postgres state changes — particularly process death detected by pgctld —
+// reach the orchestrator promptly even when the local monitor is disabled.
+//
+// When the health channel is closed (buffer full), we return Unavailable to
+// force the client to reconnect and receive a fresh initial snapshot.
+func (s *managerService) ManagerHealthStream(
+	stream multipoolermanagerpb.MultiPoolerManager_ManagerHealthStreamServer,
+) error {
+	ctx := stream.Context()
+
+	// Read the start message. The first client message must be a start message.
+	startMsg, err := stream.Recv()
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "expected start message: %v", err)
+	}
+	if startMsg.GetStart() == nil {
+		return status.Error(codes.InvalidArgument, "first message must be a start message")
+	}
+
+	// Subscribe to health state changes. We use the channel as a notification
+	// signal only — the actual payload sent to the orchestrator is a full
+	// Status() snapshot rather than the lightweight gateway HealthState.
+	_, healthChan, err := s.manager.SubscribeHealth(ctx)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to subscribe to health: %v", err)
+	}
+
+	if healthChan == nil {
+		return status.Error(codes.Unavailable, "health provider not initialized")
+	}
+
+	// Send initial snapshot immediately upon connection.
+	if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL); err != nil {
+		return err
+	}
+
+	// Goroutine: read incoming client messages and forward poll requests.
+	// pollCh is buffered so bursts coalesce — only one snapshot is sent per
+	// batch of poll requests received while the send loop is busy.
+	pollCh := make(chan struct{}, 1)
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				return // stream ended; send loop will exit via ctx.Done or healthChan close
+			}
+			if msg.GetPoll() != nil {
+				select {
+				case pollCh <- struct{}{}:
+				default: // already a poll pending; coalesce
+				}
+			}
+		}
+	}()
+
+	// Periodic ticker so we poll Status() even without a broadcast.
+	// This catches postgres process death (reported by pgctld) within
+	// managerHealthPollingInterval even when the local monitor is disabled.
+	pollTicker := time.NewTicker(managerHealthPollingInterval)
+	defer pollTicker.Stop()
+
+	// Stream updates until the client disconnects or the context is cancelled.
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case _, ok := <-healthChan:
+			if !ok {
+				// Channel closed because the buffer was full. Return Unavailable
+				// so the client reconnects and receives a fresh initial snapshot.
+				return status.Error(codes.Unavailable, "health stream buffer full, reconnect required")
+			}
+			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_BROADCAST); err != nil {
+				return err
+			}
+		case <-pollCh:
+			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_POLL); err != nil {
+				return err
+			}
+		case <-pollTicker.C:
+			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_HEARTBEAT); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// sendManagerHealthSnapshot fetches the current Status and sends it as a
+// ManagerHealthSnapshot on the stream.
+//
+// This is called both for the initial snapshot and for subsequent updates. We
+// always fetch a fresh Status() to ensure we have the latest information, even
+// if the health notification was coalesced or delayed.
+func (s *managerService) sendManagerHealthSnapshot(
+	ctx context.Context,
+	stream multipoolermanagerpb.MultiPoolerManager_ManagerHealthStreamServer,
+	trigger multipoolermanagerdatapb.SnapshotTrigger,
+) error {
+	st, err := s.manager.Status(ctx)
+	if err != nil {
+		return mterrors.ToGRPC(err)
+	}
+
+	healthSnapshot := &multipoolermanagerdatapb.ManagerHealthSnapshot{
+		Status:  &multipoolermanagerdatapb.StatusResponse{Status: st},
+		Timeout: durationpb.New(manager.DefaultRecommendedStalenessTimeout),
+		Trigger: trigger,
+	}
+
+	response := &multipoolermanagerdatapb.ManagerHealthStreamResponse{
+		Snapshot: healthSnapshot,
+	}
+
+	return stream.Send(response)
 }

--- a/go/services/multipooler/manager/health_provider.go
+++ b/go/services/multipooler/manager/health_provider.go
@@ -35,6 +35,12 @@ const (
 	// to detect a stale/dead health stream.
 	defaultRecommendedStalenessTimeout = 90 * time.Second
 
+	// DefaultRecommendedStalenessTimeout is the recommended staleness timeout
+	// advertised to orchestrators in ManagerHealthSnapshot.timeout. If the
+	// orchestrator receives no message within this window it should treat the
+	// pooler as unreachable and reconnect.
+	DefaultRecommendedStalenessTimeout time.Duration = defaultRecommendedStalenessTimeout
+
 	// defaultHealthHeartbeatInterval is the interval between periodic health
 	// broadcasts when no state changes occur.
 	defaultHealthHeartbeatInterval = 30 * time.Second

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -376,7 +376,13 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 
 	// Mark as initialized after successful restore
 	return telemetry.WithSpan(ctx, "restore/mark-initialized", func(_ context.Context) error {
-		return pm.setInitialized()
+		if err := pm.setInitialized(); err != nil {
+			return err
+		}
+		// Push an immediate health snapshot so the orchestrator learns about
+		// IsInitialized=true without waiting for the next 30-second heartbeat.
+		pm.broadcastHealth()
+		return nil
 	})
 }
 

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -34,6 +34,18 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 )
 
+// broadcastHealth broadcasts the current health state to all subscribers.
+//
+// This should be called whenever there is a state change that clients should be
+// aware of (e.g., PostgreSQL availability, replication status, etc.). Clients
+// will receive the latest health snapshot immediately if they are connected, or
+// upon their next connection if they are not currently connected.
+func (pm *MultiPoolerManager) broadcastHealth() {
+	if pm.healthStreamer != nil {
+		pm.healthStreamer.Broadcast()
+	}
+}
+
 // WaitForLSN waits for PostgreSQL server to reach a specific LSN position
 func (pm *MultiPoolerManager) WaitForLSN(ctx context.Context, targetLsn string) error {
 	if err := pm.checkReady(); err != nil {
@@ -119,7 +131,15 @@ func (pm *MultiPoolerManager) SetPrimaryConnInfo(ctx context.Context, primary *c
 	pm.mu.Unlock()
 
 	// Call the locked version that assumes action lock is already held
-	return pm.setPrimaryConnInfoLocked(ctx, host, port, stopReplicationBefore, startReplicationAfter)
+	if err := pm.setPrimaryConnInfoLocked(ctx, host, port, stopReplicationBefore, startReplicationAfter); err != nil {
+		return err
+	}
+
+	// Push an immediate health snapshot so orchestrators learn about the new
+	// replication configuration (e.g., cleared primary_conninfo) without waiting
+	// for the next 30-second heartbeat.
+	pm.broadcastHealth()
+	return nil
 }
 
 // setPrimaryConnInfoLocked sets the primary connection info for a standby server.
@@ -606,6 +626,10 @@ func (pm *MultiPoolerManager) UpdateSynchronousStandbyList(ctx context.Context, 
 		"reload_config", reloadConfig,
 		"consensus_term", consensusTerm,
 		"force", force)
+
+	// Push an immediate health snapshot so orchestrators learn about the changed
+	// synchronous standby list without waiting for the next 30-second heartbeat.
+	pm.broadcastHealth()
 	return nil
 }
 

--- a/go/test/endtoend/multipooler/manager_health_stream_test.go
+++ b/go/test/endtoend/multipooler/manager_health_stream_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// TestManagerHealthStream_SnapshotOnSetPrimaryConnInfo verifies that a snapshot
+// is pushed to an open ManagerHealthStream promptly after SetPrimaryConnInfo is
+// called. SetPrimaryConnInfo calls broadcastHealth() at the end of its work, so
+// the stream client should not need to wait for the periodic poll ticker.
+func TestManagerHealthStream_SnapshotOnSetPrimaryConnInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+	setupPoolerTest(t, setup, WithoutReplication())
+
+	waitForManagerReady(t, setup, setup.StandbyMultipooler)
+
+	// Connect to the standby's manager service.
+	standbyClient, err := shardsetup.NewMultipoolerClient(setup.StandbyMultipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { standbyClient.Close() })
+
+	// Open a ManagerHealthStream. Cancel it at test teardown.
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	t.Cleanup(cancelStream)
+
+	stream, err := standbyClient.Manager.ManagerHealthStream(streamCtx)
+	require.NoError(t, err)
+
+	// Send the start message to open the stream.
+	require.NoError(t, stream.Send(&multipoolermanagerdatapb.ManagerHealthStreamClientMessage{
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamClientMessage_Start{
+			Start: &multipoolermanagerdatapb.ManagerHealthStreamStartRequest{},
+		},
+	}))
+
+	// Drain the initial snapshot that the server sends immediately on connection.
+	initial, err := stream.Recv()
+	require.NoError(t, err, "expected initial snapshot on stream open")
+	require.Equal(t, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL,
+		initial.GetSnapshot().GetTrigger(), "first message should be an initial snapshot")
+
+	// Call SetPrimaryConnInfo on the standby. This configures primary_conninfo
+	// (without starting replication) and calls broadcastHealth() at the end,
+	// which should cause the stream to send a broadcast-triggered snapshot.
+	primary := &clustermetadatapb.MultiPooler{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      setup.CellName,
+			Name:      setup.PrimaryMultipooler.Name,
+		},
+		Hostname: "localhost",
+		PortMap:  map[string]int32{"postgres": int32(setup.PrimaryPgctld.PgPort)},
+	}
+	_, err = standbyClient.Manager.SetPrimaryConnInfo(t.Context(), &multipoolermanagerdatapb.SetPrimaryConnInfoRequest{
+		Primary:               primary,
+		StopReplicationBefore: false,
+		StartReplicationAfter: false,
+		Force:                 true,
+	})
+	require.NoError(t, err, "SetPrimaryConnInfo should succeed on standby")
+
+	// Receive snapshots until we see one with SNAPSHOT_TRIGGER_BROADCAST.
+	// We skip over any heartbeat snapshots that may arrive concurrently.
+	// We use the test context so there is no arbitrary deadline shorter than the
+	// overall test timeout.
+	for {
+		snapCh := make(chan *multipoolermanagerdatapb.ManagerHealthStreamResponse, 1)
+		go func() {
+			msg, err := stream.Recv()
+			if err == nil {
+				snapCh <- msg
+			}
+		}()
+
+		select {
+		case snap := <-snapCh:
+			require.NotNil(t, snap.GetSnapshot(), "received message should contain a snapshot")
+			if snap.GetSnapshot().GetTrigger() == multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_BROADCAST {
+				return // test passed
+			}
+			// Not a broadcast snapshot (e.g. a concurrent heartbeat); keep waiting.
+		case <-t.Context().Done():
+			t.Fatal("no broadcast snapshot received before test timeout — SetPrimaryConnInfo may not be triggering a broadcast")
+		}
+	}
+}

--- a/proto/multiorchdata.proto
+++ b/proto/multiorchdata.proto
@@ -93,4 +93,12 @@ message PoolerHealthState {
   // it accepts connections. Mirrors multipoolermanagerdata.Status.postgres_running.
   // Used to distinguish SIGSTOP (process alive but unresponsive) from SIGKILL (process dead).
   bool is_postgres_running = 17;
+
+  // Stream health fields (populated when multiorch uses ManagerHealthStream).
+
+  // Whether a ManagerHealthStream stream is currently active for this pooler.
+  bool stream_connected = 20;
+
+  // The time at which the current stream was established.
+  google.protobuf.Timestamp stream_connected_since = 21;
 }

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -291,6 +291,69 @@ message StatusResponse {
   Status status = 1;
 }
 
+// ManagerHealthStreamClientMessage is sent from the orchestrator to the pooler.
+// The first message on a new stream must be a start message; subsequent messages
+// may be poll requests.
+message ManagerHealthStreamClientMessage {
+  oneof message {
+    // Sent once at stream open to identify the orchestrator.
+    ManagerHealthStreamStartRequest start = 1;
+
+    // Requests an immediate health snapshot from the pooler.
+    // Used by the orchestrator to trigger fresh state on demand (e.g. in tests).
+    ManagerHealthStreamPollRequest poll = 2;
+  }
+}
+
+// ManagerHealthStreamStartRequest is sent as the first message inside
+// ManagerHealthStreamClientMessage. There are no fields in this message; its
+// presence is the signal to start the stream.
+message ManagerHealthStreamStartRequest {
+}
+
+// ManagerHealthStreamPollRequest triggers an immediate health snapshot.
+// The message carries no payload; its presence on the stream is the signal.
+message ManagerHealthStreamPollRequest {
+}
+
+// ManagerHealthStreamResponse is sent by the pooler on connection, on every
+// state change, on poll request, and periodically as a heartbeat snapshot.
+// Every message is a full health snapshot — there are no incremental updates.
+message ManagerHealthStreamResponse {
+  // The full health state of the pooler.
+  ManagerHealthSnapshot snapshot = 1;
+}
+
+// SnapshotTrigger describes why a ManagerHealthSnapshot was sent.
+enum SnapshotTrigger {
+  // Default / unknown trigger. Not used by the server.
+  SNAPSHOT_TRIGGER_UNSPECIFIED = 0;
+  // Sent immediately when the stream is first opened.
+  SNAPSHOT_TRIGGER_INITIAL = 1;
+  // Triggered by a state-change broadcast (e.g. type change, SetPrimaryConnInfo).
+  SNAPSHOT_TRIGGER_BROADCAST = 2;
+  // Triggered by an explicit poll request from the orchestrator.
+  SNAPSHOT_TRIGGER_POLL = 3;
+  // Sent by the periodic heartbeat ticker.
+  SNAPSHOT_TRIGGER_HEARTBEAT = 4;
+}
+
+// ManagerHealthSnapshot is a full health snapshot of the pooler.
+// Sent immediately on connection, on any state change, and periodically as a
+// heartbeat when no state change has occurred.
+message ManagerHealthSnapshot {
+  // Full health state of the pooler.
+  StatusResponse status = 1;
+
+  // The duration the orchestrator should use to detect a stale or dead stream.
+  // If no message is received within this duration, the pooler should be marked
+  // unhealthy.
+  google.protobuf.Duration timeout = 2;
+
+  // Why this snapshot was sent. Useful for diagnostics and testing.
+  SnapshotTrigger trigger = 3;
+}
+
 // Replication statistics for a connected follower from pg_stat_replication
 message ReplicationStats {
   // PostgreSQL backend process ID for this replication connection

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -173,4 +173,20 @@ service MultiPoolerManager {
   rpc SetPostgresRestartsEnabled(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
       returns (multipoolermanagerdata.SetPostgresRestartsEnabledResponse);
 
+  // ManagerHealthStream is a bidirectional health stream between orchestrator
+  // and pooler.
+  //
+  // The orchestrator sends a start message (ManagerHealthStreamClientMessage
+  // with the start field set) to open the stream, then may send poll requests
+  // at any time to trigger an immediate snapshot.
+  //
+  // The pooler sends a full health snapshot on connection, on every state
+  // change, in response to poll requests, and periodically as a heartbeat.
+  // Every message is a complete snapshot — there are no incremental updates.
+  //
+  // The orchestrator MUST implement a staleness timeout. The recommended
+  // timeout is provided in the timeout field of each snapshot. If no message is
+  // received within this timeout, the pooler should be marked unhealthy.
+  rpc ManagerHealthStream(stream multipoolermanagerdata.ManagerHealthStreamClientMessage)
+      returns (stream multipoolermanagerdata.ManagerHealthStreamResponse);
 }


### PR DESCRIPTION
Add a bidirectional gRPC health stream from multipooler to multiorch, replacing the periodic `Status` RPC poll. Poolers push a full health snapshot on connection, on every state change, and as a periodic heartbeat. The orchestrator can send a poll request to trigger an immediate snapshot.

Proto:
- Add `ManagerHealthStream` RPC to `MultiPoolerManager` (bidirectional)
- Add `ManagerHealthStreamClientMessage` (start / poll variants)
- Add `ManagerHealthStreamResponse` and `ManagerHealthSnapshot` message types
- Add SnapshotTrigger enum (`INITIAL`, `BROADCAST`, `POLL`, `HEARTBEAT`) so each snapshot carries the reason it was sent
- Add `stream_connected`, `stream_connected_since`, `stream_snapshots_received` fields to PoolerHealthState

Multipooler server (grpcmanagerservice):
- Implement `ManagerHealthStream` handler: reads start message, sends a full `Status()` snapshot on connection, on each `healthStreamer` broadcast, and on poll requests from the orchestrator
- Add `broadcastHealth()` nil-safe wrapper for pm.healthStreamer.Broadcast()
- Call `broadcastHealth()` after SetPrimaryConnInfo, `UpdateSynchronousStandbyList`, and restore/mark-initialized so role and replication changes propagate immediately rather than waiting for the next heartbeat

RPC client:
- Add ManagerHealthStream send/recv interface
- Add ManagerHealthStream to MultiPoolerClient interface and gRPC client
- Add FakeManagerHealthStream and ManagerHealthStream to FakeClient

Multiorch client (health_stream.go, new):
- HealthStream maintains one ManagerHealthStream stream per pooler
- Sends start message on connect, applies snapshots into PoolerStore
- Poll(poolerID) sends a poll request on the active stream
- Exponential backoff reconnect (1s -> 30s cap) on disconnect
- Application-level staleness watchdog: cancels the stream and triggers reconnect if no snapshot arrives within timeout_seconds (default 90s); catches "live TCP, silent server goroutine" failures that gRPC keepalive does not cover. Timeout is seeded from each snapshot timeout_seconds.

Tests:
- Unit tests for HealthStream: snapshot apply (primary/replica), Poll, disconnect/reconnect, concurrent store update, deleted pooler, postgres ready time preservation, type mismatch, staleness timeout
- Integration test TestManagerHealthStream_SnapshotOnSetPrimaryConnInfo: opens a real stream to a standby pooler, calls SetPrimaryConnInfo, and asserts a SNAPSHOT_TRIGGER_BROADCAST snapshot arrives promptly

Part of MUL-357