### PR TITLE
fix(multigateway): address PR #828 review follow-ups for wrapped EXECUTE

### DIFF
--- a/go/common/fakepgserver/handler.go
+++ b/go/common/fakepgserver/handler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -178,6 +179,12 @@ func (h *fakeHandler) HandleSync(ctx context.Context, conn *server.Conn) error {
 
 // ConnectionClosed handles connection cleanup.
 func (h *fakeHandler) ConnectionClosed(conn *server.Conn) {}
+
+// GetPreparedStatementInfo returns nil — fakepgserver does not manage
+// gateway-level prepared statement consolidation.
+func (h *fakeHandler) GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo {
+	return nil
+}
 
 // Ensure fakeHandler implements server.Handler.
 var _ server.Handler = (*fakeHandler)(nil)

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
 
@@ -101,6 +102,10 @@ func (h *testHandler) HandleSync(ctx context.Context, conn *Conn) error {
 }
 
 func (h *testHandler) ConnectionClosed(conn *Conn) {}
+
+func (h *testHandler) GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo {
+	return nil
+}
 
 // testConn wraps both read and write buffers for testing.
 type testConn struct {

--- a/go/common/pgprotocol/server/handler.go
+++ b/go/common/pgprotocol/server/handler.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -113,4 +114,11 @@ type Handler interface {
 	// rolling back active transactions and releasing reserved connections.
 	// The connection's context may already be cancelled at this point.
 	ConnectionClosed(conn *Conn)
+
+	// GetPreparedStatementInfo returns metadata for a SQL-level prepared
+	// statement registered under the given user-visible name on connID.
+	// Returns nil if no such statement exists. This is used by the planner
+	// to resolve wrapped EXECUTE forms (EXPLAIN EXECUTE, CREATE TABLE AS
+	// EXECUTE) without type-asserting to a concrete handler implementation.
+	GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo
 }

--- a/go/common/pgprotocol/server/handler_test.go
+++ b/go/common/pgprotocol/server/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -216,3 +217,7 @@ func (h *testHandlerWithState) HandleSync(ctx context.Context, conn *Conn) error
 }
 
 func (h *testHandlerWithState) ConnectionClosed(conn *Conn) {}
+
+func (h *testHandlerWithState) GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo {
+	return nil
+}

--- a/go/common/pgprotocol/server/startup_test.go
+++ b/go/common/pgprotocol/server/startup_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -268,6 +269,10 @@ func (m *mockHandler) HandleSync(ctx context.Context, conn *Conn) error {
 }
 
 func (m *mockHandler) ConnectionClosed(conn *Conn) {}
+
+func (m *mockHandler) GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo {
+	return nil
+}
 
 // mockHashProvider implements scram.PasswordHashProvider for testing.
 // It accepts a single password for any user/database combination.

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -114,6 +114,12 @@ func (h *MultiGatewayHandler) Consolidator() *preparedstatement.Consolidator {
 	return h.psc
 }
 
+// GetPreparedStatementInfo returns metadata for a SQL-level prepared
+// statement registered under the given user-visible name on connID.
+func (h *MultiGatewayHandler) GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo {
+	return h.psc.GetPreparedStatementInfo(connID, name)
+}
+
 // errAbortedTransaction is the error returned when queries are executed in an aborted transaction.
 // PostgreSQL returns SQLSTATE 25P02 (in_failed_sql_transaction) for this condition.
 var errAbortedTransaction = mterrors.NewPgError("ERROR", mterrors.PgSSInFailedTransaction,

--- a/go/services/multigateway/planner/execute_unwrap.go
+++ b/go/services/multigateway/planner/execute_unwrap.go
@@ -20,7 +20,6 @@ import (
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
-	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
 // tryUnwrapWrappedExecute detects statements of the form `EXPLAIN EXECUTE p`
@@ -60,18 +59,10 @@ func (p *Planner) tryUnwrapWrappedExecute(sql string, stmt ast.Stmt, conn *serve
 		return nil, nil
 	}
 
-	// Reach into the gateway handler's consolidator to look up the user name.
-	// The planner only has a *server.Conn, but the conn's Handler is our
-	// MultiGatewayHandler which owns the consolidator.
-	mh, ok := conn.Handler().(*handler.MultiGatewayHandler)
-	if !ok {
-		// Unknown handler type — should only happen in tests that don't wire
-		// a MultiGatewayHandler. Fall through to the normal dispatch (which
-		// will fail at execution time with "prepared statement does not exist"
-		// just like today).
-		return nil, nil
-	}
-	psi := mh.Consolidator().GetPreparedStatementInfo(conn.ConnectionID(), execStmt.Name)
+	// Look up the user-visible prepared statement name via the Handler
+	// interface. The handler's consolidator maps the user name to a
+	// canonical name and the associated PreparedStatementInfo.
+	psi := conn.Handler().GetPreparedStatementInfo(conn.ConnectionID(), execStmt.Name)
 	if psi == nil {
 		return nil, mterrors.NewInvalidPreparedStatementError(execStmt.Name)
 	}

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -316,6 +316,16 @@ func (e *Executor) reserveAndStreamExecute(
 		}
 	}
 
+	// If the query references a gateway-managed prepared statement (wrapped
+	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), ensure it is
+	// parsed on this newly created backend connection before running the query.
+	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
+		if err := e.ensurePreparedWithName(ctx, reservedConn.Conn(), preparedStmt); err != nil {
+			reservedConn.Release(reserved.ReleaseError)
+			return nil, fmt.Errorf("failed to ensure prepared statement on new reserved connection: %w", err)
+		}
+	}
+
 	// Execute the actual query and stream results to the callback as they arrive,
 	// matching the non-reserved StreamExecute path. This avoids buffering the entire
 	// result set in memory for large queries inside transactions.
