### PR TITLE
feat(multigateway): add per-query metrics tracking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -323,6 +323,11 @@ linters:
       - linters:
           - unconvert
         path: ^go/common/parser/
+      # grpc.WithBlock is deprecated upstream but still required by the etcd v3 client
+      - linters:
+          - staticcheck
+        path: ^go/common/topoclient/etcdtopo/store\.go$
+        text: "SA1019: grpc.WithBlock"
 formatters:
   enable:
     - gofumpt

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -373,43 +373,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Top 10 query shapes by p99 latency. Labelled by query.fingerprint (xxh3-64 of the normalized SQL). The '__other__' series aggregates all fingerprints outside the registry's tracked top-N.",
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 38
-      },
-      "id": 57,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "topk(10, histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval]))))",
-          "legendFormat": "p99 - {{query_fingerprint}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Top Queries by p99 Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "description": "Per-query-shape snapshot: calls/s, latency percentiles, error rate. Click the fingerprint link to open /debug/queries on zone1's multigateway where the full normalized SQL is listed (use browser find to jump to the row).",
+      "description": "Per-query performance breakdown over the selected time range. Each numeric column is a sparkline of that metric over time; the % of runtime bar shows how much total gateway time this query shape consumed.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -424,119 +388,203 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "fingerprint"
+              "options": "query"
             },
             "properties": [
               {
-                "id": "links",
-                "value": [
-                  {
-                    "title": "Open /debug/queries",
-                    "url": "http://localhost:15100/debug/queries?sort=calls",
-                    "targetBlank": true
-                  }
-                ]
+                "id": "custom.width",
+                "value": 560
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "% of runtime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient",
+                  "valueDisplayMode": "text"
+                }
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "min",
+                "value": 0
               },
               {
                 "id": "custom.width",
-                "value": 180
+                "value": 150
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "calls/s"
+              "options": "count / s"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "ops"
+                "value": "none"
               },
               {
                 "id": "decimals",
                 "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p99 ms"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ms"
               },
               {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "p95 ms"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ms"
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "sparkline"
+                }
               },
               {
-                "id": "decimals",
-                "value": 2
+                "id": "custom.width",
+                "value": 150
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "p50 ms"
+              "options": "total time (s)"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "ms"
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "error rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
+                "value": "none"
               },
               {
                 "id": "decimals",
                 "value": 3
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "sparkline"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50 (ms)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "sparkline"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99 (ms)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "sparkline"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rows / s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "sparkline"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 38
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 47
       },
-      "id": 58,
+      "id": 402,
       "options": {
         "showHeader": true,
+        "cellHeight": "lg",
         "sortBy": [
           {
-            "displayName": "calls/s",
+            "displayName": "% of runtime",
             "desc": true
           }
         ]
@@ -550,8 +598,10 @@
           },
           "editorMode": "code",
           "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval]))",
-          "format": "table",
-          "instant": true,
+          "format": "time_series",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{query_fingerprint}}",
           "refId": "A"
         },
         {
@@ -560,9 +610,11 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "1000 * histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
-          "format": "table",
-          "instant": true,
+          "expr": "sum by (query_fingerprint) (increase(mg_gateway_query_duration_seconds_sum{job=\"multigateway\"}[$__rate_interval]))",
+          "format": "time_series",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{query_fingerprint}}",
           "refId": "B"
         },
         {
@@ -571,9 +623,11 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "1000 * histogram_quantile(0.95, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
-          "format": "table",
-          "instant": true,
+          "expr": "1000 * histogram_quantile(0.50, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "format": "time_series",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{query_fingerprint}}",
           "refId": "C"
         },
         {
@@ -582,9 +636,11 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "1000 * histogram_quantile(0.50, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
-          "format": "table",
-          "instant": true,
+          "expr": "1000 * histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "format": "time_series",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{query_fingerprint}}",
           "refId": "D"
         },
         {
@@ -593,14 +649,63 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_errors_total{job=\"multigateway\"}[$__rate_interval])) / clamp_min(sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval])), 0.001)",
+          "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_rows_returned_sum{job=\"multigateway\"}[$__rate_interval]))",
+          "format": "time_series",
+          "instant": false,
+          "range": true,
+          "legendFormat": "{{query_fingerprint}}",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (query_fingerprint, query_normalized_sql) (mg_gateway_query_info{job=\"multigateway\"})",
           "format": "table",
           "instant": true,
-          "refId": "E"
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (query_fingerprint) (increase(mg_gateway_query_duration_seconds_sum{job=\"multigateway\"}[$__range])) / scalar(sum(increase(mg_gateway_query_duration_seconds_sum{job=\"multigateway\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "refId": "G"
         }
       ],
-      "title": "Top Queries",
+      "title": "Per-Query Performance",
       "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "A": {
+              "stat": "mean",
+              "timeField": "Time"
+            },
+            "B": {
+              "stat": "sum",
+              "timeField": "Time"
+            },
+            "C": {
+              "stat": "mean",
+              "timeField": "Time"
+            },
+            "D": {
+              "stat": "mean",
+              "timeField": "Time"
+            },
+            "E": {
+              "stat": "mean",
+              "timeField": "Time"
+            }
+          }
+        },
         {
           "id": "joinByField",
           "options": {
@@ -612,27 +717,27 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Time 5": true
+              "Time": true,
+              "Value #F": true,
+              "query_fingerprint": true
             },
             "indexByName": {
-              "query_fingerprint": 0,
-              "Value #A": 1,
-              "Value #B": 2,
-              "Value #C": 3,
-              "Value #D": 4,
-              "Value #E": 5
+              "query_normalized_sql": 0,
+              "Value #G": 1,
+              "Trend #A": 2,
+              "Trend #B": 3,
+              "Trend #C": 4,
+              "Trend #D": 5,
+              "Trend #E": 6
             },
             "renameByName": {
-              "query_fingerprint": "fingerprint",
-              "Value #A": "calls/s",
-              "Value #B": "p99 ms",
-              "Value #C": "p95 ms",
-              "Value #D": "p50 ms",
-              "Value #E": "error rate"
+              "query_normalized_sql": "query",
+              "Value #G": "% of runtime",
+              "Trend #A": "count / s",
+              "Trend #B": "total time (s)",
+              "Trend #C": "p50 (ms)",
+              "Trend #D": "p99 (ms)",
+              "Trend #E": "rows / s"
             }
           }
         },
@@ -642,7 +747,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "calls/s",
+                "field": "% of runtime",
                 "desc": true
               }
             ]
@@ -651,11 +756,58 @@
         {
           "id": "limit",
           "options": {
-            "limitField": 15
+            "limitField": 50
           }
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Same data as 'Top Queries by p99 Latency' but the legend shows the normalized SQL instead of the fingerprint hash. Joined via mg_gateway_query_info using PromQL group_left.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))) * on (query_fingerprint) group_left(query_normalized_sql) max by (query_fingerprint, query_normalized_sql) (mg_gateway_query_info{job=\"multigateway\"})",
+          "legendFormat": "{{query_normalized_sql}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Queries by p99 Latency (by SQL)",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -673,7 +825,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 54
       },
       "id": 55,
       "targets": [
@@ -721,7 +873,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 54
       },
       "id": 56,
       "targets": [
@@ -746,7 +898,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "id": 160,
       "panels": [],
@@ -769,7 +921,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 64
       },
       "id": 161,
       "targets": [
@@ -804,7 +956,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 64
       },
       "id": 162,
       "targets": [
@@ -829,7 +981,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 73
       },
       "id": 200,
       "panels": [],
@@ -852,7 +1004,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 74
       },
       "id": 5,
       "targets": [
@@ -888,7 +1040,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 74
       },
       "id": 6,
       "targets": [
@@ -936,7 +1088,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 83
       },
       "id": 7,
       "targets": [
@@ -972,7 +1124,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 83
       },
       "id": 8,
       "targets": [
@@ -1026,7 +1178,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 92
       },
       "id": 9,
       "targets": [
@@ -1062,7 +1214,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 92
       },
       "id": 10,
       "targets": [
@@ -1097,7 +1249,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 94
+        "y": 101
       },
       "id": 11,
       "targets": [
@@ -1143,7 +1295,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 94
+        "y": 101
       },
       "id": 12,
       "targets": [
@@ -1181,7 +1333,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 110
       },
       "id": 250,
       "panels": [],
@@ -1204,7 +1356,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 104
+        "y": 111
       },
       "id": 251,
       "targets": [
@@ -1250,7 +1402,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 104
+        "y": 111
       },
       "id": 252,
       "targets": [
@@ -1296,7 +1448,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 104
+        "y": 111
       },
       "id": 253,
       "targets": [
@@ -1334,7 +1486,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 120
       },
       "id": 300,
       "panels": [],
@@ -1357,7 +1509,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 114
+        "y": 121
       },
       "id": 13,
       "targets": [
@@ -1393,7 +1545,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 121
       },
       "id": 14,
       "targets": [
@@ -1441,7 +1593,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 123
+        "y": 130
       },
       "id": 15,
       "targets": [
@@ -1477,7 +1629,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 123
+        "y": 130
       },
       "id": 16,
       "targets": [
@@ -1525,7 +1677,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 132
+        "y": 139
       },
       "id": 17,
       "targets": [
@@ -1560,7 +1712,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 132
+        "y": 139
       },
       "id": 18,
       "targets": [
@@ -1618,7 +1770,7 @@
         "h": 9,
         "w": 6,
         "x": 0,
-        "y": 141
+        "y": 148
       },
       "id": 19,
       "options": {
@@ -1666,7 +1818,7 @@
         "h": 9,
         "w": 18,
         "x": 6,
-        "y": 141
+        "y": 148
       },
       "id": 20,
       "targets": [
@@ -1704,7 +1856,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 150
+        "y": 157
       },
       "id": 400,
       "panels": [],
@@ -1727,7 +1879,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 151
+        "y": 158
       },
       "id": 21,
       "targets": [
@@ -1780,7 +1932,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 151
+        "y": 158
       },
       "id": 22,
       "targets": [
@@ -1818,7 +1970,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 160
+        "y": 167
       },
       "id": 250,
       "panels": [],
