### PR TITLE
test(queryserving): bump buffer test connect_timeout to 30s

### DIFF
--- a/go/test/endtoend/queryserving/buffer_test.go
+++ b/go/test/endtoend/queryserving/buffer_test.go
@@ -359,7 +359,7 @@ func newBufferTestClusterWithConfig(t *testing.T, bufferArgs ...string) (*shards
 func openGatewayDB(t *testing.T, setup *shardsetup.ShardSetup) *sql.DB {
 	t.Helper()
 	connStr := fmt.Sprintf(
-		"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=5",
+		"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable connect_timeout=30",
 		setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Raise `connect_timeout` from 5s to 30s in the buffer tests' gateway connection string.
- Fixes intermittent failures in `TestBufferPlannedFailover` and `TestBufferMultipleFailovers` with `read tcp ... i/o timeout`.

## Problem

When a new client connection opens during a planned failover, SCRAM auth calls `PoolerGateway.GetAuthCredentials`; the first attempt returns `MTF01` and `withBuffering` correctly re-enters via `WaitForFailoverEnd`. That wait blocks for the full failover duration (~5s observed locally, longer on CI), which exceeds `lib/pq`'s `connect_timeout=5` — a deadline it enforces over the entire connect + startup + auth handshake. The client socket times out before auth completes on the new primary, producing the flaky `i/o timeout`.

## Solution

Raise the test's `connect_timeout` to 30s so it matches the buffer window and gives new connections enough slack to survive the failover. Buffering itself is working as designed — this is a test-side client-config mismatch, not a product bug.