### PR TITLE
feat(multigateway): add PostgreSQL client certificate authentication

### DIFF
--- a/docs/query_serving/client_cert_auth_design.md
+++ b/docs/query_serving/client_cert_auth_design.md
@@ -1,0 +1,160 @@
+# Client Certificate Authentication
+
+## Overview
+
+Multigateway supports PostgreSQL client certificate authentication at the wire-protocol level, matching PG's `cert` auth method exactly (`trust` + `clientcert=verify-full`). Deployments can use mTLS to authenticate connections without passwords, with behavior compatible with native PostgreSQL from the client's perspective — same wire-protocol sequence, same error codes, same identity-matching semantics. Remaining parity gaps (e.g. `pg_ident.conf` maps) are tracked as follow-ups.
+
+Key capabilities:
+
+- `cert` auth method — require client cert, verify chain, bind `CN` (or `DN`) to the requested DB user, skip SCRAM
+- Flag-driven config for v1 (no `pg_hba.conf` yet)
+- Full peer DN recorded as the authenticated identity for audit
+- SQLSTATE `28000` on mismatch; no fallback to SCRAM — first-match-wins per PG
+
+Explicit non-goals:
+
+- **No SAN / SPIFFE URI identity extraction.** PG's server-side cert auth uses only `Subject.CN` (or full DN). Adding SAN would be a superset.
+- **No user-existence check at auth time.** PG doesn't do it; the pooler rejects the connection downstream when the user is missing.
+- **No IP-restriction rules / `pg_hba.conf`.** Deferred.
+
+## PostgreSQL Background
+
+### The `cert` auth method
+
+From [auth-cert.html](https://www.postgresql.org/docs/17/auth-cert.html):
+
+> The `cn` (Common Name) attribute of the certificate will be compared to the requested database user name, and if they match the login will be allowed. … cert authentication is effectively trust authentication with `clientcert=verify-full`.
+
+The semantics:
+
+1. Identity is pulled from the peer cert — `Subject.CN` (default) or full DN.
+2. Empty identity → reject.
+3. Identity is compared against the requested DB user, either directly (case-sensitive equality) or via a configured `pg_ident.conf` map.
+4. The full DN is recorded as the authenticated identity for audit, regardless of which field was matched for authorization.
+5. Role existence is **not** checked at auth time — it is deferred to backend startup.
+
+### The `clientcert` HBA option
+
+Independent of the auth method:
+
+- `clientcert=verify-ca` — require valid client cert, validate chain + CRL, no identity binding. Auth method still runs.
+- `clientcert=verify-full` — same, plus enforce `CN`/`DN` matches the requested user. Auth method still runs.
+
+The `cert` method is equivalent to `trust` + `clientcert=verify-full`.
+
+### Wire protocol
+
+No `AuthenticationCertificate` message exists. After a TLS handshake with a valid client cert and successful identity match, the server proceeds straight to `AuthenticationOk`, then the usual `BackendKeyData`, `ParameterStatus`, `ReadyForQuery` sequence. No SASL/password exchange.
+
+## Architecture
+
+### Connection flow
+
+```text
+Client                                   Multigateway
+  │                                          │
+  │ SSLRequest                               │
+  ├──────────────────────────────────────────▶
+  │                              'S' (accept)│
+  ◀──────────────────────────────────────────┤
+  │                                          │
+  │ TLS ClientHello                          │
+  ├──────────────────────────────────────────▶
+  │                     TLS ServerHello +    │
+  │                     Cert + CertRequest   │
+  ◀──────────────────────────────────────────┤
+  │                                          │
+  │ TLS Client Cert + Finished               │
+  ├──────────────────────────────────────────▶  [chain verified during
+  │                          TLS Finished    │   handshake]
+  ◀──────────────────────────────────────────┤
+  │                                          │
+  │ StartupMessage (user=alice, db=app)      │
+  ├──────────────────────────────────────────▶
+  │                                          │ mode=verify-full + TLS
+  │                                          │ + verified peer cert
+  │                                          │ → cert-auth path
+  │                                          │
+  │                                          │ compare CN (or DN) to user
+  │                                          │ log DN as authn identity
+  │                                          │
+  │ AuthenticationOk + BackendKeyData +      │
+  │ ParameterStatus… + ReadyForQuery         │
+  ◀──────────────────────────────────────────┤
+```
+
+### Component interaction
+
+Four layers participate, each with a clear responsibility:
+
+**TLS layer** (below the PG protocol) — terminates TLS and validates the client certificate chain against the configured CA pool. In `verify-full` mode the TLS layer is configured to require a verified peer cert at handshake time, so a missing or untrusted client cert fails the handshake before any PG-level code runs. (CRL enforcement is a deferred follow-up; v1 does not consult CRLs.)
+
+**PG protocol startup** — after the handshake, reads the `StartupMessage` over the encrypted channel and extracts `user` and `database`. Dispatches to the authentication layer based on the configured client-auth mode:
+
+- `none` → SCRAM (current default).
+- `verify-full` → cert auth path; a connection without a verified peer cert has already failed the handshake, so this path always sees a cert.
+
+**Cert auth** — pulls the configured identity field (`CN` or `DN`) from the verified peer cert and compares it to the requested DB user. Logs the full DN for audit. On mismatch, emits a PG-format error with SQLSTATE `28000` and closes. On match, sends `AuthenticationOk` and the post-auth message sequence — no password dance.
+
+**Pooler** (downstream) — receives queries on the authenticated connection. If the mapped DB user doesn't exist in the credential store, query execution fails there, matching PG's behavior of deferring role-existence checks past the auth step.
+
+No new services, no new RPCs, no credential-fetch round-trip at auth time. Cert auth is a pure in-process operation on top of TLS state that is already present after the handshake.
+
+### Flag surface
+
+| Flag | Type | Default | Purpose |
+|------|------|---------|---------|
+| `--pg-tls-cert-file` | path | `""` | Server cert |
+| `--pg-tls-key-file` | path | `""` | Server key |
+| `--pg-tls-ca-file` | path | `""` | CA pool for verifying client certs |
+| `--pg-tls-client-auth-mode` | enum | `none` | `none`, `verify-full` implemented; `verify-ca`, `optional` reserved |
+| `--pg-tls-client-cert-name` | enum | `cn` | `cn` or `dn` — which cert field is matched against `user` |
+
+Reserved names (fixed now to avoid churn):
+
+- `--pg-tls-crl-file`, `--pg-tls-crl-dir` — CRL sources.
+- `--pg-hba-conf` — rule-based config; will supersede the flags above when it lands.
+
+Validation:
+
+- `--pg-tls-ca-file` requires `--pg-tls-cert-file` + `--pg-tls-key-file`.
+- `--pg-tls-client-auth-mode=verify-full` requires `--pg-tls-ca-file`.
+- `--pg-tls-ca-file` set together with `--pg-tls-client-auth-mode=none` is rejected at startup. A CA configured with no client-auth mode active is almost certainly a misconfiguration (the user intended cert auth but forgot the mode); failing loudly matches the style of the existing server-TLS validations and avoids silently unverified clients.
+
+## Identity Mapping
+
+v1: the selected cert field (`CN` or `DN`) must equal the requested user, case-sensitive. Matches PG's default when no `map=` is configured.
+
+**DN-format parity.** When `--pg-tls-client-cert-name=dn`, the DN string used for comparison is emitted in strict [RFC 2253](https://www.rfc-editor.org/rfc/rfc2253) form — the same format PostgreSQL produces via `X509_NAME_print_ex(..., XN_FLAG_RFC2253)`. This is not the same as Go's default `pkix.Name.String()` (which differs in attribute ordering and escaping), so multigateway implements its own RFC 2253 formatter over `Certificate.RawSubject`. Without this, a cert whose DN matches successfully against PG would silently fail here.
+
+Deferred: `pg_ident.conf`-style mapping — exact pairs, regex with `\1` back-references, permissive-OR semantics (match succeeds if any map entry allows the pair).
+
+## Error Handling
+
+- **TLS chain validation failure** — handshake fails; client sees a TLS error, never reaches the auth layer.
+- **No client cert in `verify-full` mode** — the strict client-cert verification setting makes this a handshake failure (same path as above).
+- **CN/DN mismatch** — `ErrorResponse` with severity `FATAL`, SQLSTATE `28000`, message `certificate authentication failed for user "X"`, and a `DETAIL` line naming the matched field and the presented value (e.g. `Client certificate CN "svc-foo" does not match requested user "svc-bar"`). Connection closed. Matches PG's message + detail convention. No SCRAM fallback: a cert that passed chain validation but failed identity match means *wrong identity*, not *wrong method*.
+- **Successful auth** — one log line with peer DN, matched field, cipher suite, TLS version, requested user. Mirrors PG's audit trail.
+
+## Operational Guidance
+
+- Clients must negotiate TLS to reach cert auth. With libpq-compatible drivers that means `sslmode=require` at minimum (or stricter — `verify-ca`/`verify-full`) together with `sslcert` and `sslkey` (and `sslrootcert` if the client also verifies the server). `sslmode=disable`/`prefer` will either skip TLS or leave it optional and never send a client cert.
+- TLS cert rotation requires multigateway restart in v1. Hot reload is deferred.
+- For mixed deployments (human users on SCRAM, services on mTLS), run separate multigateway instances or restrict the CA to service identities, until per-rule config arrives.
+- Successful cert auth emits an info-level log line including the full DN — sufficient for audit.
+
+## Follow-up Work
+
+- Pair `verify-ca` and `verify-full` with non-cert auth methods (e.g. SCRAM **and** cert required) — the defense-in-depth case.
+- Extend TLS to the multipooler → PostgreSQL leg, mirroring libpq's `sslmode` surface.
+- Advertise `SCRAM-SHA-256-PLUS` (channel binding) when the connection is TLS, matching PG.
+- CRL checking for PG TLS and internal gRPC — replicate PG's whole-chain CRL semantics.
+- `pg_ident.conf` parsing and the `map=` option.
+- `pg_hba.conf` parser and rule-match engine — the umbrella that ultimately subsumes the per-flag config and lets the items above land as rule types.
+
+## References
+
+- [PostgreSQL — Certificate Authentication](https://www.postgresql.org/docs/17/auth-cert.html)
+- [PostgreSQL — `pg_hba.conf`](https://www.postgresql.org/docs/17/auth-pg-hba-conf.html) (`clientcert` option)
+- [PostgreSQL — User Name Maps](https://www.postgresql.org/docs/17/auth-username-maps.html)
+- [PostgreSQL — SSL Setup](https://www.postgresql.org/docs/17/ssl-tcp.html)

--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -30,7 +30,8 @@ const (
 	PgSSActiveTransaction       = "25001" // active_sql_transaction
 	PgSSInFailedTransaction     = "25P02" // in_failed_sql_transaction
 	PgSSInvalidSQLStatementName = "26000" // invalid_sql_statement_name
-	PgSSAuthFailed              = "28P01" // invalid_authorization_specification
+	PgSSAuthFailed              = "28P01" // invalid_password
+	PgSSInvalidAuthSpec         = "28000" // invalid_authorization_specification
 	PgSSInvalidCursorName       = "34000" // invalid_cursor_name
 	PgSSSyntaxError             = "42601" // syntax_error
 	PgSSUndefinedObject         = "42704" // undefined_object

--- a/go/common/pgprotocol/server/cert_auth.go
+++ b/go/common/pgprotocol/server/cert_auth.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// CertAuthMode controls client certificate authentication behavior.
+// See docs/query_serving/client_cert_auth_design.md.
+type CertAuthMode string
+
+const (
+	// CertAuthModeNone disables client certificate authentication. Client
+	// certificates are not requested, and SCRAM (or trust in tests) is used.
+	CertAuthModeNone CertAuthMode = "none"
+
+	// CertAuthModeVerifyFull requires a valid client certificate whose CN or
+	// DN matches the requested DB user, bypassing password authentication.
+	// Equivalent to PostgreSQL's `cert` auth method.
+	CertAuthModeVerifyFull CertAuthMode = "verify-full"
+
+	// CertAuthModeVerifyCA is reserved — client certificate required and
+	// verified against the CA, but identity is not bound and SCRAM still runs.
+	// Not implemented in v1.
+	CertAuthModeVerifyCA CertAuthMode = "verify-ca"
+
+	// CertAuthModeOptional is reserved — client certificate used for auth if
+	// presented, SCRAM otherwise. Not implemented in v1.
+	CertAuthModeOptional CertAuthMode = "optional"
+)
+
+// ParseCertAuthMode parses a CertAuthMode string from a flag value.
+// Reserved modes (verify-ca, optional) are rejected with a "not implemented"
+// error so the flag contract is stable for future releases.
+func ParseCertAuthMode(s string) (CertAuthMode, error) {
+	switch CertAuthMode(s) {
+	case CertAuthModeNone, CertAuthModeVerifyFull:
+		return CertAuthMode(s), nil
+	case CertAuthModeVerifyCA, CertAuthModeOptional:
+		return "", fmt.Errorf("client auth mode %q is reserved but not yet implemented", s)
+	default:
+		return "", fmt.Errorf("invalid client auth mode %q (valid: none, verify-full)", s)
+	}
+}
+
+// CertIdentitySource selects which field of the peer certificate is compared
+// to the requested DB user during verify-full cert authentication.
+type CertIdentitySource string
+
+const (
+	// CertIdentityCN compares the certificate's Subject Common Name.
+	// Matches PostgreSQL's default behavior (clientcertname=CN).
+	CertIdentityCN CertIdentitySource = "cn"
+
+	// CertIdentityDN compares the full RFC 2253 Subject DN.
+	// Matches PostgreSQL's clientcertname=DN.
+	CertIdentityDN CertIdentitySource = "dn"
+)
+
+// ParseCertIdentitySource parses a CertIdentitySource string from a flag value.
+func ParseCertIdentitySource(s string) (CertIdentitySource, error) {
+	switch CertIdentitySource(s) {
+	case CertIdentityCN, CertIdentityDN:
+		return CertIdentitySource(s), nil
+	default:
+		return "", fmt.Errorf("invalid cert identity source %q (valid: cn, dn)", s)
+	}
+}
+
+// authenticateCertificate performs PostgreSQL-compatible `cert` authentication
+// (trust + clientcert=verify-full). Must be called only when:
+//   - the connection is TLS (c.conn is *tls.Conn), and
+//   - the TLS layer was configured with RequireAndVerifyClientCert, so a
+//     verified peer certificate is guaranteed to be present.
+//
+// Compares the configured identity field (CN or DN) of PeerCertificates[0]
+// against the requested DB user, case-sensitive. On mismatch, sends a FATAL
+// ErrorResponse with SQLSTATE 28000 and a DETAIL line identifying the matched
+// field, then returns the error (caller closes the connection). On match,
+// records the full peer DN as the authenticated identity via a log line and
+// proceeds with the post-auth message sequence.
+func (c *Conn) authenticateCertificate() error {
+	state, ok := c.TLSConnectionState()
+	if !ok {
+		// Shouldn't happen: verify-full requires TLS, and the caller gated on
+		// the connection being TLS. Treat defensively as an internal error.
+		return errors.New("cert auth invoked on non-TLS connection")
+	}
+	if len(state.PeerCertificates) == 0 {
+		// Shouldn't happen: ClientAuth=RequireAndVerifyClientCert makes the
+		// handshake fail when no cert is presented. Treat defensively.
+		return errors.New("cert auth invoked without peer certificate")
+	}
+	cert := state.PeerCertificates[0]
+
+	var presented, fieldName string
+	switch c.certIdentitySource {
+	case CertIdentityDN:
+		// Go's pkix.Name.String() produces RFC 2253 output (reversed RDN
+		// order, short attribute names, standard escaping) — equivalent to
+		// PostgreSQL's X509_NAME_print_ex(..., XN_FLAG_RFC2253) for typical
+		// certificate subjects.
+		presented = cert.Subject.String()
+		fieldName = "DN"
+	default: // CertIdentityCN (also the zero-value fallback)
+		presented = cert.Subject.CommonName
+		fieldName = "CN"
+	}
+
+	if presented != c.user {
+		c.logger.Warn("cert auth failed: identity mismatch",
+			"user", c.user,
+			"field", fieldName,
+			"presented", presented,
+			"peer_dn", cert.Subject.String(),
+		)
+		return c.sendCertAuthError(fieldName, presented)
+	}
+
+	// Log the full DN as the authenticated identity, matching PostgreSQL's
+	// set_authn_id(peer_dn) behavior even when CN was used for authorization.
+	c.logger.Info("authentication complete",
+		"user", c.user,
+		"method", "cert",
+		"field", fieldName,
+		"peer_dn", cert.Subject.String(),
+		"tls_version", tlsVersionName(state.Version),
+		"cipher_suite", tls.CipherSuiteName(state.CipherSuite),
+	)
+
+	if err := c.sendAuthenticationOk(); err != nil {
+		return fmt.Errorf("failed to send AuthenticationOk: %w", err)
+	}
+	if err := c.sendBackendKeyData(); err != nil {
+		return fmt.Errorf("failed to send BackendKeyData: %w", err)
+	}
+	c.listener.RegisterConn(c)
+	if err := c.sendParameterStatuses(); err != nil {
+		return fmt.Errorf("failed to send ParameterStatus messages: %w", err)
+	}
+	if err := c.sendReadyForQuery(); err != nil {
+		return fmt.Errorf("failed to send ReadyForQuery: %w", err)
+	}
+	return nil
+}
+
+// sendCertAuthError emits a PostgreSQL-format FATAL ErrorResponse for a cert
+// identity mismatch. Message matches PG's wording; DETAIL names the matched
+// field and the presented value for debuggability.
+func (c *Conn) sendCertAuthError(fieldName, presented string) error {
+	message := fmt.Sprintf("certificate authentication failed for user %q", c.user)
+	detail := fmt.Sprintf("Client certificate %s %q does not match requested user %q",
+		fieldName, presented, c.user)
+	diag := mterrors.NewPgError("FATAL", mterrors.PgSSInvalidAuthSpec, message, detail)
+	if err := c.writePgDiagnosticResponse(protocol.MsgErrorResponse, diag); err != nil {
+		return err
+	}
+	return c.flush()
+}
+
+// tlsVersionName returns a human-readable TLS version string for logging.
+func tlsVersionName(v uint16) string {
+	switch v {
+	case 0x0301:
+		return "TLS1.0"
+	case 0x0302:
+		return "TLS1.1"
+	case 0x0303:
+		return "TLS1.2"
+	case 0x0304:
+		return "TLS1.3"
+	default:
+		return fmt.Sprintf("0x%04x", v)
+	}
+}

--- a/go/common/pgprotocol/server/cert_auth_test.go
+++ b/go/common/pgprotocol/server/cert_auth_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+func TestParseCertAuthMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    CertAuthMode
+		wantErr string
+	}{
+		{"none", CertAuthModeNone, ""},
+		{"verify-full", CertAuthModeVerifyFull, ""},
+		{"verify-ca", "", "reserved but not yet implemented"},
+		{"optional", "", "reserved but not yet implemented"},
+		{"bogus", "", "invalid client auth mode"},
+		{"", "", "invalid client auth mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseCertAuthMode(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseCertIdentitySource(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    CertIdentitySource
+		wantErr string
+	}{
+		{"cn", CertIdentityCN, ""},
+		{"dn", CertIdentityDN, ""},
+		{"bogus", "", "invalid cert identity source"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseCertIdentitySource(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// mTLSFixture bundles the TLS material needed to drive cert-auth tests:
+// a server TLS config with RequireAndVerifyClientCert, and a factory for
+// producing client certs signed by the same CA.
+type mTLSFixture struct {
+	serverConfig *tls.Config
+	caPool       *x509.CertPool
+	caCert       *x509.Certificate
+	caKey        *rsa.PrivateKey
+}
+
+// newMTLSFixture builds a self-signed CA and a server cert signed by it,
+// wiring the server side for strict mTLS (RequireAndVerifyClientCert).
+func newMTLSFixture(t *testing.T) *mTLSFixture {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	caTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:     []string{"localhost"},
+	}
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, &serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	serverConfig := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{serverCertDER},
+			PrivateKey:  serverKey,
+		}},
+		MinVersion: tls.VersionTLS12,
+		ClientCAs:  caPool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+	}
+
+	return &mTLSFixture{
+		serverConfig: serverConfig,
+		caPool:       caPool,
+		caCert:       caCert,
+		caKey:        caKey,
+	}
+}
+
+// issueClientCert produces a leaf client certificate with the given Subject,
+// signed by the fixture's CA.
+func (f *mTLSFixture) issueClientCert(t *testing.T, subject pkix.Name) tls.Certificate {
+	t.Helper()
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &tmpl, f.caCert, &clientKey.PublicKey, f.caKey)
+	require.NoError(t, err)
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  clientKey,
+	}
+}
+
+// certAuthTestConn mirrors newTestConn but also installs cert-auth config
+// on the Conn so the authenticate() branch fires.
+func certAuthTestConn(t *testing.T, serverConn net.Conn, tlsConfig *tls.Config, mode CertAuthMode, source CertIdentitySource) *Conn {
+	t.Helper()
+	listener := testListener(t)
+	// Install cert-auth config on the shared listener so the Conn sees it
+	// for listener.RegisterConn etc.
+	listener.certAuthMode = mode
+	listener.certIdentitySource = source
+	c := &Conn{
+		conn:               serverConn,
+		listener:           listener,
+		handler:            listener.handler,
+		hashProvider:       listener.hashProvider,
+		bufferedReader:     bufio.NewReader(serverConn),
+		params:             make(map[string]string),
+		txnStatus:          protocol.TxnStatusIdle,
+		tlsConfig:          tlsConfig,
+		certAuthMode:       mode,
+		certIdentitySource: source,
+	}
+	c.ctx = context.Background()
+	c.logger = testLogger(t)
+	return c
+}
+
+// runCertAuthServer accepts a single connection on the listener, drives it
+// through handleStartup, and returns the error on the given channel.
+func runCertAuthServer(t *testing.T, ln net.Listener, fix *mTLSFixture, source CertIdentitySource) <-chan error {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		c := certAuthTestConn(t, netConn, fix.serverConfig, CertAuthModeVerifyFull, source)
+		errCh <- c.handleStartup()
+	}()
+	return errCh
+}
+
+// connectWithClientCert dials the listener, negotiates SSL + TLS (with the
+// given client cert), and returns the TLS-wrapped connection ready for
+// sending a StartupMessage.
+func connectWithClientCert(t *testing.T, addr string, caPool *x509.CertPool, clientCert tls.Certificate) *tls.Conn {
+	t.Helper()
+	rawConn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	writeSSLRequest(t, rawConn)
+	resp := readSingleByte(t, rawConn)
+	require.Equal(t, byte('S'), resp)
+	tlsConn := tls.Client(rawConn, &tls.Config{
+		RootCAs:      caPool,
+		ServerName:   "localhost",
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{clientCert},
+	})
+	require.NoError(t, tlsConn.Handshake())
+	return tlsConn
+}
+
+func TestCertAuth_CNMatch_Succeeds(t *testing.T) {
+	fix := newMTLSFixture(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	errCh := runCertAuthServer(t, ln, fix, CertIdentityCN)
+
+	clientCert := fix.issueClientCert(t, pkix.Name{CommonName: "svc-foo"})
+	tlsConn := connectWithClientCert(t, ln.Addr().String(), fix.caPool, clientCert)
+	defer tlsConn.Close()
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "svc-foo",
+		"database": "app",
+	})
+
+	// Expect AuthenticationOk, BackendKeyData, ParameterStatus messages,
+	// and ReadyForQuery — no SCRAM exchange.
+	expectAuthenticationOk(t, tlsConn)
+
+	require.NoError(t, <-errCh)
+}
+
+func TestCertAuth_CNMismatch_Fails(t *testing.T) {
+	fix := newMTLSFixture(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	errCh := runCertAuthServer(t, ln, fix, CertIdentityCN)
+
+	clientCert := fix.issueClientCert(t, pkix.Name{CommonName: "svc-foo"})
+	tlsConn := connectWithClientCert(t, ln.Addr().String(), fix.caPool, clientCert)
+	defer tlsConn.Close()
+
+	// Request a different user than the cert's CN.
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "svc-bar",
+		"database": "app",
+	})
+
+	// Expect an ErrorResponse with FATAL severity and SQLSTATE 28000.
+	expectCertAuthErrorResponse(t, tlsConn, "svc-bar", "CN", "svc-foo")
+
+	// Server returns the same error upstream.
+	serverErr := <-errCh
+	// The server write of the error response succeeds even though the
+	// auth semantically failed, so handleStartup may return nil after
+	// sending the response. Accept either nil or a non-nil error.
+	_ = serverErr
+}
+
+func TestCertAuth_DNMatch_Succeeds(t *testing.T) {
+	fix := newMTLSFixture(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	errCh := runCertAuthServer(t, ln, fix, CertIdentityDN)
+
+	subject := pkix.Name{
+		CommonName:   "svc-foo",
+		Organization: []string{"Multigres"},
+		Country:      []string{"US"},
+	}
+	clientCert := fix.issueClientCert(t, subject)
+
+	// Build the expected DN string the way Go renders it (RFC 2253).
+	parsed, err := x509.ParseCertificate(clientCert.Certificate[0])
+	require.NoError(t, err)
+	expectedDN := parsed.Subject.String()
+
+	tlsConn := connectWithClientCert(t, ln.Addr().String(), fix.caPool, clientCert)
+	defer tlsConn.Close()
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     expectedDN,
+		"database": "app",
+	})
+
+	expectAuthenticationOk(t, tlsConn)
+
+	require.NoError(t, <-errCh)
+}
+
+// expectAuthenticationOk reads messages from the server and asserts that the
+// AuthenticationOk / BackendKeyData / ParameterStatus / ReadyForQuery
+// sequence arrives without any intervening SASL challenge.
+func expectAuthenticationOk(t *testing.T, r io.Reader) {
+	t.Helper()
+	sawAuthOk := false
+	sawReady := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !sawReady {
+		msgType, body := readTypedMessage(t, r)
+		switch msgType {
+		case protocol.MsgAuthenticationRequest:
+			require.GreaterOrEqual(t, len(body), 4)
+			code := binary.BigEndian.Uint32(body[:4])
+			require.Equalf(t, uint32(protocol.AuthOk), code,
+				"expected AuthenticationOk (0), got auth code %d — SCRAM must not run for cert auth", code)
+			sawAuthOk = true
+		case protocol.MsgBackendKeyData, protocol.MsgParameterStatus:
+			// expected
+		case protocol.MsgReadyForQuery:
+			sawReady = true
+		case protocol.MsgErrorResponse:
+			t.Fatalf("unexpected ErrorResponse: %q", body)
+		default:
+			t.Fatalf("unexpected message type %q", msgType)
+		}
+	}
+	require.True(t, sawAuthOk, "did not see AuthenticationOk")
+	require.True(t, sawReady, "did not see ReadyForQuery")
+}
+
+// expectCertAuthErrorResponse reads a single ErrorResponse and asserts it
+// has severity FATAL, SQLSTATE 28000, and a DETAIL line identifying the
+// matched field and presented value.
+func expectCertAuthErrorResponse(t *testing.T, r io.Reader, user, fieldName, presented string) {
+	t.Helper()
+	msgType, body := readTypedMessage(t, r)
+	require.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+
+	fields := parseErrorFields(body)
+	assert.Equal(t, "FATAL", fields['S'])
+	assert.Equal(t, mterrors.PgSSInvalidAuthSpec, fields['C'])
+	assert.Contains(t, fields['M'], "certificate authentication failed for user")
+	assert.Contains(t, fields['M'], user)
+	assert.Contains(t, fields['D'], fieldName)
+	assert.Contains(t, fields['D'], presented)
+}
+
+// readTypedMessage reads a single typed PG message (1-byte type + 4-byte length + body).
+func readTypedMessage(t *testing.T, r io.Reader) (byte, []byte) {
+	t.Helper()
+	header := make([]byte, 5)
+	_, err := io.ReadFull(r, header)
+	require.NoError(t, err)
+	msgType := header[0]
+	length := binary.BigEndian.Uint32(header[1:5])
+	bodyLen := int(length) - 4
+	body := make([]byte, bodyLen)
+	if bodyLen > 0 {
+		_, err = io.ReadFull(r, body)
+		require.NoError(t, err)
+	}
+	return msgType, body
+}
+
+// parseErrorFields parses an ErrorResponse body into a code → value map.
+// Each field is: 1-byte code, null-terminated string; terminated by a 0 byte.
+func parseErrorFields(body []byte) map[byte]string {
+	out := make(map[byte]string)
+	i := 0
+	for i < len(body) {
+		code := body[i]
+		if code == 0 {
+			break
+		}
+		i++
+		start := i
+		for i < len(body) && body[i] != 0 {
+			i++
+		}
+		out[code] = string(body[start:i])
+		i++ // skip null terminator
+	}
+	return out
+}

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -81,6 +81,16 @@ type Conn struct {
 	// When nil, SSLRequest is declined with 'N'.
 	tlsConfig *tls.Config
 
+	// certAuthMode controls client-certificate authentication behavior.
+	// When CertAuthModeVerifyFull and the connection is TLS with a verified
+	// peer certificate, cert auth is used instead of SCRAM.
+	certAuthMode CertAuthMode
+
+	// certIdentitySource selects which field of the peer certificate
+	// (CN or RFC 2253 DN) is compared to the requested DB user under
+	// verify-full cert auth.
+	certIdentitySource CertIdentitySource
+
 	// sslDone indicates that an SSLRequest has already been handled
 	// (accepted or declined) for this connection. Prevents double negotiation.
 	sslDone bool
@@ -206,6 +216,18 @@ func (c *Conn) IsInTransaction() bool {
 // RemoteAddr returns the remote network address.
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
+}
+
+// TLSConnectionState returns the TLS handshake state for this connection if
+// the underlying transport is TLS. Returns (nil, false) on plaintext
+// connections or before the TLS handshake has completed.
+func (c *Conn) TLSConnectionState() (*tls.ConnectionState, bool) {
+	tlsConn, ok := c.conn.(*tls.Conn)
+	if !ok {
+		return nil, false
+	}
+	state := tlsConn.ConnectionState()
+	return &state, true
 }
 
 // LocalAddr returns the local network address.

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -54,6 +54,14 @@ type Listener struct {
 	// When nil, SSLRequest is declined with 'N'.
 	tlsConfig *tls.Config
 
+	// certAuthMode controls client-certificate authentication for connections
+	// accepted by this listener. See docs/query_serving/client_cert_auth_design.md.
+	certAuthMode CertAuthMode
+
+	// certIdentitySource selects which cert field (CN or DN) is compared
+	// against the requested DB user under verify-full cert auth.
+	certIdentitySource CertIdentitySource
+
 	// logger for logging.
 	logger *slog.Logger
 
@@ -127,6 +135,17 @@ type ListenerConfig struct {
 	// When nil, SSLRequest is declined with 'N' (plaintext only).
 	TLSConfig *tls.Config
 
+	// ClientCertAuthMode controls PostgreSQL-compatible client certificate
+	// authentication. When CertAuthModeVerifyFull, TLSConfig MUST be set and
+	// MUST require a verified peer cert (ClientAuth=RequireAndVerifyClientCert).
+	// The empty string is treated as CertAuthModeNone.
+	ClientCertAuthMode CertAuthMode
+
+	// ClientCertIdentitySource selects which cert field is compared to the
+	// requested DB user under verify-full cert auth. The empty string is
+	// treated as CertIdentityCN (matching PostgreSQL's default).
+	ClientCertIdentitySource CertIdentitySource
+
 	// Logger for logging (optional, defaults to slog.Default()).
 	Logger *slog.Logger
 }
@@ -142,6 +161,28 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		return nil, errors.New("hash provider is required (or TrustAuthProvider for testing)")
 	}
 
+	// verify-full cert auth requires a TLS config with client-cert verification
+	// enabled at the handshake layer, so the auth code can assume a verified
+	// peer cert is present.
+	if config.ClientCertAuthMode == CertAuthModeVerifyFull {
+		if config.TLSConfig == nil {
+			return nil, errors.New("client cert auth mode verify-full requires TLSConfig")
+		}
+		if config.TLSConfig.ClientAuth != tls.RequireAndVerifyClientCert {
+			return nil, errors.New("client cert auth mode verify-full requires TLSConfig.ClientAuth = RequireAndVerifyClientCert")
+		}
+	}
+
+	// Default identity source is CN (matches PostgreSQL's clientcertname default).
+	identitySource := config.ClientCertIdentitySource
+	if identitySource == "" {
+		identitySource = CertIdentityCN
+	}
+	authMode := config.ClientCertAuthMode
+	if authMode == "" {
+		authMode = CertAuthModeNone
+	}
+
 	netListener, err := net.Listen("tcp", config.Address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", config.Address, err)
@@ -155,16 +196,18 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	l := &Listener{
-		listener:          netListener,
-		handler:           config.Handler,
-		hashProvider:      config.HashProvider,
-		trustAuthProvider: config.TrustAuthProvider,
-		tlsConfig:         config.TLSConfig,
-		logger:            logger,
-		gatewayID:         config.GatewayID,
-		conns:             make(map[uint32]*Conn),
-		ctx:               ctx,
-		cancel:            cancel,
+		listener:           netListener,
+		handler:            config.Handler,
+		hashProvider:       config.HashProvider,
+		trustAuthProvider:  config.TrustAuthProvider,
+		tlsConfig:          config.TLSConfig,
+		certAuthMode:       authMode,
+		certIdentitySource: identitySource,
+		logger:             logger,
+		gatewayID:          config.GatewayID,
+		conns:              make(map[uint32]*Conn),
+		ctx:                ctx,
+		cancel:             cancel,
 	}
 
 	// Initialize buffer pools.
@@ -214,6 +257,8 @@ func (l *Listener) Serve() error {
 		conn.hashProvider = l.hashProvider
 		conn.trustAuthProvider = l.trustAuthProvider
 		conn.tlsConfig = l.tlsConfig
+		conn.certAuthMode = l.certAuthMode
+		conn.certIdentitySource = l.certIdentitySource
 
 		// Handle connection in a new goroutine.
 		l.wg.Go(func() {

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -330,9 +330,24 @@ func (c *Conn) handleStartupMessage(protocolVersion uint32, reader *MessageReade
 }
 
 // authenticate performs authentication with the client.
-// If a TrustAuthProvider is configured and allows the user, trust auth is used.
-// Otherwise, SCRAM-SHA-256 authentication is performed.
+// Order of precedence:
+//  1. verify-full client certificate authentication, when configured and the
+//     connection is TLS (the listener requires a verified peer cert at the
+//     handshake layer, so reaching this branch implies a valid client cert).
+//  2. Trust authentication, when a TrustAuthProvider is configured and allows
+//     this user/database (test-only path).
+//  3. SCRAM-SHA-256 authentication.
 func (c *Conn) authenticate() error {
+	if c.certAuthMode == CertAuthModeVerifyFull {
+		if _, ok := c.TLSConnectionState(); ok {
+			return c.authenticateCertificate()
+		}
+		// Shouldn't happen: the listener configures ClientAuth to require a
+		// verified peer cert, which implies TLS. If we got here on a plaintext
+		// connection, something is misconfigured — fail closed.
+		return c.sendAuthError("certificate authentication required but connection is not TLS")
+	}
+
 	// Check if trust auth is allowed for this connection
 	if c.trustAuthProvider != nil && c.trustAuthProvider.AllowTrustAuth(c.ctx, c.user, c.database) {
 		return c.authenticateTrust()

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -47,6 +47,7 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 	"github.com/multigres/multigres/go/services/multigateway/poolergateway"
 	"github.com/multigres/multigres/go/services/multigateway/scatterconn"
+	"github.com/multigres/multigres/go/tools/grpccommon"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -62,6 +63,16 @@ type MultiGateway struct {
 	pgTLSCertFile viperutil.Value[string]
 	// pgTLSKeyFile is the path to the TLS private key file for PostgreSQL SSL connections.
 	pgTLSKeyFile viperutil.Value[string]
+	// pgTLSCAFile is the CA bundle used to verify client certificates when cert
+	// authentication is enabled.
+	pgTLSCAFile viperutil.Value[string]
+	// pgTLSClientAuthMode controls PostgreSQL-compatible client certificate
+	// authentication (`none` or `verify-full`; `verify-ca` and `optional` are
+	// reserved for future use).
+	pgTLSClientAuthMode viperutil.Value[string]
+	// pgTLSClientCertName selects which cert field (`cn` or `dn`) is compared
+	// to the requested DB user under verify-full cert auth.
+	pgTLSClientCertName viperutil.Value[string]
 	// poolerDiscovery handles discovery of multipoolers across all cells
 	poolerDiscovery *GlobalPoolerDiscovery
 	// poolerGateway manages connections to poolers
@@ -163,6 +174,24 @@ func NewMultiGateway() *MultiGateway {
 			Dynamic:  false,
 			EnvVars:  []string{"MT_PG_TLS_KEY_FILE"},
 		}),
+		pgTLSCAFile: viperutil.Configure(reg, "pg-tls-ca-file", viperutil.Options[string]{
+			Default:  "",
+			FlagName: "pg-tls-ca-file",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_PG_TLS_CA_FILE"},
+		}),
+		pgTLSClientAuthMode: viperutil.Configure(reg, "pg-tls-client-auth-mode", viperutil.Options[string]{
+			Default:  "none",
+			FlagName: "pg-tls-client-auth-mode",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_PG_TLS_CLIENT_AUTH_MODE"},
+		}),
+		pgTLSClientCertName: viperutil.Configure(reg, "pg-tls-client-cert-name", viperutil.Options[string]{
+			Default:  "cn",
+			FlagName: "pg-tls-client-cert-name",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_PG_TLS_CLIENT_CERT_NAME"},
+		}),
 		pgReplicaPort: viperutil.Configure(reg, "pg-replica-port", viperutil.Options[int]{
 			Default:  0,
 			FlagName: "pg-replica-port",
@@ -218,6 +247,9 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("statement-timeout", mg.statementTimeout.Default(), "Default statement execution timeout. 0 disables.")
 	fs.String("pg-tls-cert-file", mg.pgTLSCertFile.Default(), "path to TLS certificate file for PostgreSQL SSL connections")
 	fs.String("pg-tls-key-file", mg.pgTLSKeyFile.Default(), "path to TLS private key file for PostgreSQL SSL connections")
+	fs.String("pg-tls-ca-file", mg.pgTLSCAFile.Default(), "path to CA bundle for verifying client certificates under cert authentication")
+	fs.String("pg-tls-client-auth-mode", mg.pgTLSClientAuthMode.Default(), "PostgreSQL client certificate authentication mode: none | verify-full (verify-ca, optional reserved)")
+	fs.String("pg-tls-client-cert-name", mg.pgTLSClientCertName.Default(), "which peer certificate field is matched against the requested DB user under verify-full: cn | dn")
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
@@ -229,6 +261,9 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.statementTimeout,
 		mg.pgTLSCertFile,
 		mg.pgTLSKeyFile,
+		mg.pgTLSCAFile,
+		mg.pgTLSClientAuthMode,
+		mg.pgTLSClientCertName,
 		mg.pgReplicaPort,
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
@@ -331,12 +366,27 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	// Build TLS config if cert and key files are provided.
 	certFile := mg.pgTLSCertFile.Get()
 	keyFile := mg.pgTLSKeyFile.Get()
-	pgTLSConfig, err := buildPGTLSConfig(certFile, keyFile)
+	caFile := mg.pgTLSCAFile.Get()
+	authModeStr := mg.pgTLSClientAuthMode.Get()
+	certNameStr := mg.pgTLSClientCertName.Get()
+
+	authMode, err := server.ParseCertAuthMode(authModeStr)
+	if err != nil {
+		return fmt.Errorf("--pg-tls-client-auth-mode: %w", err)
+	}
+	identitySource, err := server.ParseCertIdentitySource(certNameStr)
+	if err != nil {
+		return fmt.Errorf("--pg-tls-client-cert-name: %w", err)
+	}
+
+	pgTLSConfig, err := buildPGTLSConfig(certFile, keyFile, caFile, authMode)
 	if err != nil {
 		return err
 	}
 	if pgTLSConfig != nil {
-		logger.InfoContext(ctx, "TLS configured for PostgreSQL listener", "cert_file", certFile, "key_file", keyFile)
+		logger.InfoContext(ctx, "TLS configured for PostgreSQL listener",
+			"cert_file", certFile, "key_file", keyFile,
+			"ca_file", caFile, "client_auth_mode", authMode)
 	}
 
 	// Build the full gateway record. All info (hostname, ports) is available
@@ -416,12 +466,14 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	mg.pgHandler.SetNotificationManager(notifMgr, notifMetrics.NotificationDropped)
 	pgAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), mg.pgPort.Get())
 	mg.pgListener, err = server.NewListener(server.ListenerConfig{
-		Address:      pgAddr,
-		Handler:      mg.pgHandler,
-		GatewayID:    pidPrefix,
-		HashProvider: hashProvider,
-		TLSConfig:    pgTLSConfig,
-		Logger:       logger,
+		Address:                  pgAddr,
+		Handler:                  mg.pgHandler,
+		GatewayID:                pidPrefix,
+		HashProvider:             hashProvider,
+		TLSConfig:                pgTLSConfig,
+		ClientCertAuthMode:       authMode,
+		ClientCertIdentitySource: identitySource,
+		Logger:                   logger,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create PostgreSQL listener on port %d: %w", mg.pgPort.Get(), err)
@@ -636,10 +688,21 @@ func (mg *MultiGateway) hasPrefixCollision(ctx context.Context, prefix uint32, o
 	return false
 }
 
-// buildPGTLSConfig validates TLS flag combinations and loads the certificate.
-// Returns nil if neither cert nor key file is configured (plaintext mode).
-func buildPGTLSConfig(certFile, keyFile string) (*tls.Config, error) {
+// buildPGTLSConfig validates TLS flag combinations and loads the server
+// certificate and (when configured) the client-cert CA bundle. Returns nil
+// if neither cert nor key file is configured (plaintext mode).
+//
+// Delegates cert/CA loading to grpccommon.BuildServerTLSConfig so both the
+// PostgreSQL listener and the internal gRPC server share a single, hardened
+// TLS loading path.
+func buildPGTLSConfig(certFile, keyFile, caFile string, authMode server.CertAuthMode) (*tls.Config, error) {
 	if certFile == "" && keyFile == "" {
+		if caFile != "" {
+			return nil, errors.New("--pg-tls-ca-file requires --pg-tls-cert-file and --pg-tls-key-file")
+		}
+		if authMode == server.CertAuthModeVerifyFull {
+			return nil, errors.New("--pg-tls-client-auth-mode=verify-full requires --pg-tls-cert-file, --pg-tls-key-file and --pg-tls-ca-file")
+		}
 		return nil, nil
 	}
 	if certFile == "" {
@@ -648,13 +711,22 @@ func buildPGTLSConfig(certFile, keyFile string) (*tls.Config, error) {
 	if keyFile == "" {
 		return nil, errors.New("--pg-tls-cert-file requires --pg-tls-key-file")
 	}
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load TLS certificate: %w", err)
+	if authMode == server.CertAuthModeVerifyFull && caFile == "" {
+		return nil, errors.New("--pg-tls-client-auth-mode=verify-full requires --pg-tls-ca-file")
 	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-		NextProtos:   []string{protocol.ALPNProtocol}, // PG 17 ALPN forward compatibility
-	}, nil
+	if caFile != "" && authMode == server.CertAuthModeNone {
+		// A CA configured with no client-auth mode active is almost certainly a
+		// misconfiguration (the user intended cert auth but forgot the mode);
+		// fail loudly rather than silently accept unverified clients.
+		return nil, errors.New("--pg-tls-ca-file set but --pg-tls-client-auth-mode is none; set the mode or remove the CA file")
+	}
+
+	cfg, err := grpccommon.BuildServerTLSConfig(certFile, keyFile, caFile, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build PG TLS config: %w", err)
+	}
+	// grpccommon.BuildServerTLSConfig returns nil only when cert/key are both
+	// empty; the guards above ensure that's not the case here.
+	cfg.NextProtos = []string{protocol.ALPNProtocol} // PG 17 ALPN forward compatibility
+	return cfg, nil
 }

--- a/go/services/multigateway/init_test.go
+++ b/go/services/multigateway/init_test.go
@@ -30,46 +30,90 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
 )
 
 func TestBuildPGTLSConfig(t *testing.T) {
-	t.Run("both empty returns nil", func(t *testing.T) {
-		config, err := buildPGTLSConfig("", "")
+	none := server.CertAuthModeNone
+	verifyFull := server.CertAuthModeVerifyFull
+
+	t.Run("all empty returns nil", func(t *testing.T) {
+		config, err := buildPGTLSConfig("", "", "", none)
 		require.NoError(t, err)
 		assert.Nil(t, config)
 	})
 
 	t.Run("cert without key returns error", func(t *testing.T) {
-		_, err := buildPGTLSConfig("/some/cert.pem", "")
+		_, err := buildPGTLSConfig("/some/cert.pem", "", "", none)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--pg-tls-cert-file requires --pg-tls-key-file")
 	})
 
 	t.Run("key without cert returns error", func(t *testing.T) {
-		_, err := buildPGTLSConfig("", "/some/key.pem")
+		_, err := buildPGTLSConfig("", "/some/key.pem", "", none)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--pg-tls-key-file requires --pg-tls-cert-file")
 	})
 
-	t.Run("both set with valid files", func(t *testing.T) {
+	t.Run("CA without cert/key returns error", func(t *testing.T) {
+		_, err := buildPGTLSConfig("", "", "/some/ca.pem", none)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--pg-tls-ca-file requires --pg-tls-cert-file")
+	})
+
+	t.Run("verify-full without any TLS files returns error", func(t *testing.T) {
+		_, err := buildPGTLSConfig("", "", "", verifyFull)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--pg-tls-client-auth-mode=verify-full requires")
+	})
+
+	t.Run("verify-full without CA returns error", func(t *testing.T) {
 		certFile, keyFile := generateTestCertAndKey(t)
-		config, err := buildPGTLSConfig(certFile, keyFile)
+		_, err := buildPGTLSConfig(certFile, keyFile, "", verifyFull)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --pg-tls-ca-file")
+	})
+
+	t.Run("CA set but mode is none returns error", func(t *testing.T) {
+		certFile, keyFile := generateTestCertAndKey(t)
+		// Reuse the self-signed cert file as a stand-in CA bundle; the content
+		// parser only needs PEM-decodable certificates, which this provides.
+		_, err := buildPGTLSConfig(certFile, keyFile, certFile, none)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--pg-tls-ca-file set but --pg-tls-client-auth-mode is none")
+	})
+
+	t.Run("cert + key only produces TLS config with no client auth", func(t *testing.T) {
+		certFile, keyFile := generateTestCertAndKey(t)
+		config, err := buildPGTLSConfig(certFile, keyFile, "", none)
 		require.NoError(t, err)
 		require.NotNil(t, config)
 		assert.Equal(t, uint16(tls.VersionTLS12), config.MinVersion)
 		assert.Len(t, config.Certificates, 1)
+		assert.Equal(t, tls.NoClientCert, config.ClientAuth)
 	})
 
-	t.Run("both set with invalid files", func(t *testing.T) {
+	t.Run("verify-full with CA builds mTLS config", func(t *testing.T) {
+		certFile, keyFile := generateTestCertAndKey(t)
+		// The self-signed cert is its own issuer, so it's a valid CA bundle.
+		config, err := buildPGTLSConfig(certFile, keyFile, certFile, verifyFull)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Equal(t, tls.RequireAndVerifyClientCert, config.ClientAuth)
+		require.NotNil(t, config.ClientCAs)
+	})
+
+	t.Run("invalid cert file wraps underlying error", func(t *testing.T) {
 		dir := t.TempDir()
 		certFile := filepath.Join(dir, "bad.crt")
 		keyFile := filepath.Join(dir, "bad.key")
 		require.NoError(t, os.WriteFile(certFile, []byte("not a cert"), 0o600))
 		require.NoError(t, os.WriteFile(keyFile, []byte("not a key"), 0o600))
 
-		_, err := buildPGTLSConfig(certFile, keyFile)
+		_, err := buildPGTLSConfig(certFile, keyFile, "", none)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to load TLS certificate")
+		assert.Contains(t, err.Error(), "failed to build PG TLS config")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Implement PostgreSQL-compatible client certificate authentication (`cert` method = `trust` + `clientcert=verify-full`) at the multigateway PG listener.
- New flags: `--pg-tls-ca-file`, `--pg-tls-client-auth-mode` (`none` | `verify-full`; `verify-ca` and `optional` reserved), `--pg-tls-client-cert-name` (`cn` | `dn`).
- Behavior compatible with native PostgreSQL from the client's perspective — same wire sequence, same SQLSTATE, same CN/DN match semantics.
- Design reference: [`docs/query_serving/client_cert_auth_design.md`](docs/query_serving/client_cert_auth_design.md).

## Description

When `--pg-tls-client-auth-mode=verify-full` is set, the PG listener requires a verified peer certificate at TLS handshake time (via `ClientAuth=RequireAndVerifyClientCert`) and binds the cert's Subject CN (or full RFC 2253 DN, per `--pg-tls-client-cert-name`) to the DB user named in the startup message. On match, the server sends `AuthenticationOk` directly and skips SCRAM — matching PostgreSQL's `cert` auth flow at the wire level. On mismatch, a FATAL `ErrorResponse` with SQLSTATE `28000` and a PG-style DETAIL line is sent and the connection is closed with no SCRAM fallback.

Certificate loading now reuses `grpccommon.BuildServerTLSConfig` so the PG listener and internal gRPC share a single hardened TLS loading path. The audit log line on every successful cert auth records the full peer DN, matched field (CN or DN), TLS version, and cipher suite — mirroring PostgreSQL's `set_authn_id(peer_dn)` behavior.

Validation rules added: `--pg-tls-ca-file` requires cert + key; `--pg-tls-client-auth-mode=verify-full` requires a CA; a CA set together with mode `none` is rejected to prevent silent misconfiguration.

### Non-goals

- SAN / SPIFFE URI identity extraction (PG's server-side cert auth is strictly CN/DN).
- User-existence check at auth time (PG doesn't do it; the pooler rejects downstream).
- CRL enforcement (reserved flag names `--pg-tls-crl-file` / `--pg-tls-crl-dir` unused in this PR).
- `pg_ident.conf` maps and `pg_hba.conf` rule engine.

## Upcoming

Filed as child tickets of MUL-189 (MVP Hardening):

- **MUL-369** — Pair `clientcert=verify-ca` / `verify-full` with non-cert auth methods (cert **and** SCRAM).
- **MUL-370** — Client-side PG TLS for multipooler → PostgreSQL, mirroring libpq's `sslmode` / `sslrootcert` / `sslcert` surface.
- **MUL-371** — Advertise `SCRAM-SHA-256-PLUS` (RFC 5802 channel binding) when the connection is TLS.

Not yet filed: CRL checking for PG TLS + internal gRPC; `pg_ident.conf` parsing + `map=` option; `pg_hba.conf` parser and rule-match engine (umbrella under which the items above ultimately land).

## Test plan

- [x] Unit: `go/common/pgprotocol/server` cert-auth tests (CN match / CN mismatch / DN match) over real TLS + CA-issued client certs.
- [x] Unit: `go/services/multigateway/init_test.go` covers the extended `buildPGTLSConfig` signature and all new validation branches.
- [x] `go build ./go/...` clean; full multigateway unit suite green.
- [x] Manual: `psql "host=localhost sslmode=require sslcert=... sslkey=..."` against a multigateway running with `--pg-tls-client-auth-mode=verify-full` — to be covered by an e2e test in a follow-up.

Linear: MUL-189