### PR TITLE
fix(multigateway): rollback implicit transaction before returning isolation level error

### DIFF
--- a/go/services/multigateway/handler/transaction_helpers.go
+++ b/go/services/multigateway/handler/transaction_helpers.go
@@ -127,6 +127,7 @@ func (h *MultiGatewayHandler) executeWithImplicitTransaction(
 		//     error out matching PostgreSQL behavior — SET TRANSACTION ISOLATION LEVEL
 		//     must be called before any query.
 		if ast.IsBeginStatement(stmt) {
+			wasImplicitTx := isImplicitTx
 			isImplicitTx = false
 			if txStmt, ok := stmt.(*ast.TransactionStmt); ok && txStmt.Options != nil && len(txStmt.Options.Items) > 0 {
 				if state.PendingBeginQuery != "" {
@@ -136,7 +137,7 @@ func (h *MultiGatewayHandler) executeWithImplicitTransaction(
 					// Backend transaction already has queries executed.
 					// PostgreSQL rejects this with SQLSTATE 25001.
 					// Rollback the implicit transaction before returning the error.
-					if isImplicitTx {
+					if wasImplicitTx {
 						_ = silentExecute(ast.NewRollbackStmt())
 					}
 					return mterrors.NewPgError("ERROR", mterrors.PgSSActiveTransaction,

--- a/go/services/multigateway/handler/transaction_helpers_test.go
+++ b/go/services/multigateway/handler/transaction_helpers_test.go
@@ -381,3 +381,48 @@ func TestExecuteWithImplicitTransaction_AlreadyInTransaction_CommitMidBatch(t *t
 	// Already in transaction: no initial BEGIN, but after COMMIT, new implicit segment starts
 	require.Equal(t, []string{"OTHER", "COMMIT", "BEGIN", "OTHER", "COMMIT"}, stmtDescriptions(mock.executedStmts))
 }
+
+func TestExecuteWithImplicitTransaction_BeginWithIsolationAfterQuery_RollsBackImplicitTx(t *testing.T) {
+	// Regression test: when a batch runs a query inside an implicit transaction and
+	// then issues BEGIN ISOLATION LEVEL SERIALIZABLE, Multigres must rollback the
+	// implicit transaction it opened before returning the error — otherwise the
+	// backend PostgreSQL connection is left with an open transaction and goes back
+	// into the pool in a dirty state.
+	mock := &trackingMockExecutor{errOnCallIndex: -1}
+	h := newTestHandler(mock)
+	state := NewMultiGatewayConnectionState()
+	stmts := parseStmts(t, "SELECT 1; BEGIN ISOLATION LEVEL SERIALIZABLE")
+
+	err := h.executeWithImplicitTransaction(
+		context.Background(), newImplicitTxTestConn(), state,
+		"SELECT 1; BEGIN ISOLATION LEVEL SERIALIZABLE", stmts,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil },
+	)
+
+	require.Error(t, err)
+	// Implicit transaction must be rolled back before returning the error.
+	// Without the fix, ROLLBACK is missing: ["BEGIN", "OTHER"].
+	require.Equal(t, []string{"BEGIN", "OTHER", "ROLLBACK"}, stmtDescriptions(mock.executedStmts))
+}
+
+func TestExecuteWithImplicitTransaction_BeginWithIsolationInExplicitTx_DoesNotRollback(t *testing.T) {
+	// When already inside an explicit transaction (user issued BEGIN earlier),
+	// Multigres must return the same error but must NOT issue a ROLLBACK —
+	// the client owns that transaction and must decide to roll it back themselves.
+	mock := &trackingMockExecutor{errOnCallIndex: -1}
+	h := newTestHandler(mock)
+	state := NewMultiGatewayConnectionState()
+	tc := server.NewTestConn(&bytes.Buffer{})
+	tc.Conn.SetTxnStatus(protocol.TxnStatusInBlock) // already in an explicit transaction
+	stmts := parseStmts(t, "SELECT 1; BEGIN ISOLATION LEVEL SERIALIZABLE")
+
+	err := h.executeWithImplicitTransaction(
+		context.Background(), tc.Conn, state,
+		"SELECT 1; BEGIN ISOLATION LEVEL SERIALIZABLE", stmts,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil },
+	)
+
+	require.Error(t, err)
+	// No ROLLBACK — the explicit transaction belongs to the client.
+	require.Equal(t, []string{"OTHER"}, stmtDescriptions(mock.executedStmts))
+}


### PR DESCRIPTION
## Problem

When a batch like `SELECT 1; BEGIN ISOLATION LEVEL SERIALIZABLE` arrives, Multigres injects a silent `BEGIN` to wrap the batch in an implicit transaction. When the user's `BEGIN ISOLATION LEVEL SERIALIZABLE` is then rejected (SQLSTATE 25001 isolation level must be set before any query), the implicit transaction was never rolled back. The PostgreSQL connection returned to the pool with an open transaction, risking dirty state for the next client that received it.

Root cause: `isImplicitTx` was set to `false` at the top of the `BEGIN` handler then immediately checked so the rollback branch was dead code.

## Fix

Save the flag before clearing it (`wasImplicitTx := isImplicitTx`) and use the saved value for the rollback check. No rollback is issued for explicit transactions (client-owned) only for implicit ones (Multigres-owned).

## Tests

- `BeginWithIsolationAfterQuery_RollsBackImplicitTx` verifies ROLLBACK is sent before the error is returned for an implicit transaction
- `BeginWithIsolationInExplicitTx_DoesNotRollback` verifies Multigres does not touch a client-owned explicit transaction