### PR TITLE
fix(multipooler): retry ensurePreparedWithName via validate callback on reserved NewConn

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -21,12 +21,13 @@
 package clustermetadata
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (

--- a/go/pb/consensus/consensusservice.pb.go
+++ b/go/pb/consensus/consensusservice.pb.go
@@ -21,12 +21,13 @@
 package consensus
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	consensusdata "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -22,6 +22,7 @@ package consensus
 
 import (
 	context "context"
+
 	consensusdata "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	grpc "google.golang.org/grpc"

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -21,13 +21,14 @@
 package consensusdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/mtrpc/mtrpc.pb.go
+++ b/go/pb/mtrpc/mtrpc.pb.go
@@ -24,12 +24,13 @@
 package mtrpc
 
 import (
-	query "github.com/multigres/multigres/go/pb/query"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	query "github.com/multigres/multigres/go/pb/query"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -21,15 +21,16 @@
 package multiadmin
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multiadmin/multiadminservice_grpc.pb.go
+++ b/go/pb/multiadmin/multiadminservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multiadmin
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multigatewayservice/multigatewayservice.pb.go
+++ b/go/pb/multigatewayservice/multigatewayservice.pb.go
@@ -24,11 +24,12 @@
 package multigatewayservice
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/pb/multigatewayservice/multigatewayservice_grpc.pb.go
+++ b/go/pb/multigatewayservice/multigatewayservice_grpc.pb.go
@@ -25,6 +25,7 @@ package multigatewayservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multiorch/multiorchservice.pb.go
+++ b/go/pb/multiorch/multiorchservice.pb.go
@@ -21,13 +21,14 @@
 package multiorch
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multiorch/multiorchservice_grpc.pb.go
+++ b/go/pb/multiorch/multiorchservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multiorch
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/multiorchdata/multiorchdata.pb.go
+++ b/go/pb/multiorchdata/multiorchdata.pb.go
@@ -21,15 +21,16 @@
 package multiorchdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdata "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -21,11 +21,12 @@
 package multipoolermanager
 
 import (
+	reflect "reflect"
+	unsafe "unsafe"
+
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -22,6 +22,7 @@ package multipoolermanager
 
 import (
 	context "context"
+
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -21,14 +21,15 @@
 package multipoolermanagerdata
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -24,15 +24,16 @@
 package multipoolerservice
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpc "github.com/multigres/multigres/go/pb/mtrpc"
 	query "github.com/multigres/multigres/go/pb/query"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/multipoolerservice/multipoolerservice_grpc.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice_grpc.pb.go
@@ -25,6 +25,7 @@ package multipoolerservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/pgctldservice/pgctldservice.pb.go
+++ b/go/pb/pgctldservice/pgctldservice.pb.go
@@ -21,13 +21,14 @@
 package pgctldservice
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (

--- a/go/pb/pgctldservice/pgctldservice_grpc.pb.go
+++ b/go/pb/pgctldservice/pgctldservice_grpc.pb.go
@@ -22,6 +22,7 @@ package pgctldservice
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -24,12 +24,13 @@
 package query
 
 import (
-	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -66,7 +66,8 @@ type PoolManager interface {
 
 	// NewReservedConn creates a new reserved connection for the specified user.
 	// Settings are provided as a map and internally converted via the shared SettingsCache.
-	NewReservedConn(ctx context.Context, settings map[string]string, user string) (*reserved.Conn, error)
+	// Options (see reserved.ReservedConnOption) are forwarded to the underlying reserved pool.
+	NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
 
 	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
 	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -401,14 +401,16 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // Settings are converted via the shared SettingsCache for consistent bucket assignment.
 // The connection is assigned a unique ID for client-side tracking.
 // The caller must call Release() when done with the connection.
-func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string) (*reserved.Conn, error) {
+// Options (see reserved.ReservedConnOption) are forwarded to the underlying reserved pool;
+// WithValidate in particular enables retry on stale-socket errors during connection setup.
+func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	pool, err := m.getOrCreateUserPool(user)
 	if err != nil {
 		return nil, err
 	}
 	// Convert map to *Settings via the shared cache
 	s := m.settingsCache.GetOrCreate(settings)
-	return pool.NewReservedConn(ctx, s)
+	return pool.NewReservedConn(ctx, s, opts...)
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.

--- a/go/services/multipooler/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/connpoolmanager/user_pool.go
@@ -238,9 +238,10 @@ func (p *UserPool) GetRegularConnWithSettings(ctx context.Context, settings *con
 
 // NewReservedConn creates a new reserved connection for transactions or portal operations.
 // The connection is already authenticated as the pool's user.
-func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Settings) (*reserved.Conn, error) {
+// Options (see reserved.ReservedConnOption) are forwarded to the underlying reserved pool.
+func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Settings, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	p.touchActivity()
-	return p.reservedPool.NewConn(ctx, settings)
+	return p.reservedPool.NewConn(ctx, settings, opts...)
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -287,8 +287,24 @@ func (e *Executor) reserveAndStreamExecute(
 		"begin_tx", beginTx,
 		"query", sql)
 
+	// If the query references a gateway-managed prepared statement (wrapped
+	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), the Parse must
+	// land on the same backend connection the query will run on. Wire it
+	// through the reserved pool's validate hook so that if the first write
+	// hits a silently-closed socket (idle timeout on the backend), the pool
+	// taints the stale conn and retries on a fresh one.
+	//
+	// Running Parse before BEGIN is safe — prepared statements are session
+	// level, not transaction level.
+	var reservedOpts []reserved.ReservedConnOption
+	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
+		reservedOpts = append(reservedOpts, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+			return e.ensurePreparedWithName(ctx, conn, preparedStmt)
+		}))
+	}
+
 	// Create a reserved connection
-	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user)
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user, reservedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
@@ -313,16 +329,6 @@ func (e *Executor) reserveAndStreamExecute(
 		if err := reservedConn.BeginWithQuery(ctx, beginQuery); err != nil {
 			reservedConn.Release(reserved.ReleaseError)
 			return nil, err
-		}
-	}
-
-	// If the query references a gateway-managed prepared statement (wrapped
-	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), ensure it is
-	// parsed on this newly created backend connection before running the query.
-	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
-		if err := e.ensurePreparedWithName(ctx, reservedConn.Conn(), preparedStmt); err != nil {
-			reservedConn.Release(reserved.ReleaseError)
-			return nil, fmt.Errorf("failed to ensure prepared statement on new reserved connection: %w", err)
 		}
 	}
 

--- a/go/services/multipooler/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool.go
@@ -23,10 +23,49 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
 )
+
+// maxNewConnAttempts is the maximum number of times NewConn will try to
+// obtain and validate a pooled connection. Mirrors regular.maxQueryAttempts.
+const maxNewConnAttempts = 3
+
+// newConnRetryBackoff is the delay between NewConn attempts when the
+// previous attempt's validate callback reported a connection error.
+// Matches regular.retryBackoff style to give PostgreSQL a brief window
+// to finish starting up when the underlying error is due to a restart.
+const newConnRetryBackoff = 100 * time.Millisecond
+
+// ReservedConnOption configures a NewConn call on a reserved Pool.
+// See WithValidate.
+type ReservedConnOption func(*reservedConnOpts)
+
+// reservedConnOpts is the internal options bag populated by
+// ReservedConnOption functions. Zero value means "no validate hook,
+// behave as before".
+type reservedConnOpts struct {
+	validate func(context.Context, *regular.Conn) error
+}
+
+// WithValidate attaches a callback that runs on the underlying regular
+// connection before the reserved connection is registered. If the
+// callback returns a connection error (per mterrors.IsConnectionError),
+// the pool taints the pooled conn (forcing a fresh socket on the next
+// get) and retries up to maxNewConnAttempts. Non-connection errors are
+// returned unchanged with the pooled conn recycled normally.
+//
+// This is the pool-layer equivalent of retryOnConnectionError in the
+// regular pool: it transparently recovers from silent stale-socket
+// failures on the first write to a freshly-handed-out reserved
+// connection (e.g. a Parse issued during connection setup).
+func WithValidate(fn func(context.Context, *regular.Conn) error) ReservedConnOption {
+	return func(o *reservedConnOpts) {
+		o.validate = fn
+	}
+}
 
 // PoolConfig holds configuration for the reserved pool.
 type PoolConfig struct {
@@ -152,7 +191,13 @@ func (p *Pool) idleKiller(interval time.Duration) {
 // NewConn acquires a new reserved connection.
 // The connection is assigned a unique ID for client-side tracking.
 // The connection is already authenticated as the pool's configured user.
-func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn, error) {
+//
+// If a validate callback is supplied via WithValidate, it runs on the
+// underlying regular connection before the reservation is registered.
+// A connection error from validate taints the pooled conn and triggers
+// a retry (up to maxNewConnAttempts), transparently recovering from
+// stale sockets that PostgreSQL silently closed.
+func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts ...ReservedConnOption) (*Conn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -160,10 +205,14 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn
 	}
 	p.mu.Unlock()
 
-	// Get a regular connection from the pool.
-	pooled, err := p.conns.GetWithSettings(ctx, settings)
+	var o reservedConnOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	pooled, err := p.getValidatedConn(ctx, settings, o.validate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get connection: %w", err)
+		return nil, err
 	}
 
 	// Generate unique ID. Since lastID is initialized with Unix nanoseconds,
@@ -189,6 +238,69 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn
 		"process_id", rc.ProcessID())
 
 	return rc, nil
+}
+
+// getValidatedConn acquires a pooled regular connection and, if a
+// validate callback is provided, runs it against the connection before
+// returning. On a connection-error from validate, the pooled conn is
+// tainted (forcing a fresh socket on the next get) and the acquire is
+// retried up to maxNewConnAttempts. Non-connection errors cause the
+// pooled conn to be recycled normally and the error is returned
+// unchanged.
+//
+// The retry logic mirrors retryOnConnectionError in regular_conn.go: a
+// brief backoff (newConnRetryBackoff) between attempts gives PostgreSQL
+// time to come back after a restart, and ctx cancellation short-circuits
+// the loop.
+func (p *Pool) getValidatedConn(ctx context.Context, settings *connstate.Settings, validate func(context.Context, *regular.Conn) error) (regular.PooledConn, error) {
+	if validate == nil {
+		pooled, err := p.conns.GetWithSettings(ctx, settings)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get connection: %w", err)
+		}
+		return pooled, nil
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxNewConnAttempts; attempt++ {
+		pooled, err := p.conns.GetWithSettings(ctx, settings)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get connection: %w", err)
+		}
+
+		if err := validate(ctx, pooled.Conn); err == nil {
+			return pooled, nil
+		} else if !mterrors.IsConnectionError(err) {
+			pooled.Recycle()
+			return nil, err
+		} else {
+			// Connection error: taint the stale socket and close it.
+			// Taint returns the slot to the pool as empty, which
+			// schedules a replacement; the subsequent Recycle (with
+			// pool==nil after Taint) closes the orphaned socket so it
+			// does not linger until the idle killer reaps it.
+			pooled.Taint()
+			pooled.Recycle()
+			lastErr = err
+		}
+
+		if attempt == maxNewConnAttempts {
+			break
+		}
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+
+		backoffTimer := time.NewTimer(newConnRetryBackoff)
+		select {
+		case <-backoffTimer.C:
+		case <-ctx.Done():
+			backoffTimer.Stop()
+			return nil, context.Cause(ctx)
+		}
+	}
+
+	return nil, fmt.Errorf("reserved connection validate failed after %d attempts: %w", maxNewConnAttempts, lastErr)
 }
 
 // Get retrieves a reserved connection by ID and resets its expiry time.

