### PR TITLE
feat(pgctld): add --init-db-sql-file flag to run SQL after initdb

### DIFF
--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/constants"
 )
@@ -60,6 +61,30 @@ func TestPgInitdbArgsEnvVar(t *testing.T) {
 		_, pc := GetRootCommand()
 		pc.pgInitdbArgs.Set("--encoding=UTF-8")
 		assert.Equal(t, "--encoding=UTF-8", pc.pgInitdbArgs.Get())
+	})
+}
+
+func TestInitDbSQLFilesFlag(t *testing.T) {
+	t.Run("defaults to empty slice", func(t *testing.T) {
+		_, pc := GetRootCommand()
+		assert.Empty(t, pc.initDbSQLFiles.Get())
+	})
+
+	t.Run("accepts repeated flag", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--init-db-sql-file", "/tmp/a.sql",
+			"--init-db-sql-file", "/tmp/b.sql",
+		}))
+		assert.Equal(t, []string{"/tmp/a.sql", "/tmp/b.sql"}, pc.initDbSQLFiles.Get())
+	})
+
+	t.Run("accepts comma-separated values", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--init-db-sql-file", "/tmp/a.sql,/tmp/b.sql",
+		}))
+		assert.Equal(t, []string{"/tmp/a.sql", "/tmp/b.sql"}, pc.initDbSQLFiles.Get())
 	})
 }
 

--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -86,6 +86,19 @@ func TestInitDbSQLFilesFlag(t *testing.T) {
 		}))
 		assert.Equal(t, []string{"/tmp/a.sql", "/tmp/b.sql"}, pc.initDbSQLFiles.Get())
 	})
+
+	t.Run("POSTGRES_INITDB_SQL_FILES env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgInitDbSQLFilesEnvVar, "/tmp/a.sql")
+		_, pc := GetRootCommand()
+		assert.Equal(t, []string{"/tmp/a.sql"}, pc.initDbSQLFiles.Get())
+	})
+
+	t.Run("flag overrides POSTGRES_INITDB_SQL_FILES env var", func(t *testing.T) {
+		t.Setenv(constants.PgInitDbSQLFilesEnvVar, "/tmp/env.sql")
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{"--init-db-sql-file", "/tmp/flag.sql"}))
+		assert.Equal(t, []string{"/tmp/flag.sql"}, pc.initDbSQLFiles.Get())
+	})
 }
 
 func TestPgBackRestFlags(t *testing.T) {

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -110,11 +110,11 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 		return nil, fmt.Errorf("failed to create postgres config: %w", err)
 	}
 
