### PR TITLE
test(multiorch): fix flaky TestHealthStream_ConcurrentWatcherUpdate

### DIFF
--- a/go/services/multiorch/recovery/health_stream_test.go
+++ b/go/services/multiorch/recovery/health_stream_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -318,15 +319,16 @@ func TestHealthStream_ConcurrentWatcherUpdate(t *testing.T) {
 	stream := <-streamCh
 	waitForStart(t, stream.Sent)
 
-	// Concurrently promote the pooler in the topology (simulates PoolerWatcher update)
-	// before the snapshot is applied.
-	go func() {
+	// Concurrently promote the pooler in the topology (simulates PoolerWatcher update).
+	// The WaitGroup ensures the promotion is applied before we assert the final state.
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		time.Sleep(5 * time.Millisecond)
 		poolerStore.DoUpdate(key, func(existing *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
 			existing.MultiPooler.Type = clustermetadata.PoolerType_PRIMARY
 			return existing
 		})
-	}()
+	})
 
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
 		PoolerType:      clustermetadata.PoolerType_REPLICA,
@@ -337,6 +339,8 @@ func TestHealthStream_ConcurrentWatcherUpdate(t *testing.T) {
 		s, ok := poolerStore.Get(key)
 		return ok && s.IsLastCheckValid
 	}, 2*time.Second, 10*time.Millisecond)
+
+	wg.Wait()
 
 	result, _ := poolerStore.Get(key)
 	// The watcher's topology promotion must be preserved.

--- a/go/services/multiorch/recovery/healthcheck_rpc_test.go
+++ b/go/services/multiorch/recovery/healthcheck_rpc_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -424,12 +425,15 @@ func TestPollPooler_DeletedDuringPoll(t *testing.T) {
 	re.poolerStore.Set(poolerKey, pooler)
 
 	// Delete the pooler while the RPC is in-flight.
-	go func() {
+	var wg sync.WaitGroup
+	wg.Go(func() {
 		time.Sleep(10 * time.Millisecond)
 		re.poolerStore.Delete(poolerKey)
-	}()
+	})
 
 	re.pollPooler(ctx, poolerID, pooler, false /* forceDiscovery */)
+
+	wg.Wait()
 
 	_, ok := re.poolerStore.Get(poolerKey)
 	require.False(t, ok, "deleted pooler should not be resurrected by health check")

--- a/go/services/multiorch/store/store_test.go
+++ b/go/services/multiorch/store/store_test.go
@@ -15,10 +15,13 @@
 package store
 
 import (
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/pb/clustermetadata"
@@ -301,4 +304,33 @@ func TestProtoStore_RangeCloningBehavior(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "original_db", retrieved.MultiPooler.Database)
 	require.True(t, retrieved.IsUpToDate)
+}
+
+// TestProtoStore_DoUpdate_Concurrent verifies that concurrent DoUpdate calls do not
+// lose updates. runtime.Gosched() inside the callback maximises the conflict window
+// for a hypothetical Get+Set implementation: with DoUpdate's mutex held throughout,
+// Gosched merely queues other goroutines at the lock; with Get+Set, it fires between
+// the read and write, letting other goroutines read a stale value.
+func TestProtoStore_DoUpdate_Concurrent(t *testing.T) {
+	s := NewProtoStore[string, *wrapperspb.Int64Value]()
+	s.Set("k", wrapperspb.Int64(0))
+
+	const n = 500
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			s.DoUpdate("k", func(v *wrapperspb.Int64Value) *wrapperspb.Int64Value {
+				runtime.Gosched()
+				v.Value++
+				return v
+			})
+		}()
+	}
+	wg.Wait()
+
+	result, ok := s.Get("k")
+	require.True(t, ok)
+	require.EqualValues(t, n, result.Value)
 }


### PR DESCRIPTION
The test fired a goroutine with time.Sleep(5ms) to promote a pooler to PRIMARY, then checked the result after waiting for a snapshot to be applied. Under the race detector the snapshot was applied in under 5ms, so the goroutine fired after the final Get() and the assertion saw the original REPLICA type.

Fix by adding a WaitGroup so wg.Wait() runs before the final Get(), guaranteeing the promotion is applied regardless of ordering.

Also add TestProtoStore_DoUpdate_Concurrent to store_test.go for testing lost-update protection.