### PR TITLE
WIP: feat(multipooler): add DRAINED serving status

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -265,6 +265,76 @@ func (AsyncReplicationFallbackMode) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{3}
 }
 
+// RemoveReason classifies why a pooler is being permanently removed
+// from the topology. Paired with MultiPooler.removed_at on tombstoned
+// records so operators and tooling can filter/understand historical
+// decommissions without parsing free text.
+type RemoveReason int32
+
+const (
+	// REMOVE_REASON_UNKNOWN is the zero value. Written by callers that do
+	// not specify a reason; consumers should treat this as
+	// "removed-but-unclassified."
+	RemoveReason_REMOVE_REASON_UNKNOWN RemoveReason = 0
+	// REMOVE_REASON_SCALE_DOWN. Removing this pooler as part of a planned
+	// capacity reduction.
+	RemoveReason_REMOVE_REASON_SCALE_DOWN RemoveReason = 1
+	// REMOVE_REASON_DECOMMISSION. The underlying host / pod is being
+	// permanently retired.
+	RemoveReason_REMOVE_REASON_DECOMMISSION RemoveReason = 2
+	// REMOVE_REASON_REPLACED. Pooler replaced by a new one (e.g., rolling
+	// update where the replacement has a different identity).
+	RemoveReason_REMOVE_REASON_REPLACED RemoveReason = 3
+	// REMOVE_REASON_OPERATOR_REQUESTED. Operator or admin explicitly
+	// requested removal via RPC without specifying a more specific reason.
+	RemoveReason_REMOVE_REASON_OPERATOR_REQUESTED RemoveReason = 4
+)
+
+// Enum value maps for RemoveReason.
+var (
+	RemoveReason_name = map[int32]string{
+		0: "REMOVE_REASON_UNKNOWN",
+		1: "REMOVE_REASON_SCALE_DOWN",
+		2: "REMOVE_REASON_DECOMMISSION",
+		3: "REMOVE_REASON_REPLACED",
+		4: "REMOVE_REASON_OPERATOR_REQUESTED",
+	}
+	RemoveReason_value = map[string]int32{
+		"REMOVE_REASON_UNKNOWN":            0,
+		"REMOVE_REASON_SCALE_DOWN":         1,
+		"REMOVE_REASON_DECOMMISSION":       2,
+		"REMOVE_REASON_REPLACED":           3,
+		"REMOVE_REASON_OPERATOR_REQUESTED": 4,
+	}
+)
+
+func (x RemoveReason) Enum() *RemoveReason {
+	p := new(RemoveReason)
+	*p = x
+	return p
+}
+
+func (x RemoveReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RemoveReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[4].Descriptor()
+}
+
+func (RemoveReason) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[4]
+}
+
+func (x RemoveReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RemoveReason.Descriptor instead.
+func (RemoveReason) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
+}
+
 // LeadershipSignal describes a leader's self-reported status for its current term.
 // Only published by nodes that are or were primary (primary_term != 0).
 // 0 (UNKNOWN) means the field was not intentionally set.
@@ -311,11 +381,11 @@ func (x LeadershipSignal) String() string {
 }
 
 func (LeadershipSignal) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[4].Descriptor()
+	return file_clustermetadata_proto_enumTypes[5].Descriptor()
 }
 
 func (LeadershipSignal) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[4]
+	return &file_clustermetadata_proto_enumTypes[5]
 }
 
 func (x LeadershipSignal) Number() protoreflect.EnumNumber {
@@ -324,7 +394,70 @@ func (x LeadershipSignal) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LeadershipSignal.Descriptor instead.
 func (LeadershipSignal) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{5}
+}
+
+// ServingSignal indicates whether a pooler is currently accepting
+// client-query RPCs. This is the signal gateway consumes to route traffic.
+// Unlike LeadershipSignal, ServingSignal is NOT term-scoped; absence after
+// process restart means unknown, not drained. Consumers treat absence as
+// ACTIVE.
+type ServingSignal int32
+
+const (
+	ServingSignal_SERVING_SIGNAL_UNKNOWN ServingSignal = 0
+	// Node is actively accepting query traffic.
+	ServingSignal_SERVING_SIGNAL_ACTIVE ServingSignal = 1
+	// Node is draining: not accepting new client-query RPCs, finishing
+	// in-flight queries. Gateway should stop routing new traffic to this node.
+	// The node may continue participating in consensus as a replica.
+	//
+	// Distinct from PoolerType.DRAINED, which is the topology-declared state
+	// written by multiorch for involuntary (data-diverged) drains. A pooler
+	// may report SERVING_SIGNAL_DRAINING for either a self-initiated voluntary
+	// drain or a response to an observed PoolerType.DRAINED on its own record.
+	ServingSignal_SERVING_SIGNAL_DRAINING ServingSignal = 2
+)
+
+// Enum value maps for ServingSignal.
+var (
+	ServingSignal_name = map[int32]string{
+		0: "SERVING_SIGNAL_UNKNOWN",
+		1: "SERVING_SIGNAL_ACTIVE",
+		2: "SERVING_SIGNAL_DRAINING",
+	}
+	ServingSignal_value = map[string]int32{
+		"SERVING_SIGNAL_UNKNOWN":  0,
+		"SERVING_SIGNAL_ACTIVE":   1,
+		"SERVING_SIGNAL_DRAINING": 2,
+	}
+)
+
+func (x ServingSignal) Enum() *ServingSignal {
+	p := new(ServingSignal)
+	*p = x
+	return p
+}
+
+func (x ServingSignal) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ServingSignal) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[6].Descriptor()
+}
+
+func (ServingSignal) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[6]
+}
+
+func (x ServingSignal) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ServingSignal.Descriptor instead.
+func (ServingSignal) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{6}
 }
 
 // ComponentType represents the type of Multigres component
@@ -368,11 +501,11 @@ func (x ID_ComponentType) String() string {
 }
 
 func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[5].Descriptor()
+	return file_clustermetadata_proto_enumTypes[7].Descriptor()
 }
 
 func (ID_ComponentType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[5]
+	return &file_clustermetadata_proto_enumTypes[7]
 }
 
 func (x ID_ComponentType) Number() protoreflect.EnumNumber {
@@ -896,7 +1029,16 @@ type MultiPooler struct {
 	PoolerDir string `protobuf:"bytes,10,opt,name=pooler_dir,json=poolerDir,proto3" json:"pooler_dir,omitempty"`
 	// PgDataDir is the PostgreSQL data directory path (from the PGDATA environment variable).
 	// Used by multiadmin to compute the primary's data directory for pgBackRest.
-	PgDataDir     string `protobuf:"bytes,11,opt,name=pg_data_dir,json=pgDataDir,proto3" json:"pg_data_dir,omitempty"`
+	PgDataDir string `protobuf:"bytes,11,opt,name=pg_data_dir,json=pgDataDir,proto3" json:"pg_data_dir,omitempty"`
+	// removed_at marks the node as permanently removed from the topology
+	// by intention (operator scale-down, decommission). Set best-effort by
+	// the pooler during a Drain() with remove_from_topology=true; absence
+	// means "not a tombstoned record." Consumers treat presence as
+	// "this node is not coming back."
+	RemovedAt *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=removed_at,json=removedAt,proto3" json:"removed_at,omitempty"`
+	// remove_reason classifies the removal. Only meaningful when
+	// removed_at is set.
+	RemoveReason  RemoveReason `protobuf:"varint,13,opt,name=remove_reason,json=removeReason,proto3,enum=clustermetadata.RemoveReason" json:"remove_reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1006,6 +1148,20 @@ func (x *MultiPooler) GetPgDataDir() string {
 		return x.PgDataDir
 	}
 	return ""
+}
+
+func (x *MultiPooler) GetRemovedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RemovedAt
+	}
+	return nil
+}
+
+func (x *MultiPooler) GetRemoveReason() RemoveReason {
+	if x != nil {
+		return x.RemoveReason
+	}
+	return RemoveReason_REMOVE_REASON_UNKNOWN
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -1924,6 +2080,62 @@ func (x *AvailabilityStatus) GetLeadershipStatus() *LeadershipStatus {
 	return nil
 }
 
+// ServingStatus is published by all poolers that accept query traffic.
+// It lets gateway distinguish an actively serving node from one that is
+// draining. Absent after process restart; consumers treat absence as ACTIVE.
+//
+// Sources: self-reported by the pooler (fast path) or synthesized by the
+// coordinator from observed health state, following the same pattern as
+// AvailabilityStatus.
+//
+// Why a wrapper message (vs. a bare ServingSignal field): leaves room
+// for additional routing-layer signals (e.g., a draining-since timestamp)
+// without a proto field-number change — same reason AvailabilityStatus
+// wraps LeadershipSignal.
+type ServingStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Signal        ServingSignal          `protobuf:"varint,1,opt,name=signal,proto3,enum=clustermetadata.ServingSignal" json:"signal,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServingStatus) Reset() {
+	*x = ServingStatus{}
+	mi := &file_clustermetadata_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServingStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServingStatus) ProtoMessage() {}
+
+func (x *ServingStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServingStatus.ProtoReflect.Descriptor instead.
+func (*ServingStatus) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ServingStatus) GetSignal() ServingSignal {
+	if x != nil {
+		return x.Signal
+	}
+	return ServingSignal_SERVING_SIGNAL_UNKNOWN
+}
+
 var File_clustermetadata_proto protoreflect.FileDescriptor
 
 const file_clustermetadata_proto_rawDesc = "" +
@@ -1961,7 +2173,7 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bendpoint\x18\x03 \x01(\tR\bendpoint\x12\x1d\n" +
 	"\n" +
 	"key_prefix\x18\x04 \x01(\tR\tkeyPrefix\x12.\n" +
-	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\x98\x04\n" +
+	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\x97\x05\n" +
 	"\vMultiPooler\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x1a\n" +
 	"\bdatabase\x18\x02 \x01(\tR\bdatabase\x12\x1f\n" +
@@ -1976,7 +2188,10 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\n" +
 	"pooler_dir\x18\n" +
 	" \x01(\tR\tpoolerDir\x12\x1e\n" +
-	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x1a:\n" +
+	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x129\n" +
+	"\n" +
+	"removed_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tremovedAt\x12B\n" +
+	"\rremove_reason\x18\r \x01(\x0e2\x1d.clustermetadata.RemoveReasonR\fremoveReason\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf1\x01\n" +
@@ -2047,7 +2262,9 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\fprimary_term\x18\x01 \x01(\x03R\vprimaryTerm\x129\n" +
 	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"d\n" +
 	"\x12AvailabilityStatus\x12N\n" +
-	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus*@\n" +
+	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus\"G\n" +
+	"\rServingStatus\x126\n" +
+	"\x06signal\x18\x01 \x01(\x0e2\x1e.clustermetadata.ServingSignalR\x06signal*@\n" +
 	"\n" +
 	"PoolerType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
@@ -2068,11 +2285,21 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x1cAsyncReplicationFallbackMode\x12+\n" +
 	"'ASYNC_REPLICATION_FALLBACK_MODE_UNKNOWN\x10\x00\x12)\n" +
 	"%ASYNC_REPLICATION_FALLBACK_MODE_ALLOW\x10\x01\x12*\n" +
-	"&ASYNC_REPLICATION_FALLBACK_MODE_REJECT\x10\x02*z\n" +
+	"&ASYNC_REPLICATION_FALLBACK_MODE_REJECT\x10\x02*\xa9\x01\n" +
+	"\fRemoveReason\x12\x19\n" +
+	"\x15REMOVE_REASON_UNKNOWN\x10\x00\x12\x1c\n" +
+	"\x18REMOVE_REASON_SCALE_DOWN\x10\x01\x12\x1e\n" +
+	"\x1aREMOVE_REASON_DECOMMISSION\x10\x02\x12\x1a\n" +
+	"\x16REMOVE_REASON_REPLACED\x10\x03\x12$\n" +
+	" REMOVE_REASON_OPERATOR_REQUESTED\x10\x04*z\n" +
 	"\x10LeadershipSignal\x12\x1d\n" +
 	"\x19LEADERSHIP_SIGNAL_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18LEADERSHIP_SIGNAL_ACTIVE\x10\x01\x12)\n" +
-	"%LEADERSHIP_SIGNAL_REQUESTING_DEMOTION\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
+	"%LEADERSHIP_SIGNAL_REQUESTING_DEMOTION\x10\x02*c\n" +
+	"\rServingSignal\x12\x1a\n" +
+	"\x16SERVING_SIGNAL_UNKNOWN\x10\x00\x12\x19\n" +
+	"\x15SERVING_SIGNAL_ACTIVE\x10\x01\x12\x1b\n" +
+	"\x17SERVING_SIGNAL_DRAINING\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
 
 var (
 	file_clustermetadata_proto_rawDescOnce sync.Once
@@ -2086,80 +2313,86 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                   // 0: clustermetadata.PoolerType
 	(PoolerServingStatus)(0),          // 1: clustermetadata.PoolerServingStatus
 	(QuorumType)(0),                   // 2: clustermetadata.QuorumType
 	(AsyncReplicationFallbackMode)(0), // 3: clustermetadata.AsyncReplicationFallbackMode
-	(LeadershipSignal)(0),             // 4: clustermetadata.LeadershipSignal
-	(ID_ComponentType)(0),             // 5: clustermetadata.ID.ComponentType
-	(*GlobalTopoConfig)(nil),          // 6: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),                      // 7: clustermetadata.Cell
-	(*Database)(nil),                  // 8: clustermetadata.Database
-	(*ShardInitClaim)(nil),            // 9: clustermetadata.ShardInitClaim
-	(*BackupLocation)(nil),            // 10: clustermetadata.BackupLocation
-	(*FilesystemBackup)(nil),          // 11: clustermetadata.FilesystemBackup
-	(*S3Backup)(nil),                  // 12: clustermetadata.S3Backup
-	(*MultiPooler)(nil),               // 13: clustermetadata.MultiPooler
-	(*MultiGateway)(nil),              // 14: clustermetadata.MultiGateway
-	(*MultiOrch)(nil),                 // 15: clustermetadata.MultiOrch
-	(*ID)(nil),                        // 16: clustermetadata.ID
-	(*KeyRange)(nil),                  // 17: clustermetadata.KeyRange
-	(*DurabilityPolicy)(nil),          // 18: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),                // 19: clustermetadata.RuleNumber
-	(*ShardRule)(nil),                 // 20: clustermetadata.ShardRule
-	(*PoolerPosition)(nil),            // 21: clustermetadata.PoolerPosition
-	(*HighestKnownRule)(nil),          // 22: clustermetadata.HighestKnownRule
-	(*TermRevocation)(nil),            // 23: clustermetadata.TermRevocation
-	(*ConsensusStatus)(nil),           // 24: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),          // 25: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),        // 26: clustermetadata.AvailabilityStatus
-	nil,                               // 27: clustermetadata.MultiPooler.PortMapEntry
-	nil,                               // 28: clustermetadata.MultiGateway.PortMapEntry
-	nil,                               // 29: clustermetadata.MultiOrch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),     // 30: google.protobuf.Timestamp
+	(RemoveReason)(0),                 // 4: clustermetadata.RemoveReason
+	(LeadershipSignal)(0),             // 5: clustermetadata.LeadershipSignal
+	(ServingSignal)(0),                // 6: clustermetadata.ServingSignal
+	(ID_ComponentType)(0),             // 7: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil),          // 8: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),                      // 9: clustermetadata.Cell
+	(*Database)(nil),                  // 10: clustermetadata.Database
+	(*ShardInitClaim)(nil),            // 11: clustermetadata.ShardInitClaim
+	(*BackupLocation)(nil),            // 12: clustermetadata.BackupLocation
+	(*FilesystemBackup)(nil),          // 13: clustermetadata.FilesystemBackup
+	(*S3Backup)(nil),                  // 14: clustermetadata.S3Backup
+	(*MultiPooler)(nil),               // 15: clustermetadata.MultiPooler
+	(*MultiGateway)(nil),              // 16: clustermetadata.MultiGateway
+	(*MultiOrch)(nil),                 // 17: clustermetadata.MultiOrch
+	(*ID)(nil),                        // 18: clustermetadata.ID
+	(*KeyRange)(nil),                  // 19: clustermetadata.KeyRange
+	(*DurabilityPolicy)(nil),          // 20: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),                // 21: clustermetadata.RuleNumber
+	(*ShardRule)(nil),                 // 22: clustermetadata.ShardRule
+	(*PoolerPosition)(nil),            // 23: clustermetadata.PoolerPosition
+	(*HighestKnownRule)(nil),          // 24: clustermetadata.HighestKnownRule
+	(*TermRevocation)(nil),            // 25: clustermetadata.TermRevocation
+	(*ConsensusStatus)(nil),           // 26: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),          // 27: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),        // 28: clustermetadata.AvailabilityStatus
+	(*ServingStatus)(nil),             // 29: clustermetadata.ServingStatus
+	nil,                               // 30: clustermetadata.MultiPooler.PortMapEntry
+	nil,                               // 31: clustermetadata.MultiGateway.PortMapEntry
+	nil,                               // 32: clustermetadata.MultiOrch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),     // 33: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	10, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	18, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	16, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	16, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
-	11, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
-	12, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	16, // 6: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	17, // 7: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	12, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
+	20, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	18, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	18, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	13, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
+	14, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
+	18, // 6: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
+	19, // 7: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 8: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
 	1,  // 9: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	27, // 10: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	16, // 11: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	28, // 12: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	16, // 13: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	29, // 14: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
-	5,  // 15: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
-	2,  // 16: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	3,  // 17: clustermetadata.DurabilityPolicy.async_fallback:type_name -> clustermetadata.AsyncReplicationFallbackMode
-	19, // 18: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	16, // 19: clustermetadata.ShardRule.primary_id:type_name -> clustermetadata.ID
-	16, // 20: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	18, // 21: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	16, // 22: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	30, // 23: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	20, // 24: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	20, // 25: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
-	16, // 26: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	30, // 27: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	23, // 28: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	21, // 29: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	22, // 30: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
-	4,  // 31: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	25, // 32: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	33, // [33:33] is the sub-list for method output_type
-	33, // [33:33] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	30, // 10: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	33, // 11: clustermetadata.MultiPooler.removed_at:type_name -> google.protobuf.Timestamp
+	4,  // 12: clustermetadata.MultiPooler.remove_reason:type_name -> clustermetadata.RemoveReason
+	18, // 13: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	31, // 14: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	18, // 15: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	32, // 16: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	7,  // 17: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	2,  // 18: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
+	3,  // 19: clustermetadata.DurabilityPolicy.async_fallback:type_name -> clustermetadata.AsyncReplicationFallbackMode
+	21, // 20: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	18, // 21: clustermetadata.ShardRule.primary_id:type_name -> clustermetadata.ID
+	18, // 22: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	20, // 23: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	18, // 24: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	33, // 25: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	22, // 26: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
+	22, // 27: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
+	18, // 28: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	33, // 29: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	25, // 30: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	23, // 31: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	24, // 32: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
+	5,  // 33: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	27, // 34: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	6,  // 35: clustermetadata.ServingStatus.signal:type_name -> clustermetadata.ServingSignal
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }
@@ -2176,8 +2409,8 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   24,
+			NumEnums:      8,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,13 +39,15 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xfb\t\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xd1\n" +
+	"\n" +
 	"\x12MultiPoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
 	"\x10StartReplication\x12/.multipoolermanagerdata.StartReplicationRequest\x1a0.multipoolermanagerdata.StartReplicationResponse\x12r\n" +
 	"\x0fStopReplication\x12..multipoolermanagerdata.StopReplicationRequest\x1a/.multipoolermanagerdata.StopReplicationResponse\x12W\n" +
-	"\x06Status\x12%.multipoolermanagerdata.StatusRequest\x1a&.multipoolermanagerdata.StatusResponse\x12W\n" +
+	"\x06Status\x12%.multipoolermanagerdata.StatusRequest\x1a&.multipoolermanagerdata.StatusResponse\x12T\n" +
+	"\x05Drain\x12$.multipoolermanagerdata.DrainRequest\x1a%.multipoolermanagerdata.DrainResponse\x12W\n" +
 	"\x06Backup\x12%.multipoolermanagerdata.BackupRequest\x1a&.multipoolermanagerdata.BackupResponse\x12x\n" +
 	"\x11RestoreFromBackup\x120.multipoolermanagerdata.RestoreFromBackupRequest\x1a1.multipoolermanagerdata.RestoreFromBackupResponse\x12c\n" +
 	"\n" +
@@ -60,50 +62,54 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.StartReplicationRequest)(nil),            // 1: multipoolermanagerdata.StartReplicationRequest
 	(*multipoolermanagerdata.StopReplicationRequest)(nil),             // 2: multipoolermanagerdata.StopReplicationRequest
 	(*multipoolermanagerdata.StatusRequest)(nil),                      // 3: multipoolermanagerdata.StatusRequest
-	(*multipoolermanagerdata.BackupRequest)(nil),                      // 4: multipoolermanagerdata.BackupRequest
-	(*multipoolermanagerdata.RestoreFromBackupRequest)(nil),           // 5: multipoolermanagerdata.RestoreFromBackupRequest
-	(*multipoolermanagerdata.GetBackupsRequest)(nil),                  // 6: multipoolermanagerdata.GetBackupsRequest
-	(*multipoolermanagerdata.GetBackupByJobIdRequest)(nil),            // 7: multipoolermanagerdata.GetBackupByJobIdRequest
-	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 8: multipoolermanagerdata.ExpireBackupsRequest
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 9: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 10: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 11: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 12: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 13: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 14: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 15: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 16: multipoolermanagerdata.RestoreFromBackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 17: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 18: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 19: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 20: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 21: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.DrainRequest)(nil),                       // 4: multipoolermanagerdata.DrainRequest
+	(*multipoolermanagerdata.BackupRequest)(nil),                      // 5: multipoolermanagerdata.BackupRequest
+	(*multipoolermanagerdata.RestoreFromBackupRequest)(nil),           // 6: multipoolermanagerdata.RestoreFromBackupRequest
+	(*multipoolermanagerdata.GetBackupsRequest)(nil),                  // 7: multipoolermanagerdata.GetBackupsRequest
+	(*multipoolermanagerdata.GetBackupByJobIdRequest)(nil),            // 8: multipoolermanagerdata.GetBackupByJobIdRequest
+	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 9: multipoolermanagerdata.ExpireBackupsRequest
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 10: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 11: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 12: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 13: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 14: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 15: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.DrainResponse)(nil),                      // 16: multipoolermanagerdata.DrainResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 17: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 18: multipoolermanagerdata.RestoreFromBackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 19: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 20: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 21: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 22: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 23: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultiPoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
 	1,  // 1: multipoolermanager.MultiPoolerManager.StartReplication:input_type -> multipoolermanagerdata.StartReplicationRequest
 	2,  // 2: multipoolermanager.MultiPoolerManager.StopReplication:input_type -> multipoolermanagerdata.StopReplicationRequest
 	3,  // 3: multipoolermanager.MultiPoolerManager.Status:input_type -> multipoolermanagerdata.StatusRequest
