### PR TITLE
feat(multiorch): make ManagerHealthStream timing configurable by orchestrator

### DIFF
--- a/go/common/timeouts/rpc.go
+++ b/go/common/timeouts/rpc.go
@@ -20,3 +20,18 @@ import "time"
 // RemoteOperationTimeout is the default timeout for remote operations such as
 // RPC calls, etcd data fetches, and synchronous replication health checks.
 const RemoteOperationTimeout = 15 * time.Second
+
+// DefaultHealthStreamStalenessTimeout is the default staleness watchdog timeout for
+// ManagerHealthStream connections. If no message is received within this window
+// the client reconnects and the server advertises this value in the start response.
+const DefaultHealthStreamStalenessTimeout = 90 * time.Second
+
+// DefaultHealthHeartbeatInterval is the interval between periodic health
+// broadcasts when no state changes occur.
+const DefaultHealthHeartbeatInterval = 30 * time.Second
+
+// DefaultSnapshotInterval is the proactive snapshot rate used when the
+// orchestrator does not specify snapshot_interval in the start message.
+// This guarantees that postgres state changes (e.g. process death) reach the
+// orchestrator within this interval even when the local monitor is disabled.
+const DefaultSnapshotInterval = 5 * time.Second

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -423,7 +423,7 @@ func (x BackupMetadata_Status) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use BackupMetadata_Status.Descriptor instead.
 func (BackupMetadata_Status) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41, 0}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42, 0}
 }
 
 // Primary connection information parsed from PostgreSQL's primary_conninfo setting
@@ -1553,12 +1553,21 @@ func (*ManagerHealthStreamClientMessage_Start) isManagerHealthStreamClientMessag
 func (*ManagerHealthStreamClientMessage_Poll) isManagerHealthStreamClientMessage_Message() {}
 
 // ManagerHealthStreamStartRequest is sent as the first message inside
-// ManagerHealthStreamClientMessage. There are no fields in this message; its
-// presence is the signal to start the stream.
+// ManagerHealthStreamClientMessage to open the stream and negotiate timing.
 type ManagerHealthStreamStartRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// snapshot_interval is how often the server should proactively push
+	// a snapshot when no state-change broadcast has occurred.
+	// Zero means use the server default (currently 5s).
+	SnapshotInterval *durationpb.Duration `protobuf:"bytes,1,opt,name=snapshot_interval,json=snapshotInterval,proto3" json:"snapshot_interval,omitempty"`
+	// staleness_timeout is the window after which the client will treat
+	// the stream as stale and reconnect. The server echoes the actual value it
+	// will use in ManagerHealthStreamStartResponse and in every subsequent
+	// ManagerHealthSnapshot.timeout_seconds.
+	// Zero means use the server default (currently 90s).
+	StalenessTimeout *durationpb.Duration `protobuf:"bytes,2,opt,name=staleness_timeout,json=stalenessTimeout,proto3" json:"staleness_timeout,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ManagerHealthStreamStartRequest) Reset() {
@@ -1589,6 +1598,20 @@ func (x *ManagerHealthStreamStartRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ManagerHealthStreamStartRequest.ProtoReflect.Descriptor instead.
 func (*ManagerHealthStreamStartRequest) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ManagerHealthStreamStartRequest) GetSnapshotInterval() *durationpb.Duration {
+	if x != nil {
+		return x.SnapshotInterval
+	}
+	return nil
+}
+
+func (x *ManagerHealthStreamStartRequest) GetStalenessTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.StalenessTimeout
+	}
+	return nil
 }
 
 // ManagerHealthStreamPollRequest triggers an immediate health snapshot.
@@ -1629,20 +1652,81 @@ func (*ManagerHealthStreamPollRequest) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{17}
 }
 
-// ManagerHealthStreamResponse is sent by the pooler on connection, on every
-// state change, on poll request, and periodically as a heartbeat snapshot.
-// Every message is a full health snapshot — there are no incremental updates.
+// ManagerHealthStreamStartResponse is the first message the server sends after
+// receiving a valid start message. It reports the actual values the server will
+// use, which may differ from the requested values if they were clamped or adjusted.
+type ManagerHealthStreamStartResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// snapshot_interval is the per-stream proactive snapshot interval.
+	SnapshotInterval *durationpb.Duration `protobuf:"bytes,1,opt,name=snapshot_interval,json=snapshotInterval,proto3" json:"snapshot_interval,omitempty"`
+	// staleness_timeout is the staleness window that will be echoed in
+	// every subsequent ManagerHealthSnapshot.timeout_seconds.
+	StalenessTimeout *durationpb.Duration `protobuf:"bytes,2,opt,name=staleness_timeout,json=stalenessTimeout,proto3" json:"staleness_timeout,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ManagerHealthStreamStartResponse) Reset() {
+	*x = ManagerHealthStreamStartResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagerHealthStreamStartResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagerHealthStreamStartResponse) ProtoMessage() {}
+
+func (x *ManagerHealthStreamStartResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagerHealthStreamStartResponse.ProtoReflect.Descriptor instead.
+func (*ManagerHealthStreamStartResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ManagerHealthStreamStartResponse) GetSnapshotInterval() *durationpb.Duration {
+	if x != nil {
+		return x.SnapshotInterval
+	}
+	return nil
+}
+
+func (x *ManagerHealthStreamStartResponse) GetStalenessTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.StalenessTimeout
+	}
+	return nil
+}
+
+// ManagerHealthStreamResponse is sent by the pooler to the orchestrator.
+// The first message is always a ManagerHealthStreamStartResponse confirming
+// the negotiated timing; subsequent messages are health snapshots.
 type ManagerHealthStreamResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The full health state of the pooler.
