### PR TITLE
test(multiorch): verify failover works with etcd down

### DIFF
--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -83,7 +83,7 @@ func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem
 	// need to trigger failover.
 	for _, pooler := range cohort {
 		if pooler.MultiPooler == nil ||
-			pooler.MultiPooler.Type != clustermetadatapb.PoolerType_PRIMARY ||
+			pooler.PoolerType != clustermetadatapb.PoolerType_PRIMARY ||
 			!pooler.IsLastCheckValid ||
 			!pooler.IsPostgresReady {
 			continue

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -114,6 +114,13 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	preFailoverSuccess, preFailoverFailed := validator.Stats()
 	t.Logf("Pre-failover writes: %d successful, %d failed", preFailoverSuccess, preFailoverFailed)
 
+	// Stop etcd before any failover: consensus runs via gRPC between multipoolers
+	// and multigateway learns the new primary via PrimaryObservation health streams,
+	// so neither component requires etcd during or after failover.
+	t.Log("Stopping etcd to verify etcd-independent failover...")
+	setup.StopEtcd(t)
+	t.Log("etcd stopped; all failovers will proceed without etcd")
+
 	// Perform 3 consecutive failovers
 	for i := range 3 {
 		t.Logf("=== Failover iteration %d ===", i+1)
@@ -171,12 +178,16 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// Wait for killed multipooler to rejoin as standby (always wait, even on last iteration)
 		waitForNodeToRejoinAsStandby(t, setup, currentPrimaryName, newPrimaryName, newPrimaryTerm, 2*time.Second)
 
-		// No need to restart validator or switch connections - multigateway automatically routes to new primary
-		// We track failed writes just for debugging purposes, but during a failover it is expected
-		// that we will see some failures (at least until we get to buffering)
+		// Verify multigateway has rerouted to the new primary by confirming a write succeeds.
+		require.Eventually(t, func() bool {
+			return validator.WriteNow(t.Context()) == nil
+		}, 10*time.Second, 200*time.Millisecond,
+			"multigateway should route writes to new primary %s after failover", newPrimaryName)
+		t.Logf("Iteration %d: multigateway confirmed routing writes to %s", i+1, newPrimaryName)
+
 		successWrites, failedWrites := validator.Stats()
-		t.Logf("Iteration %d: %d successful, %d failed writes so far (multigateway auto-routing to %s)",
-			i+1, successWrites, failedWrites, newPrimaryName)
+		t.Logf("Iteration %d: %d successful, %d failed writes so far",
+			i+1, successWrites, failedWrites)
 		time.Sleep(200 * time.Millisecond) // Let writes accumulate before next failover
 	}
 

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -105,6 +105,19 @@ func (s *ShardSetup) Context() context.Context {
 	return s.runningCtx
 }
 
+// StopEtcd gracefully stops the etcd process to simulate an etcd outage.
+func (s *ShardSetup) StopEtcd(t *testing.T) {
+	t.Helper()
+	if s.EtcdCmd == nil {
+		t.Fatal("StopEtcd: no etcd process to stop")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, stopped := s.EtcdCmd.Stop(ctx)
+	require.True(t, stopped, "StopEtcd: failed to stop etcd process within deadline")
+	t.Log("StopEtcd: etcd process stopped")
+}
+
 // GetMultipoolerInstance returns a multipooler instance by name, or nil if not found.
 func (s *ShardSetup) GetMultipoolerInstance(name string) *MultipoolerInstance {
 	if s == nil || s.Multipoolers == nil {

--- a/go/test/endtoend/shardsetup/writer_validator.go
+++ b/go/test/endtoend/shardsetup/writer_validator.go
@@ -248,6 +248,19 @@ func (w *WriterValidator) Stats() (successful, failed int) {
 	return len(w.successful), len(w.failed)
 }
 
+// WriteNow performs a single write immediately, records the result, and returns any error.
+// Useful for probing whether the connection is routed to a writable primary.
+// Safe to call concurrently with running workers.
+func (w *WriterValidator) WriteNow(ctx context.Context) error {
+	id := w.nextID.Add(1)
+	ctx, cancel := context.WithTimeout(ctx, w.queryTimeout)
+	defer cancel()
+	// #nosec G202 -- tableName is a constant from test setup, not user-controlled.
+	_, err := w.db.ExecContext(ctx, "INSERT INTO "+w.tableName+" (id) VALUES ($1)", id)
+	w.recordResult(id, err)
+	return err
+}
+
 // Verify checks that all successful writes are present in at least one of the provided poolers.
 func (w *WriterValidator) Verify(t *testing.T, poolers []*MultiPoolerTestClient) error {
 	t.Helper()


### PR DESCRIPTION
Stop etcd before running the dead primary recovery test iterations to verify that consensus (gRPC between multipoolers) and multigateway routing (PrimaryObservation streams) both work independently of etcd.

Adds StopEtcd to ShardSetup and WriteNow to WriterValidator. Uses WriteNow to assert per-iteration that multigateway routes writes to the new primary.

Also fixes appoint_leader.go to use the self-reported PoolerType from gRPC health checks rather than MultiPooler.Type from etcd, which goes stale when etcd is down and caused elections to be incorrectly skipped.