-	4,  // 4: multipoolermanager.MultiPoolerManager.Backup:input_type -> multipoolermanagerdata.BackupRequest
-	5,  // 5: multipoolermanager.MultiPoolerManager.RestoreFromBackup:input_type -> multipoolermanagerdata.RestoreFromBackupRequest
-	6,  // 6: multipoolermanager.MultiPoolerManager.GetBackups:input_type -> multipoolermanagerdata.GetBackupsRequest
-	7,  // 7: multipoolermanager.MultiPoolerManager.GetBackupByJobId:input_type -> multipoolermanagerdata.GetBackupByJobIdRequest
-	8,  // 8: multipoolermanager.MultiPoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
-	9,  // 9: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	10, // 10: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	11, // 11: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	12, // 12: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	13, // 13: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	14, // 14: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	15, // 15: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	16, // 16: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
-	17, // 17: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	18, // 18: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	19, // 19: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	20, // 20: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	21, // 21: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	11, // [11:22] is the sub-list for method output_type
-	0,  // [0:11] is the sub-list for method input_type
+	4,  // 4: multipoolermanager.MultiPoolerManager.Drain:input_type -> multipoolermanagerdata.DrainRequest
+	5,  // 5: multipoolermanager.MultiPoolerManager.Backup:input_type -> multipoolermanagerdata.BackupRequest
+	6,  // 6: multipoolermanager.MultiPoolerManager.RestoreFromBackup:input_type -> multipoolermanagerdata.RestoreFromBackupRequest
+	7,  // 7: multipoolermanager.MultiPoolerManager.GetBackups:input_type -> multipoolermanagerdata.GetBackupsRequest
+	8,  // 8: multipoolermanager.MultiPoolerManager.GetBackupByJobId:input_type -> multipoolermanagerdata.GetBackupByJobIdRequest
+	9,  // 9: multipoolermanager.MultiPoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
+	10, // 10: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	11, // 11: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	12, // 12: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	13, // 13: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	14, // 14: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	15, // 15: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	16, // 16: multipoolermanager.MultiPoolerManager.Drain:output_type -> multipoolermanagerdata.DrainResponse
+	17, // 17: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	18, // 18: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
+	19, // 19: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	20, // 20: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	21, // 21: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	22, // 22: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	23, // 23: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	12, // [12:24] is the sub-list for method output_type
+	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -144,6 +144,33 @@ func local_request_MultiPoolerManager_Status_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+func request_MultiPoolerManager_Drain_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.DrainRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Drain(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerManager_Drain_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.DrainRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Drain(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultiPoolerManager_Backup_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq multipoolermanagerdata.BackupRequest
@@ -435,6 +462,26 @@ func RegisterMultiPoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_Status_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Drain_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/Drain", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/Drain"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerManager_Drain_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_Drain_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Backup_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -670,6 +717,23 @@ func RegisterMultiPoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_Status_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Drain_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/Drain", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/Drain"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerManager_Drain_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_Drain_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Backup_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -797,6 +861,7 @@ var (
 	pattern_MultiPoolerManager_StartReplication_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "StartReplication"}, ""))
 	pattern_MultiPoolerManager_StopReplication_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "StopReplication"}, ""))
 	pattern_MultiPoolerManager_Status_0                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "Status"}, ""))
+	pattern_MultiPoolerManager_Drain_0                      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "Drain"}, ""))
 	pattern_MultiPoolerManager_Backup_0                     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "Backup"}, ""))
 	pattern_MultiPoolerManager_RestoreFromBackup_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "RestoreFromBackup"}, ""))
 	pattern_MultiPoolerManager_GetBackups_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "GetBackups"}, ""))
