### PR TITLE
fix(multigateway): handle transaction statements in extended-protocol portal planning

### DIFF
--- a/docs/query_serving/benchmarking/pgbench.md
+++ b/docs/query_serving/benchmarking/pgbench.md
@@ -66,9 +66,6 @@ run takes ~20 minutes.
 
 ### Known limitations
 
-- **Extended protocol + multiple clients through multigateway** fails with `cursor
-already exists` errors. This is a known limitation of transaction-mode connection
-  pooling with the extended query protocol and is tracked for improvement.
 - **50 clients** can exceed `max_connections` on small test clusters. The test
   gracefully skips failed scenarios.
 

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -202,12 +202,10 @@ func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn) (*en
 // PortalStreamExecute with the portal's bound parameters.
 //
 // Statements that produce a plan are delegated to Plan to reuse existing planning logic.
-//
-// Currently handles:
-//   - Gateway-managed SET/SHOW/RESET (e.g., statement_timeout) — executed locally
-//     without a PostgreSQL round-trip.
-//   - RESET ALL — must be sent to PostgreSQL AND also reset gateway-managed variables.
-//     The returned plan handles both via Sequence[Route, ApplySessionState].
+// This covers any statement whose semantics cannot be preserved by a plain portal
+// execute on a pooled backend connection — for example, gateway-managed session
+// variables, LISTEN/UNLISTEN/NOTIFY, DISCARD, temp-table creation, and
+// BEGIN/COMMIT/ROLLBACK.
 func (p *Planner) PlanPortal(
 	portalInfo *preparedstatement.PortalInfo,
 	conn *server.Conn,

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -271,6 +271,13 @@ func (p *Planner) PlanPortal(
 		}
 		return nil, nil
 
+	case ast.T_TransactionStmt:
+		// BEGIN/COMMIT/ROLLBACK must run through the gateway's transaction
+		// primitive — executing them as a normal portal on a pooled backend
+		// connection leaks open (or aborted) transactions across clients when
+		// the connection is recycled.
+		return p.Plan(portalInfo.PreparedStatementInfo.Query, stmt, conn)
+
 	default:
 		return nil, nil
 	}

--- a/go/services/multigateway/planner/transaction_stmt_test.go
+++ b/go/services/multigateway/planner/transaction_stmt_test.go
@@ -94,9 +94,11 @@ func TestPlanPortal_RegularSelectFallsThrough(t *testing.T) {
 }
 
 // TestPlanPortal_SavepointFallsThrough confirms that savepoint variants
-// (which the simple-protocol Plan() passes through via planDefault) are
-// still routed to the backend in the extended path — only BEGIN/COMMIT/
-// ROLLBACK need the local primitive.
+// are still planned through the TransactionPrimitive in the extended path.
+// Plan() routes every TransactionStmt kind through planTransactionStmt, and
+// the primitive's StreamExecute forwards savepoint variants to the backend —
+// the important invariant is that the gateway owns dispatch rather than
+// letting a raw portal Bind+Execute run on a pooled connection.
 func TestPlanPortal_SavepointFallsThrough(t *testing.T) {
 	tests := []string{
 		"SAVEPOINT sp1",

--- a/go/services/multigateway/planner/transaction_stmt_test.go
+++ b/go/services/multigateway/planner/transaction_stmt_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+)
+
+// newPortalInfoFor parses sql and wraps the resulting single statement as a
+// PortalInfo the way the handler would at Bind time.
+func newPortalInfoFor(t *testing.T, sql string) *preparedstatement.PortalInfo {
+	t.Helper()
+	psi, err := preparedstatement.NewPreparedStatementInfo(
+		protoutil.NewPreparedStatement("ppstmt", sql, nil),
+	)
+	require.NoError(t, err)
+	portal := protoutil.NewPortal("ppstmt", psi.Name, nil, nil, nil)
+	return preparedstatement.NewPortalInfo(psi, portal)
+}
+
+// TestPlanPortal_TransactionStmt pins that BEGIN/COMMIT/ROLLBACK over the
+// extended protocol resolve to the TransactionPrimitive so they are handled
+// locally by the gateway. If this returns nil the executor sends the
+// statement to a pooled backend connection, which leaks open (or aborted)
+// transactions across clients when the connection is recycled.
+func TestPlanPortal_TransactionStmt(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantKind ast.TransactionStmtKind
+	}{
+		{name: "BEGIN", sql: "BEGIN", wantKind: ast.TRANS_STMT_BEGIN},
+		{name: "START TRANSACTION", sql: "START TRANSACTION", wantKind: ast.TRANS_STMT_START},
+		{name: "COMMIT", sql: "COMMIT", wantKind: ast.TRANS_STMT_COMMIT},
+		{name: "END (COMMIT alias)", sql: "END", wantKind: ast.TRANS_STMT_COMMIT},
+		{name: "ROLLBACK", sql: "ROLLBACK", wantKind: ast.TRANS_STMT_ROLLBACK},
+		{name: "BEGIN ISOLATION LEVEL SERIALIZABLE", sql: "BEGIN ISOLATION LEVEL SERIALIZABLE", wantKind: ast.TRANS_STMT_BEGIN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+			p := NewPlanner("default", logger, nil)
+			testConn := server.NewTestConn(&bytes.Buffer{})
+
+			portalInfo := newPortalInfoFor(t, tt.sql)
+			plan, err := p.PlanPortal(portalInfo, testConn.Conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan, "PlanPortal must return a non-nil plan for %s — a nil plan would send the statement to a pooled backend connection and leak transaction state", tt.sql)
+
+			prim, ok := plan.Primitive.(*engine.TransactionPrimitive)
+			require.True(t, ok, "expected TransactionPrimitive, got %T", plan.Primitive)
+			assert.Equal(t, tt.wantKind, prim.Kind)
+			assert.Equal(t, tt.sql, prim.Query, "original SQL text must be preserved so BEGIN options (isolation level, access mode) survive to the deferred-BEGIN path")
+		})
+	}
+}
+
+// TestPlanPortal_RegularSelectFallsThrough pins the non-transaction default:
+// routable queries return (nil, nil) from PlanPortal so the executor uses
+// the portal fast path.
+func TestPlanPortal_RegularSelectFallsThrough(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	portalInfo := newPortalInfoFor(t, "SELECT 1")
+	plan, err := p.PlanPortal(portalInfo, testConn.Conn)
+	require.NoError(t, err)
+	assert.Nil(t, plan, "PlanPortal should return nil for plain routable SELECTs (handled by the portal fast path)")
+}
+
+// TestPlanPortal_SavepointFallsThrough confirms that savepoint variants
+// (which the simple-protocol Plan() passes through via planDefault) are
+// still routed to the backend in the extended path — only BEGIN/COMMIT/
+// ROLLBACK need the local primitive.
+func TestPlanPortal_SavepointFallsThrough(t *testing.T) {
+	tests := []string{
+		"SAVEPOINT sp1",
+		"RELEASE SAVEPOINT sp1",
+		"ROLLBACK TO SAVEPOINT sp1",
+	}
+
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+			p := NewPlanner("default", logger, nil)
+			testConn := server.NewTestConn(&bytes.Buffer{})
+
+			portalInfo := newPortalInfoFor(t, sql)
+			plan, err := p.PlanPortal(portalInfo, testConn.Conn)
+			require.NoError(t, err)
+
+			// Savepoint statements still go through the TransactionPrimitive
+			// (that's what planTransactionStmt returns for every Kind), but the
+			// primitive's StreamExecute passes them through to the backend.
+			// The key point is the gateway owns dispatch — no direct portal
+			// Bind+Execute on a pooled connection for any TransactionStmt.
+			require.NotNil(t, plan)
+			_, ok := plan.Primitive.(*engine.TransactionPrimitive)
+			assert.True(t, ok, "every TransactionStmt must go through TransactionPrimitive, got %T", plan.Primitive)
+		})
+	}
+}

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
@@ -276,6 +277,90 @@ func TestZeroColumnResults(t *testing.T) {
 					}
 				}
 			})