@@ -1840,7 +1992,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 161
+        "y": 168
       },
       "id": 251,
       "options": {
@@ -1903,7 +2055,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 161
+        "y": 168
       },
       "id": 252,
       "options": {
@@ -1944,7 +2096,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 161
+        "y": 168
       },
       "id": 253,
       "options": {
@@ -1985,7 +2137,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 170
+        "y": 177
       },
       "id": 254,
       "options": {
@@ -2025,7 +2177,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 170
+        "y": 177
       },
       "id": 255,
       "options": {
@@ -2088,7 +2240,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 170
+        "y": 177
       },
       "id": 256,
       "options": {

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -373,6 +373,197 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "Top 10 query shapes by p99 latency. Labelled by query.fingerprint (xxh3-64 of the normalized SQL). The '__other__' series aggregates all fingerprints outside the registry's tracked top-N.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 160,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "topk(10, histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval]))))",
+          "legendFormat": "p99 - {{query_fingerprint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Queries by p99 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Per-query-shape snapshot: calls/s, latency percentiles, error rate. Click the fingerprint link to open /debug/queries on zone1's multigateway where the full normalized SQL is listed (use browser find to jump to the row).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "fingerprint" },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open /debug/queries",
+                    "url": "http://localhost:15100/debug/queries?sort=calls",
+                    "targetBlank": true
+                  }
+                ]
+              },
+              { "id": "custom.width", "value": 180 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "calls/s" },
+            "properties": [{ "id": "unit", "value": "ops" }, { "id": "decimals", "value": 2 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p99 ms" },
+            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p95 ms" },
+            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p50 ms" },
+            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "error rate" },
+            "properties": [{ "id": "unit", "value": "percentunit" }, { "id": "decimals", "value": 3 }]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 161,
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "calls/s", "desc": true }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval]))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "editorMode": "code",
+          "expr": "1000 * histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "editorMode": "code",
+          "expr": "1000 * histogram_quantile(0.95, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "editorMode": "code",
+          "expr": "1000 * histogram_quantile(0.50, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "format": "table",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_errors_total{job=\"multigateway\"}[$__rate_interval])) / clamp_min(sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval])), 0.001)",
+          "format": "table",
+          "instant": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Top Queries",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": { "byField": "query_fingerprint", "mode": "outer" }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true
+            },
+            "indexByName": {
+              "query_fingerprint": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5
+            },
+            "renameByName": {
+              "query_fingerprint": "fingerprint",
+              "Value #A": "calls/s",
+              "Value #B": "p99 ms",
+              "Value #C": "p95 ms",
+              "Value #D": "p50 ms",
+              "Value #E": "error rate"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "calls/s", "desc": true }]
+          }
+        },
+        {
+          "id": "limit",
+          "options": { "limitField": 15 }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
       "description": "Transaction duration percentiles (BEGIN to COMMIT/ROLLBACK).",
       "fieldConfig": {
         "defaults": {

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -384,9 +384,9 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 38
       },
-      "id": 160,
+      "id": 57,
       "targets": [
         {
           "datasource": {
@@ -414,13 +414,18 @@
         "defaults": {
           "custom": {
             "align": "auto",
-            "cellOptions": { "type": "auto" },
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "fingerprint" },
+            "matcher": {
+              "id": "byName",
+              "options": "fingerprint"
+            },
             "properties": [
               {
                 "id": "links",
@@ -432,28 +437,91 @@
                   }
                 ]
               },
-              { "id": "custom.width", "value": 180 }
+              {
+                "id": "custom.width",
+                "value": 180
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "calls/s" },
-            "properties": [{ "id": "unit", "value": "ops" }, { "id": "decimals", "value": 2 }]
+            "matcher": {
+              "id": "byName",
+              "options": "calls/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "p99 ms" },
-            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+            "matcher": {
+              "id": "byName",
+              "options": "p99 ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "p95 ms" },
-            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+            "matcher": {
+              "id": "byName",
+              "options": "p95 ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "p50 ms" },
-            "properties": [{ "id": "unit", "value": "ms" }, { "id": "decimals", "value": 2 }]
+            "matcher": {
+              "id": "byName",
+              "options": "p50 ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
           },
           {
-            "matcher": { "id": "byName", "options": "error rate" },
-            "properties": [{ "id": "unit", "value": "percentunit" }, { "id": "decimals", "value": 3 }]
+            "matcher": {
+              "id": "byName",
+              "options": "error rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
           }
         ]
       },
@@ -461,17 +529,25 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 38
       },
-      "id": 161,
+      "id": 58,
       "options": {
         "showHeader": true,
-        "sortBy": [{ "displayName": "calls/s", "desc": true }]
+        "sortBy": [
+          {
+            "displayName": "calls/s",
+            "desc": true
+          }
+        ]
       },
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
           "editorMode": "code",
           "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval]))",
           "format": "table",
@@ -479,7 +555,10 @@
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
           "editorMode": "code",
           "expr": "1000 * histogram_quantile(0.99, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
           "format": "table",
@@ -487,7 +566,10 @@
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
           "editorMode": "code",
           "expr": "1000 * histogram_quantile(0.95, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
           "format": "table",
@@ -495,7 +577,10 @@
           "refId": "C"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
           "editorMode": "code",
           "expr": "1000 * histogram_quantile(0.50, sum by (le, query_fingerprint) (rate(mg_gateway_query_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
           "format": "table",
@@ -503,7 +588,10 @@
           "refId": "D"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
           "editorMode": "code",
           "expr": "sum by (query_fingerprint) (rate(mg_gateway_query_errors_total{job=\"multigateway\"}[$__rate_interval])) / clamp_min(sum by (query_fingerprint) (rate(mg_gateway_query_duration_seconds_count{job=\"multigateway\"}[$__rate_interval])), 0.001)",
           "format": "table",
@@ -515,7 +603,10 @@
       "transformations": [
         {
           "id": "joinByField",
-          "options": { "byField": "query_fingerprint", "mode": "outer" }
+          "options": {
+            "byField": "query_fingerprint",
+            "mode": "outer"
+          }
         },
         {
           "id": "organize",
@@ -549,12 +640,19 @@
           "id": "sortBy",
           "options": {
             "fields": {},
-            "sort": [{ "field": "calls/s", "desc": true }]
+            "sort": [
+              {
+                "field": "calls/s",
+                "desc": true
+              }
+            ]
           }
         },
         {
           "id": "limit",
-          "options": { "limitField": 15 }
+          "options": {
+            "limitField": 15
+          }
         }
       ],
       "type": "table"
@@ -575,7 +673,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 47
       },
       "id": 55,
       "targets": [
@@ -623,7 +721,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 47
       },
       "id": 56,
       "targets": [
@@ -648,7 +746,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 56
       },
       "id": 160,
       "panels": [],
@@ -671,7 +769,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 57
       },
       "id": 161,
       "targets": [
@@ -706,7 +804,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 57
       },
       "id": 162,
       "targets": [
@@ -731,7 +829,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 66
       },
       "id": 200,
       "panels": [],
@@ -754,7 +852,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 67
       },
       "id": 5,
       "targets": [
@@ -790,7 +888,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 67
       },
       "id": 6,
       "targets": [
@@ -838,7 +936,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 76
       },
       "id": 7,
       "targets": [
@@ -874,7 +972,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 76
       },
       "id": 8,
       "targets": [
@@ -928,7 +1026,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 85
       },
       "id": 9,
       "targets": [
@@ -964,7 +1062,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 85
       },
       "id": 10,
       "targets": [
@@ -999,7 +1097,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 94
       },
       "id": 11,
       "targets": [
@@ -1045,7 +1143,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 94
       },
       "id": 12,
       "targets": [
@@ -1083,7 +1181,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 103
       },
       "id": 250,
       "panels": [],
@@ -1106,7 +1204,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 95
+        "y": 104
       },
       "id": 251,
       "targets": [
@@ -1152,7 +1250,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 95
+        "y": 104
       },
       "id": 252,
       "targets": [
@@ -1198,7 +1296,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 95
+        "y": 104
       },
       "id": 253,
       "targets": [
@@ -1236,7 +1334,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 113
       },
       "id": 300,
       "panels": [],
@@ -1259,7 +1357,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 105
+        "y": 114
       },
       "id": 13,
       "targets": [
@@ -1295,7 +1393,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 105
+        "y": 114
       },
       "id": 14,
       "targets": [
@@ -1343,7 +1441,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 114
+        "y": 123
       },
       "id": 15,
       "targets": [
@@ -1379,7 +1477,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 123
       },
       "id": 16,
       "targets": [
@@ -1427,7 +1525,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 123
+        "y": 132
       },
       "id": 17,
       "targets": [
@@ -1462,7 +1560,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 123
+        "y": 132
       },
       "id": 18,
       "targets": [
@@ -1520,7 +1618,7 @@
         "h": 9,
         "w": 6,
         "x": 0,
-        "y": 132
+        "y": 141
       },
       "id": 19,
       "options": {
@@ -1568,7 +1666,7 @@
         "h": 9,
         "w": 18,
         "x": 6,
-        "y": 132
+        "y": 141
       },
       "id": 20,
       "targets": [
@@ -1606,7 +1704,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 141
+        "y": 150
       },
       "id": 400,
       "panels": [],
@@ -1629,7 +1727,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 142
+        "y": 151
       },
       "id": 21,
       "targets": [
@@ -1682,7 +1780,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 142
+        "y": 151
       },
       "id": 22,
       "targets": [
@@ -1720,7 +1818,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 151
+        "y": 160
       },
       "id": 250,
       "panels": [],