--- a/go/services/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool_test.go
@@ -16,6 +16,7 @@ package reserved
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
@@ -680,4 +682,190 @@ func TestPool_NewConnAfterPoolRecreation(t *testing.T) {
 		assert.Greater(t, conn.ConnID(), maxPool1ID, "new pool IDs should be greater than old pool IDs")
 		conn.Release(ReleaseCommit)
 	}
+}
+
+// connErrFATAL returns a PgDiagnostic that IsConnectionError recognises
+// (Class 08 / FATAL 57P01 admin_shutdown). Used to drive the validate-retry
+// path below.
+func connErrFATAL() error {
+	return &mterrors.PgDiagnostic{
+		MessageType: 'E',
+		Severity:    "FATAL",
+		Code:        "57P01",
+		Message:     "terminating connection due to administrator command",
+	}
+}
+
+// TestPool_NewConn_NilValidate covers the nil-validate case: existing
+// behavior must be unchanged — a single pooled conn is returned without
+// ever consulting a callback.
+func TestPool_NewConn_NilValidate(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Release(ReleaseCommit)
+
+	stats := pool.Stats()
+	assert.Equal(t, 1, stats.Active)
+	assert.Equal(t, int64(1), stats.ReserveCount)
+}
+
+// TestPool_NewConn_WithValidate_Success covers the happy path: validate
+// is invoked exactly once on the pooled conn, and the returned reserved
+// conn wraps that same pooled conn.
+func TestPool_NewConn_WithValidate_Success(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	var calls int
+	var lastConn *regular.Conn
+	conn, err := pool.NewConn(ctx, nil, WithValidate(func(_ context.Context, c *regular.Conn) error {
+		calls++
+		lastConn = c
+		return nil
+	}))
+	require.NoError(t, err)
+	defer conn.Release(ReleaseCommit)
+
+	assert.Equal(t, 1, calls, "validate must run exactly once on success")
+	assert.Same(t, lastConn, conn.Conn(), "reserved conn must wrap the validated pooled conn")
+}
+
+// TestPool_NewConn_WithValidate_RetriesOnConnectionError covers the
+// key retry case: validate reports a connection error the first time,
+// the pool taints the stale pooled conn and retries on a fresh socket,
+// and the returned reserved conn wraps the replacement.
+func TestPool_NewConn_WithValidate_RetriesOnConnectionError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	var (
+		calls     int
+		firstConn *regular.Conn
+		finalConn *regular.Conn
+	)
+	conn, err := pool.NewConn(ctx, nil, WithValidate(func(_ context.Context, c *regular.Conn) error {
+		calls++
+		switch calls {
+		case 1:
+			firstConn = c
+			return connErrFATAL()
+		default:
+			finalConn = c
+			return nil
+		}
+	}))
+	require.NoError(t, err)
+	defer conn.Release(ReleaseCommit)
+
+	assert.Equal(t, 2, calls, "validate must be re-invoked on the replacement conn")
+	require.NotNil(t, firstConn)
+	require.NotNil(t, finalConn)
+	assert.NotSame(t, firstConn, finalConn,
+		"the stale conn should have been tainted and replaced by a fresh one")
+	assert.True(t, firstConn.IsClosed(),
+		"tainted conn should be closed after retry")
+	assert.Same(t, finalConn, conn.Conn(),
+		"reserved conn must wrap the replacement pooled conn")
+
+	// Reservation bookkeeping only records the final success.
+	stats := pool.Stats()
+	assert.Equal(t, 1, stats.Active)
+	assert.Equal(t, int64(1), stats.ReserveCount)
+}
+
+// TestPool_NewConn_WithValidate_NonConnectionErrorNoRetry covers the
+// non-connection-error branch: the error propagates verbatim, the
+// pooled conn is recycled (not tainted, so it stays available), and
+// validate runs exactly once.
+func TestPool_NewConn_WithValidate_NonConnectionErrorNoRetry(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	sentinel := errors.New("not a connection error")
+	var (
+		calls    int
+		seenConn *regular.Conn
+	)
+	conn, err := pool.NewConn(ctx, nil, WithValidate(func(_ context.Context, c *regular.Conn) error {
+		calls++
+		seenConn = c
+		return sentinel
+	}))
+	require.Nil(t, conn)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "non-connection errors must propagate unchanged")
+	assert.Equal(t, 1, calls, "no retry on non-connection errors")
+
+	// No reservation was registered.
+	stats := pool.Stats()
+	assert.Equal(t, 0, stats.Active)
+	assert.Equal(t, int64(0), stats.ReserveCount)
+
+	// The pooled conn was recycled, not tainted: it remains alive and
+	// available for the next acquisition.
+	require.NotNil(t, seenConn)
+	assert.False(t, seenConn.IsClosed(),
+		"non-connection error must recycle (not taint) the pooled conn")
+}
+
+// TestPool_NewConn_WithValidate_ExhaustedRetries covers the case where
+// validate always reports a connection error: NewConn must stop after
+// maxNewConnAttempts and return the final error wrapped with context.
+func TestPool_NewConn_WithValidate_ExhaustedRetries(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	var calls int
+	conn, err := pool.NewConn(ctx, nil, WithValidate(func(_ context.Context, _ *regular.Conn) error {
+		calls++
+		return connErrFATAL()
+	}))
+	require.Nil(t, conn)
+	require.Error(t, err)
+	assert.Equal(t, maxNewConnAttempts, calls,
+		"validate must be invoked exactly maxNewConnAttempts times")
+	assert.Contains(t, err.Error(), "reserved connection validate failed after")
+	// The underlying connection error must remain accessible via errors
+	// unwrapping so callers can still classify it.
+	assert.True(t, mterrors.IsConnectionError(err),
+		"wrapped error must still unwrap to a connection error")
+
+	// No reservation was registered.
+	stats := pool.Stats()
+	assert.Equal(t, 0, stats.Active)
+	assert.Equal(t, int64(0), stats.ReserveCount)
 }


