### PR TITLE
fix(multipooler): initialize topoPublisher in newRemedialActionTestManager

### DIFF
--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -590,12 +590,13 @@ func newRemedialActionTestManager(t *testing.T, multipooler *clustermetadatapb.M
 	t.Cleanup(func() { ts.Close() })
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 	return &MultiPoolerManager{
-		logger:       slog.Default(),
-		actionLock:   NewActionLock(),
-		multipooler:  multipooler,
-		serviceID:    multipooler.Id,
-		topoClient:   ts,
-		servingState: NewStateManager(slog.Default(), multipooler),
+		logger:        slog.Default(),
+		actionLock:    NewActionLock(),
+		multipooler:   multipooler,
+		serviceID:     multipooler.Id,
+		topoClient:    ts,
+		servingState:  NewStateManager(slog.Default(), multipooler),
+		topoPublisher: newTopoPublisher(slog.Default(), ts),
 	}
 }
 


### PR DESCRIPTION
Notify() now dereferences the receiver to acquire its mutex before checking the action lock, so a nil topoPublisher panics. The test helper was constructing MultiPoolerManager without this field.

Looks like an uncaught merge conflict from https://github.com/multigres/multigres/pull/842