### PR TITLE
test(queryserving): increase client timeout in buffer test workers

### DIFF
--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -35,6 +35,17 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
+const (
+	// bufferWindow matches the --buffer-window flag used by newBufferTestCluster.
+	bufferWindow = 10 * time.Second
+
+	// clientQueryTimeout is the per-query deadline for test workers. It must
+	// comfortably exceed bufferWindow so that a request buffered during failover
+	// survives the full drain before the client side gives up. A 20 s margin
+	// above the buffer window keeps the test robust on loaded CI machines.
+	clientQueryTimeout = bufferWindow + 20*time.Second
+)
+
 // TestBufferPlannedFailover verifies that multigateway's failover buffering
 // absorbs a planned failover with zero application-visible errors.
 //
@@ -413,7 +424,7 @@ func triggerFailover(t *testing.T, setup *shardsetup.ShardSetup) {
 
 // execTransaction runs a single INSERT inside a BEGIN/COMMIT transaction.
 func execTransaction(db *sql.DB, id int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), clientQueryTimeout)
 	defer cancel()
 
 	tx, err := db.BeginTx(ctx, nil)
@@ -430,7 +441,7 @@ func execTransaction(db *sql.DB, id int64) error {
 // execPrepared runs a single INSERT using a prepared statement.
 // database/sql automatically uses the extended query protocol with $1 params.
 func execPrepared(db *sql.DB, id int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), clientQueryTimeout)
 	defer cancel()
 
 	stmt, err := db.PrepareContext(ctx, "INSERT INTO buf_prep_test (id, val) VALUES ($1, $2)")


### PR DESCRIPTION
The 15 s per-query deadline in execPrepared and execTransaction left only a 5 s margin above the 10 s buffer window. On a loaded CI machine the failover + drain could consume that margin, causing one request to hit the client deadline before multigateway responded, producing a spurious failure in the TestBufferTransactionsAndPreparedStatements test.

Fixed by replacing the hardcoded 15 s with a named clientQueryTimeout constant that makes the relationship to the buffer window explicit and gives a comfortable margin for slow CI runs.

Note that this will not increase the runtime of the test, just reduce the risk of spurious failures.