### PR TITLE
fix(pgctld): add connect_timeout to pg_rewind source connection string

### DIFF
--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -693,7 +693,10 @@ func (s *PgCtldService) PgRewind(ctx context.Context, req *pb.PgRewindRequest) (
 
 	// Construct source server connection string (without password - will use PGPASSWORD env var)
 	// Include application_name if provided (used for replication identification)
-	sourceServer := fmt.Sprintf("host=%s port=%d user=%s dbname=postgres",
+	// connect_timeout ensures pg_rewind fails fast if the source is not yet ready to accept
+	// connections (e.g. newly-promoted primary still in crash recovery), allowing the caller
+	// to retry rather than blocking for the OS TCP timeout.
+	sourceServer := fmt.Sprintf("host=%s port=%d user=%s dbname=postgres connect_timeout=5",
 		req.GetSourceHost(), req.GetSourcePort(), s.ctldConfig.User)
 	if req.GetApplicationName() != "" {
 		sourceServer = fmt.Sprintf("%s application_name=%s", sourceServer, req.GetApplicationName())


### PR DESCRIPTION
Without connect_timeout, pg_rewind can block indefinitely waiting for the source postgres to accept connections. A newly-started primary might need time to start accepting connections, causing the pg_rewind dry-run to stall and DemoteStalePrimary to time out. With connect_timeout=5, pg_rewind fails faster, allowing multiorch to retry on the next recovery cycle (~1s later) by which time the primary is ready.