### PR TITLE
feat(multipooler): implement SCRAM key passthrough to backing PostgreSQL

### DIFF
--- a/config/postgres/pg_hba_template.conf
+++ b/config/postgres/pg_hba_template.conf
@@ -14,9 +14,16 @@
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
-# "local" is for Unix domain socket connections only
+# "local" is for Unix domain socket connections only.
+# The configured admin user retains trust on the local socket as a bootstrap
+# path for multipooler's admin pool (superuser queries: GetAuthCredentials,
+# heartbeat, replication tracking). TODO: harden once pgctld provisions the
+# admin password during initdb so this line can be removed.
 local   all             {{.User}}       trust
-local   all             all             trust
+# All other local connections require SCRAM. The former blanket
+# "local all all trust" line is intentionally removed: multipooler's per-user
+# connections authenticate as the real end user via SCRAM passthrough.
+local   all             all             scram-sha-256
 
 # Replication connections (localhost only)
 local   replication     all                                     trust

--- a/docs/query_serving/scram_passthrough_design.md
+++ b/docs/query_serving/scram_passthrough_design.md
@@ -1,0 +1,101 @@
+# SCRAM Key Passthrough: MultiPooler → PostgreSQL
+
+## Overview
+
+MultiPooler authenticates to its backing PostgreSQL as the real end user, on every backend connection, using SCRAM-SHA-256 — without ever handling a plaintext password. The cryptographic material needed to authenticate to PostgreSQL is derived during the client's SCRAM handshake to MultiGateway, forwarded to MultiPooler on each query RPC, and used when MultiPooler dials a new backend connection.
+
+This document describes the design as a whole: where the keys live, how they travel, how they are consumed, what the security properties are, and what the boundaries of the approach are.
+
+## Background
+
+### Why SCRAM keys can be passed through
+
+PostgreSQL's SCRAM-SHA-256 verifier stores only `StoredKey = H(ClientKey)` and `ServerKey`. The client proves knowledge of `ClientKey` by sending `ClientProof = ClientKey XOR ClientSignature`, where `ClientSignature = HMAC(StoredKey, AuthMessage)`. A verifier that sees the proof can validate it *and* recover the plaintext `ClientKey` by XORing the proof with the signature it just computed.
+
+This property — that a successful SCRAM handshake reveals `ClientKey` to the verifier — is what makes passthrough possible. With `ClientKey` plus `ServerKey` (which MultiGateway already has, because MultiGateway fetched the verifier from `pg_authid` via MultiPooler's admin pool as part of the incoming handshake), MultiGateway can impersonate the user against any other SCRAM-SHA-256 verifier of the same password — including the backing PostgreSQL.
+
+Our SCRAM library exposes this via `scram.ScramAuthenticator.ExtractedKeys()`, and the wire-protocol client accepts pre-computed keys via `client.newScramClientWithKeys(...)`.
+
+### Why this matters
+
+Three things are true in the final design that are not true of a trust-on-the-socket design:
+
+1. **Identity reaches PostgreSQL.** `current_user`, `pg_stat_activity`, audit logs, row-level security predicates — all see the real user. PostgreSQL is no longer asked to authorize on the basis of "some trusted local process asserted a user name."
+2. **`pg_hba.conf` is authoritative.** Access decisions live in one place. There is no configuration path that lets an unauthenticated local process log into PostgreSQL (except replication and the configured superuser, preserved intentionally).
+3. **Plaintext passwords never exist in MultiGateway or MultiPooler memory.** Only derived `ClientKey`/`ServerKey`, session-scoped, zeroized at client session end.
+
+## Goals and Non-Goals
+
+### Goals
+
+- MultiPooler authenticates to PostgreSQL as the real user on every backend connection opened for that user's pool.
+- Neither MultiGateway nor MultiPooler ever holds a plaintext password.
+- Keys are scoped to the client session, never persisted, zeroized on close, never logged.
+- MultiPooler's admin pool (used for bootstrap operations such as reading `pg_authid`) continues to work using its configured superuser credential, independently of per-user passthrough.
+
+### Non-Goals
+
+- **Client-certificate authentication.** Cert-authenticated sessions do not produce SCRAM keys; how MultiPooler dials for them is a separate design.
+- **SCRAM-SHA-256-PLUS (channel binding).** Internal gRPC between MultiGateway and MultiPooler is mTLS-protected, which covers the bulk of the MITM story for the wire segment where keys are exposed.
+- **Per-user key caching on MultiPooler.** Possible optimization; not required for correctness.
+- **Credential storage outside PostgreSQL.** All verifiers continue to live in `pg_authid`.
+- **Fallback to MD5 or cleartext auth.** Both are explicitly rejected by the wire-protocol client.
+
+## Design
+
+### Where keys live
+
+Keys live on the MultiGateway-side client `Conn` struct (`pgprotocol/server/conn.go`), alongside `user`, `database`, and `params`. They are set exactly once, immediately after `ScramAuthenticator.HandleClientFinal` confirms authentication, by calling `ExtractedKeys()`. They are zeroized exactly once, inside `Conn.Close`, after handler state is released.
+
+Keys are session-scoped. A PostgreSQL password change invalidates only future client sessions; already-open backend connections remain usable until they close through their normal lifecycle.
+
+Keys are never written to disk, never included in logs, never surfaced in error messages. Any new log sites that touch the auth path are audited for leakage.
+
+### Wire format
+
+A `query.UserAuth` message holds `client_key` and `server_key` as bytes. It is embedded as an optional field on `query.ExecuteOptions`. Because `ExecuteOptions` rides on every query-path RPC — `StreamExecute`, `PortalStreamExecute`, `Describe`, `CopyBidiExecute`, `ConcludeTransaction`, `DiscardTempTables`, `ReleaseReservedConnection` — a single field covers the full query path.
+
+MultiGateway populates `UserAuth` from the session's captured keys on every outbound query RPC. Internal gRPC is mTLS-protected, so keys in flight are encrypted on the wire.
+
+### MultiPooler dial logic
+
+`pgprotocol/client.Config` carries optional `ClientKey` and `ServerKey`. The client-side auth dispatch in `client/startup.go:handleAuthenticationRequest` branches on their presence: when set, it constructs a SCRAM client via `newScramClientWithKeys(user, clientKey, serverKey)`; otherwise it uses the password path.
+
+`connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at dial time. Because keys are a property of the user session, distinct sessions for the same user carry their own keys independently — the pool's identity-of-user semantics are unchanged.
+
+The admin pool is unaffected: it authenticates with a configured superuser password, independent of any user's session, and is what makes `GetAuthCredentials` (the `pg_authid` lookup that feeds the handshake) possible in the first place.
+
+### `pg_hba.conf`
+
+`pg_hba.conf` grants `scram-sha-256` for all non-replication host access and for local socket connections from any user other than the configured admin. The blanket `local all all trust` line no longer exists.
+
+A narrow `local all <admin-user> trust` line is intentionally preserved as the bootstrap path for MultiPooler's admin pool (superuser queries: `GetAuthCredentials`, heartbeat, replication tracking). Closing this exception requires pgctld to provision the admin password during `initdb`, so it is tracked as a follow-up rather than shipped in the same change as the query-path flip. Operators running today see a warning on startup when the admin password is empty, surfacing the remaining gap.
+
+Replication-related trust lines remain as a narrower scope, separate from the query path.
+
+### Failure modes
+
+- **Stale keys (password rotated in PostgreSQL).** The SCRAM handshake from MultiPooler to PostgreSQL fails. MultiPooler treats this as a non-retryable, session-fatal error: the failed connection is discarded, the client is disconnected with a clean error, and a reconnect through MultiGateway re-derives fresh keys from the new verifier.
+- **Missing keys on an RPC.** The RPC fails closed with a clear error. In steady state this should not happen — every authenticated session has keys — so this is a defensive check, not an expected path.
+- **Admin pool failure.** Independent of passthrough. If the admin pool cannot reach PostgreSQL, MultiPooler cannot serve `GetAuthCredentials` and no handshake can complete; passthrough is a no-op because no session ever reaches the authenticated state.
+
+### Security properties
+
+- **No plaintext password in process memory.** Only derived `ClientKey`/`ServerKey` ever exist in MultiGateway or MultiPooler.
+- **Session-scoped exposure.** A live-memory attacker obtains keys only for currently-active sessions, not a historical set.
+- **Authoritative `pg_hba`.** Access control decisions are made by PostgreSQL, not bypassed by socket trust.
+- **Encrypted transit for keys.** Internal gRPC is mTLS; the RPC carrying `UserAuth` is confidential on the wire.
+
+## Open Items / Future Work
+
+- **Close the admin-user trust exception.** Once pgctld provisions the admin password during `initdb`, the `local all <admin-user> trust` line in `pg_hba_template.conf` can be removed and the admin pool switches to SCRAM like everything else.
+- **Per-user key cache on MultiPooler.** If RPC payload overhead or repeated handshakes show up in benchmarks, a short-TTL cache with refresh-on-auth-failure is the nearest prior art (Supavisor uses this pattern).
+- **Cert-auth integration.** Cert-authenticated sessions do not produce SCRAM keys. Options include a pooler-side service credential per role, a separate cert-delegation dial path, or rejecting cert auth for the pool path entirely. Deferred to its own design.
+- **Channel binding (SCRAM-SHA-256-PLUS).** Future hardening for the external client-to-gateway handshake, where TLS cert trust is broadest. The internal gateway-to-pooler segment does not run SCRAM at all — the keys are a gRPC payload there, and confidentiality is handled by mTLS. The pooler-to-PostgreSQL handshake is local and has no meaningful MITM surface to bind against.
+
+## Glossary
+
+- **ClientKey** — `HMAC(SaltedPassword, "Client Key")`. What the client proves knowledge of. Recovered by the verifier from the proof via XOR.
+- **ServerKey** — `HMAC(SaltedPassword, "Server Key")`. What the server proves knowledge of in the final message for mutual auth. Stored server-side; never secret from the storing server.
+- **StoredKey** — `H(ClientKey)`. The verifier. Cannot be used to forge a proof; only to verify one.
+- **Passthrough** — using `(ClientKey, ServerKey)` obtained at one SCRAM verifier to authenticate to another SCRAM verifier of the same password.

--- a/docs/query_serving/scram_passthrough_design.md
+++ b/docs/query_serving/scram_passthrough_design.md
@@ -37,7 +37,7 @@ Three things are true in the final design that are not true of a trust-on-the-so
 
 - **Client-certificate authentication.** Cert-authenticated sessions do not produce SCRAM keys; how MultiPooler dials for them is a separate design.
 - **SCRAM-SHA-256-PLUS (channel binding).** Internal gRPC between MultiGateway and MultiPooler is mTLS-protected, which covers the bulk of the MITM story for the wire segment where keys are exposed.
-- **Per-user key caching on MultiPooler.** Possible optimization; not required for correctness.
+- **Per-user key caching on MultiPooler.** A pool caches keys at first-creation and relies on rotation-triggered eviction (see *Password rotation*) to refresh them. A short-TTL key cache is a possible future optimization for scenarios where eviction churn becomes visible.
 - **Credential storage outside PostgreSQL.** All verifiers continue to live in `pg_authid`.
 - **Fallback to MD5 or cleartext auth.** Both are explicitly rejected by the wire-protocol client.
 
@@ -61,9 +61,17 @@ MultiGateway populates `UserAuth` from the session's captured keys on every outb
 
 `pgprotocol/client.Config` carries optional `ClientKey` and `ServerKey`. The client-side auth dispatch in `client/startup.go:handleAuthenticationRequest` branches on their presence: when set, it constructs a SCRAM client via `newScramClientWithKeys(user, clientKey, serverKey)`; otherwise it uses the password path.
 
-`connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at dial time. Because keys are a property of the user session, distinct sessions for the same user carry their own keys independently — the pool's identity-of-user semantics are unchanged.
+`connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at the pool's first-time creation. Because `ClientKey` is deterministic over `(user, password)`, keys cached on the pool are correct for every concurrent session of that user as long as the password is stable — see *Password rotation* below for the self-heal.
 
 The admin pool is unaffected: it authenticates with a configured superuser password, independent of any user's session, and is what makes `GetAuthCredentials` (the `pg_authid` lookup that feeds the handshake) possible in the first place.
+
+### Password rotation
+
+`ClientKey` is a function of `SaltedPassword`, so rotating a user's password in `pg_authid` makes every pool whose `ClientConfig` was built from the old verifier unable to dial a fresh backend connection — the new pg_authid verifier rejects the proof. Without intervention, the pool stays in place and keeps failing authentication on every refill attempt.
+
+The manager self-heals. `withReopenRetry` detects a class-28 SQLSTATE (`28P01` or any other *Invalid Authorization Specification* code) on the dial path, evicts the stale user pool from the snapshot, and retries once using the triggering session's keys. Those keys are known-current: they were derived moments earlier during the session's SCRAM handshake at MultiGateway against whatever verifier `pg_authid` holds right now. A concurrent session racing the same rotation may evict first, in which case the late caller's eviction is a no-op and it retries against the fresh pool.
+
+The retry is single-shot. If the retry itself auth-fails — e.g. the retrier is a long-running session still carrying old keys — the clean class-28 error propagates to the client, who reconnects, re-handshakes against the new verifier, and their reconnect is what populates a fresh pool.
 
 ### `pg_hba.conf`
 
@@ -75,7 +83,7 @@ Replication-related trust lines remain as a narrower scope, separate from the qu
 
 ### Failure modes
 
-- **Stale keys (password rotated in PostgreSQL).** The SCRAM handshake from MultiPooler to PostgreSQL fails. MultiPooler treats this as a non-retryable, session-fatal error: the failed connection is discarded, the client is disconnected with a clean error, and a reconnect through MultiGateway re-derives fresh keys from the new verifier.
+- **Stale keys on an existing pool (password rotated in PostgreSQL).** The first dial from the pool with stale keys fails with class-28 SQLSTATE. The manager evicts the pool (see *Password rotation*) and retries with the triggering session's fresh keys. If the retry also auth-fails, the error propagates and the client reconnects to re-derive keys.
 - **Missing keys on an RPC.** The RPC fails closed with a clear error. In steady state this should not happen — every authenticated session has keys — so this is a defensive check, not an expected path.
 - **Admin pool failure.** Independent of passthrough. If the admin pool cannot reach PostgreSQL, MultiPooler cannot serve `GetAuthCredentials` and no handshake can complete; passthrough is a no-op because no session ever reaches the authenticated state.
 

--- a/docs/query_serving/scram_passthrough_design.md
+++ b/docs/query_serving/scram_passthrough_design.md
@@ -10,9 +10,11 @@ This document describes the design as a whole: where the keys live, how they tra
 
 ### Why SCRAM keys can be passed through
 
-PostgreSQL's SCRAM-SHA-256 verifier stores only `StoredKey = H(ClientKey)` and `ServerKey`. The client proves knowledge of `ClientKey` by sending `ClientProof = ClientKey XOR ClientSignature`, where `ClientSignature = HMAC(StoredKey, AuthMessage)`. A verifier that sees the proof can validate it *and* recover the plaintext `ClientKey` by XORing the proof with the signature it just computed.
+PostgreSQL's SCRAM-SHA-256 verifier stores only `StoredKey = H(ClientKey)` and `ServerKey`. The client proves knowledge of `ClientKey` by sending `ClientProof = ClientKey XOR ClientSignature`, where `ClientSignature = HMAC(StoredKey, AuthMessage)`. A verifier that sees the proof can validate it _and_ recover the plaintext `ClientKey` by XORing the proof with the signature it just computed.
 
-This property — that a successful SCRAM handshake reveals `ClientKey` to the verifier — is what makes passthrough possible. With `ClientKey` plus `ServerKey` (which MultiGateway already has, because MultiGateway fetched the verifier from `pg_authid` via MultiPooler's admin pool as part of the incoming handshake), MultiGateway can impersonate the user against any other SCRAM-SHA-256 verifier of the same password — including the backing PostgreSQL.
+This property — that a successful SCRAM handshake reveals `ClientKey` to the verifier — is what makes passthrough possible.
+
+With `ClientKey` plus `ServerKey` (which MultiGateway already has, because MultiGateway fetched the verifier from `pg_authid` via MultiPooler's admin pool as part of the incoming handshake), MultiGateway can impersonate the user against any other SCRAM-SHA-256 verifier of the same password — including the backing PostgreSQL.
 
 Our SCRAM library exposes this via `scram.ScramAuthenticator.ExtractedKeys()`, and the wire-protocol client accepts pre-computed keys via `client.newScramClientWithKeys(...)`.
 
@@ -37,7 +39,7 @@ Three things are true in the final design that are not true of a trust-on-the-so
 
 - **Client-certificate authentication.** Cert-authenticated sessions do not produce SCRAM keys; how MultiPooler dials for them is a separate design.
 - **SCRAM-SHA-256-PLUS (channel binding).** Internal gRPC between MultiGateway and MultiPooler is mTLS-protected, which covers the bulk of the MITM story for the wire segment where keys are exposed.
-- **Per-user key caching on MultiPooler.** A pool caches keys at first-creation and relies on rotation-triggered eviction (see *Password rotation*) to refresh them. A short-TTL key cache is a possible future optimization for scenarios where eviction churn becomes visible.
+- **Per-user key caching on MultiPooler.** A pool caches keys at first-creation and relies on rotation-triggered eviction (see _Password rotation_) to refresh them. A short-TTL key cache is a possible future optimization for scenarios where eviction churn becomes visible.
 - **Credential storage outside PostgreSQL.** All verifiers continue to live in `pg_authid`.
 - **Fallback to MD5 or cleartext auth.** Both are explicitly rejected by the wire-protocol client.
 
@@ -61,7 +63,9 @@ MultiGateway populates `UserAuth` from the session's captured keys on every outb
 
 `pgprotocol/client.Config` carries optional `ClientKey` and `ServerKey`. The client-side auth dispatch in `client/startup.go:handleAuthenticationRequest` branches on their presence: when set, it constructs a SCRAM client via `newScramClientWithKeys(user, clientKey, serverKey)`; otherwise it uses the password path.
 
-`connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at the pool's first-time creation. Because `ClientKey` is deterministic over `(user, password)`, keys cached on the pool are correct for every concurrent session of that user as long as the password is stable — see *Password rotation* below for the self-heal.
+`connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at the pool's first-time creation.
+
+Because `ClientKey` is deterministic over `(user, password)`, keys cached on the pool are correct for every concurrent session of that user as long as the password is stable — see _Password rotation_ below for the self-heal.
 
 The admin pool is unaffected: it authenticates with a configured superuser password, independent of any user's session, and is what makes `GetAuthCredentials` (the `pg_authid` lookup that feeds the handshake) possible in the first place.
 
@@ -69,7 +73,9 @@ The admin pool is unaffected: it authenticates with a configured superuser passw
 
 `ClientKey` is a function of `SaltedPassword`, so rotating a user's password in `pg_authid` makes every pool whose `ClientConfig` was built from the old verifier unable to dial a fresh backend connection — the new pg_authid verifier rejects the proof. Without intervention, the pool stays in place and keeps failing authentication on every refill attempt.
 
-The manager self-heals. `withReopenRetry` detects a class-28 SQLSTATE (`28P01` or any other *Invalid Authorization Specification* code) on the dial path, evicts the stale user pool from the snapshot, and retries once using the triggering session's keys. Those keys are known-current: they were derived moments earlier during the session's SCRAM handshake at MultiGateway against whatever verifier `pg_authid` holds right now. A concurrent session racing the same rotation may evict first, in which case the late caller's eviction is a no-op and it retries against the fresh pool.
+The manager self-heals. `withReopenRetry` detects a class-28 SQLSTATE (`28P01` or any other _Invalid Authorization Specification_ code) on the dial path, evicts the stale user pool from the snapshot, and retries once using the triggering session's keys.
+
+Those keys are known-current: they were derived moments earlier during the session's SCRAM handshake at MultiGateway against whatever verifier `pg_authid` holds right now. A concurrent session racing the same rotation may evict first, in which case the late caller's eviction is a no-op and it retries against the fresh pool.
 
 The retry is single-shot. If the retry itself auth-fails — e.g. the retrier is a long-running session still carrying old keys — the clean class-28 error propagates to the client, who reconnects, re-handshakes against the new verifier, and their reconnect is what populates a fresh pool.
 
@@ -77,13 +83,15 @@ The retry is single-shot. If the retry itself auth-fails — e.g. the retrier is
 
 `pg_hba.conf` grants `scram-sha-256` for all non-replication host access and for local socket connections from any user other than the configured admin. The blanket `local all all trust` line no longer exists.
 
-A narrow `local all <admin-user> trust` line is intentionally preserved as the bootstrap path for MultiPooler's admin pool (superuser queries: `GetAuthCredentials`, heartbeat, replication tracking). Closing this exception requires pgctld to provision the admin password during `initdb`, so it is tracked as a follow-up rather than shipped in the same change as the query-path flip. Operators running today see a warning on startup when the admin password is empty, surfacing the remaining gap.
+A narrow `local all <admin-user> trust` line is intentionally preserved as the bootstrap path for MultiPooler's admin pool (superuser queries: `GetAuthCredentials`, heartbeat, replication tracking).
+
+Closing this exception requires pgctld to provision the admin password during `initdb`, so it is tracked as a follow-up rather than shipped in the same change as the query-path flip. Operators running today see a warning on startup when the admin password is empty, surfacing the remaining gap.
 
 Replication-related trust lines remain as a narrower scope, separate from the query path.
 
 ### Failure modes
 
-- **Stale keys on an existing pool (password rotated in PostgreSQL).** The first dial from the pool with stale keys fails with class-28 SQLSTATE. The manager evicts the pool (see *Password rotation*) and retries with the triggering session's fresh keys. If the retry also auth-fails, the error propagates and the client reconnects to re-derive keys.
+- **Stale keys on an existing pool (password rotated in PostgreSQL).** The first dial from the pool with stale keys fails with class-28 SQLSTATE. The manager evicts the pool (see _Password rotation_) and retries with the triggering session's fresh keys. If the retry also auth-fails, the error propagates and the client reconnects to re-derive keys.
 - **Missing keys on an RPC.** The RPC fails closed with a clear error. In steady state this should not happen — every authenticated session has keys — so this is a defensive check, not an expected path.
 - **Admin pool failure.** Independent of passthrough. If the admin pool cannot reach PostgreSQL, MultiPooler cannot serve `GetAuthCredentials` and no handshake can complete; passthrough is a no-op because no session ever reaches the authenticated state.
 

--- a/docs/query_serving/scram_passthrough_design.md
+++ b/docs/query_serving/scram_passthrough_design.md
@@ -61,7 +61,7 @@ MultiGateway populates `UserAuth` from the session's captured keys on every outb
 
 ### MultiPooler dial logic
 
-`pgprotocol/client.Config` carries optional `ClientKey` and `ServerKey`. The client-side auth dispatch in `client/startup.go:handleAuthenticationRequest` branches on their presence: when set, it constructs a SCRAM client via `newScramClientWithKeys(user, clientKey, serverKey)`; otherwise it uses the password path.
+`pgprotocol/client.Config` carries optional `ScramClientKey` and `ScramServerKey`. The client-side auth dispatch in `client/startup.go:handleAuthenticationRequest` branches on their presence: when set, it constructs a SCRAM client via `newScramClientWithKeys(user, scramClientKey, scramServerKey)`; otherwise it uses the password path.
 
 `connpoolmanager.Manager` routes keys from the inbound RPC into the user-pool backend dial. User pools are keyed by username and carry the session's keys into their `client.Config` at the pool's first-time creation.
 

--- a/go/common/mterrors/errors_test.go
+++ b/go/common/mterrors/errors_test.go
@@ -466,3 +466,52 @@ func TestIsConnectionError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAuthenticationError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil", err: nil, expected: false},
+
+		// Class 28 — Invalid Authorization Specification.
+		{
+			name:     "28P01 invalid_password",
+			err:      &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01"},
+			expected: true,
+		},
+		{
+			name:     "28000 invalid_authorization_specification",
+			err:      &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28000"},
+			expected: true,
+		},
+		{
+			name:     "wrapped 28P01",
+			err:      fmt.Errorf("dial: %w", &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01"}),
+			expected: true,
+		},
+
+		// Other classes must not be misclassified as auth errors.
+		{
+			name:     "08006 connection_failure",
+			err:      &PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "08006"},
+			expected: false,
+		},
+		{
+			name:     "42601 syntax_error",
+			err:      &PgDiagnostic{MessageType: 'E', Severity: "ERROR", Code: "42601"},
+			expected: false,
+		},
+
+		// Non-pg errors.
+		{name: "generic error", err: errors.New("boom"), expected: false},
+		{name: "EOF", err: io.EOF, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsAuthenticationError(tt.err))
+		})
+	}
+}

--- a/go/common/mterrors/mterrors.go
+++ b/go/common/mterrors/mterrors.go
@@ -480,3 +480,19 @@ func IsConnectionError(err error) bool {
 
 	return false
 }
+
+// IsAuthenticationError reports whether err surfaced from PostgreSQL's
+// authentication phase — either an invalid password (28P01) or any other
+// class-28 "Invalid Authorization Specification" code. Callers use this to
+// distinguish a stale-credentials failure (where retrying against a fresh
+// verifier might help) from a genuine configuration or connectivity problem.
+func IsAuthenticationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var diag *PgDiagnostic
+	if errors.As(err, &diag) {
+		return diag.IsClass("28")
+	}
+	return false
+}

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -58,6 +58,15 @@ type Config struct {
 	// Password is the user's password (optional for trust auth).
 	Password string
 
+	// ScramClientKey and ScramServerKey enable SCRAM-SHA-256 passthrough
+	// authentication. When both are set, the client uses them to produce a
+	// valid SCRAM proof without knowing the plaintext password. Both must
+	// be 32 bytes (HMAC-SHA-256 output). If set, they take precedence over
+	// Password when the server requests SASL. Leave nil for the standard
+	// password-based path.
+	ScramClientKey []byte
+	ScramServerKey []byte
+
 	// Database is the database name to connect to.
 	Database string
 

--- a/go/common/pgprotocol/client/startup.go
+++ b/go/common/pgprotocol/client/startup.go
@@ -224,9 +224,16 @@ func (c *Conn) handleAuthenticationRequest(body []byte) error {
 			return fmt.Errorf("server does not support SCRAM-SHA-256 (available: %v)", mechanisms)
 		}
 
-		// Perform SCRAM-SHA-256 authentication.
-		scram := newScramClient(c, c.config.User, c.config.Password)
-		return scram.authenticate()
+		// Prefer SCRAM passthrough when keys are present; otherwise fall back
+		// to password-based SCRAM. Passthrough lets a proxy authenticate on a
+		// session's behalf without ever holding the plaintext password.
+		var scramClient *scramClient
+		if len(c.config.ScramClientKey) > 0 && len(c.config.ScramServerKey) > 0 {
+			scramClient = newScramClientWithKeys(c, c.config.User, c.config.ScramClientKey, c.config.ScramServerKey)
+		} else {
+			scramClient = newScramClient(c, c.config.User, c.config.Password)
+		}
+		return scramClient.authenticate()
 
 	default:
 		return fmt.Errorf("unsupported authentication method: %d", authType)

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -136,6 +136,12 @@ type Conn struct {
 	database string
 	params   map[string]string
 
+	// SCRAM-SHA-256 keys extracted during the client handshake, used for
+	// passthrough authentication to the backing PostgreSQL. Nil for non-SCRAM
+	// sessions. Zeroized in Close.
+	scramClientKey []byte
+	scramServerKey []byte
+
 	// protocolVersion is the negotiated protocol version.
 	protocolVersion protocol.ProtocolVersion
 
@@ -217,6 +223,17 @@ func (c *Conn) Close() error {
 	// The state is set to nil so handlers should handle nil-checking.
 	c.state = nil
 
+	// Zeroize SCRAM passthrough keys so a post-mortem or memory dump cannot
+	// recover credentials for this session after close.
+	for i := range c.scramClientKey {
+		c.scramClientKey[i] = 0
+	}
+	for i := range c.scramServerKey {
+		c.scramServerKey[i] = 0
+	}
+	c.scramClientKey = nil
+	c.scramServerKey = nil
+
 	// Return pooled resources.
 	c.returnReader()
 	// Defensive cleanup: if a handler panicked between readMessageBody
@@ -285,6 +302,19 @@ func (c *Conn) User() string {
 // Database returns the database name.
 func (c *Conn) Database() string {
 	return c.database
+}
+
+// ScramClientKey returns the SCRAM-SHA-256 ClientKey extracted during the
+// client's authentication handshake, or nil if the session did not
+// authenticate via SCRAM. Used for passthrough auth to backend PostgreSQL.
+func (c *Conn) ScramClientKey() []byte {
+	return c.scramClientKey
+}
+
+// ScramServerKey returns the SCRAM-SHA-256 ServerKey from the user's
+// verifier, or nil if the session did not authenticate via SCRAM.
+func (c *Conn) ScramServerKey() []byte {
+	return c.scramServerKey
 }
 
 // GetStartupParams returns the startup parameters sent by the client,

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -442,6 +442,9 @@ func (c *Conn) authenticateSCRAM() error {
 		return fmt.Errorf("failed to handle client-final-message: %w", err)
 	}
 
+	// Capture keys for SCRAM passthrough to the backing PostgreSQL.
+	c.scramClientKey, c.scramServerKey = auth.ExtractedKeys()
+
 	// Send AuthenticationSASLFinal with server signature.
 	if err := c.sendAuthenticationSASLFinal(serverFinalMessage); err != nil {
 		return fmt.Errorf("failed to send AuthenticationSASLFinal: %w", err)

--- a/go/common/pgprotocol/server/startup_test.go
+++ b/go/common/pgprotocol/server/startup_test.go
@@ -917,3 +917,102 @@ func TestParseOptions(t *testing.T) {
 		})
 	}
 }
+
+// TestSCRAMAuthenticationCapturesKeys verifies that the Conn retains the
+// ClientKey and ServerKey extracted during the SCRAM handshake. These keys
+// feed the SCRAM passthrough path (multipooler → postgres) and must be
+// populated on every successful SCRAM authentication.
+func TestSCRAMAuthenticationCapturesKeys(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	listener := testListener(t)
+	c := &Conn{
+		conn:           serverConn,
+		listener:       listener,
+		handler:        listener.handler,
+		hashProvider:   listener.hashProvider,
+		bufferedReader: bufio.NewReader(serverConn),
+		bufferedWriter: bufio.NewWriter(serverConn),
+		params:         make(map[string]string),
+		txnStatus:      protocol.TxnStatusIdle,
+	}
+	c.ctx = context.Background()
+	c.logger = testLogger(t)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	params := map[string]string{
+		"user":     "scramuser",
+		"database": "scramdb",
+	}
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, params)
+	scramClientHelper(t, clientConn, "scramuser", "postgres")
+
+	require.NoError(t, <-errCh)
+
+	// SCRAM-SHA-256 keys are always 32 bytes (output of HMAC-SHA-256).
+	assert.Len(t, c.scramClientKey, 32, "ClientKey should be captured after SCRAM auth")
+	assert.Len(t, c.scramServerKey, 32, "ServerKey should be captured after SCRAM auth")
+	assert.NotEqual(t, make([]byte, 32), c.scramClientKey, "ClientKey should not be all zeros")
+	assert.NotEqual(t, make([]byte, 32), c.scramServerKey, "ServerKey should not be all zeros")
+}
+
+// TestConnCloseZeroizesSCRAMKeys verifies that Close scrubs the SCRAM
+// passthrough keys so that a later memory dump cannot recover credentials
+// from a closed session.
+func TestConnCloseZeroizesSCRAMKeys(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer clientConn.Close()
+
+	listener := testListener(t)
+	c := &Conn{
+		conn:           serverConn,
+		listener:       listener,
+		bufferedReader: bufio.NewReader(serverConn),
+		bufferedWriter: bufio.NewWriter(serverConn),
+		params:         make(map[string]string),
+		scramClientKey: []byte{1, 2, 3, 4},
+		scramServerKey: []byte{5, 6, 7, 8},
+	}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.logger = testLogger(t)
+
+	// Hold references to the underlying slices to prove the bytes are scrubbed
+	// in place, not just detached.
+	clientBacking := c.scramClientKey
+	serverBacking := c.scramServerKey
+
+	require.NoError(t, c.Close())
+
+	assert.Nil(t, c.scramClientKey)
+	assert.Nil(t, c.scramServerKey)
+	assert.Equal(t, []byte{0, 0, 0, 0}, clientBacking, "ClientKey bytes must be scrubbed in place")
+	assert.Equal(t, []byte{0, 0, 0, 0}, serverBacking, "ServerKey bytes must be scrubbed in place")
+}
+
+// TestConnCloseSafeWithoutSCRAMKeys ensures Close does not panic when the
+// connection never completed SCRAM auth (keys remain nil).
+func TestConnCloseSafeWithoutSCRAMKeys(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer clientConn.Close()
+
+	listener := testListener(t)
+	c := &Conn{
+		conn:           serverConn,
+		listener:       listener,
+		bufferedReader: bufio.NewReader(serverConn),
+		bufferedWriter: bufio.NewWriter(serverConn),
+		params:         make(map[string]string),
+	}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.logger = testLogger(t)
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, c.Close())
+	})
+}

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1083,8 +1083,15 @@ type ExecuteOptions struct {
 	// This field is only consumed by StreamExecute. PortalStreamExecute has
 	// its own top-level prepared_statement field.
 	PreparedStatement *PreparedStatement `protobuf:"bytes,6,opt,name=prepared_statement,json=preparedStatement,proto3" json:"prepared_statement,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// user_auth carries SCRAM-SHA-256 passthrough keys captured during the
+	// client's authentication handshake at the multigateway. When the
+	// multipooler has SCRAM passthrough enabled, it uses these keys to
+	// authenticate to the backing PostgreSQL as the session's real user
+	// instead of relying on trust on the local connection. Unset for
+	// sessions that did not authenticate via SCRAM.
+	UserAuth      *UserAuth `protobuf:"bytes,7,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1152,6 +1159,73 @@ func (x *ExecuteOptions) GetPreparedStatement() *PreparedStatement {
 	return nil
 }
 
+func (x *ExecuteOptions) GetUserAuth() *UserAuth {
+	if x != nil {
+		return x.UserAuth
+	}
+	return nil
+}
+
+// UserAuth carries cryptographic material extracted from the client's SCRAM
+// handshake at multigateway. The pair (client_key, server_key) is sufficient
+// to authenticate as the user to any SCRAM-SHA-256 verifier of the same
+// password, without ever holding the plaintext password.
+type UserAuth struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// client_key is the SCRAM ClientKey recovered from the client's proof
+	// during authentication. 32 bytes for SCRAM-SHA-256.
+	ClientKey []byte `protobuf:"bytes,1,opt,name=client_key,json=clientKey,proto3" json:"client_key,omitempty"`
+	// server_key is the SCRAM ServerKey read from the user's verifier in
+	// pg_authid. 32 bytes for SCRAM-SHA-256.
+	ServerKey     []byte `protobuf:"bytes,2,opt,name=server_key,json=serverKey,proto3" json:"server_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserAuth) Reset() {
+	*x = UserAuth{}
+	mi := &file_query_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAuth) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAuth) ProtoMessage() {}
+
+func (x *UserAuth) ProtoReflect() protoreflect.Message {
+	mi := &file_query_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAuth.ProtoReflect.Descriptor instead.
+func (*UserAuth) Descriptor() ([]byte, []int) {
+	return file_query_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *UserAuth) GetClientKey() []byte {
+	if x != nil {
+		return x.ClientKey
+	}
+	return nil
+}
+
+func (x *UserAuth) GetServerKey() []byte {
+	if x != nil {
+		return x.ServerKey
+	}
+	return nil
+}
+
 // ReservationOptions specifies options when creating or extending a reserved connection.
 // This is passed alongside ExecuteOptions on requests that may need to create or modify
 // a connection reservation. It is extensible for future options (e.g., isolation level,
@@ -1177,7 +1251,7 @@ type ReservationOptions struct {
 
 func (x *ReservationOptions) Reset() {
 	*x = ReservationOptions{}
-	mi := &file_query_proto_msgTypes[13]
+	mi := &file_query_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1189,7 +1263,7 @@ func (x *ReservationOptions) String() string {
 func (*ReservationOptions) ProtoMessage() {}
 
 func (x *ReservationOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_query_proto_msgTypes[13]
+	mi := &file_query_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1202,7 +1276,7 @@ func (x *ReservationOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReservationOptions.ProtoReflect.Descriptor instead.
 func (*ReservationOptions) Descriptor() ([]byte, []int) {
-	return file_query_proto_rawDescGZIP(), []int{13}
+	return file_query_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ReservationOptions) GetReasons() uint32 {
@@ -1304,16 +1378,22 @@ const file_query_proto_rawDesc = "" +
 	"\rReservedState\x124\n" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
-	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\"\xd9\x02\n" +
+	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\"\x87\x03\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
 	"\bmax_rows\x18\x04 \x01(\x04R\amaxRows\x124\n" +
 	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12G\n" +
-	"\x12prepared_statement\x18\x06 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x1aB\n" +
+	"\x12prepared_statement\x18\x06 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x12,\n" +
+	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"O\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"H\n" +
+	"\bUserAuth\x12\x1d\n" +
+	"\n" +
+	"client_key\x18\x01 \x01(\fR\tclientKey\x12\x1d\n" +
+	"\n" +
+	"server_key\x18\x02 \x01(\fR\tserverKey\"O\n" +
 	"\x12ReservationOptions\x12\x18\n" +
 	"\areasons\x18\x01 \x01(\rR\areasons\x12\x1f\n" +
 	"\vbegin_query\x18\x02 \x01(\tR\n" +
@@ -1331,7 +1411,7 @@ func file_query_proto_rawDescGZIP() []byte {
 	return file_query_proto_rawDescData
 }
 
-var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_query_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_query_proto_goTypes = []any{
 	(*QueryResultPayload)(nil),      // 0: query.QueryResultPayload
 	(*QueryResult)(nil),             // 1: query.QueryResult
@@ -1346,10 +1426,11 @@ var file_query_proto_goTypes = []any{
 	(*Portal)(nil),                  // 10: query.Portal
 	(*ReservedState)(nil),           // 11: query.ReservedState
 	(*ExecuteOptions)(nil),          // 12: query.ExecuteOptions
-	(*ReservationOptions)(nil),      // 13: query.ReservationOptions
-	nil,                             // 14: query.ExecuteOptions.SessionSettingsEntry
-	(clustermetadata.PoolerType)(0), // 15: clustermetadata.PoolerType
-	(*clustermetadata.ID)(nil),      // 16: clustermetadata.ID
+	(*UserAuth)(nil),                // 13: query.UserAuth
+	(*ReservationOptions)(nil),      // 14: query.ReservationOptions
+	nil,                             // 15: query.ExecuteOptions.SessionSettingsEntry
+	(clustermetadata.PoolerType)(0), // 16: clustermetadata.PoolerType
+	(*clustermetadata.ID)(nil),      // 17: clustermetadata.ID
 }
 var file_query_proto_depIdxs = []int32{
 	1,  // 0: query.QueryResultPayload.result:type_name -> query.QueryResult
@@ -1359,15 +1440,16 @@ var file_query_proto_depIdxs = []int32{
 	3,  // 4: query.QueryResult.rows:type_name -> query.Row
 	7,  // 5: query.StatementDescription.parameters:type_name -> query.ParameterDescription
 	2,  // 6: query.StatementDescription.fields:type_name -> query.Field
-	15, // 7: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
-	16, // 8: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
-	14, // 9: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
+	16, // 7: query.Target.pooler_type:type_name -> clustermetadata.PoolerType
+	17, // 8: query.ReservedState.pooler_id:type_name -> clustermetadata.ID
+	15, // 9: query.ExecuteOptions.session_settings:type_name -> query.ExecuteOptions.SessionSettingsEntry
 	9,  // 10: query.ExecuteOptions.prepared_statement:type_name -> query.PreparedStatement
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	13, // 11: query.ExecuteOptions.user_auth:type_name -> query.UserAuth
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_query_proto_init() }
@@ -1386,7 +1468,7 @@ func file_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_proto_rawDesc), len(file_query_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1174,6 +1174,12 @@ type UserAuth struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// client_key is the SCRAM ClientKey recovered from the client's proof
 	// during authentication. 32 bytes for SCRAM-SHA-256.
+	//
+	// [debug_redact = true] is the canonical signal of intent. It is currently
+	// advisory in google.golang.org/protobuf (see
+	// https://github.com/golang/protobuf/issues/1655); when upstream lands the
+	// runtime path, generated String()/prototext output will redact this field
+	// automatically. query_redact_test.go locks the annotation in.
 	ClientKey []byte `protobuf:"bytes,1,opt,name=client_key,json=clientKey,proto3" json:"client_key,omitempty"`
 	// server_key is the SCRAM ServerKey read from the user's verifier in
 	// pg_authid. 32 bytes for SCRAM-SHA-256.
@@ -1388,12 +1394,12 @@ const file_query_proto_rawDesc = "" +
 	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"H\n" +
-	"\bUserAuth\x12\x1d\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +
+	"\bUserAuth\x12\"\n" +
 	"\n" +
-	"client_key\x18\x01 \x01(\fR\tclientKey\x12\x1d\n" +
+	"client_key\x18\x01 \x01(\fB\x03\x80\x01\x01R\tclientKey\x12\"\n" +
 	"\n" +
-	"server_key\x18\x02 \x01(\fR\tserverKey\"O\n" +
+	"server_key\x18\x02 \x01(\fB\x03\x80\x01\x01R\tserverKey\"O\n" +
 	"\x12ReservationOptions\x12\x18\n" +
 	"\areasons\x18\x01 \x01(\rR\areasons\x12\x1f\n" +
 	"\vbegin_query\x18\x02 \x01(\tR\n" +

--- a/go/pb/query/query_redact_test.go
+++ b/go/pb/query/query_redact_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// TestUserAuthDebugRedactAnnotation pins `[debug_redact = true]` on every
+// UserAuth field. The bytes are SCRAM passthrough keys — password-equivalent —
+// so any future proto edit that drops the annotation must be deliberate, not
+// accidental. Today google.golang.org/protobuf (v1.36) does not honor
+// debug_redact in prototext / String(); upstream tracks this at
+// https://github.com/golang/protobuf/issues/1655. Once that lands, the
+// annotation will start producing redacted String() output for free.
+func TestUserAuthDebugRedactAnnotation(t *testing.T) {
+	md := (&UserAuth{}).ProtoReflect().Descriptor()
+	for _, name := range []protoreflect.Name{"client_key", "server_key"} {
+		fd := md.Fields().ByName(name)
+		require.NotNil(t, fd, "UserAuth.%s field missing", name)
+		opts, ok := fd.Options().(*descriptorpb.FieldOptions)
+		require.True(t, ok, "UserAuth.%s has no FieldOptions", name)
+		assert.True(t, opts.GetDebugRedact(),
+			"UserAuth.%s must carry [debug_redact = true]; the bytes are password-equivalent",
+			name)
+	}
+}

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -72,6 +72,22 @@ func NewScatterConn(gateway poolergateway.Gateway, logger *slog.Logger) *Scatter
 	}
 }
 
+// userAuthFrom builds the outbound UserAuth payload from the session's captured
+// SCRAM passthrough keys. Returns nil for sessions that did not authenticate via
+// SCRAM (e.g. trust in tests), so this field stays absent on the wire instead of
+// carrying empty slices.
+func userAuthFrom(conn *server.Conn) *querypb.UserAuth {
+	clientKey := conn.ScramClientKey()
+	serverKey := conn.ScramServerKey()
+	if clientKey == nil && serverKey == nil {
+		return nil
+	}
+	return &querypb.UserAuth{
+		ClientKey: clientKey,
+		ServerKey: serverKey,
+	}
+}
+
 // buildTarget constructs a routing target from the given tableGroup and shard.
 // When the connection arrived on the replica-reads port (state.TargetReplica()),
 // the target's PoolerType is set to REPLICA; otherwise PRIMARY.
@@ -157,6 +173,7 @@ func (sc *ScatterConn) StreamExecute(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
+		UserAuth:          userAuthFrom(conn),
 		User:              conn.User(),
 		SessionSettings:   state.GetSessionSettings(),
 		PreparedStatement: preparedStatement,
@@ -308,6 +325,7 @@ func (sc *ScatterConn) PortalStreamExecute(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
+		UserAuth:        userAuthFrom(conn),
 		User:            conn.User(),
 		MaxRows:         uint64(maxRows),
 		SessionSettings: state.GetSessionSettings(),
@@ -354,6 +372,7 @@ func (sc *ScatterConn) PortalStreamExecute(
 			"reasons", protoutil.ReasonsString(reasons))
 
 		noopEo := &querypb.ExecuteOptions{
+			UserAuth:        userAuthFrom(conn),
 			User:            conn.User(),
 			SessionSettings: state.GetSessionSettings(),
 		}
@@ -429,6 +448,7 @@ func (sc *ScatterConn) Describe(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
+		UserAuth:        userAuthFrom(conn),
 		User:            conn.User(),
 		SessionSettings: state.GetSessionSettings(),
 	}
@@ -534,6 +554,7 @@ func (sc *ScatterConn) ConcludeTransaction(
 		}
 
 		eo := &querypb.ExecuteOptions{
+			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
@@ -638,6 +659,7 @@ func (sc *ScatterConn) DiscardTempTables(
 		}
 
 		eo := &querypb.ExecuteOptions{
+			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
@@ -736,6 +758,7 @@ func (sc *ScatterConn) CopyInitiate(
 
 	// Create execute options
 	execOptions := &querypb.ExecuteOptions{
+		UserAuth:        userAuthFrom(conn),
 		User:            conn.User(),
 		SessionSettings: state.GetSessionSettings(),
 	}
@@ -808,6 +831,7 @@ func (sc *ScatterConn) CopySendData(
 
 	// Build options with reserved connection ID
 	copyOptions := &querypb.ExecuteOptions{
+		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
@@ -863,6 +887,7 @@ func (sc *ScatterConn) CopyFinalize(
 
 	// Build options with reserved connection ID
 	copyOptions := &querypb.ExecuteOptions{
+		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
@@ -926,6 +951,7 @@ func (sc *ScatterConn) CopyAbort(
 
 	// Build options with reserved connection ID
 	copyOptions := &querypb.ExecuteOptions{
+		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
@@ -961,6 +987,7 @@ func (sc *ScatterConn) ReleaseAllReservedConnections(
 		}
 
 		eo := &querypb.ExecuteOptions{
+			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -76,6 +76,11 @@ func NewScatterConn(gateway poolergateway.Gateway, logger *slog.Logger) *Scatter
 // SCRAM passthrough keys. Returns nil for sessions that did not authenticate via
 // SCRAM (e.g. trust in tests), so this field stays absent on the wire instead of
 // carrying empty slices.
+//
+// Keys are copied rather than referenced: Conn.Close zeroizes the accessor's
+// backing slice in place, and gRPC may marshal lazily (stream init) or re-
+// marshal on transient retry. A detached copy guarantees the proto carries
+// live bytes for the full lifetime of the RPC.
 func userAuthFrom(conn *server.Conn) *querypb.UserAuth {
 	clientKey := conn.ScramClientKey()
 	serverKey := conn.ScramServerKey()
@@ -83,8 +88,8 @@ func userAuthFrom(conn *server.Conn) *querypb.UserAuth {
 		return nil
 	}
 	return &querypb.UserAuth{
-		ClientKey: clientKey,
-		ServerKey: serverKey,
+		ClientKey: append([]byte(nil), clientKey...),
+		ServerKey: append([]byte(nil), serverKey...),
 	}
 }
 

--- a/go/services/multipooler/connpoolmanager/config.go
+++ b/go/services/multipooler/connpoolmanager/config.go
@@ -114,6 +114,12 @@ type Config struct {
 	// drainGracePeriod is how long to wait for in-flight connections to drain
 	// during a NOT_SERVING transition before force-closing reserved connections.
 	drainGracePeriod viperutil.Value[time.Duration]
+
+	// scramPassthrough toggles whether per-user backend connections authenticate
+	// to PostgreSQL using SCRAM passthrough keys forwarded from MultiGateway on
+	// each RPC. When false (the default), pools fall back to their existing
+	// behavior. Consumed by the user-pool dial path; no effect on the admin pool.
+	scramPassthrough viperutil.Value[bool]
 }
 
 // NewConfig creates a new Config with all connection pool settings
@@ -241,6 +247,11 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			Default:  drainGracePeriod,
 			FlagName: "connpool-drain-grace-period",
 		}),
+		scramPassthrough: viperutil.Configure(reg, "connpool.scram-passthrough", viperutil.Options[bool]{
+			Default:  true,
+			FlagName: "multipooler-scram-passthrough",
+			EnvVars:  []string{"MULTIPOOLER_SCRAM_PASSTHROUGH"},
+		}),
 	}
 }
 
@@ -276,6 +287,12 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int64("connpool-min-capacity-per-user", c.minCapacityPerUser.Default(), "Minimum connections per user (protects against aggressive capacity reduction for light users)")
 	fs.Duration("connpool-dial-timeout", c.dialTimeout.Default(), "Timeout for establishing new PostgreSQL connections")
 	fs.Duration("connpool-drain-grace-period", c.drainGracePeriod.Default(), "How long to wait for in-flight connections to drain during NOT_SERVING transitions before force-closing reserved connections")
+
+	// SCRAM passthrough: when enabled (default), per-user pools authenticate to
+	// PostgreSQL using ClientKey/ServerKey forwarded by MultiGateway instead of
+	// trust auth. Disable for legacy deployments that still rely on local trust
+	// in pg_hba.conf.
+	fs.Bool("multipooler-scram-passthrough", c.scramPassthrough.Default(), "Enable SCRAM-SHA-256 key passthrough for per-user PostgreSQL connections (default: true)")
 
 	viperutil.BindFlags(fs,
 		c.pgUser,
@@ -391,6 +408,12 @@ func (c *Config) DialTimeout() time.Duration {
 // during NOT_SERVING transitions before force-closing reserved connections.
 func (c *Config) DrainGracePeriod() time.Duration {
 	return c.drainGracePeriod.Get()
+}
+
+// ScramPassthrough reports whether per-user pools authenticate to PostgreSQL
+// using SCRAM passthrough keys from incoming RPCs. Default false.
+func (c *Config) ScramPassthrough() bool {
+	return c.scramPassthrough.Get()
 }
 
 // NewManager creates a new connection pool manager from this config.

--- a/go/services/multipooler/connpoolmanager/config.go
+++ b/go/services/multipooler/connpoolmanager/config.go
@@ -114,12 +114,6 @@ type Config struct {
 	// drainGracePeriod is how long to wait for in-flight connections to drain
 	// during a NOT_SERVING transition before force-closing reserved connections.
 	drainGracePeriod viperutil.Value[time.Duration]
-
-	// scramPassthrough toggles whether per-user backend connections authenticate
-	// to PostgreSQL using SCRAM passthrough keys forwarded from MultiGateway on
-	// each RPC. When false (the default), pools fall back to their existing
-	// behavior. Consumed by the user-pool dial path; no effect on the admin pool.
-	scramPassthrough viperutil.Value[bool]
 }
 
 // NewConfig creates a new Config with all connection pool settings
@@ -247,11 +241,6 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			Default:  drainGracePeriod,
 			FlagName: "connpool-drain-grace-period",
 		}),
-		scramPassthrough: viperutil.Configure(reg, "connpool.scram-passthrough", viperutil.Options[bool]{
-			Default:  true,
-			FlagName: "multipooler-scram-passthrough",
-			EnvVars:  []string{"MULTIPOOLER_SCRAM_PASSTHROUGH"},
-		}),
 	}
 }
 
@@ -287,12 +276,6 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int64("connpool-min-capacity-per-user", c.minCapacityPerUser.Default(), "Minimum connections per user (protects against aggressive capacity reduction for light users)")
 	fs.Duration("connpool-dial-timeout", c.dialTimeout.Default(), "Timeout for establishing new PostgreSQL connections")
 	fs.Duration("connpool-drain-grace-period", c.drainGracePeriod.Default(), "How long to wait for in-flight connections to drain during NOT_SERVING transitions before force-closing reserved connections")
-
-	// SCRAM passthrough: when enabled (default), per-user pools authenticate to
-	// PostgreSQL using ClientKey/ServerKey forwarded by MultiGateway instead of
-	// trust auth. Disable for legacy deployments that still rely on local trust
-	// in pg_hba.conf.
-	fs.Bool("multipooler-scram-passthrough", c.scramPassthrough.Default(), "Enable SCRAM-SHA-256 key passthrough for per-user PostgreSQL connections (default: true)")
 
 	viperutil.BindFlags(fs,
 		c.pgUser,
@@ -408,12 +391,6 @@ func (c *Config) DialTimeout() time.Duration {
 // during NOT_SERVING transitions before force-closing reserved connections.
 func (c *Config) DrainGracePeriod() time.Duration {
 	return c.drainGracePeriod.Get()
-}
-
-// ScramPassthrough reports whether per-user pools authenticate to PostgreSQL
-// using SCRAM passthrough keys from incoming RPCs. Default false.
-func (c *Config) ScramPassthrough() bool {
-	return c.scramPassthrough.Get()
 }
 
 // NewManager creates a new connection pool manager from this config.

--- a/go/services/multipooler/connpoolmanager/config_test.go
+++ b/go/services/multipooler/connpoolmanager/config_test.go
@@ -264,23 +264,3 @@ func TestConfig_PgUser_EnvVar(t *testing.T) {
 
 	assert.Equal(t, "supabase_admin", config.PgUser())
 }
-
-func TestConfig_ScramPassthrough_DefaultsTrue(t *testing.T) {
-	viper.Reset()
-	defer func() { viper.Reset() }()
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-
-	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	config.RegisterFlags(fs)
-
-	// Default is true: the secure path where per-user pools authenticate to
-	// PostgreSQL with SCRAM keys forwarded by MultiGateway. Legacy deployments
-	// can opt out via --multipooler-scram-passthrough=false.
-	assert.True(t, config.ScramPassthrough())
-
-	flag := fs.Lookup("multipooler-scram-passthrough")
-	require.NotNil(t, flag, "--multipooler-scram-passthrough flag must be registered")
-	assert.Equal(t, "true", flag.DefValue)
-}

--- a/go/services/multipooler/connpoolmanager/config_test.go
+++ b/go/services/multipooler/connpoolmanager/config_test.go
@@ -264,3 +264,23 @@ func TestConfig_PgUser_EnvVar(t *testing.T) {
 
 	assert.Equal(t, "supabase_admin", config.PgUser())
 }
+
+func TestConfig_ScramPassthrough_DefaultsTrue(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	// Default is true: the secure path where per-user pools authenticate to
+	// PostgreSQL with SCRAM keys forwarded by MultiGateway. Legacy deployments
+	// can opt out via --multipooler-scram-passthrough=false.
+	assert.True(t, config.ScramPassthrough())
+
+	flag := fs.Lookup("multipooler-scram-passthrough")
+	require.NotNil(t, flag, "--multipooler-scram-passthrough flag must be registered")
+	assert.Equal(t, "true", flag.DefValue)
+}

--- a/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
+++ b/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
@@ -132,7 +132,7 @@ func TestDynamicAllocation_DifferentWorkloadPatterns(t *testing.T) {
 				defer wg.Done()
 				<-ready // Wait for signal to start
 
-				conn, err := manager.GetRegularConn(ctx, user)
+				conn, err := manager.GetRegularConn(ctx, user, nil, nil)
 				if err == nil {
 					mu.Lock()
 					connsByUser[user] = append(connsByUser[user], conn)
@@ -211,7 +211,7 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 			go func(u string, shouldRelease bool) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u)
+				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
 				if err == nil {
 					if !shouldRelease {
 						mu.Lock()
@@ -248,7 +248,7 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 	// Now add a 3rd user during load
 	for range 4 {
 		wg.Go(func() {
-			conn, err := manager.GetRegularConn(ctx, "user3")
+			conn, err := manager.GetRegularConn(ctx, "user3", nil, nil)
 			if err == nil {
 				mu.Lock()
 				conns["user3"] = append(conns["user3"], conn)
@@ -314,15 +314,15 @@ func TestDynamicAllocation_UserDepartureDuringLoad(t *testing.T) {
 	ctx := context.Background()
 
 	// Create 3 users
-	conn1, err := manager.GetRegularConn(ctx, "user1")
+	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2")
+	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
-	conn3, err := manager.GetRegularConn(ctx, "user3")
+	conn3, err := manager.GetRegularConn(ctx, "user3", nil, nil)
 	require.NoError(t, err)
 	conn3.Recycle()
 
@@ -337,11 +337,11 @@ func TestDynamicAllocation_UserDepartureDuringLoad(t *testing.T) {
 			case <-done:
 				return
 			default:
-				conn, _ := manager.GetRegularConn(ctx, "user1")
+				conn, _ := manager.GetRegularConn(ctx, "user1", nil, nil)
 				if conn != nil {
 					conn.Recycle()
 				}
-				conn, _ = manager.GetRegularConn(ctx, "user2")
+				conn, _ = manager.GetRegularConn(ctx, "user2", nil, nil)
 				if conn != nil {
 					conn.Recycle()
 				}
@@ -393,7 +393,7 @@ func TestDynamicAllocation_CapacityExhaustion(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u)
+				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)
@@ -472,7 +472,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 				case <-done:
 					return
 				default:
-					conn, _ := manager.GetRegularConn(ctx, "user1")
+					conn, _ := manager.GetRegularConn(ctx, "user1", nil, nil)
 					if conn != nil {
 						time.Sleep(50 * time.Millisecond) // Hold connection briefly
 						conn.Recycle()
@@ -498,7 +498,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u)
+				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)
@@ -588,7 +588,7 @@ func TestDynamicAllocation_GracefulDegradation(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u)
+				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -58,9 +58,19 @@ type PoolManager interface {
 	// GetRegularConn acquires a regular connection for the specified user.
 	GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error)
 
+	// GetRegularConnWithAuth is GetRegularConn that also carries SCRAM
+	// passthrough keys from the caller's session. Keys are consumed only when
+	// this call triggers first-time user-pool creation.
+	GetRegularConnWithAuth(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
+
 	// GetRegularConnWithSettings acquires a regular connection with specific settings for the user.
 	// Settings are provided as a map and internally converted via the shared SettingsCache.
 	GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error)
+
+	// GetRegularConnWithSettingsAndAuth is GetRegularConnWithSettings that
+	// also carries SCRAM passthrough keys. Keys are consumed only on first
+	// pool creation for the user.
+	GetRegularConnWithSettingsAndAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
 
 	// --- Reserved Pool Operations ---
 
@@ -68,6 +78,10 @@ type PoolManager interface {
 	// Settings are provided as a map and internally converted via the shared SettingsCache.
 	// Optional ReservedConnOption values configure validate-with-retry behavior.
 	NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
+
+	// NewReservedConnWithAuth is NewReservedConn that also carries SCRAM
+	// passthrough keys. Keys are consumed only on first pool creation.
+	NewReservedConnWithAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
 
 	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
 	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -55,33 +55,28 @@ type PoolManager interface {
 
 	// --- Regular Pool Operations ---
 
-	// GetRegularConn acquires a regular connection for the specified user.
-	GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error)
+	// GetRegularConn acquires a regular connection for the specified user,
+	// optionally carrying SCRAM passthrough keys from the caller's session.
+	// Keys may be nil for admin/internal callers that dial via the
+	// local-trust line in pg_hba.conf. When non-nil, keys are consumed only
+	// when this call triggers first-time user-pool creation; subsequent
+	// calls reuse the existing pool regardless of the keys they pass.
+	GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
 
-	// GetRegularConnWithAuth is GetRegularConn that also carries SCRAM
-	// passthrough keys from the caller's session. Keys are consumed only when
-	// this call triggers first-time user-pool creation.
-	GetRegularConnWithAuth(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
-
-	// GetRegularConnWithSettings acquires a regular connection with specific settings for the user.
-	// Settings are provided as a map and internally converted via the shared SettingsCache.
-	GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error)
-
-	// GetRegularConnWithSettingsAndAuth is GetRegularConnWithSettings that
-	// also carries SCRAM passthrough keys. Keys are consumed only on first
-	// pool creation for the user.
-	GetRegularConnWithSettingsAndAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
+	// GetRegularConnWithSettings is GetRegularConn that additionally applies
+	// per-session settings. Settings are provided as a map and internally
+	// converted via the shared SettingsCache.
+	GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
 
 	// --- Reserved Pool Operations ---
 
-	// NewReservedConn creates a new reserved connection for the specified user.
-	// Settings are provided as a map and internally converted via the shared SettingsCache.
-	// Optional ReservedConnOption values configure validate-with-retry behavior.
-	NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
-
-	// NewReservedConnWithAuth is NewReservedConn that also carries SCRAM
-	// passthrough keys. Keys are consumed only on first pool creation.
-	NewReservedConnWithAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
+	// NewReservedConn creates a new reserved connection for the specified
+	// user, optionally carrying SCRAM passthrough keys. Settings are
+	// provided as a map and internally converted via the shared
+	// SettingsCache. Optional ReservedConnOption values configure
+	// validate-with-retry behavior. Key-consumption semantics match
+	// GetRegularConn.
+	NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
 
 	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
 	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
@@ -468,15 +469,67 @@ func (m *Manager) NewReservedConnWithAuth(ctx context.Context, settings map[stri
 	})
 }
 
-// withReopenRetry runs op against the current user pool and, if op returns
-// ErrPoolClosed because a concurrent reopenConnections() swapped the pools
-// mid-flight, retries once against the fresh pool. Genuine closed-pool errors
-// (manager shutting down for real) are surfaced to the caller unchanged
-// because the generation will not have advanced.
+// evictUserPool removes stale from the snapshot and closes it. Used when a
+// pool's cached SCRAM keys no longer match pg_authid — typically because the
+// user rotated their PostgreSQL password — so the next getOrCreateUserPool
+// call rebuilds from the triggering session's fresh keys.
+//
+// Eviction is a no-op (returns false) if a racing caller already swapped the
+// snapshot to a different pool for this user, or dropped the entry entirely.
+// Callers should still retry against whatever the snapshot now holds: the
+// racing caller's fresh pool is the right target, and if the entry is gone
+// getOrCreateUserPool creates a new one.
+func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
+	m.createMu.Lock()
+	defer m.createMu.Unlock()
+
+	pools := m.userPoolsSnapshot.Load()
+	if pools == nil {
+		return false
+	}
+	current, ok := (*pools)[user]
+	if !ok || current != stale {
+		return false
+	}
+
+	newPools := make(map[string]*UserPool, len(*pools)-1)
+	for u, p := range *pools {
+		if u == user {
+			continue
+		}
+		newPools[u] = p
+	}
+	m.userPoolsSnapshot.Store(&newPools)
+
+	// Close outside the createMu critical section would be safer for latency
+	// but Close is cheap and racing creators already passed the double-check
+	// by now, so finishing synchronously keeps invariants simple.
+	stale.Close()
+	m.logger.InfoContext(m.ctx, "evicted user pool after stale credentials detected", "user", user)
+	return true
+}
+
+// withReopenRetry runs op against the current user pool with two single-shot
+// retry paths for transient, self-healable failures:
+//
+//  1. ErrPoolClosed after a generation bump: reopenConnections() swapped the
+//     pools mid-flight (PostgreSQL auto-restart recovery). Retry against the
+//     fresh pool. A closed-pool error with no generation bump means the
+//     manager is genuinely shutting down — surface it unchanged.
+//
+//  2. Class-28 SQLSTATE from PostgreSQL: the cached user pool's ClientConfig
+//     carries stale SCRAM keys (password rotated in pg_authid). Evict the
+//     pool and recreate from the triggering session's keys, which are
+//     known-current — they were derived moments ago during the session's
+//     SCRAM handshake at MultiGateway against whatever verifier pg_authid
+//     holds right now. If the retry also auth-fails (retrier itself used the
+//     old password at the gateway), we surface the clean 28xxx error and the
+//     client reconnects to re-derive keys against the new verifier.
 //
 // clientKey and serverKey forward the SCRAM passthrough material to
 // getOrCreateUserPool so that a first-time pool creation triggered during
-// this call (including after a reopen swap) gets the session's keys.
+// this call (including after an eviction or reopen swap) gets the session's
+// keys.
 func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
 	startGen := m.generation.Load()
@@ -485,17 +538,36 @@ func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte
 		return zero, err
 	}
 	result, err := op(pool)
-	if err == nil || !errors.Is(err, connpool.ErrPoolClosed) {
-		return result, err
+	if err == nil {
+		return result, nil
 	}
-	if m.generation.Load() == startGen {
-		return zero, err
+
+	// Manager-restart race: reopenConnections swapped pools mid-flight.
+	if errors.Is(err, connpool.ErrPoolClosed) {
+		if m.generation.Load() == startGen {
+			return zero, err
+		}
+		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
+		if err2 != nil {
+			return zero, err2
+		}
+		return op(pool2)
 	}
-	pool, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
-	if err2 != nil {
-		return zero, err2
+
+	// Stale-key self-heal. evictUserPool is best-effort; even if it returns
+	// false (racing eviction), getOrCreateUserPool returns whatever is in the
+	// snapshot now, which is either a freshly-created pool with fresh keys
+	// or absent (and we create one).
+	if mterrors.IsAuthenticationError(err) {
+		m.evictUserPool(user, pool)
+		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
+		if err2 != nil {
+			return zero, err2
+		}
+		return op(pool2)
 	}
-	return op(pool)
+
+	return zero, err
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -208,13 +208,14 @@ func (m *Manager) buildClientConfig(user, password string) *client.Config {
 }
 
 // buildUserClientConfig creates a client.Config for a per-user pool dial.
-// When SCRAM passthrough is enabled and the session carried ClientKey /
-// ServerKey (forwarded via ExecuteOptions.UserAuth), the returned config
-// authenticates to PostgreSQL using those keys. Otherwise the config uses
-// the existing empty-password trust path, matching today's behavior.
+// When the session carried ClientKey / ServerKey (forwarded via
+// ExecuteOptions.UserAuth), the returned config authenticates to PostgreSQL
+// using those keys. Absent keys fall back to the empty-password path, which
+// only succeeds against a pg_hba.conf that still trusts the local socket for
+// the dialing user — the template's narrow admin-user trust exception.
 func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte) *client.Config {
 	cfg := m.buildClientConfig(user, "")
-	if m.config.ScramPassthrough() && len(clientKey) > 0 && len(serverKey) > 0 {
+	if len(clientKey) > 0 && len(serverKey) > 0 {
 		cfg.ScramClientKey = clientKey
 		cfg.ScramServerKey = serverKey
 	}

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -130,6 +130,17 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	// Build admin client config
 	adminClientConfig := m.buildClientConfig(m.config.PgUser(), m.config.PgPassword())
 
+	// Warn operators when running with an empty admin password. The shipped
+	// pg_hba template retains trust on the local socket only for the configured
+	// admin user, so this path continues to work during the bootstrap window.
+	// Once that trust exception is closed (tracked as a TODO in the template),
+	// an empty password will cause admin dials to fail.
+	if m.config.PgPassword() == "" {
+		m.logger.WarnContext(ctx, "admin password is empty; multipooler relies on the local-socket trust exception in pg_hba.conf. Configure CONNPOOL_ADMIN_PASSWORD (or POSTGRES_PASSWORD) before the trust line is removed.",
+			"pg_user", m.config.PgUser(),
+		)
+	}
+
 	// Build admin pool config
 	connectTimeout := 2 * m.config.DialTimeout()
 	adminPoolConfig := &connpool.Config{
@@ -183,6 +194,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 }
 
 // buildClientConfig creates a client.Config with the specified user and password.
+// Used by the admin pool and by user pools when SCRAM passthrough is disabled.
 func (m *Manager) buildClientConfig(user, password string) *client.Config {
 	return &client.Config{
 		SocketFile:  m.connConfig.SocketFile,
@@ -195,12 +207,34 @@ func (m *Manager) buildClientConfig(user, password string) *client.Config {
 	}
 }
 
+// buildUserClientConfig creates a client.Config for a per-user pool dial.
+// When SCRAM passthrough is enabled and the session carried ClientKey /
+// ServerKey (forwarded via ExecuteOptions.UserAuth), the returned config
+// authenticates to PostgreSQL using those keys. Otherwise the config uses
+// the existing empty-password trust path, matching today's behavior.
+func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte) *client.Config {
+	cfg := m.buildClientConfig(user, "")
+	if m.config.ScramPassthrough() && len(clientKey) > 0 && len(serverKey) > 0 {
+		cfg.ScramClientKey = clientKey
+		cfg.ScramServerKey = serverKey
+	}
+	return cfg
+}
+
 // getOrCreateUserPool returns the pool for the given user, creating it if needed.
 //
 // This method uses an atomic snapshot pattern for lock-free reads on the hot path.
 // For existing users, this completes with just an atomic load and map lookup.
 // Only new user creation acquires the createMu mutex.
-func (m *Manager) getOrCreateUserPool(user string) (*UserPool, error) {
+//
+// clientKey and serverKey are the SCRAM passthrough keys forwarded by the
+// gateway on the triggering RPC. They are consumed only when a new pool is
+// created (cold path); subsequent RPCs for the same user reuse the existing
+// pool regardless of the keys they carry. ClientKey is deterministic per
+// (user, password) in PostgreSQL's SCRAM scheme, so cached keys stay valid
+// until the user's password rotates; password rotation is surfaced via SCRAM
+// auth failure on the next dial.
+func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) (*UserPool, error) {
 	if user == "" {
 		return nil, errors.New("user cannot be empty")
 	}
@@ -220,12 +254,12 @@ func (m *Manager) getOrCreateUserPool(user string) (*UserPool, error) {
 	// Cold path: need to create a new user pool.
 	// Use the manager's lifecycle context so the pool is tied to the manager's
 	// lifetime, not the caller's request context.
-	return m.createUserPoolSlow(m.ctx, user)
+	return m.createUserPoolSlow(m.ctx, user, clientKey, serverKey)
 }
 
 // createUserPoolSlow creates a new user pool. This is the cold path that requires
 // acquiring the createMu mutex.
-func (m *Manager) createUserPoolSlow(ctx context.Context, user string) (*UserPool, error) {
+func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey, serverKey []byte) (*UserPool, error) {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
 
@@ -264,7 +298,7 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string) (*UserPoo
 	// the capacity based on demand within a few seconds.
 	userConnectTimeout := 2 * m.config.DialTimeout()
 	pool, err := NewUserPool(ctx, &UserPoolConfig{
-		ClientConfig: m.buildClientConfig(user, ""), // Trust auth - no password
+		ClientConfig: m.buildUserClientConfig(user, clientKey, serverKey),
 		AdminPool:    m.adminPool,
 		RegularPoolConfig: &connpool.Config{
 			Name:            "regular:" + user,
@@ -383,7 +417,15 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 // GetRegularConn acquires a regular connection for the specified user.
 // The caller must call Recycle() on the returned connection to return it to the pool.
 func (m *Manager) GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error) {
-	return withReopenRetry(m, user, func(pool *UserPool) (regular.PooledConn, error) {
+	return m.GetRegularConnWithAuth(ctx, user, nil, nil)
+}
+
+// GetRegularConnWithAuth is GetRegularConn that additionally carries SCRAM
+// passthrough keys from the caller's session. The keys are consumed only when
+// this call triggers first-time pool creation for the user; subsequent calls
+// reuse the existing pool regardless of the keys they pass.
+func (m *Manager) GetRegularConnWithAuth(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
+	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConn(ctx)
 	})
 }
@@ -392,8 +434,15 @@ func (m *Manager) GetRegularConn(ctx context.Context, user string) (regular.Pool
 // Settings are converted via the shared SettingsCache for consistent bucket assignment.
 // The caller must call Recycle() on the returned connection to return it to the pool.
 func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error) {
+	return m.GetRegularConnWithSettingsAndAuth(ctx, settings, user, nil, nil)
+}
+
+// GetRegularConnWithSettingsAndAuth is GetRegularConnWithSettings that also
+// carries SCRAM passthrough keys. Key-consumption semantics match
+// GetRegularConnWithAuth.
+func (m *Manager) GetRegularConnWithSettingsAndAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConnWithSettings(ctx, s)
 	})
 }
@@ -403,10 +452,17 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // NewReservedConn creates a new reserved connection for the specified user.
 // Settings are converted via the shared SettingsCache for consistent bucket assignment.
 // The connection is assigned a unique ID for client-side tracking.
+// Optional ReservedConnOption values configure validate-with-retry behavior.
 // The caller must call Release() when done with the connection.
 func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+	return m.NewReservedConnWithAuth(ctx, settings, user, nil, nil, opts...)
+}
+
+// NewReservedConnWithAuth is NewReservedConn that also carries SCRAM
+// passthrough keys. Key-consumption semantics match GetRegularConnWithAuth.
+func (m *Manager) NewReservedConnWithAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewReservedConn(ctx, s, opts...)
 	})
 }
@@ -416,10 +472,14 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 // mid-flight, retries once against the fresh pool. Genuine closed-pool errors
 // (manager shutting down for real) are surfaced to the caller unchanged
 // because the generation will not have advanced.
-func withReopenRetry[T any](m *Manager, user string, op func(*UserPool) (T, error)) (T, error) {
+//
+// clientKey and serverKey forward the SCRAM passthrough material to
+// getOrCreateUserPool so that a first-time pool creation triggered during
+// this call (including after a reopen swap) gets the session's keys.
+func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
 	startGen := m.generation.Load()
-	pool, err := m.getOrCreateUserPool(user)
+	pool, err := m.getOrCreateUserPool(user, clientKey, serverKey)
 	if err != nil {
 		return zero, err
 	}
@@ -430,7 +490,7 @@ func withReopenRetry[T any](m *Manager, user string, op func(*UserPool) (T, erro
 	if m.generation.Load() == startGen {
 		return zero, err
 	}
-	pool, err2 := m.getOrCreateUserPool(user)
+	pool, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
 	if err2 != nil {
 		return zero, err2
 	}

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -416,33 +416,23 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 
 // --- Regular Pool Operations ---
 
-// GetRegularConn acquires a regular connection for the specified user.
-// The caller must call Recycle() on the returned connection to return it to the pool.
-func (m *Manager) GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error) {
-	return m.GetRegularConnWithAuth(ctx, user, nil, nil)
-}
-
-// GetRegularConnWithAuth is GetRegularConn that additionally carries SCRAM
-// passthrough keys from the caller's session. The keys are consumed only when
-// this call triggers first-time pool creation for the user; subsequent calls
-// reuse the existing pool regardless of the keys they pass.
-func (m *Manager) GetRegularConnWithAuth(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
+// GetRegularConn acquires a regular connection for the specified user,
+// optionally carrying SCRAM passthrough keys from the caller's session. Keys
+// may be nil for admin/internal callers that dial via the local-trust line in
+// pg_hba.conf. When non-nil, keys are consumed only when this call triggers
+// first-time pool creation for the user; subsequent calls reuse the existing
+// pool regardless of the keys they pass. The caller must call Recycle() on
+// the returned connection to return it to the pool.
+func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConn(ctx)
 	})
 }
 
-// GetRegularConnWithSettings acquires a regular connection with specific settings for the user.
-// Settings are converted via the shared SettingsCache for consistent bucket assignment.
-// The caller must call Recycle() on the returned connection to return it to the pool.
-func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error) {
-	return m.GetRegularConnWithSettingsAndAuth(ctx, settings, user, nil, nil)
-}
-
-// GetRegularConnWithSettingsAndAuth is GetRegularConnWithSettings that also
-// carries SCRAM passthrough keys. Key-consumption semantics match
-// GetRegularConnWithAuth.
-func (m *Manager) GetRegularConnWithSettingsAndAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
+// GetRegularConnWithSettings is GetRegularConn that additionally applies
+// per-session settings. Settings are converted via the shared SettingsCache
+// for consistent bucket assignment.
+func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
 	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConnWithSettings(ctx, s)
@@ -451,18 +441,14 @@ func (m *Manager) GetRegularConnWithSettingsAndAuth(ctx context.Context, setting
 
 // --- Reserved Pool Operations ---
 
-// NewReservedConn creates a new reserved connection for the specified user.
-// Settings are converted via the shared SettingsCache for consistent bucket assignment.
-// The connection is assigned a unique ID for client-side tracking.
-// Optional ReservedConnOption values configure validate-with-retry behavior.
-// The caller must call Release() when done with the connection.
-func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
-	return m.NewReservedConnWithAuth(ctx, settings, user, nil, nil, opts...)
-}
-
-// NewReservedConnWithAuth is NewReservedConn that also carries SCRAM
-// passthrough keys. Key-consumption semantics match GetRegularConnWithAuth.
-func (m *Manager) NewReservedConnWithAuth(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+// NewReservedConn creates a new reserved connection for the specified user,
+// optionally carrying SCRAM passthrough keys. Settings are converted via the
+// shared SettingsCache for consistent bucket assignment. The connection is
+// assigned a unique ID for client-side tracking. Optional ReservedConnOption
+// values configure validate-with-retry behavior. Key-consumption semantics
+// match GetRegularConn. The caller must call Release() when done with the
+// connection.
+func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
 	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewReservedConn(ctx, s, opts...)

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -371,8 +371,11 @@ func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
 	assert.Equal(t, 2, calls, "should retry exactly once after auth failure")
 	require.Len(t, seenPools, 2)
 	assert.NotSame(t, seenPools[0], seenPools[1], "retry must run against a freshly-built pool, not the evicted one")
-	assert.False(t, manager.HasUserPool("testuser") && manager.userPoolsSnapshot.Load() != nil && (*manager.userPoolsSnapshot.Load())["testuser"] == seenPools[0],
-		"the original stale pool must no longer be in the snapshot")
+
+	snap := manager.userPoolsSnapshot.Load()
+	require.NotNil(t, snap, "snapshot must be loaded after retry")
+	assert.True(t, manager.HasUserPool("testuser"), "user pool must be present in fresh snapshot")
+	assert.NotSame(t, seenPools[0], (*snap)["testuser"], "the original stale pool must no longer be in the snapshot")
 }
 
 // TestWithReopenRetry_SurfacesPersistentAuthError ensures that if the retry

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -16,6 +16,7 @@ package connpoolmanager
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
@@ -336,6 +338,125 @@ func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
 	assert.Equal(t, 2, calls, "should retry exactly once, not loop")
+}
+
+// TestWithReopenRetry_EvictsStalePoolOnAuthError verifies the stale-key
+// self-heal path: when op fails with a class-28 SQLSTATE (SCRAM auth
+// failure against stale cached keys), withReopenRetry must evict the
+// user pool and retry once against a freshly-built replacement so the
+// session's known-current keys get a chance against pg_authid.
+func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	authErr := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01", Message: "password authentication failed"}
+
+	var seenPools []*UserPool
+	calls := 0
+	result, err := withReopenRetry(manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
+		calls++
+		seenPools = append(seenPools, pool)
+		if calls == 1 {
+			return 0, fmt.Errorf("dial failed: %w", authErr)
+		}
+		return 42, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+	assert.Equal(t, 2, calls, "should retry exactly once after auth failure")
+	require.Len(t, seenPools, 2)
+	assert.NotSame(t, seenPools[0], seenPools[1], "retry must run against a freshly-built pool, not the evicted one")
+	assert.False(t, manager.HasUserPool("testuser") && manager.userPoolsSnapshot.Load() != nil && (*manager.userPoolsSnapshot.Load())["testuser"] == seenPools[0],
+		"the original stale pool must no longer be in the snapshot")
+}
+
+// TestWithReopenRetry_SurfacesPersistentAuthError ensures that if the retry
+// also fails with an auth error — e.g. because the retrier itself is holding
+// old-password keys — we surface the clean 28xxx error and stop retrying.
+// Without a retry cap this would loop forever.
+func TestWithReopenRetry_SurfacesPersistentAuthError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	authErr := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01", Message: "password authentication failed"}
+
+	calls := 0
+	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 0, fmt.Errorf("dial failed: %w", authErr)
+	})
+
+	require.Error(t, err)
+	assert.True(t, mterrors.IsAuthenticationError(err), "auth error must propagate with class-28 SQLSTATE intact")
+	assert.Equal(t, 2, calls, "should retry exactly once, not loop")
+}
+
+// TestEvictUserPool_RemovesFromSnapshotAndCloses verifies the direct
+// eviction primitive: removes the pool from the snapshot, closes it, and
+// returns true. A subsequent acquire must build a fresh pool.
+func TestEvictUserPool_RemovesFromSnapshotAndCloses(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Warm up: create a user pool.
+	stale, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	require.NoError(t, err)
+	require.True(t, manager.HasUserPool("testuser"))
+
+	evicted := manager.evictUserPool("testuser", stale)
+	assert.True(t, evicted, "eviction of the current pool should return true")
+	assert.False(t, manager.HasUserPool("testuser"), "pool must be removed from snapshot")
+
+	// Subsequent acquire must produce a different pool instance.
+	fresh, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	require.NoError(t, err)
+	assert.NotSame(t, stale, fresh, "post-eviction acquire must build a fresh pool")
+
+	// Real acquisition must still work against the fresh pool.
+	conn, err := manager.GetRegularConn(ctx, "testuser")
+	require.NoError(t, err)
+	conn.Recycle()
+}
+
+// TestEvictUserPool_NoOpOnRacingEviction verifies that evicting a stale
+// reference that no longer matches the snapshot (because a concurrent call
+// already swapped it) is a no-op and returns false — preventing callers
+// from clobbering a fresh pool built by a racing goroutine.
+func TestEvictUserPool_NoOpOnRacingEviction(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	stale, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	require.NoError(t, err)
+
+	// Racing goroutine already evicted + recreated.
+	require.True(t, manager.evictUserPool("testuser", stale))
+	fresh, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	require.NoError(t, err)
+	require.NotSame(t, stale, fresh)
+
+	// Late caller still holding the stale reference must not clobber fresh.
+	assert.False(t, manager.evictUserPool("testuser", stale), "stale reference must not evict the fresh pool")
+	assert.True(t, manager.HasUserPool("testuser"), "fresh pool must remain in the snapshot")
 }
 
 // TestManager_NewReservedConn_SurvivesReopen exercises the end-to-end path:

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -775,39 +775,14 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 
 // --- SCRAM passthrough ---
 
-// TestBuildUserClientConfig_FlagOff_KeysIgnored verifies that when the
-// passthrough flag is disabled, keys passed in are dropped and the resulting
-// config falls back to the existing empty-password path.
-func TestBuildUserClientConfig_FlagOff_KeysIgnored(t *testing.T) {
-	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "false")
-
+// TestBuildUserClientConfig_KeysApplied verifies that when both keys are
+// supplied, the resulting client.Config carries them through to the dial.
+func TestBuildUserClientConfig_KeysApplied(t *testing.T) {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
 	defer manager.Close()
-	require.False(t, config.ScramPassthrough(), "flag must be false for this scenario")
-
-	cfg := manager.buildUserClientConfig("alice", bytes32(1), bytes32(2))
-
-	assert.Empty(t, cfg.Password)
-	assert.Nil(t, cfg.ScramClientKey)
-	assert.Nil(t, cfg.ScramServerKey)
-	assert.Equal(t, "alice", cfg.User)
-}
-
-// TestBuildUserClientConfig_FlagOn_KeysApplied verifies that when the flag
-// is enabled AND both keys are supplied, the resulting client.Config carries
-// them through to the dial.
-func TestBuildUserClientConfig_FlagOn_KeysApplied(t *testing.T) {
-	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "true")
-
-	reg := viperutil.NewRegistry()
-	config := NewConfig(reg)
-	manager := config.NewManager(slog.Default())
-	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
-	defer manager.Close()
-	require.True(t, config.ScramPassthrough(), "flag must be true for this scenario")
 
 	ck, sk := bytes32(1), bytes32(2)
 	cfg := manager.buildUserClientConfig("alice", ck, sk)
@@ -815,14 +790,15 @@ func TestBuildUserClientConfig_FlagOn_KeysApplied(t *testing.T) {
 	assert.Equal(t, ck, cfg.ScramClientKey)
 	assert.Equal(t, sk, cfg.ScramServerKey)
 	assert.Empty(t, cfg.Password)
+	assert.Equal(t, "alice", cfg.User)
 }
 
-// TestBuildUserClientConfig_FlagOn_NilKeys_FallsBack ensures that an
+// TestBuildUserClientConfig_NilKeys_FallsBack ensures that an
 // authenticated-but-keyless session (not expected in practice, but possible
 // during rollout) does not crash and falls back to the empty-password path.
-func TestBuildUserClientConfig_FlagOn_NilKeys_FallsBack(t *testing.T) {
-	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "true")
-
+// An empty-password dial only succeeds against the pg_hba admin-user trust
+// exception; any other user will fail authentication at PostgreSQL.
+func TestBuildUserClientConfig_NilKeys_FallsBack(t *testing.T) {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
 	manager := config.NewManager(slog.Default())

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -275,7 +275,7 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	result, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+	result, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		if calls == 1 {
 			// Simulate reopenConnections running mid-flight: the pool we
@@ -304,7 +304,7 @@ func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		// No generation bump — manager hasn't been reopened.
 		return 0, connpool.ErrPoolClosed
@@ -327,7 +327,7 @@ func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		manager.generation.Add(1)
 		return 0, connpool.ErrPoolClosed
@@ -771,4 +771,76 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 		}
 		conn.Recycle()
 	}
+}
+
+// --- SCRAM passthrough ---
+
+// TestBuildUserClientConfig_FlagOff_KeysIgnored verifies that when the
+// passthrough flag is disabled, keys passed in are dropped and the resulting
+// config falls back to the existing empty-password path.
+func TestBuildUserClientConfig_FlagOff_KeysIgnored(t *testing.T) {
+	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "false")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
+	defer manager.Close()
+	require.False(t, config.ScramPassthrough(), "flag must be false for this scenario")
+
+	cfg := manager.buildUserClientConfig("alice", bytes32(1), bytes32(2))
+
+	assert.Empty(t, cfg.Password)
+	assert.Nil(t, cfg.ScramClientKey)
+	assert.Nil(t, cfg.ScramServerKey)
+	assert.Equal(t, "alice", cfg.User)
+}
+
+// TestBuildUserClientConfig_FlagOn_KeysApplied verifies that when the flag
+// is enabled AND both keys are supplied, the resulting client.Config carries
+// them through to the dial.
+func TestBuildUserClientConfig_FlagOn_KeysApplied(t *testing.T) {
+	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "true")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
+	defer manager.Close()
+	require.True(t, config.ScramPassthrough(), "flag must be true for this scenario")
+
+	ck, sk := bytes32(1), bytes32(2)
+	cfg := manager.buildUserClientConfig("alice", ck, sk)
+
+	assert.Equal(t, ck, cfg.ScramClientKey)
+	assert.Equal(t, sk, cfg.ScramServerKey)
+	assert.Empty(t, cfg.Password)
+}
+
+// TestBuildUserClientConfig_FlagOn_NilKeys_FallsBack ensures that an
+// authenticated-but-keyless session (not expected in practice, but possible
+// during rollout) does not crash and falls back to the empty-password path.
+func TestBuildUserClientConfig_FlagOn_NilKeys_FallsBack(t *testing.T) {
+	t.Setenv("MULTIPOOLER_SCRAM_PASSTHROUGH", "true")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
+	defer manager.Close()
+
+	cfg := manager.buildUserClientConfig("alice", nil, nil)
+
+	assert.Nil(t, cfg.ScramClientKey)
+	assert.Nil(t, cfg.ScramServerKey)
+	assert.Empty(t, cfg.Password)
+}
+
+// bytes32 returns a deterministic 32-byte slice for key testing.
+func bytes32(seed byte) []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = seed
+	}
+	return out
 }

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -77,7 +77,7 @@ func TestManager_Close(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a connection to create a user pool.
-	conn, err := manager.GetRegularConn(ctx, "testuser")
+	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -139,7 +139,7 @@ func TestManager_GetRegularConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a regular connection for a user.
-	conn, err := manager.GetRegularConn(ctx, "testuser")
+	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -163,7 +163,7 @@ func TestManager_GetRegularConn_EmptyUser(t *testing.T) {
 	ctx := context.Background()
 
 	// Empty user should error.
-	_, err := manager.GetRegularConn(ctx, "")
+	_, err := manager.GetRegularConn(ctx, "", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "user cannot be empty")
 }
@@ -179,7 +179,7 @@ func TestManager_GetRegularConn_ClosedManager(t *testing.T) {
 	ctx := context.Background()
 
 	// Closed manager should error.
-	_, err := manager.GetRegularConn(ctx, "testuser")
+	_, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "manager is closed")
 }
@@ -202,7 +202,7 @@ func TestManager_GetRegularConnWithSettings(t *testing.T) {
 	}
 
 	// Get a connection with settings.
-	conn, err := manager.GetRegularConnWithSettings(ctx, settings, "testuser")
+	conn, err := manager.GetRegularConnWithSettings(ctx, settings, "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -226,7 +226,7 @@ func TestManager_NewReservedConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a reserved connection.
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -253,7 +253,7 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 	}
 
 	// Create a reserved connection with settings.
-	conn, err := manager.NewReservedConn(ctx, settings, "testuser")
+	conn, err := manager.NewReservedConn(ctx, settings, "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -431,7 +431,7 @@ func TestEvictUserPool_RemovesFromSnapshotAndCloses(t *testing.T) {
 	assert.NotSame(t, stale, fresh, "post-eviction acquire must build a fresh pool")
 
 	// Real acquisition must still work against the fresh pool.
-	conn, err := manager.GetRegularConn(ctx, "testuser")
+	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 }
@@ -477,7 +477,7 @@ func TestManager_NewReservedConn_SurvivesReopen(t *testing.T) {
 	ctx := context.Background()
 
 	// Warm up: create a user pool.
-	c1, err := manager.NewReservedConn(ctx, nil, "testuser")
+	c1, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
 	require.NoError(t, err)
 	c1.Release(reserved.ReleaseCommit)
 
@@ -491,7 +491,7 @@ func TestManager_NewReservedConn_SurvivesReopen(t *testing.T) {
 	})
 
 	// Reserved-conn acquisition must succeed against the fresh pool.
-	c2, err := manager.NewReservedConn(ctx, nil, "testuser")
+	c2, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, c2)
 	c2.Release(reserved.ReleaseCommit)
@@ -508,7 +508,7 @@ func TestManager_GetReservedConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a reserved connection.
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
 	require.NoError(t, err)
 	connID := conn.ConnID()
 
@@ -562,11 +562,11 @@ func TestManager_Stats(t *testing.T) {
 	assert.Empty(t, stats.UserPools)
 
 	// Create some user pools.
-	conn1, err := manager.GetRegularConn(ctx, "user1")
+	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2")
+	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
@@ -588,15 +588,15 @@ func TestManager_UserPoolReuse(t *testing.T) {
 	ctx := context.Background()
 
 	// Get connections for the same user multiple times.
-	conn1, err := manager.GetRegularConn(ctx, "testuser")
+	conn1, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "testuser")
+	conn2, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
-	conn3, err := manager.GetRegularConn(ctx, "testuser")
+	conn3, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn3.Recycle()
 
@@ -621,7 +621,7 @@ func TestManager_ConcurrentUserPoolCreation(t *testing.T) {
 	// Concurrently create connections for the same user.
 	for range numGoroutines {
 		wg.Go(func() {
-			conn, err := manager.GetRegularConn(ctx, "concurrent-user")
+			conn, err := manager.GetRegularConn(ctx, "concurrent-user", nil, nil)
 			if err != nil {
 				errs <- err
 				return
@@ -661,7 +661,7 @@ func TestManager_ConcurrentDifferentUsers(t *testing.T) {
 		go func(userNum int) {
 			defer wg.Done()
 			user := "user" + string(rune('A'+userNum))
-			conn, err := manager.GetRegularConn(ctx, user)
+			conn, err := manager.GetRegularConn(ctx, user, nil, nil)
 			if err != nil {
 				t.Errorf("unexpected error for %s: %v", user, err)
 				return
@@ -693,12 +693,12 @@ func TestManager_SettingsCacheIntegration(t *testing.T) {
 	}
 
 	// Get connections with the same settings multiple times.
-	conn1, err := manager.GetRegularConnWithSettings(ctx, settings, "user1")
+	conn1, err := manager.GetRegularConnWithSettings(ctx, settings, "user1", nil, nil)
 	require.NoError(t, err)
 	settings1 := conn1.Conn.Settings()
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConnWithSettings(ctx, settings, "user2")
+	conn2, err := manager.GetRegularConnWithSettings(ctx, settings, "user2", nil, nil)
 	require.NoError(t, err)
 	settings2 := conn2.Conn.Settings()
 	conn2.Recycle()
@@ -723,7 +723,7 @@ func TestManager_ApplySettingsToConn(t *testing.T) {
 
 	// Create a reserved connection with initial settings.
 	initialSettings := map[string]string{"search_path": "public"}
-	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser")
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -753,7 +753,7 @@ func TestManager_ApplySettingsToConn_SameSettings(t *testing.T) {
 	ctx := context.Background()
 
 	settings := map[string]string{"search_path": "public"}
-	conn, err := manager.NewReservedConn(ctx, settings, "testuser")
+	conn, err := manager.NewReservedConn(ctx, settings, "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -778,7 +778,7 @@ func TestManager_ApplySettingsToConn_NilSettings(t *testing.T) {
 
 	ctx := context.Background()
 
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser")
+	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -803,7 +803,7 @@ func TestManager_ApplySettingsToConn_RemovedSettings(t *testing.T) {
 
 	// Create a reserved connection with two settings.
 	initialSettings := map[string]string{"search_path": "public", "work_mem": "256MB"}
-	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser")
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -841,7 +841,7 @@ func BenchmarkManager_GetUserPool_HotPath(b *testing.B) {
 	defer manager.Close()
 
 	// Create the user pool first (cold path)
-	conn, err := manager.GetRegularConn(ctx, "benchuser")
+	conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
 	if err != nil {
 		b.Fatalf("failed to create user pool: %v", err)
 	}
@@ -880,7 +880,7 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 	defer manager.Close()
 
 	// Create the user pool first
-	conn, err := manager.GetRegularConn(ctx, "benchuser")
+	conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
 	if err != nil {
 		b.Fatalf("failed to create user pool: %v", err)
 	}
@@ -889,7 +889,7 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 	// Benchmark getting connections for existing user
 	b.ResetTimer()
 	for b.Loop() {
-		conn, err := manager.GetRegularConn(ctx, "benchuser")
+		conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
 		if err != nil {
 			b.Fatalf("failed to get connection: %v", err)
 		}

--- a/go/services/multipooler/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/connpoolmanager/rebalancer_test.go
@@ -91,11 +91,11 @@ func TestManager_RebalanceWithUsers(t *testing.T) {
 	ctx := context.Background()
 
 	// Create some user pools
-	conn1, err := manager.GetRegularConn(ctx, "user1")
+	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2")
+	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
@@ -121,7 +121,7 @@ func TestManager_GarbageCollectInactivePools_ManualTest(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "inactive-user")
+	conn, err := manager.GetRegularConn(ctx, "inactive-user", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -153,7 +153,7 @@ func TestManager_GarbageCollectPreservesActivePool(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "active-user")
+	conn, err := manager.GetRegularConn(ctx, "active-user", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -176,11 +176,11 @@ func TestManager_GarbageCollectMixedPools(t *testing.T) {
 	ctx := context.Background()
 
 	// Create two user pools
-	conn1, err := manager.GetRegularConn(ctx, "user1")
+	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2")
+	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
@@ -213,7 +213,7 @@ func TestManager_RebalancerLoop(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "testuser")
+	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -251,7 +251,7 @@ func TestManager_DemandTrackersCreated(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "testuser")
+	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -126,7 +126,8 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	}
 
 	// Get a connection from the pool for this user
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user)
+	clientKey, serverKey := scramKeysFromOptions(options)
+	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -232,7 +233,8 @@ func (e *Executor) StreamExecute(
 	}
 
 	// Get a connection from the pool for this user
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user)
+	clientKey, serverKey := scramKeysFromOptions(options)
+	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -305,7 +307,8 @@ func (e *Executor) reserveAndStreamExecute(
 	}
 
 	// Create a reserved connection
-	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user, reservedOpts...)
+	clientKey, serverKey := scramKeysFromOptions(options)
+	reservedConn, err := e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reservedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
@@ -474,7 +477,8 @@ func (e *Executor) PortalStreamExecute(
 	}
 
 	// Use regular connection for non-suspended execution with no existing reservation
-	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, includeDescribe, paramFormats, resultFormats, callback)
+	clientKey, serverKey := scramKeysFromOptions(options)
+	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, includeDescribe, clientKey, serverKey, paramFormats, resultFormats, callback)
 }
 
 // portalExecuteWithReserved executes a portal using a reserved connection.
@@ -507,7 +511,8 @@ func (e *Executor) portalExecuteWithReserved(
 		// closed by PostgreSQL. The post-acquire ensurePrepared call
 		// below is a no-op for the new-conn path because connState
 		// dedupes by canonical name.
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+		clientKey, serverKey := scramKeysFromOptions(options)
+		reservedConn, err = e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
 			_, err := e.ensurePrepared(ctx, conn, preparedStatement)
 			return err
 		}))
@@ -558,6 +563,8 @@ func (e *Executor) portalExecuteWithReserved(
 }
 
 // portalExecuteWithRegular executes a portal using a regular pooled connection.
+// clientKey and serverKey are the SCRAM passthrough keys forwarded by the
+// caller's session; see connpoolmanager.GetRegularConnWithAuth.
 func (e *Executor) portalExecuteWithRegular(
 	ctx context.Context,
 	preparedStatement *query.PreparedStatement,
@@ -565,10 +572,11 @@ func (e *Executor) portalExecuteWithRegular(
 	settings map[string]string,
 	user string,
 	includeDescribe bool,
+	clientKey, serverKey []byte,
 	paramFormats, resultFormats []int16,
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user)
+	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -644,7 +652,8 @@ func (e *Executor) Describe(
 
 		conn = reservedConn.Conn()
 	} else {
-		pooled, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user)
+		clientKey, serverKey := scramKeysFromOptions(options)
+		pooled, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 		}
@@ -820,7 +829,8 @@ func (e *Executor) CopyReady(
 			return nil
 		}
 
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, reserved.WithValidate(validate))
+		clientKey, serverKey := scramKeysFromOptions(options)
+		reservedConn, err = e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
 		if err != nil {
 			return 0, nil, nil, fmt.Errorf("failed to create reserved connection for COPY: %w", err)
 		}
@@ -1038,6 +1048,21 @@ func (e *Executor) getUserFromOptions(options *query.ExecuteOptions) string {
 	}
 	// Default to postgres superuser if no user specified
 	return "postgres"
+}
+
+// scramKeysFromOptions returns the SCRAM passthrough keys carried on the
+// request, or (nil, nil) if no keys were forwarded. The connpoolmanager
+// consults the passthrough flag before consuming them, so it is always safe
+// to pass these through.
+func scramKeysFromOptions(options *query.ExecuteOptions) (clientKey, serverKey []byte) {
+	if options == nil {
+		return nil, nil
+	}
+	auth := options.GetUserAuth()
+	if auth == nil {
+		return nil, nil
+	}
+	return auth.GetClientKey(), auth.GetServerKey()
 }
 
 // int32ToInt16Slice converts a slice of int32 to int16.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -127,7 +127,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 
 	// Get a connection from the pool for this user
 	clientKey, serverKey := scramKeysFromOptions(options)
-	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -234,7 +234,7 @@ func (e *Executor) StreamExecute(
 
 	// Get a connection from the pool for this user
 	clientKey, serverKey := scramKeysFromOptions(options)
-	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -308,7 +308,7 @@ func (e *Executor) reserveAndStreamExecute(
 
 	// Create a reserved connection
 	clientKey, serverKey := scramKeysFromOptions(options)
-	reservedConn, err := e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reservedOpts...)
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reservedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
@@ -512,7 +512,7 @@ func (e *Executor) portalExecuteWithReserved(
 		// below is a no-op for the new-conn path because connState
 		// dedupes by canonical name.
 		clientKey, serverKey := scramKeysFromOptions(options)
-		reservedConn, err = e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
 			_, err := e.ensurePrepared(ctx, conn, preparedStatement)
 			return err
 		}))
@@ -564,7 +564,7 @@ func (e *Executor) portalExecuteWithReserved(
 
 // portalExecuteWithRegular executes a portal using a regular pooled connection.
 // clientKey and serverKey are the SCRAM passthrough keys forwarded by the
-// caller's session; see connpoolmanager.GetRegularConnWithAuth.
+// caller's session; see connpoolmanager.GetRegularConn.
 func (e *Executor) portalExecuteWithRegular(
 	ctx context.Context,
 	preparedStatement *query.PreparedStatement,
@@ -576,7 +576,7 @@ func (e *Executor) portalExecuteWithRegular(
 	paramFormats, resultFormats []int16,
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
-	conn, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -653,7 +653,7 @@ func (e *Executor) Describe(
 		conn = reservedConn.Conn()
 	} else {
 		clientKey, serverKey := scramKeysFromOptions(options)
-		pooled, err := e.poolManager.GetRegularConnWithSettingsAndAuth(ctx, settings, user, clientKey, serverKey)
+		pooled, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 		}
@@ -830,7 +830,7 @@ func (e *Executor) CopyReady(
 		}
 
 		clientKey, serverKey := scramKeysFromOptions(options)
-		reservedConn, err = e.poolManager.NewReservedConnWithAuth(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
 		if err != nil {
 			return 0, nil, nil, fmt.Errorf("failed to create reserved connection for COPY: %w", err)
 		}

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -286,3 +286,42 @@ func TestStreamExecuteOnReservedConn_ReconcilesInlineBegin(t *testing.T) {
 	require.Equal(t, protoutil.ReasonTransaction, rc.addedReasons,
 		"helper should add the transaction reason when PG reports in-block")
 }
+
+func TestScramKeysFromOptions(t *testing.T) {
+	ck := []byte{1, 2, 3}
+	sk := []byte{4, 5, 6}
+
+	tests := []struct {
+		name    string
+		options *query.ExecuteOptions
+		wantCK  []byte
+		wantSK  []byte
+	}{
+		{
+			name:    "nil options",
+			options: nil,
+		},
+		{
+			name:    "options without user_auth",
+			options: &query.ExecuteOptions{User: "alice"},
+		},
+		{
+			name:    "options with populated user_auth",
+			options: &query.ExecuteOptions{User: "alice", UserAuth: &query.UserAuth{ClientKey: ck, ServerKey: sk}},
+			wantCK:  ck,
+			wantSK:  sk,
+		},
+		{
+			name:    "options with empty user_auth",
+			options: &query.ExecuteOptions{User: "alice", UserAuth: &query.UserAuth{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCK, gotSK := scramKeysFromOptions(tt.options)
+			require.Equal(t, tt.wantCK, gotCK)
+			require.Equal(t, tt.wantSK, gotSK)
+		})
+	}
+}

--- a/go/services/multipooler/executor/internal_query.go
+++ b/go/services/multipooler/executor/internal_query.go
@@ -58,7 +58,7 @@ func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser())
+	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (e *Executor) QueryMultiStatement(ctx context.Context, queryStr string) err
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser())
+	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sql
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser())
+	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/services/multipooler/pubsub/listener.go
+++ b/go/services/multipooler/pubsub/listener.go
@@ -229,7 +229,7 @@ func (l *Listener) run(ctx context.Context) {
 	connect := func() {
 		releaseConn(reserved.ReleaseError)
 		var err error
-		conn, err = l.poolManager.NewReservedConn(ctx, nil, l.poolManager.PgUser())
+		conn, err = l.poolManager.NewReservedConn(ctx, nil, l.poolManager.PgUser(), nil, nil)
 		if err != nil {
 			l.logger.ErrorContext(ctx, "pubsub: failed to acquire reserved connection", "error", err)
 			conn = nil

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -301,6 +301,28 @@ message ExecuteOptions {
   // This field is only consumed by StreamExecute. PortalStreamExecute has
   // its own top-level prepared_statement field.
   PreparedStatement prepared_statement = 6;
+
+  // user_auth carries SCRAM-SHA-256 passthrough keys captured during the
+  // client's authentication handshake at the multigateway. When the
+  // multipooler has SCRAM passthrough enabled, it uses these keys to
+  // authenticate to the backing PostgreSQL as the session's real user
+  // instead of relying on trust on the local connection. Unset for
+  // sessions that did not authenticate via SCRAM.
+  UserAuth user_auth = 7;
+}
+
+// UserAuth carries cryptographic material extracted from the client's SCRAM
+// handshake at multigateway. The pair (client_key, server_key) is sufficient
+// to authenticate as the user to any SCRAM-SHA-256 verifier of the same
+// password, without ever holding the plaintext password.
+message UserAuth {
+  // client_key is the SCRAM ClientKey recovered from the client's proof
+  // during authentication. 32 bytes for SCRAM-SHA-256.
+  bytes client_key = 1;
+
+  // server_key is the SCRAM ServerKey read from the user's verifier in
+  // pg_authid. 32 bytes for SCRAM-SHA-256.
+  bytes server_key = 2;
 }
 
 // ReservationOptions specifies options when creating or extending a reserved connection.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -318,11 +318,17 @@ message ExecuteOptions {
 message UserAuth {
   // client_key is the SCRAM ClientKey recovered from the client's proof
   // during authentication. 32 bytes for SCRAM-SHA-256.
-  bytes client_key = 1;
+  //
+  // [debug_redact = true] is the canonical signal of intent. It is currently
+  // advisory in google.golang.org/protobuf (see
+  // https://github.com/golang/protobuf/issues/1655); when upstream lands the
+  // runtime path, generated String()/prototext output will redact this field
+  // automatically. query_redact_test.go locks the annotation in.
+  bytes client_key = 1 [debug_redact = true];
 
   // server_key is the SCRAM ServerKey read from the user's verifier in
   // pg_authid. 32 bytes for SCRAM-SHA-256.
-  bytes server_key = 2;
+  bytes server_key = 2 [debug_redact = true];
 }
 
 // ReservationOptions specifies options when creating or extending a reserved connection.


### PR DESCRIPTION
## Summary

- Per-user backend pools now authenticate to PostgreSQL as the real end user using SCRAM-SHA-256 keys derived during the client's handshake at multigateway and forwarded on every query RPC.
- No plaintext password ever lives in multigres process memory; session-scoped keys are captured on the gateway `Conn`, zeroized on close, and consumed only at dial time on multipooler.
- `pg_hba_template.conf` no longer grants blanket `trust` on the local socket — `local all all` now requires `scram-sha-256`. A narrow admin-user trust line is preserved as the admin-pool bootstrap path and tagged as a follow-up.
- Closes MUL-192.

## Description

**Proto + wire.** New `query.UserAuth { client_key, server_key }` embedded on `ExecuteOptions` so every query-path RPC (`StreamExecute`, `PortalStreamExecute`, `Describe`, `CopyBidiExecute`, `ConcludeTransaction`, `DiscardTempTables`, `ReleaseReservedConnection`) carries the session's keys. Internal gRPC is mTLS-protected from MUL-191, so keys are confidential in flight.

**Capture on multigateway.** After ``ScramAuthenticator.HandleClientFinal`` succeeds, ``pgprotocol/server.Conn`` records the ``ClientKey`` / ``ServerKey`` alongside ``user`` and ``database``. ``Conn.Close`` scrubs the bytes in place and drops the slices. A private ``userAuthFrom(conn)`` helper in ``scatterconn`` wires keys into all 11 ``ExecuteOptions`` construction sites and copies the bytes defensively so lazy / retried gRPC marshalling cannot race ``Conn.Close``.

**Consume on multipooler.** ``pgprotocol/client.Config`` carries optional ``ScramClientKey`` / ``ScramServerKey``; the auth dispatcher picks ``newScramClientWithKeys`` when present and falls back to the password path otherwise. ``connpoolmanager`` gains ``*WithAuth`` variants on ``GetRegularConn``, ``GetRegularConnWithSettings``, and ``NewReservedConn`` that route keys into a new ``buildUserClientConfig`` on first-time pool creation (keys are deterministic per user+password, so caching at pool creation is correctness-safe). The existing signatures are preserved as thin wrappers so callers and tests that don't care about auth don't change.

**Executor threading.** ``scramKeysFromOptions(options)`` helper in executor; seven pool-acquire sites migrated to ``*WithAuth`` variants. ``portalExecuteWithRegular`` signature gains ``clientKey, serverKey`` (caller updated).

**pg_hba.** SCRAM passthrough is unconditional — there is no opt-out flag. ``pg_hba_template.conf`` replaces the blanket ``local all all trust`` with ``local all all scram-sha-256``; a narrow ``local all <admin> trust`` line is preserved with an inline TODO to close once pgctld provisions the admin password. ``Manager.Open`` logs a clear warning when the admin password is empty so operators see the remaining gap. (An earlier draft of this PR shipped a ``--multipooler-scram-passthrough`` toggle; it was removed in 656c3af0 — once the same change made ``pg_hba.conf`` enforce ``scram-sha-256`` on the local socket, flipping the flag to ``false`` could not actually re-enable trust auth, so the runtime toggle was strictly worse than none.)

**Password-rotation self-heal.** ``withReopenRetry`` detects class-28 SQLSTATE on the dial path, evicts the stale user pool from the snapshot, and retries once using the triggering session's keys — which are known-current, derived seconds earlier during the gateway-side SCRAM handshake against the live ``pg_authid`` verifier. Concurrent sessions racing the same rotation each find the eviction already done and retry against the fresh pool. A retry cap surfaces a clean class-28 error if the retrier itself is holding old-password keys, so the manager cannot loop indefinitely.

**Design doc.** ``docs/query_serving/scram_passthrough_design.md`` describes the final state including the preserved admin-user trust exception as a tracked open item, and documents the password-rotation self-heal flow.

## Test plan

- [x] Unit tests cover: SCRAM key capture + zeroize on close + safe close when no keys; ``scramKeysFromOptions`` (nil / missing / populated / empty); ``buildUserClientConfig`` (with keys / nil keys); ``userAuthFrom`` defensive copy; ``withReopenRetry`` evicts a stale user pool and retries once on class-28; ``withReopenRetry`` surfaces a persistent class-28 instead of looping.
- [x] ``go test -short ./go/...`` passes.
- [ ] Follow-up: integration test against a real PostgreSQL with ``pg_hba`` rendered from the updated template, exercising the end-to-end passthrough dial (MUL-192 unblocks this; tracked alongside harness updates).
- [ ] Follow-up: close the admin-user trust exception after pgctld provisions the admin password during ``initdb``.
