### PR TITLE
fix(multipooler): retry on stale-socket connection errors during reserved-conn acquisition

### DIFF
--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -172,9 +172,14 @@ accessed via `Get()`, its expiry time is reset.
 `WithValidate(fn)` option attaches a callback that runs against the underlying
 `*regular.Conn` before the reserved connection is registered in the active map.
 A connection-class error from the callback (e.g. the first user-issued write
-revealed a silently closed socket) taints the pooled conn and triggers a retry
-on a fresh socket, up to `constants.MaxConnPoolRetryAttempts` total. Non-connection
-errors propagate unchanged.
+revealed a silently closed socket) triggers a retry on a fresh socket, up to
+`constants.MaxConnPoolRetryAttempts` total. Any validate failure — connection
+or otherwise — taints the pooled conn rather than recycling it, because
+validate hooks perform real state-modifying work (Parse, BEGIN, COPY
+initiation) whose mid-failure can leave the conn in a partially modified state
+(e.g. BEGIN succeeded, `InitiateCopyFromStdin` then failed: conn is stuck in
+failed-transaction `'E'` state). Discarding the conn is the safe default and
+matches the pre-primitive behavior at every call site.
 
 This is the reserved-pool analog of the regular pool's
 `retryOnConnectionError`. It is wired by every executor call site that

--- a/docs/query_serving/connection_pooling.md
+++ b/docs/query_serving/connection_pooling.md
@@ -114,6 +114,25 @@ messages until `ReadyForQuery` to keep connections clean. Connection-level error
 (read failures, broken pipes) cause the connection to be closed rather than
 returned to the pool.
 
+**Stale-Connection Retry:**
+
+A pooled socket can be silently closed by PostgreSQL while it sits idle (idle
+session timeout, server restart, etc.). The first write on that socket fails
+with a connection-class error (EOF, EPIPE, FATAL 57P0x). The regular pool
+recovers transparently in two places, both bounded by
+`constants.MaxConnPoolRetryAttempts` attempts with `constants.ConnPoolRetryBackoff`
+between them:
+
+- `regular.Pool.GetWithSettings` retries when applying SETs hits a stale socket
+  during acquisition (the underlying connpool closes the conn but does not
+  retry on its own); each attempt dials a fresh replacement.
+- `Conn.QueryWithRetry` / `QueryStreamingWithRetry` / `QueryArgsWithRetry`
+  reconnect the same socket in place via `retryOnConnectionError` and re-run
+  the op.
+
+Together these cover both acquisition-time and execution-time stale-socket
+failures for the non-reserved query path.
+
 #### ReservedPool
 
 **Purpose:** Long-lived connections for transactions and portal operations.
@@ -146,6 +165,33 @@ Reserved connections have two timeout configurations:
 A background goroutine runs at 1/10th of the inactivity timeout interval to scan
 and kill connections that have exceeded their timeout. Each time a connection is
 accessed via `Get()`, its expiry time is reset.
+
+**Stale-Connection Retry on Acquisition:**
+
+`reserved.Pool.NewConn` accepts variadic `ReservedConnOption` values. The
+`WithValidate(fn)` option attaches a callback that runs against the underlying
+`*regular.Conn` before the reserved connection is registered in the active map.
+A connection-class error from the callback (e.g. the first user-issued write
+revealed a silently closed socket) taints the pooled conn and triggers a retry
+on a fresh socket, up to `constants.MaxConnPoolRetryAttempts` total. Non-connection
+errors propagate unchanged.
+
+This is the reserved-pool analog of the regular pool's
+`retryOnConnectionError`. It is wired by every executor call site that
+allocates a fresh reserved conn:
+
+- `reserveAndStreamExecute` — `ensurePreparedWithName` runs in validate when
+  the request carries a wrapped EXECUTE prepared statement.
+- `portalExecuteWithReserved` (new-conn branch) — `ensurePrepared` runs in
+  validate; the post-acquire `ensurePrepared` becomes a no-op (deduped by
+  per-connection state).
+- `CopyInitiate` (new-conn branch) — BEGIN-if-needed and
+  `InitiateCopyFromStdin` run in validate; the captured COPY format and column
+  formats are used after acquisition.
+
+Existing-reserved-conn paths (`GetReservedConn`) are not exposed: those conns
+are actively held and never sit idle in the regular pool, so PostgreSQL's idle
+timeout cannot have closed them between uses.
 
 ## Dynamic Fair Share Allocation
 
@@ -569,8 +615,10 @@ type PoolManager interface {
     GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error)
     GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error)
 
-    // Reserved pool operations (per-user)
-    NewReservedConn(ctx context.Context, settings map[string]string, user string) (*reserved.Conn, error)
+    // Reserved pool operations (per-user). Optional ReservedConnOption
+    // values (e.g. WithValidate) are forwarded to the underlying reserved
+    // pool to enable stale-socket retry during acquisition.
+    NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
     GetReservedConn(connID int64, user string) (*reserved.Conn, bool)
 
     Stats() ManagerStats

--- a/docs/query_serving/prepared_statements_design.md
+++ b/docs/query_serving/prepared_statements_design.md
@@ -243,11 +243,21 @@ is exercised for a given query.
 ### Connection Stickiness
 
 Because reconnection on a regular pool connection wipes per-connection
-prepared statement state, the wrapped-EXECUTE path cannot use the
-retry-on-connection-error variant of `QueryStreaming`: a silent reconnect
-would leave the backend without the statement the rewritten SQL references.
-The path uses plain `QueryStreaming` instead and surfaces connection errors
-to the caller, who can reissue the query at the application level.
+prepared statement state, the wrapped-EXECUTE path on the regular pool
+cannot use the retry-on-connection-error variant of `QueryStreaming`: a
+silent reconnect would leave the backend without the statement the
+rewritten SQL references. The regular path uses plain `QueryStreaming`
+instead and surfaces connection errors to the caller, who can reissue
+the query at the application level.
+
+The reserved-pool wrapped-EXECUTE path (`reserveAndStreamExecute` in
+`executor.go` and the `portalExecuteWithReserved` new-conn branch) does
+recover from stale sockets transparently: it wires `ensurePreparedWithName`
+/ `ensurePrepared` through `reserved.WithValidate`, so a connection-class
+error on the Parse triggers a retry on a fresh socket and re-runs the
+Parse there before the conn is registered. Both the empty-settings and
+non-empty-settings cases benefit. See `connection_pooling.md` for the
+underlying primitive.
 
 ### Scope and Known Limitation
 