-	// If the target database is not the default "postgres" (always created by initdb),
-	// start PostgreSQL transiently and create it — same as docker-library/postgres does.
-	if cfg.Database != constants.DefaultPostgresDatabase {
-		if err := setupDatabase(logger, cfg); err != nil {
-			return nil, fmt.Errorf("failed to create database %q: %w", cfg.Database, err)
+	// Post-initdb steps that need a running server (custom DB creation, init
+	// SQL files) share a single transient PostgreSQL instance.
+	if cfg.Database != constants.DefaultPostgresDatabase || len(cfg.InitDbSQLFiles) > 0 {
+		if err := postInitdbSetup(logger, cfg); err != nil {
+			return nil, err
 		}
 	}
 
@@ -124,13 +124,61 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 	return result, nil
 }
 
+// postInitdbSetup starts a transient PostgreSQL instance and performs any
+// post-initdb setup steps: creating a custom target database (if requested)
+// and running user-provided init SQL files against the target database.
+func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
+	createDB := cfg.Database != constants.DefaultPostgresDatabase
+	runSQL := len(cfg.InitDbSQLFiles) > 0
+
+	logger.Info("Starting PostgreSQL transiently for post-initdb setup",
+		"create_database", createDB, "run_init_sql", runSQL)
+	pg, err := newPgInstance(logger, pgctld.PostgresDataDir(), pgctld.PostgresConfigFile(), cfg.Port, cfg.User)
+	if err != nil {
+		return err
+	}
+	defer pg.stop()
+
+	if createDB {
+		if err := createDatabaseOnInstance(logger, pg, cfg.Database); err != nil {
+			return fmt.Errorf("failed to create database %q: %w", cfg.Database, err)
+		}
+	}
+
+	if runSQL {
+		if err := runInitDbSQLFiles(logger, pg, cfg.Database, cfg.InitDbSQLFiles); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runInitDbSQLFiles executes each SQL file against database with
+// ON_ERROR_STOP=1 so a failing statement aborts its script.
+func runInitDbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, files []string) error {
+	for _, file := range files {
+		if _, err := os.Stat(file); err != nil {
+			return fmt.Errorf("init SQL file not accessible (%s): %w", file, err)
+		}
+		logger.Info("Running init SQL file", "file", file, "database", database)
+		out, err := pg.psql(database, "-v", "ON_ERROR_STOP=1", "-f", file)
+		if err != nil {
+			return fmt.Errorf("init SQL file failed (%s): %w\nOutput: %s", file, err, out)
+		}
+		logger.Info("Init SQL file applied", "file", file)
+	}
+	return nil
+}
+
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
 	cfg := PgCtldServiceConfig{
-		Port:     i.pgCtlCmd.pgPort.Get(),
-		User:     i.pgCtlCmd.pgUser.Get(),
-		Database: i.pgCtlCmd.pgDatabase.Get(),
-		Password: i.pgCtlCmd.pgPassword.Get(),
+		Port:           i.pgCtlCmd.pgPort.Get(),
+		User:           i.pgCtlCmd.pgUser.Get(),
+		Database:       i.pgCtlCmd.pgDatabase.Get(),
+		Password:       i.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles: i.pgCtlCmd.initDbSQLFiles.Get(),
 	}
 	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, cfg)
 	if err != nil {
@@ -147,46 +195,36 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// setupDatabase starts a transient pgInstance and creates pgDatabase if it does
-// not already exist, then stops the instance.  This mirrors what the official
+// createDatabaseOnInstance creates database on an already-running transient
+// pgInstance if it does not already exist. This mirrors what the official
 // docker-library/postgres image does in its docker_setup_db() entrypoint function.
-func setupDatabase(logger *slog.Logger, cfg PgCtldServiceConfig) error {
-	dataDir := pgctld.PostgresDataDir()
-	configFile := pgctld.PostgresConfigFile()
-
-	logger.Info("Starting PostgreSQL transiently to create database", "database", cfg.Database)
-	pg, err := newPgInstance(logger, dataDir, configFile, cfg.Port, cfg.User)
-	if err != nil {
-		return err
-	}
-	defer pg.stop()
-
+func createDatabaseOnInstance(logger *slog.Logger, pg *pgInstance, database string) error {
 	// Check whether the target database already exists.
 	// Use Go string formatting to build the SQL — the database name comes from
 	// operator config, not untrusted user input, so simple quoting is safe.
 	// Single quotes in the name are escaped as '' per the SQL standard.
 	checkOut, err := pg.psql(constants.DefaultPostgresDatabase,
 		"-Atc", fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname = '%s'",
-			strings.ReplaceAll(cfg.Database, "'", "''")),
+			strings.ReplaceAll(database, "'", "''")),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to query pg_database for %q: %w\nOutput: %s", cfg.Database, err, checkOut)
+		return fmt.Errorf("failed to query pg_database for %q: %w\nOutput: %s", database, err, checkOut)
 	}
 	if strings.TrimSpace(string(checkOut)) == "1" {
-		logger.Info("Database already exists, skipping creation", "database", cfg.Database)
+		logger.Info("Database already exists, skipping creation", "database", database)
 		return nil
 	}
 
 	// CREATE DATABASE with a double-quoted identifier; double quotes in the name
 	// are escaped as "" per the SQL standard.
-	logger.Info("Creating database", "database", cfg.Database)
+	logger.Info("Creating database", "database", database)
 	if out, err := pg.psql(constants.DefaultPostgresDatabase,
-		"-c", fmt.Sprintf(`CREATE DATABASE "%s"`, strings.ReplaceAll(cfg.Database, `"`, `""`)),
+		"-c", fmt.Sprintf(`CREATE DATABASE "%s"`, strings.ReplaceAll(database, `"`, `""`)),
 	); err != nil {
-		return fmt.Errorf("failed to create database %q: %w\nOutput: %s", cfg.Database, err, out)
+		return fmt.Errorf("failed to create database %q: %w\nOutput: %s", database, err, out)
 	}
 
-	logger.Info("Database created successfully", "database", cfg.Database)
+	logger.Info("Database created successfully", "database", database)
 	return nil
 }
 

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -129,10 +129,9 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 // and running user-provided init SQL files against the target database.
 func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	createDB := cfg.Database != constants.DefaultPostgresDatabase