@@ -1742,7 +1840,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 152
+        "y": 161
       },
       "id": 251,
       "options": {
@@ -1805,7 +1903,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 152
+        "y": 161
       },
       "id": 252,
       "options": {
@@ -1846,7 +1944,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 152
+        "y": 161
       },
       "id": 253,
       "options": {
@@ -1887,7 +1985,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 161
+        "y": 170
       },
       "id": 254,
       "options": {
@@ -1927,7 +2025,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 161
+        "y": 170
       },
       "id": 255,
       "options": {
@@ -1990,7 +2088,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 161
+        "y": 170
       },
       "id": 256,
       "options": {

--- a/go/common/parser/ast/normalizer.go
+++ b/go/common/parser/ast/normalizer.go
@@ -14,6 +14,12 @@
 
 package ast
 
+import (
+	"fmt"
+
+	"github.com/cespare/xxhash/v2"
+)
+
 // NormalizeResult holds the output of AST normalization.
 type NormalizeResult struct {
 	// NormalizedSQL is the SQL string with literals replaced by $1, $2, ...
@@ -32,6 +38,22 @@ type NormalizeResult struct {
 // WasNormalized reports whether any literals were replaced during normalization.
 func (r *NormalizeResult) WasNormalized() bool {
 	return len(r.BindValues) > 0
+}
+
+// Fingerprint returns a stable 16-character hex hash of the normalized SQL.
+// Two queries with the same NormalizedSQL produce identical fingerprints,
+// which makes the fingerprint suitable as a per-query-shape identifier for
+// metrics aggregation and cache keys.
+func (r *NormalizeResult) Fingerprint() string {
+	return FingerprintSQL(r.NormalizedSQL)
+}
+
+// FingerprintSQL returns a stable 16-character hex hash of the given SQL
+// string. Useful for callers that already have a normalized or
+// placeholder-form SQL (e.g. extended-protocol queries whose Parse text
+// already contains $N placeholders) and don't need to run the normalizer.
+func FingerprintSQL(sql string) string {
+	return fmt.Sprintf("%016x", xxhash.Sum64String(sql))
 }
 
 // Normalize replaces literal A_Const values in the AST with ParamRef ($1, $2, ...)

--- a/go/common/parser/ast/normalizer_test.go
+++ b/go/common/parser/ast/normalizer_test.go
@@ -212,3 +212,30 @@ func TestNormalizeSameShapeDifferentValues(t *testing.T) {
 	assert.Equal(t, "42", result1.BindValues[0].SqlString())
 	assert.Equal(t, "99", result2.BindValues[0].SqlString())
 }
+
+func TestFingerprint(t *testing.T) {
+	// Same shape, different values → same fingerprint.
+	result1 := Normalize(selectWhereInt(42))
+	result2 := Normalize(selectWhereInt(99))
+	assert.Equal(t, result1.Fingerprint(), result2.Fingerprint())
+
+	// Fingerprint is 16 hex chars.
+	assert.Len(t, result1.Fingerprint(), 16)
+
+	// Different shape → different fingerprint.
+	differentShape := &SelectStmt{
+		TargetList: &NodeList{Items: []Node{NewResTarget("", &ColumnRef{Fields: &NodeList{Items: []Node{&A_Star{}}}})}},
+		FromClause: &NodeList{Items: []Node{&RangeVar{RelName: "orders", Inh: true}}},
+		Op:         SETOP_NONE,
+	}
+	result3 := Normalize(differentShape)
+	assert.NotEqual(t, result1.Fingerprint(), result3.Fingerprint())
+}
+
+func TestFingerprintStable(t *testing.T) {
+	// Fingerprint must be deterministic across invocations.
+	result := Normalize(selectWhereInt(42))
+	fp1 := result.Fingerprint()
+	fp2 := result.Fingerprint()
+	assert.Equal(t, fp1, fp2)
+}

--- a/go/common/topoclient/etcdtopo/store.go
+++ b/go/common/topoclient/etcdtopo/store.go
@@ -148,7 +148,7 @@ func NewServerWithOpts(serverAddrs []string, root, certPath, keyPath, caPath str
 	config := clientv3.Config{
 		Endpoints:   serverAddrs,
 		DialTimeout: time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // deprecated but required by etcd client
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, // grpc.WithBlock is deprecated but required by etcd client
 	}
 
 	tlscfg, err := newTLSConfig(certPath, keyPath, caPath)

--- a/go/common/web/templates/queries_debug.html
+++ b/go/common/web/templates/queries_debug.html
@@ -56,11 +56,13 @@
       <section>
         <h4>Sort</h4>
         <p class="sort-links">
-          <a href="?sort=calls&limit={{.Limit}}"{{if eq .SortBy "calls"}} class="active"{{end}}>calls</a>
-          <a href="?sort=total_time&limit={{.Limit}}"{{if eq .SortBy "total_time"}} class="active"{{end}}>total time</a>
-          <a href="?sort=avg_time&limit={{.Limit}}"{{if eq .SortBy "avg_time"}} class="active"{{end}}>avg time</a>
-          <a href="?sort=errors&limit={{.Limit}}"{{if eq .SortBy "errors"}} class="active"{{end}}>errors</a>
-          <a href="?sort=last_seen&limit={{.Limit}}"{{if eq .SortBy "last_seen"}} class="active"{{end}}>last seen</a>
+          {{range .SortLinks}} {{if .Active}}
+          <a class="active" href="?sort={{.Key}}&amp;limit={{$.Limit}}"
+            >{{.Label}}</a
+          >
+          {{else}}
+          <a href="?sort={{.Key}}&amp;limit={{$.Limit}}">{{.Label}}</a>
+          {{end}} {{end}}
         </p>
       </section>
 
@@ -98,14 +100,22 @@
           </tbody>
         </table>
         {{else}}
-        <p><em>No tracked query fingerprints yet. Run some traffic through the gateway and this page will populate within a few seconds.</em></p>
+        <p>
+          <em
+            >No tracked query fingerprints yet. Run some traffic through the
+            gateway and this page will populate within a few seconds.</em
+          >
+        </p>
         {{end}}
       </section>
 
       <section>
         <p>
           <small>
-            <a href="/debug/queries?format=json&sort={{.SortBy}}&limit={{.Limit}}">View as JSON</a>
+            <a
+              href="/debug/queries?format=json&amp;sort={{.SortBy}}&amp;limit={{.Limit}}"
+              >View as JSON</a
+            >
           </small>
         </p>
       </section>

--- a/go/common/web/templates/queries_debug.html
+++ b/go/common/web/templates/queries_debug.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta http-equiv="refresh" content="10" />
+    <title>{{.Title}}</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="/css/pico.classless.jade.min.css" />
+    <link rel="stylesheet" href="/css/custom.css" />
+    <style>
+      td.num {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+      td code {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .sort-links a {
+        margin-right: 0.75rem;
+      }
+      .sort-links .active {
+        font-weight: bold;
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>{{.Title}}</h1>
+    </header>
+
+    <main>
+      <section>
+        <h4>Summary</h4>
+        <table>
+          <tbody>
+            <tr>
+              <th>Tracked Fingerprints</th>
+              <td>{{.TrackedFingerprints}}</td>
+            </tr>
+            <tr>
+              <th>Showing</th>
+              <td>{{.Returned}} (limit {{.Limit}})</td>
+            </tr>
+            <tr>
+              <th>Sorted By</th>
+              <td>{{.SortBy}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h4>Sort</h4>
+        <p class="sort-links">
+          <a href="?sort=calls&limit={{.Limit}}"{{if eq .SortBy "calls"}} class="active"{{end}}>calls</a>
+          <a href="?sort=total_time&limit={{.Limit}}"{{if eq .SortBy "total_time"}} class="active"{{end}}>total time</a>
+          <a href="?sort=avg_time&limit={{.Limit}}"{{if eq .SortBy "avg_time"}} class="active"{{end}}>avg time</a>
+          <a href="?sort=errors&limit={{.Limit}}"{{if eq .SortBy "errors"}} class="active"{{end}}>errors</a>
+          <a href="?sort=last_seen&limit={{.Limit}}"{{if eq .SortBy "last_seen"}} class="active"{{end}}>last seen</a>
+        </p>
+      </section>
+
+      <section>
+        <h4>Query Shapes</h4>
+        {{if .Queries}}
+        <table>
+          <thead>
+            <tr>
+              <th>Fingerprint</th>
+              <th>Query</th>
+              <th class="num">Calls</th>
+              <th class="num">Errors</th>
+              <th class="num">Avg (ms)</th>
+              <th class="num">Min (ms)</th>
+              <th class="num">Max (ms)</th>
+              <th class="num">Total Rows</th>
+              <th>Last Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Queries}}
+            <tr>
+              <td><code>{{.Fingerprint}}</code></td>
+              <td><code>{{.NormalizedSQL}}</code></td>
+              <td class="num">{{.Calls}}</td>
+              <td class="num">{{.Errors}}</td>
+              <td class="num">{{.AvgMs}}</td>
+              <td class="num">{{.MinMs}}</td>
+              <td class="num">{{.MaxMs}}</td>
+              <td class="num">{{.TotalRows}}</td>
+              <td>{{.LastSeen.Format "15:04:05"}}</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        {{else}}
+        <p><em>No tracked query fingerprints yet. Run some traffic through the gateway and this page will populate within a few seconds.</em></p>
+        {{end}}
+      </section>
+
+      <section>
+        <p>
+          <small>
+            <a href="/debug/queries?format=json&sort={{.SortBy}}&limit={{.Limit}}">View as JSON</a>
+          </small>
+        </p>
+      </section>
+    </main>
+
+    <footer>{{template "timestamp.tmpl"}}</footer>
+  </body>
+</html>

--- a/go/services/multigateway/executor/executor.go
+++ b/go/services/multigateway/executor/executor.go
@@ -91,20 +91,26 @@ func (e *Executor) StreamExecute(
 		"connection_id", conn.ConnectionID())
 
 	planStart := time.Now()
-	plan, bindVars, cacheHit, err := e.resolvePlan(ctx, queryStr, astStmt, conn)
+	plan, bindVars, cacheHit, normalizedSQL, fingerprint, err := e.resolvePlan(ctx, queryStr, astStmt, conn)
 	planTime := time.Since(planStart)
 	if err != nil {
 		e.logger.ErrorContext(ctx, "query planning failed",
 			"query", queryStr,
 			"error", err)
-		return &handler.ExecuteResult{PlanTime: planTime}, err
+		return &handler.ExecuteResult{
+			PlanTime:      planTime,
+			NormalizedSQL: normalizedSQL,
+			Fingerprint:   fingerprint,
+		}, err
 	}
 
 	result := &handler.ExecuteResult{
-		TablesUsed: plan.TablesUsed,
-		PlanType:   plan.Type,
-		PlanTime:   planTime,
-		CacheHit:   cacheHit,
+		TablesUsed:    plan.TablesUsed,
+		PlanType:      plan.Type,
+		PlanTime:      planTime,
+		CacheHit:      cacheHit,
+		NormalizedSQL: normalizedSQL,
+		Fingerprint:   fingerprint,
 	}
 
 	err = plan.StreamExecute(ctx, e.exec, conn, state, bindVars, callback)
@@ -119,22 +125,24 @@ func (e *Executor) StreamExecute(
 
 // resolvePlan obtains a query plan, using the plan cache when possible.
 // Returns the plan, bind variables extracted during normalization (nil if none),
-// whether the plan was a cache hit, and any planning error.
+// whether the plan was a cache hit, the normalized SQL string (empty for
+// non-cacheable statements), a stable fingerprint hash of that normalized SQL,
+// and any planning error.
 func (e *Executor) resolvePlan(
 	ctx context.Context,
 	queryStr string,
 	astStmt ast.Stmt,
 	conn *server.Conn,
-) (*engine.Plan, []*ast.A_Const, bool, error) {
+) (*engine.Plan, []*ast.A_Const, bool, string, string, error) {
 	if !isCacheable(astStmt) {
 		plan, err := e.planner.Plan(queryStr, astStmt, conn)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, "", "", err
 		}
 		e.logger.DebugContext(ctx, "query plan created (non-cacheable)",
 			"plan", plan.String(),
 			"tablegroup", plan.GetTableGroup())
-		return plan, nil, false, nil
+		return plan, nil, false, "", "", nil
 	}
 
 	// Normalize: replace literals with $1, $2, ... placeholders.
@@ -142,6 +150,7 @@ func (e *Executor) resolvePlan(
 	// and BindValues is empty — the plan is still cached by its SQL string.
 	normResult := ast.Normalize(astStmt)
 	normalizedSQL := normResult.NormalizedSQL
+	fingerprint := normResult.Fingerprint()
 	cacheKey := buildCacheKey(conn.Database(), normalizedSQL)
 	var bindVars []*ast.A_Const
 	if normResult.WasNormalized() {
@@ -152,20 +161,20 @@ func (e *Executor) resolvePlan(
 	if cachedPlan, ok := e.planCache.Get(ctx, cacheKey); ok {
 		e.logger.DebugContext(ctx, "plan cache hit",
 			"normalized_query", normalizedSQL)
-		return cachedPlan, bindVars, true, nil
+		return cachedPlan, bindVars, true, normalizedSQL, fingerprint, nil
 	}
 
 	// Cache miss — plan with normalized SQL/AST and cache the result.
 	plan, err := e.planner.Plan(normalizedSQL, normResult.NormalizedAST, conn)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, normalizedSQL, fingerprint, err
 	}
 
 	e.planCache.Put(cacheKey, plan)
 	e.logger.DebugContext(ctx, "plan cache miss, planned and cached",
 		"normalized_query", normalizedSQL,
 		"plan", plan.String())
-	return plan, bindVars, false, nil
+	return plan, bindVars, false, normalizedSQL, fingerprint, nil
 }
 
 // isCacheable returns true if the statement type is eligible for plan caching.
@@ -213,19 +222,27 @@ func (e *Executor) PortalStreamExecute(
 	if isCacheable(astStmt) {
 		plan, cacheHit, err := e.resolvePortalPlan(ctx, astStmt, conn)
 		planTime := time.Since(planStart)
+		normalizedSQL := astStmt.SqlString()
+		fingerprint := ast.FingerprintSQL(normalizedSQL)
 		if err != nil {
 			e.logger.ErrorContext(ctx, "portal query planning failed",
 				"query", portalInfo.PreparedStatementInfo.Query, "error", err)
-			return &handler.ExecuteResult{PlanTime: planTime}, err
+			return &handler.ExecuteResult{
+				PlanTime:      planTime,
+				NormalizedSQL: normalizedSQL,
+				Fingerprint:   fingerprint,
+			}, err
 		}
 
 		tg, sh := extractRouting(plan, e.planner.GetDefaultTableGroup(), constants.DefaultShard)
 		err = e.exec.PortalStreamExecute(ctx, tg, sh, conn, state, portalInfo, maxRows, callback)
 		return &handler.ExecuteResult{
-			TablesUsed: plan.TablesUsed,
-			PlanType:   plan.Type,
-			PlanTime:   planTime,
-			CacheHit:   cacheHit,
+			TablesUsed:    plan.TablesUsed,
+			PlanType:      plan.Type,
+			PlanTime:      planTime,
+			CacheHit:      cacheHit,
+			NormalizedSQL: normalizedSQL,
+			Fingerprint:   fingerprint,
 		}, err
 	}
 

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
 )
 
 // ExecuteResult carries plan metadata back from the executor to the handler
@@ -48,6 +49,15 @@ type ExecuteResult struct {
 
 	// CacheHit indicates whether the plan was served from the plan cache.
 	CacheHit bool
+
+	// NormalizedSQL is the query with literals replaced by $N placeholders.
+	// Empty for non-cacheable statements (utility, DDL, transactions) that
+	// don't go through normalization.
+	NormalizedSQL string
+
+	// Fingerprint is a stable 16-hex-char hash of NormalizedSQL, used to
+	// aggregate per-query-shape metrics. Empty if NormalizedSQL is empty.
+	Fingerprint string
 }
 
 // Executor defines the interface for query execution.
@@ -81,6 +91,7 @@ type MultiGatewayHandler struct {
 	slowThreshold    time.Duration
 	notifMgr         NotificationManager
 	onNotifDropped   func(ctx context.Context) // called when async notification delivery drops
+	queryRegistry    *queryregistry.Registry
 	// targetReplica is set to true for the replica-port listener. When true,
 	// new connection states target replicas so the planner routes queries there.
 	targetReplica bool
@@ -107,6 +118,20 @@ func NewMultiGatewayHandler(executor Executor, logger *slog.Logger, statementTim
 // target replicas. Must be called before connections are accepted.
 func (h *MultiGatewayHandler) SetTargetReplica(target bool) {
 	h.targetReplica = target
+}
+
+// SetQueryRegistry attaches a per-query-shape registry to the handler.
+// When set, the handler emits a `query.fingerprint` label on query metrics
+// and records aggregate stats for queries in the registry's tracked set.
+// A nil registry disables per-query tracking (all other metrics still work).
+func (h *MultiGatewayHandler) SetQueryRegistry(r *queryregistry.Registry) {
+	h.queryRegistry = r
+}
+
+// QueryRegistry returns the attached query registry, or nil if none is set.
+// Exposed so the /debug/queries HTTP handler can enumerate tracked fingerprints.
+func (h *MultiGatewayHandler) QueryRegistry() *queryregistry.Registry {
+	return h.queryRegistry
 }
 
 // Consolidator returns the prepared statement consolidator.
@@ -531,24 +556,44 @@ func (h *MultiGatewayHandler) recordQueryCompletion(
 ) {
 	dbNamespace := conn.Database()
 
+	var (
+		tablesUsed    []string
+		planType      string
+		planTime      time.Duration
+		normalizedSQL string
+		fingerprint   string
+	)
+	if result != nil {
+		tablesUsed = result.TablesUsed
+		planType = result.PlanType
+		planTime = result.PlanTime
+		normalizedSQL = result.NormalizedSQL
+		fingerprint = result.Fingerprint
+	}
+
+	// Resolve the fingerprint label: either the fingerprint itself (if tracked),
+	// __other__ (tracked query space exists but this fingerprint didn't make the
+	// cut), or __utility__ (non-cacheable statement with no fingerprint).
+	fingerprintLabel := queryregistry.UtilityLabel
+	if fingerprint != "" {
+		fingerprintLabel = h.queryRegistry.Labelize(fingerprint)
+	}
+
 	status := QueryStatusOK
 	errorType := ""
 	if err != nil {
 		status = QueryStatusError
 		errorType = mterrors.ExtractSQLSTATE(err)
-		h.metrics.queryErrors.Add(ctx, errorType, mterrors.ClassifyErrorSource(err), dbNamespace, operationName)
+		h.metrics.queryErrors.Add(ctx, errorType, mterrors.ClassifyErrorSource(err), dbNamespace, operationName, fingerprintLabel)
 	}
 
-	h.metrics.queryDuration.Record(ctx, totalDuration.Seconds(), dbNamespace, operationName, queryProtocol, errorType, status)
-	h.metrics.rowsReturned.Record(ctx, float64(rowCount), dbNamespace, operationName)
+	h.metrics.queryDuration.Record(ctx, totalDuration.Seconds(), dbNamespace, operationName, queryProtocol, errorType, status, fingerprintLabel)
+	h.metrics.rowsReturned.Record(ctx, float64(rowCount), dbNamespace, operationName, fingerprintLabel)
 
-	var tablesUsed []string
-	var planType string
-	var planTime time.Duration
-	if result != nil {
-		tablesUsed = result.TablesUsed
-		planType = result.PlanType
-		planTime = result.PlanTime
+	// Feed the registry so popular fingerprints stay tracked, their stats roll
+	// up for /debug/queries, and newly-popular queries get promoted.
+	if fingerprint != "" {
+		h.queryRegistry.Record(fingerprint, normalizedSQL, totalDuration, int(rowCount), err != nil)
 	}
 
 	for _, table := range tablesUsed {

--- a/go/services/multigateway/handler/metrics.go
+++ b/go/services/multigateway/handler/metrics.go
@@ -57,6 +57,7 @@ func (m QueryDuration) Record(
 	protocol string,
 	errorType string,
 	status QueryStatus,
+	queryFingerprint string,
 ) {
 	m.Float64Histogram.Record(ctx, val,
 		metric.WithAttributes(
@@ -65,6 +66,7 @@ func (m QueryDuration) Record(
 			attribute.String("db.query.protocol", protocol),
 			attribute.String("error.type", errorType),
 			attribute.String("status", string(status)),
+			attribute.String("query.fingerprint", queryFingerprint),
 		))
 }
 
@@ -80,6 +82,7 @@ func (m QueryErrors) Add(
 	errorSource string,
 	dbNamespace string,
 	operationName string,
+	queryFingerprint string,
 ) {
 	m.Int64Counter.Add(ctx, 1,
 		metric.WithAttributes(
@@ -87,6 +90,7 @@ func (m QueryErrors) Add(
 			attribute.String("error.source", errorSource),
 			attribute.String("db.namespace", dbNamespace),
 			attribute.String("db.operation.name", operationName),
+			attribute.String("query.fingerprint", queryFingerprint),
 		))
 }
 
@@ -101,11 +105,13 @@ func (m RowsReturned) Record(
 	val float64,
 	dbNamespace string,
 	operationName string,
+	queryFingerprint string,
 ) {
 	m.Float64Histogram.Record(ctx, val,
 		metric.WithAttributes(
 			attribute.String("db.namespace", dbNamespace),
 			attribute.String("db.operation.name", operationName),
+			attribute.String("query.fingerprint", queryFingerprint),
 		))
 }
 

--- a/go/services/multigateway/handler/queryregistry/metrics.go
+++ b/go/services/multigateway/handler/queryregistry/metrics.go
@@ -24,11 +24,6 @@ import (
 	"github.com/multigres/multigres/go/common/cache/theine"
 )
 
-// maxSQLLabelLen caps the normalized SQL exposed as a Prometheus label so that
-// downstream label storage and Grafana legends stay readable. The full text
-// remains available via /debug/queries.
-const maxSQLLabelLen = 256
-
 // meterName is the OTel meter scope for query-registry metrics.
 const meterName = "github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
 
@@ -57,13 +52,12 @@ func (r *Registry) RegisterMetrics() error {
 	_, err = meter.RegisterCallback(
 		func(_ context.Context, o metric.Observer) error {
 			r.store.Range(0, func(_ theine.StringKey, v *QueryStats) bool {
-				sql := v.normalizedSQL
-				if len(sql) > maxSQLLabelLen {
-					sql = sql[:maxSQLLabelLen]
-				}
+				// normalizedSQL is already capped at r.maxSQLLen when the
+				// registry admits the entry (see Record); reuse that cap as
+				// the single source of truth for the exposed label too.
 				o.ObserveInt64(info, 1, metric.WithAttributes(
 					attribute.String("query.fingerprint", v.fingerprint),
-					attribute.String("query.normalized_sql", sql),
+					attribute.String("query.normalized_sql", v.normalizedSQL),
 				))
 				return true
 			})

--- a/go/services/multigateway/handler/queryregistry/metrics.go
+++ b/go/services/multigateway/handler/queryregistry/metrics.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryregistry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/multigres/multigres/go/common/cache/theine"
+)
+
+// maxSQLLabelLen caps the normalized SQL exposed as a Prometheus label so that
+// downstream label storage and Grafana legends stay readable. The full text
+// remains available via /debug/queries.
+const maxSQLLabelLen = 256
+
+// meterName is the OTel meter scope for query-registry metrics.
+const meterName = "github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
+
+// RegisterMetrics wires an "info" gauge that emits one series per tracked
+// fingerprint with both the fingerprint hash and the (truncated) normalized
+// SQL as labels. Joining this against the per-fingerprint counters via
+// Prometheus's `* on(query_fingerprint) group_left(query_normalized_sql)`
+// lets dashboards label series by SQL text instead of opaque hashes.
+//
+// Safe to call on a nil or disabled registry (returns nil without registering).
+func (r *Registry) RegisterMetrics() error {
+	if r == nil || r.store == nil {
+		return nil
+	}
+
+	meter := otel.Meter(meterName)
+
+	info, err := meter.Int64ObservableGauge(
+		"mg.gateway.query.info",
+		metric.WithDescription("One series per tracked query fingerprint, exposing fingerprint→normalized SQL mapping for join queries"),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			r.store.Range(0, func(_ theine.StringKey, v *QueryStats) bool {
+				sql := v.normalizedSQL
+				if len(sql) > maxSQLLabelLen {
+					sql = sql[:maxSQLLabelLen]
+				}
+				o.ObserveInt64(info, 1, metric.WithAttributes(
+					attribute.String("query.fingerprint", v.fingerprint),
+					attribute.String("query.normalized_sql", sql),
+				))
+				return true
+			})
+			// Synthetic entries for the aggregated buckets so table joins against
+			// mg_gateway_query_info resolve for every label value emitted on the
+			// duration/errors/rows metrics — otherwise __utility__ and __other__
+			// rows would have an empty SQL column in the dashboard.
+			o.ObserveInt64(info, 1, metric.WithAttributes(
+				attribute.String("query.fingerprint", UtilityLabel),
+				attribute.String("query.normalized_sql", "(utility statements: BEGIN, COMMIT, SET, DDL, …)"),
+			))
+			o.ObserveInt64(info, 1, metric.WithAttributes(
+				attribute.String("query.fingerprint", OtherLabel),
+				attribute.String("query.normalized_sql", "(long-tail query shapes not in tracked top set)"),
+			))
+			return nil
+		},
+		info,
+	)
+	return err
+}

--- a/go/services/multigateway/handler/queryregistry/registry.go
+++ b/go/services/multigateway/handler/queryregistry/registry.go
@@ -1,0 +1,310 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package queryregistry tracks per-query-shape statistics using a W-TinyLFU
+// cache (via theine) keyed by query fingerprint. The TinyLFU doorkeeper
+// ensures one-off queries don't evict popular ones, and its frequency
+// comparison naturally promotes newly-popular queries.
+//
+// The registry is used to:
+//   - Bound Prometheus label cardinality by deciding which fingerprints get
+//     their own label value vs. fall into the "__other__" bucket.
+//   - Back a /debug/queries endpoint that exposes aggregated per-query stats
+//     (a pg_stat_statements equivalent).
+package queryregistry
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/multigres/multigres/go/common/cache/theine"
+)
+
+// OtherLabel is the fingerprint label value used for queries not in the
+// tracked top set. Keeping this bucket named lets us still emit metrics for
+// the long tail without paying cardinality cost per fingerprint.
+const OtherLabel = "__other__"
+
+// UtilityLabel is used for statements we don't fingerprint individually
+// (BEGIN/COMMIT/SET/DDL etc.) — their space is tiny and bounded.
+const UtilityLabel = "__utility__"
+
+// QueryStats holds aggregated statistics for a single query fingerprint.
+// All counters are updated with atomic ops so reads via Snapshot don't
+// need to hold any lock.
+type QueryStats struct {
+	fingerprint   string
+	normalizedSQL string
+
+	calls           atomic.Uint64
+	errors          atomic.Uint64
+	totalDurationNs atomic.Int64
+	totalRows       atomic.Uint64
+	minDurationNs   atomic.Int64
+	maxDurationNs   atomic.Int64
+	lastSeenUnixNs  atomic.Int64
+}
+
+// CachedSize implements theine's cacheval interface so theine can bound
+// the registry by bytes, not entries. The constant overhead approximates
+// the struct + pointer/atomic headers; the variable part covers the strings.
+func (s *QueryStats) CachedSize(_ bool) int64 {
+	return 256 + int64(len(s.fingerprint)) + int64(len(s.normalizedSQL))
+}
+
+// Snapshot is a point-in-time copy of a QueryStats, safe to hand out to
+// HTTP handlers or serialize to JSON.
+type Snapshot struct {
+	Fingerprint     string        `json:"fingerprint"`
+	NormalizedSQL   string        `json:"normalized_sql"`
+	Calls           uint64        `json:"calls"`
+	Errors          uint64        `json:"errors"`
+	TotalDuration   time.Duration `json:"total_duration_ns"`
+	AverageDuration time.Duration `json:"average_duration_ns"`
+	MinDuration     time.Duration `json:"min_duration_ns"`
+	MaxDuration     time.Duration `json:"max_duration_ns"`
+	TotalRows       uint64        `json:"total_rows"`
+	LastSeen        time.Time     `json:"last_seen"`
+}
+
+// Registry tracks per-fingerprint query statistics.
+// The zero value is not usable — construct via New.
+type Registry struct {
+	store      *theine.Store[theine.StringKey, *QueryStats]
+	maxSQLLen  int
+	newEntryMu sync.Mutex
+}
+
+// Config configures a Registry.
+type Config struct {
+	// MaxMemoryBytes caps the memory used by the tracked fingerprint set.
+	// A value <= 0 disables the registry (all calls become no-ops).
+	MaxMemoryBytes int
+	// MaxSQLLength caps the stored representative normalized SQL for each
+	// fingerprint. Queries longer than this are truncated in the stored
+	// copy; the fingerprint itself is still computed over the full text.
+	MaxSQLLength int
+}
+
+// DefaultConfig returns reasonable defaults for the registry.
+func DefaultConfig() Config {
+	return Config{
+		MaxMemoryBytes: 2 * 1024 * 1024, // 2 MB
+		MaxSQLLength:   4096,
+	}
+}
+
+// New constructs a Registry with the given config.
+// If cfg.MaxMemoryBytes <= 0 the registry is disabled and all methods become no-ops.
+func New(cfg Config) *Registry {
+	r := &Registry{maxSQLLen: cfg.MaxSQLLength}
+	if cfg.MaxMemoryBytes > 0 {
+		r.store = theine.NewStore[theine.StringKey, *QueryStats](int64(cfg.MaxMemoryBytes), true)
+	}
+	return r
+}
+
+// NewForTest constructs a Registry without the TinyLFU doorkeeper so tests
+// can assert deterministic admission behavior.
+func NewForTest(cfg Config) *Registry {
+	r := &Registry{maxSQLLen: cfg.MaxSQLLength}
+	if cfg.MaxMemoryBytes > 0 {
+		r.store = theine.NewStore[theine.StringKey, *QueryStats](int64(cfg.MaxMemoryBytes), false)
+	}
+	return r
+}
+
+// Record updates stats for the given fingerprint. If the fingerprint is not
+// yet tracked, the TinyLFU admission policy decides whether to admit it —
+// one-off queries won't enter the tracked set on their first hit.
+func (r *Registry) Record(fingerprint, normalizedSQL string, duration time.Duration, rows int, hadError bool) {
+	if r == nil || r.store == nil || fingerprint == "" {
+		return
+	}
+
+	stats, ok := r.store.Get(theine.StringKey(fingerprint), 0)
+	if !ok {
+		// Try to admit — may fail if TinyLFU rejects a cold entry.
+		stats = r.admit(fingerprint, normalizedSQL)
+		if stats == nil {
+			return
+		}
+	}
+
+	durNs := duration.Nanoseconds()
+	stats.calls.Add(1)
+	stats.totalDurationNs.Add(durNs)
+	if rows > 0 {
+		stats.totalRows.Add(uint64(rows))
+	}
+	if hadError {
+		stats.errors.Add(1)
+	}
+	stats.lastSeenUnixNs.Store(time.Now().UnixNano())
+
+	// Update min/max with CAS loops.
+	for {
+		cur := stats.minDurationNs.Load()
+		if cur != 0 && durNs >= cur {
+			break
+		}
+		if stats.minDurationNs.CompareAndSwap(cur, durNs) {
+			break
+		}
+	}
+	for {
+		cur := stats.maxDurationNs.Load()
+		if durNs <= cur {
+			break
+		}
+		if stats.maxDurationNs.CompareAndSwap(cur, durNs) {
+			break
+		}
+	}
+}
+
+// admit attempts to insert a new QueryStats entry for fingerprint.
+// Returns the stats (either newly admitted or racing winner's), or nil if
+// TinyLFU rejected the admission.
+func (r *Registry) admit(fingerprint, normalizedSQL string) *QueryStats {
+	r.newEntryMu.Lock()
+	defer r.newEntryMu.Unlock()
+
+	// Re-check after acquiring lock: another goroutine may have admitted it.
+	if existing, ok := r.store.Get(theine.StringKey(fingerprint), 0); ok {
+		return existing
+	}
+
+	truncated := normalizedSQL
+	if r.maxSQLLen > 0 && len(truncated) > r.maxSQLLen {
+		truncated = truncated[:r.maxSQLLen]
+	}
+	stats := &QueryStats{
+		fingerprint:   fingerprint,
+		normalizedSQL: truncated,
+	}
+	if !r.store.Set(theine.StringKey(fingerprint), stats, 0, 0) {
+		return nil
+	}
+	// Reload through Get so we return the authoritative stored pointer —
+	// theine may have rejected via doorkeeper and returned false without
+	// actually admitting.
+	stored, ok := r.store.Get(theine.StringKey(fingerprint), 0)
+	if !ok {
+		return nil
+	}
+	return stored
+}
+
+// Labelize returns the fingerprint if it is currently tracked in the
+// registry, otherwise returns OtherLabel. Use this as the value for
+// a Prometheus/OTel label to bound cardinality.
+func (r *Registry) Labelize(fingerprint string) string {
+	if r == nil || r.store == nil || fingerprint == "" {
+		return OtherLabel
+	}
+	if _, ok := r.store.Get(theine.StringKey(fingerprint), 0); ok {
+		return fingerprint
+	}
+	return OtherLabel
+}
+
+// SortKey identifies how Top should sort results.
+type SortKey string
+
+const (
+	SortByCalls       SortKey = "calls"
+	SortByTotalTime   SortKey = "total_time"
+	SortByAverageTime SortKey = "avg_time"
+	SortByErrors      SortKey = "errors"
+	SortByLastSeen    SortKey = "last_seen"
+)
+
+// Top returns up to `limit` snapshots of the currently-tracked query
+// statistics, sorted by the given key in descending order. Passing
+// limit <= 0 returns all tracked entries.
+func (r *Registry) Top(limit int, sortBy SortKey) []Snapshot {
+	if r == nil || r.store == nil {
+		return nil
+	}
+
+	var snapshots []Snapshot
+	r.store.Range(0, func(_ theine.StringKey, v *QueryStats) bool {
+		snapshots = append(snapshots, v.snapshot())
+		return true
+	})
+
+	sortSnapshots(snapshots, sortBy)
+	if limit > 0 && len(snapshots) > limit {
+		snapshots = snapshots[:limit]
+	}
+	return snapshots
+}
+
+// Len returns the number of fingerprints currently tracked in the registry.
+func (r *Registry) Len() int {
+	if r == nil || r.store == nil {
+		return 0
+	}
+	return r.store.Len()
+}
+
+// Close stops the background maintenance goroutine.
+// Safe to call on a nil or disabled registry.
+func (r *Registry) Close() {
+	if r == nil || r.store == nil {
+		return
+	}
+	r.store.Close()
+}
+
+func (s *QueryStats) snapshot() Snapshot {
+	calls := s.calls.Load()
+	total := time.Duration(s.totalDurationNs.Load())
+	var avg time.Duration
+	if calls > 0 {
+		avg = total / time.Duration(calls)
+	}
+	return Snapshot{
+		Fingerprint:     s.fingerprint,
+		NormalizedSQL:   s.normalizedSQL,
+		Calls:           calls,
+		Errors:          s.errors.Load(),
+		TotalDuration:   total,
+		AverageDuration: avg,
+		MinDuration:     time.Duration(s.minDurationNs.Load()),
+		MaxDuration:     time.Duration(s.maxDurationNs.Load()),
+		TotalRows:       s.totalRows.Load(),
+		LastSeen:        time.Unix(0, s.lastSeenUnixNs.Load()),
+	}
+}
+
+func sortSnapshots(snapshots []Snapshot, sortBy SortKey) {
+	var less func(i, j int) bool
+	switch sortBy {
+	case SortByTotalTime:
+		less = func(i, j int) bool { return snapshots[i].TotalDuration > snapshots[j].TotalDuration }
+	case SortByAverageTime:
+		less = func(i, j int) bool { return snapshots[i].AverageDuration > snapshots[j].AverageDuration }
+	case SortByErrors:
+		less = func(i, j int) bool { return snapshots[i].Errors > snapshots[j].Errors }
+	case SortByLastSeen:
+		less = func(i, j int) bool { return snapshots[i].LastSeen.After(snapshots[j].LastSeen) }
+	default:
+		less = func(i, j int) bool { return snapshots[i].Calls > snapshots[j].Calls }
+	}
+	sort.Slice(snapshots, less)
+}

--- a/go/services/multigateway/handler/queryregistry/registry_test.go
+++ b/go/services/multigateway/handler/queryregistry/registry_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryregistry
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabledRegistry(t *testing.T) {
+	r := New(Config{MaxMemoryBytes: 0})
+	defer r.Close()
+
+	// All calls are no-ops but must not panic.
+	r.Record("abc", "SELECT 1", time.Millisecond, 1, false)
+	assert.Equal(t, OtherLabel, r.Labelize("abc"))
+	assert.Empty(t, r.Top(10, SortByCalls))
+	assert.Zero(t, r.Len())
+}
+
+func TestNilRegistry(t *testing.T) {
+	var r *Registry
+	// Nil-safe methods: all no-ops, no panic.
+	r.Record("abc", "SELECT 1", time.Millisecond, 1, false)
+	assert.Equal(t, OtherLabel, r.Labelize("abc"))
+	assert.Empty(t, r.Top(10, SortByCalls))
+	assert.Zero(t, r.Len())
+	r.Close()
+}
+
+func TestRecordAndLabelize(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	fp := "abc123"
+	sql := "SELECT * FROM users WHERE id = $1"
+
+	r.Record(fp, sql, 2*time.Millisecond, 5, false)
+	assert.Equal(t, fp, r.Labelize(fp))
+
+	// Unknown fingerprints bucket into OtherLabel.
+	assert.Equal(t, OtherLabel, r.Labelize("never-seen"))
+}
+
+func TestRecordStatsAggregation(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	fp := "abc123"
+	sql := "SELECT 1"
+
+	r.Record(fp, sql, 1*time.Millisecond, 10, false)
+	r.Record(fp, sql, 3*time.Millisecond, 20, false)
+	r.Record(fp, sql, 2*time.Millisecond, 0, true) // error, no rows
+
+	snapshots := r.Top(10, SortByCalls)
+	require.Len(t, snapshots, 1)
+
+	s := snapshots[0]
+	assert.Equal(t, fp, s.Fingerprint)
+	assert.Equal(t, sql, s.NormalizedSQL)
+	assert.EqualValues(t, 3, s.Calls)
+	assert.EqualValues(t, 1, s.Errors)
+	assert.EqualValues(t, 30, s.TotalRows)
+	assert.Equal(t, 6*time.Millisecond, s.TotalDuration)
+	assert.Equal(t, 2*time.Millisecond, s.AverageDuration)
+	assert.Equal(t, 1*time.Millisecond, s.MinDuration)
+	assert.Equal(t, 3*time.Millisecond, s.MaxDuration)
+	assert.False(t, s.LastSeen.IsZero())
+}
+
+func TestTopSortByCalls(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	// fp1: 5 calls; fp2: 10 calls; fp3: 1 call.
+	for range 5 {
+		r.Record("fp1", "q1", time.Millisecond, 0, false)
+	}
+	for range 10 {
+		r.Record("fp2", "q2", time.Millisecond, 0, false)
+	}
+	r.Record("fp3", "q3", time.Millisecond, 0, false)
+
+	top := r.Top(3, SortByCalls)
+	require.Len(t, top, 3)
+	assert.Equal(t, "fp2", top[0].Fingerprint)
+	assert.Equal(t, "fp1", top[1].Fingerprint)
+	assert.Equal(t, "fp3", top[2].Fingerprint)
+}
+
+func TestTopSortByTotalTime(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	r.Record("fast", "q1", 1*time.Millisecond, 0, false)
+	r.Record("fast", "q1", 1*time.Millisecond, 0, false)
+	r.Record("slow", "q2", 100*time.Millisecond, 0, false)
+
+	top := r.Top(2, SortByTotalTime)
+	require.Len(t, top, 2)
+	assert.Equal(t, "slow", top[0].Fingerprint)
+	assert.Equal(t, "fast", top[1].Fingerprint)
+}
+
+func TestTopLimit(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	for i := range 20 {
+		fp := fmt.Sprintf("fp-%02d", i)
+		r.Record(fp, "q", time.Millisecond, 0, false)
+	}
+
+	assert.Len(t, r.Top(5, SortByCalls), 5)
+	assert.Len(t, r.Top(0, SortByCalls), 20) // 0 = unlimited
+}
+
+func TestTopEmpty(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	assert.Empty(t, r.Top(10, SortByCalls))
+}
+
+func TestSQLTruncation(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MaxSQLLength = 10
+	r := NewForTest(cfg)
+	defer r.Close()
+
+	r.Record("fp", "SELECT * FROM this_is_a_very_long_table_name", time.Millisecond, 0, false)
+	top := r.Top(1, SortByCalls)
+	require.Len(t, top, 1)
+	assert.Len(t, top[0].NormalizedSQL, 10)
+	assert.Equal(t, "SELECT * F", top[0].NormalizedSQL)
+}
+
+func TestLabelizeEmptyFingerprint(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	assert.Equal(t, OtherLabel, r.Labelize(""))
+}
+
+func TestRecordEmptyFingerprint(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	// Empty fingerprint is ignored (no-op, no panic).
+	r.Record("", "SELECT 1", time.Millisecond, 0, false)
+	assert.Zero(t, r.Len())
+}
+
+func TestConcurrentRecord(t *testing.T) {
+	r := NewForTest(DefaultConfig())
+	defer r.Close()
+
+	const goroutines = 20
+	const perGoroutine = 500
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			for range perGoroutine {
+				r.Record("shared", "q", time.Microsecond, 1, false)
+			}
+		})
+	}
+	wg.Wait()
+
+	top := r.Top(1, SortByCalls)
+	require.Len(t, top, 1)
+	assert.EqualValues(t, goroutines*perGoroutine, top[0].Calls)
+	assert.EqualValues(t, goroutines*perGoroutine, top[0].TotalRows)
+}
+
+func TestCardinalityBounded(t *testing.T) {
+	// Tiny memory budget so the registry can hold only a few entries.
+	// We drive far more distinct fingerprints through it and assert the
+	// tracked set stays small — the whole point of TinyLFU admission.
+	r := New(Config{MaxMemoryBytes: 4096, MaxSQLLength: 64})
+	defer r.Close()
+
+	const churn = 5000
+	for i := range churn {
+		fp := fmt.Sprintf("fp-%05d", i)
+		// Two hits each so the doorkeeper lets them through admission; the
+		// policy still evicts cold entries once the cache fills.
+		r.Record(fp, fmt.Sprintf("SELECT * FROM t%d", i), time.Microsecond, 0, false)
+		r.Record(fp, fmt.Sprintf("SELECT * FROM t%d", i), time.Microsecond, 0, false)
+	}
+
+	// Tracked fingerprints must be far less than the churn count — this is
+	// what keeps Prometheus label cardinality bounded.
+	assert.Less(t, r.Len(), 500, "registry should be bounded well below churn count")
+}
+
+func TestDoorkeeperRejectsOneOff(t *testing.T) {
+	// This test uses the production New (with doorkeeper enabled) to verify
+	// that one-off queries don't enter the registry on first hit. A second
+	// hit is required to pass the bloom-filter admission.
+	r := New(DefaultConfig())
+	defer r.Close()
+
+	r.Record("one-off", "SELECT 1", time.Millisecond, 0, false)
+	// Doorkeeper rejects on first admission: nothing tracked yet.
+	assert.Equal(t, OtherLabel, r.Labelize("one-off"))
+
+	// Second call: doorkeeper sees the bit already set and admits.
+	r.Record("one-off", "SELECT 1", time.Millisecond, 0, false)
+	assert.Equal(t, "one-off", r.Labelize("one-off"))
+}

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -424,6 +424,9 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		MaxMemoryBytes: mg.queryMetricsMemory.Get(),
 		MaxSQLLength:   mg.queryMetricsSQLMaxBytes.Get(),
 	})
+	if err := mg.queryRegistry.RegisterMetrics(); err != nil {
+		logger.WarnContext(ctx, "failed to register query info metric", "error", err)
+	}
 
 	// Create and start PostgreSQL protocol listener
 	mg.pgHandler = handler.NewMultiGatewayHandler(mg.executor, logger, mg.statementTimeout.Get())

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -45,6 +45,7 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/buffer"
 	"github.com/multigres/multigres/go/services/multigateway/executor"
 	"github.com/multigres/multigres/go/services/multigateway/handler"
+	"github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
 	"github.com/multigres/multigres/go/services/multigateway/poolergateway"
 	"github.com/multigres/multigres/go/services/multigateway/scatterconn"
 	"github.com/multigres/multigres/go/tools/viperutil"
@@ -97,6 +98,15 @@ type MultiGateway struct {
 	statementTimeout viperutil.Value[time.Duration]
 	// planCacheMemory is the maximum memory (bytes) for the plan cache (0 disables)
 	planCacheMemory viperutil.Value[int]
+	// queryMetricsMemory is the maximum memory (bytes) for per-query-shape metrics
+	// tracking (0 disables fingerprint labeling and /debug/queries).
+	queryMetricsMemory viperutil.Value[int]
+	// queryMetricsSQLMaxBytes is the maximum bytes of representative normalized
+	// SQL stored per tracked fingerprint.
+	queryMetricsSQLMaxBytes viperutil.Value[int]
+	// queryRegistry tracks per-fingerprint query statistics; shared across
+	// primary and replica handlers so metrics aggregate to the same bucket.
+	queryRegistry *queryregistry.Registry
 	// senv is the serving environment
 	senv *servenv.ServEnv
 	// connConfig holds RPC client configuration (TLS, etc.) for multipooler connections
@@ -151,6 +161,18 @@ func NewMultiGateway() *MultiGateway {
 			Dynamic:  false,
 			EnvVars:  []string{"MT_PLAN_CACHE_MEMORY"},
 		}),
+		queryMetricsMemory: viperutil.Configure(reg, "query-metrics-memory", viperutil.Options[int]{
+			Default:  2 * 1024 * 1024, // 2 MB; 0 disables per-query tracking
+			FlagName: "query-metrics-memory",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_QUERY_METRICS_MEMORY"},
+		}),
+		queryMetricsSQLMaxBytes: viperutil.Configure(reg, "query-metrics-sql-max-bytes", viperutil.Options[int]{
+			Default:  4096,
+			FlagName: "query-metrics-sql-max-bytes",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_QUERY_METRICS_SQL_MAX_BYTES"},
+		}),
 		pgTLSCertFile: viperutil.Configure(reg, "pg-tls-cert-file", viperutil.Options[string]{
 			Default:  "",
 			FlagName: "pg-tls-cert-file",
@@ -193,6 +215,7 @@ func NewMultiGateway() *MultiGateway {
 				{"Live", "URL for liveness check", "/live"},
 				{"Ready", "URL for readiness check", "/ready"},
 				{"Consolidator", "Prepared statement consolidator stats", "/debug/consolidator"},
+				{"Queries", "Per-query-shape metrics", "/debug/queries"},
 			},
 		},
 	}
@@ -222,6 +245,8 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
 	fs.Int("plan-cache-memory", mg.planCacheMemory.Default(), "maximum memory in bytes for the query plan cache; 0 disables caching")
+	fs.Int("query-metrics-memory", mg.queryMetricsMemory.Default(), "memory budget (bytes) for per-query-shape metrics tracking; 0 disables per-query metrics and /debug/queries")
+	fs.Int("query-metrics-sql-max-bytes", mg.queryMetricsSQLMaxBytes.Default(), "maximum bytes of representative normalized SQL stored per tracked fingerprint")
 	viperutil.BindFlags(fs,
 		mg.cell,
 		mg.serviceID,
@@ -234,6 +259,8 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
 		mg.planCacheMemory,
+		mg.queryMetricsMemory,
+		mg.queryMetricsSQLMaxBytes,
 	)
 	mg.bufferConfig.RegisterFlags(fs)
 	mg.senv.RegisterFlags(fs)
@@ -390,8 +417,17 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	pidPrefix := multigateway.PidPrefix
 	logger.InfoContext(ctx, "registered gateway", "pid_prefix", pidPrefix)
 
+	// Construct the per-query-shape metrics registry. Shared across primary
+	// and replica handlers so a query hitting either listener aggregates to
+	// the same stats bucket.
+	mg.queryRegistry = queryregistry.New(queryregistry.Config{
+		MaxMemoryBytes: mg.queryMetricsMemory.Get(),
+		MaxSQLLength:   mg.queryMetricsSQLMaxBytes.Get(),
+	})
+
 	// Create and start PostgreSQL protocol listener
 	mg.pgHandler = handler.NewMultiGatewayHandler(mg.executor, logger, mg.statementTimeout.Get())
+	mg.pgHandler.SetQueryRegistry(mg.queryRegistry)
 
 	// Wire LISTEN/NOTIFY notification manager.
 	// Uses a lazy client getter that resolves the primary pooler connection
@@ -434,6 +470,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	if replicaPort := mg.pgReplicaPort.Get(); replicaPort > 0 {
 		replicaHandler := handler.NewMultiGatewayHandler(mg.executor, logger, mg.statementTimeout.Get())
 		replicaHandler.SetTargetReplica(true)
+		replicaHandler.SetQueryRegistry(mg.queryRegistry)
 		replicaAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), replicaPort)
 		mg.pgReplicaListener, err = server.NewListener(server.ListenerConfig{
 			Address:      replicaAddr,
@@ -521,6 +558,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	mg.senv.HTTPHandleFunc("/", mg.handleIndex)
 	mg.senv.HTTPHandleFunc("/ready", mg.handleReady)
 	mg.senv.HTTPHandleFunc("/debug/consolidator", mg.handleConsolidatorDebug)
+	mg.senv.HTTPHandleFunc("/debug/queries", mg.handleQueriesDebug)
 
 	mg.senv.OnClose(func() {
 		mg.Shutdown()
@@ -571,6 +609,11 @@ func (mg *MultiGateway) Shutdown() {
 	// Close executor (plan cache cleanup)
 	if mg.executor != nil {
 		mg.executor.Close()
+	}
+
+	// Close per-query-shape metrics registry.
+	if mg.queryRegistry != nil {
+		mg.queryRegistry.Close()
 	}
 
 	// Stop failover buffer

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -150,7 +150,18 @@ type QueriesDebugStatus struct {
 	Returned            int         `json:"returned"`
 	Limit               int         `json:"limit"`
 	SortBy              string      `json:"sort_by"`
+	SortLinks           []SortLink  `json:"-"`
 	Queries             []QueryView `json:"queries"`
+}
+
+// SortLink represents one sort option on the /debug/queries page.
+// Precomputed in the handler so the HTML template can iterate without
+// using Go-template string literals inside attribute values (which
+// breaks HTML linters that don't understand Go templates).
+type SortLink struct {
+	Key    string
+	Label  string
+	Active bool
 }
 
 // durationToMs renders a duration as a fixed-width millisecond string with
@@ -215,12 +226,29 @@ func (mg *MultiGateway) handleQueriesDebug(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	sortOptions := []struct{ Key, Label string }{
+		{"calls", "calls"},
+		{"total_time", "total time"},
+		{"avg_time", "avg time"},
+		{"errors", "errors"},
+		{"last_seen", "last seen"},
+	}
+	sortLinks := make([]SortLink, len(sortOptions))
+	for i, opt := range sortOptions {
+		sortLinks[i] = SortLink{
+			Key:    opt.Key,
+			Label:  opt.Label,
+			Active: opt.Key == sortName,
+		}
+	}
+
 	view := QueriesDebugStatus{
 		Title:               "Per-Query Metrics",
 		TrackedFingerprints: registry.Len(),
 		Returned:            len(snapshots),
 		Limit:               limit,
 		SortBy:              sortName,
+		SortLinks:           sortLinks,
 		Queries:             queries,
 	}
 

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/web"
+	"github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
 )
 
 // PoolerStatus represents the status of a multipooler instance.
@@ -124,6 +126,115 @@ func (mg *MultiGateway) handleReady(w http.ResponseWriter, r *http.Request) {
 type ConsolidatorDebugStatus struct {
 	Title string
 	Stats preparedstatement.ConsolidatorStats
+}
+
+// QueryView is a presentation-ready view of a queryregistry.Snapshot with
+// pre-formatted millisecond fields so the HTML template doesn't get mixed
+// units from time.Duration.String() (µs, ms, s).
+type QueryView struct {
+	Fingerprint   string    `json:"fingerprint"`
+	NormalizedSQL string    `json:"normalized_sql"`
+	Calls         uint64    `json:"calls"`
+	Errors        uint64    `json:"errors"`
+	AvgMs         string    `json:"avg_ms"`
+	MinMs         string    `json:"min_ms"`
+	MaxMs         string    `json:"max_ms"`
+	TotalRows     uint64    `json:"total_rows"`
+	LastSeen      time.Time `json:"last_seen"`
+}
+
+// QueriesDebugStatus is the view-model for the /debug/queries HTML page.
+type QueriesDebugStatus struct {
+	Title               string      `json:"title"`
+	TrackedFingerprints int         `json:"tracked_fingerprints"`
+	Returned            int         `json:"returned"`
+	Limit               int         `json:"limit"`
+	SortBy              string      `json:"sort_by"`
+	Queries             []QueryView `json:"queries"`
+}
+
+// durationToMs renders a duration as a fixed-width millisecond string with
+// 3 decimal places so the dashboard columns align. Zero durations print as
+// "0.000".
+func durationToMs(d time.Duration) string {
+	return fmt.Sprintf("%.3f", float64(d.Microseconds())/1000.0)
+}
+
+// handleQueriesDebug serves per-query-shape statistics.
+// Renders HTML by default; pass ?format=json for machine-readable output.
+// Query params:
+//
+//	limit: max entries to return (default 50, 0 = unlimited)
+//	sort:  one of calls (default), total_time, avg_time, errors, last_seen
+func (mg *MultiGateway) handleQueriesDebug(w http.ResponseWriter, r *http.Request) {
+	registry := mg.pgHandler.QueryRegistry()
+
+	limit := 50
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			limit = n
+		}
+	}
+
+	sortName := r.URL.Query().Get("sort")
+	if sortName == "" {
+		sortName = "calls"
+	}
+	var sortBy queryregistry.SortKey
+	switch sortName {
+	case "total_time":
+		sortBy = queryregistry.SortByTotalTime
+	case "avg_time":
+		sortBy = queryregistry.SortByAverageTime
+	case "errors":
+		sortBy = queryregistry.SortByErrors
+	case "last_seen":
+		sortBy = queryregistry.SortByLastSeen
+	default:
+		sortBy = queryregistry.SortByCalls
+		sortName = "calls"
+	}
+
+	var snapshots []queryregistry.Snapshot
+	if registry != nil {
+		snapshots = registry.Top(limit, sortBy)
+	}
+
+	queries := make([]QueryView, len(snapshots))
+	for i, s := range snapshots {
+		queries[i] = QueryView{
+			Fingerprint:   s.Fingerprint,
+			NormalizedSQL: s.NormalizedSQL,
+			Calls:         s.Calls,
+			Errors:        s.Errors,
+			AvgMs:         durationToMs(s.AverageDuration),
+			MinMs:         durationToMs(s.MinDuration),
+			MaxMs:         durationToMs(s.MaxDuration),
+			TotalRows:     s.TotalRows,
+			LastSeen:      s.LastSeen,
+		}
+	}
+
+	view := QueriesDebugStatus{
+		Title:               "Per-Query Metrics",
+		TrackedFingerprints: registry.Len(),
+		Returned:            len(snapshots),
+		Limit:               limit,
+		SortBy:              sortName,
+		Queries:             queries,
+	}
+
+	if r.URL.Query().Get("format") == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(view); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to encode JSON: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if err := web.Templates.ExecuteTemplate(w, "queries_debug.html", &view); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
+	}
 }
 
 // handleConsolidatorDebug serves the prepared statement consolidator debug page.

--- a/go/services/multigateway/status_test.go
+++ b/go/services/multigateway/status_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multigateway
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+	"github.com/multigres/multigres/go/services/multigateway/handler/queryregistry"
+)
+
+func TestHandleQueriesDebugReturnsJSON(t *testing.T) {
+	registry := queryregistry.NewForTest(queryregistry.DefaultConfig())
+	defer registry.Close()
+
+	// Populate a couple of fingerprints.
+	registry.Record("fp1", "SELECT * FROM users WHERE id = $1", 2*time.Millisecond, 10, false)
+	registry.Record("fp2", "SELECT * FROM orders WHERE user_id = $1", 5*time.Millisecond, 20, true)
+	registry.Record("fp2", "SELECT * FROM orders WHERE user_id = $1", 5*time.Millisecond, 20, false)
+
+	h := handler.NewMultiGatewayHandler(nil, slog.Default(), 0)
+	h.SetQueryRegistry(registry)
+	mg := &MultiGateway{pgHandler: h}
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/queries?limit=10&sort=calls&format=json", nil)
+	rec := httptest.NewRecorder()
+	mg.handleQueriesDebug(rec, req)
+
+	resp := rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var decoded struct {
+		TrackedFingerprints int                      `json:"tracked_fingerprints"`
+		Returned            int                      `json:"returned"`
+		Queries             []queryregistry.Snapshot `json:"queries"`
+	}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+
+	assert.Equal(t, 2, decoded.TrackedFingerprints)
+	assert.Equal(t, 2, decoded.Returned)
+	require.Len(t, decoded.Queries, 2)
+	// fp2 has 2 calls vs fp1's 1 call → fp2 first when sorted by calls.
+	assert.Equal(t, "fp2", decoded.Queries[0].Fingerprint)
+	assert.Equal(t, "fp1", decoded.Queries[1].Fingerprint)
+}
+
+func TestHandleQueriesDebugWithNilRegistry(t *testing.T) {
+	h := handler.NewMultiGatewayHandler(nil, slog.Default(), 0)
+	// No registry set.
+	mg := &MultiGateway{pgHandler: h}
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/queries?format=json", nil)
+	rec := httptest.NewRecorder()
+	mg.handleQueriesDebug(rec, req)
+
+	resp := rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.EqualValues(t, 0, decoded["tracked_fingerprints"])
+	assert.EqualValues(t, 0, decoded["returned"])
+}
+
+func TestHandleQueriesDebugHTMLDefault(t *testing.T) {
+	registry := queryregistry.NewForTest(queryregistry.DefaultConfig())
+	defer registry.Close()
+	registry.Record("fp1", "SELECT 1", time.Millisecond, 1, false)
+
+	h := handler.NewMultiGatewayHandler(nil, slog.Default(), 0)
+	h.SetQueryRegistry(registry)
+	mg := &MultiGateway{pgHandler: h}
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/queries", nil)
+	rec := httptest.NewRecorder()
+	mg.handleQueriesDebug(rec, req)
+
+	resp := rec.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	html := string(body)
+	assert.Contains(t, html, "<!doctype html>")
+	assert.Contains(t, html, "Per-Query Metrics")
+	assert.Contains(t, html, "fp1")
+	assert.Contains(t, html, "SELECT 1")
+}

--- a/go/tools/s3mock/tls_test.go
+++ b/go/tools/s3mock/tls_test.go
@@ -25,9 +25,6 @@ func TestGenerateTLSConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateTLSConfig() failed: %v", err)
 	}
-	if cfg == nil {
-		t.Fatal("generateTLSConfig() returned nil config")
-	}
 	if len(cfg.Certificates) != 1 {
 		t.Fatalf("expected 1 certificate, got %d", len(cfg.Certificates))
 	}


### PR DESCRIPTION
## Summary

- Normalize each query via the existing AST normalizer, hash the normalized SQL with xxh3, and attach the resulting 16-char `query.fingerprint` label to existing `mg.gateway.query.*` OTel metrics — so per-shape trends are queryable in Prometheus without putting query text in a label.
- Track aggregate per-fingerprint stats (calls, errors, min/avg/max latency, rows) in-process using a new registry backed by the existing Theine W-TinyLFU cache (with the bloom doorkeeper enabled). Cardinality is bounded by the cache; fingerprints outside the tracked set fold into `__other__`.
- Expose `GET /debug/queries` (HTML + `?format=json`) on the multigateway admin port with the tracked fingerprints, sortable by calls / total time / avg time / errors / last seen, auto-refreshing every 10s.
- Add two Grafana panels in the **Multigateway – Query Metrics** row: _Top Queries by p99 Latency_ (timeseries) and _Top Queries_ (table with fingerprint, calls/s, p99/p95/p50 ms, error rate; fingerprint column links to `/debug/queries`).

Closes MUL-212.

## Description

### Why bounded-cardinality fingerprint labeling

Raw SQL text has effectively unbounded cardinality (one series per literal), so using it as a Prometheus label would blow up the scrape. The registry wraps `theine.Store` with doorkeeper admission (first-touch ignored, admission on repeat) so one-off queries never enter the tracked set. `Labelize(fp)` returns either the fingerprint or `__other__`; that's the value that lands on the metric label, keeping cardinality bounded by the configured cache size.

### Feature wiring

- `ast.NormalizeResult.Fingerprint()` — stable `xxh3` hash over the existing normalized SQL; `ast.FingerprintSQL(s)` for callers that already have a normalized string (used on the extended-protocol / portal path).
- Executor populates `ExecuteResult.NormalizedSQL` + `.Fingerprint` on both simple and portal paths.
- `handler.recordQueryCompletion` calls `registry.Record(...)` and passes `registry.Labelize(fp)` as the `query.fingerprint` label to `QueryDuration`, `QueryErrors`, and `RowsReturned`.
- Non-cacheable statements (BEGIN / COMMIT / SET / DDL) label as `__utility__` instead — their space is small and bounded.
- Registry is shared between primary and replica handlers so a shape hits the same bucket regardless of which listener served it.
- `Close()` wired into `Shutdown`.

### Config flags

| Flag | Default | Notes |
|---|---|---|
| `--query-metrics-memory` | `2 MiB` | Registry byte budget. `0` disables per-query tracking (all other metrics still work). |
| `--query-metrics-sql-max-bytes` | `4096` | Truncation cap for the representative normalized SQL stored per fingerprint. |

## Test plan

- [x] Unit tests for `NormalizeResult.Fingerprint` (determinism, shape-invariance, collision-by-shape).
- [x] `queryregistry` unit tests covering disabled / nil registry, stats aggregation, sort orders, SQL truncation, empty-fingerprint no-op, concurrent writes (race-detector clean), **cardinality bound under 5k-fingerprint churn**, and TinyLFU doorkeeper admission.
- [x] HTTP handler tests for `/debug/queries` — JSON body, HTML default, nil-registry path.
- [x] Local end-to-end validation: `pgbench -c 4 -j 2 -T 300` against a local cluster populated nine distinct fingerprints (positive- and negative-delta pgbench variants) totalling ~295k calls; both `/debug/queries` and Grafana panels showed live data.

## Example dashboard
<img width="1370" height="855" alt="Screenshot 2026-04-22 at 18 19 44" src="https://github.com/user-attachments/assets/54f4652a-4ab4-43ee-aec6-edb5af8ff267" />