--- a/go/common/constants/connpool.go
+++ b/go/common/constants/connpool.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "time"
+
+// Connection-pool retry constants. Used by both the regular pool
+// (retryOnConnectionError around individual query ops) and the reserved
+// pool (acquire+validate retry on NewConn). Kept together so the two
+// retry regimes stay in lockstep.
+const (
+	// MaxConnPoolRetryAttempts is the maximum number of attempts for
+	// retrying a connection-pool operation that hit a connection-class
+	// error. On each retry, the underlying socket is replaced.
+	MaxConnPoolRetryAttempts = 3
+
+	// ConnPoolRetryBackoff is the delay between retry attempts. The
+	// short pause gives PostgreSQL time to finish starting up when the
+	// connection error is due to a restart.
+	ConnPoolRetryBackoff = 100 * time.Millisecond
+)

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -604,8 +604,16 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 			return format, columnFormats, nil
 
 		case protocol.MsgErrorResponse:
-			// Parse and return the error
-			return 0, nil, c.parseError(body)
+			// Parse the error, then drain the trailing ReadyForQuery so
+			// the connection is left in a clean state and is safe to
+			// return to the pool. Without this, the next operation on
+			// this socket would see the leftover RFQ as its first
+			// response and fail with "received ReadyForQuery before X".
+			// waitForReadyForQuery also updates txnStatus from the RFQ
+			// payload, which we want even on the error path.
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			return 0, nil, pgErr
 
 		case protocol.MsgNoticeResponse:
 			// Skip notices (PostgreSQL might send notices before CopyInResponse)

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -66,7 +66,8 @@ type PoolManager interface {
 
 	// NewReservedConn creates a new reserved connection for the specified user.
 	// Settings are provided as a map and internally converted via the shared SettingsCache.
-	NewReservedConn(ctx context.Context, settings map[string]string, user string) (*reserved.Conn, error)
+	// Optional ReservedConnOption values configure validate-with-retry behavior.
+	NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
 
 	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
 	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -401,14 +401,14 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // Settings are converted via the shared SettingsCache for consistent bucket assignment.
 // The connection is assigned a unique ID for client-side tracking.
 // The caller must call Release() when done with the connection.
-func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string) (*reserved.Conn, error) {
+func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	pool, err := m.getOrCreateUserPool(user)
 	if err != nil {
 		return nil, err
 	}
 	// Convert map to *Settings via the shared cache
 	s := m.settingsCache.GetOrCreate(settings)
-	return pool.NewReservedConn(ctx, s)
+	return pool.NewReservedConn(ctx, s, opts...)
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.

--- a/go/services/multipooler/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/connpoolmanager/user_pool.go
@@ -237,10 +237,11 @@ func (p *UserPool) GetRegularConnWithSettings(ctx context.Context, settings *con
 }
 
 // NewReservedConn creates a new reserved connection for transactions or portal operations.
-// The connection is already authenticated as the pool's user.
-func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Settings) (*reserved.Conn, error) {
+// The connection is already authenticated as the pool's user. Optional
+// ReservedConnOption values configure validate-with-retry behavior.
+func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Settings, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	p.touchActivity()
-	return p.reservedPool.NewConn(ctx, settings)
+	return p.reservedPool.NewConn(ctx, settings, opts...)
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -493,14 +493,25 @@ func (e *Executor) portalExecuteWithReserved(
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 	} else {
-		// Create a new reserved connection
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user)
+		// Create a new reserved connection. Wire ensurePrepared as the
+		// validate hook so that the Parse — the first user-issued write
+		// on this freshly acquired socket — triggers a transparent
+		// retry on a fresh socket if the pooled conn has been silently
+		// closed by PostgreSQL. The post-acquire ensurePrepared call
+		// below is a no-op for the new-conn path because connState
+		// dedupes by canonical name.
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+			_, err := e.ensurePrepared(ctx, conn, preparedStatement)
+			return err
+		}))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create reserved connection for user %s: %w", user, err)
 		}
 	}
 