-	runSQL := len(cfg.InitDbSQLFiles) > 0
 
 	logger.Info("Starting PostgreSQL transiently for post-initdb setup",
-		"create_database", createDB, "run_init_sql", runSQL)
+		"create_database", createDB, "init_sql_files", len(cfg.InitDbSQLFiles))
 	pg, err := newPgInstance(logger, pgctld.PostgresDataDir(), pgctld.PostgresConfigFile(), cfg.Port, cfg.User)
 	if err != nil {
 		return err
@@ -145,10 +144,8 @@ func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 		}
 	}
 
-	if runSQL {
-		if err := runInitDbSQLFiles(logger, pg, cfg.Database, cfg.InitDbSQLFiles); err != nil {
-			return err
-		}
+	if err := runInitDbSQLFiles(logger, pg, cfg.Database, cfg.InitDbSQLFiles); err != nil {
+		return err
 	}
 
 	return nil

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -48,6 +48,7 @@ type PgCtlCommand struct {
 	pgHbaTemplate      viperutil.Value[string]
 	postgresConfigTmpl viperutil.Value[string]
 	pgInitdbArgs       viperutil.Value[string]
+	initDbSQLFiles     viperutil.Value[[]string]
 
 	vc        *viperutil.ViperConfig
 	lg        *servenv.Logger
@@ -114,6 +115,11 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars:  []string{constants.PgInitdbArgsEnvVar},
 			Dynamic:  false,
 		}),
+		initDbSQLFiles: viperutil.Configure(reg, "init-db-sql-file", viperutil.Options[[]string]{
+			Default:  []string{},
+			FlagName: "init-db-sql-file",
+			Dynamic:  false,
+		}),
 		vc:        viperutil.NewViperConfig(reg),
 		lg:        servenv.NewLogger(reg, telemetry),
 		telemetry: telemetry,
@@ -164,6 +170,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("pg-hba-template", pc.pgHbaTemplate.Default(), "Path to custom pg_hba.conf template file")
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
+	root.PersistentFlags().StringSlice("init-db-sql-file", pc.initDbSQLFiles.Default(), "Path to a .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order.")
 
 	pc.vc.RegisterFlags(root.PersistentFlags())
 	pc.lg.RegisterFlags(root.PersistentFlags())