### PR DESCRIPTION
## Summary

Adds a pool-layer retry primitive for stale connections on newly reserved
connections, and uses it to fix a flaky integration test
(`TestWrappedPreparedStatementExecution/multigateway/create_temp_table_as_execute`).

### Root cause

The reserved connection pool could hand out a regular pooled conn that
PostgreSQL silently closed (idle timeout). The first write — the Parse
issued by `ensurePreparedWithName` for wrapped `EXECUTE` forms —
would fail with `broken pipe`. Non-reserved queries already recover
from this via `retryOnConnectionError` in `regular_conn.go`, but the
reserved path had no equivalent.

### The primitive

New `ReservedConnOption` / `WithValidate` on `reserved.Pool.NewConn`,
plumbed through `Manager` and `UserPool` as a variadic option so
existing call sites stay untouched. When the validate callback reports
a connection error (`mterrors.IsConnectionError`), the pooled conn is
tainted (forcing a fresh socket on the next acquisition) and `NewConn`
retries up to `maxNewConnAttempts`, mirroring the constants/style of
`retryOnConnectionError` in `regular_conn.go`. Non-connection errors
propagate unchanged with the pooled conn recycled normally. Context
cancellation short-circuits the loop.

### The call site

`executor.reserveAndStreamExecute` now builds a validate closure from
`options.GetPreparedStatement()` and passes `WithValidate(closure)` into
`NewReservedConn`. The standalone `ensurePreparedWithName` call on the
new reserved conn is gone — the closure does that work during
connection setup, so a stale socket is retried transparently. This
also moves `Parse` to before `BEGIN`, which is safe because PG
prepared statements are session-level rather than transaction-level,
and as a side benefit the retry now covers the `beginTx` case too.

### Why pool-layer

Putting retry at the pool layer means the executor stays unaware of
reconnection, and any future `NewReservedConn` caller can opt in
simply by passing a `WithValidate` closure.

### Follow-up

The `NewReservedConn` call sites at `executor.go:520` (portal
execution) and `executor.go:774` (COPY) have the same latent
stale-socket exposure but are out of scope for this PR — they are
candidates for a future change using the same primitive.

## Test plan

- [x] Unit tests for `reserved.Pool.NewConn`: nil validate, happy path,
      retry-on-connection-error (verifies taint+replacement), non-conn
      error propagation (verifies recycle, no retry), and exhausted
      retries (verifies error wrapping and attempt count)
- [x] `go test -short ./go/services/multipooler/pools/reserved/...`
- [x] `go test -short ./go/services/multipooler/executor/...`
- [x] `go test -short ./go/services/multipooler/connpoolmanager/...`
- [x] `go test -run TestWrappedPreparedStatementExecution ./go/test/endtoend/queryserving/...`
      (the formerly flaky integration test — passes in this run, the
      flake is intermittent so deterministic reproduction in
      integration form is non-trivial; the unit tests cover the retry
      behavior)