### PR TITLE
refactor(multiorch): embed multipoolermanagerdata.Status into PooleHealthState

### DIFF
--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -46,12 +46,29 @@ const (
 //
 // MultiPoolerConsensus provides consensus APIs for leader election
 type MultiPoolerConsensusClient interface {
-	// Leader Appointment Protocol
+	// BeginTerm initiates a new leadership term by requesting the current leader
+	// to step down. The current leader will revoke its leadership and trigger a
+	// new election, allowing the coordinator to select a new leader based on the
+	// latest replication state of the followers. This is used by MultiOrch during
+	// failover to ensure that the old leader steps down gracefully and does not
+	// continue to accept writes, which could lead to data divergence.
 	BeginTerm(ctx context.Context, in *consensusdata.BeginTermRequest, opts ...grpc.CallOption) (*consensusdata.BeginTermResponse, error)
-	// Status and Health
+	// Status provides the current status of the consensus service, including the
+	// health of the cluster, the current leader, and any ongoing elections. This
+	// is used by MultiOrch to monitor the cluster and determine if it needs to
+	// trigger failover or other recovery actions.
 	Status(ctx context.Context, in *consensusdata.StatusRequest, opts ...grpc.CallOption) (*consensusdata.StatusResponse, error)
+	// GetLeadershipView provides information about the current leader and
+	// followers in the cluster, including their health status and replication
+	// lag. This is used by MultiOrch to make informed decisions about failover.
 	GetLeadershipView(ctx context.Context, in *consensusdata.LeadershipViewRequest, opts ...grpc.CallOption) (*consensusdata.LeadershipViewResponse, error)
-	// Replication
+	// CanReachPrimary is a health check used by MultiOrch to determine if a
+	// follower can reach the primary.
+	//
+	// This is used during failover to check if a candidate is healthy and has
+	// network connectivity to the primary before attempting to promote it. It can
+	// also be used for monitoring and alerting purposes to detect network issues
+	// or replication problems that could affect the cluster's health.
 	CanReachPrimary(ctx context.Context, in *consensusdata.CanReachPrimaryRequest, opts ...grpc.CallOption) (*consensusdata.CanReachPrimaryResponse, error)
 }
 
@@ -109,12 +126,29 @@ func (c *multiPoolerConsensusClient) CanReachPrimary(ctx context.Context, in *co
 //
 // MultiPoolerConsensus provides consensus APIs for leader election
 type MultiPoolerConsensusServer interface {
-	// Leader Appointment Protocol
+	// BeginTerm initiates a new leadership term by requesting the current leader
+	// to step down. The current leader will revoke its leadership and trigger a
+	// new election, allowing the coordinator to select a new leader based on the
+	// latest replication state of the followers. This is used by MultiOrch during
+	// failover to ensure that the old leader steps down gracefully and does not
+	// continue to accept writes, which could lead to data divergence.
 	BeginTerm(context.Context, *consensusdata.BeginTermRequest) (*consensusdata.BeginTermResponse, error)
-	// Status and Health
+	// Status provides the current status of the consensus service, including the
+	// health of the cluster, the current leader, and any ongoing elections. This
+	// is used by MultiOrch to monitor the cluster and determine if it needs to
+	// trigger failover or other recovery actions.
 	Status(context.Context, *consensusdata.StatusRequest) (*consensusdata.StatusResponse, error)
+	// GetLeadershipView provides information about the current leader and
+	// followers in the cluster, including their health status and replication
+	// lag. This is used by MultiOrch to make informed decisions about failover.
 	GetLeadershipView(context.Context, *consensusdata.LeadershipViewRequest) (*consensusdata.LeadershipViewResponse, error)
-	// Replication
+	// CanReachPrimary is a health check used by MultiOrch to determine if a
+	// follower can reach the primary.
+	//
+	// This is used during failover to check if a candidate is healthy and has
+	// network connectivity to the primary before attempting to promote it. It can
+	// also be used for monitoring and alerting purposes to detect network issues
+	// or replication problems that could affect the cluster's health.
 	CanReachPrimary(context.Context, *consensusdata.CanReachPrimaryRequest) (*consensusdata.CanReachPrimaryResponse, error)
 	mustEmbedUnimplementedMultiPoolerConsensusServer()
 }

--- a/go/pb/multiorchdata/multiorchdata.pb.go
+++ b/go/pb/multiorchdata/multiorchdata.pb.go
@@ -45,7 +45,7 @@ const (
 // It contains:
 // - Core pooler metadata (embedded MultiPooler from topology)
 // - Timestamps for staleness detection
-// - Health metrics from Status RPC
+// - Full health status from the Status RPC (embedded as multipoolermanagerdata.Status)
 // - Computed fields for quick access
 type PoolerHealthState struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -60,49 +60,21 @@ type PoolerHealthState struct {
 	LastCheckAttempted  *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_check_attempted,json=lastCheckAttempted,proto3" json:"last_check_attempted,omitempty"`
 	LastCheckSuccessful *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=last_check_successful,json=lastCheckSuccessful,proto3" json:"last_check_successful,omitempty"`
 	LastSeen            *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`
-	// Health status from Status RPC (populated after successful health check).
-	// This is the type the pooler reports itself as, which may differ from
-	// the topology type (multi_pooler.type) if there's a failover in progress
-	// or type mismatch.
-	PoolerType clustermetadata.PoolerType `protobuf:"varint,7,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
-	// Primary-specific status (populated when pooler_type == PRIMARY)
-	PrimaryStatus *multipoolermanagerdata.PrimaryStatus `protobuf:"bytes,8,opt,name=primary_status,json=primaryStatus,proto3" json:"primary_status,omitempty"`
-	// Replica-specific status (populated when pooler_type == REPLICA)
-	ReplicationStatus *multipoolermanagerdata.StandbyReplicationStatus `protobuf:"bytes,9,opt,name=replication_status,json=replicationStatus,proto3" json:"replication_status,omitempty"`
-	// Whether PostgreSQL is currently running and accepting connections on this node.
-	// Determined from the Status RPC's postgres_ready field.
-	// Used to determine PrimaryReachable in the analyzer - a primary with postgres down
-	// should trigger PrimaryIsDead recovery even if the previous PrimaryStatus data exists.
-	IsPostgresReady bool `protobuf:"varint,10,opt,name=is_postgres_ready,json=isPostgresReady,proto3" json:"is_postgres_ready,omitempty"`
-	// Whether the pooler considers itself initialized.
-	// Determined from the Status RPC's is_initialized field.
-	// This is based on the data directory state, not LSN.
-	IsInitialized bool `protobuf:"varint,11,opt,name=is_initialized,json=isInitialized,proto3" json:"is_initialized,omitempty"`
-	// Whether the PostgreSQL data directory exists.
-	// Determined from the Status RPC's has_data_directory field.
-	HasDataDirectory bool `protobuf:"varint,12,opt,name=has_data_directory,json=hasDataDirectory,proto3" json:"has_data_directory,omitempty"`
-	// Consensus term information from Status RPC
-	ConsensusTerm *multipoolermanagerdata.ConsensusTerm `protobuf:"bytes,13,opt,name=consensus_term,json=consensusTerm,proto3" json:"consensus_term,omitempty"`
 	// Consensus status from ConsensusStatus RPC (for divergence detection)
 	ConsensusStatus *consensusdata.StatusResponse `protobuf:"bytes,14,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
-	// Cohort members from the most recent multigres.rule_history record,
-	// populated from the Status RPC response. An empty list (not nil) on an
-	// initialized pooler signals the shard needs its initial cohort established.
-	CohortMembers []*clustermetadata.ID `protobuf:"bytes,15,rep,name=cohort_members,json=cohortMembers,proto3" json:"cohort_members,omitempty"`
 	// Timestamp of the last time PostgreSQL specifically responded as healthy
 	// (i.e. pg_isready passed). Never cleared on failure — callers must compare
 	// against time.Now() to detect staleness.
 	LastPostgresReadyTime *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=last_postgres_ready_time,json=lastPostgresReadyTime,proto3" json:"last_postgres_ready_time,omitempty"`
-	// Whether the PostgreSQL process exists on this node, regardless of whether
-	// it accepts connections. Mirrors multipoolermanagerdata.Status.postgres_running.
-	// Used to distinguish SIGSTOP (process alive but unresponsive) from SIGKILL (process dead).
-	IsPostgresRunning bool `protobuf:"varint,17,opt,name=is_postgres_running,json=isPostgresRunning,proto3" json:"is_postgres_running,omitempty"`
 	// Whether a ManagerHealthStream stream is currently active for this pooler.
 	StreamConnected bool `protobuf:"varint,20,opt,name=stream_connected,json=streamConnected,proto3" json:"stream_connected,omitempty"`
 	// The time at which the current stream was established.
 	StreamConnectedSince *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=stream_connected_since,json=streamConnectedSince,proto3" json:"stream_connected_since,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Full health status from the most recent successful Status RPC or
+	// ManagerHealthStream snapshot. Nil until the first successful check.
+	Status        *multipoolermanagerdata.Status `protobuf:"bytes,22,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PoolerHealthState) Reset() {
@@ -177,65 +149,9 @@ func (x *PoolerHealthState) GetLastSeen() *timestamppb.Timestamp {
 	return nil
 }
 
-func (x *PoolerHealthState) GetPoolerType() clustermetadata.PoolerType {
-	if x != nil {
-		return x.PoolerType
-	}
-	return clustermetadata.PoolerType(0)
-}
-
-func (x *PoolerHealthState) GetPrimaryStatus() *multipoolermanagerdata.PrimaryStatus {
-	if x != nil {
-		return x.PrimaryStatus
-	}
-	return nil
-}
-
-func (x *PoolerHealthState) GetReplicationStatus() *multipoolermanagerdata.StandbyReplicationStatus {
-	if x != nil {
-		return x.ReplicationStatus
-	}
-	return nil
-}
-
-func (x *PoolerHealthState) GetIsPostgresReady() bool {
-	if x != nil {
-		return x.IsPostgresReady
-	}
-	return false
-}
-
-func (x *PoolerHealthState) GetIsInitialized() bool {
-	if x != nil {
-		return x.IsInitialized
-	}
-	return false
-}
-
-func (x *PoolerHealthState) GetHasDataDirectory() bool {
-	if x != nil {
-		return x.HasDataDirectory
-	}
-	return false
-}
-
-func (x *PoolerHealthState) GetConsensusTerm() *multipoolermanagerdata.ConsensusTerm {
-	if x != nil {
-		return x.ConsensusTerm
-	}
-	return nil
-}
-
 func (x *PoolerHealthState) GetConsensusStatus() *consensusdata.StatusResponse {
 	if x != nil {
 		return x.ConsensusStatus
-	}
-	return nil
-}
-
-func (x *PoolerHealthState) GetCohortMembers() []*clustermetadata.ID {
-	if x != nil {
-		return x.CohortMembers
 	}
 	return nil
 }
@@ -245,13 +161,6 @@ func (x *PoolerHealthState) GetLastPostgresReadyTime() *timestamppb.Timestamp {
 		return x.LastPostgresReadyTime
 	}
 	return nil
-}
-
-func (x *PoolerHealthState) GetIsPostgresRunning() bool {
-	if x != nil {
-		return x.IsPostgresRunning
-	}
-	return false
 }
 
 func (x *PoolerHealthState) GetStreamConnected() bool {
@@ -268,11 +177,18 @@ func (x *PoolerHealthState) GetStreamConnectedSince() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *PoolerHealthState) GetStatus() *multipoolermanagerdata.Status {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
 var File_multiorchdata_proto protoreflect.FileDescriptor
 
 const file_multiorchdata_proto_rawDesc = "" +
 	"\n" +
-	"\x13multiorchdata.proto\x12\rmultiorchdata\x1a\x15clustermetadata.proto\x1a\x13consensusdata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmultipoolermanagerdata.proto\"\xc1\t\n" +
+	"\x13multiorchdata.proto\x12\rmultiorchdata\x1a\x15clustermetadata.proto\x1a\x13consensusdata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cmultipoolermanagerdata.proto\"\xa4\a\n" +
 	"\x11PoolerHealthState\x12?\n" +
 	"\fmulti_pooler\x18\x01 \x01(\v2\x1c.clustermetadata.MultiPoolerR\vmultiPooler\x12!\n" +
 	"\ris_up_to_date\x18\x02 \x01(\bR\n" +
@@ -280,22 +196,14 @@ const file_multiorchdata_proto_rawDesc = "" +
 	"\x13is_last_check_valid\x18\x03 \x01(\bR\x10isLastCheckValid\x12L\n" +
 	"\x14last_check_attempted\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x12lastCheckAttempted\x12N\n" +
 	"\x15last_check_successful\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x13lastCheckSuccessful\x127\n" +
-	"\tlast_seen\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\blastSeen\x12<\n" +
-	"\vpooler_type\x18\a \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
-	"poolerType\x12L\n" +
-	"\x0eprimary_status\x18\b \x01(\v2%.multipoolermanagerdata.PrimaryStatusR\rprimaryStatus\x12_\n" +
-	"\x12replication_status\x18\t \x01(\v20.multipoolermanagerdata.StandbyReplicationStatusR\x11replicationStatus\x12*\n" +
-	"\x11is_postgres_ready\x18\n" +
-	" \x01(\bR\x0fisPostgresReady\x12%\n" +
-	"\x0eis_initialized\x18\v \x01(\bR\risInitialized\x12,\n" +
-	"\x12has_data_directory\x18\f \x01(\bR\x10hasDataDirectory\x12L\n" +
-	"\x0econsensus_term\x18\r \x01(\v2%.multipoolermanagerdata.ConsensusTermR\rconsensusTerm\x12H\n" +
-	"\x10consensus_status\x18\x0e \x01(\v2\x1d.consensusdata.StatusResponseR\x0fconsensusStatus\x12:\n" +
-	"\x0ecohort_members\x18\x0f \x03(\v2\x13.clustermetadata.IDR\rcohortMembers\x12S\n" +
-	"\x18last_postgres_ready_time\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x15lastPostgresReadyTime\x12.\n" +
-	"\x13is_postgres_running\x18\x11 \x01(\bR\x11isPostgresRunning\x12)\n" +
+	"\tlast_seen\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\blastSeen\x12H\n" +
+	"\x10consensus_status\x18\x0e \x01(\v2\x1d.consensusdata.StatusResponseR\x0fconsensusStatus\x12S\n" +
+	"\x18last_postgres_ready_time\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x15lastPostgresReadyTime\x12)\n" +
 	"\x10stream_connected\x18\x14 \x01(\bR\x0fstreamConnected\x12P\n" +
-	"\x16stream_connected_since\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\x14streamConnectedSinceB4Z2github.com/multigres/multigres/go/pb/multiorchdatab\x06proto3"
+	"\x16stream_connected_since\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\x14streamConnectedSince\x126\n" +
+	"\x06status\x18\x16 \x01(\v2\x1e.multipoolermanagerdata.StatusR\x06statusJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"J\x04\b\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\r\x10\x0eJ\x04\b\x0f\x10\x10J\x04\b\x11\x10\x12R\vpooler_typeR\x0eprimary_statusR\x12replication_statusR\x11is_postgres_readyR\x0eis_initializedR\x12has_data_directoryR\x0econsensus_termR\x0ecohort_membersR\x13is_postgres_runningB4Z2github.com/multigres/multigres/go/pb/multiorchdatab\x06proto3"
 
 var (
 	file_multiorchdata_proto_rawDescOnce sync.Once
@@ -311,34 +219,26 @@ func file_multiorchdata_proto_rawDescGZIP() []byte {
 
 var file_multiorchdata_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_multiorchdata_proto_goTypes = []any{
-	(*PoolerHealthState)(nil),                               // 0: multiorchdata.PoolerHealthState
-	(*clustermetadata.MultiPooler)(nil),                     // 1: clustermetadata.MultiPooler
-	(*timestamppb.Timestamp)(nil),                           // 2: google.protobuf.Timestamp
-	(clustermetadata.PoolerType)(0),                         // 3: clustermetadata.PoolerType
-	(*multipoolermanagerdata.PrimaryStatus)(nil),            // 4: multipoolermanagerdata.PrimaryStatus
-	(*multipoolermanagerdata.StandbyReplicationStatus)(nil), // 5: multipoolermanagerdata.StandbyReplicationStatus
-	(*multipoolermanagerdata.ConsensusTerm)(nil),            // 6: multipoolermanagerdata.ConsensusTerm
-	(*consensusdata.StatusResponse)(nil),                    // 7: consensusdata.StatusResponse
-	(*clustermetadata.ID)(nil),                              // 8: clustermetadata.ID
+	(*PoolerHealthState)(nil),             // 0: multiorchdata.PoolerHealthState
+	(*clustermetadata.MultiPooler)(nil),   // 1: clustermetadata.MultiPooler
+	(*timestamppb.Timestamp)(nil),         // 2: google.protobuf.Timestamp
+	(*consensusdata.StatusResponse)(nil),  // 3: consensusdata.StatusResponse
+	(*multipoolermanagerdata.Status)(nil), // 4: multipoolermanagerdata.Status
 }
 var file_multiorchdata_proto_depIdxs = []int32{
-	1,  // 0: multiorchdata.PoolerHealthState.multi_pooler:type_name -> clustermetadata.MultiPooler
-	2,  // 1: multiorchdata.PoolerHealthState.last_check_attempted:type_name -> google.protobuf.Timestamp
-	2,  // 2: multiorchdata.PoolerHealthState.last_check_successful:type_name -> google.protobuf.Timestamp
-	2,  // 3: multiorchdata.PoolerHealthState.last_seen:type_name -> google.protobuf.Timestamp
-	3,  // 4: multiorchdata.PoolerHealthState.pooler_type:type_name -> clustermetadata.PoolerType
-	4,  // 5: multiorchdata.PoolerHealthState.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
-	5,  // 6: multiorchdata.PoolerHealthState.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
-	6,  // 7: multiorchdata.PoolerHealthState.consensus_term:type_name -> multipoolermanagerdata.ConsensusTerm
-	7,  // 8: multiorchdata.PoolerHealthState.consensus_status:type_name -> consensusdata.StatusResponse
-	8,  // 9: multiorchdata.PoolerHealthState.cohort_members:type_name -> clustermetadata.ID
-	2,  // 10: multiorchdata.PoolerHealthState.last_postgres_ready_time:type_name -> google.protobuf.Timestamp
-	2,  // 11: multiorchdata.PoolerHealthState.stream_connected_since:type_name -> google.protobuf.Timestamp
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	1, // 0: multiorchdata.PoolerHealthState.multi_pooler:type_name -> clustermetadata.MultiPooler
+	2, // 1: multiorchdata.PoolerHealthState.last_check_attempted:type_name -> google.protobuf.Timestamp
+	2, // 2: multiorchdata.PoolerHealthState.last_check_successful:type_name -> google.protobuf.Timestamp
+	2, // 3: multiorchdata.PoolerHealthState.last_seen:type_name -> google.protobuf.Timestamp
+	3, // 4: multiorchdata.PoolerHealthState.consensus_status:type_name -> consensusdata.StatusResponse
+	2, // 5: multiorchdata.PoolerHealthState.last_postgres_ready_time:type_name -> google.protobuf.Timestamp
+	2, // 6: multiorchdata.PoolerHealthState.stream_connected_since:type_name -> google.protobuf.Timestamp
+	4, // 7: multiorchdata.PoolerHealthState.status:type_name -> multipoolermanagerdata.Status
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_multiorchdata_proto_init() }

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -113,14 +113,14 @@ func (c *Coordinator) discoverMaxTerm(cohort []*multiorchdatapb.PoolerHealthStat
 
 	for _, pooler := range cohort {
 		// Invariant: poolers in the cohort with successful health checks must have ConsensusTerm populated
-		if pooler.IsLastCheckValid && pooler.ConsensusTerm == nil {
+		if pooler.IsLastCheckValid && pooler.GetStatus().GetConsensusTerm() == nil {
 			return 0, mterrors.Errorf(mtrpcpb.Code_INTERNAL,
 				"healthy pooler %s in cohort missing consensus term data - health check invariant violated",
 				pooler.MultiPooler.Id.Name)
 		}
 
-		if pooler.ConsensusTerm != nil && pooler.ConsensusTerm.TermNumber > maxTerm {
-			maxTerm = pooler.ConsensusTerm.TermNumber
+		if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil && ct.TermNumber > maxTerm {
+			maxTerm = ct.TermNumber
 		}
 	}
 
@@ -561,7 +561,8 @@ func (c *Coordinator) preVote(ctx context.Context, cohort []*multiorchdatapb.Poo
 	// can't participate.
 	var eligiblePoolers []*multiorchdatapb.PoolerHealthState
 	for _, pooler := range cohort {
-		if pooler.IsLastCheckValid && pooler.IsInitialized && pooler.ConsensusTerm != nil && pooler.IsPostgresReady {
+		status := pooler.GetStatus()
+		if pooler.IsLastCheckValid && status.GetIsInitialized() && status.GetConsensusTerm() != nil && status.GetPostgresReady() {
 			eligiblePoolers = append(eligiblePoolers, pooler)
 		}
 	}
@@ -588,16 +589,16 @@ func (c *Coordinator) preVote(ctx context.Context, cohort []*multiorchdatapb.Poo
 	// to give the other coordinator a chance to complete their election.
 	for _, pooler := range eligiblePoolers {
 		// Check if this pooler recently accepted a term from another coordinator
-		if pooler.ConsensusTerm.LastAcceptanceTime != nil {
-			lastAcceptanceTime := pooler.ConsensusTerm.LastAcceptanceTime.AsTime()
+		if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil && ct.LastAcceptanceTime != nil {
+			lastAcceptanceTime := ct.LastAcceptanceTime.AsTime()
 			timeSinceAcceptance := now.Sub(lastAcceptanceTime)
 
 			// If the acceptance was recent (within our window), back off
 			if timeSinceAcceptance < recentAcceptanceWindow && timeSinceAcceptance >= 0 {
 				c.logger.InfoContext(ctx, "detected recent term acceptance, backing off to avoid disruption",
 					"pooler", pooler.MultiPooler.Id.Name,
-					"accepted_term", pooler.ConsensusTerm.TermNumber,
-					"accepted_from", pooler.ConsensusTerm.AcceptedTermFromCoordinatorId,
+					"accepted_term", ct.TermNumber,
+					"accepted_from", ct.AcceptedTermFromCoordinatorId,
 					"time_since_acceptance", timeSinceAcceptance,
 					"backoff_window", recentAcceptanceWindow)
 

--- a/go/services/multiorch/consensus/leader_appointment_prevote_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_prevote_test.go
@@ -67,9 +67,11 @@ func createPoolerForPreVote(name string, isHealthy bool, termNumber int64, lastA
 	return &multiorchdatapb.PoolerHealthState{
 		MultiPooler:      pooler,
 		IsLastCheckValid: isHealthy,
-		ConsensusTerm:    consensusTerm,
-		IsInitialized:    isInitialized,
-		IsPostgresReady:  isHealthy && isInitialized, // postgres is ready if healthy and initialized
+		Status: &multipoolermanagerdatapb.Status{
+			ConsensusTerm: consensusTerm,
+			IsInitialized: isInitialized,
+			PostgresReady: isHealthy && isInitialized, // postgres is ready if healthy and initialized
+		},
 	}
 }
 
@@ -222,10 +224,10 @@ func TestPreVote(t *testing.T) {
 
 		// Create 3 poolers: 2 healthy but with postgres not ready, 1 healthy with postgres ready
 		pooler1 := createPoolerForPreVote("mp1", true /* isHealthy */, 5 /* termNumber */, nil /* lastAcceptanceTime */, nil /* acceptedFrom */)
-		pooler1.IsPostgresReady = false // postgres not ready
+		pooler1.Status.PostgresReady = false // postgres not ready
 
 		pooler2 := createPoolerForPreVote("mp2", true /* isHealthy */, 5 /* termNumber */, nil /* lastAcceptanceTime */, nil /* acceptedFrom */)
-		pooler2.IsPostgresReady = false // postgres not ready
+		pooler2.Status.PostgresReady = false // postgres not ready
 
 		pooler3 := createPoolerForPreVote("mp3", true /* isHealthy */, 5 /* termNumber */, nil /* lastAcceptanceTime */, nil /* acceptedFrom */)
 		// pooler3 has postgres ready (default from helper)

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -105,8 +105,10 @@ func createMockNode(fakeClient *rpcclient.FakeClient, name string, term int64, w
 	return &multiorchdatapb.PoolerHealthState{
 		MultiPooler:      pooler,
 		IsLastCheckValid: healthy,
-		IsInitialized:    term > 0,
-		ConsensusTerm:    consensusTerm,
+		Status: &multipoolermanagerdatapb.Status{
+			IsInitialized: term > 0,
+			ConsensusTerm: consensusTerm,
+		},
 	}
 }
 
@@ -1399,13 +1401,13 @@ func TestAppointLeader(t *testing.T) {
 
 		// Create 3 nodes: mp1 (most advanced WAL), mp2, mp3
 		mp1 := createMockNode(fakeClient, "mp1", 5, "0/3000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
-		mp1.IsPostgresReady = true
+		mp1.Status.PostgresReady = true
 
 		mp2 := createMockNode(fakeClient, "mp2", 5, "0/2000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
-		mp2.IsPostgresReady = true
+		mp2.Status.PostgresReady = true
 
 		mp3 := createMockNode(fakeClient, "mp3", 5, "0/1000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
-		mp3.IsPostgresReady = true
+		mp3.Status.PostgresReady = true
 
 		// mp3 rejects the term during BeginTerm
 		mp3Key := topoclient.MultiPoolerIDString(mp3.MultiPooler.Id)
@@ -1494,14 +1496,14 @@ func TestAppointInitialLeader(t *testing.T) {
 
 		// Fresh standbys at term 0 (brand new nodes, just restored from backup)
 		mp1 := createMockNode(fakeClient, "mp1", 0, "0/2000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
-		mp1.IsInitialized = true
-		mp1.IsPostgresReady = true
-		mp1.ConsensusTerm = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 0}
+		mp1.Status.IsInitialized = true
+		mp1.Status.PostgresReady = true
+		mp1.Status.ConsensusTerm = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 0}
 
 		mp2 := createMockNode(fakeClient, "mp2", 0, "0/1000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
-		mp2.IsInitialized = true
-		mp2.IsPostgresReady = true
-		mp2.ConsensusTerm = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 0}
+		mp2.Status.IsInitialized = true
+		mp2.Status.PostgresReady = true
+		mp2.Status.ConsensusTerm = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 0}
 
 		require.NoError(t, ts.CreateMultiPooler(ctx, mp1.MultiPooler))
 		require.NoError(t, ts.CreateMultiPooler(ctx, mp2.MultiPooler))

--- a/go/services/multiorch/grpcserver/server.go
+++ b/go/services/multiorch/grpcserver/server.go
@@ -171,12 +171,12 @@ func (s *MultiOrchServer) buildPoolerHealthList(req *multiorchpb.ShardStatusRequ
 		}
 
 		// Get pooler type string
-		poolerType := p.PoolerType.String()
+		poolerType := p.GetStatus().GetPoolerType().String()
 
 		healthList = append(healthList, &multiorchpb.PoolerHealth{
 			PoolerId:      p.MultiPooler.Id,
 			Reachable:     p.IsLastCheckValid,
-			PostgresReady: p.IsPostgresReady,
+			PostgresReady: p.GetStatus().GetPostgresReady(),
 			PoolerType:    poolerType,
 			LastCheck:     p.LastCheckAttempted,
 		})

--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -83,9 +83,9 @@ func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem
 	// need to trigger failover.
 	for _, pooler := range cohort {
 		if pooler.MultiPooler == nil ||
-			pooler.PoolerType != clustermetadatapb.PoolerType_PRIMARY ||
+			pooler.GetStatus().GetPoolerType() != clustermetadatapb.PoolerType_PRIMARY ||
 			!pooler.IsLastCheckValid ||
-			!pooler.IsPostgresReady {
+			!pooler.GetStatus().GetPostgresReady() {
 			continue
 		}
 		if types.PrimaryNeedsReplacement(pooler) {

--- a/go/services/multiorch/recovery/actions/demote_stale_primary.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_primary.go
@@ -197,7 +197,7 @@ func (a *DemoteStalePrimaryAction) findCorrectPrimary(shardKey commontypes.Shard
 		}
 
 		// Check if this pooler is a PRIMARY
-		poolerType := pooler.PoolerType
+		poolerType := pooler.GetStatus().GetPoolerType()
 		if poolerType == clustermetadatapb.PoolerType_UNKNOWN && pooler.MultiPooler != nil {
 			poolerType = pooler.MultiPooler.Type
 		}
@@ -205,8 +205,8 @@ func (a *DemoteStalePrimaryAction) findCorrectPrimary(shardKey commontypes.Shard
 		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
 			// Get its PrimaryTerm (not consensus term)
 			var primaryTerm int64
-			if pooler.ConsensusTerm != nil {
-				primaryTerm = pooler.ConsensusTerm.PrimaryTerm
+			if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
+				primaryTerm = ct.PrimaryTerm
 			}
 
 			if primaryTerm > maxPrimaryTerm {

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -172,12 +172,12 @@ func (a *ShardInitAction) getInitializedPoolers(shardKey commontypes.ShardKey) (
 			pooler.MultiPooler.Shard != shardKey.Shard {
 			return true
 		}
-		if len(pooler.CohortMembers) > 0 {
+		if len(pooler.GetStatus().GetCohortMembers()) > 0 {
 			cohortEstablished = true
 			initialized = nil
 			return false // stop iteration
 		}
-		if pooler.IsInitialized {
+		if pooler.GetStatus().GetIsInitialized() {
 			initialized = append(initialized, pooler)
 		}
 		return true

--- a/go/services/multiorch/recovery/actions/shard_init_action_test.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action_test.go
@@ -30,6 +30,7 @@ import (
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
@@ -79,8 +80,10 @@ var testShardInitShardKey = commontypes.ShardKey{
 
 func makePoolerState(cell, name, db, tableGroup, shard string, initialized bool, cohortMembers []*clustermetadatapb.ID) *multiorchdatapb.PoolerHealthState {
 	return &multiorchdatapb.PoolerHealthState{
-		IsInitialized: initialized,
-		CohortMembers: cohortMembers,
+		Status: &multipoolermanagerdatapb.Status{
+			IsInitialized: initialized,
+			CohortMembers: cohortMembers,
+		},
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id: &clustermetadatapb.ID{
 				Component: clustermetadatapb.ID_MULTIPOOLER,

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -211,7 +211,7 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	// Determine pooler type from health check (PoolerType).
 	// Nodes are never created with topology type PRIMARY, so health check is authoritative.
 	// Fall back to topology type only if health check type is UNKNOWN.
-	poolerType := pooler.PoolerType
+	poolerType := pooler.GetStatus().GetPoolerType()
 	if poolerType == clustermetadatapb.PoolerType_UNKNOWN {
 		poolerType = pooler.MultiPooler.Type
 	}
@@ -223,8 +223,8 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 		IsPrimary:        poolerType == clustermetadatapb.PoolerType_PRIMARY,
 		LastCheckValid:   pooler.IsLastCheckValid,
 		IsInitialized:    store.IsInitialized(pooler),
-		HasDataDirectory: pooler.HasDataDirectory,
-		CohortMembers:    pooler.CohortMembers,
+		HasDataDirectory: pooler.GetStatus().GetHasDataDirectory(),
+		CohortMembers:    pooler.GetStatus().GetCohortMembers(),
 		AnalyzedAt:       time.Now(),
 	}
 
@@ -238,14 +238,13 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	}
 
 	// Store primary term (term when this pooler was promoted to primary)
-	if pooler.ConsensusTerm != nil {
-		analysis.PrimaryTerm = pooler.ConsensusTerm.PrimaryTerm
+	if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
+		analysis.PrimaryTerm = ct.PrimaryTerm
 	}
 
 	// If this is a REPLICA, populate replica-specific fields
 	if !analysis.IsPrimary {
-		if pooler.ReplicationStatus != nil {
-			rs := pooler.ReplicationStatus
+		if rs := pooler.GetStatus().GetReplicationStatus(); rs != nil {
 			analysis.ReplicationStopped = rs.IsWalReplayPaused
 
 			// Extract primary connection info
@@ -270,12 +269,12 @@ func findHighestTermRawPooler(poolers map[string]*multiorchdatapb.PoolerHealthSt
 		if pooler == nil || pooler.MultiPooler == nil || pooler.MultiPooler.Id == nil {
 			continue
 		}
-		if pooler.PoolerType != clustermetadatapb.PoolerType_PRIMARY {
+		if pooler.GetStatus().GetPoolerType() != clustermetadatapb.PoolerType_PRIMARY {
 			continue
 		}
 		var term int64
-		if pooler.ConsensusTerm != nil {
-			term = pooler.ConsensusTerm.PrimaryTerm
+		if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
+			term = ct.PrimaryTerm
 		}
 		if best == nil || term > bestTerm {
 			best = pooler
@@ -315,7 +314,7 @@ func (g *AnalysisGenerator) allReplicasConnectedToPrimary(
 		}
 
 		// Skip non-replicas
-		replicaType := pooler.PoolerType
+		replicaType := pooler.GetStatus().GetPoolerType()
 		if replicaType == clustermetadatapb.PoolerType_UNKNOWN {
 			replicaType = pooler.MultiPooler.Type
 		}
@@ -351,12 +350,13 @@ func (g *AnalysisGenerator) isReplicaConnectedToPrimary(
 	}
 
 	// Replica must have replication status
-	if replica.ReplicationStatus == nil {
+	rs := replica.GetStatus().GetReplicationStatus()
+	if rs == nil {
 		return false
 	}
 
 	// Replica must have PrimaryConnInfo pointing to the primary
-	connInfo := replica.ReplicationStatus.PrimaryConnInfo
+	connInfo := rs.PrimaryConnInfo
 	if connInfo == nil || connInfo.Host == "" {
 		return false
 	}
@@ -371,12 +371,12 @@ func (g *AnalysisGenerator) isReplicaConnectedToPrimary(
 	}
 
 	// Replica must have received WAL (indicates connection was established)
-	if replica.ReplicationStatus.LastReceiveLsn == "" {
+	if rs.LastReceiveLsn == "" {
 		return false
 	}
 
 	// WAL receiver must be in streaming state
-	if replica.ReplicationStatus.WalReceiverStatus != "streaming" {
+	if rs.WalReceiverStatus != "streaming" {
 		return false
 	}
 
@@ -389,13 +389,13 @@ func (g *AnalysisGenerator) isReplicaConnectedToPrimary(
 	// If the last heartbeat is older than WAL receiver timeout, the connection
 	// is effectively dead even if the replica hasn't noticed yet, so we check
 	// that as well.
-	if ts := replica.ReplicationStatus.LastMsgReceiveTime; ts != nil {
+	if ts := rs.LastMsgReceiveTime; ts != nil {
 		threshold := defaultReplicationHeartbeatStalenessThreshold
 		delay := g.now().Sub(ts.AsTime())
-		if d := replica.ReplicationStatus.WalReceiverTimeout; d != nil && delay > d.AsDuration() {
+		if d := rs.WalReceiverTimeout; d != nil && delay > d.AsDuration() {
 			return false
 		}
-		if d := replica.ReplicationStatus.WalReceiverStatusInterval; d != nil && d.AsDuration() > 0 {
+		if d := rs.WalReceiverStatusInterval; d != nil && d.AsDuration() > 0 {
 			threshold = replicationHeartbeatStalenessMultiplier * d.AsDuration()
 		}
 		if delay > threshold {
@@ -438,17 +438,17 @@ func (g *AnalysisGenerator) computeShardLevelFields(sa *ShardAnalysis, poolers m
 	if topologyPrimary != nil {
 		sa.HighestTermDiscoveredPrimaryID = topologyPrimary.MultiPooler.Id
 		sa.PrimaryPoolerReachable = topologyPrimary.IsLastCheckValid
-		sa.PrimaryPostgresReady = topologyPrimary.IsPostgresReady
-		sa.PrimaryPostgresRunning = topologyPrimary.IsPostgresRunning
+		sa.PrimaryPostgresReady = topologyPrimary.GetStatus().GetPostgresReady()
+		sa.PrimaryPostgresRunning = topologyPrimary.GetStatus().GetPostgresRunning()
 		sa.PrimaryHasResigned = types.PrimaryNeedsReplacement(topologyPrimary)
-		sa.PrimaryReachable = topologyPrimary.IsLastCheckValid && topologyPrimary.IsPostgresReady && !sa.PrimaryHasResigned
+		sa.PrimaryReachable = topologyPrimary.IsLastCheckValid && topologyPrimary.GetStatus().GetPostgresReady() && !sa.PrimaryHasResigned
 		if topologyPrimary.LastPostgresReadyTime != nil {
 			sa.PrimaryLastPostgresReadyTime = topologyPrimary.LastPostgresReadyTime.AsTime()
 		}
 
 		// Populate the standby list from the topology primary (used by IsInStandbyList).
-		if topologyPrimary.PrimaryStatus != nil && topologyPrimary.PrimaryStatus.SyncReplicationConfig != nil {
-			sa.PrimaryStandbyIDs = topologyPrimary.PrimaryStatus.SyncReplicationConfig.StandbyIds
+		if ps := topologyPrimary.GetStatus().GetPrimaryStatus(); ps != nil && ps.SyncReplicationConfig != nil {
+			sa.PrimaryStandbyIDs = ps.SyncReplicationConfig.StandbyIds
 		}
 	}
 

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -61,10 +61,12 @@ func TestAnalysisGenerator_GenerateShardAnalyses_SinglePrimary(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
-			Lsn:   "0/1234567",
-			Ready: true,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+				Lsn:   "0/1234567",
+				Ready: true,
+			},
 		},
 	}
 	ps.Set("multipooler-cell1-primary-1", primary)
@@ -116,11 +118,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
-			Lsn:                "0/1234567",
-			Ready:              true,
-			ConnectedFollowers: []*clustermetadatapb.ID{replica1ID, replica2ID},
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+				Lsn:                "0/1234567",
+				Ready:              true,
+				ConnectedFollowers: []*clustermetadatapb.ID{replica1ID, replica2ID},
+			},
 		},
 	}
 	ps.Set("multipooler-cell1-primary-1", primary)
@@ -137,10 +141,12 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: false,
-			Lag:               durationpb.New(100 * time.Millisecond), // 100ms lag
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: false,
+				Lag:               durationpb.New(100 * time.Millisecond), // 100ms lag
+			},
 		},
 	}
 	ps.Set("multipooler-cell1-replica-1", replica1)
@@ -157,10 +163,12 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: false,
-			Lag:               durationpb.New(15 * time.Second), // 15s lag (> 10s threshold)
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: false,
+				Lag:               durationpb.New(15 * time.Second), // 15s lag (> 10s threshold)
+			},
 		},
 	}
 	ps.Set("multipooler-cell1-replica-2", replica2)
@@ -209,9 +217,11 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		IsPostgresReady:  true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+			PostgresReady: true,
+		},
 	}
 	ps.Set("multipooler-cell1-primary-1", primary)
 
@@ -227,11 +237,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: false,
-			Lag:               durationpb.New(500 * time.Millisecond),
-			LastReplayLsn:     "0/1234567",
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: false,
+				Lag:               durationpb.New(500 * time.Millisecond),
+				LastReplayLsn:     "0/1234567",
+			},
 		},
 	}
 	ps.Set("multipooler-cell1-replica-1", replica)
@@ -272,7 +284,9 @@ func TestAnalysisGenerator_GenerateShardAnalyses_MultipleTableGroups(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		},
 	}
 	ps.Set("multipooler-cell1-tg1-primary", tg1Primary)
 
@@ -291,7 +305,9 @@ func TestAnalysisGenerator_GenerateShardAnalyses_MultipleTableGroups(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		},
 	}
 	ps.Set("multipooler-cell1-tg2-primary", tg2Primary)
 
@@ -329,8 +345,10 @@ func TestGenerateShardAnalyses_SkipsNilEntries(t *testing.T) {
 			TableGroup: "tg1",
 			Shard:      "shard1",
 		},
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 		IsLastCheckValid: true,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+		},
 	})
 
 	gen := NewAnalysisGenerator(ps, nil)
@@ -357,10 +375,12 @@ func TestPopulatePrimaryInfo_NoPrimaryInShard(t *testing.T) {
 			TableGroup: "tg1",
 			Shard:      "shard1",
 		},
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 		IsLastCheckValid: true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			LastReplayLsn: "0/1234",
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				LastReplayLsn: "0/1234",
+			},
 		},
 	})
 
@@ -380,7 +400,7 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 	primaryID := "multipooler-cell1-primary"
 	replicaID := "multipooler-cell1-replica"
 
-	// Primary with IsPostgresReady: false (postgres is down)
+	// Primary with PostgresReady: false (postgres is down)
 	ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id: &clustermetadatapb.ID{
@@ -392,10 +412,12 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 			TableGroup: "tg1",
 			Shard:      "shard1",
 		},
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 		IsLastCheckValid: true,
-		IsPostgresReady:  false, // Postgres is down!
-		PrimaryStatus:    &multipoolermanagerdatapb.PrimaryStatus{Lsn: "0/1234"},
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+			PostgresReady: false, // Postgres is down!
+			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{Lsn: "0/1234"},
+		},
 	})
 
 	ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
@@ -409,10 +431,12 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 			TableGroup: "tg1",
 			Shard:      "shard1",
 		},
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 		IsLastCheckValid: true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			LastReplayLsn: "0/1234",
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				LastReplayLsn: "0/1234",
+			},
 		},
 	})
 
@@ -534,10 +558,12 @@ func TestIsInStandbyList(t *testing.T) {
 				},
 				IsLastCheckValid: true,
 				IsUpToDate:       true,
-				IsPostgresReady:  true,
 				LastSeen:         timestamppb.Now(),
-				PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-				PrimaryStatus:    tt.primaryStatus,
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+					PostgresReady: true,
+					PrimaryStatus: tt.primaryStatus,
+				},
 			})
 
 			generator := NewAnalysisGenerator(ps, nil)
@@ -573,10 +599,12 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:            clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid:      true,
-			IsPostgresReady:       true,
 			LastPostgresReadyTime: timestamppb.New(respondedAt),
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: true,
+			},
 		})
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
@@ -590,8 +618,10 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			},
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
@@ -625,9 +655,11 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: false, // Pooler unreachable
-			IsPostgresReady:  false,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: false,
+			},
 		})
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
@@ -641,8 +673,10 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			},
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
@@ -676,9 +710,11 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: false, // Primary pooler is down
-			IsPostgresReady:  false,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: false,
+			},
 		})
 
 		now := time.Now()
@@ -695,15 +731,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:     "0/1234567",
-				WalReceiverStatus:  "streaming",
-				LastMsgReceiveTime: timestamppb.New(now.Add(-5 * time.Second)),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:     "0/1234567",
+					WalReceiverStatus:  "streaming",
+					LastMsgReceiveTime: timestamppb.New(now.Add(-5 * time.Second)),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -720,15 +758,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:     "0/1234567",
-				WalReceiverStatus:  "streaming",
-				LastMsgReceiveTime: timestamppb.New(now.Add(-5 * time.Second)),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:     "0/1234567",
+					WalReceiverStatus:  "streaming",
+					LastMsgReceiveTime: timestamppb.New(now.Add(-5 * time.Second)),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -760,9 +800,11 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: false,
-			IsPostgresReady:  false,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: false,
+			},
 		})
 
 		// Replica 1 - connected
@@ -777,15 +819,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:     "0/1234567",
-				WalReceiverStatus:  "streaming",
-				LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:     "0/1234567",
+					WalReceiverStatus:  "streaming",
+					LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -802,10 +846,12 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:        clustermetadatapb.PoolerType_REPLICA,
-			IsLastCheckValid:  true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				// No PrimaryConnInfo - replica is disconnected
+			IsLastCheckValid: true,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:        clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					// No PrimaryConnInfo - replica is disconnected
+				},
 			},
 		})
 
@@ -835,9 +881,11 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: false,
-			IsPostgresReady:  false,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: false,
+			},
 		})
 
 		// Replica is unreachable
@@ -852,8 +900,10 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: false, // Replica unreachable
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			},
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
@@ -882,9 +932,11 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: true,
-			IsPostgresReady:  true,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: true,
+			},
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
@@ -914,9 +966,11 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: false,
-			IsPostgresReady:  false,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				PostgresReady: false,
+			},
 		})
 
 		// Replica pointing to different host
@@ -931,15 +985,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:     "0/1234567",
-				WalReceiverStatus:  "streaming",
-				LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "different-host", // Wrong host!
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:     "0/1234567",
+					WalReceiverStatus:  "streaming",
+					LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "different-host", // Wrong host!
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -966,7 +1022,9 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			},
 		})
 
 		for _, status := range []string{"", "starting", "waiting", "stopping"} {
@@ -977,15 +1035,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 					TableGroup: "tg1",
 					Shard:      "shard1",
 				},
-				PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 				IsLastCheckValid: true,
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					LastReceiveLsn:     "0/1234567",
-					WalReceiverStatus:  status, // not "streaming"
-					LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
-					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-						Host: "primary-host",
-						Port: 5432,
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType: clustermetadatapb.PoolerType_REPLICA,
+					ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+						LastReceiveLsn:     "0/1234567",
+						WalReceiverStatus:  status, // not "streaming"
+						LastMsgReceiveTime: timestamppb.New(time.Now().Add(-5 * time.Second)),
+						PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+							Host: "primary-host",
+							Port: 5432,
+						},
 					},
 				},
 			})
@@ -1013,7 +1073,9 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			},
 		})
 
 		fixedNow := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -1026,16 +1088,18 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:     "0/1234567",
-				WalReceiverStatus:  "streaming",
-				LastMsgReceiveTime: timestamppb.New(staleTime),
-				// WalReceiverStatusInterval intentionally nil — exercises fallback path
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:     "0/1234567",
+					WalReceiverStatus:  "streaming",
+					LastMsgReceiveTime: timestamppb.New(staleTime),
+					// WalReceiverStatusInterval intentionally nil — exercises fallback path
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -1064,7 +1128,9 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			},
 		})
 
 		fixedNow := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -1079,16 +1145,18 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:            "0/1234567",
-				WalReceiverStatus:         "streaming",
-				LastMsgReceiveTime:        timestamppb.New(staleTime),
-				WalReceiverStatusInterval: durationpb.New(interval),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:            "0/1234567",
+					WalReceiverStatus:         "streaming",
+					LastMsgReceiveTime:        timestamppb.New(staleTime),
+					WalReceiverStatusInterval: durationpb.New(interval),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -1118,7 +1186,9 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			},
 		})
 
 		fixedNow := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -1135,17 +1205,19 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:            "0/1234567",
-				WalReceiverStatus:         "streaming",
-				LastMsgReceiveTime:        timestamppb.New(lastMsgReceiveTime),
-				WalReceiverStatusInterval: durationpb.New(10 * time.Second),
-				WalReceiverTimeout:        durationpb.New(walReceiverTimeout),
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:            "0/1234567",
+					WalReceiverStatus:         "streaming",
+					LastMsgReceiveTime:        timestamppb.New(lastMsgReceiveTime),
+					WalReceiverStatusInterval: durationpb.New(10 * time.Second),
+					WalReceiverTimeout:        durationpb.New(walReceiverTimeout),
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -1176,7 +1248,9 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				Hostname:   "primary-host",
 				PortMap:    map[string]int32{"postgres": 5432},
 			},
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+			},
 		})
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
@@ -1186,15 +1260,17 @@ func TestAllReplicasConnectedToPrimary(t *testing.T) {
 				TableGroup: "tg1",
 				Shard:      "shard1",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 			IsLastCheckValid: true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				LastReceiveLsn:    "0/1234567",
-				WalReceiverStatus: "streaming",
-				// LastMsgReceiveTime intentionally nil
-				PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
-					Host: "primary-host",
-					Port: 5432,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					LastReceiveLsn:    "0/1234567",
+					WalReceiverStatus: "streaming",
+					// LastMsgReceiveTime intentionally nil
+					PrimaryConnInfo: &multipoolermanagerdatapb.PrimaryConnInfo{
+						Host: "primary-host",
+						Port: 5432,
+					},
 				},
 			},
 		})
@@ -1239,14 +1315,16 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		IsPostgresReady:  true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-		PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
-			Lsn:   "0/1234567",
-			Ready: true,
-			SyncReplicationConfig: &multipoolermanagerdatapb.SynchronousReplicationConfiguration{
-				StandbyIds: []*clustermetadatapb.ID{replica1ID},
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+			PostgresReady: true,
+			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+				Lsn:   "0/1234567",
+				Ready: true,
+				SyncReplicationConfig: &multipoolermanagerdatapb.SynchronousReplicationConfiguration{
+					StandbyIds: []*clustermetadatapb.ID{replica1ID},
+				},
 			},
 		},
 	})
@@ -1263,10 +1341,12 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: false,
-			Lag:               durationpb.New(100 * time.Millisecond),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: false,
+				Lag:               durationpb.New(100 * time.Millisecond),
+			},
 		},
 	})
 
@@ -1282,10 +1362,12 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: false,
-			Lag:               durationpb.New(100 * time.Millisecond),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: false,
+				Lag:               durationpb.New(100 * time.Millisecond),
+			},
 		},
 	})
 
@@ -1341,23 +1423,27 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 	// New (correct) primary: higher PrimaryTerm, postgres running.
 	ps.Set("multipooler-cell1-new-primary", &multiorchdatapb.PoolerHealthState{
 		MultiPooler:      shardConfig(newPrimaryID),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 		IsLastCheckValid: true,
-		IsPostgresReady:  true,
 		LastSeen:         timestamppb.Now(),
-		ConsensusTerm:    &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 11, PrimaryTerm: 6},
 		ConsensusStatus:  &consensusdatapb.StatusResponse{CurrentTerm: 11},
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+			PostgresReady: true,
+			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 11, PrimaryTerm: 6},
+		},
 	})
 
 	// Stale primary: lower PrimaryTerm, postgres NOT running (just came back after being killed).
 	ps.Set("multipooler-cell1-stale-primary", &multiorchdatapb.PoolerHealthState{
 		MultiPooler:      shardConfig(stalePrimaryID),
-		PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 		IsLastCheckValid: true,
-		IsPostgresReady:  false,
 		LastSeen:         timestamppb.Now(),
-		ConsensusTerm:    &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10, PrimaryTerm: 5},
 		ConsensusStatus:  &consensusdatapb.StatusResponse{CurrentTerm: 10},
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+			PostgresReady: false,
+			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10, PrimaryTerm: 5},
+		},
 	})
 
 	// Replica.
@@ -1366,9 +1452,11 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 			Id: replicaID, Database: "testdb", TableGroup: "default", Shard: "0",
 			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
-		PoolerType:       clustermetadatapb.PoolerType_REPLICA,
 		IsLastCheckValid: true,
 		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+		},
 	})
 
 	generator := NewAnalysisGenerator(ps, nil)
@@ -1595,15 +1683,17 @@ func setupMultiplePrimariesStoreWithReachability(t *testing.T, primaries []prima
 				Type:       clustermetadatapb.PoolerType_PRIMARY,
 				Hostname:   "localhost",
 			},
-			PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
 			IsLastCheckValid: p.reachable,
 			IsUpToDate:       true,
 			ConsensusStatus: &consensusdatapb.StatusResponse{
 				CurrentTerm: p.consensusTerm,
 			},
-			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{
-				TermNumber:  p.consensusTerm,
-				PrimaryTerm: p.primaryTerm,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+				ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{
+					TermNumber:  p.consensusTerm,
+					PrimaryTerm: p.primaryTerm,
+				},
 			},
 		}
 		ps.Set(poolerID, poolerState)
@@ -1624,7 +1714,9 @@ func TestGenerateShardAnalyses_GroupsByShardKey(t *testing.T) {
 				Shard:      shard,
 				Type:       typ,
 			},
-			PoolerType: typ,
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: typ,
+			},
 		}
 	}
 
@@ -1665,7 +1757,9 @@ func TestGenerateShardAnalysis_ReturnsAllPoolersInShard(t *testing.T) {
 			Database: "db", TableGroup: "tg", Shard: "0",
 			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
-		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		},
 	})
 	ps.Set("multipooler-c1-replica", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
@@ -1673,7 +1767,9 @@ func TestGenerateShardAnalysis_ReturnsAllPoolersInShard(t *testing.T) {
 			Database: "db", TableGroup: "tg", Shard: "0",
 			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
-		PoolerType: clustermetadatapb.PoolerType_REPLICA,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+		},
 	})
 
 	gen := NewAnalysisGenerator(ps, nil)

--- a/go/services/multiorch/recovery/discovery_test.go
+++ b/go/services/multiorch/recovery/discovery_test.go
@@ -310,7 +310,7 @@ func TestDiscovery_PreservesTimestamps(t *testing.T) {
 	)
 	startEngine(t, engine)
 
-	poolerStoreDiscovered := func(val int) func() bool {
+	poolerStoreDiscovered := func(_ int) func() bool {
 		return func() bool {
 			_, ok := engine.poolerStore.Get(poolerKey("zone1", "pooler1"))
 			return ok

--- a/go/services/multiorch/recovery/health_stream.go
+++ b/go/services/multiorch/recovery/health_stream.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -358,20 +359,12 @@ func (hs *HealthStream) applySnapshot(ctx context.Context, poolerID string, pool
 		existing.LastSeen = now
 		existing.IsUpToDate = true
 		existing.IsLastCheckValid = true
-		existing.IsPostgresReady = status.PostgresReady
+		existing.Status = proto.Clone(status).(*multipoolermanagerdatapb.Status)
 		if status.PostgresReady {
 			existing.LastPostgresReadyTime = now
 		}
 		// NOTE: when PostgresReady is false, LastPostgresReadyTime is intentionally
 		// left at its previous value so callers can reason about "last known good" time.
-		existing.IsPostgresRunning = status.PostgresRunning
-		existing.PoolerType = status.PoolerType
-		existing.PrimaryStatus = status.PrimaryStatus
-		existing.ReplicationStatus = status.ReplicationStatus
-		existing.IsInitialized = status.IsInitialized
-		existing.HasDataDirectory = status.HasDataDirectory
-		existing.ConsensusTerm = status.ConsensusTerm
-		existing.CohortMembers = status.CohortMembers
 		return existing
 	}
 
@@ -401,8 +394,10 @@ func (hs *HealthStream) markConnected(poolerID string) {
 func (hs *HealthStream) markDisconnected(poolerID string) {
 	cb := func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
 		existing.IsLastCheckValid = false
-		existing.IsPostgresReady = false
-		existing.IsPostgresRunning = false
+		if existing.Status != nil {
+			existing.Status.PostgresReady = false
+			existing.Status.PostgresRunning = false
+		}
 		existing.StreamConnected = false
 		return existing
 	}

--- a/go/services/multiorch/recovery/health_stream_test.go
+++ b/go/services/multiorch/recovery/health_stream_test.go
@@ -130,12 +130,12 @@ func TestHealthStream_UpdatesStore_Primary(t *testing.T) {
 	require.True(t, updated.IsUpToDate)
 	require.NotNil(t, updated.LastSeen)
 	require.NotNil(t, updated.LastCheckSuccessful)
-	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType)
-	require.NotNil(t, updated.PrimaryStatus)
-	require.Equal(t, "0/123ABC", updated.PrimaryStatus.Lsn)
-	require.True(t, updated.PrimaryStatus.Ready)
-	require.Len(t, updated.PrimaryStatus.ConnectedFollowers, 2)
-	require.Nil(t, updated.ReplicationStatus)
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.GetStatus().GetPoolerType())
+	require.NotNil(t, updated.GetStatus().GetPrimaryStatus())
+	require.Equal(t, "0/123ABC", updated.GetStatus().GetPrimaryStatus().GetLsn())
+	require.True(t, updated.GetStatus().GetPrimaryStatus().GetReady())
+	require.Len(t, updated.GetStatus().GetPrimaryStatus().GetConnectedFollowers(), 2)
+	require.Nil(t, updated.GetStatus().GetReplicationStatus())
 }
 
 // TestHealthStream_UpdatesStore_Replica tests that a REPLICA snapshot is applied to the store.
@@ -181,18 +181,18 @@ func TestHealthStream_UpdatesStore_Replica(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 
 	updated, _ := poolerStore.Get(key)
-	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.PoolerType)
-	require.NotNil(t, updated.ReplicationStatus)
-	require.Equal(t, "0/123ABC", updated.ReplicationStatus.LastReplayLsn)
-	require.Equal(t, "0/123DEF", updated.ReplicationStatus.LastReceiveLsn)
-	require.False(t, updated.ReplicationStatus.IsWalReplayPaused)
-	require.Equal(t, "not paused", updated.ReplicationStatus.WalReplayPauseState)
-	require.Equal(t, int64(500), updated.ReplicationStatus.Lag.AsDuration().Milliseconds())
-	require.Equal(t, "2025-01-19 20:00:00.000000+00", updated.ReplicationStatus.LastXactReplayTimestamp)
-	require.NotNil(t, updated.ReplicationStatus.PrimaryConnInfo)
-	require.Equal(t, "primary-host", updated.ReplicationStatus.PrimaryConnInfo.Host)
-	require.Equal(t, int32(5432), updated.ReplicationStatus.PrimaryConnInfo.Port)
-	require.Nil(t, updated.PrimaryStatus)
+	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.GetStatus().GetPoolerType())
+	require.NotNil(t, updated.GetStatus().GetReplicationStatus())
+	require.Equal(t, "0/123ABC", updated.GetStatus().GetReplicationStatus().GetLastReplayLsn())
+	require.Equal(t, "0/123DEF", updated.GetStatus().GetReplicationStatus().GetLastReceiveLsn())
+	require.False(t, updated.GetStatus().GetReplicationStatus().GetIsWalReplayPaused())
+	require.Equal(t, "not paused", updated.GetStatus().GetReplicationStatus().GetWalReplayPauseState())
+	require.Equal(t, int64(500), updated.GetStatus().GetReplicationStatus().GetLag().AsDuration().Milliseconds())
+	require.Equal(t, "2025-01-19 20:00:00.000000+00", updated.GetStatus().GetReplicationStatus().GetLastXactReplayTimestamp())
+	require.NotNil(t, updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo())
+	require.Equal(t, "primary-host", updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo().GetHost())
+	require.Equal(t, int32(5432), updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo().GetPort())
+	require.Nil(t, updated.GetStatus().GetPrimaryStatus())
 }
 
 // TestHealthStream_Poll tests that Poll() sends a poll message and a subsequent snapshot is applied.
@@ -223,7 +223,7 @@ func TestHealthStream_Poll(t *testing.T) {
 	})
 	require.Eventually(t, func() bool {
 		s, ok := poolerStore.Get(key)
-		return ok && s.PrimaryStatus != nil && s.PrimaryStatus.Lsn == "0/AAAAAA"
+		return ok && s.GetStatus().GetPrimaryStatus() != nil && s.GetStatus().GetPrimaryStatus().GetLsn() == "0/AAAAAA"
 	}, 2*time.Second, 10*time.Millisecond, "initial snapshot should be applied")
 
 	// Trigger a poll.
@@ -238,7 +238,7 @@ func TestHealthStream_Poll(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		s, ok := poolerStore.Get(key)
-		return ok && s.PrimaryStatus != nil && s.PrimaryStatus.Lsn == "0/BBBBBB"
+		return ok && s.GetStatus().GetPrimaryStatus() != nil && s.GetStatus().GetPrimaryStatus().GetLsn() == "0/BBBBBB"
 	}, 2*time.Second, 10*time.Millisecond, "polled snapshot should be applied")
 }
 
@@ -561,9 +561,9 @@ func TestHealthStream_TypeMismatch(t *testing.T) {
 	updated, _ := poolerStore.Get(key)
 	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.MultiPooler.Type,
 		"topology type should remain REPLICA")
-	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType,
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.GetStatus().GetPoolerType(),
 		"reported type should be PRIMARY")
-	require.NotNil(t, updated.PrimaryStatus)
-	require.Equal(t, "0/FFFFFF", updated.PrimaryStatus.Lsn)
-	require.True(t, updated.PrimaryStatus.Ready)
+	require.NotNil(t, updated.GetStatus().GetPrimaryStatus())
+	require.Equal(t, "0/FFFFFF", updated.GetStatus().GetPrimaryStatus().GetLsn())
+	require.True(t, updated.GetStatus().GetPrimaryStatus().GetReady())
 }

--- a/go/services/multiorch/recovery/healthcheck.go
+++ b/go/services/multiorch/recovery/healthcheck.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -164,8 +165,10 @@ func (re *Engine) pollPooler(ctx context.Context, poolerID *clustermetadata.ID, 
 			existing.LastCheckAttempted = now
 			existing.IsUpToDate = true // We tried, don't retry immediately
 			existing.IsLastCheckValid = false
-			existing.IsPostgresReady = false   // Assume Postgres is down if we can't reach the pooler
-			existing.IsPostgresRunning = false // Unknown — assume false when pooler is unreachable
+			if existing.Status != nil {
+				existing.Status.PostgresReady = false   // Assume Postgres is down if we can't reach the pooler
+				existing.Status.PostgresRunning = false // Unknown — assume false when pooler is unreachable
+			}
 			return existing
 		})
 		return
@@ -186,23 +189,12 @@ func (re *Engine) pollPooler(ctx context.Context, poolerID *clustermetadata.ID, 
 		existing.LastSeen = successTime
 		existing.IsUpToDate = true
 		existing.IsLastCheckValid = true
-		existing.IsPostgresReady = status.PostgresReady
+		existing.Status = proto.Clone(status).(*multipoolermanagerdatapb.Status)
 		if status.PostgresReady {
 			existing.LastPostgresReadyTime = successTime
 		}
 		// NOTE: when PostgresReady is false, LastPostgresReadyTime is intentionally
 		// left at its previous value so callers can reason about "last known good" time.
-
-		// Status RPC now includes initialization fields and works without db connection
-		existing.IsPostgresRunning = status.PostgresRunning
-		existing.PoolerType = status.PoolerType
-		existing.PrimaryStatus = status.PrimaryStatus
-		existing.ReplicationStatus = status.ReplicationStatus
-		existing.IsInitialized = status.IsInitialized
-		existing.HasDataDirectory = status.HasDataDirectory
-		existing.ConsensusTerm = status.ConsensusTerm
-		existing.CohortMembers = status.CohortMembers
-
 		existing.ConsensusStatus = consensusState
 		return existing
 	})

--- a/go/services/multiorch/recovery/healthcheck_rpc_test.go
+++ b/go/services/multiorch/recovery/healthcheck_rpc_test.go
@@ -113,21 +113,21 @@ func TestPollPooler_UpdatesStore_Primary(t *testing.T) {
 	require.NotNil(t, updated.LastCheckSuccessful, "LastCheckSuccessful should be set")
 
 	// Check that PRIMARY-specific fields were populated
-	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType, "should report PRIMARY type")
-	require.NotNil(t, updated.PrimaryStatus, "PrimaryStatus should be populated")
-	require.Equal(t, "0/123ABC", updated.PrimaryStatus.Lsn, "LSN should match response")
-	require.True(t, updated.PrimaryStatus.Ready, "should be ready")
-	require.Len(t, updated.PrimaryStatus.ConnectedFollowers, 2, "should have 2 connected followers")
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.GetStatus().GetPoolerType(), "should report PRIMARY type")
+	require.NotNil(t, updated.GetStatus().GetPrimaryStatus(), "PrimaryStatus should be populated")
+	require.Equal(t, "0/123ABC", updated.GetStatus().GetPrimaryStatus().GetLsn(), "LSN should match response")
+	require.True(t, updated.GetStatus().GetPrimaryStatus().GetReady(), "should be ready")
+	require.Len(t, updated.GetStatus().GetPrimaryStatus().GetConnectedFollowers(), 2, "should have 2 connected followers")
 
 	// Check that REPLICA fields are not populated
-	require.Nil(t, updated.ReplicationStatus, "ReplicationStatus should be nil for PRIMARY")
+	require.Nil(t, updated.GetStatus().GetReplicationStatus(), "ReplicationStatus should be nil for PRIMARY")
 
 	// Check that CohortMembers are propagated from Status response
-	require.Len(t, updated.CohortMembers, 2, "CohortMembers should be propagated from Status response")
-	require.Equal(t, "zone1", updated.CohortMembers[0].Cell)
-	require.Equal(t, "pooler1", updated.CohortMembers[0].Name)
-	require.Equal(t, "zone1", updated.CohortMembers[1].Cell)
-	require.Equal(t, "replica1", updated.CohortMembers[1].Name)
+	require.Len(t, updated.GetStatus().GetCohortMembers(), 2, "CohortMembers should be propagated from Status response")
+	require.Equal(t, "zone1", updated.GetStatus().GetCohortMembers()[0].GetCell())
+	require.Equal(t, "pooler1", updated.GetStatus().GetCohortMembers()[0].GetName())
+	require.Equal(t, "zone1", updated.GetStatus().GetCohortMembers()[1].GetCell())
+	require.Equal(t, "replica1", updated.GetStatus().GetCohortMembers()[1].GetName())
 
 	// Check that LastPostgresReadyTime is NOT set when PostgresReady is false (default in this mock)
 	require.Nil(t, updated.LastPostgresReadyTime, "LastPostgresReadyTime should not be set when PostgresReady is false")
@@ -211,20 +211,20 @@ func TestPollPooler_UpdatesStore_Replica(t *testing.T) {
 	require.NotNil(t, updated.LastSeen, "LastSeen should be set")
 
 	// Check that REPLICA-specific fields were populated
-	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.PoolerType, "should report REPLICA type")
-	require.NotNil(t, updated.ReplicationStatus, "ReplicationStatus should be populated")
-	require.Equal(t, "0/123ABC", updated.ReplicationStatus.LastReplayLsn, "replay LSN should match response")
-	require.Equal(t, "0/123DEF", updated.ReplicationStatus.LastReceiveLsn, "receive LSN should match response")
-	require.False(t, updated.ReplicationStatus.IsWalReplayPaused, "WAL replay should not be paused")
-	require.Equal(t, "not paused", updated.ReplicationStatus.WalReplayPauseState)
-	require.Equal(t, int64(500), updated.ReplicationStatus.Lag.AsDuration().Milliseconds(), "lag should be 500ms")
-	require.Equal(t, "2025-01-19 20:00:00.000000+00", updated.ReplicationStatus.LastXactReplayTimestamp)
-	require.NotNil(t, updated.ReplicationStatus.PrimaryConnInfo, "primary conn info should be set")
-	require.Equal(t, "primary-host", updated.ReplicationStatus.PrimaryConnInfo.Host)
-	require.Equal(t, int32(5432), updated.ReplicationStatus.PrimaryConnInfo.Port)
+	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.GetStatus().GetPoolerType(), "should report REPLICA type")
+	require.NotNil(t, updated.GetStatus().GetReplicationStatus(), "ReplicationStatus should be populated")
+	require.Equal(t, "0/123ABC", updated.GetStatus().GetReplicationStatus().GetLastReplayLsn(), "replay LSN should match response")
+	require.Equal(t, "0/123DEF", updated.GetStatus().GetReplicationStatus().GetLastReceiveLsn(), "receive LSN should match response")
+	require.False(t, updated.GetStatus().GetReplicationStatus().GetIsWalReplayPaused(), "WAL replay should not be paused")
+	require.Equal(t, "not paused", updated.GetStatus().GetReplicationStatus().GetWalReplayPauseState())
+	require.Equal(t, int64(500), updated.GetStatus().GetReplicationStatus().GetLag().AsDuration().Milliseconds(), "lag should be 500ms")
+	require.Equal(t, "2025-01-19 20:00:00.000000+00", updated.GetStatus().GetReplicationStatus().GetLastXactReplayTimestamp())
+	require.NotNil(t, updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo(), "primary conn info should be set")
+	require.Equal(t, "primary-host", updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo().GetHost())
+	require.Equal(t, int32(5432), updated.GetStatus().GetReplicationStatus().GetPrimaryConnInfo().GetPort())
 
 	// Check that PRIMARY fields are not populated
-	require.Nil(t, updated.PrimaryStatus, "PrimaryStatus should be nil for REPLICA")
+	require.Nil(t, updated.GetStatus().GetPrimaryStatus(), "PrimaryStatus should be nil for REPLICA")
 }
 
 // TestPollPooler_RPCFailure tests that polling failure is properly recorded in the store
@@ -605,10 +605,10 @@ func TestPollPooler_TypeMismatch(t *testing.T) {
 	// Topology type is in MultiPooler.Type
 	require.Equal(t, clustermetadata.PoolerType_REPLICA, updated.MultiPooler.Type, "topology type should remain REPLICA")
 	// Reported type is in PoolerType
-	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.PoolerType, "reported type should be PRIMARY")
+	require.Equal(t, clustermetadata.PoolerType_PRIMARY, updated.GetStatus().GetPoolerType(), "reported type should be PRIMARY")
 
 	// Should have populated PRIMARY fields (what the pooler actually reports)
-	require.NotNil(t, updated.PrimaryStatus, "PrimaryStatus should be populated")
-	require.Equal(t, "0/FFFFFF", updated.PrimaryStatus.Lsn)
-	require.True(t, updated.PrimaryStatus.Ready)
+	require.NotNil(t, updated.GetStatus().GetPrimaryStatus(), "PrimaryStatus should be populated")
+	require.Equal(t, "0/FFFFFF", updated.GetStatus().GetPrimaryStatus().GetLsn())
+	require.True(t, updated.GetStatus().GetPrimaryStatus().GetReady())
 }

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -742,10 +742,13 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 			},
 			IsLastCheckValid: true,
 			IsUpToDate:       true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				IsWalReplayPaused: true, // Replication stopped
+			LastSeen:         timestamppb.Now(),
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					IsWalReplayPaused: true, // Replication stopped
+				},
 			},
-			LastSeen: timestamppb.Now(),
 		}
 		engine.poolerStore.Set("multipooler-cell1-replica-pooler", replicaPooler)
 
@@ -800,10 +803,13 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 			},
 			IsLastCheckValid: true,
 			IsUpToDate:       true,
-			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-				IsWalReplayPaused: true, // Replication stopped
+			LastSeen:         timestamppb.Now(),
+			Status: &multipoolermanagerdatapb.Status{
+				PoolerType: clustermetadatapb.PoolerType_REPLICA,
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					IsWalReplayPaused: true, // Replication stopped
+				},
 			},
-			LastSeen: timestamppb.Now(),
 		}
 		engine.poolerStore.Set("multipooler-cell1-replica-pooler", replicaPooler)
 
@@ -890,10 +896,13 @@ func TestRecoveryLoop_ValidationPreventsStaleRecovery(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: true, // Replication stopped
+		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: true, // Replication stopped
+			},
 		},
-		LastSeen: timestamppb.Now(),
 	}
 	engine.poolerStore.Set("multipooler-cell1-replica-pooler", replicaPooler)
 
@@ -1238,10 +1247,13 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: true, // Problem
+		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: true, // Problem
+			},
 		},
-		LastSeen: timestamppb.Now(),
 	}
 	engine.poolerStore.Set("multipooler-cell1-replica1-pooler", replica1Pooler)
 
@@ -1254,10 +1266,13 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: true, // Problem
+		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: true, // Problem
+			},
 		},
-		LastSeen: timestamppb.Now(),
 	}
 	engine.poolerStore.Set("multipooler-cell1-replica2-pooler", replica2Pooler)
 
@@ -1423,10 +1438,13 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: true,
+		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: true,
+			},
 		},
-		LastSeen: timestamppb.Now(),
 	}
 	engine.poolerStore.Set("multipooler-cell1-replica-pooler", replicaPooler)
 
@@ -1540,10 +1558,13 @@ func TestRecoveryLoop_TracingSpans(t *testing.T) {
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
-		ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-			IsWalReplayPaused: true,
+		LastSeen:         timestamppb.Now(),
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType: clustermetadatapb.PoolerType_REPLICA,
+			ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+				IsWalReplayPaused: true,
+			},
 		},
-		LastSeen: timestamppb.Now(),
 	}
 	engine.poolerStore.Set("multipooler-zone1-replica-pooler", replicaPooler)
 

--- a/go/services/multiorch/store/pooler_health_state.go
+++ b/go/services/multiorch/store/pooler_health_state.go
@@ -86,5 +86,5 @@ func IsInitialized(p *multiorchdata.PoolerHealthState) bool {
 
 	// Use the IsInitialized field from Status RPC directly.
 	// This is based on data directory state, not LSN.
-	return p.IsInitialized
+	return p.GetStatus().GetIsInitialized()
 }

--- a/go/services/multiorch/store/pooler_health_state_test.go
+++ b/go/services/multiorch/store/pooler_health_state_test.go
@@ -37,7 +37,7 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: false,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    true, // even if field is true, unreachable means not initialized
+				Status:           &multipoolermanagerdata.Status{IsInitialized: true}, // even if field is true, unreachable means not initialized
 			},
 			expected: false,
 		},
@@ -46,7 +46,7 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      nil,
-				IsInitialized:    true,
+				Status:           &multipoolermanagerdata.Status{IsInitialized: true},
 			},
 			expected: false,
 		},
@@ -55,7 +55,7 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    true,
+				Status:           &multipoolermanagerdata.Status{IsInitialized: true},
 			},
 			expected: true,
 		},
@@ -64,7 +64,7 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    false,
+				Status:           &multipoolermanagerdata.Status{IsInitialized: false},
 			},
 			expected: false,
 		},
@@ -73,9 +73,11 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-				IsInitialized:    true,
-				PrimaryStatus:    &multipoolermanagerdata.PrimaryStatus{Lsn: "0/1234"},
+				Status: &multipoolermanagerdata.Status{
+					PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+					IsInitialized: true,
+					PrimaryStatus: &multipoolermanagerdata.PrimaryStatus{Lsn: "0/1234"},
+				},
 			},
 			expected: true,
 		},
@@ -84,10 +86,12 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-				IsInitialized:    true,
-				ReplicationStatus: &multipoolermanagerdata.StandbyReplicationStatus{
-					LastReplayLsn: "0/1234",
+				Status: &multipoolermanagerdata.Status{
+					PoolerType:    clustermetadatapb.PoolerType_REPLICA,
+					IsInitialized: true,
+					ReplicationStatus: &multipoolermanagerdata.StandbyReplicationStatus{
+						LastReplayLsn: "0/1234",
+					},
 				},
 			},
 			expected: true,
@@ -97,10 +101,12 @@ func TestIsInitialized(t *testing.T) {
 			pooler: &multiorchdata.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-				IsInitialized:    false,
-				ReplicationStatus: &multipoolermanagerdata.StandbyReplicationStatus{
-					LastReplayLsn: "0/1234",
+				Status: &multipoolermanagerdata.Status{
+					PoolerType:    clustermetadatapb.PoolerType_REPLICA,
+					IsInitialized: false,
+					ReplicationStatus: &multipoolermanagerdata.StandbyReplicationStatus{
+						LastReplayLsn: "0/1234",
+					},
 				},
 			},
 			expected: false,

--- a/go/services/multiorch/store/pooler_info_test.go
+++ b/go/services/multiorch/store/pooler_info_test.go
@@ -37,7 +37,7 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: false,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    true,
+				Status:           &multipoolermanagerdatapb.Status{IsInitialized: true},
 			},
 			expected: false,
 		},
@@ -46,7 +46,7 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    true,
+				Status:           &multipoolermanagerdatapb.Status{IsInitialized: true},
 			},
 			expected: true,
 		},
@@ -55,7 +55,7 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				IsInitialized:    false,
+				Status:           &multipoolermanagerdatapb.Status{IsInitialized: false},
 			},
 			expected: false,
 		},
@@ -64,10 +64,10 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_PRIMARY,
-				IsInitialized:    true,
-				PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
-					Lsn: "0/123ABC",
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+					IsInitialized: true,
+					PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{Lsn: "0/123ABC"},
 				},
 			},
 			expected: true,
@@ -77,10 +77,12 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-				IsInitialized:    true,
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					LastReplayLsn: "0/123ABC",
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType:    clustermetadatapb.PoolerType_REPLICA,
+					IsInitialized: true,
+					ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+						LastReplayLsn: "0/123ABC",
+					},
 				},
 			},
 			expected: true,
@@ -90,10 +92,12 @@ func TestPoolerHealthState_IsInitialized(t *testing.T) {
 			pooler: &multiorchdatapb.PoolerHealthState{
 				IsLastCheckValid: true,
 				MultiPooler:      &clustermetadatapb.MultiPooler{},
-				PoolerType:       clustermetadatapb.PoolerType_REPLICA,
-				IsInitialized:    false,
-				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
-					LastReplayLsn: "0/123ABC",
+				Status: &multipoolermanagerdatapb.Status{
+					PoolerType:    clustermetadatapb.PoolerType_REPLICA,
+					IsInitialized: false,
+					ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+						LastReplayLsn: "0/123ABC",
+					},
 				},
 			},
 			expected: false,

--- a/proto/consensusservice.proto
+++ b/proto/consensusservice.proto
@@ -23,12 +23,34 @@ option go_package = "github.com/multigres/multigres/go/pb/consensus";
 // MultiPoolerConsensus provides consensus APIs for leader election
 service MultiPoolerConsensus {
   // Leader Appointment Protocol
+
+  // BeginTerm initiates a new leadership term by requesting the current leader
+  // to step down. The current leader will revoke its leadership and trigger a
+  // new election, allowing the coordinator to select a new leader based on the
+  // latest replication state of the followers. This is used by MultiOrch during
+  // failover to ensure that the old leader steps down gracefully and does not
+  // continue to accept writes, which could lead to data divergence.
   rpc BeginTerm(consensusdata.BeginTermRequest) returns (consensusdata.BeginTermResponse);
 
   // Status and Health
+
+  // Status provides the current status of the consensus service, including the
+  // health of the cluster, the current leader, and any ongoing elections. This
+  // is used by MultiOrch to monitor the cluster and determine if it needs to
+  // trigger failover or other recovery actions.
   rpc Status(consensusdata.StatusRequest) returns (consensusdata.StatusResponse);
+
+  // GetLeadershipView provides information about the current leader and
+  // followers in the cluster, including their health status and replication
+  // lag. This is used by MultiOrch to make informed decisions about failover.
   rpc GetLeadershipView(consensusdata.LeadershipViewRequest) returns (consensusdata.LeadershipViewResponse);
 
-  // Replication
+  // CanReachPrimary is a health check used by MultiOrch to determine if a
+  // follower can reach the primary.
+  //
+  // This is used during failover to check if a candidate is healthy and has
+  // network connectivity to the primary before attempting to promote it. It can
+  // also be used for monitoring and alerting purposes to detect network issues
+  // or replication problems that could affect the cluster's health.
   rpc CanReachPrimary(consensusdata.CanReachPrimaryRequest) returns (consensusdata.CanReachPrimaryResponse);
 }

--- a/proto/multiorchdata.proto
+++ b/proto/multiorchdata.proto
@@ -29,7 +29,7 @@ option go_package = "github.com/multigres/multigres/go/pb/multiorchdata";
 // It contains:
 // - Core pooler metadata (embedded MultiPooler from topology)
 // - Timestamps for staleness detection
-// - Health metrics from Status RPC
+// - Full health status from the Status RPC (embedded as multipoolermanagerdata.Status)
 // - Computed fields for quick access
 message PoolerHealthState {
   // Core pooler metadata from topology.
@@ -46,53 +46,20 @@ message PoolerHealthState {
   google.protobuf.Timestamp last_check_successful = 5;
   google.protobuf.Timestamp last_seen = 6;
 
-  // Health status from Status RPC (populated after successful health check).
-  // This is the type the pooler reports itself as, which may differ from
-  // the topology type (multi_pooler.type) if there's a failover in progress
-  // or type mismatch.
-  clustermetadata.PoolerType pooler_type = 7;
-
-  // Primary-specific status (populated when pooler_type == PRIMARY)
-  multipoolermanagerdata.PrimaryStatus primary_status = 8;
-
-  // Replica-specific status (populated when pooler_type == REPLICA)
-  multipoolermanagerdata.StandbyReplicationStatus replication_status = 9;
-
-  // Whether PostgreSQL is currently running and accepting connections on this node.
-  // Determined from the Status RPC's postgres_ready field.
-  // Used to determine PrimaryReachable in the analyzer - a primary with postgres down
-  // should trigger PrimaryIsDead recovery even if the previous PrimaryStatus data exists.
-  bool is_postgres_ready = 10;
-
-  // Whether the pooler considers itself initialized.
-  // Determined from the Status RPC's is_initialized field.
-  // This is based on the data directory state, not LSN.
-  bool is_initialized = 11;
-
-  // Whether the PostgreSQL data directory exists.
-  // Determined from the Status RPC's has_data_directory field.
-  bool has_data_directory = 12;
-
-  // Consensus term information from Status RPC
-  multipoolermanagerdata.ConsensusTerm consensus_term = 13;
+  // Field numbers 7–13, 15, 17 were individual mirrored Status fields;
+  // replaced by the embedded status field below (field 22).
+  reserved 7, 8, 9, 10, 11, 12, 13, 15, 17;
+  reserved "pooler_type", "primary_status", "replication_status",
+           "is_postgres_ready", "is_initialized", "has_data_directory",
+           "consensus_term", "cohort_members", "is_postgres_running";
 
   // Consensus status from ConsensusStatus RPC (for divergence detection)
   consensusdata.StatusResponse consensus_status = 14;
-
-  // Cohort members from the most recent multigres.rule_history record,
-  // populated from the Status RPC response. An empty list (not nil) on an
-  // initialized pooler signals the shard needs its initial cohort established.
-  repeated clustermetadata.ID cohort_members = 15;
 
   // Timestamp of the last time PostgreSQL specifically responded as healthy
   // (i.e. pg_isready passed). Never cleared on failure — callers must compare
   // against time.Now() to detect staleness.
   google.protobuf.Timestamp last_postgres_ready_time = 16;
-
-  // Whether the PostgreSQL process exists on this node, regardless of whether
-  // it accepts connections. Mirrors multipoolermanagerdata.Status.postgres_running.
-  // Used to distinguish SIGSTOP (process alive but unresponsive) from SIGKILL (process dead).
-  bool is_postgres_running = 17;
 
   // Stream health fields (populated when multiorch uses ManagerHealthStream).
 
@@ -101,4 +68,8 @@ message PoolerHealthState {
 
   // The time at which the current stream was established.
   google.protobuf.Timestamp stream_connected_since = 21;
+
+  // Full health status from the most recent successful Status RPC or
+  // ManagerHealthStream snapshot. Nil until the first successful check.
+  multipoolermanagerdata.Status status = 22;
 }


### PR DESCRIPTION
Replace the 9 individual Status-mirroring fields in PoolerHealthState with a single embedded multipoolermanagerdata.Status status = 22 field. This removes the maintenance burden of keeping PoolerHealthState in sync with Status — any new Status field is automatically carried through once the status is stored.

Proto (multiorchdata.proto):
- Reserve field numbers 7–13, 15, 17 and their names to prevent reuse
- Remove: pooler_type, primary_status, replication_status, is_postgres_ready, is_initialized, has_data_directory, consensus_term, cohort_members, is_postgres_running
- Add: multipoolermanagerdata.Status status = 22

Write paths (health_stream.go, healthcheck.go):
- Replace 8–9 field-by-field assignments with a single proto.Clone(status).(*multipoolermanagerdatapb.Status) assignment
- Failure/disconnect paths clear PostgresReady and PostgresRunning on the embedded Status rather than top-level fields

Read paths:
- All callers updated to use pooler.GetStatus().GetFoo() nil-safe accessors
- Files updated: grpcserver/server.go, consensus/leader_appointment.go, recovery/analysis/generator.go, recovery/actions/{appoint_leader, demote_stale_primary,shard_init_action}.go, store/pooler_health_state.go

Tests:
- All struct literals and field assertions updated to use the embedded Status field across: health_stream_test.go, healthcheck_rpc_test.go, recovery_loop_test.go, actions/shard_init_action_test.go, analysis/generator_test.go, consensus/leader_appointment{,_prevote}_test.go, store/{pooler_health_state,pooler_info}_test.go

----

Also adding some documentation to RPC protocol files.

Part of MUL-357