@@ -648,6 +658,16 @@ func (e *Executor) ensurePreparedWithName(ctx context.Context, conn *regular.Con
 	existing := connState.GetPreparedStatement(stmt.Name)
 	if existing != nil && existing.Query == stmt.Query {
 		return nil
+	}
+	// If the name is already taken with a different query (e.g. from a
+	// different gateway instance that reused the same canonical name space),
+	// close the stale statement first — PostgreSQL rejects Parse for an
+	// already-existing prepared statement name.
+	if existing != nil {
+		if err := conn.CloseStatement(ctx, stmt.Name); err != nil {
+			return fmt.Errorf("failed to close stale prepared statement %q: %w", stmt.Name, err)
+		}
+		connState.DeletePreparedStatement(stmt.Name)
 	}
 	if err := conn.Parse(ctx, stmt.Name, stmt.Query, stmt.ParamTypes); err != nil {
 		return fmt.Errorf("failed to parse statement %q: %w", stmt.Name, err)

--- a/go/test/endtoend/queryserving/prepared_stmt_test.go
+++ b/go/test/endtoend/queryserving/prepared_stmt_test.go
@@ -288,6 +288,27 @@ func TestWrappedPreparedStatementExecution(t *testing.T) {
 				assert.Equal(t, 3, count)
 			})
 
+			t.Run("create_temp_table_as_execute", func(t *testing.T) {
+				// CREATE TEMP TABLE ... AS EXECUTE goes through TempTableRoute →
+				// reserveAndStreamExecute, which creates a brand-new reserved
+				// connection. The prepared statement must be parsed on that
+				// new connection before the rewritten SQL runs — otherwise
+				// the backend errors with "prepared statement does not exist".
+				_, err := db.ExecContext(ctx, fmt.Sprintf("PREPARE p_ctas_temp AS SELECT id, value FROM %s ORDER BY id", tableName))
+				require.NoError(t, err)
+				defer func() { _, _ = db.ExecContext(ctx, "DEALLOCATE p_ctas_temp") }()
+
+				_, err = db.ExecContext(ctx, "CREATE TEMP TABLE temp_ctas_target AS EXECUTE p_ctas_temp")
+				require.NoError(t, err)
+				defer func() { _, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS temp_ctas_target") }()
+
+				// The temp table must contain the same rows as the source.
+				var count int
+				err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM temp_ctas_target").Scan(&count)
+				require.NoError(t, err)
+				assert.Equal(t, 3, count)
+			})
+
 			t.Run("explain_create_table_as_execute", func(t *testing.T) {
 				// Doubly-nested: EXPLAIN wrapping CREATE TABLE AS EXECUTE.
 				// pgregress select_into.sql and write_parallel.sql use this shape.


### PR DESCRIPTION
## Summary

- Follow-up to #828. Three review comments were acknowledged in replies but the code changes never landed before the PR was merged. This PR lands them.
- Fixes a functional bug where `CREATE TEMP TABLE t AS EXECUTE p` fails on the new-reserved-connection path with `prepared statement "stmtN" does not exist`.
- Fixes a cross-gateway name-collision path in `ensurePreparedWithName` and removes a concrete-type assertion on the handler.

## Problem

Three issues raised by @GuptaManan100 on #828 were replied to with "Good call — done" / "Fixed now" / "Ack, fixed now", but the corresponding code changes never made it into the merged PR:

1. `planner/execute_unwrap.go` still typecasts the handler to `*handler.MultiGatewayHandler` instead of using an interface method.
2. `executor.reserveAndStreamExecute` (the new-reserved-connection path used by `CREATE TEMP TABLE ... AS EXECUTE`) never calls `ensurePreparedWithName`, so the freshly reserved backend connection has no chance to parse the gateway-managed prepared statement and the query fails with ``prepared statement "stmtN" does not exist``.
3. `ensurePreparedWithName` calls `conn.Parse` unconditionally when `existing.Query != stmt.Query`. If two gateways independently named their statements the same (e.g., both picked `stmt42`), the second Parse fails with a duplicate-name error instead of closing the stale statement and re-preparing.

## Solution

1. Add `GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo` to the `pgprotocol/server.Handler` interface, implement it on the multigateway handler (delegating to the session consolidator) and on the test/fake handlers, and update `execute_unwrap.go` to use the interface.
2. In `reserveAndStreamExecute`, after the `BeginWithQuery` block and before `QueryStreaming`, ensure the prepared statement is parsed on the newly reserved connection. Add an e2e subtest `create_temp_table_as_execute` in `prepared_stmt_test.go` that exercises the full pipeline.
3. In `ensurePreparedWithName`, when an existing entry has a different query body, call `conn.CloseStatement` and delete the cached entry before parsing the new one.