-	// Ensure the statement is prepared on this connection (with consolidation)
+	// Ensure the statement is prepared on this connection (with consolidation).
+	// For the new-conn branch this is a no-op because the validate hook above
+	// already parsed it; for the existing-conn branch this is the only call.
 	canonicalName, err := e.ensurePrepared(ctx, reservedConn.Conn(), preparedStatement)
 	if err != nil {
 		reservedConn.Release(reserved.ReleaseError)
@@ -737,8 +748,12 @@ func (e *Executor) CopyReady(
 		"query", copyQuery,
 		"user", user)
 
-	var reservedConn *reserved.Conn
-	var err error
+	var (
+		reservedConn  *reserved.Conn
+		err           error
+		format        int16
+		columnFormats []int16
+	)
 
 	// Check if we should use an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
@@ -746,40 +761,57 @@ func (e *Executor) CopyReady(
 		if reservedConn == nil {
 			return 0, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
+
+		// Existing reserved conns are actively held (never idle in the
+		// regular pool), so PostgreSQL's idle timeout cannot have closed
+		// the socket between uses. InitiateCopyFromStdin runs directly
+		// here without a stale-socket retry hop.
+		format, columnFormats, err = reservedConn.Conn().InitiateCopyFromStdin(ctx, copyQuery)
+		if err != nil {
+			reservedConn.Release(reserved.ReleaseError)
+			return 0, nil, nil, fmt.Errorf("failed to initiate COPY FROM STDIN: %w", err)
+		}
 	} else {
-		// Create a new reserved connection (COPY requires connection affinity)
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user)
+		// New reserved conn — wire BEGIN-if-needed and InitiateCopyFromStdin
+		// through the validate hook so that the first writes on this
+		// freshly acquired socket can be transparently retried on a fresh
+		// socket if the pooled conn was silently closed by PostgreSQL.
+		// Capture format / columnFormats via closure for use after acquisition.
+		requiresBegin := protoutil.RequiresBegin(protoutil.GetReasons(reservationOptions))
+		beginQuery := "BEGIN"
+		if reservationOptions != nil && reservationOptions.BeginQuery != "" {
+			beginQuery = reservationOptions.BeginQuery
+		}
+
+		validate := func(ctx context.Context, conn *regular.Conn) error {
+			if requiresBegin {
+				if _, err := conn.Query(ctx, beginQuery); err != nil {
+					return fmt.Errorf("failed to begin transaction for COPY: %w", err)
+				}
+			}
+			var initErr error
+			format, columnFormats, initErr = conn.InitiateCopyFromStdin(ctx, copyQuery)
+			if initErr != nil {
+				return fmt.Errorf("failed to initiate COPY FROM STDIN: %w", initErr)
+			}
+			return nil
+		}
+
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, reserved.WithValidate(validate))
 		if err != nil {
 			return 0, nil, nil, fmt.Errorf("failed to create reserved connection for COPY: %w", err)
 		}
 
-		// If this is a transaction reservation, execute BEGIN before COPY.
-		// This handles the deferred-BEGIN case where the client sent BEGIN
-		// but no query has been executed yet to create a reserved connection.
-		if protoutil.RequiresBegin(protoutil.GetReasons(reservationOptions)) {
-			beginQuery := "BEGIN"
-			if reservationOptions != nil && reservationOptions.BeginQuery != "" {
-				beginQuery = reservationOptions.BeginQuery
-			}
-			if err := reservedConn.BeginWithQuery(ctx, beginQuery); err != nil {
-				reservedConn.Release(reserved.ReleaseError)
-				return 0, nil, nil, fmt.Errorf("failed to begin transaction for COPY: %w", err)
-			}
+		// validate ran BEGIN via the raw *regular.Conn, which bypassed
+		// reserved.Conn.BeginWithQuery's bookkeeping. Mark the
+		// reservation reason explicitly so the txn shows up in
+		// RemainingReasons / RequiresBegin checks.
+		if requiresBegin {
+			reservedConn.AddReservationReason(protoutil.ReasonTransaction)
 		}
 	}
 
 	connID := reservedConn.ConnID()
-
-	// Get the pooled connection for COPY operations
-	conn := reservedConn.Conn()
-
-	// Send COPY command and read CopyInResponse
-	format, columnFormats, err := conn.InitiateCopyFromStdin(ctx, copyQuery)
-	if err != nil {
-		// Connection is in bad state after failed COPY initiation - close it instead of recycling
-		reservedConn.Release(reserved.ReleaseError)
-		return 0, nil, nil, fmt.Errorf("failed to initiate COPY FROM STDIN: %w", err)
-	}
 
 	// Mark the connection as reserved for COPY. If the connection is also
 	// reserved for a transaction, this adds the COPY reason alongside it.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -287,8 +287,25 @@ func (e *Executor) reserveAndStreamExecute(
 		"begin_tx", beginTx,
 		"query", sql)
 
+	// If the query references a gateway-managed prepared statement (wrapped
+	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), parse it during
+	// reserved-connection acquisition. Doing the Parse via the validate
+	// callback lets the reserved pool transparently swap a stale (silently
+	// closed) socket for a fresh one before we register the connection — the
+	// failure mode that flaked TestWrappedPreparedStatementExecution.
+	//
+	// Parse is a session-level operation in PostgreSQL, so running it before
+	// BEGIN is safe; the prepared statement persists into the transaction.
+	var reservedOpts []reserved.ReservedConnOption
+	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
+		validate := func(ctx context.Context, conn *regular.Conn) error {
+			return e.ensurePreparedWithName(ctx, conn, preparedStmt)
+		}
+		reservedOpts = append(reservedOpts, reserved.WithValidate(validate))
+	}
+
 	// Create a reserved connection
-	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user)
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user, reservedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
@@ -313,16 +330,6 @@ func (e *Executor) reserveAndStreamExecute(
 		if err := reservedConn.BeginWithQuery(ctx, beginQuery); err != nil {
 			reservedConn.Release(reserved.ReleaseError)
 			return nil, err
-		}
-	}
-
-	// If the query references a gateway-managed prepared statement (wrapped
-	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), ensure it is
-	// parsed on this newly created backend connection before running the query.
-	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
-		if err := e.ensurePreparedWithName(ctx, reservedConn.Conn(), preparedStmt); err != nil {
-			reservedConn.Release(reserved.ReleaseError)
-			return nil, fmt.Errorf("failed to ensure prepared statement on new reserved connection: %w", err)
 		}
 	}
 