@@ -811,6 +876,7 @@ var (
 	forward_MultiPoolerManager_StartReplication_0           = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_StopReplication_0            = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_Status_0                     = runtime.ForwardResponseMessage
+	forward_MultiPoolerManager_Drain_0                      = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_Backup_0                     = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_RestoreFromBackup_0          = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_GetBackups_0                 = runtime.ForwardResponseMessage

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	MultiPoolerManager_StartReplication_FullMethodName           = "/multipoolermanager.MultiPoolerManager/StartReplication"
 	MultiPoolerManager_StopReplication_FullMethodName            = "/multipoolermanager.MultiPoolerManager/StopReplication"
 	MultiPoolerManager_Status_FullMethodName                     = "/multipoolermanager.MultiPoolerManager/Status"
+	MultiPoolerManager_Drain_FullMethodName                      = "/multipoolermanager.MultiPoolerManager/Drain"
 	MultiPoolerManager_Backup_FullMethodName                     = "/multipoolermanager.MultiPoolerManager/Backup"
 	MultiPoolerManager_RestoreFromBackup_FullMethodName          = "/multipoolermanager.MultiPoolerManager/RestoreFromBackup"
 	MultiPoolerManager_GetBackups_FullMethodName                 = "/multipoolermanager.MultiPoolerManager/GetBackups"
@@ -63,6 +64,15 @@ type MultiPoolerManagerClient interface {
 	// The multipooler returns information based on what type it believes itself to be,
 	// avoiding disparity between what MultiOrch thinks versus actual state
 	Status(ctx context.Context, in *multipoolermanagerdata.StatusRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.StatusResponse, error)
+	// Drain initiates voluntary draining of the pooler. The pooler stops
+	// accepting new client-query RPCs, finishes in-flight queries (up to
+	// drain_timeout), and — if currently primary — restarts as standby and
+	// signals resignation to multiorch (same path as EmergencyDemote).
+	//
+	// Idempotent: calling Drain on an already-draining node returns the
+	// current drain state. Calling with permanent=true upgrades a
+	// non-permanent drain to permanent.
+	Drain(ctx context.Context, in *multipoolermanagerdata.DrainRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.DrainResponse, error)
 	// Backup performs a backup
 	Backup(ctx context.Context, in *multipoolermanagerdata.BackupRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.BackupResponse, error)
 	// RestoreFromBackup restores from a backup
@@ -138,6 +148,16 @@ func (c *multiPoolerManagerClient) Status(ctx context.Context, in *multipoolerma
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.StatusResponse)
 	err := c.cc.Invoke(ctx, MultiPoolerManager_Status_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *multiPoolerManagerClient) Drain(ctx context.Context, in *multipoolermanagerdata.DrainRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.DrainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.DrainResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerManager_Drain_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -233,6 +253,15 @@ type MultiPoolerManagerServer interface {
 	// The multipooler returns information based on what type it believes itself to be,
 	// avoiding disparity between what MultiOrch thinks versus actual state
 	Status(context.Context, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error)
+	// Drain initiates voluntary draining of the pooler. The pooler stops
+	// accepting new client-query RPCs, finishes in-flight queries (up to
+	// drain_timeout), and — if currently primary — restarts as standby and
+	// signals resignation to multiorch (same path as EmergencyDemote).
+	//
+	// Idempotent: calling Drain on an already-draining node returns the
+	// current drain state. Calling with permanent=true upgrades a
+	// non-permanent drain to permanent.
+	Drain(context.Context, *multipoolermanagerdata.DrainRequest) (*multipoolermanagerdata.DrainResponse, error)
 	// Backup performs a backup
 	Backup(context.Context, *multipoolermanagerdata.BackupRequest) (*multipoolermanagerdata.BackupResponse, error)
 	// RestoreFromBackup restores from a backup
@@ -285,6 +314,9 @@ func (UnimplementedMultiPoolerManagerServer) StopReplication(context.Context, *m
 }
 func (UnimplementedMultiPoolerManagerServer) Status(context.Context, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Status not implemented")
+}
+func (UnimplementedMultiPoolerManagerServer) Drain(context.Context, *multipoolermanagerdata.DrainRequest) (*multipoolermanagerdata.DrainResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Drain not implemented")
 }
 func (UnimplementedMultiPoolerManagerServer) Backup(context.Context, *multipoolermanagerdata.BackupRequest) (*multipoolermanagerdata.BackupResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Backup not implemented")
@@ -396,6 +428,24 @@ func _MultiPoolerManager_Status_Handler(srv interface{}, ctx context.Context, de
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(MultiPoolerManagerServer).Status(ctx, req.(*multipoolermanagerdata.StatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MultiPoolerManager_Drain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.DrainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerManagerServer).Drain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerManager_Drain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerManagerServer).Drain(ctx, req.(*multipoolermanagerdata.DrainRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -537,6 +587,10 @@ var MultiPoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Status",
 			Handler:    _MultiPoolerManager_Status_Handler,
+		},
+		{
+			MethodName: "Drain",
+			Handler:    _MultiPoolerManager_Drain_Handler,
 		},
 		{
 			MethodName: "Backup",

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -423,7 +423,7 @@ func (x BackupMetadata_Status) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use BackupMetadata_Status.Descriptor instead.
 func (BackupMetadata_Status) EnumDescriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41, 0}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43, 0}
 }
 
 // Primary connection information parsed from PostgreSQL's primary_conninfo setting
@@ -1251,8 +1251,14 @@ type Status struct {
 	// This is the combined check: process must exist AND respond to pg_isready.
 	// Use postgres_running to check only if the process exists.
 	PostgresReady bool `protobuf:"varint,14,opt,name=postgres_ready,json=postgresReady,proto3" json:"postgres_ready,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// query_serving_status is the self-reported routing-layer signal
+	// gateway consumes to decide whether to send new client queries.
+	// Absence (after process restart) means ACTIVE. Distinct from
+	// MultiPooler.serving_status (PoolerServingStatus), which is a
+	// topology-lifecycle enum.
+	QueryServingStatus *clustermetadata.ServingStatus `protobuf:"bytes,15,opt,name=query_serving_status,json=queryServingStatus,proto3" json:"query_serving_status,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Status) Reset() {
@@ -1381,6 +1387,13 @@ func (x *Status) GetPostgresReady() bool {
 		return x.PostgresReady
 	}
 	return false
+}
+
+func (x *Status) GetQueryServingStatus() *clustermetadata.ServingStatus {
+	if x != nil {
+		return x.QueryServingStatus
+	}
+	return nil
 }
 
 // Status gets unified status that works for both PRIMARY and REPLICA poolers
@@ -1884,6 +1897,161 @@ func (x *EmergencyDemoteResponse) GetConnectionsTerminated() int32 {
 	return 0
 }
 
+// DrainRequest initiates voluntary drain of this pooler.
+type DrainRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// remove_from_topology indicates whether this pooler is being
+	// decommissioned. When true, the pooler will write a best-effort
+	// tombstone (removed_at + remove_reason) to its MultiPooler topology
+	// record on eventual shutdown.
+	RemoveFromTopology bool `protobuf:"varint,1,opt,name=remove_from_topology,json=removeFromTopology,proto3" json:"remove_from_topology,omitempty"`
+	// drain_timeout is the maximum wall-clock time to wait for in-flight
+	// client queries to finish before forcibly terminating connections.
+	// If unset or zero, defaults to 5s. Mirrors EmergencyDemoteRequest.drain_timeout.
+	DrainTimeout *durationpb.Duration `protobuf:"bytes,2,opt,name=drain_timeout,json=drainTimeout,proto3" json:"drain_timeout,omitempty"`
+	// remove_reason classifies the removal. Only meaningful when
+	// remove_from_topology=true; ignored otherwise. If
+	// remove_from_topology=true and this field is UNKNOWN, the tombstone
+	// will record UNKNOWN — callers are expected to set a real reason.
+	RemoveReason  clustermetadata.RemoveReason `protobuf:"varint,3,opt,name=remove_reason,json=removeReason,proto3,enum=clustermetadata.RemoveReason" json:"remove_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DrainRequest) Reset() {
+	*x = DrainRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DrainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DrainRequest) ProtoMessage() {}
+
+func (x *DrainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DrainRequest.ProtoReflect.Descriptor instead.
+func (*DrainRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *DrainRequest) GetRemoveFromTopology() bool {
+	if x != nil {
+		return x.RemoveFromTopology
+	}
+	return false
+}
+
+func (x *DrainRequest) GetDrainTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.DrainTimeout
+	}
+	return nil
+}
+
+func (x *DrainRequest) GetRemoveReason() clustermetadata.RemoveReason {
+	if x != nil {
+		return x.RemoveReason
+	}
+	return clustermetadata.RemoveReason(0)
+}
+
+// DrainResponse reports the outcome of a Drain request.
+type DrainResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// was_already_draining is true if the pooler was already in DRAINING
+	// state when this RPC arrived.
+	WasAlreadyDraining bool `protobuf:"varint,1,opt,name=was_already_draining,json=wasAlreadyDraining,proto3" json:"was_already_draining,omitempty"`
+	// primary_path_taken is true if the pooler was primary at drain entry
+	// and followed the EmergencyDemote path (restart as standby + signal
+	// resignation). False for non-primary drains.
+	PrimaryPathTaken bool `protobuf:"varint,2,opt,name=primary_path_taken,json=primaryPathTaken,proto3" json:"primary_path_taken,omitempty"`
+	// connections_terminated is the number of client connections that were
+	// forcibly terminated after drain_timeout expired. Mirrors
+	// EmergencyDemoteResponse.connections_terminated.
+	ConnectionsTerminated int32 `protobuf:"varint,3,opt,name=connections_terminated,json=connectionsTerminated,proto3" json:"connections_terminated,omitempty"`
+	// remove_from_topology reflects the effective flag after this call.
+	// Sticky: once true, it stays true. If the pooler was already draining
+	// without topology removal and this call passed remove_from_topology=true,
+	// this field will be true. Calling Drain with remove_from_topology=false
+	// on a node already slated for topology removal does NOT downgrade —
+	// this field remains true.
+	RemoveFromTopology bool `protobuf:"varint,4,opt,name=remove_from_topology,json=removeFromTopology,proto3" json:"remove_from_topology,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *DrainResponse) Reset() {
+	*x = DrainResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DrainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DrainResponse) ProtoMessage() {}
+
+func (x *DrainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DrainResponse.ProtoReflect.Descriptor instead.
+func (*DrainResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *DrainResponse) GetWasAlreadyDraining() bool {
+	if x != nil {
+		return x.WasAlreadyDraining
+	}
+	return false
+}
+
+func (x *DrainResponse) GetPrimaryPathTaken() bool {
+	if x != nil {
+		return x.PrimaryPathTaken
+	}
+	return false
+}
+
+func (x *DrainResponse) GetConnectionsTerminated() int32 {
+	if x != nil {
+		return x.ConnectionsTerminated
+	}
+	return 0
+}
+
+func (x *DrainResponse) GetRemoveFromTopology() bool {
+	if x != nil {
+		return x.RemoveFromTopology
+	}
+	return false
+}
+
 // DemoteStalePrimary demotes a stale primary that came back online after failover.
 // This is a complete operation that:
 // 1. Stops postgres if running
@@ -1905,7 +2073,7 @@ type DemoteStalePrimaryRequest struct {
 
 func (x *DemoteStalePrimaryRequest) Reset() {
 	*x = DemoteStalePrimaryRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +2085,7 @@ func (x *DemoteStalePrimaryRequest) String() string {
 func (*DemoteStalePrimaryRequest) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[22]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +2098,7 @@ func (x *DemoteStalePrimaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryRequest.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{22}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DemoteStalePrimaryRequest) GetSource() *clustermetadata.MultiPooler {
@@ -1968,7 +2136,7 @@ type DemoteStalePrimaryResponse struct {
 
 func (x *DemoteStalePrimaryResponse) Reset() {
 	*x = DemoteStalePrimaryResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1980,7 +2148,7 @@ func (x *DemoteStalePrimaryResponse) String() string {
 func (*DemoteStalePrimaryResponse) ProtoMessage() {}
 
 func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[23]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1993,7 +2161,7 @@ func (x *DemoteStalePrimaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DemoteStalePrimaryResponse.ProtoReflect.Descriptor instead.
 func (*DemoteStalePrimaryResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{23}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DemoteStalePrimaryResponse) GetSuccess() bool {
@@ -2052,7 +2220,7 @@ type PromoteRequest struct {
 
 func (x *PromoteRequest) Reset() {
 	*x = PromoteRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2064,7 +2232,7 @@ func (x *PromoteRequest) String() string {
 func (*PromoteRequest) ProtoMessage() {}
 
 func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[24]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2077,7 +2245,7 @@ func (x *PromoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteRequest.ProtoReflect.Descriptor instead.
 func (*PromoteRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{24}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PromoteRequest) GetConsensusTerm() int64 {
@@ -2150,7 +2318,7 @@ type PromoteResponse struct {
 
 func (x *PromoteResponse) Reset() {
 	*x = PromoteResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2162,7 +2330,7 @@ func (x *PromoteResponse) String() string {
 func (*PromoteResponse) ProtoMessage() {}
 
 func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[25]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2175,7 +2343,7 @@ func (x *PromoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteResponse.ProtoReflect.Descriptor instead.
 func (*PromoteResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{25}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PromoteResponse) GetLsnPosition() string {
@@ -2223,7 +2391,7 @@ type ConfigureSynchronousReplicationRequest struct {
 
 func (x *ConfigureSynchronousReplicationRequest) Reset() {
 	*x = ConfigureSynchronousReplicationRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2235,7 +2403,7 @@ func (x *ConfigureSynchronousReplicationRequest) String() string {
 func (*ConfigureSynchronousReplicationRequest) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[26]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2248,7 +2416,7 @@ func (x *ConfigureSynchronousReplicationRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ConfigureSynchronousReplicationRequest.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{26}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ConfigureSynchronousReplicationRequest) GetSynchronousCommit() SynchronousCommitLevel {
@@ -2301,7 +2469,7 @@ type ConfigureSynchronousReplicationResponse struct {
 
 func (x *ConfigureSynchronousReplicationResponse) Reset() {
 	*x = ConfigureSynchronousReplicationResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2313,7 +2481,7 @@ func (x *ConfigureSynchronousReplicationResponse) String() string {
 func (*ConfigureSynchronousReplicationResponse) ProtoMessage() {}
 
 func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[27]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2326,7 +2494,7 @@ func (x *ConfigureSynchronousReplicationResponse) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use ConfigureSynchronousReplicationResponse.ProtoReflect.Descriptor instead.
 func (*ConfigureSynchronousReplicationResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{27}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
 }
 
 // UpdateSynchronousStandbyList updates the synchronous standby list
@@ -2351,7 +2519,7 @@ type UpdateSynchronousStandbyListRequest struct {
 
 func (x *UpdateSynchronousStandbyListRequest) Reset() {
 	*x = UpdateSynchronousStandbyListRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2363,7 +2531,7 @@ func (x *UpdateSynchronousStandbyListRequest) String() string {
 func (*UpdateSynchronousStandbyListRequest) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[28]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2376,7 +2544,7 @@ func (x *UpdateSynchronousStandbyListRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpdateSynchronousStandbyListRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{28}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *UpdateSynchronousStandbyListRequest) GetOperation() StandbyUpdateOperation {
@@ -2429,7 +2597,7 @@ type UpdateSynchronousStandbyListResponse struct {
 
 func (x *UpdateSynchronousStandbyListResponse) Reset() {
 	*x = UpdateSynchronousStandbyListResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2441,7 +2609,7 @@ func (x *UpdateSynchronousStandbyListResponse) String() string {
 func (*UpdateSynchronousStandbyListResponse) ProtoMessage() {}
 
 func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[29]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2454,7 +2622,7 @@ func (x *UpdateSynchronousStandbyListResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateSynchronousStandbyListResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSynchronousStandbyListResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{29}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
 }
 
 // ConsensusTerm represents the consensus term information for the pooler
@@ -2481,7 +2649,7 @@ type ConsensusTerm struct {
 
 func (x *ConsensusTerm) Reset() {
 	*x = ConsensusTerm{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2493,7 +2661,7 @@ func (x *ConsensusTerm) String() string {
 func (*ConsensusTerm) ProtoMessage() {}
 
 func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[30]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2506,7 +2674,7 @@ func (x *ConsensusTerm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusTerm.ProtoReflect.Descriptor instead.
 func (*ConsensusTerm) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{30}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ConsensusTerm) GetTermNumber() int64 {
@@ -2567,7 +2735,7 @@ type BackupRequest struct {
 
 func (x *BackupRequest) Reset() {
 	*x = BackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2579,7 +2747,7 @@ func (x *BackupRequest) String() string {
 func (*BackupRequest) ProtoMessage() {}
 
 func (x *BackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[31]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2592,7 +2760,7 @@ func (x *BackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupRequest.ProtoReflect.Descriptor instead.
 func (*BackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{31}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *BackupRequest) GetForcePrimary() bool {
@@ -2635,7 +2803,7 @@ type BackupResponse struct {
 
 func (x *BackupResponse) Reset() {
 	*x = BackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2647,7 +2815,7 @@ func (x *BackupResponse) String() string {
 func (*BackupResponse) ProtoMessage() {}
 
 func (x *BackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2660,7 +2828,7 @@ func (x *BackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupResponse.ProtoReflect.Descriptor instead.
 func (*BackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *BackupResponse) GetBackupId() string {
@@ -2682,7 +2850,7 @@ type RestoreFromBackupRequest struct {
 
 func (x *RestoreFromBackupRequest) Reset() {
 	*x = RestoreFromBackupRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2694,7 +2862,7 @@ func (x *RestoreFromBackupRequest) String() string {
 func (*RestoreFromBackupRequest) ProtoMessage() {}
 
 func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2707,7 +2875,7 @@ func (x *RestoreFromBackupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupRequest.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RestoreFromBackupRequest) GetBackupId() string {
@@ -2726,7 +2894,7 @@ type RestoreFromBackupResponse struct {
 
 func (x *RestoreFromBackupResponse) Reset() {
 	*x = RestoreFromBackupResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2738,7 +2906,7 @@ func (x *RestoreFromBackupResponse) String() string {
 func (*RestoreFromBackupResponse) ProtoMessage() {}
 
 func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2751,7 +2919,7 @@ func (x *RestoreFromBackupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreFromBackupResponse.ProtoReflect.Descriptor instead.
 func (*RestoreFromBackupResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
 }
 
 // GetBackupsRequest requests backup information
@@ -2764,7 +2932,7 @@ type GetBackupsRequest struct {
 
 func (x *GetBackupsRequest) Reset() {
 	*x = GetBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2776,7 +2944,7 @@ func (x *GetBackupsRequest) String() string {
 func (*GetBackupsRequest) ProtoMessage() {}
 
 func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2789,7 +2957,7 @@ func (x *GetBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetBackupsRequest) GetLimit() uint32 {
@@ -2809,7 +2977,7 @@ type GetBackupsResponse struct {
 
 func (x *GetBackupsResponse) Reset() {
 	*x = GetBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2821,7 +2989,7 @@ func (x *GetBackupsResponse) String() string {
 func (*GetBackupsResponse) ProtoMessage() {}
 
 func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,7 +3002,7 @@ func (x *GetBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupsResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetBackupsResponse) GetBackups() []*BackupMetadata {
@@ -2855,7 +3023,7 @@ type GetBackupByJobIdRequest struct {
 
 func (x *GetBackupByJobIdRequest) Reset() {
 	*x = GetBackupByJobIdRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2867,7 +3035,7 @@ func (x *GetBackupByJobIdRequest) String() string {
 func (*GetBackupByJobIdRequest) ProtoMessage() {}
 
 func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2880,7 +3048,7 @@ func (x *GetBackupByJobIdRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdRequest.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetBackupByJobIdRequest) GetJobId() string {
@@ -2902,7 +3070,7 @@ type GetBackupByJobIdResponse struct {
 
 func (x *GetBackupByJobIdResponse) Reset() {
 	*x = GetBackupByJobIdResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2914,7 +3082,7 @@ func (x *GetBackupByJobIdResponse) String() string {
 func (*GetBackupByJobIdResponse) ProtoMessage() {}
 
 func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2927,7 +3095,7 @@ func (x *GetBackupByJobIdResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBackupByJobIdResponse.ProtoReflect.Descriptor instead.
 func (*GetBackupByJobIdResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetBackupByJobIdResponse) GetBackup() *BackupMetadata {
@@ -2950,7 +3118,7 @@ type ExpireBackupsRequest struct {
 
 func (x *ExpireBackupsRequest) Reset() {
 	*x = ExpireBackupsRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2962,7 +3130,7 @@ func (x *ExpireBackupsRequest) String() string {
 func (*ExpireBackupsRequest) ProtoMessage() {}
 
 func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2975,7 +3143,7 @@ func (x *ExpireBackupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ExpireBackupsRequest) GetOverrides() map[string]string {
@@ -2996,7 +3164,7 @@ type ExpireBackupsResponse struct {
 
 func (x *ExpireBackupsResponse) Reset() {
 	*x = ExpireBackupsResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3008,7 +3176,7 @@ func (x *ExpireBackupsResponse) String() string {
 func (*ExpireBackupsResponse) ProtoMessage() {}
 
 func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[40]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3021,7 +3189,7 @@ func (x *ExpireBackupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireBackupsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireBackupsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{40}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ExpireBackupsResponse) GetExpiredBackupIds() []string {
@@ -3055,7 +3223,7 @@ type BackupMetadata struct {
 
 func (x *BackupMetadata) Reset() {
 	*x = BackupMetadata{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3067,7 +3235,7 @@ func (x *BackupMetadata) String() string {
 func (*BackupMetadata) ProtoMessage() {}
 
 func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[41]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3080,7 +3248,7 @@ func (x *BackupMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupMetadata.ProtoReflect.Descriptor instead.
 func (*BackupMetadata) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{41}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *BackupMetadata) GetTableGroup() string {
@@ -3169,7 +3337,7 @@ type RewindToSourceRequest struct {
 
 func (x *RewindToSourceRequest) Reset() {
 	*x = RewindToSourceRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3181,7 +3349,7 @@ func (x *RewindToSourceRequest) String() string {
 func (*RewindToSourceRequest) ProtoMessage() {}
 
 func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[42]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3362,7 @@ func (x *RewindToSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceRequest.ProtoReflect.Descriptor instead.
 func (*RewindToSourceRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{42}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *RewindToSourceRequest) GetSource() *clustermetadata.MultiPooler {
@@ -3219,7 +3387,7 @@ type RewindToSourceResponse struct {
 
 func (x *RewindToSourceResponse) Reset() {
 	*x = RewindToSourceResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3231,7 +3399,7 @@ func (x *RewindToSourceResponse) String() string {
 func (*RewindToSourceResponse) ProtoMessage() {}
 
 func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[43]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3244,7 +3412,7 @@ func (x *RewindToSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RewindToSourceResponse.ProtoReflect.Descriptor instead.
 func (*RewindToSourceResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{43}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *RewindToSourceResponse) GetSuccess() bool {
@@ -3281,7 +3449,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3293,7 +3461,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[44]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3306,7 +3474,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{44}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -3326,7 +3494,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3338,7 +3506,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[45]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3351,7 +3519,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{47}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -3409,7 +3577,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x05ready\x18\x02 \x01(\bR\x05ready\x12D\n" +
 	"\x13connected_followers\x18\x03 \x03(\v2\x13.clustermetadata.IDR\x12connectedFollowers\x12s\n" +
 	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\x12!\n" +
-	"\fprimary_term\x18\x05 \x01(\x03R\vprimaryTerm\"\xaf\x06\n" +
+	"\fprimary_term\x18\x05 \x01(\x03R\vprimaryTerm\"\x81\a\n" +
 	"\x06Status\x12<\n" +
 	"\vpooler_type\x18\x01 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
 	"poolerType\x12L\n" +
@@ -3426,7 +3594,8 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x0fpostgres_action\x18\v \x01(\x0e2&.multipoolermanagerdata.PostgresActionR\x0epostgresAction\x12S\n" +
 	"\x18postgres_action_duration\x18\f \x01(\v2\x19.google.protobuf.DurationR\x16postgresActionDuration\x12:\n" +
 	"\x0ecohort_members\x18\r \x03(\v2\x13.clustermetadata.IDR\rcohortMembers\x12%\n" +
-	"\x0epostgres_ready\x18\x0e \x01(\bR\rpostgresReady\"\x0f\n" +
+	"\x0epostgres_ready\x18\x0e \x01(\bR\rpostgresReady\x12P\n" +
+	"\x14query_serving_status\x18\x0f \x01(\v2\x1e.clustermetadata.ServingStatusR\x12queryServingStatus\"\x0f\n" +
 	"\rStatusRequest\"H\n" +
 	"\x0eStatusResponse\x126\n" +
 	"\x06status\x18\x01 \x01(\v2\x1e.multipoolermanagerdata.StatusR\x06status\"\xcc\x01\n" +
@@ -3450,7 +3619,16 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x13was_already_demoted\x18\x01 \x01(\bR\x11wasAlreadyDemoted\x12%\n" +
 	"\x0econsensus_term\x18\x02 \x01(\x03R\rconsensusTerm\x12!\n" +
 	"\flsn_position\x18\x03 \x01(\tR\vlsnPosition\x125\n" +
-	"\x16connections_terminated\x18\x04 \x01(\x05R\x15connectionsTerminated\"\x8e\x01\n" +
+	"\x16connections_terminated\x18\x04 \x01(\x05R\x15connectionsTerminated\"\xc4\x01\n" +
+	"\fDrainRequest\x120\n" +
+	"\x14remove_from_topology\x18\x01 \x01(\bR\x12removeFromTopology\x12>\n" +
+	"\rdrain_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\fdrainTimeout\x12B\n" +
+	"\rremove_reason\x18\x03 \x01(\x0e2\x1d.clustermetadata.RemoveReasonR\fremoveReason\"\xd8\x01\n" +
+	"\rDrainResponse\x120\n" +
+	"\x14was_already_draining\x18\x01 \x01(\bR\x12wasAlreadyDraining\x12,\n" +
+	"\x12primary_path_taken\x18\x02 \x01(\bR\x10primaryPathTaken\x125\n" +
+	"\x16connections_terminated\x18\x03 \x01(\x05R\x15connectionsTerminated\x120\n" +
+	"\x14remove_from_topology\x18\x04 \x01(\bR\x12removeFromTopology\"\x8e\x01\n" +
 	"\x19DemoteStalePrimaryRequest\x124\n" +
 	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultiPoolerR\x06source\x12%\n" +
 	"\x0econsensus_term\x18\x02 \x01(\x03R\rconsensusTerm\x12\x14\n" +
@@ -3597,7 +3775,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresAction)(0),                             // 0: multipoolermanagerdata.PostgresAction
 	(SnapshotTrigger)(0),                            // 1: multipoolermanagerdata.SnapshotTrigger
@@ -3628,94 +3806,101 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*ManagerHealthSnapshot)(nil),                   // 26: multipoolermanagerdata.ManagerHealthSnapshot
 	(*EmergencyDemoteRequest)(nil),                  // 27: multipoolermanagerdata.EmergencyDemoteRequest
 	(*EmergencyDemoteResponse)(nil),                 // 28: multipoolermanagerdata.EmergencyDemoteResponse
-	(*DemoteStalePrimaryRequest)(nil),               // 29: multipoolermanagerdata.DemoteStalePrimaryRequest
-	(*DemoteStalePrimaryResponse)(nil),              // 30: multipoolermanagerdata.DemoteStalePrimaryResponse
-	(*PromoteRequest)(nil),                          // 31: multipoolermanagerdata.PromoteRequest
-	(*PromoteResponse)(nil),                         // 32: multipoolermanagerdata.PromoteResponse
-	(*ConfigureSynchronousReplicationRequest)(nil),  // 33: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	(*ConfigureSynchronousReplicationResponse)(nil), // 34: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
-	(*UpdateSynchronousStandbyListRequest)(nil),     // 35: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
-	(*UpdateSynchronousStandbyListResponse)(nil),    // 36: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	(*ConsensusTerm)(nil),                           // 37: multipoolermanagerdata.ConsensusTerm
-	(*BackupRequest)(nil),                           // 38: multipoolermanagerdata.BackupRequest
-	(*BackupResponse)(nil),                          // 39: multipoolermanagerdata.BackupResponse
-	(*RestoreFromBackupRequest)(nil),                // 40: multipoolermanagerdata.RestoreFromBackupRequest
-	(*RestoreFromBackupResponse)(nil),               // 41: multipoolermanagerdata.RestoreFromBackupResponse
-	(*GetBackupsRequest)(nil),                       // 42: multipoolermanagerdata.GetBackupsRequest
-	(*GetBackupsResponse)(nil),                      // 43: multipoolermanagerdata.GetBackupsResponse
-	(*GetBackupByJobIdRequest)(nil),                 // 44: multipoolermanagerdata.GetBackupByJobIdRequest
-	(*GetBackupByJobIdResponse)(nil),                // 45: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*ExpireBackupsRequest)(nil),                    // 46: multipoolermanagerdata.ExpireBackupsRequest
-	(*ExpireBackupsResponse)(nil),                   // 47: multipoolermanagerdata.ExpireBackupsResponse
-	(*BackupMetadata)(nil),                          // 48: multipoolermanagerdata.BackupMetadata
-	(*RewindToSourceRequest)(nil),                   // 49: multipoolermanagerdata.RewindToSourceRequest
-	(*RewindToSourceResponse)(nil),                  // 50: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),       // 51: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),      // 52: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                                 // 53: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                 // 54: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),         // 55: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),       // 56: google.protobuf.Timestamp
-	(*clustermetadata.MultiPooler)(nil), // 57: clustermetadata.MultiPooler
-	(*clustermetadata.ID)(nil),          // 58: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),     // 59: clustermetadata.PoolerType
+	(*DrainRequest)(nil),                            // 29: multipoolermanagerdata.DrainRequest
+	(*DrainResponse)(nil),                           // 30: multipoolermanagerdata.DrainResponse
+	(*DemoteStalePrimaryRequest)(nil),               // 31: multipoolermanagerdata.DemoteStalePrimaryRequest
+	(*DemoteStalePrimaryResponse)(nil),              // 32: multipoolermanagerdata.DemoteStalePrimaryResponse
+	(*PromoteRequest)(nil),                          // 33: multipoolermanagerdata.PromoteRequest
+	(*PromoteResponse)(nil),                         // 34: multipoolermanagerdata.PromoteResponse
+	(*ConfigureSynchronousReplicationRequest)(nil),  // 35: multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	(*ConfigureSynchronousReplicationResponse)(nil), // 36: multipoolermanagerdata.ConfigureSynchronousReplicationResponse
+	(*UpdateSynchronousStandbyListRequest)(nil),     // 37: multipoolermanagerdata.UpdateSynchronousStandbyListRequest
+	(*UpdateSynchronousStandbyListResponse)(nil),    // 38: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	(*ConsensusTerm)(nil),                           // 39: multipoolermanagerdata.ConsensusTerm
+	(*BackupRequest)(nil),                           // 40: multipoolermanagerdata.BackupRequest
+	(*BackupResponse)(nil),                          // 41: multipoolermanagerdata.BackupResponse
+	(*RestoreFromBackupRequest)(nil),                // 42: multipoolermanagerdata.RestoreFromBackupRequest
+	(*RestoreFromBackupResponse)(nil),               // 43: multipoolermanagerdata.RestoreFromBackupResponse
+	(*GetBackupsRequest)(nil),                       // 44: multipoolermanagerdata.GetBackupsRequest
+	(*GetBackupsResponse)(nil),                      // 45: multipoolermanagerdata.GetBackupsResponse
+	(*GetBackupByJobIdRequest)(nil),                 // 46: multipoolermanagerdata.GetBackupByJobIdRequest
+	(*GetBackupByJobIdResponse)(nil),                // 47: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*ExpireBackupsRequest)(nil),                    // 48: multipoolermanagerdata.ExpireBackupsRequest
+	(*ExpireBackupsResponse)(nil),                   // 49: multipoolermanagerdata.ExpireBackupsResponse
+	(*BackupMetadata)(nil),                          // 50: multipoolermanagerdata.BackupMetadata
+	(*RewindToSourceRequest)(nil),                   // 51: multipoolermanagerdata.RewindToSourceRequest
+	(*RewindToSourceResponse)(nil),                  // 52: multipoolermanagerdata.RewindToSourceResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),       // 53: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),      // 54: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                                   // 55: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                   // 56: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),           // 57: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),         // 58: google.protobuf.Timestamp
+	(*clustermetadata.MultiPooler)(nil),   // 59: clustermetadata.MultiPooler
+	(*clustermetadata.ID)(nil),            // 60: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),       // 61: clustermetadata.PoolerType
+	(*clustermetadata.ServingStatus)(nil), // 62: clustermetadata.ServingStatus
+	(clustermetadata.RemoveReason)(0),     // 63: clustermetadata.RemoveReason
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	55, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	57, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	7,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	56, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	55, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	55, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	55, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
-	57, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
+	58, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	57, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	57, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	57, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	59, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
 	2,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	8,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	5,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	3,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	58, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	58, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	60, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	60, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	17, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	59, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	61, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	18, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	8,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	37, // 17: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
+	39, // 17: multipoolermanagerdata.Status.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
 	0,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	55, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	58, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
-	19, // 21: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	23, // 22: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
-	24, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	26, // 24: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
-	21, // 25: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	55, // 26: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
-	1,  // 27: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	55, // 28: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
-	57, // 29: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
-	33, // 30: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	58, // 31: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
-	58, // 32: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
-	58, // 33: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
-	5,  // 34: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
-	3,  // 35: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	58, // 36: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
-	4,  // 37: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
-	58, // 38: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
-	58, // 39: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
-	58, // 40: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
-	56, // 41: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
-	58, // 42: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
-	53, // 43: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
-	48, // 44: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
-	48, // 45: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	54, // 46: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	6,  // 47: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	59, // 48: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	57, // 49: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
-	50, // [50:50] is the sub-list for method output_type
-	50, // [50:50] is the sub-list for method input_type
-	50, // [50:50] is the sub-list for extension type_name
-	50, // [50:50] is the sub-list for extension extendee
-	0,  // [0:50] is the sub-list for field type_name
+	57, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	60, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
+	62, // 21: multipoolermanagerdata.Status.query_serving_status:type_name -> clustermetadata.ServingStatus
+	19, // 22: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
+	23, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
+	24, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
+	26, // 25: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
+	21, // 26: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
+	57, // 27: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	1,  // 28: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
+	57, // 29: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
+	57, // 30: multipoolermanagerdata.DrainRequest.drain_timeout:type_name -> google.protobuf.Duration
+	63, // 31: multipoolermanagerdata.DrainRequest.remove_reason:type_name -> clustermetadata.RemoveReason
+	59, // 32: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
+	35, // 33: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
+	60, // 34: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
+	60, // 35: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
+	60, // 36: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
+	5,  // 37: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
+	3,  // 38: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
+	60, // 39: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
+	4,  // 40: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
+	60, // 41: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
+	60, // 42: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
+	60, // 43: multipoolermanagerdata.ConsensusTerm.accepted_term_from_coordinator_id:type_name -> clustermetadata.ID
+	58, // 44: multipoolermanagerdata.ConsensusTerm.last_acceptance_time:type_name -> google.protobuf.Timestamp
+	60, // 45: multipoolermanagerdata.ConsensusTerm.leader_id:type_name -> clustermetadata.ID
+	55, // 46: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	50, // 47: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
+	50, // 48: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
+	56, // 49: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	6,  // 50: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
+	61, // 51: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	59, // 52: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	53, // [53:53] is the sub-list for method output_type
+	53, // [53:53] is the sub-list for method input_type
+	53, // [53:53] is the sub-list for extension type_name
+	53, // [53:53] is the sub-list for extension extendee
+	0,  // [0:53] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }
@@ -3733,7 +3918,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -1546,8 +1546,14 @@ type StreamPoolerHealthResponse struct {
 	// replication_lag_ns is the current replication lag in nanoseconds,
 	// measured via heartbeat timestamps. Zero on the primary or when unknown.
 	ReplicationLagNs int64 `protobuf:"varint,6,opt,name=replication_lag_ns,json=replicationLagNs,proto3" json:"replication_lag_ns,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// query_serving_status is the self-reported routing-layer signal
+	// gateway consumes to decide whether to send new client queries.
+	// Absence (after process restart or for older poolers) is treated as
+	// ACTIVE. Distinct from serving_status above, which reflects topology
+	// lifecycle (SERVING/NOT_SERVING/BACKUP/RESTORE).
+	QueryServingStatus *clustermetadata.ServingStatus `protobuf:"bytes,7,opt,name=query_serving_status,json=queryServingStatus,proto3" json:"query_serving_status,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *StreamPoolerHealthResponse) Reset() {
@@ -1620,6 +1626,13 @@ func (x *StreamPoolerHealthResponse) GetReplicationLagNs() int64 {
 		return x.ReplicationLagNs
 	}
 	return 0
+}
+
+func (x *StreamPoolerHealthResponse) GetQueryServingStatus() *clustermetadata.ServingStatus {
+	if x != nil {
+		return x.QueryServingStatus
+	}
+	return nil
 }
 
 // PrimaryObservation represents a pooler's view of who the primary is.
@@ -1878,14 +1891,15 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
 	"\aoptions\x18\x03 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"#\n" +
 	"!ReleaseReservedConnectionResponse\"\x1b\n" +
-	"\x19StreamPoolerHealthRequest\"\xa8\x03\n" +
+	"\x19StreamPoolerHealthRequest\"\xfa\x03\n" +
 	"\x1aStreamPoolerHealthResponse\x12%\n" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12K\n" +
 	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12W\n" +
 	"\x13primary_observation\x18\x04 \x01(\v2&.multipoolerservice.PrimaryObservationR\x12primaryObservation\x12]\n" +
 	"\x1drecommended_staleness_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1brecommendedStalenessTimeout\x12,\n" +
-	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\"k\n" +
+	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\x12P\n" +
+	"\x14query_serving_status\x18\a \x01(\v2\x1e.clustermetadata.ServingStatusR\x12queryServingStatus\"k\n" +
 	"\x12PrimaryObservation\x122\n" +
 	"\n" +
 	"primary_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\tprimaryId\x12!\n" +
@@ -1974,7 +1988,8 @@ var file_multipoolerservice_proto_goTypes = []any{
 	(*clustermetadata.ID)(nil),                // 37: clustermetadata.ID
 	(clustermetadata.PoolerServingStatus)(0),  // 38: clustermetadata.PoolerServingStatus
 	(*durationpb.Duration)(nil),               // 39: google.protobuf.Duration
-	(*query.PgNotification)(nil),              // 40: query.PgNotification
+	(*clustermetadata.ServingStatus)(nil),     // 40: clustermetadata.ServingStatus
+	(*query.PgNotification)(nil),              // 41: query.PgNotification
 }
 var file_multipoolerservice_proto_depIdxs = []int32{
 	27, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
@@ -2028,36 +2043,37 @@ var file_multipoolerservice_proto_depIdxs = []int32{
 	38, // 48: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
 	24, // 49: multipoolerservice.StreamPoolerHealthResponse.primary_observation:type_name -> multipoolerservice.PrimaryObservation
 	39, // 50: multipoolerservice.StreamPoolerHealthResponse.recommended_staleness_timeout:type_name -> google.protobuf.Duration
-	37, // 51: multipoolerservice.PrimaryObservation.primary_id:type_name -> clustermetadata.ID
-	27, // 52: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
-	40, // 53: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
-	4,  // 54: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
-	6,  // 55: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
-	8,  // 56: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
-	10, // 57: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
-	12, // 58: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
-	14, // 59: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
-	16, // 60: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
-	18, // 61: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
-	20, // 62: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
-	22, // 63: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
-	25, // 64: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
-	5,  // 65: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
-	7,  // 66: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
-	9,  // 67: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
-	11, // 68: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
-	13, // 69: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
-	15, // 70: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
-	17, // 71: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
-	19, // 72: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
-	21, // 73: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
-	23, // 74: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
-	26, // 75: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
-	65, // [65:76] is the sub-list for method output_type
-	54, // [54:65] is the sub-list for method input_type
-	54, // [54:54] is the sub-list for extension type_name
-	54, // [54:54] is the sub-list for extension extendee
-	0,  // [0:54] is the sub-list for field type_name
+	40, // 51: multipoolerservice.StreamPoolerHealthResponse.query_serving_status:type_name -> clustermetadata.ServingStatus
+	37, // 52: multipoolerservice.PrimaryObservation.primary_id:type_name -> clustermetadata.ID
+	27, // 53: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
+	41, // 54: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
+	4,  // 55: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
+	6,  // 56: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
+	8,  // 57: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
+	10, // 58: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
+	12, // 59: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
+	14, // 60: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
+	16, // 61: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
+	18, // 62: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
+	20, // 63: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
+	22, // 64: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
+	25, // 65: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
+	5,  // 66: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
+	7,  // 67: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
+	9,  // 68: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
+	11, // 69: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
+	13, // 70: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
+	15, // 71: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
+	17, // 72: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
+	19, // 73: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
+	21, // 74: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
+	23, // 75: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
+	26, // 76: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
+	66, // [66:77] is the sub-list for method output_type
+	55, // [55:66] is the sub-list for method input_type
+	55, // [55:55] is the sub-list for extension type_name
+	55, // [55:55] is the sub-list for extension extendee
+	0,  // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_multipoolerservice_proto_init() }

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -217,15 +217,16 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	}
 
 	analysis := &PoolerAnalysis{
-		PoolerID:         pooler.MultiPooler.Id,
-		ShardKey:         shardKey,
-		PoolerType:       poolerType,
-		IsPrimary:        poolerType == clustermetadatapb.PoolerType_PRIMARY,
-		LastCheckValid:   pooler.IsLastCheckValid,
-		IsInitialized:    store.IsInitialized(pooler),
-		HasDataDirectory: pooler.GetStatus().GetHasDataDirectory(),
-		CohortMembers:    pooler.GetStatus().GetCohortMembers(),
-		AnalyzedAt:       time.Now(),
+		PoolerID:              pooler.MultiPooler.Id,
+		ShardKey:              shardKey,
+		PoolerType:            poolerType,
+		IsPrimary:             poolerType == clustermetadatapb.PoolerType_PRIMARY,
+		LastCheckValid:        pooler.IsLastCheckValid,
+		IsInitialized:         store.IsInitialized(pooler),
+		HasDataDirectory:      pooler.GetStatus().GetHasDataDirectory(),
+		CohortMembers:         pooler.GetStatus().GetCohortMembers(),
+		AnalyzedAt:            time.Now(),
+		IsVoluntarilyDraining: types.IsVoluntarilyDraining(pooler),
 	}
 
 	// Compute staleness

--- a/go/services/multiorch/recovery/analysis/replica_not_in_standby_list_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_in_standby_list_analyzer.go
@@ -58,6 +58,13 @@ func (a *ReplicaNotInStandbyListAnalyzer) analyzePooler(sa *ShardAnalysis, poole
 		return nil, nil
 	}
 
+	// Skip voluntarily-draining replicas: they have asked to be removed from
+	// serving, so recovering them back into the standby list would fight the
+	// operator's intent.
+	if poolerAnalysis.IsVoluntarilyDraining {
+		return nil, nil
+	}
+
 	// Skip if replica is not initialized
 	if !poolerAnalysis.IsInitialized {
 		return nil, nil

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer.go
@@ -54,6 +54,12 @@ func (a *ReplicaNotReplicatingAnalyzer) analyzePooler(sa *ShardAnalysis, poolerA
 		return nil, nil
 	}
 
+	// Skip voluntarily-draining replicas: they have asked to be removed from
+	// serving, so forcing replication back on would fight the operator's intent.
+	if poolerAnalysis.IsVoluntarilyDraining {
+		return nil, nil
+	}
+
 	// Skip if replica is not initialized (ShardNeedsInitialization handles that)
 	if !poolerAnalysis.IsInitialized {
 		return nil, nil

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -156,6 +156,12 @@ type PoolerAnalysis struct {
 	// ConsensusStatus RPC.
 	// Nil if the ConsensusStatus RPC failed or has not yet been called.
 	ConsensusStatus *clustermetadatapb.ConsensusStatus
+
+	// IsVoluntarilyDraining reports that the pooler has self-signalled a
+	// voluntary drain (ServingSignal.DRAINING) while not being in the
+	// involuntary PoolerType.DRAINED state. Analyzers should skip recovery
+	// actions on these poolers — they have asked to be removed from serving.
+	IsVoluntarilyDraining bool
 }
 
 // comparePrimaryTimeline compares two primary PoolerAnalysis entries by PrimaryTerm only.

--- a/go/services/multiorch/recovery/types/pooler_signals.go
+++ b/go/services/multiorch/recovery/types/pooler_signals.go
@@ -48,3 +48,14 @@ func PrimaryNeedsReplacement(p *multiorchdatapb.PoolerHealthState) bool {
 	// Verify the signal is for the current primary term, not a stale one.
 	return leadershipStatus.PrimaryTerm != 0 && leadershipStatus.PrimaryTerm == p.ConsensusStatus.GetPrimaryTerm()
 }
+
+// IsVoluntarilyDraining reports whether a pooler has self-signalled a
+// voluntary drain via its query-serving status. Returns false for the
+// involuntary data-diverged case (PoolerType.DRAINED, which is handled
+// separately by the fix_replication flow).
+func IsVoluntarilyDraining(p *multiorchdatapb.PoolerHealthState) bool {
+	if p.GetStatus().GetQueryServingStatus().GetSignal() != clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING {
+		return false
+	}
+	return p.GetStatus().GetPoolerType() != clustermetadatapb.PoolerType_DRAINED
+}

--- a/go/services/multiorch/recovery/types/pooler_signals_test.go
+++ b/go/services/multiorch/recovery/types/pooler_signals_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+func TestIsVoluntarilyDraining(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *multiorchdatapb.PoolerHealthState
+		want  bool
+	}{
+		{
+			name: "draining replica reports voluntary",
+			state: &multiorchdatapb.PoolerHealthState{
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_REPLICA,
+					QueryServingStatus: &clustermetadatapb.ServingStatus{
+						Signal: clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "draining primary reports voluntary",
+			state: &multiorchdatapb.PoolerHealthState{
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+					QueryServingStatus: &clustermetadatapb.ServingStatus{
+						Signal: clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "involuntary PoolerType.DRAINED is not voluntary even with DRAINING signal",
+			state: &multiorchdatapb.PoolerHealthState{
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_DRAINED,
+					QueryServingStatus: &clustermetadatapb.ServingStatus{
+						Signal: clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ACTIVE signal is not voluntary drain",
+			state: &multiorchdatapb.PoolerHealthState{
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_REPLICA,
+					QueryServingStatus: &clustermetadatapb.ServingStatus{
+						Signal: clustermetadatapb.ServingSignal_SERVING_SIGNAL_ACTIVE,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "missing QueryServingStatus is not voluntary drain",
+			state: &multiorchdatapb.PoolerHealthState{
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsVoluntarilyDraining(tc.state))
+		})
+	}
+}

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -86,6 +86,15 @@ func (s *managerService) Status(ctx context.Context, req *multipoolermanagerdata
 	}, nil
 }
 
+// Drain initiates voluntary draining of the pooler.
+func (s *managerService) Drain(ctx context.Context, req *multipoolermanagerdatapb.DrainRequest) (*multipoolermanagerdatapb.DrainResponse, error) {
+	resp, err := s.manager.Drain(ctx, req)
+	if err != nil {
+		return nil, mterrors.ToGRPC(err)
+	}
+	return resp, nil
+}
+
 // Backup performs a backup
 func (s *managerService) Backup(ctx context.Context, req *multipoolermanagerdatapb.BackupRequest) (*multipoolermanagerdatapb.BackupResponse, error) {
 	backupID, err := s.manager.Backup(ctx, req.ForcePrimary, req.Type, req.JobId, req.Overrides)

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
@@ -41,6 +42,16 @@ type poolerService struct {
 	pooler *poolerserver.QueryPoolerServer
 	pubsub *pubsub.Listener
 }
+
+// TODO(query-serving): implement drain-aware query serving. When
+// s.pooler.HealthProvider reports clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+// this service should react appropriately (e.g. reject new client-query
+// RPCs with codes.Unavailable, close idle reserved connections, wait for
+// in-flight queries up to a drain_timeout and then forcibly terminate
+// remaining connections). Today the pooler only *advertises* DRAINING
+// over streaming health so upstream consumers (multigateway) stop
+// routing new traffic; no server-side enforcement is performed on the
+// query path. See PR #866 and the drained-pooler-state design doc.
 
 func RegisterPoolerServices(senv *servenv.ServEnv, grpc *servenv.GrpcServer) {
 	// Register ourselves to be invoked when the pooler starts
@@ -605,6 +616,12 @@ func healthStateToProto(state *poolerserver.HealthState) *multipoolerpb.StreamPo
 	}
 
 	resp.ReplicationLagNs = state.ReplicationLagNs
+
+	if state.ServingSignal != clustermetadatapb.ServingSignal_SERVING_SIGNAL_UNKNOWN {
+		resp.QueryServingStatus = &clustermetadatapb.ServingStatus{
+			Signal: state.ServingSignal,
+		}
+	}
 
 	return resp
 }

--- a/go/services/multipooler/grpcpoolerservice/service_test.go
+++ b/go/services/multipooler/grpcpoolerservice/service_test.go
@@ -16,6 +16,7 @@ package grpcpoolerservice
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
+	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 )
 
 func TestGetAuthCredentials_Validation(t *testing.T) {
@@ -101,4 +104,68 @@ func (m *mockHealthStream) Context() context.Context {
 
 func (m *mockHealthStream) Send(*multipoolerpb.StreamPoolerHealthResponse) error {
 	return nil
+}
+
+// fakeHealthProvider returns a fixed HealthState on subscription so tests can
+// assert how health state flows through healthStateToProto.
+type fakeHealthProvider struct {
+	state *poolerserver.HealthState
+}
+
+func (f *fakeHealthProvider) GetHealthState(ctx context.Context) (*poolerserver.HealthState, error) {
+	return f.state, nil
+}
+
+func (f *fakeHealthProvider) SubscribeHealth(ctx context.Context) (*poolerserver.HealthState, <-chan *poolerserver.HealthState, error) {
+	ch := make(chan *poolerserver.HealthState)
+	// Close immediately so StreamPoolerHealth returns after sending the initial state.
+	close(ch)
+	return f.state, ch, nil
+}
+
+// capturingHealthStream records every response sent by StreamPoolerHealth.
+type capturingHealthStream struct {
+	multipoolerpb.MultiPoolerService_StreamPoolerHealthServer
+	ctx       context.Context
+	responses []*multipoolerpb.StreamPoolerHealthResponse
+}
+
+func (c *capturingHealthStream) Context() context.Context {
+	return c.ctx
+}
+
+func (c *capturingHealthStream) Send(resp *multipoolerpb.StreamPoolerHealthResponse) error {
+	c.responses = append(c.responses, resp)
+	return nil
+}
+
+func TestStreamPoolerHealth_PublishesServingSignal(t *testing.T) {
+	fake := &fakeHealthProvider{
+		state: &poolerserver.HealthState{
+			ServingSignal: clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+		},
+	}
+
+	pooler := poolerserver.NewQueryPoolerServer(
+		slog.Default(),
+		nil, // poolManager
+		nil, // poolerID
+		"tg",
+		"shard",
+		fake,
+		0,
+	)
+	srv := &poolerService{pooler: pooler}
+
+	stream := &capturingHealthStream{ctx: context.Background()}
+	err := srv.StreamPoolerHealth(&multipoolerpb.StreamPoolerHealthRequest{}, stream)
+	require.NoError(t, err)
+	require.NotEmpty(t, stream.responses)
+
+	resp := stream.responses[0]
+	require.NotNil(t, resp.QueryServingStatus, "QueryServingStatus should be populated")
+	assert.Equal(t,
+		clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING,
+		resp.QueryServingStatus.Signal,
+	)
 }

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -379,6 +379,9 @@ func (mp *MultiPooler) Shutdown() {
 			logger.Warn("Voluntary Drain on shutdown failed; continuing", "error", err)
 		}
 		cancel()
+		// Drive the manager through its own shutdown path so
+		// writeDrainTombstoneIfNeeded runs before the topo store closes.
+		mp.poolerManager.Shutdown()
 	}
 
 	mp.tr.Unregister()

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -37,6 +38,7 @@ import (
 	"github.com/multigres/multigres/go/tools/viperutil"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
 // MultiPooler represents the main multipooler instance with all configuration and state
@@ -66,9 +68,10 @@ type MultiPooler struct {
 	// connPoolConfig holds connection pool configuration (manager created inside MultiPoolerManager)
 	connPoolConfig *connpoolmanager.Config
 
-	ts           topoclient.Store
-	tr           *toporeg.TopoReg
-	serverStatus Status
+	ts            topoclient.Store
+	tr            *toporeg.TopoReg
+	poolerManager *manager.MultiPoolerManager
+	serverStatus  Status
 }
 
 func (mp *MultiPooler) CobraPreRunE(cmd *cobra.Command) error {
@@ -308,6 +311,7 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create multipooler: %w", err)
 	}
+	mp.poolerManager = poolerManager
 
 	// Start the MultiPoolerManager
 	poolerManager.Start(mp.senv)
@@ -361,7 +365,22 @@ func (mp *MultiPooler) RunDefault() error {
 }
 
 func (mp *MultiPooler) Shutdown() {
-	mp.senv.GetLogger().Info("multipooler shutting down")
+	logger := mp.senv.GetLogger()
+	logger.Info("multipooler shutting down")
+
+	// Trigger a non-permanent voluntary Drain so consumers observe
+	// ServingSignal.DRAINING before the process exits. Idempotent: if an RPC
+	// already drained (potentially with remove_from_topology=true), this call
+	// is a no-op and preserves the existing state.
+	if mp.poolerManager != nil {
+		//nolint:gocritic // legitimate background entry point during shutdown
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if _, err := mp.poolerManager.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{}); err != nil {
+			logger.Warn("Voluntary Drain on shutdown failed; continuing", "error", err)
+		}
+		cancel()
+	}
+
 	mp.tr.Unregister()
 	mp.ts.Close()
 }

--- a/go/services/multipooler/manager/health_provider.go
+++ b/go/services/multipooler/manager/health_provider.go
@@ -70,6 +70,11 @@ type healthStreamer struct {
 	poolerType         clustermetadatapb.PoolerType
 	primaryObservation *poolerserver.PrimaryObservation
 
+	// servingSignal holds the most recent routing-layer serving signal (see
+	// clustermetadatapb.ServingSignal). Zero (UNKNOWN) is treated as ACTIVE by
+	// consumers. Updated via SetServingSignal.
+	servingSignal clustermetadatapb.ServingSignal
+
 	// Client management
 	clients map[chan *poolerserver.HealthState]struct{}
 
@@ -77,7 +82,7 @@ type healthStreamer struct {
 	recommendedStalenessTimeout time.Duration
 
 	// replicationLagNs holds the most recent replication lag in nanoseconds.
-	// Zero on the primary or when not yet measured. Updated via SetReplicationLag.
+	// Zero on the primary or when not yet measured. Updated via SetReplicationLag
 	replicationLagNs atomic.Int64
 }
 
@@ -149,6 +154,16 @@ func (hs *healthStreamer) SetReplicationLag(lagNs int64) {
 	hs.replicationLagNs.Store(lagNs)
 }
 
+// SetServingSignal updates the routing-layer serving signal reported in the
+// health stream and broadcasts immediately so consumers observe the change
+// without waiting for the next heartbeat.
+func (hs *healthStreamer) SetServingSignal(signal clustermetadatapb.ServingSignal) {
+	hs.mu.Lock()
+	defer hs.mu.Unlock()
+	hs.servingSignal = signal
+	hs.broadcastLocked()
+}
+
 // buildStateLocked builds the current health state. Caller must hold hs.mu.
 func (hs *healthStreamer) buildStateLocked() *poolerserver.HealthState {
 	return &poolerserver.HealthState{
@@ -162,6 +177,7 @@ func (hs *healthStreamer) buildStateLocked() *poolerserver.HealthState {
 		PrimaryObservation:          hs.primaryObservation,
 		RecommendedStalenessTimeout: hs.recommendedStalenessTimeout,
 		ReplicationLagNs:            hs.replicationLagNs.Load(),
+		ServingSignal:               hs.servingSignal,
 	}
 }
 
@@ -264,6 +280,7 @@ func (pm *MultiPoolerManager) runHealthHeartbeat(ctx context.Context, interval t
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			pm.observeInvoluntaryDrain(ctx)
 			if pm.healthStreamer != nil {
 				// Refresh replication lag before broadcasting so clients see
 				// up-to-date lag without requiring a separate state-change event.
@@ -274,4 +291,28 @@ func (pm *MultiPoolerManager) runHealthHeartbeat(ctx context.Context, interval t
 			}
 		}
 	}
+}
+
+// observeInvoluntaryDrain checks whether multiorch has marked this pooler's
+// MultiPooler topology record as PoolerType_DRAINED (the involuntary,
+// data-diverged flow) and transitions the local drain state to DRAINING so
+// ServingSignal.DRAINING flows over the health stream. Voluntary and
+// involuntary cases publish the same signal — gateway does not need to read
+// topology. Non-fatal: topology errors are logged and retried on the next tick.
+func (pm *MultiPoolerManager) observeInvoluntaryDrain(ctx context.Context) {
+	if pm.topoClient == nil || pm.serviceID == nil {
+		return
+	}
+	info, err := pm.topoClient.GetMultiPooler(ctx, pm.serviceID)
+	if err != nil {
+		pm.logger.DebugContext(ctx, "observeInvoluntaryDrain: GetMultiPooler failed", "error", err)
+		return
+	}
+	if info == nil || info.MultiPooler == nil {
+		return
+	}
+	if info.MultiPooler.Type != clustermetadatapb.PoolerType_DRAINED {
+		return
+	}
+	pm.enterDraining(false, clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN)
 }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -139,6 +139,14 @@ type MultiPoolerManager struct {
 	// election. Protected by mu. Cleared when this node is elected primary again.
 	resignedPrimaryAtTerm int64
 
+	// drainSignal tracks the pooler's voluntary-drain lifecycle. Protected by mu.
+	// Zero value (SERVING_SIGNAL_UNKNOWN) is treated as ACTIVE by consumers; only
+	// flips to DRAINING via enterDraining(). Never reset — drain is terminal.
+	drainSignal    clustermetadatapb.ServingSignal
+	drainPermanent bool
+	drainReason    clustermetadatapb.RemoveReason
+	drainStartedAt time.Time
+
 	// pgMonitor manages the PostgreSQL monitoring loop.
 	pgMonitor *timer.PeriodicRunner
 
@@ -411,6 +419,9 @@ func (pm *MultiPoolerManager) Pause() (resume func()) {
 // Unlike Pause(), Shutdown does not return a resume function, signaling permanent closure.
 // Safe to call multiple times and safe to call even if never opened.
 func (pm *MultiPoolerManager) Shutdown() {
+	// Best-effort tombstone write for permanent drains. Must run before
+	// closeLocked cancels the context.
+	pm.writeDrainTombstoneIfNeeded()
 	pm.closeLocked("shutdown")
 }
 

--- a/go/services/multipooler/manager/rpc_drain.go
+++ b/go/services/multipooler/manager/rpc_drain.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/eventlog"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// tombstoneWriteTimeout bounds the topology update attempted on shutdown after
+// a permanent drain. Shutdown must not hang; etcd errors are logged and
+// swallowed.
+const tombstoneWriteTimeout = 2 * time.Second
+
+// writeDrainTombstoneIfNeeded writes a best-effort tombstone (removed_at +
+// remove_reason) to this pooler's MultiPooler topology record when the
+// manager is permanently draining. Called from Shutdown. Errors are logged,
+// not returned — the signal published over streaming health is the
+// authoritative channel; the tombstone is an etcd-backed hint for consumers
+// that reconnect after this pooler is gone.
+func (pm *MultiPoolerManager) writeDrainTombstoneIfNeeded() {
+	pm.mu.Lock()
+	signal := pm.drainSignal
+	permanent := pm.drainPermanent
+	reason := pm.drainReason
+	pm.mu.Unlock()
+
+	if signal != clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING || !permanent {
+		return
+	}
+
+	if pm.topoClient == nil || pm.serviceID == nil {
+		pm.logger.Warn("Skipping drain tombstone: topo client or service ID unavailable")
+		return
+	}
+
+	// Shutdown has no incoming context to inherit; start a fresh bounded one so
+	// the write cannot hang past tombstoneWriteTimeout even if etcd is slow.
+	//nolint:gocritic // legitimate background entry point during shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), tombstoneWriteTimeout)
+	defer cancel()
+
+	now := timestamppb.Now()
+	_, err := pm.topoClient.UpdateMultiPoolerFields(ctx, pm.serviceID, func(mp *clustermetadatapb.MultiPooler) error {
+		mp.RemovedAt = now
+		mp.RemoveReason = reason
+		return nil
+	})
+	if err != nil {
+		pm.logger.Warn("Failed to write drain tombstone on shutdown; continuing", "error", err)
+		return
+	}
+	pm.logger.Info("Wrote drain tombstone on shutdown", "reason", reason.String())
+}
+
+// Drain initiates voluntary drain of this pooler. See
+// multipoolermanagerservice.proto for semantics. The RPC is idempotent:
+// calling on an already-draining node returns the current state.
+//
+// This implementation covers the replica (non-primary) path. The primary
+// path — restart as standby, signal resignation — lands in a later phase.
+// Likewise, forced termination of lingering client connections after
+// drain_timeout is out of scope here; the plan defers server-side
+// drain-aware query-serving behaviour.
+func (pm *MultiPoolerManager) Drain(ctx context.Context, req *multipoolermanagerdatapb.DrainRequest) (_ *multipoolermanagerdatapb.DrainResponse, retErr error) {
+	if err := pm.checkReady(); err != nil {
+		return nil, err
+	}
+
+	ctx, err := pm.actionLock.Acquire(ctx, "Drain")
+	if err != nil {
+		return nil, err
+	}
+	defer pm.actionLock.Release(ctx)
+
+	removeFromTopology := req.GetRemoveFromTopology()
+	reason := req.GetRemoveReason()
+	nodeName := pm.serviceID.GetName()
+	reasonStr := drainReasonString(removeFromTopology, reason)
+
+	eventlog.Emit(ctx, pm.logger, eventlog.Started, eventlog.NodeDrain{NodeName: nodeName, Reason: reasonStr})
+	defer func() {
+		if retErr == nil {
+			eventlog.Emit(ctx, pm.logger, eventlog.Success, eventlog.NodeDrain{NodeName: nodeName, Reason: reasonStr})
+		} else {
+			eventlog.Emit(ctx, pm.logger, eventlog.Failed, eventlog.NodeDrain{NodeName: nodeName, Reason: reasonStr}, "error", retErr)
+		}
+	}()
+
+	wasAlreadyDraining := pm.enterDraining(removeFromTopology, reason)
+
+	// Primary path: reuse the EmergencyDemote core to transition this node to
+	// standby and signal resignation so the coordinator can trigger an
+	// immediate election.
+	primaryPathTaken := false
+	var connectionsTerminated int32
+	if pm.getPoolerType() == clustermetadatapb.PoolerType_PRIMARY {
+		drainTimeout := req.GetDrainTimeout().AsDuration()
+		if drainTimeout <= 0 {
+			drainTimeout = 5 * time.Second
+		}
+		result, err := pm.demoteToStandbyLocked(ctx, drainTimeout)
+		if err != nil {
+			return nil, err
+		}
+		primaryPathTaken = true
+		connectionsTerminated = result.connectionsTerminated
+	}
+
+	_, effectiveRemoveFromTopology, _, _ := pm.drainSnapshot()
+
+	return &multipoolermanagerdatapb.DrainResponse{
+		WasAlreadyDraining:    wasAlreadyDraining,
+		PrimaryPathTaken:      primaryPathTaken,
+		ConnectionsTerminated: connectionsTerminated,
+		RemoveFromTopology:    effectiveRemoveFromTopology,
+	}, nil
+}
+
+// drainReasonString maps drain intent to the string value stored on the
+// NodeDrain event. Used by the event log consumers to distinguish
+// voluntary drains from the existing involuntary drain flow ("rewind_not_feasible").
+func drainReasonString(removeFromTopology bool, reason clustermetadatapb.RemoveReason) string {
+	if !removeFromTopology {
+		return "voluntary_temporary"
+	}
+	switch reason {
+	case clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN:
+		return "voluntary_permanent_scale_down"
+	case clustermetadatapb.RemoveReason_REMOVE_REASON_DECOMMISSION:
+		return "voluntary_permanent_decommission"
+	case clustermetadatapb.RemoveReason_REMOVE_REASON_REPLACED:
+		return "voluntary_permanent_replaced"
+	case clustermetadatapb.RemoveReason_REMOVE_REASON_OPERATOR_REQUESTED:
+		return "voluntary_permanent_operator_requested"
+	default:
+		return "voluntary_permanent_unknown"
+	}
+}
+
+// enterDraining transitions the manager into DRAINING. Idempotent: returns
+// wasAlreadyDraining=true when called on a manager already draining.
+// Upgrades permanent from false to true (never the reverse). When already
+// permanent, a non-UNKNOWN reason replaces the stored one (last-writer-wins).
+//
+// On the first transition to DRAINING, the healthStreamer is notified so the
+// signal flows into the next published HealthState immediately.
+func (pm *MultiPoolerManager) enterDraining(permanent bool, reason clustermetadatapb.RemoveReason) (wasAlreadyDraining bool) {
+	pm.mu.Lock()
+	if pm.drainSignal == clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING {
+		if permanent && !pm.drainPermanent {
+			pm.drainPermanent = true
+			pm.drainReason = reason
+		} else if pm.drainPermanent && reason != clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN {
+			pm.drainReason = reason
+		}
+		pm.mu.Unlock()
+		return true
+	}
+	pm.drainSignal = clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING
+	pm.drainPermanent = permanent
+	if permanent {
+		pm.drainReason = reason
+	}
+	pm.drainStartedAt = time.Now()
+	pm.mu.Unlock()
+
+	if pm.healthStreamer != nil {
+		pm.healthStreamer.SetServingSignal(clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING)
+	}
+	return false
+}
+
+// currentServingSignal returns the signal to publish in HealthState. Treats
+// the zero/UNKNOWN value as ACTIVE so consumers see a stable signal from
+// process start.
+func (pm *MultiPoolerManager) currentServingSignal() clustermetadatapb.ServingSignal {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	if pm.drainSignal == clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING {
+		return clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING
+	}
+	return clustermetadatapb.ServingSignal_SERVING_SIGNAL_ACTIVE
+}
+
+// drainSnapshot returns the current drain-state values for consumers that
+// need the full picture (tombstone writer, tests).
+func (pm *MultiPoolerManager) drainSnapshot() (signal clustermetadatapb.ServingSignal, permanent bool, reason clustermetadatapb.RemoveReason, startedAt time.Time) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.drainSignal, pm.drainPermanent, pm.drainReason, pm.drainStartedAt
+}

--- a/go/services/multipooler/manager/rpc_drain_test.go
+++ b/go/services/multipooler/manager/rpc_drain_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
+)
+
+// newDrainReadyManager returns a test manager prepared to accept Drain calls:
+// state is Ready and actionLock is initialised. healthStreamer is left nil;
+// enterDraining tolerates that.
+func newDrainReadyManager(t *testing.T) *MultiPoolerManager {
+	t.Helper()
+	pm, _ := newTestManagerWithMock("tg", "shard")
+	pm.mu.Lock()
+	pm.state = ManagerStateReady
+	pm.mu.Unlock()
+	pm.actionLock = NewActionLock()
+	return pm
+}
+
+func TestDrainState_DefaultActive(t *testing.T) {
+	pm, _ := newTestManagerWithMock("tg", "shard")
+
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_ACTIVE, pm.currentServingSignal())
+
+	signal, permanent, reason, startedAt := pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_UNKNOWN, signal)
+	assert.False(t, permanent)
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN, reason)
+	assert.True(t, startedAt.IsZero())
+}
+
+func TestDrainState_EnterDraining_Transitions(t *testing.T) {
+	pm, _ := newTestManagerWithMock("tg", "shard")
+
+	wasAlreadyDraining := pm.enterDraining(false, clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN)
+	assert.False(t, wasAlreadyDraining)
+
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, pm.currentServingSignal())
+
+	signal, permanent, _, startedAt := pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, signal)
+	assert.False(t, permanent)
+	assert.False(t, startedAt.IsZero())
+}
+
+func TestDrainState_EnterDraining_UpgradesToPermanent(t *testing.T) {
+	pm, _ := newTestManagerWithMock("tg", "shard")
+
+	pm.enterDraining(false, clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN)
+	_, _, _, firstStartedAt := pm.drainSnapshot()
+
+	wasAlreadyDraining := pm.enterDraining(true, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN)
+	assert.True(t, wasAlreadyDraining)
+
+	signal, permanent, reason, startedAt := pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, signal)
+	assert.True(t, permanent)
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN, reason)
+	assert.Equal(t, firstStartedAt, startedAt)
+}
+
+func TestDrainState_EnterDraining_NoDowngrade(t *testing.T) {
+	pm, _ := newTestManagerWithMock("tg", "shard")
+
+	pm.enterDraining(true, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN)
+
+	wasAlreadyDraining := pm.enterDraining(false, clustermetadatapb.RemoveReason_REMOVE_REASON_UNKNOWN)
+	assert.True(t, wasAlreadyDraining)
+
+	_, permanent, reason, _ := pm.drainSnapshot()
+	assert.True(t, permanent, "permanent must not downgrade")
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN, reason)
+}
+
+func TestDrainState_EnterDraining_ReasonLastWriterWins(t *testing.T) {
+	pm, _ := newTestManagerWithMock("tg", "shard")
+
+	pm.enterDraining(true, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN)
+
+	pm.enterDraining(true, clustermetadatapb.RemoveReason_REMOVE_REASON_DECOMMISSION)
+
+	_, permanent, reason, _ := pm.drainSnapshot()
+	assert.True(t, permanent)
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_DECOMMISSION, reason)
+}
+
+func TestDrain_ReplicaPath(t *testing.T) {
+	pm := newDrainReadyManager(t)
+
+	resp, err := pm.Drain(context.Background(), &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: false,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.WasAlreadyDraining)
+	assert.False(t, resp.PrimaryPathTaken)
+	assert.False(t, resp.RemoveFromTopology)
+
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, pm.currentServingSignal())
+}
+
+func TestDrain_PermanentWritesTombstoneOnShutdown(t *testing.T) {
+	pm := newDrainReadyManager(t)
+	pm.isOpen = true
+	ctx := context.Background()
+
+	// Register the MultiPooler in the topology so UpdateMultiPoolerFields can find it.
+	pm.multipooler.Id = pm.serviceID
+	require.NoError(t, pm.topoClient.CreateMultiPooler(ctx, pm.multipooler))
+
+	_, err := pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: true,
+		RemoveReason:       clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN,
+	})
+	require.NoError(t, err)
+
+	pm.writeDrainTombstoneIfNeeded()
+
+	info, err := pm.topoClient.GetMultiPooler(ctx, pm.serviceID)
+	require.NoError(t, err)
+	require.NotNil(t, info.MultiPooler.RemovedAt)
+	assert.Equal(
+		t,
+		clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN,
+		info.MultiPooler.RemoveReason,
+	)
+	assert.WithinDuration(t, time.Now(), info.MultiPooler.RemovedAt.AsTime(), 5*time.Second)
+}
+
+func TestObservesInvoluntaryDrain_PublishesDraining(t *testing.T) {
+	pm := newDrainReadyManager(t)
+	ctx := context.Background()
+
+	pm.multipooler.Id = pm.serviceID
+	pm.multipooler.Type = clustermetadatapb.PoolerType_REPLICA
+	require.NoError(t, pm.topoClient.CreateMultiPooler(ctx, pm.multipooler))
+
+	// Externally mark the pooler as involuntarily DRAINED in topology.
+	_, err := pm.topoClient.UpdateMultiPoolerFields(ctx, pm.serviceID, func(mp *clustermetadatapb.MultiPooler) error {
+		mp.Type = clustermetadatapb.PoolerType_DRAINED
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Invoke the observer that the heartbeat would call periodically.
+	pm.observeInvoluntaryDrain(ctx)
+
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, pm.currentServingSignal())
+	_, permanent, _, _ := pm.drainSnapshot()
+	assert.False(t, permanent, "involuntary drain must not flip the permanent flag")
+}
+
+func TestObservesInvoluntaryDrain_NonDrained_NoTransition(t *testing.T) {
+	pm := newDrainReadyManager(t)
+	ctx := context.Background()
+
+	pm.multipooler.Id = pm.serviceID
+	pm.multipooler.Type = clustermetadatapb.PoolerType_REPLICA
+	require.NoError(t, pm.topoClient.CreateMultiPooler(ctx, pm.multipooler))
+
+	pm.observeInvoluntaryDrain(ctx)
+
+	assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_ACTIVE, pm.currentServingSignal())
+}
+
+func TestDrain_NonPermanent_NoTombstone(t *testing.T) {
+	pm := newDrainReadyManager(t)
+	ctx := context.Background()
+
+	pm.multipooler.Id = pm.serviceID
+	require.NoError(t, pm.topoClient.CreateMultiPooler(ctx, pm.multipooler))
+
+	_, err := pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: false,
+	})
+	require.NoError(t, err)
+
+	pm.writeDrainTombstoneIfNeeded()
+
+	info, err := pm.topoClient.GetMultiPooler(ctx, pm.serviceID)
+	require.NoError(t, err)
+	assert.Nil(t, info.MultiPooler.RemovedAt, "non-permanent drain must not write a tombstone")
+}
+
+func TestDrain_IdempotentAndPermanentUpgrade(t *testing.T) {
+	pm := newDrainReadyManager(t)
+	ctx := context.Background()
+
+	resp, err := pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{})
+	require.NoError(t, err)
+	assert.False(t, resp.WasAlreadyDraining)
+	assert.False(t, resp.RemoveFromTopology)
+
+	resp, err = pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: true,
+		RemoveReason:       clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.WasAlreadyDraining)
+	assert.True(t, resp.RemoveFromTopology)
+	_, _, reason, _ := pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN, reason)
+
+	resp, err = pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: false,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.WasAlreadyDraining)
+	assert.True(t, resp.RemoveFromTopology, "remove_from_topology must not downgrade")
+	_, _, reason, _ = pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN, reason)
+
+	resp, err = pm.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: true,
+		RemoveReason:       clustermetadatapb.RemoveReason_REMOVE_REASON_DECOMMISSION,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.RemoveFromTopology)
+	_, _, reason, _ = pm.drainSnapshot()
+	assert.Equal(t, clustermetadatapb.RemoveReason_REMOVE_REASON_DECOMMISSION, reason)
+}
+
+// TestServingSignalPublishes verifies that setting DRAINING on the health
+// streamer causes subscribers to receive a HealthState carrying the
+// DRAINING signal.
+func TestServingSignalPublishes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hs := newHealthStreamer(logger, nil, "tg", "0")
+
+	ch := make(chan *poolerserver.HealthState, 10)
+	hs.clients[ch] = struct{}{}
+
+	hs.SetServingSignal(clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING)
+
+	select {
+	case state := <-ch:
+		require.NotNil(t, state)
+		assert.Equal(t, clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING, state.ServingSignal)
+	case <-time.After(time.Second):
+		t.Fatal("expected broadcast with DRAINING signal")
+	}
+}

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -864,6 +864,43 @@ func (pm *MultiPoolerManager) EmergencyDemote(ctx context.Context, consensusTerm
 // In the case that the dead primary received the RPC, it should just
 // shut down itself.
 func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consensusTerm int64, drainTimeout time.Duration) (*multipoolermanagerdatapb.EmergencyDemoteResponse, error) {
+	result, err := pm.demoteToStandbyLocked(ctx, drainTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if !result.wasAlreadyDemoted {
+		pm.logger.InfoContext(ctx, "Demote completed successfully",
+			"final_lsn", result.finalLSN,
+			"consensus_term", consensusTerm,
+			"connections_terminated", result.connectionsTerminated)
+	}
+
+	return &multipoolermanagerdatapb.EmergencyDemoteResponse{
+		WasAlreadyDemoted:     result.wasAlreadyDemoted,
+		ConsensusTerm:         consensusTerm,
+		LsnPosition:           result.finalLSN,
+		ConnectionsTerminated: result.connectionsTerminated,
+	}, nil
+}
+
+// demoteToStandbyResult captures the outcome of the shared primary-demote core
+// invoked by emergencyDemoteLocked and by the primary-path of voluntary Drain.
+type demoteToStandbyResult struct {
+	wasAlreadyDemoted     bool
+	finalLSN              string
+	connectionsTerminated int32
+}
+
+// demoteToStandbyLocked performs the primary-to-standby transition common to
+// EmergencyDemote and voluntary Drain. Callers must already hold the action
+// lock.
+//
+// The sequence: guardrail-check → snapshot demotion state → (if already
+// complete) return idempotently → NOT_SERVING → drain writes → terminate
+// remaining write connections → capture final LSN → signal resignation →
+// restart postgres as standby → clear primary observation.
+func (pm *MultiPoolerManager) demoteToStandbyLocked(ctx context.Context, drainTimeout time.Duration) (*demoteToStandbyResult, error) {
 	// Verify action lock is held
 	if err := AssertActionLockHeld(ctx); err != nil {
 		return nil, err
@@ -884,11 +921,9 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 
 	// If everything is already complete, return early (fully idempotent)
 	if state.isNotServing && state.isReplicaInTopology && state.isReadOnly {
-		return &multipoolermanagerdatapb.EmergencyDemoteResponse{
-			WasAlreadyDemoted:     true,
-			ConsensusTerm:         consensusTerm,
-			LsnPosition:           state.finalLSN,
-			ConnectionsTerminated: 0,
+		return &demoteToStandbyResult{
+			wasAlreadyDemoted: true,
+			finalLSN:          state.finalLSN,
 		}, nil
 	}
 
@@ -899,13 +934,11 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	}
 
 	// Drain write connections
-
 	if err := pm.drainWriteActivity(ctx, drainTimeout); err != nil {
 		return nil, err
 	}
 
 	// Terminate Remaining Write Connections
-
 	connectionsTerminated, err := pm.terminateWriteConnections(ctx)
 	if err != nil {
 		// Log but don't fail - connections will eventually timeout
@@ -921,8 +954,8 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 
 	// Signal voluntary resignation so the coordinator can trigger an immediate
 	// election without waiting for a heartbeat timeout. Use this node's own
-	// primary_term (not the incoming consensusTerm) so the coordinator can
-	// correlate the signal with the term at which this node was elected.
+	// primary_term so the coordinator can correlate the signal with the term
+	// at which this node was elected.
 	if term, err := pm.consensusState.GetTerm(ctx); err == nil && term.GetPrimaryTerm() != 0 {
 		if err := pm.setResignedPrimaryAtTerm(ctx, term.GetPrimaryTerm()); err != nil {
 			return nil, mterrors.Wrap(err, "failed to set resigned primary term")
@@ -942,16 +975,10 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	// otherwise restart postgres on this demoted node.
 	pm.rewindPending.Store(true)
 
-	pm.logger.InfoContext(ctx, "Demote completed successfully",
-		"final_lsn", finalLSN,
-		"consensus_term", consensusTerm,
-		"connections_terminated", connectionsTerminated)
-
-	return &multipoolermanagerdatapb.EmergencyDemoteResponse{
-		WasAlreadyDemoted:     false,
-		ConsensusTerm:         consensusTerm,
-		LsnPosition:           finalLSN,
-		ConnectionsTerminated: connectionsTerminated,
+	return &demoteToStandbyResult{
+		wasAlreadyDemoted:     false,
+		finalLSN:              finalLSN,
+		connectionsTerminated: connectionsTerminated,
 	}, nil
 }
 

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -307,6 +307,9 @@ func (pm *MultiPoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 		PostgresRunning:  pm.isPostgresRunning(ctx),
 		PostgresRole:     pm.getRole(ctx),
 		ShardId:          pm.getShardID(),
+		QueryServingStatus: &clustermetadatapb.ServingStatus{
+			Signal: pm.currentServingSignal(),
+		},
 	}
 
 	if action, duration := pm.actionLock.ActiveAction(); action != multipoolermanagerdatapb.PostgresAction_POSTGRES_ACTION_UNSPECIFIED {

--- a/go/services/multipooler/poolerserver/health_provider.go
+++ b/go/services/multipooler/poolerserver/health_provider.go
@@ -45,6 +45,11 @@ type HealthState struct {
 	// ReplicationLagNs is the current replication lag in nanoseconds,
 	// measured via heartbeat timestamps. Zero on the primary or when unknown.
 	ReplicationLagNs int64
+
+	// ServingSignal is the self-reported routing-layer signal. See
+	// clustermetadatapb.ServingSignal. Zero value (UNKNOWN) is treated as
+	// ACTIVE by consumers.
+	ServingSignal clustermetadatapb.ServingSignal
 }
 
 // PrimaryObservation represents a pooler's view of who the primary is.

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -519,33 +519,6 @@ func verifyStandbyDataConsistency(t *testing.T, name string, inst *shardsetup.Mu
 	assert.Equal(t, expectedChecksum, standbyChecksum, "Standby %s should have identical data to primary", name)
 }
 
-// checkPrimary checks if a specific multipooler is the primary.
-// Returns the multipooler name if it's a primary, empty string otherwise.
-// waitForNewPrimary waits for a new primary (different from oldPrimaryName) to be elected.
-func waitForNewPrimary(t *testing.T, setup *shardsetup.ShardSetup, oldPrimaryName string, timeout time.Duration) string {
-	t.Helper()
-
-	var poolers []*shardsetup.MultipoolerInstance
-	for _, inst := range setup.Multipoolers {
-		poolers = append(poolers, inst)
-	}
-
-	return shardsetup.EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
-		func(statuses []shardsetup.PoolerStatusResult) (string, bool, string) {
-			for _, r := range statuses {
-				if r.Name == oldPrimaryName || r.Err != nil || r.Status == nil {
-					continue
-				}
-				if r.Status.IsInitialized && r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY {
-					return r.Name, true, ""
-				}
-			}
-			return "", false, fmt.Sprintf("no new primary elected yet (old primary: %s)", oldPrimaryName)
-		},
-		"new primary not elected within %v", timeout,
-	)
-}
-
 // waitForNodeToRejoinAsStandby waits for a killed multipooler to be restarted by multiorch
 // and rejoin the cluster as a standby replica. It verifies the node is on the correct term,
 // streaming replication, and that the primary has added it back to its standby list.

--- a/go/test/endtoend/multiorch/drain_failover_test.go
+++ b/go/test/endtoend/multiorch/drain_failover_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// TestPrimaryDrain_TriggersFailover exercises the golden operator path: an
+// explicit Drain RPC on the current primary triggers the EmergencyDemote-style
+// demote-to-standby, multiorch observes REQUESTING_DEMOTION, elects a new
+// primary, and client writes via multigateway land on the new primary.
+func TestPrimaryDrain_TriggersFailover(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(3),
+		shardsetup.WithMultigateway(),
+	)
+	t.Cleanup(cleanup)
+	setup.StartMultiOrchs(t.Context(), t)
+
+	oldPrimary := setup.GetPrimary(t)
+	oldPrimaryName := oldPrimary.Name
+
+	// Capture the old primary's consensus term for the resignation-signal check.
+	client, err := shardsetup.NewMultipoolerClient(oldPrimary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	statusResp, err := client.Manager.Status(context.Background(), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	oldTerm := statusResp.Status.ConsensusTerm.GetPrimaryTerm()
+	require.NotZero(t, oldTerm, "old primary should have a non-zero primary term")
+
+	// Act: Drain RPC on the primary.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := client.Manager.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{})
+	require.NoError(t, err, "Drain RPC should succeed")
+	require.True(t, resp.PrimaryPathTaken, "Drain on primary should take the primary path")
+
+	// Assert: new primary elected.
+	newPrimaryName := waitForNewPrimary(t, setup, oldPrimaryName, 20*time.Second)
+	require.NotEqual(t, oldPrimaryName, newPrimaryName)
+
+	// Assert: former primary signals REQUESTING_DEMOTION for the old term.
+	// AvailabilityStatus lives on the Consensus.Status response, not Manager.Status.
+	require.Eventually(t, func() bool {
+		statusCtx, statusCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer statusCancel()
+		s, err := client.Consensus.Status(statusCtx, &consensusdatapb.StatusRequest{})
+		if err != nil {
+			return false
+		}
+		ls := s.GetAvailabilityStatus().GetLeadershipStatus()
+		return ls != nil &&
+			ls.Signal == clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION &&
+			ls.PrimaryTerm == oldTerm
+	}, 10*time.Second, 500*time.Millisecond, "former primary should advertise REQUESTING_DEMOTION for old term")
+
+	// Assert: write via multigateway succeeds and is readable.
+	dsn := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	pgxConn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer pgxConn.Close(context.Background())
+
+	_, err = pgxConn.Exec(ctx, `CREATE TABLE IF NOT EXISTS drain_failover_test (id int primary key, note text)`)
+	require.NoError(t, err, "CREATE TABLE against new primary via gateway should succeed")
+	_, err = pgxConn.Exec(ctx, `INSERT INTO drain_failover_test (id, note) VALUES (1, 'after-drain')`)
+	require.NoError(t, err, "INSERT via gateway should succeed")
+
+	var note string
+	err = pgxConn.QueryRow(ctx, `SELECT note FROM drain_failover_test WHERE id = 1`).Scan(&note)
+	require.NoError(t, err)
+	assert.Equal(t, "after-drain", note)
+}
+
+// TestPrimaryDrain_NoHealthyReplica_DoesNotSplitBrain proves the coordinator
+// does not zombie-promote when the primary drains with no eligible candidate.
+// The pooler demotes regardless (it does not introspect cluster state), and the
+// former primary's postgres goes read-only — but multiorch must NOT promote
+// anyone.
+func TestPrimaryDrain_NoHealthyReplica_DoesNotSplitBrain(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(3),
+	)
+	t.Cleanup(cleanup)
+	setup.StartMultiOrchs(t.Context(), t)
+
+	oldPrimary := setup.GetPrimary(t)
+	replicas := setup.GetStandbys()
+	require.Len(t, replicas, 2)
+
+	// Stop both replica multipooler processes so multiorch has no eligible target.
+	for _, r := range replicas {
+		r.Multipooler.TerminateGracefully(t.Logf, 10*time.Second)
+	}
+
+	client, err := shardsetup.NewMultipoolerClient(oldPrimary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Give multiorch a few recovery cycles to mark both replicas unreachable.
+	time.Sleep(5 * time.Second)
+
+	// Act.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	resp, err := client.Manager.Drain(ctx, &multipoolermanagerdatapb.DrainRequest{})
+	require.NoError(t, err)
+	require.True(t, resp.PrimaryPathTaken, "Drain should take primary path even in degraded cluster")
+
+	// Assert: former primary's postgres is read-only.
+	oldPrimaryDSN := shardsetup.GetTestUserDSN("localhost", oldPrimary.Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	require.Eventually(t, func() bool {
+		pgCtx, pgCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer pgCancel()
+		conn, err := pgx.Connect(pgCtx, oldPrimaryDSN)
+		if err != nil {
+			return true // postgres may be unavailable during demote — that also proves non-writable
+		}
+		defer conn.Close(context.Background())
+		_, err = conn.Exec(pgCtx, `CREATE TABLE degraded_drain_test (id int)`)
+		return err != nil // any write error proves read-only / non-writable
+	}, 15*time.Second, 500*time.Millisecond, "former primary should reject writes after Drain")
+
+	// Assert: no pooler *other than the old primary* becomes PRIMARY. Hold 20s =
+	// ≥15 recovery cycles past the 4s grace. The stopped replicas are excluded
+	// from the probe because their gRPC is down (Err != nil continue). The old
+	// primary is explicitly allowed because its topology record cannot be cleared
+	// without a successor — the assertion is that multiorch did not promote a
+	// different pooler.
+	assertNoNewPrimaryElected(t, setup, oldPrimary.Name, 20*time.Second, 2*time.Second)
+}
+
+// TestPrimaryDrain_SIGTERM_TriggersFailover exercises the safety-net path:
+// SIGTERM to the primary multipooler process triggers the in-process auto-Drain,
+// and multiorch elects a new primary. This is the real k8s ops path when
+// preStop didn't run (forced delete, node pressure, kubelet eviction).
+func TestPrimaryDrain_SIGTERM_TriggersFailover(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(3),
+		shardsetup.WithMultigateway(),
+	)
+	t.Cleanup(cleanup)
+	setup.StartMultiOrchs(t.Context(), t)
+
+	oldPrimary := setup.GetPrimary(t)
+	oldPrimaryName := oldPrimary.Name
+
+	// Act: SIGTERM the primary. Generous grace window (30s) to allow the
+	// in-process Drain on shutdown to complete the demote.
+	oldPrimary.Multipooler.TerminateGracefully(t.Logf, 30*time.Second)
+
+	// Assert: new primary elected.
+	newPrimaryName := waitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
+	require.NotEqual(t, oldPrimaryName, newPrimaryName)
+
+	// Assert: write via multigateway succeeds.
+	dsn := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pgxConn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer pgxConn.Close(context.Background())
+
+	_, err = pgxConn.Exec(ctx, `CREATE TABLE IF NOT EXISTS sigterm_drain_test (id int primary key)`)
+	require.NoError(t, err)
+	_, err = pgxConn.Exec(ctx, `INSERT INTO sigterm_drain_test (id) VALUES (1)`)
+	require.NoError(t, err)
+}

--- a/go/test/endtoend/multiorch/drain_signal_test.go
+++ b/go/test/endtoend/multiorch/drain_signal_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// TestDrainingReplica_StoppedReplication_MultiorchSkipsRecovery provokes a
+// condition that would normally make ReplicaNotReplicating fire — a draining
+// replica with paused WAL replay — and asserts multiorch emits NO Problems
+// for that pooler over a 20s window. Proves the IsVoluntarilyDraining skip
+// works against a real fault condition.
+func TestDrainingReplica_StoppedReplication_MultiorchSkipsRecovery(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+	)
+	t.Cleanup(cleanup)
+	setup.StartMultiOrchs(t.Context(), t)
+
+	replicas := setup.GetStandbys()
+	require.NotEmpty(t, replicas)
+	replicaA := replicas[0]
+
+	client, err := shardsetup.NewMultipoolerClient(replicaA.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := context.Background()
+
+	// Drain the replica.
+	drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	resp, err := client.Manager.Drain(drainCtx, &multipoolermanagerdatapb.DrainRequest{})
+	cancel()
+	require.NoError(t, err)
+	assert.False(t, resp.PrimaryPathTaken, "replica Drain should not take primary path")
+
+	// Pause WAL replay — would normally fire ReplicaNotReplicating.
+	stopCtx, stopCancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err = client.Manager.StopReplication(stopCtx, &multipoolermanagerdatapb.StopReplicationRequest{
+		Mode: multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_ONLY,
+		Wait: true,
+	})
+	stopCancel()
+	require.NoError(t, err)
+
+	// Sanity: WAL replay is actually paused.
+	sCtx, sCancel := context.WithTimeout(ctx, 2*time.Second)
+	st, err := client.Manager.Status(sCtx, &multipoolermanagerdatapb.StatusRequest{})
+	sCancel()
+	require.NoError(t, err)
+	require.NotNil(t, st.Status.ReplicationStatus)
+	assert.True(t, st.Status.ReplicationStatus.IsWalReplayPaused, "WAL replay should be paused")
+
+	// Connect to the multiorch and hold the no-problem assertion.
+	require.NotEmpty(t, setup.MultiOrchInstances, "test requires a multiorch instance")
+	var moInst *shardsetup.ProcessInstance
+	for _, mi := range setup.MultiOrchInstances {
+		moInst = mi
+		break
+	}
+	moClient, err := shardsetup.NewMultiOrchClient(moInst.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = moClient.Close() })
+
+	replicaID := setup.GetMultipoolerID(replicaA.Name)
+	require.NotNil(t, replicaID)
+
+	assertNoShardProblemsForPooler(t, moClient, replicaID,
+		"postgres", constants.DefaultTableGroup, constants.DefaultShard,
+		20*time.Second, 1*time.Second)
+}
+
+// TestReplicaDrain_SignalPropagatesToMultiorch proves: (a) Drain on a replica
+// publishes DRAINING observable via its own Status RPC within 5s, and (b)
+// primary's consensus term / standby list stay unchanged over a 10s hold
+// (no cohort-change triggered by drain — deferred work).
+func TestReplicaDrain_SignalPropagatesToMultiorch(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+	)
+	t.Cleanup(cleanup)
+	setup.StartMultiOrchs(t.Context(), t)
+
+	replicas := setup.GetStandbys()
+	require.NotEmpty(t, replicas)
+	replicaA := replicas[0]
+	primary := setup.GetPrimary(t)
+
+	replicaClient, err := shardsetup.NewMultipoolerClient(replicaA.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = replicaClient.Close() })
+	primaryClient, err := shardsetup.NewMultipoolerClient(primary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = primaryClient.Close() })
+
+	ctx := context.Background()
+
+	// Capture baseline consensus state from the primary.
+	psCtx, psCancel := context.WithTimeout(ctx, 2*time.Second)
+	before, err := primaryClient.Manager.Status(psCtx, &multipoolermanagerdatapb.StatusRequest{})
+	psCancel()
+	require.NoError(t, err)
+	baseTerm := before.Status.ConsensusTerm.GetPrimaryTerm()
+	require.NotNil(t, before.Status.PrimaryStatus, "primary should have PrimaryStatus populated")
+	var baseStandbyIDs []string
+	if sync := before.Status.PrimaryStatus.GetSyncReplicationConfig(); sync != nil {
+		for _, id := range sync.StandbyIds {
+			baseStandbyIDs = append(baseStandbyIDs, id.GetName())
+		}
+	}
+
+	// Act: Drain replica.
+	dCtx, dCancel := context.WithTimeout(ctx, 5*time.Second)
+	resp, err := replicaClient.Manager.Drain(dCtx, &multipoolermanagerdatapb.DrainRequest{})
+	dCancel()
+	require.NoError(t, err)
+	assert.False(t, resp.PrimaryPathTaken)
+
+	// Assert (positive): signal visible in the replica's own Status within 5s.
+	require.Eventually(t, func() bool {
+		sCtx, sCancel := context.WithTimeout(ctx, 2*time.Second)
+		defer sCancel()
+		s, err := replicaClient.Manager.Status(sCtx, &multipoolermanagerdatapb.StatusRequest{})
+		if err != nil || s.Status == nil || s.Status.QueryServingStatus == nil {
+			return false
+		}
+		return s.Status.QueryServingStatus.Signal == clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING
+	}, 5*time.Second, 200*time.Millisecond, "replica should self-report DRAINING")
+
+	// Assert (negative): over 10s, primary's consensus term and standby list unchanged.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		cCtx, cCancel := context.WithTimeout(ctx, 2*time.Second)
+		s, err := primaryClient.Manager.Status(cCtx, &multipoolermanagerdatapb.StatusRequest{})
+		cCancel()
+		require.NoError(t, err)
+		assert.Equal(t, baseTerm, s.Status.ConsensusTerm.GetPrimaryTerm(), "primary term must not change")
+		var currentStandbyIDs []string
+		if sync := s.Status.GetPrimaryStatus().GetSyncReplicationConfig(); sync != nil {
+			for _, id := range sync.StandbyIds {
+				currentStandbyIDs = append(currentStandbyIDs, id.GetName())
+			}
+		}
+		assert.ElementsMatch(t, baseStandbyIDs, currentStandbyIDs,
+			"standby list must not change — cohort updates are deferred work")
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/go/test/endtoend/multiorch/multiorch_helpers.go
+++ b/go/test/endtoend/multiorch/multiorch_helpers.go
@@ -15,6 +15,7 @@
 package multiorch
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -23,7 +24,9 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiorchpb "github.com/multigres/multigres/go/pb/multiorch"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 )
@@ -56,6 +59,109 @@ func waitForReplicationBroken(t *testing.T, inst *shardsetup.MultipoolerInstance
 			return true, ""
 		},
 		"replication should be broken (primary_conninfo cleared) within %v", timeout,
+	)
+}
+
+// assertNoShardProblemsForPooler polls multiorch.GetShardStatus throughout a
+// hold window and fails the test if any DetectedProblem references poolerID.
+// Use this to prove multiorch did NOT act on a pooler (e.g., the draining-replica
+// analyzer skip, where absence-of-problem is the thing being asserted).
+func assertNoShardProblemsForPooler(
+	t *testing.T,
+	moClient *shardsetup.MultiOrchClient,
+	poolerID *clustermetadatapb.ID,
+	database, tableGroup, shard string,
+	hold time.Duration,
+	pollInterval time.Duration,
+) {
+	t.Helper()
+
+	poolerIDStr := topoclient.MultiPoolerIDString(poolerID)
+	deadline := time.Now().Add(hold)
+	ticks := 0
+	for time.Now().Before(deadline) {
+		ticks++
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		resp, err := moClient.GetShardStatus(ctx, &multiorchpb.ShardStatusRequest{
+			Database:   database,
+			TableGroup: tableGroup,
+			Shard:      shard,
+		})
+		cancel()
+		require.NoError(t, err, "GetShardStatus failed at tick %d", ticks)
+		for _, p := range resp.Problems {
+			if p.PoolerId != nil && topoclient.MultiPoolerIDString(p.PoolerId) == poolerIDStr {
+				t.Fatalf("unexpected problem for pooler %s at tick %d: code=%s description=%s",
+					poolerIDStr, ticks, p.Code, p.Description)
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("assertNoShardProblemsForPooler: %s remained problem-free over %d ticks (%v)", poolerIDStr, ticks, hold)
+}
+
+// assertNoNewPrimaryElected polls every pooler's Status RPC over a hold window
+// and fails if any pooler other than allowedPrimary reports PoolerType=PRIMARY.
+// Use when proving that multiorch did NOT elect a new primary (e.g., the
+// degraded-cluster test where no eligible candidate exists). The allowedPrimary
+// is typically the old primary whose topology record cannot be cleared without
+// a successor.
+func assertNoNewPrimaryElected(
+	t *testing.T,
+	setup *shardsetup.ShardSetup,
+	allowedPrimary string,
+	hold time.Duration,
+	pollInterval time.Duration,
+) {
+	t.Helper()
+
+	poolers := make([]*shardsetup.MultipoolerInstance, 0, len(setup.Multipoolers))
+	for _, inst := range setup.Multipoolers {
+		poolers = append(poolers, inst)
+	}
+
+	deadline := time.Now().Add(hold)
+	ticks := 0
+	for time.Now().Before(deadline) {
+		ticks++
+		statuses := shardsetup.FetchPoolerStatuses(t, poolers)
+		for _, r := range statuses {
+			if r.Err != nil || r.Status == nil || r.Name == allowedPrimary {
+				continue
+			}
+			if r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY {
+				t.Fatalf("unexpected promotion at tick %d: pooler %s reports PoolerType=PRIMARY",
+					ticks, r.Name)
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("assertNoNewPrimaryElected: no pooler other than %s became PRIMARY over %d ticks (%v)",
+		allowedPrimary, ticks, hold)
+}
+
+// waitForNewPrimary waits for a new primary (different from oldPrimaryName) to be elected.
+func waitForNewPrimary(t *testing.T, setup *shardsetup.ShardSetup, oldPrimaryName string, timeout time.Duration) string {
+	t.Helper()
+
+	var poolers []*shardsetup.MultipoolerInstance
+	for _, inst := range setup.Multipoolers {
+		poolers = append(poolers, inst)
+	}
+
+	return shardsetup.EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
+		func(statuses []shardsetup.PoolerStatusResult) (string, bool, string) {
+			for _, r := range statuses {
+				if r.Name == oldPrimaryName || r.Err != nil || r.Status == nil {
+					continue
+				}
+				if r.Status.IsInitialized && r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY {
+					return r.Name, true, ""
+				}
+			}
+			return "", false, fmt.Sprintf("no new primary elected yet (old primary: %s)", oldPrimaryName)
+		},
+		"new primary not elected within %v", timeout,
 	)
 }
 

--- a/go/test/endtoend/multipooler/drain_test.go
+++ b/go/test/endtoend/multipooler/drain_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// TestObservedInvoluntaryDrain_SelfReportsDRAINING proves the pooler's heartbeat
+// loop re-publishes ServingSignal.DRAINING after observing its own MultiPooler
+// record transition to PoolerType.DRAINED in topology. This is the bridge that
+// makes voluntary and involuntary drains look identical to the gateway.
+func TestObservedInvoluntaryDrain_SelfReportsDRAINING(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+	)
+	t.Cleanup(cleanup)
+
+	// Pick a replica as the subject — primary stays up so bootstrap/durability
+	// is satisfied. The draining pooler just needs a running heartbeat loop.
+	replicas := setup.GetStandbys()
+	require.NotEmpty(t, replicas)
+	inst := replicas[0]
+
+	client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Act: flip PoolerType to DRAINED in topology directly.
+	poolerID := setup.GetMultipoolerID(inst.Name)
+	require.NotNil(t, poolerID)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = setup.TopoServer.UpdateMultiPoolerFields(ctx, poolerID, func(mp *clustermetadatapb.MultiPooler) error {
+		mp.Type = clustermetadatapb.PoolerType_DRAINED
+		return nil
+	})
+	cancel()
+	require.NoError(t, err)
+
+	// Assert: within one heartbeat interval (30s) + slack, pooler self-reports DRAINING.
+	require.Eventually(t, func() bool {
+		sCtx, sCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer sCancel()
+		s, err := client.Manager.Status(sCtx, &multipoolermanagerdatapb.StatusRequest{})
+		if err != nil || s.Status == nil || s.Status.QueryServingStatus == nil {
+			return false
+		}
+		return s.Status.QueryServingStatus.Signal == clustermetadatapb.ServingSignal_SERVING_SIGNAL_DRAINING
+	}, 45*time.Second, 2*time.Second, "pooler should self-report DRAINING within one heartbeat (30s) + slack")
+}
+
+// TestPermanentDrain_WritesTombstone proves the Drain-RPC → permanence-sticky →
+// Shutdown → writeDrainTombstoneIfNeeded chain. After a permanent Drain RPC
+// and a graceful SIGTERM, the pooler's MultiPooler topology record must have
+// RemovedAt set and RemoveReason = SCALE_DOWN.
+func TestPermanentDrain_WritesTombstone(t *testing.T) {
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+	)
+	t.Cleanup(cleanup)
+
+	replicas := setup.GetStandbys()
+	require.NotEmpty(t, replicas)
+	replicaA := replicas[0]
+	replicaID := setup.GetMultipoolerID(replicaA.Name)
+	require.NotNil(t, replicaID)
+
+	client, err := shardsetup.NewMultipoolerClient(replicaA.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Act: permanent Drain RPC, then graceful shutdown.
+	dCtx, dCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = client.Manager.Drain(dCtx, &multipoolermanagerdatapb.DrainRequest{
+		RemoveFromTopology: true,
+		RemoveReason:       clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN,
+	})
+	dCancel()
+	require.NoError(t, err)
+
+	replicaA.Multipooler.TerminateGracefully(t.Logf, 15*time.Second)
+
+	// Assert: tombstone fields set on the topology record.
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		mp, err := setup.TopoServer.GetMultiPooler(ctx, replicaID)
+		if err != nil || mp == nil || mp.MultiPooler == nil {
+			return false
+		}
+		return mp.MultiPooler.RemovedAt != nil &&
+			mp.MultiPooler.RemoveReason == clustermetadatapb.RemoveReason_REMOVE_REASON_SCALE_DOWN
+	}, 10*time.Second, 250*time.Millisecond, "tombstone fields should be set after permanent drain shutdown")
+}

--- a/go/test/endtoend/shardsetup/pooler_diagnostics.go
+++ b/go/test/endtoend/shardsetup/pooler_diagnostics.go
@@ -31,7 +31,7 @@ import (
 // with the reason and FormatPoolerDiagnostics output.
 func checkPoolerCondition(t *testing.T, poolers []*MultipoolerInstance, condition func(name string, s *multipoolermanagerdatapb.Status) (bool, string)) []string {
 	t.Helper()
-	statuses := fetchPoolerStatuses(t, poolers)
+	statuses := FetchPoolerStatuses(t, poolers)
 	var failures []string
 	for _, r := range statuses {
 		if r.Err != nil {
@@ -54,9 +54,9 @@ type PoolerStatusResult struct {
 	Err    error
 }
 
-// fetchPoolerStatuses fetches the status of each pooler in order, returning a slice
+// FetchPoolerStatuses fetches the status of each pooler in order, returning a slice
 // that preserves the input ordering (no map iteration randomness).
-func fetchPoolerStatuses(t *testing.T, poolers []*MultipoolerInstance) []PoolerStatusResult {
+func FetchPoolerStatuses(t *testing.T, poolers []*MultipoolerInstance) []PoolerStatusResult {
 	results := make([]PoolerStatusResult, 0, len(poolers))
 	for _, inst := range poolers {
 		client, err := NewMultipoolerClient(inst.Multipooler.GrpcPort)
@@ -93,7 +93,7 @@ func EventuallyPoolersCondition[T any](
 	t.Helper()
 	var result T
 	require.Eventually(t, func() bool {
-		statuses := fetchPoolerStatuses(t, poolers)
+		statuses := FetchPoolerStatuses(t, poolers)
 		val, met, reason := condition(statuses)
 		if !met {
 			for _, r := range statuses {

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -690,7 +690,7 @@ func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time
 	}
 
 	logClusterState := func() {
-		for _, r := range fetchPoolerStatuses(t, poolers) {
+		for _, r := range FetchPoolerStatuses(t, poolers) {
 			if r.Err != nil {
 				t.Logf("RequireRecovery: %s: fetch error: %v", r.Name, r.Err)
 			} else {

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -166,6 +166,16 @@ message MultiPooler {
   // Used by multiadmin to compute the primary's data directory for pgBackRest.
   string pg_data_dir = 11;
 
+  // removed_at marks the node as permanently removed from the topology
+  // by intention (operator scale-down, decommission). Set best-effort by
+  // the pooler during a Drain() with remove_from_topology=true; absence
+  // means "not a tombstoned record." Consumers treat presence as
+  // "this node is not coming back."
+  google.protobuf.Timestamp removed_at = 12;
+
+  // remove_reason classifies the removal. Only meaningful when
+  // removed_at is set.
+  RemoveReason remove_reason = 13;
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -330,6 +340,33 @@ enum AsyncReplicationFallbackMode {
   // ASYNC_REPLICATION_FALLBACK_MODE_REJECT rejects the leader appointment
   // if synchronous replication cannot be established to meet quorum requirements
   ASYNC_REPLICATION_FALLBACK_MODE_REJECT = 2;
+}
+
+// RemoveReason classifies why a pooler is being permanently removed
+// from the topology. Paired with MultiPooler.removed_at on tombstoned
+// records so operators and tooling can filter/understand historical
+// decommissions without parsing free text.
+enum RemoveReason {
+  // REMOVE_REASON_UNKNOWN is the zero value. Written by callers that do
+  // not specify a reason; consumers should treat this as
+  // "removed-but-unclassified."
+  REMOVE_REASON_UNKNOWN = 0;
+
+  // REMOVE_REASON_SCALE_DOWN. Removing this pooler as part of a planned
+  // capacity reduction.
+  REMOVE_REASON_SCALE_DOWN = 1;
+
+  // REMOVE_REASON_DECOMMISSION. The underlying host / pod is being
+  // permanently retired.
+  REMOVE_REASON_DECOMMISSION = 2;
+
+  // REMOVE_REASON_REPLACED. Pooler replaced by a new one (e.g., rolling
+  // update where the replacement has a different identity).
+  REMOVE_REASON_REPLACED = 3;
+
+  // REMOVE_REASON_OPERATOR_REQUESTED. Operator or admin explicitly
+  // requested removal via RPC without specifying a more specific reason.
+  REMOVE_REASON_OPERATOR_REQUESTED = 4;
 }
 
 // =============================================================================
@@ -520,4 +557,42 @@ message LeadershipStatus {
 message AvailabilityStatus {
   // leadership_status is only set by poolers that are or have been primary.
   LeadershipStatus leadership_status = 1;
+}
+
+// ServingSignal indicates whether a pooler is currently accepting
+// client-query RPCs. This is the signal gateway consumes to route traffic.
+// Unlike LeadershipSignal, ServingSignal is NOT term-scoped; absence after
+// process restart means unknown, not drained. Consumers treat absence as
+// ACTIVE.
+enum ServingSignal {
+  SERVING_SIGNAL_UNKNOWN = 0;
+
+  // Node is actively accepting query traffic.
+  SERVING_SIGNAL_ACTIVE = 1;
+
+  // Node is draining: not accepting new client-query RPCs, finishing
+  // in-flight queries. Gateway should stop routing new traffic to this node.
+  // The node may continue participating in consensus as a replica.
+  //
+  // Distinct from PoolerType.DRAINED, which is the topology-declared state
+  // written by multiorch for involuntary (data-diverged) drains. A pooler
+  // may report SERVING_SIGNAL_DRAINING for either a self-initiated voluntary
+  // drain or a response to an observed PoolerType.DRAINED on its own record.
+  SERVING_SIGNAL_DRAINING = 2;
+}
+
+// ServingStatus is published by all poolers that accept query traffic.
+// It lets gateway distinguish an actively serving node from one that is
+// draining. Absent after process restart; consumers treat absence as ACTIVE.
+//
+// Sources: self-reported by the pooler (fast path) or synthesized by the
+// coordinator from observed health state, following the same pattern as
+// AvailabilityStatus.
+//
+// Why a wrapper message (vs. a bare ServingSignal field): leaves room
+// for additional routing-layer signals (e.g., a draining-since timestamp)
+// without a proto field-number change — same reason AvailabilityStatus
+// wraps LeadershipSignal.
+message ServingStatus {
+  ServingSignal signal = 1;
 }

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -241,6 +241,13 @@ message Status {
   // This is the combined check: process must exist AND respond to pg_isready.
   // Use postgres_running to check only if the process exists.
   bool postgres_ready = 14;
+
+  // query_serving_status is the self-reported routing-layer signal
+  // gateway consumes to decide whether to send new client queries.
+  // Absence (after process restart) means ACTIVE. Distinct from
+  // MultiPooler.serving_status (PoolerServingStatus), which is a
+  // topology-lifecycle enum.
+  clustermetadata.ServingStatus query_serving_status = 15;
 }
 
 // PostgresAction identifies a long-running postgres manager operation.
@@ -353,6 +360,51 @@ message EmergencyDemoteResponse {
 
   // Number of connections that were terminated
   int32 connections_terminated = 4;
+}
+
+// DrainRequest initiates voluntary drain of this pooler.
+message DrainRequest {
+  // remove_from_topology indicates whether this pooler is being
+  // decommissioned. When true, the pooler will write a best-effort
+  // tombstone (removed_at + remove_reason) to its MultiPooler topology
+  // record on eventual shutdown.
+  bool remove_from_topology = 1;
+
+  // drain_timeout is the maximum wall-clock time to wait for in-flight
+  // client queries to finish before forcibly terminating connections.
+  // If unset or zero, defaults to 5s. Mirrors EmergencyDemoteRequest.drain_timeout.
+  google.protobuf.Duration drain_timeout = 2;
+
+  // remove_reason classifies the removal. Only meaningful when
+  // remove_from_topology=true; ignored otherwise. If
+  // remove_from_topology=true and this field is UNKNOWN, the tombstone
+  // will record UNKNOWN — callers are expected to set a real reason.
+  clustermetadata.RemoveReason remove_reason = 3;
+}
+
+// DrainResponse reports the outcome of a Drain request.
+message DrainResponse {
+  // was_already_draining is true if the pooler was already in DRAINING
+  // state when this RPC arrived.
+  bool was_already_draining = 1;
+
+  // primary_path_taken is true if the pooler was primary at drain entry
+  // and followed the EmergencyDemote path (restart as standby + signal
+  // resignation). False for non-primary drains.
+  bool primary_path_taken = 2;
+
+  // connections_terminated is the number of client connections that were
+  // forcibly terminated after drain_timeout expired. Mirrors
+  // EmergencyDemoteResponse.connections_terminated.
+  int32 connections_terminated = 3;
+
+  // remove_from_topology reflects the effective flag after this call.
+  // Sticky: once true, it stays true. If the pooler was already draining
+  // without topology removal and this call passed remove_from_topology=true,
+  // this field will be true. Calling Drain with remove_from_topology=false
+  // on a node already slated for topology removal does NOT downgrade —
+  // this field remains true.
+  bool remove_from_topology = 4;
 }
 
 // DemoteStalePrimary demotes a stale primary that came back online after failover.

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -45,6 +45,21 @@ service MultiPoolerManager {
     returns (multipoolermanagerdata.StatusResponse);
 
   //
+  // Pooler Lifecycle
+  //
+
+  // Drain initiates voluntary draining of the pooler. The pooler stops
+  // accepting new client-query RPCs, finishes in-flight queries (up to
+  // drain_timeout), and — if currently primary — restarts as standby and
+  // signals resignation to multiorch (same path as EmergencyDemote).
+  //
+  // Idempotent: calling Drain on an already-draining node returns the
+  // current drain state. Calling with permanent=true upgrades a
+  // non-permanent drain to permanent.
+  rpc Drain(multipoolermanagerdata.DrainRequest)
+    returns (multipoolermanagerdata.DrainResponse);
+
+  //
   // Backup and Restore
   // All of these RPCs perform backups and restores in the context
   // of the database, table group and shard this multipooler serves.

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -424,6 +424,13 @@ message StreamPoolerHealthResponse {
   // replication_lag_ns is the current replication lag in nanoseconds,
   // measured via heartbeat timestamps. Zero on the primary or when unknown.
   int64 replication_lag_ns = 6;
+
+  // query_serving_status is the self-reported routing-layer signal
+  // gateway consumes to decide whether to send new client queries.
+  // Absence (after process restart or for older poolers) is treated as
+  // ACTIVE. Distinct from serving_status above, which reflects topology
+  // lifecycle (SERVING/NOT_SERVING/BACKUP/RESTORE).
+  clustermetadata.ServingStatus query_serving_status = 7;
 }
 
 // PrimaryObservation represents a pooler's view of who the primary is.


### PR DESCRIPTION
**Currently, this draft PR only has proto changes. At this point, the goal is to get feedback for the data we are going to expose and the Drain RPC interface**

## Summary

- Adds the proto surface for voluntary pooler draining (Phase 1 of the drained-pooler-state plan).
- Introduces `ServingSignal` / `ServingStatus` so a pooler can self-report a routing-layer signal (`ACTIVE` / `DRAINING`) to multigateway, independent of the topology-lifecycle `PoolerServingStatus`.
- Adds a `Drain` RPC on `MultiPoolerManager` covering both replicas and primaries, with graceful in-flight query draining and an optional permanent (tombstone) mode.
- Adds `permanent_drain_at` and `permanent_drain_reason` tombstone fields on the `MultiPooler` topo record.

## Description

**`ServingSignal` + `ServingStatus` (clustermetadata.proto)**
A bare-named enum (sibling of `LeadershipSignal`) with `UNKNOWN` / `ACTIVE` / `DRAINING`, wrapped in a `ServingStatus` message so future routing-layer signals can be added without reshaping `Status`. This is returned from `MultiPoolerManager.Status` as `query_serving_status` and is distinct from the existing `PoolerServingStatus` on the topo record, which tracks lifecycle (provisioning/serving/deleting) rather than instantaneous routing intent.

**`Drain` RPC (multipoolermanagerservice.proto / multipoolermanagerdata.proto)**
Voluntary, graceful withdrawal from serving. The pooler flips to `DRAINING`, finishes in-flight queries up to `drain_timeout`, and — if primary — performs the demote using the same path as `EmergencyDemote`. Separate from `EmergencyDemote` because:
- it applies to replicas too (no demote needed),
- it is two-phase (stop new queries, wait for in-flight, then demote),
- it carries the permanent-tombstone concept (`permanent`, `permanent_drain_reason`), which is a voluntary-lifecycle concern, not HA,
- it is idempotent and a non-permanent drain can be upgraded to permanent.

**Tombstone fields on `MultiPooler`**
`permanent_drain_at` (timestamp) and `permanent_drain_reason` (`SCALE_DOWN` / `DECOMMISSION` / `REPLACED` / `OPERATOR_REQUESTED`) persist the fact that a pooler has been permanently removed from service so downstream components (multiorch, multigateway) can treat it as gone without relying on liveness alone.

## Scope

Proto surface only. Implementation (manager state machine, gateway consumption, multiorch handling, tests) lands in later phases of the plan so the wire contract can be reviewed first.