-	Snapshot      *ManagerHealthSnapshot `protobuf:"bytes,1,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	// Types that are valid to be assigned to Message:
+	//
+	//	*ManagerHealthStreamResponse_Start
+	//	*ManagerHealthStreamResponse_Snapshot
+	Message       isManagerHealthStreamResponse_Message `protobuf_oneof:"message"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ManagerHealthStreamResponse) Reset() {
 	*x = ManagerHealthStreamResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[18]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1654,7 +1738,7 @@ func (x *ManagerHealthStreamResponse) String() string {
 func (*ManagerHealthStreamResponse) ProtoMessage() {}
 
 func (x *ManagerHealthStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[18]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1667,15 +1751,51 @@ func (x *ManagerHealthStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManagerHealthStreamResponse.ProtoReflect.Descriptor instead.
 func (*ManagerHealthStreamResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{18}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ManagerHealthStreamResponse) GetMessage() isManagerHealthStreamResponse_Message {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *ManagerHealthStreamResponse) GetStart() *ManagerHealthStreamStartResponse {
+	if x != nil {
+		if x, ok := x.Message.(*ManagerHealthStreamResponse_Start); ok {
+			return x.Start
+		}
+	}
+	return nil
 }
 
 func (x *ManagerHealthStreamResponse) GetSnapshot() *ManagerHealthSnapshot {
 	if x != nil {
-		return x.Snapshot
+		if x, ok := x.Message.(*ManagerHealthStreamResponse_Snapshot); ok {
+			return x.Snapshot
+		}
 	}
 	return nil
 }
+
+type isManagerHealthStreamResponse_Message interface {
+	isManagerHealthStreamResponse_Message()
+}
+
+type ManagerHealthStreamResponse_Start struct {
+	// Sent once immediately after the start message is received.
+	Start *ManagerHealthStreamStartResponse `protobuf:"bytes,1,opt,name=start,proto3,oneof"`
+}
+
+type ManagerHealthStreamResponse_Snapshot struct {
+	// Full health snapshot, sent on connection, state change, poll, or heartbeat.
+	Snapshot *ManagerHealthSnapshot `protobuf:"bytes,2,opt,name=snapshot,proto3,oneof"`
+}
+
+func (*ManagerHealthStreamResponse_Start) isManagerHealthStreamResponse_Message() {}
+
+func (*ManagerHealthStreamResponse_Snapshot) isManagerHealthStreamResponse_Message() {}
 
 // ManagerHealthSnapshot is a full health snapshot of the pooler.
 // Sent immediately on connection, on any state change, and periodically as a
@@ -1696,7 +1816,7 @@ type ManagerHealthSnapshot struct {
 
 func (x *ManagerHealthSnapshot) Reset() {
 	*x = ManagerHealthSnapshot{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[19]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1708,7 +1828,7 @@ func (x *ManagerHealthSnapshot) String() string {
 func (*ManagerHealthSnapshot) ProtoMessage() {}
 
 func (x *ManagerHealthSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[19]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1721,7 +1841,7 @@ func (x *ManagerHealthSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManagerHealthSnapshot.ProtoReflect.Descriptor instead.
 func (*ManagerHealthSnapshot) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{19}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ManagerHealthSnapshot) GetStatus() *StatusResponse {
@@ -1763,7 +1883,7 @@ type EmergencyDemoteRequest struct {
 
 func (x *EmergencyDemoteRequest) Reset() {
 	*x = EmergencyDemoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[20]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1775,7 +1895,7 @@ func (x *EmergencyDemoteRequest) String() string {
 func (*EmergencyDemoteRequest) ProtoMessage() {}
 
 func (x *EmergencyDemoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[20]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1788,7 +1908,7 @@ func (x *EmergencyDemoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyDemoteRequest.ProtoReflect.Descriptor instead.
 func (*EmergencyDemoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{20}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *EmergencyDemoteRequest) GetConsensusTerm() int64 {
@@ -1828,7 +1948,7 @@ type EmergencyDemoteResponse struct {
 
 func (x *EmergencyDemoteResponse) Reset() {
 	*x = EmergencyDemoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1840,7 +1960,7 @@ func (x *EmergencyDemoteResponse) String() string {
 func (*EmergencyDemoteResponse) ProtoMessage() {}
 
 func (x *EmergencyDemoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[21]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1853,7 +1973,7 @@ func (x *EmergencyDemoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmergencyDemoteResponse.ProtoReflect.Descriptor instead.
 func (*EmergencyDemoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{21}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *EmergencyDemoteResponse) GetWasAlreadyDemoted() bool {
@@ -1905,7 +2025,7 @@ type DemoteStalePrimaryRequest struct {
 
 func (x *DemoteStalePrimaryRequest) Reset() {
 	*x = DemoteStalePrimaryRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +2037,7 @@ func (x *DemoteStalePrimaryRequest) String() string {
 func (*DemoteStalePrimaryRequest) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +2050,7 @@ func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryRequest.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DemoteStalePrimaryRequest) GetSource() *clustermetadata.MultiPooler {
@@ -1968,7 +2088,7 @@ type DemoteStalePrimaryResponse struct {
 
 func (x *DemoteStalePrimaryResponse) Reset() {
 	*x = DemoteStalePrimaryResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1980,7 +2100,7 @@ func (x *DemoteStalePrimaryResponse) String() string {
 func (*DemoteStalePrimaryResponse) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1993,7 +2113,7 @@ func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryResponse.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DemoteStalePrimaryResponse) GetSuccess() bool {
@@ -2052,7 +2172,7 @@ type PromoteRequest struct {
 
 func (x *PromoteRequest) Reset() {
 	*x = PromoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2064,7 +2184,7 @@ func (x *PromoteRequest) String() string {
 func (*PromoteRequest) ProtoMessage() {}
 
 func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2077,7 +2197,7 @@ func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteRequest.ProtoReflect.Descriptor instead.
 func (*PromoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PromoteRequest) GetConsensusTerm() int64 {
@@ -2150,7 +2270,7 @@ type PromoteResponse struct {
 
 func (x *PromoteResponse) Reset() {
 	*x = PromoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2162,7 +2282,7 @@ func (x *PromoteResponse) String() string {
 func (*PromoteResponse) ProtoMessage() {}
 
 func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2175,7 +2295,7 @@ func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteResponse.ProtoReflect.Descriptor instead.
 func (*PromoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PromoteResponse) GetLsnPosition() string {
@@ -2223,7 +2343,7 @@ type ConfigureSynchronousReplicationRequest struct {
 
 func (x *ConfigureSynchronousReplicationRequest) Reset() {
 	*x = ConfigureSynchronousReplicationRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2235,7 +2355,7 @@ func (x *ConfigureSynchronousReplicationRequest) String() string {
 func (*ConfigureSynchronousReplicationRequest) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2248,7 +2368,7 @@ func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ConfigureSynchronousReplicationRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ConfigureSynchronousReplicationRequest) GetSynchronousCommit() SynchronousCommitLevel {
@@ -2301,7 +2421,7 @@ type ConfigureSynchronousReplicationResponse struct {
 
 func (x *ConfigureSynchronousReplicationResponse) Reset() {
 	*x = ConfigureSynchronousReplicationResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2313,7 +2433,7 @@ func (x *ConfigureSynchronousReplicationResponse) String() string {
 func (*ConfigureSynchronousReplicationResponse) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2326,7 +2446,7 @@ func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use ConfigureSynchronousReplicationResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
 }
 
 // UpdateSynchronousStandbyList updates the synchronous standby list
@@ -2351,7 +2471,7 @@ type UpdateSynchronousStandbyListRequest struct {
 
 func (x *UpdateSynchronousStandbyListRequest) Reset() {
 	*x = UpdateSynchronousStandbyListRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2363,7 +2483,7 @@ func (x *UpdateSynchronousStandbyListRequest) String() string {
 func (*UpdateSynchronousStandbyListRequest) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2376,7 +2496,7 @@ func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpdateSynchronousStandbyListRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *UpdateSynchronousStandbyListRequest) GetOperation() StandbyUpdateOperation {
@@ -2429,7 +2549,7 @@ type UpdateSynchronousStandbyListResponse struct {
 
 func (x *UpdateSynchronousStandbyListResponse) Reset() {
 	*x = UpdateSynchronousStandbyListResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2441,7 +2561,7 @@ func (x *UpdateSynchronousStandbyListResponse) String() string {
 func (*UpdateSynchronousStandbyListResponse) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2454,7 +2574,7 @@ func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateSynchronousStandbyListResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
 }
 
 // ConsensusTerm represents the consensus term information for the pooler
@@ -2481,7 +2601,7 @@ type ConsensusTerm struct {
 
 func (x *ConsensusTerm) Reset() {
 	*x = ConsensusTerm{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2493,7 +2613,7 @@ func (x *ConsensusTerm) String() string {
 func (*ConsensusTerm) ProtoMessage() {}
 
 func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2506,7 +2626,7 @@ func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusTerm.ProtoReflect.Descriptor instead.
 func (*ConsensusTerm) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ConsensusTerm) GetTermNumber() int64 {
@@ -2567,7 +2687,7 @@ type BackupRequest struct {
 
 func (x *BackupRequest) Reset() {
 	*x = BackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2579,7 +2699,7 @@ func (x *BackupRequest) String() string {
 func (*BackupRequest) ProtoMessage() {}
 
 func (x *BackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2592,7 +2712,7 @@ func (x *BackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupRequest.ProtoReflect.Descriptor instead.
 func (*BackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *BackupRequest) GetForcePrimary() bool {
@@ -2635,7 +2755,7 @@ type BackupResponse struct {
 
 func (x *BackupResponse) Reset() {
 	*x = BackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2647,7 +2767,7 @@ func (x *BackupResponse) String() string {
 func (*BackupResponse) ProtoMessage() {}
 
 func (x *BackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2660,7 +2780,7 @@ func (x *BackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupResponse.ProtoReflect.Descriptor instead.
 func (*BackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *BackupResponse) GetBackupId() string {
@@ -2682,7 +2802,7 @@ type RestoreFromBackupRequest struct {
 
 func (x *RestoreFromBackupRequest) Reset() {
 	*x = RestoreFromBackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2694,7 +2814,7 @@ func (x *RestoreFromBackupRequest) String() string {
 func (*RestoreFromBackupRequest) ProtoMessage() {}
 
 func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2707,7 +2827,7 @@ func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *RestoreFromBackupRequest) GetBackupId() string {
@@ -2726,7 +2846,7 @@ type RestoreFromBackupResponse struct {
 
 func (x *RestoreFromBackupResponse) Reset() {
 	*x = RestoreFromBackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2738,7 +2858,7 @@ func (x *RestoreFromBackupResponse) String() string {
 func (*RestoreFromBackupResponse) ProtoMessage() {}
 
 func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2751,7 +2871,7 @@ func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupResponse.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
 }
 
 // GetBackupsRequest requests backup information
@@ -2764,7 +2884,7 @@ type GetBackupsRequest struct {
 
 func (x *GetBackupsRequest) Reset() {
 	*x = GetBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2776,7 +2896,7 @@ func (x *GetBackupsRequest) String() string {
 func (*GetBackupsRequest) ProtoMessage() {}
 
 func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2789,7 +2909,7 @@ func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetBackupsRequest) GetLimit() uint32 {
@@ -2809,7 +2929,7 @@ type GetBackupsResponse struct {
 
 func (x *GetBackupsResponse) Reset() {
 	*x = GetBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2821,7 +2941,7 @@ func (x *GetBackupsResponse) String() string {
 func (*GetBackupsResponse) ProtoMessage() {}
 
 func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,7 +2954,7 @@ func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetBackupsResponse) GetBackups() []*BackupMetadata {
@@ -2855,7 +2975,7 @@ type GetBackupByJobIdRequest struct {
 
 func (x *GetBackupByJobIdRequest) Reset() {
 	*x = GetBackupByJobIdRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2867,7 +2987,7 @@ func (x *GetBackupByJobIdRequest) String() string {
 func (*GetBackupByJobIdRequest) ProtoMessage() {}
 
 func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2880,7 +3000,7 @@ func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetBackupByJobIdRequest) GetJobId() string {
@@ -2902,7 +3022,7 @@ type GetBackupByJobIdResponse struct {
 
 func (x *GetBackupByJobIdResponse) Reset() {
 	*x = GetBackupByJobIdResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2914,7 +3034,7 @@ func (x *GetBackupByJobIdResponse) String() string {
 func (*GetBackupByJobIdResponse) ProtoMessage() {}
 
 func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2927,7 +3047,7 @@ func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetBackupByJobIdResponse) GetBackup() *BackupMetadata {
@@ -2950,7 +3070,7 @@ type ExpireBackupsRequest struct {
 
 func (x *ExpireBackupsRequest) Reset() {
 	*x = ExpireBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2962,7 +3082,7 @@ func (x *ExpireBackupsRequest) String() string {
 func (*ExpireBackupsRequest) ProtoMessage() {}
 
 func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2975,7 +3095,7 @@ func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ExpireBackupsRequest) GetOverrides() map[string]string {
@@ -2996,7 +3116,7 @@ type ExpireBackupsResponse struct {
 
 func (x *ExpireBackupsResponse) Reset() {
 	*x = ExpireBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3008,7 +3128,7 @@ func (x *ExpireBackupsResponse) String() string {
 func (*ExpireBackupsResponse) ProtoMessage() {}
 
 func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3021,7 +3141,7 @@ func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ExpireBackupsResponse) GetExpiredBackupIds() []string {
@@ -3055,7 +3175,7 @@ type BackupMetadata struct {
 
 func (x *BackupMetadata) Reset() {
 	*x = BackupMetadata{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3067,7 +3187,7 @@ func (x *BackupMetadata) String() string {
 func (*BackupMetadata) ProtoMessage() {}
 
 func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3080,7 +3200,7 @@ func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupMetadata.ProtoReflect.Descriptor instead.
 func (*BackupMetadata) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *BackupMetadata) GetTableGroup() string {
@@ -3169,7 +3289,7 @@ type RewindToSourceRequest struct {
 
 func (x *RewindToSourceRequest) Reset() {
 	*x = RewindToSourceRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3181,7 +3301,7 @@ func (x *RewindToSourceRequest) String() string {
 func (*RewindToSourceRequest) ProtoMessage() {}
 
 func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3314,7 @@ func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceRequest.ProtoReflect.Descriptor instead.
 func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RewindToSourceRequest) GetSource() *clustermetadata.MultiPooler {
@@ -3219,7 +3339,7 @@ type RewindToSourceResponse struct {
 
 func (x *RewindToSourceResponse) Reset() {
 	*x = RewindToSourceResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3231,7 +3351,7 @@ func (x *RewindToSourceResponse) String() string {
 func (*RewindToSourceResponse) ProtoMessage() {}
 
 func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3244,7 +3364,7 @@ func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceResponse.ProtoReflect.Descriptor instead.
 func (*RewindToSourceResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *RewindToSourceResponse) GetSuccess() bool {
@@ -3281,7 +3401,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3293,7 +3413,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3306,7 +3426,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -3326,7 +3446,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3338,7 +3458,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3351,7 +3471,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{46}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -3433,11 +3553,18 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	" ManagerHealthStreamClientMessage\x12O\n" +
 	"\x05start\x18\x01 \x01(\v27.multipoolermanagerdata.ManagerHealthStreamStartRequestH\x00R\x05start\x12L\n" +
 	"\x04poll\x18\x02 \x01(\v26.multipoolermanagerdata.ManagerHealthStreamPollRequestH\x00R\x04pollB\t\n" +
-	"\amessage\"!\n" +
-	"\x1fManagerHealthStreamStartRequest\" \n" +
-	"\x1eManagerHealthStreamPollRequest\"h\n" +
-	"\x1bManagerHealthStreamResponse\x12I\n" +
-	"\bsnapshot\x18\x01 \x01(\v2-.multipoolermanagerdata.ManagerHealthSnapshotR\bsnapshot\"\xcf\x01\n" +
+	"\amessage\"\xb1\x01\n" +
+	"\x1fManagerHealthStreamStartRequest\x12F\n" +
+	"\x11snapshot_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10snapshotInterval\x12F\n" +
+	"\x11staleness_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x10stalenessTimeout\" \n" +
+	"\x1eManagerHealthStreamPollRequest\"\xb2\x01\n" +
+	" ManagerHealthStreamStartResponse\x12F\n" +
+	"\x11snapshot_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10snapshotInterval\x12F\n" +
+	"\x11staleness_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x10stalenessTimeout\"\xc7\x01\n" +
+	"\x1bManagerHealthStreamResponse\x12P\n" +
+	"\x05start\x18\x01 \x01(\v28.multipoolermanagerdata.ManagerHealthStreamStartResponseH\x00R\x05start\x12K\n" +
+	"\bsnapshot\x18\x02 \x01(\v2-.multipoolermanagerdata.ManagerHealthSnapshotH\x00R\bsnapshotB\t\n" +
+	"\amessage\"\xcf\x01\n" +
 	"\x15ManagerHealthSnapshot\x12>\n" +
 	"\x06status\x18\x01 \x01(\v2&.multipoolermanagerdata.StatusResponseR\x06status\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12A\n" +
@@ -3597,7 +3724,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresAction)(0),                             // 0: multipoolermanagerdata.PostgresAction
 	(SnapshotTrigger)(0),                            // 1: multipoolermanagerdata.SnapshotTrigger
@@ -3624,98 +3751,104 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*ManagerHealthStreamClientMessage)(nil),        // 22: multipoolermanagerdata.ManagerHealthStreamClientMessage
 	(*ManagerHealthStreamStartRequest)(nil),         // 23: multipoolermanagerdata.ManagerHealthStreamStartRequest
 	(*ManagerHealthStreamPollRequest)(nil),          // 24: multipoolermanagerdata.ManagerHealthStreamPollRequest
-	(*ManagerHealthStreamResponse)(nil),             // 25: multipoolermanagerdata.ManagerHealthStreamResponse
-	(*ManagerHealthSnapshot)(nil),                   // 26: multipoolermanagerdata.ManagerHealthSnapshot
-	(*EmergencyDemoteRequest)(nil),                  // 27: multipoolermanagerdata.EmergencyDemoteRequest
-	(*EmergencyDemoteResponse)(nil),                 // 28: multipoolermanagerdata.EmergencyDemoteResponse
-	(*DemoteStalePrimaryRequest)(nil),               // 29: multipoolermanagerdata.DemoteStalePrimaryRequest
-	(*DemoteStalePrimaryResponse)(nil),              // 30: multipoolermanagerdata.DemoteStalePrimaryResponse
-	(*PromoteRequest)(nil),                          // 31: multipoolermanagerdata.PromoteRequest
-	(*PromoteResponse)(nil),                         // 32: multipoolermanagerdata.PromoteResponse
-	(*ConfigureSynchronousReplicationRequest)(nil),  // 33: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	(*ConfigureSynchronousReplicationResponse)(nil), // 34: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
-	(*UpdateSynchronousStandbyListRequest)(nil),     // 35: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
-	(*UpdateSynchronousStandbyListResponse)(nil),    // 36: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	(*ConsensusTerm)(nil),                           // 37: multipoolermanagerdata.ConsensusTerm
-	(*BackupRequest)(nil),                           // 38: multipoolermanagerdata.BackupRequest
-	(*BackupResponse)(nil),                          // 39: multipoolermanagerdata.BackupResponse
-	(*RestoreFromBackupRequest)(nil),                // 40: multipoolermanagerdata.RestoreFromBackupRequest
-	(*RestoreFromBackupResponse)(nil),               // 41: multipoolermanagerdata.RestoreFromBackupResponse
-	(*GetBackupsRequest)(nil),                       // 42: multipoolermanagerdata.GetBackupsRequest
-	(*GetBackupsResponse)(nil),                      // 43: multipoolermanagerdata.GetBackupsResponse
-	(*GetBackupByJobIdRequest)(nil),                 // 44: multipoolermanagerdata.GetBackupByJobIdRequest
-	(*GetBackupByJobIdResponse)(nil),                // 45: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*ExpireBackupsRequest)(nil),                    // 46: multipoolermanagerdata.ExpireBackupsRequest
-	(*ExpireBackupsResponse)(nil),                   // 47: multipoolermanagerdata.ExpireBackupsResponse
-	(*BackupMetadata)(nil),                          // 48: multipoolermanagerdata.BackupMetadata
-	(*RewindToSourceRequest)(nil),                   // 49: multipoolermanagerdata.RewindToSourceRequest
-	(*RewindToSourceResponse)(nil),                  // 50: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),       // 51: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),      // 52: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                                 // 53: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                 // 54: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),         // 55: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),       // 56: google.protobuf.Timestamp
-	(*clustermetadata.MultiPooler)(nil), // 57: clustermetadata.MultiPooler
-	(*clustermetadata.ID)(nil),          // 58: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),     // 59: clustermetadata.PoolerType
+	(*ManagerHealthStreamStartResponse)(nil),        // 25: multipoolermanagerdata.ManagerHealthStreamStartResponse
+	(*ManagerHealthStreamResponse)(nil),             // 26: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*ManagerHealthSnapshot)(nil),                   // 27: multipoolermanagerdata.ManagerHealthSnapshot
+	(*EmergencyDemoteRequest)(nil),                  // 28: multipoolermanagerdata.EmergencyDemoteRequest
+	(*EmergencyDemoteResponse)(nil),                 // 29: multipoolermanagerdata.EmergencyDemoteResponse
+	(*DemoteStalePrimaryRequest)(nil),               // 30: multipoolermanagerdata.DemoteStalePrimaryRequest
+	(*DemoteStalePrimaryResponse)(nil),              // 31: multipoolermanagerdata.DemoteStalePrimaryResponse
+	(*PromoteRequest)(nil),                          // 32: multipoolermanagerdata.PromoteRequest
+	(*PromoteResponse)(nil),                         // 33: multipoolermanagerdata.PromoteResponse
+	(*ConfigureSynchronousReplicationRequest)(nil),  // 34: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	(*ConfigureSynchronousReplicationResponse)(nil), // 35: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
+	(*UpdateSynchronousStandbyListRequest)(nil),     // 36: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
+	(*UpdateSynchronousStandbyListResponse)(nil),    // 37: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	(*ConsensusTerm)(nil),                           // 38: multipoolermanagerdata.ConsensusTerm
+	(*BackupRequest)(nil),                           // 39: multipoolermanagerdata.BackupRequest
+	(*BackupResponse)(nil),                          // 40: multipoolermanagerdata.BackupResponse
+	(*RestoreFromBackupRequest)(nil),                // 41: multipoolermanagerdata.RestoreFromBackupRequest
+	(*RestoreFromBackupResponse)(nil),               // 42: multipoolermanagerdata.RestoreFromBackupResponse
+	(*GetBackupsRequest)(nil),                       // 43: multipoolermanagerdata.GetBackupsRequest
+	(*GetBackupsResponse)(nil),                      // 44: multipoolermanagerdata.GetBackupsResponse
+	(*GetBackupByJobIdRequest)(nil),                 // 45: multipoolermanagerdata.GetBackupByJobIdRequest
+	(*GetBackupByJobIdResponse)(nil),                // 46: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*ExpireBackupsRequest)(nil),                    // 47: multipoolermanagerdata.ExpireBackupsRequest
+	(*ExpireBackupsResponse)(nil),                   // 48: multipoolermanagerdata.ExpireBackupsResponse
+	(*BackupMetadata)(nil),                          // 49: multipoolermanagerdata.BackupMetadata
+	(*RewindToSourceRequest)(nil),                   // 50: multipoolermanagerdata.RewindToSourceRequest
+	(*RewindToSourceResponse)(nil),                  // 51: multipoolermanagerdata.RewindToSourceResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),       // 52: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),      // 53: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                                 // 54: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                 // 55: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),         // 56: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),       // 57: google.protobuf.Timestamp
+	(*clustermetadata.MultiPooler)(nil), // 58: clustermetadata.MultiPooler
+	(*clustermetadata.ID)(nil),          // 59: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),     // 60: clustermetadata.PoolerType
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	55, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	56, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	7,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	56, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	55, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	55, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	55, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
-	57, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
+	57, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	56, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	56, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	56, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	58, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
 	2,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	8,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	5,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	3,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	58, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	58, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	59, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	59, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	17, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	59, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	60, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	18, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	8,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	37, // 17: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
+	38, // 17: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
 	0,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	55, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	58, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
+	56, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	59, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
 	19, // 21: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
 	23, // 22: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	24, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	26, // 24: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
-	21, // 25: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	55, // 26: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
-	1,  // 27: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	55, // 28: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
-	57, // 29: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
-	33, // 30: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	58, // 31: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
-	58, // 32: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
-	58, // 33: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
-	5,  // 34: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
-	3,  // 35: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	58, // 36: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
-	4,  // 37: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
-	58, // 38: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
-	58, // 39: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
-	58, // 40: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
-	56, // 41: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
-	58, // 42: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
-	53, // 43: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
-	48, // 44: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
-	48, // 45: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	54, // 46: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	6,  // 47: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	59, // 48: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	57, // 49: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
-	50, // [50:50] is the sub-list for method output_type
-	50, // [50:50] is the sub-list for method input_type
-	50, // [50:50] is the sub-list for extension type_name
-	50, // [50:50] is the sub-list for extension extendee
-	0,  // [0:50] is the sub-list for field type_name
+	56, // 24: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	56, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	56, // 26: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	56, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	25, // 28: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
+	27, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
+	21, // 30: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
+	56, // 31: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	1,  // 32: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
+	56, // 33: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
+	58, // 34: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
+	34, // 35: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	59, // 36: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
+	59, // 37: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
+	59, // 38: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
+	5,  // 39: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
+	3,  // 40: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
+	59, // 41: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
+	4,  // 42: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
+	59, // 43: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
+	59, // 44: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
+	59, // 45: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
+	57, // 46: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
+	59, // 47: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
+	54, // 48: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	49, // 49: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
+	49, // 50: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
+	55, // 51: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	6,  // 52: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
+	60, // 53: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	58, // 54: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	55, // [55:55] is the sub-list for method output_type
+	55, // [55:55] is the sub-list for method input_type
+	55, // [55:55] is the sub-list for extension type_name
+	55, // [55:55] is the sub-list for extension extendee
+	0,  // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3727,13 +3860,17 @@ func file_multipoolermanagerdata_proto_init() {
 		(*ManagerHealthStreamClientMessage_Start)(nil),
 		(*ManagerHealthStreamClientMessage_Poll)(nil),
 	}
+	file_multipoolermanagerdata_proto_msgTypes[19].OneofWrappers = []any{
+		(*ManagerHealthStreamResponse_Start)(nil),
+		(*ManagerHealthStreamResponse_Snapshot)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   48,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiorch/recovery/health_stream.go
+++ b/go/services/multiorch/recovery/health_stream.go
@@ -16,15 +16,18 @@ package recovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -39,19 +42,6 @@ const (
 
 	// streamReconnectMaxBackoff caps the exponential backoff between retries.
 	streamReconnectMaxBackoff = 30 * time.Second
-
-	// streamStalenessTimeout is the default maximum time to wait for a health
-	// snapshot before treating the stream as stale and reconnecting.
-	//
-	// This is an application-level watchdog that catches the "server goroutine
-	// stuck but TCP alive" failure mode that gRPC keepalive does not cover.
-	// gRPC keepalive (10s ping / 10s timeout) handles dead TCP connections;
-	// this constant handles a live connection whose send loop has deadlocked.
-	//
-	// The server guarantees a snapshot at least every managerHealthPollingInterval
-	// (5s), so messages normally arrive far more frequently than this. The value
-	// is seeded from the server's recommended timeout in each snapshot.
-	streamStalenessTimeout = 90 * time.Second
 )
 
 // streamEntry holds the lifecycle handles for one active stream goroutine.
@@ -64,21 +54,31 @@ type streamEntry struct {
 	stream rpcclient.ManagerHealthStream
 }
 
-// HealthStream maintains one HealthStream stream per pooler. It replaces the
-// polling loop: instead of periodically calling the Status RPC, each pooler
+// HealthStream maintains one ManagerHealthStream stream per pooler. It replaces
+// the polling loop: instead of periodically calling the Status RPC, each pooler
 // pushes health snapshots to multiorch via a long-lived gRPC stream.
 //
 // When a snapshot arrives the HealthStream writes the same health fields into
 // the pooler store that the old pollPooler function wrote on success. On stream
 // disconnect the pooler is marked unreachable and reconnection is attempted
 // with exponential backoff (1s → 2s → … → 30s cap).
+//
+// The orchestrator sends its preferred snapshot_interval and staleness_timeout
+// in the start message. The server echoes back the actual values it will use in
+// a ManagerHealthStreamStartResponse, which the client uses to arm its staleness
+// watchdog.
 type HealthStream struct {
 	logger    *slog.Logger
 	rpcClient rpcclient.MultiPoolerClient
 	store     *store.PoolerStore
 
-	// stalenessTimeout overrides streamStalenessTimeout if positive.
-	// Set via WithStalenessTimeout; used in tests.
+	// snapshotInterval is requested from the server as the proactive snapshot
+	// tick rate. Zero means use the server default (currently 5s).
+	snapshotInterval time.Duration
+
+	// stalenessTimeout is sent to the server and used to arm the staleness
+	// watchdog (seeded from the start response). Zero means server default
+	// (timeouts.DefaultHealthStreamStalenessTimeout).
 	stalenessTimeout time.Duration
 
 	// Active stream goroutines, keyed by pooler ID string.
@@ -94,7 +94,16 @@ type HealthStream struct {
 // Option is a functional option for NewHealthStream.
 type Option func(*HealthStream)
 
-// WithStalenessTimeout overrides the default staleness timeout. Intended for tests.
+// WithSnapshotInterval sets the proactive snapshot interval sent to the server
+// in the start message.
+func WithSnapshotInterval(d time.Duration) Option {
+	return func(hs *HealthStream) {
+		hs.snapshotInterval = d
+	}
+}
+
+// WithStalenessTimeout sets the staleness timeout sent to the server and used
+// to arm the client-side staleness watchdog. Intended for tests.
 func WithStalenessTimeout(d time.Duration) Option {
 	return func(hs *HealthStream) {
 		hs.stalenessTimeout = d
@@ -216,45 +225,59 @@ func (hs *HealthStream) runStream(ctx context.Context, poolerID string, entry *s
 	}
 }
 
-// streamOnce opens one HealthStream stream and reads until the stream fails or
+// streamOnce opens one ManagerHealthStream and reads until the stream fails or
 // the context is cancelled. Returns (connected, err): connected is true if the
 // stream was established before any error occurred.
 func (hs *HealthStream) streamOnce(ctx context.Context, poolerID string, poolerHealth *multiorchdatapb.PoolerHealthState, entry *streamEntry) (connected bool, _ error) {
-	// Staleness watchdog: cancel the stream if no snapshot arrives within the
+	// Build the start request, sending the orchestrator's preferred timing.
+	// Zero values are omitted so the server uses its own defaults.
+	startReq := &multipoolermanagerdatapb.ManagerHealthStreamStartRequest{}
+	if hs.snapshotInterval > 0 {
+		startReq.SnapshotInterval = durationpb.New(hs.snapshotInterval)
+	}
+	if hs.stalenessTimeout > 0 {
+		startReq.StalenessTimeout = durationpb.New(hs.stalenessTimeout)
+	}
+
+	// Seed the staleness watchdog before any message is received. This is the
+	// value we sent; the server will confirm (or adjust) it in the start response,
+	// at which point we reset the watchdog to the echoed value.
+	initialStaleness := timeouts.DefaultHealthStreamStalenessTimeout
+	if hs.stalenessTimeout > 0 {
+		initialStaleness = hs.stalenessTimeout
+	}
+
+	// Staleness watchdog: cancel the stream if no message arrives within the
 	// timeout. This catches the "server goroutine stuck but TCP alive" failure
 	// mode that gRPC keepalive does not cover.
 	//
-	// The watchdog context is what we pass to ManagerHealthStream; cancelling it
+	// The watchdog context is passed to ManagerHealthStream so cancelling it
 	// terminates the gRPC stream and causes stream.Recv() to return an error.
 	watchdogCtx, cancelWatchdog := context.WithCancel(ctx)
 	defer cancelWatchdog()
 
-	// Resolve the effective staleness timeout (WithStalenessTimeout overrides the default).
-	effectiveStalenessTimeout := streamStalenessTimeout
-	if hs.stalenessTimeout > 0 {
-		effectiveStalenessTimeout = hs.stalenessTimeout
-	}
-
-	// resetCh is used by the recv loop to reset the staleness timer. The
-	// duration is taken from each snapshot's recommended timeout.
+	// resetCh carries the new timer duration whenever a message is received.
+	// Buffered so the recv loop never blocks on the watchdog goroutine.
 	resetCh := make(chan time.Duration, 1)
 	go func() {
-		timer := time.NewTimer(effectiveStalenessTimeout)
+		current := initialStaleness
+		timer := time.NewTimer(current)
 		defer timer.Stop()
 		for {
 			select {
 			case d := <-resetCh:
+				current = d
 				if !timer.Stop() {
 					select {
 					case <-timer.C:
 					default:
 					}
 				}
-				timer.Reset(d)
+				timer.Reset(current)
 			case <-timer.C:
-				hs.logger.WarnContext(ctx, "health stream stale: no snapshot received within timeout, reconnecting",
+				hs.logger.WarnContext(ctx, "health stream stale: no message received within timeout, reconnecting",
 					"pooler_id", poolerID,
-					"timeout", effectiveStalenessTimeout,
+					"timeout", current,
 				)
 				cancelWatchdog()
 				return
@@ -269,13 +292,41 @@ func (hs *HealthStream) streamOnce(ctx context.Context, poolerID string, poolerH
 		return false, fmt.Errorf("open stream: %w", err)
 	}
 
-	// Send the start message so the server starts sending snapshots.
+	// Send the start message with the negotiated timing preferences.
 	if err := stream.Send(&multipoolermanagerdatapb.ManagerHealthStreamClientMessage{
 		Message: &multipoolermanagerdatapb.ManagerHealthStreamClientMessage_Start{
-			Start: &multipoolermanagerdatapb.ManagerHealthStreamStartRequest{},
+			Start: startReq,
 		},
 	}); err != nil {
 		return false, fmt.Errorf("send start: %w", err)
+	}
+
+	// Read the start response — the first server message confirms the actual
+	// timing values the server will use.
+	firstMsg, err := stream.Recv()
+	if err != nil {
+		if watchdogCtx.Err() != nil && ctx.Err() == nil {
+			return false, errors.New("staleness timeout waiting for start response")
+		}
+		return false, fmt.Errorf("recv start response: %w", err)
+	}
+	startResp := firstMsg.GetStart()
+	if startResp == nil {
+		return false, fmt.Errorf("expected start response, got %T", firstMsg.GetMessage())
+	}
+	// Determine the effective staleness for the watchdog:
+	//   - If a local override is set (WithStalenessTimeout), use it directly.
+	//     This preserves sub-second precision used in tests.
+	//   - Otherwise, use the server-confirmed value from the start response.
+	confirmedStaleness := initialStaleness
+	if hs.stalenessTimeout == 0 {
+		if s := startResp.StalenessTimeout.AsDuration(); s > 0 {
+			confirmedStaleness = s
+		}
+	}
+	select {
+	case resetCh <- confirmedStaleness:
+	default:
 	}
 
 	// Expose the live stream so Poll() can send requests.
@@ -296,22 +347,25 @@ func (hs *HealthStream) streamOnce(ctx context.Context, poolerID string, poolerH
 			// Distinguish a staleness-triggered cancellation from an external one
 			// so the caller can log a useful error message.
 			if watchdogCtx.Err() != nil && ctx.Err() == nil {
-				return true, fmt.Errorf("staleness timeout: no snapshot received within %s", effectiveStalenessTimeout)
+				return true, fmt.Errorf("staleness timeout: no snapshot received within %s", confirmedStaleness)
 			}
 			return true, fmt.Errorf("recv: %w", err)
 		}
-		if resp.Snapshot != nil {
-			// Reset the staleness watchdog using the server's recommended timeout.
-			timeout := resp.Snapshot.Timeout.AsDuration()
-			if timeout <= 0 {
-				timeout = effectiveStalenessTimeout
+		if snap := resp.GetSnapshot(); snap != nil {
+			// Reset the staleness watchdog. Prefer the local override (which
+			// preserves sub-second precision); fall back to the server-echoed value.
+			timeout := confirmedStaleness
+			if hs.stalenessTimeout == 0 {
+				if s := snap.Timeout.AsDuration(); s > 0 {
+					timeout = s
+				}
 			}
 			select {
 			case resetCh <- timeout:
 			default:
 				// A reset is already pending; the watchdog will pick it up.
 			}
-			hs.applySnapshot(ctx, poolerID, poolerHealth, resp.Snapshot)
+			hs.applySnapshot(ctx, poolerID, poolerHealth, snap)
 		}
 	}
 }

--- a/go/services/multiorch/recovery/health_stream_test.go
+++ b/go/services/multiorch/recovery/health_stream_test.go
@@ -37,10 +37,34 @@ import (
 // makeSnapshot wraps a Status into a HealthStreamResponse snapshot.
 func makeSnapshot(status *multipoolermanagerdatapb.Status) *multipoolermanagerdatapb.ManagerHealthStreamResponse {
 	return &multipoolermanagerdatapb.ManagerHealthStreamResponse{
-		Snapshot: &multipoolermanagerdatapb.ManagerHealthSnapshot{
-			Status: &multipoolermanagerdatapb.StatusResponse{Status: status},
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamResponse_Snapshot{
+			Snapshot: &multipoolermanagerdatapb.ManagerHealthSnapshot{
+				Status: &multipoolermanagerdatapb.StatusResponse{Status: status},
+			},
 		},
 	}
+}
+
+// makeStartResponse builds a ManagerHealthStreamStartResponse with the given
+// timing values and wraps it in a ManagerHealthStreamResponse.
+func makeStartResponse(snapshotInterval, stalenessTimeout time.Duration) *multipoolermanagerdatapb.ManagerHealthStreamResponse {
+	return &multipoolermanagerdatapb.ManagerHealthStreamResponse{
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamResponse_Start{
+			Start: &multipoolermanagerdatapb.ManagerHealthStreamStartResponse{
+				SnapshotInterval: durationpb.New(snapshotInterval),
+				StalenessTimeout: durationpb.New(stalenessTimeout),
+			},
+		},
+	}
+}
+
+// completeHandshake reads the start message from the client and injects a
+// default start response on the stream. Tests that need to verify specific
+// timing values should inject their own start response instead.
+func completeHandshake(t *testing.T, stream *rpcclient.FakeManagerHealthStream) {
+	t.Helper()
+	waitForStart(t, stream.Sent)
+	stream.Ch <- makeStartResponse(5*time.Second, 90*time.Second)
 }
 
 // newTestHealthStream creates a HealthStream wired to the given FakeClient and store.
@@ -107,7 +131,7 @@ func TestHealthStream_UpdatesStore_Primary(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
 		PoolerType: clustermetadata.PoolerType_PRIMARY,
@@ -157,7 +181,7 @@ func TestHealthStream_UpdatesStore_Replica(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
 		PoolerType: clustermetadata.PoolerType_REPLICA,
@@ -214,7 +238,7 @@ func TestHealthStream_Poll(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Inject initial snapshot.
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
@@ -271,7 +295,7 @@ func TestHealthStream_Disconnect(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Inject one snapshot so the stream is "connected" with valid data.
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
@@ -317,7 +341,7 @@ func TestHealthStream_ConcurrentWatcherUpdate(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Concurrently promote the pooler in the topology (simulates PoolerWatcher update).
 	// The WaitGroup ensures the promotion is applied before we assert the final state.
@@ -335,10 +359,14 @@ func TestHealthStream_ConcurrentWatcherUpdate(t *testing.T) {
 		PostgresRunning: true,
 	})
 
+	// Wait until both the snapshot has been applied (IsLastCheckValid) and the
+	// concurrent watcher update has run (Type == PRIMARY). The goroutine fires
+	// 5ms after being spawned; using a combined condition ensures we don't race
+	// past the assertion before the watcher update lands.
 	require.Eventually(t, func() bool {
 		s, ok := poolerStore.Get(key)
-		return ok && s.IsLastCheckValid
-	}, 2*time.Second, 10*time.Millisecond)
+		return ok && s.IsLastCheckValid && s.MultiPooler.Type == clustermetadata.PoolerType_PRIMARY
+	}, 2*time.Second, 10*time.Millisecond, "watcher's topology update should not be overwritten by snapshot")
 
 	wg.Wait()
 
@@ -371,7 +399,7 @@ func TestHealthStream_DeletedDuringStream(t *testing.T) {
 	sm.Start(key)
 
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Delete the pooler from the store before the snapshot arrives.
 	poolerStore.Delete(key)
@@ -406,7 +434,7 @@ func TestHealthStream_LastPostgresReadyTime(t *testing.T) {
 
 		sm.Start(key)
 		stream := <-streamCh
-		waitForStart(t, stream.Sent)
+		completeHandshake(t, stream)
 
 		before := time.Now()
 		stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
@@ -448,7 +476,7 @@ func TestHealthStream_LastPostgresReadyTime(t *testing.T) {
 
 		sm.Start(key)
 		stream := <-streamCh
-		waitForStart(t, stream.Sent)
+		completeHandshake(t, stream)
 
 		stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
 			PoolerType:    clustermetadata.PoolerType_PRIMARY,
@@ -492,7 +520,7 @@ func TestHealthStream_StalenessTimeout(t *testing.T) {
 
 	// First stream connection.
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Send one snapshot so the stream is marked connected.
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
@@ -522,6 +550,57 @@ func TestHealthStream_StalenessTimeout(t *testing.T) {
 	}
 }
 
+// TestHealthStream_StartResponseConfig verifies that the start response from the server
+// is used to arm the staleness watchdog, and that WithSnapshotInterval / WithStalenessTimeout
+// options populate the start request sent to the server.
+func TestHealthStream_StartResponseConfig(t *testing.T) {
+	ctx := t.Context()
+
+	fakeClient := rpcclient.NewFakeClient()
+	streamCh := make(chan *rpcclient.FakeManagerHealthStream, 1)
+	fakeClient.OnManagerHealthStream = func(_ string, s *rpcclient.FakeManagerHealthStream) {
+		streamCh <- s
+	}
+
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+	// Request snapshot_interval=2s and staleness_timeout=20s.
+	sm := newTestHealthStream(ctx, fakeClient, poolerStore,
+		WithSnapshotInterval(2*time.Second),
+		WithStalenessTimeout(20*time.Second),
+	)
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "config-pooler"}
+	key := seedPooler(poolerStore, poolerID, clustermetadata.PoolerType_PRIMARY)
+
+	sm.Start(key)
+
+	stream := <-streamCh
+
+	// Verify the client sent our preferred values in the start message.
+	select {
+	case msg := <-stream.Sent:
+		req := msg.GetStart()
+		require.NotNil(t, req, "first message should be a start message")
+		require.Equal(t, durationpb.New(2*time.Second), req.SnapshotInterval, "snapshot_interval should be 2s")
+		require.Equal(t, durationpb.New(20*time.Second), req.StalenessTimeout, "staleness_timeout should be 20s")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for start message")
+	}
+
+	// Server responds with confirmed values.
+	stream.Ch <- makeStartResponse(2*time.Second, 20*time.Second)
+
+	// Send an initial snapshot so the stream is marked connected.
+	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
+		PoolerType:    clustermetadata.PoolerType_PRIMARY,
+		PostgresReady: true,
+	})
+	require.Eventually(t, func() bool {
+		s, ok := poolerStore.Get(key)
+		return ok && s.IsLastCheckValid
+	}, 2*time.Second, 10*time.Millisecond, "initial snapshot should be applied")
+}
+
 // TestHealthStream_TypeMismatch tests that when a pooler reports a different type than topology,
 // both are preserved: MultiPooler.Type stays as topology, PoolerType reflects what the pooler reports.
 func TestHealthStream_TypeMismatch(t *testing.T) {
@@ -542,7 +621,7 @@ func TestHealthStream_TypeMismatch(t *testing.T) {
 
 	sm.Start(key)
 	stream := <-streamCh
-	waitForStart(t, stream.Sent)
+	completeHandshake(t, stream)
 
 	// Pooler reports PRIMARY (type mismatch).
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
+	"github.com/multigres/multigres/go/common/timeouts"
 	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multipooler/manager"
@@ -149,25 +150,21 @@ func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *mu
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)
 }
 
-// managerHealthPollingInterval is how often ManagerHealthStream proactively
-// polls Status() even without a broadcast notification. This guarantees that
-// postgres state changes (e.g. process death) reach the orchestrator within
-// this interval even when the multipooler's local monitor is disabled.
-const managerHealthPollingInterval = 5 * time.Second
-
 // ManagerHealthStream is the bidirectional health stream implementation.
 //
-// The orchestrator sends a start message to open the stream, then may send poll
-// requests at any time to trigger an immediate snapshot.
+// The orchestrator sends a start message (optionally carrying snapshot_interval
+// and staleness_timeout preferences) to open the stream. The server responds
+// immediately with a ManagerHealthStreamStartResponse confirming the actual
+// values it will use. Subsequent messages are health snapshots.
 //
 // On each healthStreamer broadcast or poll request we call Status() to build a
 // full snapshot and send it. Every message is a complete snapshot — there are
-// no incremental updates or separate heartbeat message types.
+// no incremental updates.
 //
 // In addition to broadcast-driven snapshots, we also send a snapshot every
-// managerHealthPollingInterval (5s) regardless of broadcasts. This ensures that
-// postgres state changes — particularly process death detected by pgctld —
-// reach the orchestrator promptly even when the local monitor is disabled.
+// snapshotInterval regardless of broadcasts. This ensures that postgres state
+// changes — particularly process death detected by pgctld — reach the
+// orchestrator promptly even when the local monitor is disabled.
 //
 // When the health channel is closed (buffer full), we return Unavailable to
 // force the client to reconnect and receive a fresh initial snapshot.
@@ -181,8 +178,35 @@ func (s *managerService) ManagerHealthStream(
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "expected start message: %v", err)
 	}
-	if startMsg.GetStart() == nil {
+	req := startMsg.GetStart()
+	if req == nil {
 		return status.Error(codes.InvalidArgument, "first message must be a start message")
+	}
+
+	// Resolve effective timing values from the request, falling back to defaults.
+	// Use AsDuration() rather than direct .Seconds access: proto fields are nil
+	// when not set, and AsDuration() is nil-safe (returns 0 for nil).
+	snapshotInterval := timeouts.DefaultSnapshotInterval
+	if d := req.SnapshotInterval.AsDuration(); d > 0 {
+		snapshotInterval = d
+	}
+
+	timeout := timeouts.DefaultHealthStreamStalenessTimeout
+	if d := req.StalenessTimeout.AsDuration(); d > 0 {
+		timeout = d
+	}
+
+	// Send start response so the orchestrator knows the actual values in use.
+	response := &multipoolermanagerdatapb.ManagerHealthStreamResponse{
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamResponse_Start{
+			Start: &multipoolermanagerdatapb.ManagerHealthStreamStartResponse{
+				SnapshotInterval: durationpb.New(snapshotInterval),
+				StalenessTimeout: durationpb.New(timeout),
+			},
+		},
+	}
+	if err := stream.Send(response); err != nil {
+		return status.Errorf(codes.Internal, "send start response: %v", err)
 	}
 
 	// Subscribe to health state changes. We use the channel as a notification
@@ -198,7 +222,7 @@ func (s *managerService) ManagerHealthStream(
 	}
 
 	// Send initial snapshot immediately upon connection.
-	if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL); err != nil {
+	if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL, timeout); err != nil {
 		return err
 	}
 
@@ -223,9 +247,15 @@ func (s *managerService) ManagerHealthStream(
 
 	// Periodic ticker so we poll Status() even without a broadcast.
 	// This catches postgres process death (reported by pgctld) within
-	// managerHealthPollingInterval even when the local monitor is disabled.
-	pollTicker := time.NewTicker(managerHealthPollingInterval)
+	// snapshotInterval even when the local monitor is disabled.
+	pollTicker := time.NewTicker(snapshotInterval)
 	defer pollTicker.Stop()
+
+	// Convenience function to send a snapshot with the given trigger, used by
+	// all cases in the select below.
+	sendSnapshot := func(trigger multipoolermanagerdatapb.SnapshotTrigger) error {
+		return s.sendManagerHealthSnapshot(ctx, stream, trigger, timeout)
+	}
 
 	// Stream updates until the client disconnects or the context is cancelled.
 	for {
@@ -238,15 +268,15 @@ func (s *managerService) ManagerHealthStream(
 				// so the client reconnects and receives a fresh initial snapshot.
 				return status.Error(codes.Unavailable, "health stream buffer full, reconnect required")
 			}
-			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_BROADCAST); err != nil {
+			if err := sendSnapshot(multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_BROADCAST); err != nil {
 				return err
 			}
 		case <-pollCh:
-			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_POLL); err != nil {
+			if err := sendSnapshot(multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_POLL); err != nil {
 				return err
 			}
 		case <-pollTicker.C:
-			if err := s.sendManagerHealthSnapshot(ctx, stream, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_HEARTBEAT); err != nil {
+			if err := sendSnapshot(multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_HEARTBEAT); err != nil {
 				return err
 			}
 		}
@@ -263,6 +293,7 @@ func (s *managerService) sendManagerHealthSnapshot(
 	ctx context.Context,
 	stream multipoolermanagerpb.MultiPoolerManager_ManagerHealthStreamServer,
 	trigger multipoolermanagerdatapb.SnapshotTrigger,
+	timeout time.Duration,
 ) error {
 	st, err := s.manager.Status(ctx)
 	if err != nil {
@@ -271,12 +302,14 @@ func (s *managerService) sendManagerHealthSnapshot(
 
 	healthSnapshot := &multipoolermanagerdatapb.ManagerHealthSnapshot{
 		Status:  &multipoolermanagerdatapb.StatusResponse{Status: st},
-		Timeout: durationpb.New(manager.DefaultRecommendedStalenessTimeout),
+		Timeout: durationpb.New(timeout),
 		Trigger: trigger,
 	}
 
 	response := &multipoolermanagerdatapb.ManagerHealthStreamResponse{
-		Snapshot: healthSnapshot,
+		Message: &multipoolermanagerdatapb.ManagerHealthStreamResponse_Snapshot{
+			Snapshot: healthSnapshot,
+		},
 	}
 
 	return stream.Send(response)

--- a/go/services/multipooler/manager/health_provider.go
+++ b/go/services/multipooler/manager/health_provider.go
@@ -34,16 +34,6 @@ const (
 	// defaultRecommendedStalenessTimeout is the duration clients should use
 	// to detect a stale/dead health stream.
 	defaultRecommendedStalenessTimeout = 90 * time.Second
-
-	// DefaultRecommendedStalenessTimeout is the recommended staleness timeout
-	// advertised to orchestrators in ManagerHealthSnapshot.timeout. If the
-	// orchestrator receives no message within this window it should treat the
-	// pooler as unreachable and reconnect.
-	DefaultRecommendedStalenessTimeout time.Duration = defaultRecommendedStalenessTimeout
-
-	// defaultHealthHeartbeatInterval is the interval between periodic health
-	// broadcasts when no state changes occur.
-	defaultHealthHeartbeatInterval = 30 * time.Second
 )
 
 // healthStreamer streams health information to subscribers.

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	"github.com/multigres/multigres/go/services/multipooler/connpoolmanager"
@@ -376,7 +377,7 @@ func (pm *MultiPoolerManager) Open() {
 
 	// Start health heartbeat goroutine and transition to SERVING.
 	// SetState notifies all components (query service, heartbeat, health streamer).
-	go pm.runHealthHeartbeat(pm.ctx, defaultHealthHeartbeatInterval)
+	go pm.runHealthHeartbeat(pm.ctx, timeouts.DefaultHealthHeartbeatInterval)
 	if err := pm.servingState.SetState(pm.ctx, pm.multipooler.Type, clustermetadatapb.PoolerServingStatus_SERVING); err != nil {
 		pm.logger.ErrorContext(pm.ctx, "Failed to transition to SERVING on open", "error", err)
 	}

--- a/go/test/endtoend/multipooler/manager_health_stream_test.go
+++ b/go/test/endtoend/multipooler/manager_health_stream_test.go
@@ -59,11 +59,16 @@ func TestManagerHealthStream_SnapshotOnSetPrimaryConnInfo(t *testing.T) {
 		},
 	}))
 
-	// Drain the initial snapshot that the server sends immediately on connection.
+	// The first server message is a start response confirming the timing values.
+	startResp, err := stream.Recv()
+	require.NoError(t, err, "expected start response on stream open")
+	require.NotNil(t, startResp.GetStart(), "first message should be a start response")
+
+	// The second message is the initial health snapshot.
 	initial, err := stream.Recv()
-	require.NoError(t, err, "expected initial snapshot on stream open")
+	require.NoError(t, err, "expected initial snapshot after start response")
 	require.Equal(t, multipoolermanagerdatapb.SnapshotTrigger_SNAPSHOT_TRIGGER_INITIAL,
-		initial.GetSnapshot().GetTrigger(), "first message should be an initial snapshot")
+		initial.GetSnapshot().GetTrigger(), "second message should be an initial snapshot")
 
 	// Call SetPrimaryConnInfo on the standby. This configures primary_conninfo
 	// (without starting replication) and calls broadcastHealth() at the end,

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -278,9 +278,19 @@ message ManagerHealthStreamClientMessage {
 }
 
 // ManagerHealthStreamStartRequest is sent as the first message inside
-// ManagerHealthStreamClientMessage. There are no fields in this message; its
-// presence is the signal to start the stream.
+// ManagerHealthStreamClientMessage to open the stream and negotiate timing.
 message ManagerHealthStreamStartRequest {
+  // snapshot_interval is how often the server should proactively push
+  // a snapshot when no state-change broadcast has occurred.
+  // Zero means use the server default (currently 5s).
+  google.protobuf.Duration snapshot_interval = 1;
+
+  // staleness_timeout is the window after which the client will treat
+  // the stream as stale and reconnect. The server echoes the actual value it
+  // will use in ManagerHealthStreamStartResponse and in every subsequent
+  // ManagerHealthSnapshot.timeout_seconds.
+  // Zero means use the server default (currently 90s).
+  google.protobuf.Duration staleness_timeout = 2;
 }
 
 // ManagerHealthStreamPollRequest triggers an immediate health snapshot.
@@ -288,12 +298,28 @@ message ManagerHealthStreamStartRequest {
 message ManagerHealthStreamPollRequest {
 }
 
-// ManagerHealthStreamResponse is sent by the pooler on connection, on every
-// state change, on poll request, and periodically as a heartbeat snapshot.
-// Every message is a full health snapshot — there are no incremental updates.
+// ManagerHealthStreamStartResponse is the first message the server sends after
+// receiving a valid start message. It reports the actual values the server will
+// use, which may differ from the requested values if they were clamped or adjusted.
+message ManagerHealthStreamStartResponse {
+  // snapshot_interval is the per-stream proactive snapshot interval.
+  google.protobuf.Duration snapshot_interval = 1;
+
+  // staleness_timeout is the staleness window that will be echoed in
+  // every subsequent ManagerHealthSnapshot.timeout_seconds.
+  google.protobuf.Duration staleness_timeout = 2;
+}
+
+// ManagerHealthStreamResponse is sent by the pooler to the orchestrator.
+// The first message is always a ManagerHealthStreamStartResponse confirming
+// the negotiated timing; subsequent messages are health snapshots.
 message ManagerHealthStreamResponse {
-  // The full health state of the pooler.
-  ManagerHealthSnapshot snapshot = 1;
+  oneof message {
+    // Sent once immediately after the start message is received.
+    ManagerHealthStreamStartResponse start = 1;
+    // Full health snapshot, sent on connection, state change, poll, or heartbeat.
+    ManagerHealthSnapshot snapshot = 2;
+  }
 }
 
 // SnapshotTrigger describes why a ManagerHealthSnapshot was sent.


### PR DESCRIPTION
The orchestrator now negotiates snapshot_interval and staleness_timeout with the pooler on stream open. The pooler echoes back the actual values it will use in a ManagerHealthStreamStartResponse.

- snapshot_interval: how often the server proactively pushes snapshots when no state-change broadcast has occurred (default 5s)
- staleness_timeout: echoed in every snapshot so the client can arm a watchdog to detect a stuck stream (default 90s)

Fixes a nil pointer panic when the orchestrator omits timing fields from the start message (direct .Seconds field access on nil *durationpb.Duration).  Switches to AsDuration() which is nil-safe.

Consolidates staleness timeout, heartbeat interval, and snapshot interval constants into go/common/timeouts as DefaultHealthStreamStalenessTimeout, DefaultHealthHeartbeatInterval, and DefaultSnapshotInterval.

Closes MUL-360