--- a/go/services/multipooler/pools/regular/pool.go
+++ b/go/services/multipooler/pools/regular/pool.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
@@ -87,8 +89,52 @@ func (p *Pool) Get(ctx context.Context) (PooledConn, error) {
 
 // GetWithSettings returns a connection from the pool with the given settings applied.
 // The connection is already authenticated as the pool's configured user.
+//
+// When settings are non-empty, the underlying connpool issues SET commands
+// during acquisition (connpool/pool.go ApplySettings). If that first write
+// hits a stale socket — a connection PostgreSQL closed silently while it
+// sat idle in the pool — the connpool closes the conn and surfaces a
+// connection-class error. Without retry here, callers see that error
+// transparently even though a fresh socket would succeed. We retry with
+// the same regime as the reserved pool (constants.MaxConnPoolRetryAttempts
+// attempts, constants.ConnPoolRetryBackoff between them); each attempt
+// dials a replacement conn since the previous one was closed.
+//
+// Non-connection errors (timeout, malformed SETs, pool closed) propagate
+// unchanged. The settings==nil/empty fast path is unaffected: that case
+// never runs ApplySettings, so there is no acquisition-time stale-socket
+// hazard to retry.
 func (p *Pool) GetWithSettings(ctx context.Context, settings *connstate.Settings) (PooledConn, error) {
-	return p.pool.GetWithSettings(ctx, settings)
+	if settings == nil || settings.IsEmpty() {
+		return p.pool.GetWithSettings(ctx, settings)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= constants.MaxConnPoolRetryAttempts; attempt++ {
+		pooled, err := p.pool.GetWithSettings(ctx, settings)
+		if err == nil {
+			return pooled, nil
+		}
+		if !mterrors.IsConnectionError(err) {
+			return nil, err
+		}
+		lastErr = err
+
+		if attempt == constants.MaxConnPoolRetryAttempts {
+			break
+		}
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		backoffTimer := time.NewTimer(constants.ConnPoolRetryBackoff)
+		select {
+		case <-backoffTimer.C:
+		case <-ctx.Done():
+			backoffTimer.Stop()
+			return nil, context.Cause(ctx)
+		}
+	}
+	return nil, fmt.Errorf("regular connection acquisition failed after %d attempts: %w", constants.MaxConnPoolRetryAttempts, lastErr)
 }
 
 // Close closes all connections in the pool.

--- a/go/services/multipooler/pools/regular/pool_test.go
+++ b/go/services/multipooler/pools/regular/pool_test.go
@@ -16,12 +16,15 @@ package regular
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
@@ -96,6 +99,102 @@ func TestPool_GetWithSettings(t *testing.T) {
 
 	// Verify SET was actually called.
 	assert.Greater(t, server.GetPatternCalledNum(`SELECT pg_catalog\.set_config\(.+\)`), 0, "SET command should have been called")
+}
+
+// TestPool_GetWithSettings_RetriesOnConnectionError covers the case
+// where applying SETs during acquisition hits a stale socket: the
+// connpool closes the conn and surfaces a connection-class error, and
+// the regular pool wrapper retries with a fresh socket.
+func TestPool_GetWithSettings_RetriesOnConnectionError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.OrderMatters()
+
+	// First attempt: SET issued by ApplySettings comes back as a FATAL
+	// 57P01 (admin_shutdown). The connpool will close the conn.
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query: "SELECT pg_catalog.set_config*",
+		Error: connErrFATAL(),
+	})
+	// Second attempt (after retry on a fresh socket): SET succeeds.
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query:       "SELECT pg_catalog.set_config*",
+		QueryResult: &sqltypes.Result{},
+	})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	settings := connstate.NewSettings(map[string]string{"search_path": "public"}, 0)
+
+	pooled, err := pool.GetWithSettings(context.Background(), settings)
+	require.NoError(t, err)
+	require.NotNil(t, pooled)
+	defer pooled.Recycle()
+
+	assert.Equal(t, settings, pooled.Conn.Settings(),
+		"retried acquisition must still leave the conn marked with the desired settings")
+	server.VerifyAllExecutedOrFail()
+}
+
+// TestPool_GetWithSettings_NonConnectionErrorNoRetry covers the
+// non-connection-error branch: the error propagates verbatim with no
+// retry.
+func TestPool_GetWithSettings_NonConnectionErrorNoRetry(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.OrderMatters()
+
+	// The first (and only) SET attempt fails with a plain Go error,
+	// which IsConnectionError will not classify as a connection error.
+	server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+		Query: "SELECT pg_catalog.set_config*",
+		Error: errors.New("syntax error in SET"),
+	})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	settings := connstate.NewSettings(map[string]string{"search_path": "public"}, 0)
+
+	pooled, err := pool.GetWithSettings(context.Background(), settings)
+	require.Error(t, err)
+	require.Nil(t, pooled)
+	assert.False(t, mterrors.IsConnectionError(err),
+		"non-connection error must propagate unchanged, not be wrapped as connection failure")
+	server.VerifyAllExecutedOrFail()
+}
+
+// TestPool_GetWithSettings_ExhaustedRetries covers the case where SET
+// fails with a connection error on every attempt: GetWithSettings
+// returns the wrapped final error after constants.MaxConnPoolRetryAttempts.
+func TestPool_GetWithSettings_ExhaustedRetries(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+
+	server.OrderMatters()
+
+	for range constants.MaxConnPoolRetryAttempts {
+		server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
+			Query: "SELECT pg_catalog.set_config*",
+			Error: connErrFATAL(),
+		})
+	}
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	settings := connstate.NewSettings(map[string]string{"search_path": "public"}, 0)
+
+	pooled, err := pool.GetWithSettings(context.Background(), settings)
+	require.Error(t, err)
+	require.Nil(t, pooled)
+	assert.Contains(t, err.Error(), "regular connection acquisition failed after")
+	assert.True(t, mterrors.IsConnectionError(err),
+		"wrapped error must still unwrap to a connection error")
+	server.VerifyAllExecutedOrFail()
 }
 
 func TestPool_Close(t *testing.T) {

--- a/go/services/multipooler/pools/regular/regular_conn.go
+++ b/go/services/multipooler/pools/regular/regular_conn.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
@@ -31,14 +32,6 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
 )
-
-// maxQueryAttempts is the maximum number of attempts for retrying queries.
-// On connection error, the connection is reconnected and the query retried.
-const maxQueryAttempts = 3
-
-// retryBackoff is the delay between retry attempts. This gives PostgreSQL
-// time to finish starting up when the connection error is due to a restart.
-const retryBackoff = 100 * time.Millisecond
 
 // errStreamingAlreadyStarted is a sentinel used internally to signal that a
 // streaming query's callback was already invoked, so retrying would duplicate