@@ -179,6 +186,7 @@ management for PostgreSQL servers.`,
 		pc.pgHbaTemplate,
 		pc.postgresConfigTmpl,
 		pc.pgInitdbArgs,
+		pc.initDbSQLFiles,
 	)
 
 	// Add all subcommands

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -118,6 +118,7 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 		initDbSQLFiles: viperutil.Configure(reg, "init-db-sql-file", viperutil.Options[[]string]{
 			Default:  []string{},
 			FlagName: "init-db-sql-file",
+			EnvVars:  []string{constants.PgInitDbSQLFilesEnvVar},
 			Dynamic:  false,
 		}),
 		vc:        viperutil.NewViperConfig(reg),
@@ -170,7 +171,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("pg-hba-template", pc.pgHbaTemplate.Default(), "Path to custom pg_hba.conf template file")
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
-	root.PersistentFlags().StringSlice("init-db-sql-file", pc.initDbSQLFiles.Default(), "Path to a .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order.")
+	root.PersistentFlags().StringSlice("init-db-sql-file", pc.initDbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitDbSQLFilesEnvVar+" env var).")
 
 	pc.vc.RegisterFlags(root.PersistentFlags())
 	pc.lg.RegisterFlags(root.PersistentFlags())

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -144,10 +144,11 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	pgbackrestCertDir := s.pgbackrestCertDir.Get()
 
 	pgctldConfig := PgCtldServiceConfig{
-		Port:     s.pgCtlCmd.pgPort.Get(),
-		User:     s.pgCtlCmd.pgUser.Get(),
-		Database: s.pgCtlCmd.pgDatabase.Get(),
-		Password: s.pgCtlCmd.pgPassword.Get(),
+		Port:           s.pgCtlCmd.pgPort.Get(),
+		User:           s.pgCtlCmd.pgUser.Get(),
+		Database:       s.pgCtlCmd.pgDatabase.Get(),
+		Password:       s.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles: s.pgCtlCmd.initDbSQLFiles.Get(),
 	}
 
 	pgctldService, err := NewPgCtldService(
@@ -215,11 +216,12 @@ func reapOrphanedChildren(logger *slog.Logger) {
 // parameters. These are the most commonly passed parameters and are grouped
 // here to reduce argument lists.
 type PgCtldServiceConfig struct {
-	Port       int
-	User       string
-	Database   string
-	Password   string
-	InitdbArgs string
+	Port           int
+	User           string
+	Database       string
+	Password       string
+	InitdbArgs     string
+	InitDbSQLFiles []string
 }
 
 // PgCtldService implements the pgctld gRPC service

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -278,6 +279,95 @@ touch "$2/pg_hba.conf"
 		argsOut := string(argsBytes)
 		assert.Contains(t, argsOut, "--locale-provider=icu")
 		assert.Contains(t, argsOut, "--icu-locale=en_US.UTF-8")
+	})
+}
+
+func TestRunInitDbSQLFiles(t *testing.T) {
+	t.Run("executes each file in order with expected psql args", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_init_sql_test")
+		defer cleanup()
+
+		argsLog := filepath.Join(baseDir, "psql-args.log")
+
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		testutil.MockBinary(t, binDir, "psql", `echo "$@" >> `+argsLog)
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		fileA := filepath.Join(baseDir, "a.sql")
+		fileB := filepath.Join(baseDir, "b.sql")
+		require.NoError(t, os.WriteFile(fileA, []byte("CREATE TABLE a();"), 0o644))
+		require.NoError(t, os.WriteFile(fileB, []byte("CREATE TABLE b();"), 0o644))
+
+		logger := slog.New(slog.DiscardHandler)
+		pg := &pgInstance{
+			socketDir: "/tmp",
+			port:      5432,
+			user:      "postgres",
+			logger:    logger,
+		}
+		err := runInitDbSQLFiles(logger, pg, "mydb", []string{fileA, fileB})
+		require.NoError(t, err)
+
+		logBytes, err := os.ReadFile(argsLog)
+		require.NoError(t, err)
+		lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+		require.Len(t, lines, 2, "expected one psql invocation per file")
+
+		assert.Contains(t, lines[0], fileA, "first invocation should reference a.sql")
+		assert.Contains(t, lines[1], fileB, "second invocation should reference b.sql")
+		for _, line := range lines {
+			assert.Contains(t, line, "ON_ERROR_STOP=1")
+			assert.Contains(t, line, "-d mydb")
+		}
+	})
+
+	t.Run("returns error on missing file without invoking psql", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		// nil pgInstance is safe here: os.Stat runs before the first psql call.
+		err := runInitDbSQLFiles(logger, nil, "mydb", []string{"/nonexistent/file.sql"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not accessible")
+	})
+
+	t.Run("aborts on first file failure and skips remaining", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_init_sql_fail_test")
+		defer cleanup()
+
+		runLog := filepath.Join(baseDir, "psql-runs.log")
+
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		testutil.MockBinary(t, binDir, "psql", `
+echo "$@" >> `+runLog+`
+if [[ "$*" == *"fail.sql"* ]]; then
+    echo "mock psql: simulated failure" >&2
+    exit 1
+fi
+`)
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		failFile := filepath.Join(baseDir, "fail.sql")
+		nextFile := filepath.Join(baseDir, "next.sql")
+		require.NoError(t, os.WriteFile(failFile, []byte("BAD"), 0o644))
+		require.NoError(t, os.WriteFile(nextFile, []byte("OK"), 0o644))
+
+		logger := slog.New(slog.DiscardHandler)
+		pg := &pgInstance{
+			socketDir: "/tmp",
+			port:      5432,
+			user:      "postgres",
+			logger:    logger,
+		}
+		err := runInitDbSQLFiles(logger, pg, "mydb", []string{failFile, nextFile})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fail.sql")
+
+		logBytes, err := os.ReadFile(runLog)
+		require.NoError(t, err)
+		got := string(logBytes)
+		assert.Contains(t, got, "fail.sql", "first file should have been invoked")
+		assert.NotContains(t, got, "next.sql", "remaining files must not be invoked after a failure")
 	})
 }
 

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -40,6 +40,10 @@ const (
 	// PgInitdbArgsEnvVar is the environment variable for extra arguments passed to initdb.
 	PgInitdbArgsEnvVar = "POSTGRES_INITDB_ARGS"
 
+	// PgInitDbSQLFilesEnvVar is the environment variable for init SQL files to run after initdb.
+	// Multiple files are comma-separated.
+	PgInitDbSQLFilesEnvVar = "POSTGRES_INITDB_SQL_FILES"
+
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.
 	DefaultPostgresDatabase = "postgres"

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -83,6 +83,10 @@ type ProcessInstance struct {
 	PgBackRestPort      int                        // pgBackRest server port (multipooler, pgctld)
 	PgBackRestCertDir   string                     // pgBackRest TLS certificate directory (pgctld)
 
+	// InitDbSQLFiles is a list of SQL files executed after initdb against the
+	// target database when InitDataDir runs on this pgctld instance.
+	InitDbSQLFiles []string
+
 	// BackupLocation stores backup configuration from topology (used by pgctld)
 	BackupLocation *clustermetadatapb.BackupLocation
 }
@@ -139,6 +143,10 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 	}
 	if p.PgBackRestCertDir != "" {
 		args = append(args, "--pgbackrest-cert-dir", p.PgBackRestCertDir)
+	}
+
+	for _, file := range p.InitDbSQLFiles {
+		args = append(args, "--init-db-sql-file", file)
 	}
 
 	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -74,6 +74,7 @@ type SetupConfig struct {
 	OTelCollectorEndpoint               string   // OTLP HTTP endpoint for multigateway span export (empty = disabled)
 	EnableMetricsExport                 bool     // Enable Prometheus metrics export on all services
 	LogLevel                            string   // --log-level for multipooler/multiorch/multigateway (empty = "debug")
+	InitDbSQLFiles                      []string // Paths to .sql files executed on each pgctld after initdb against the target database
 }
 
 // SetupOption is a function that configures setup creation.
@@ -218,6 +219,16 @@ func WithMetricsExport() SetupOption {
 	return func(c *SetupConfig) {
 		c.EnableMultigateway = true
 		c.EnableMetricsExport = true
+	}
+}
+
+// WithInitDbSQLFiles forwards the given SQL file paths to every pgctld in the
+// shard via --init-db-sql-file. pgctld runs each file against the target
+// database after initdb completes (during the InitDataDir RPC triggered by
+// shard bootstrap). Files run in the order provided.
+func WithInitDbSQLFiles(files ...string) SetupOption {
+	return func(c *SetupConfig) {
+		c.InitDbSQLFiles = files
 	}
 }
 
@@ -468,6 +479,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		}
 
 		inst.Multipooler.LogLevel = config.LogLevel
+		inst.Pgctld.InitDbSQLFiles = config.InitDbSQLFiles
 		multipoolerInstances = append(multipoolerInstances, inst)
 
 		t.Logf("Created multipooler instance '%s': pgctld gRPC=%d, PG=%d, multipooler gRPC=%d",

--- a/go/test/endtoend/shardsetup/shardsetup_test.go
+++ b/go/test/endtoend/shardsetup/shardsetup_test.go
@@ -17,6 +17,8 @@ package shardsetup
 import (
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -333,4 +335,52 @@ func TestShardSetup_WriterValidator(t *testing.T) {
 		err := validator.Verify(t, poolerClients)
 		return err == nil
 	}, 5*time.Second, 100*time.Millisecond, "all successful writes should be present across poolers")
+}
+
+// TestShardSetup_InitDbSQLFilesExecuted validates the --init-db-sql-file flag
+// end-to-end: pgctld runs each provided SQL file against the target database
+// during InitDataDir (triggered by shard bootstrap). We assert that the
+// artifacts those files create — a table with data, and a cluster-wide role —
+// exist on the elected primary.
+func TestShardSetup_InitDbSQLFilesExecuted(t *testing.T) {
+	skipIfShort(t)
+
+	sqlDir := t.TempDir()
+	tableFile := filepath.Join(sqlDir, "01-table.sql")
+	roleFile := filepath.Join(sqlDir, "02-role.sql")
+
+	require.NoError(t, os.WriteFile(tableFile, []byte(`
+CREATE TABLE IF NOT EXISTS init_db_sql_test (
+    id   int PRIMARY KEY,
+    note text NOT NULL
+);
+INSERT INTO init_db_sql_test (id, note) VALUES (1, 'from-init-sql');
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(roleFile, []byte(`
+CREATE ROLE init_db_sql_role NOLOGIN;
+`), 0o644))
+
+	setup, cleanup := NewIsolated(t,
+		WithMultipoolerCount(2),
+		WithInitDbSQLFiles(tableFile, roleFile),
+	)
+	defer cleanup()
+
+	ctx := t.Context()
+
+	// Primary must have the table row created by the first init SQL file.
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	note, err := QueryStringValue(ctx, primaryClient.Pooler,
+		"SELECT note FROM init_db_sql_test WHERE id = 1")
+	require.NoError(t, err, "primary should be queryable for init-sql table")
+	assert.Equal(t, "from-init-sql", note, "row inserted by init SQL must be present on primary")
+
+	// Primary must also have the cluster-wide role created by the second init SQL file.
+	roleFound, err := QueryStringValue(ctx, primaryClient.Pooler,
+		"SELECT 1 FROM pg_roles WHERE rolname = 'init_db_sql_role'")
+	require.NoError(t, err)
+	assert.Equal(t, "1", roleFound, "role created by init SQL must exist")
 }