+		})
+	}
+}
+
+// TestExtendedProtocol_TransactionIsolation is the end-to-end regression for
+// extended-protocol BEGIN/COMMIT/ROLLBACK handling in the gateway planner.
+// Before the fix, sending BEGIN over the extended protocol fell through to
+// the default "execute portal on backend" path, so the BEGIN ran on a pooled
+// backend connection instead of opening a reserved gateway transaction. The
+// subsequent INSERT routed through the normal autocommit path — committing
+// immediately — and a ROLLBACK issued over the same session had no effect.
+// This test issues every control statement over the extended protocol (the
+// same pattern pgbench -M extended uses) and confirms ROLLBACK actually
+// discards the write.
+func TestExtendedProtocol_TransactionIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	// Run against both direct postgres and multigateway so the test pins the
+	// expected behavior (postgres) and catches the proxy regression.
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			// Unique table per target — direct postgres and multigateway share
+			// the same backend, so both subtests would otherwise race on the
+			// same name via concurrent cleanup.
+			tableName := "test_ext_txn_iso_" + target.Name
+
+			setupConn := connectLowLevelToPort(t, ctx, target.Port)
+			_, err := setupConn.Query(ctx, "DROP TABLE IF EXISTS "+tableName)
+			require.NoError(t, err)
+			_, err = setupConn.Query(ctx, "CREATE TABLE "+tableName+" (id int)")
+			require.NoError(t, err)
+			setupConn.Close()
+
+			t.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				c := connectLowLevelToPort(t, cleanupCtx, target.Port)
+				defer c.Close()
+				_, _ = c.Query(cleanupCtx, "DROP TABLE IF EXISTS "+tableName)
+			})
+
+			conn := connectLowLevelToPort(t, ctx, target.Port)
+			defer conn.Close()
+
+			// Each PrepareAndExecute issues Parse + Bind + Execute + Sync,
+			// i.e. the full extended-protocol cycle, which is exactly how
+			// pgbench -M extended sends BEGIN / DML / COMMIT.
+			noopCb := func(context.Context, *sqltypes.Result) error { return nil }
+
+			require.NoError(t, conn.PrepareAndExecute(ctx, "", "BEGIN", nil, noopCb))
+			// After BEGIN, the backend must report 'T' on its ReadyForQuery.
+			// Without the fix, the gateway's pooled BEGIN closes with the next
+			// Sync and we'd see 'I' here instead.
+			assert.Equal(t, protocol.TxnStatusInBlock, conn.TxnStatus(),
+				"ReadyForQuery after BEGIN should report 'T' (in transaction)")
+
+			require.NoError(t, conn.PrepareAndExecute(ctx,
+				"", "INSERT INTO "+tableName+" VALUES (1)", nil, noopCb))
+			assert.Equal(t, protocol.TxnStatusInBlock, conn.TxnStatus(),
+				"ReadyForQuery after INSERT in transaction should still report 'T'")
+
+			require.NoError(t, conn.PrepareAndExecute(ctx, "", "ROLLBACK", nil, noopCb))
+			assert.Equal(t, protocol.TxnStatusIdle, conn.TxnStatus(),
+				"ReadyForQuery after ROLLBACK should report 'I' (idle)")
+
+			// The real assertion: ROLLBACK must have discarded the INSERT.
+			// Without the fix this reads "1" on multigateway because the
+			// INSERT ran in its own autocommit transaction, outside the
+			// phantom BEGIN that never updated gateway-side txn state.
+			results, err := conn.Query(ctx, "SELECT COUNT(*) FROM "+tableName)
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			require.NotEmpty(t, results[0].Rows)
+			got := string(results[0].Rows[0].Values[0])
+			assert.Equal(t, "0", got,
+				"ROLLBACK should discard the INSERT; got %s row(s) — the gateway is not honoring BEGIN over the extended protocol", got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add `T_TransactionStmt` case to `planner.PlanPortal` so BEGIN/COMMIT/ROLLBACK sent over the extended protocol flow through the existing `TransactionPrimitive` instead of being Bind+Execute'd on a pooled backend connection.
- Add unit tests pinning PlanPortal's handling of all transaction kinds plus the routable-fallthrough default.
- Add an e2e test that issues BEGIN → INSERT → ROLLBACK entirely via the extended protocol and asserts the ROLLBACK actually discards the INSERT.

## Problem

`PlanPortal` had cases for SET/SHOW/LISTEN/temp-table DDL but no case for transaction control. For clients that use the extended protocol (e.g. `pgbench -M extended`), the default fall-through sent `BEGIN` to the backend as a regular portal, so the `BEGIN` actually executed on a pooled connection. After `Recycle()`, the open transaction stayed attached to the pool slot. The next client to pick up that slot either observed `WARNING: there is already a transaction in progress`, or — once a subsequent statement errored and poisoned the transaction — saw `ERROR: current transaction is aborted, commands ignored until end of transaction block` on its own first query.

Additionally, the gateway's own session state stayed `Idle` (because `TransactionPrimitive` never ran), so any DML that followed routed through the normal autocommit path — committing immediately — and a later ROLLBACK had no effect on data already written.

## Solution

Route `T_TransactionStmt` through `p.Plan(...)` in `PlanPortal`, which yields a `TransactionPrimitive`. That primitive handles BEGIN via the gateway's deferred-BEGIN / `ReservationOptions` flow (folded into the first real query's reservation) and COMMIT/ROLLBACK via `ConcludeTransaction` on the reserved connection. The extended path now matches the simple-query path.

## Test plan

- [x] `go test ./go/services/multigateway/planner/...` — new unit tests cover BEGIN, START, COMMIT, END (COMMIT alias), ROLLBACK, `BEGIN ISOLATION LEVEL …`, savepoint fall-through, and regular SELECT fall-through. Verified the unit tests FAIL without the planner change.
- [x] `go test -run TestExtendedProtocol_TransactionIsolation ./go/test/endtoend/queryserving/...` — new e2e test runs against both direct postgres and multigateway. Verified the multigateway subtest FAILS without the planner change (ROLLBACK doesn't discard the INSERT) and PASSES with it.
- [x] Full pgbench suite at 1c/10c — all previously-failing extended scenarios (`sustained_10c_extended`, `churn_*_extended`) now pass. Simple-protocol scenarios still pass. `sustained_50c_extended` now hits postgres `max_connections` (a capacity issue, unrelated to this fix).