@@ -424,7 +417,7 @@ func (c *Conn) Reconnect(ctx context.Context) error {
 // QueryWithRetry, QueryStreamingWithRetry and QueryArgsWithRetry execute queries
 // with automatic reconnection on connection errors.
 // On connection error the underlying socket is reconnected in-place and the
-// query is retried, up to maxQueryAttempts total attempts.
+// query is retried, up to constants.MaxConnPoolRetryAttempts total attempts.
 //
 // These methods are for stateless pool queries only. Stateful operations
 // (transactions, reserved connections, extended query protocol) must use the
@@ -480,10 +473,10 @@ func (c *Conn) QueryArgsWithRetry(ctx context.Context, sql string, args ...any) 
 
 // retryOnConnectionError executes op with automatic retry on connection error.
 // On connection error the underlying socket is reconnected in-place and op is
-// retried, up to maxQueryAttempts total. The connection is closed after
+// retried, up to constants.MaxConnPoolRetryAttempts total. The connection is closed after
 // exhausting all attempts or if reconnection fails.
 func retryOnConnectionError[T any](c *Conn, ctx context.Context, op func() (T, error)) (T, error) {
-	for attempt := 1; attempt <= maxQueryAttempts; attempt++ {
+	for attempt := 1; attempt <= constants.MaxConnPoolRetryAttempts; attempt++ {
 		val, err := execOnce(c, ctx, op)
 		switch {
 		case err == nil:
@@ -491,7 +484,7 @@ func retryOnConnectionError[T any](c *Conn, ctx context.Context, op func() (T, e
 		case !mterrors.IsConnectionError(err):
 			var zero T
 			return zero, err
-		case attempt == maxQueryAttempts:
+		case attempt == constants.MaxConnPoolRetryAttempts:
 			c.conn.Close()
 			var zero T
 			return zero, err
@@ -502,7 +495,7 @@ func retryOnConnectionError[T any](c *Conn, ctx context.Context, op func() (T, e
 		}
 		// Brief backoff before reconnecting to give PostgreSQL time to
 		// finish starting up if the error is due to a restart.
-		backoffTimer := time.NewTimer(retryBackoff)
+		backoffTimer := time.NewTimer(constants.ConnPoolRetryBackoff)
 		select {
 		case <-backoffTimer.C:
 		case <-ctx.Done():

--- a/go/services/multipooler/pools/regular/regular_conn_test.go
+++ b/go/services/multipooler/pools/regular/regular_conn_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
@@ -128,7 +129,7 @@ func TestQueryWithRetry_ClosesConnAfterMaxAttempts(t *testing.T) {
 	server.OrderMatters()
 
 	// All 3 attempts fail with connection error.
-	for range maxQueryAttempts {
+	for range constants.MaxConnPoolRetryAttempts {
 		server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
 			Query: "SELECT 1",
 			Error: connErrFATAL(),
@@ -274,7 +275,7 @@ func TestQueryStreamingWithRetry_ClosesConnAfterMaxAttempts(t *testing.T) {
 
 	server.OrderMatters()
 
-	for range maxQueryAttempts {
+	for range constants.MaxConnPoolRetryAttempts {
 		server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
 			Query: "SELECT 1",
 			Error: connErrFATAL(),
@@ -550,7 +551,7 @@ func TestQueryArgsWithRetry_ClosesConnAfterMaxAttempts(t *testing.T) {
 
 	server.OrderMatters()
 
-	for range maxQueryAttempts {
+	for range constants.MaxConnPoolRetryAttempts {
 		server.AddExpectedExecuteFetch(fakepgserver.ExpectedExecuteFetch{
 			Query: "SELECT $1",
 			Error: connErrFATAL(),

--- a/go/services/multipooler/pools/reserved/options.go
+++ b/go/services/multipooler/pools/reserved/options.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reserved
+
+import (
+	"context"
+
+	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
+)
+
+// ReservedConnOption configures a NewConn call.
+type ReservedConnOption func(*reservedConnOpts)
+
+// reservedConnOpts holds optional behavior for NewConn.
+type reservedConnOpts struct {
+	// validate, if non-nil, is invoked after a regular connection is acquired
+	// and before the reserved connection is registered. If it returns a
+	// connection error the underlying socket is tainted and another attempt
+	// is made (up to maxNewConnAttempts). Other errors are returned unchanged
+	// after recycling the connection.
+	validate func(context.Context, *regular.Conn) error
+}
+
+// WithValidate registers a callback that runs against the freshly acquired
+// regular connection. Returning a connection error triggers a transparent
+// retry against a replacement socket; returning any other error aborts
+// NewConn and propagates the error to the caller.
+func WithValidate(fn func(context.Context, *regular.Conn) error) ReservedConnOption {
+	return func(o *reservedConnOpts) {
+		o.validate = fn
+	}
+}

--- a/go/services/multipooler/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool.go
@@ -204,49 +204,53 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts .
 }
 
 // acquireValidated borrows a regular connection from the underlying pool
-// and, if validate is non-nil, runs it against the connection. Any
-// connection-classified error encountered along the way — whether from
-// GetWithSettings (stale socket exposed while applying SETs) or from
-// validate (stale socket exposed by the first user-issued write) —
-// triggers a retry on a fresh socket, up to constants.MaxConnPoolRetryAttempts. The
-// connpool itself only self-heals across ResetAllSettings failures
-// (connReopen at connpool/pool.go), not ApplySettings failures, so the
-// retry loop here closes the gap for new reserved-conn acquisition.
+// and, if validate is non-nil, runs it against the connection. A
+// connection error from validate (stale socket exposed by the first
+// user-issued write) taints the socket and triggers another attempt on
+// a fresh one, up to constants.MaxConnPoolRetryAttempts.
+//
+// Connection errors from GetWithSettings itself (stale socket exposed
+// while applying SETs) are handled inside regular.Pool.GetWithSettings,
+// which retries with the same regime; this layer does not double-retry.
 //
 // Non-connection errors propagate unchanged, with the pooled conn
-// recycled (or no conn to clean up if Get failed).
+// recycled.
 func (p *Pool) acquireValidated(
 	ctx context.Context,
 	settings *connstate.Settings,
 	validate func(context.Context, *regular.Conn) error,
 ) (regular.PooledConn, error) {
+	if validate == nil {
+		pooled, err := p.conns.GetWithSettings(ctx, settings)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get connection: %w", err)
+		}
+		return pooled, nil
+	}
+
 	var lastErr error
 	for attempt := 1; attempt <= constants.MaxConnPoolRetryAttempts; attempt++ {
 		pooled, err := p.conns.GetWithSettings(ctx, settings)
 		if err != nil {
-			if !mterrors.IsConnectionError(err) {
-				return nil, fmt.Errorf("failed to get connection: %w", err)
-			}
-			// GetWithSettings already closed the stale socket internally
-			// on ApplySettings failure (connpool/pool.go), so there is
-			// nothing for us to taint here — just record and back off.
-			lastErr = err
-		} else if validate == nil {
+			return nil, fmt.Errorf("failed to get connection: %w", err)
+		}
+
+		validateErr := validate(ctx, pooled.Conn)
+		if validateErr == nil {
 			return pooled, nil
-		} else if validateErr := validate(ctx, pooled.Conn); validateErr == nil {
-			return pooled, nil
-		} else if !mterrors.IsConnectionError(validateErr) {
+		}
+		if !mterrors.IsConnectionError(validateErr) {
 			pooled.Recycle()
 			return nil, validateErr
-		} else {
-			// Connection-level failure surfaced by validate. Taint nils
-			// out pooled.pool, so the subsequent Recycle takes the
-			// pool==nil branch and closes the orphaned socket
-			// immediately rather than waiting on the idle killer.
-			pooled.Taint()
-			pooled.Recycle()
-			lastErr = validateErr
 		}
+
+		// Connection-level failure surfaced by validate. Taint nils out
+		// pooled.pool, so the subsequent Recycle takes the pool==nil
+		// branch and closes the orphaned socket immediately rather than
+		// waiting on the idle killer.
+		pooled.Taint()
+		pooled.Recycle()
+		lastErr = validateErr
 
 		if attempt == constants.MaxConnPoolRetryAttempts {
 			break
@@ -262,7 +266,7 @@ func (p *Pool) acquireValidated(
 			return nil, context.Cause(ctx)
 		}
 	}
-	return nil, fmt.Errorf("reserved connection acquisition failed after %d attempts: %w", constants.MaxConnPoolRetryAttempts, lastErr)
+	return nil, fmt.Errorf("reserved connection validate failed after %d attempts: %w", constants.MaxConnPoolRetryAttempts, lastErr)
 }
 
 // Get retrieves a reserved connection by ID and resets its expiry time.

--- a/go/services/multipooler/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool.go
@@ -206,15 +206,22 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts .
 // acquireValidated borrows a regular connection from the underlying pool
 // and, if validate is non-nil, runs it against the connection. A
 // connection error from validate (stale socket exposed by the first
-// user-issued write) taints the socket and triggers another attempt on
-// a fresh one, up to constants.MaxConnPoolRetryAttempts.
+// user-issued write) triggers another attempt on a fresh socket, up to
+// constants.MaxConnPoolRetryAttempts.
+//
+// Any non-nil error from validate — connection or otherwise — taints
+// the pooled conn before returning or retrying. Validate hooks perform
+// real state-modifying work on the conn (Parse, BEGIN, COPY initiation),
+// so a failure in one of those steps may leave the conn in a partially
+// modified state (e.g. BEGIN succeeded, then InitiateCopyFromStdin
+// failed — the conn is now stuck in failed-transaction 'E' state).
+// Recycling such a conn back to the pool would poison the next user;
+// discarding it is the safe default and matches the pre-primitive
+// behavior of every caller (Release(ReleaseError) on failure).
 //
 // Connection errors from GetWithSettings itself (stale socket exposed
 // while applying SETs) are handled inside regular.Pool.GetWithSettings,
 // which retries with the same regime; this layer does not double-retry.
-//
-// Non-connection errors propagate unchanged, with the pooled conn
-// recycled.
 func (p *Pool) acquireValidated(
 	ctx context.Context,
 	settings *connstate.Settings,
@@ -239,17 +246,17 @@ func (p *Pool) acquireValidated(
 		if validateErr == nil {
 			return pooled, nil
 		}
-		if !mterrors.IsConnectionError(validateErr) {
-			pooled.Recycle()
-			return nil, validateErr
-		}
 
-		// Connection-level failure surfaced by validate. Taint nils out
+		// Any validate failure discards the conn. Taint nils out
 		// pooled.pool, so the subsequent Recycle takes the pool==nil
 		// branch and closes the orphaned socket immediately rather than
 		// waiting on the idle killer.
 		pooled.Taint()
 		pooled.Recycle()
+
+		if !mterrors.IsConnectionError(validateErr) {
+			return nil, validateErr
+		}
 		lastErr = validateErr
 
 		if attempt == constants.MaxConnPoolRetryAttempts {

--- a/go/services/multipooler/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
@@ -152,7 +154,13 @@ func (p *Pool) idleKiller(interval time.Duration) {
 // NewConn acquires a new reserved connection.
 // The connection is assigned a unique ID for client-side tracking.
 // The connection is already authenticated as the pool's configured user.
-func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn, error) {
+//
+// If WithValidate is supplied, the callback runs against the freshly
+// acquired *regular.Conn before the reserved connection is registered.
+// On a connection error from validate (e.g. the pool handed back a socket
+// that PostgreSQL has silently closed), the underlying connection is
+// tainted and a replacement is fetched, up to constants.MaxConnPoolRetryAttempts total.
+func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings, opts ...ReservedConnOption) (*Conn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -160,10 +168,14 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn
 	}
 	p.mu.Unlock()
 
-	// Get a regular connection from the pool.
-	pooled, err := p.conns.GetWithSettings(ctx, settings)
+	o := reservedConnOpts{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	pooled, err := p.acquireValidated(ctx, settings, o.validate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get connection: %w", err)
+		return nil, err
 	}
 
 	// Generate unique ID. Since lastID is initialized with Unix nanoseconds,
@@ -189,6 +201,68 @@ func (p *Pool) NewConn(ctx context.Context, settings *connstate.Settings) (*Conn
 		"process_id", rc.ProcessID())
 
 	return rc, nil
+}
+
+// acquireValidated borrows a regular connection from the underlying pool
+// and, if validate is non-nil, runs it against the connection. Any
+// connection-classified error encountered along the way — whether from
+// GetWithSettings (stale socket exposed while applying SETs) or from
+// validate (stale socket exposed by the first user-issued write) —
+// triggers a retry on a fresh socket, up to constants.MaxConnPoolRetryAttempts. The
+// connpool itself only self-heals across ResetAllSettings failures
+// (connReopen at connpool/pool.go), not ApplySettings failures, so the
+// retry loop here closes the gap for new reserved-conn acquisition.
+//
+// Non-connection errors propagate unchanged, with the pooled conn
+// recycled (or no conn to clean up if Get failed).
+func (p *Pool) acquireValidated(
+	ctx context.Context,
+	settings *connstate.Settings,
+	validate func(context.Context, *regular.Conn) error,
+) (regular.PooledConn, error) {
+	var lastErr error
+	for attempt := 1; attempt <= constants.MaxConnPoolRetryAttempts; attempt++ {
+		pooled, err := p.conns.GetWithSettings(ctx, settings)
+		if err != nil {
+			if !mterrors.IsConnectionError(err) {
+				return nil, fmt.Errorf("failed to get connection: %w", err)
+			}
+			// GetWithSettings already closed the stale socket internally
+			// on ApplySettings failure (connpool/pool.go), so there is
+			// nothing for us to taint here — just record and back off.
+			lastErr = err
+		} else if validate == nil {
+			return pooled, nil
+		} else if validateErr := validate(ctx, pooled.Conn); validateErr == nil {
+			return pooled, nil
+		} else if !mterrors.IsConnectionError(validateErr) {
+			pooled.Recycle()
+			return nil, validateErr
+		} else {
+			// Connection-level failure surfaced by validate. Taint nils
+			// out pooled.pool, so the subsequent Recycle takes the
+			// pool==nil branch and closes the orphaned socket
+			// immediately rather than waiting on the idle killer.
+			pooled.Taint()
+			pooled.Recycle()
+			lastErr = validateErr
+		}
+
+		if attempt == constants.MaxConnPoolRetryAttempts {
+			break
+		}
+		if ctx.Err() != nil {
+			return nil, context.Cause(ctx)
+		}
+		backoffTimer := time.NewTimer(constants.ConnPoolRetryBackoff)
+		select {
+		case <-backoffTimer.C:
+		case <-ctx.Done():
+			backoffTimer.Stop()
+			return nil, context.Cause(ctx)
+		}
+	}
+	return nil, fmt.Errorf("reserved connection acquisition failed after %d attempts: %w", constants.MaxConnPoolRetryAttempts, lastErr)
 }
 
 // Get retrieves a reserved connection by ID and resets its expiry time.

--- a/go/services/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool_test.go
@@ -725,13 +725,17 @@ func TestPool_NewConn_ValidateNonConnectionErrorPropagates(t *testing.T) {
 	assert.Nil(t, conn)
 	assert.Equal(t, 1, calls, "non-connection errors must not trigger a retry")
 
-	// No reservation was registered, and the pooled conn was recycled
-	// (not tainted): it stays alive for the next acquisition.
+	// No reservation was registered. The pooled conn is discarded
+	// (tainted + recycled) because validate ran state-modifying work on
+	// it that may have left the conn in an inconsistent state — see the
+	// acquireValidated doc for the full rationale. The happy-path
+	// non-connection-error case is indistinguishable from the
+	// state-modification case, so we discard unconditionally.
 	stats := pool.Stats()
 	assert.Equal(t, 0, stats.Active)
 	assert.Equal(t, int64(0), stats.ReserveCount, "failed acquisition should not increment ReserveCount")
 	require.NotNil(t, seenConn)
-	assert.False(t, seenConn.IsClosed(), "non-connection error must recycle (not taint) the pooled conn")
+	assert.True(t, seenConn.IsClosed(), "validate failure must taint the conn, not recycle it dirty")
 }
 
 func TestPool_NewConn_ValidateExhaustsRetries(t *testing.T) {

--- a/go/services/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool_test.go
@@ -16,18 +16,34 @@ package reserved
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
 )
+
+// connErrFATAL returns a PgDiagnostic that mterrors.IsConnectionError
+// recognises (FATAL 57P01 admin_shutdown). Used to drive the validate-retry
+// path in tests, mirroring the real silent-disconnect failure mode the
+// pool-layer retry was added to handle.
+func connErrFATAL() error {
+	return &mterrors.PgDiagnostic{
+		MessageType: 'E',
+		Severity:    "FATAL",
+		Code:        "57P01",
+		Message:     "terminating connection due to administrator command",
+	}
+}
 
 func newTestPool(t *testing.T, server *fakepgserver.Server) *Pool {
 	pool := NewPool(context.Background(), &PoolConfig{
@@ -637,6 +653,142 @@ func TestConn_ReleaseError_TaintsConnection(t *testing.T) {
 	for _, c := range conns {
 		c.Release(ReleaseCommit)
 	}
+}
+
+func TestPool_NewConn_ValidateRetriesOnConnectionError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	var calls int
+	var firstConn, lastConn *regular.Conn
+	validate := func(_ context.Context, conn *regular.Conn) error {
+		calls++
+		if calls == 1 {
+			firstConn = conn
+			return connErrFATAL() // triggers Taint + retry
+		}
+		lastConn = conn
+		return nil
+	}
+
+	conn, err := pool.NewConn(ctx, nil, WithValidate(validate))
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Release(ReleaseCommit)
+
+	// Validate should have been invoked once per attempt, and the registered
+	// reserved connection should wrap the second (replacement) socket.
+	assert.Equal(t, 2, calls)
+	require.NotNil(t, firstConn)
+	require.NotNil(t, lastConn)
+	assert.NotSame(t, firstConn, lastConn, "second attempt should receive a different *regular.Conn after Taint")
+	assert.Same(t, lastConn, conn.Conn())
+	assert.True(t, firstConn.IsClosed(), "tainted stale conn must be closed promptly, not leaked to the idle killer")
+
+	// Reservation bookkeeping only records the final success.
+	stats := pool.Stats()
+	assert.Equal(t, 1, stats.Active)
+	assert.Equal(t, int64(1), stats.ReserveCount)
+}
+
+func TestPool_NewConn_ValidateNonConnectionErrorPropagates(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	sentinel := errors.New("validate refused for business reasons")
+
+	var (
+		calls    int
+		seenConn *regular.Conn
+	)
+	validate := func(_ context.Context, c *regular.Conn) error {
+		calls++
+		seenConn = c
+		return sentinel
+	}
+
+	conn, err := pool.NewConn(ctx, nil, WithValidate(validate))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "non-connection errors must propagate unchanged")
+	assert.Nil(t, conn)
+	assert.Equal(t, 1, calls, "non-connection errors must not trigger a retry")
+
+	// No reservation was registered, and the pooled conn was recycled
+	// (not tainted): it stays alive for the next acquisition.
+	stats := pool.Stats()
+	assert.Equal(t, 0, stats.Active)
+	assert.Equal(t, int64(0), stats.ReserveCount, "failed acquisition should not increment ReserveCount")
+	require.NotNil(t, seenConn)
+	assert.False(t, seenConn.IsClosed(), "non-connection error must recycle (not taint) the pooled conn")
+}
+
+func TestPool_NewConn_ValidateExhaustsRetries(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	var calls int
+	validate := func(_ context.Context, _ *regular.Conn) error {
+		calls++
+		return connErrFATAL()
+	}
+
+	conn, err := pool.NewConn(ctx, nil, WithValidate(validate))
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.Equal(t, constants.MaxConnPoolRetryAttempts, calls, "validate should be invoked exactly constants.MaxConnPoolRetryAttempts times")
+	assert.Contains(t, err.Error(), "reserved connection acquisition failed after")
+	// The wrapped error must still classify as a connection error so
+	// upstream callers can react accordingly.
+	assert.True(t, mterrors.IsConnectionError(err), "wrapped error must still unwrap to a connection error")
+
+	stats := pool.Stats()
+	assert.Equal(t, 0, stats.Active)
+	assert.Equal(t, int64(0), stats.ReserveCount)
+}
+
+func TestPool_NewConn_NilValidateUnchanged(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// Passing no options is the canonical "no validate" call.
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Release(ReleaseCommit)
+
+	// Passing WithValidate(nil) should also behave like no validate at all.
+	conn2, err := pool.NewConn(ctx, nil, WithValidate(nil))
+	require.NoError(t, err)
+	require.NotNil(t, conn2)
+	defer conn2.Release(ReleaseCommit)
+
+	stats := pool.Stats()
+	assert.Equal(t, 2, stats.Active)
+	assert.Equal(t, int64(2), stats.ReserveCount)
 }
 
 func TestPool_NewConnAfterPoolRecreation(t *testing.T) {

--- a/go/services/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool_test.go
@@ -754,7 +754,7 @@ func TestPool_NewConn_ValidateExhaustsRetries(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, conn)
 	assert.Equal(t, constants.MaxConnPoolRetryAttempts, calls, "validate should be invoked exactly constants.MaxConnPoolRetryAttempts times")
-	assert.Contains(t, err.Error(), "reserved connection acquisition failed after")
+	assert.Contains(t, err.Error(), "reserved connection validate failed after")
 	// The wrapped error must still classify as a connection error so
 	// upstream callers can react accordingly.
 	assert.True(t, mterrors.IsConnectionError(err), "wrapped error must still unwrap to a connection error")


### PR DESCRIPTION
## Summary

- Adds a pool-layer retry primitive for reserved-connection acquisition so silent stale-socket failures (idle-timed-out PG connections) no longer surface to callers
- Closes the same gap on the regular pool path (`GetWithSettings` retry when `ApplySettings` hits a dead socket)
- Wires the new `WithValidate` hook into all three executor `NewReservedConn` call sites — `reserveAndStreamExecute`, `portalExecuteWithReserved`, and `CopyInitiate`
- Fixes a latent pgprotocol bug where `InitiateCopyFromStdin` left the conn in a dirty state on `ErrorResponse` (didn't drain the trailing RFQ)

## Problem

The reserved connection pool can hand out a regular pooled conn that PostgreSQL silently closed (idle session timeout). The first user-issued write on that socket — a `Parse`, `BEGIN`, or `InitiateCopyFromStdin` — fails with `EPIPE` / `EOF` / `FATAL 57P0x`. The non-reserved query path already recovers via `retryOnConnectionError` (in-place reconnect), but the reserved acquisition path had no equivalent. A flaky integration test (`TestWrappedPreparedStatementExecution/multigateway/create_temp_table_as_execute`) hit this against `ensurePreparedWithName` in `executor.reserveAndStreamExecute`.

A second, narrower variant of the same bug existed at `connpool.GetWithSettings`: when applying SETs failed with a connection error, the connpool closed the conn but did not retry, so callers saw the failure even though a fresh socket would have succeeded.

## Solution

Three layered fixes that share constants and retry semantics:

1. **`reserved.Pool.NewConn` accepts `ReservedConnOption`s, including `WithValidate`.** The validate callback runs on the underlying `*regular.Conn` before the reserved conn is registered. Connection-class errors taint the pooled conn (closing the socket immediately) and trigger a retry on a fresh one, up to `constants.MaxConnPoolRetryAttempts` total with `constants.ConnPoolRetryBackoff` between them. Plumbed through `Manager.NewReservedConn` and `UserPool.NewReservedConn` as a variadic option, so existing call sites are unchanged.

2. **`regular.Pool.GetWithSettings` retries on its own when settings are non-empty.** Same retry regime, same shared constants. Every existing `GetRegularConnWithSettings` caller benefits transparently — no API change.

3. **Executor wires `WithValidate` at all three new-reserved-conn call sites.** The first write (Parse / BEGIN+InitiateCopy / ensurePrepared) moves into the validate hook so the pool can retry it transparently. Existing-reserved-conn paths (`GetReservedConn`) are not exposed because those conns are actively held and never sit idle.

A side fix in `pgprotocol/client.Conn.InitiateCopyFromStdin`: on `MsgErrorResponse` we now drain to `ReadyForQuery` (via the existing `waitForReadyForQuery` helper) instead of returning early. The previous behavior left an unconsumed RFQ in the read buffer, which corrupted the next user of that socket. The original COPY-init call site masked this by always tainting on error; with the validate hook now recycling on non-connection errors, the protocol-level bug had to be fixed at the source.

Shared constants live in a new `go/common/constants/connpool.go` so the regular and reserved pools can't drift out of lockstep.

Docs (`connection_pooling.md`, `prepared_statements_design.md`) updated to describe the new retry primitive and the now-stale interface signature.