### PR DESCRIPTION
## Summary

- Adds `--init-db-sql-file` to `pgctld` (repeatable / CSV StringSlice) that runs each .sql file against the target database during `pgctld init` and the gRPC `InitDataDir` RPC.
- Mirrors Vitess's `--init_db_sql_file`, scoped to per-instance bootstrap (users, GRANTs, extensions, seed data) — the single-file design is extended to support multiple files run in order.
- Exposes the same option in shard-setup integration tests as `WithInitDbSQLFiles(...)`, with a new end-to-end test that asserts init-script artifacts exist on the elected primary after bootstrap.

## Description

Each file is executed via `psql -v ON_ERROR_STOP=1 -f <file>` against `--pg-database` using the transient PostgreSQL instance already used for custom-database creation. If both a non-default database and init SQL files are set, the transient instance starts once and handles both steps. Files are validated with `os.Stat` up front so operator misconfiguration (missing path) surfaces a clear error at the CLI boundary rather than buried inside psql stderr.

Refactor note: `setupDatabase` is split into `createDatabaseOnInstance(pg, database)` so it can share the transient instance with the new `runInitDbSQLFiles` helper, avoiding a double start/stop when both features are in use.

## Test plan

- [x] Unit: `TestInitDbSQLFilesFlag` (parsing: default / repeated / CSV)
- [x] Unit: `TestRunInitDbSQLFiles` (order, missing-file error, abort-on-first-failure with mock psql)
- [x] Integration: `TestShardSetup_InitDbSQLFilesExecuted` — bootstraps a shard with two init SQL files, verifies the created table row and cluster-wide role exist on the primary

---
Fixes: MUL-366