### PR TITLE
docs(query_serving): sync design docs with current code

### DIFF
--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -101,4 +101,5 @@ Print the PR URL when done so the user can review it.
 - **Title** must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, `ci`, `perf`. Keep it under 72 characters.
 - **Summary** should be concise — focus on _what_ and _why_, not implementation minutiae.
 - Do not pad the description with filler. Shorter is better.
-- **Do not hard-wrap paragraphs or bullet bodies in the PR body.** GitHub's PR/issue Markdown treats single newlines inside a paragraph as soft line breaks (`<br>`), so wrapping at ~70–80 chars produces visible broken-up sentences in the rendered PR. Keep each paragraph or bullet on one long line; only insert a newline to start a new paragraph, bullet, heading, or code block. Code fences and lists are fine — the rule applies to prose.
+- **Do not hard-wrap paragraphs or bullet bodies in the PR body.** GitHub's PR/issue Markdown treats single newlines inside a paragraph as soft line breaks (`<br>`), so wrapping at ~70–80 chars produces visible broken-up sentences in the rendered PR.
+- Keep each paragraph or bullet on one long line; only insert a newline to start a new paragraph, bullet, heading, or code block. Code fences and lists are fine — the rule applies to prose.

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -101,3 +101,4 @@ Print the PR URL when done so the user can review it.
 - **Title** must follow [Conventional Commits](https://www.conventionalcommits.org/): `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, `ci`, `perf`. Keep it under 72 characters.
 - **Summary** should be concise — focus on _what_ and _why_, not implementation minutiae.
 - Do not pad the description with filler. Shorter is better.
+- **Do not hard-wrap paragraphs or bullet bodies in the PR body.** GitHub's PR/issue Markdown treats single newlines inside a paragraph as soft line breaks (`<br>`), so wrapping at ~70–80 chars produces visible broken-up sentences in the rendered PR. Keep each paragraph or bullet on one long line; only insert a newline to start a new paragraph, bullet, heading, or code block. Code fences and lists are fine — the rule applies to prose.

--- a/docs/query_serving/failover_buffering.md
+++ b/docs/query_serving/failover_buffering.md
@@ -192,6 +192,7 @@ Several mechanisms prevent unbounded buffering:
   guard, multi-shard independence, and retry completion signaling
 - **`poolergateway/pooler_gateway_test.go`**: unit tests for
   `classifyError` and `withBuffering` retry loop
-- **`queryserving/buffer_test.go`**: end-to-end integration test
-  that runs continuous writes through a multigateway, triggers a
-  planned failover, and asserts zero failed writes
+- **`test/endtoend/queryserving/buffer_test.go`**: end-to-end
+  integration test that runs continuous writes through a
+  multigateway, triggers a planned failover, and asserts zero
+  failed writes

--- a/docs/query_serving/load_balancing.md
+++ b/docs/query_serving/load_balancing.md
@@ -109,7 +109,9 @@ Each `PoolerConnection` runs a background `StreamPoolerHealth` RPC against its m
 
 The LoadBalancer consumes these updates via the `onPoolerHealthUpdate` callback for two purposes:
 
-1. **Primary caching.** LoadBalancer caches the currently-serving primary per shard in `cachedPrimaries map[shardKey]*cachedPrimary`, tagged with a term. `GetConnection` for a `PRIMARY` target hits this cache first, avoiding a scan of all poolers on the hot path. Entries with `term == 0` are provisional (derived from metadata at `AddPooler` time); once a health update reports a `PrimaryObservation` with a non-zero term, the cache is reconciled and stale entries for older terms are evicted.
+1. **Primary caching.** LoadBalancer caches the currently-serving primary per shard in `cachedPrimaries map[shardKey]*cachedPrimary`, tagged with a term. `GetConnection` for a `PRIMARY` target hits this cache first, avoiding a scan of all poolers on the hot path.
+
+   Entries with `term == 0` are provisional (derived from metadata at `AddPooler` time); once a health update reports a `PrimaryObservation` with a non-zero term, the cache is reconciled and stale entries for older terms are evicted.
 
 2. **Failover coordination.** When a new primary is observed, the LoadBalancer invokes the callback registered by `SetOnPrimaryServing`, which the gateway uses to stop failover buffering and replay buffered requests against the new primary.
 

--- a/docs/query_serving/load_balancing.md
+++ b/docs/query_serving/load_balancing.md
@@ -37,7 +37,7 @@ The LoadBalancer manages connections to multipooler instances and routes queries
 
 **LoadBalancer** - Manages all pooler connections and selects the best one for each query. Maintains a map of pooler ID → PoolerConnection.
 
-**PoolerConnection** - Wraps a gRPC connection to a single multipooler instance. Implements `QueryService` interface and tracks pooler metadata (type, cell, shard).
+**PoolerConnection** - Wraps a gRPC connection to a single multipooler instance. Holds a `queryservice.QueryService` client for query execution, tracks pooler metadata (type, cell, shard), and runs a background health stream (`StreamPoolerHealth`) that reports serving state, replication lag, and the pooler's current `PrimaryObservation`.
 
 **LoadBalancerListener** - Adapter between discovery events and LoadBalancer operations. Translates `OnPoolerChanged` / `OnPoolerRemoved` callbacks into `AddPooler` / `RemovePooler` calls.
 
@@ -99,6 +99,29 @@ Connections are created and removed based on etcd topology changes:
 
 Connections persist until the pooler is removed from topology. No per-query connection creation - all queries share the same connections. gRPC handles multiplexing multiple concurrent queries over a single connection.
 
+## Health Streaming and Primary Caching
+
+Each `PoolerConnection` runs a background `StreamPoolerHealth` RPC against its multipooler. Each response carries:
+
+- Serving status (e.g. `SERVING`, `NOT_SERVING`)
+- Replication lag for replicas (`replication_lag_ns`)
+- `PrimaryObservation` — which pooler this multipooler believes is the current primary, along with a term number
+
+The LoadBalancer consumes these updates via the `onPoolerHealthUpdate` callback for two purposes:
+
+1. **Primary caching.** LoadBalancer caches the currently-serving primary per shard in `cachedPrimaries map[shardKey]*cachedPrimary`, tagged with a term. `GetConnection` for a `PRIMARY` target hits this cache first, avoiding a scan of all poolers on the hot path. Entries with `term == 0` are provisional (derived from metadata at `AddPooler` time); once a health update reports a `PrimaryObservation` with a non-zero term, the cache is reconciled and stale entries for older terms are evicted.
+
+2. **Failover coordination.** When a new primary is observed, the LoadBalancer invokes the callback registered by `SetOnPrimaryServing`, which the gateway uses to stop failover buffering and replay buffered requests against the new primary.
+
+## Replication Lag Filtering
+
+`SetReplicationLagThresholds(lowLag, highTolerance)` configures a two-tier filter for replica selection:
+
+- **lowLag**: replicas at or below this lag are considered "healthy" and are preferred.
+- **highTolerance**: absolute upper bound. Replicas exceeding this are never returned. `0` disables the upper bound.
+
+If all replicas in the preferred locality exceed `lowLag` but are still under `highTolerance`, they remain eligible — the filter degrades gracefully rather than returning no replicas.
+
 ## Error Handling
 
 ### Fail-Fast Design
@@ -147,9 +170,9 @@ discovery.RegisterListener(listener)
 // - listener.OnPoolerRemoved() for deleted poolers
 ```
 
-### QueryService Interface
+### QueryService
 
-PoolerConnection implements `queryservice.QueryService`, allowing it to be used interchangeably with other query service implementations. Internally it delegates to a gRPC client.
+PoolerConnection holds a `queryservice.QueryService` client (backed by the multipooler gRPC stub) and exposes its query methods (`StreamExecute`, `ReserveStreamExecute`, `ConcludeTransaction`, etc.) through thin wrappers so callers can treat it as a connected query endpoint.
 
 ## Operational Concerns
 
@@ -174,7 +197,3 @@ If there are a large number of replicas, each gate can connection to a different
 - **Round-robin**: Distribute load across multiple replicas in same cell
 - **Health-aware**: Skip poolers with high error rates or slow responses
 - **Weighted selection**: Route more traffic to poolers with more capacity
-
-### Health Streaming Integration
-
-When health streaming is added, LoadBalancer can avoid routing to unhealthy poolers.

--- a/docs/query_serving/query_cancellation_design.md
+++ b/docs/query_serving/query_cancellation_design.md
@@ -21,6 +21,11 @@ Key capabilities:
   cancel vs statement timeout
 - **Secret key authentication** preventing unauthorized cancellation
   of arbitrary queries
+- **Replica-reads listener support**: a gateway that runs a separate
+  listener on `--pg-replica-port` registers a second cancel function
+  (`replicaCancelFn` on `CancelManager`); cancel requests targeting
+  connections accepted on that listener are routed identically to
+  primary-listener cancels
 
 ## Background
 

--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -11,11 +11,28 @@ Inside transactions, the connection is reserved and bypasses the pool's normal `
 1. **SET variable = value**: The variable and value are stored in `SessionSettings`. A synthetic `CommandComplete (SET)` is returned to the client immediately.
 2. **RESET variable**: The variable is removed from `SessionSettings`. A synthetic `CommandComplete (RESET)` is returned.
 3. **RESET ALL**: All variables in `SessionSettings` are cleared. A synthetic `CommandComplete (RESET)` is returned.
-4. **SET LOCAL**: Passed through to PostgreSQL (transaction-scoped, not tracked by the gateway).
+4. **SET variable TO DEFAULT**: Normalized to `RESET variable` during planning (matching PostgreSQL, where `VAR_SET_DEFAULT` falls through to `VAR_RESET`).
+5. **SET LOCAL**: Passed through to PostgreSQL (transaction-scoped, not tracked by the gateway).
+6. **SET TRANSACTION / SET SESSION CHARACTERISTICS / SET var FROM CURRENT**: Passed through to PostgreSQL; not tracked by the gateway.
 
 On the next query, the pool merges `SessionSettings` with `StartupParams` (startup params from the client's initial connection). `SessionSettings` entries take precedence. The merged settings are applied to the backend connection before executing the query.
 
 When a variable is `RESET`, its entry is removed from `SessionSettings`, and the `StartupParams` value (if any) becomes visible again through the merge.
+
+## Gateway-Managed Variables
+
+A small set of session variables is intercepted by the planner (see `isGatewayManagedVariable` in `planner/variable_set_stmt.go`) and handled entirely by the gateway. These variables are **not** stored in `SessionSettings` and **not** forwarded to PostgreSQL. Instead, the planner emits a `GatewaySessionState` primitive that updates a typed `GatewayManagedVariable[T]` on the connection state.
+
+Today the set is:
+
+- **`statement_timeout`** — enforced by the gateway via context deadlines (see `statement_timeout_design.md`).
+
+Behaviour:
+
+- `SET var = value` parses and validates the value at SET time. Invalid values are rejected immediately with a PostgreSQL-compatible error (unlike regular session settings, which defer validation to the next query).
+- `RESET var` and `SET var TO DEFAULT` revert to the startup-param value (if any) or the flag default.
+- `SHOW var` reports the current gateway-managed value in PostgreSQL-compatible form.
+- `RESET ALL` clears gateway-managed variables alongside `SessionSettings`.
 
 ## Behaviour Deviations from PostgreSQL
 

--- a/docs/query_serving/transaction_design.md
+++ b/docs/query_serving/transaction_design.md
@@ -318,17 +318,27 @@ shard:
 
 ```go
 type ShardState struct {
-    Target               *query.Target
-    PoolerID             *clustermetadata.ID
-    ReservedConnectionId int64
-    ReservationReasons   uint32  // Bitmask of Reason* constants
+    // Target stores the information about the shard
+    Target *query.Target
+
+    // ReservedState holds the authoritative reservation state from
+    // the multipooler, including the pooler ID, reserved connection
+    // ID, and reservation reasons bitmask.
+    ReservedState *query.ReservedState
 }
 ```
 
+The bundled `ReservedState` message (from the multipooler RPC
+responses) carries:
+
+- `PoolerId`: the multipooler instance that owns the connection
+- `ReservedConnectionId`: the connection ID on that multipooler
+- `ReservationReasons`: `uint32` bitmask of `Reason*` constants
+
 `SetReservedConnection` stores the authoritative reservation state
 from the multipooler, setting the reasons exactly as returned (not
-OR'd). When a reserved connection is released (ReservedConnectionId
-== 0), the ShardState entry is removed via `ClearReservedConnection`.
+OR'd). `ClearReservedConnection` removes the `ShardState` entry
+when the reserved connection is released.
 
 ## RPCs
 
@@ -391,8 +401,13 @@ When a query fails while in `TxnStatusInBlock`, the connection
 transitions to `TxnStatusFailed`. In this state:
 
 - **HandleQuery**: Rejects all queries unless the first statement
-  is `ROLLBACK`. This allows both single `ROLLBACK` and batches
-  like `ROLLBACK; SELECT 1;` (matching PostgreSQL behavior)
+  is one of the recovery statements PostgreSQL accepts in this
+  state: `ROLLBACK`, `ROLLBACK TO SAVEPOINT`, or `COMMIT`
+  (treated as `ROLLBACK`). Multi-statement batches are permitted
+  as long as the first statement is a recovery statement (e.g.,
+  `ROLLBACK TO sp1; SELECT 1;`). A successful `ROLLBACK TO
+SAVEPOINT` transitions the connection back to `TxnStatusInBlock`
+  so subsequent statements can execute normally.
 - **HandleExecute** (extended query protocol): Rejects all Execute
   messages. In the extended protocol, `ROLLBACK` is typically sent
   via simple query
@@ -409,6 +424,23 @@ State transitions to `TxnStatusFailed` happen in three places:
 Timeouts (context cancellation) flow through the same error paths —
 a timed-out query in a transaction triggers the same aborted state
 transition.
+
+## LISTEN/NOTIFY in Transactions
+
+`LISTEN` and `UNLISTEN` inside an explicit transaction do not take
+effect immediately. The connection state records them in an ordered
+`pendingActions` queue (see `pendingListenAction` in
+`handler/connection_state.go`). At `COMMIT`, the handler drains the
+queue via `CommitPendingListens` and applies the net subscription
+changes against the gateway's `SubscriptionSync` (which talks to the
+`NotificationManager` and, through it, the multipooler
+`PubSubListener`). If the transaction rolls back, the pending
+actions are discarded.
+
+This matches PostgreSQL's behavior of making `LISTEN`/`UNLISTEN`
+visible only on successful commit, and ensures the client does not
+start receiving notifications on channels that its transaction
+never actually committed.
 
 ## Connection Cleanup
 


### PR DESCRIPTION
## Summary

- Audited all design docs under `docs/query_serving/` against the current implementation and updated the ones that had drifted.
- Most docs are still accurate; changes are focused on a handful of concrete mismatches plus missing coverage of features that are already implemented.

## Description

Updates:

- **transaction_design.md**
  - Fix the `ShardState` struct example — it now bundles reservation info under `ReservedState` (`PoolerId`, `ReservedConnectionId`, `ReservationReasons`) rather than exposing them as separate fields.
  - Expand aborted-transaction recovery to match handler behavior: `ROLLBACK`, `ROLLBACK TO SAVEPOINT`, and `COMMIT` (treated as `ROLLBACK`) are all accepted, and a successful `ROLLBACK TO SAVEPOINT` transitions back to `TxnStatusInBlock`.
  - Document LISTEN/NOTIFY-in-transactions handling (`pendingActions` buffer, `CommitPendingListens`, subscription sync at COMMIT).

- **load_balancing.md**
  - Correct `PoolerConnection` — it wraps a `QueryService` client, it doesn't itself implement the interface.
  - Replace the "Health Streaming Integration" future-work bullet with actual docs for the implemented mechanism: `StreamPoolerHealth`, `onPoolerHealthUpdate`, per-shard primary caching (`cachedPrimaries`), term-based reconciliation, and the `SetOnPrimaryServing` callback used by failover buffering.
  - Add a section describing `SetReplicationLagThresholds` (two-tier low-lag/high-tolerance filtering).

- **session_settings.md**
  - Document `SET var TO DEFAULT` normalization to `RESET var`, and passthrough for `SET TRANSACTION` / `SET SESSION CHARACTERISTICS` / `SET var FROM CURRENT`.
  - Add a "Gateway-Managed Variables" section covering `isGatewayManagedVariable`, `GatewayManagedVariable[T]`, validate-at-SET-time semantics, and the current sole member (`statement_timeout`).

- **query_cancellation_design.md**
  - Add key-capability bullet covering the replica-reads listener (`replicaCancelFn` on `CancelManager`).

- **failover_buffering.md**
  - Correct end-to-end test path prefix to `test/endtoend/queryserving/buffer_test.go`.

Docs left unchanged after audit: `connection_pooling.md`, `plan_cache_design.md`, `statement_timeout_design.md`, `graceful_drain_design.md`, `listen_notify_design.md`, `replica_reads_design.md`, `unsafe_statement_rejection.md`, `prepared_statements_design.md`, `benchmarking/pgbench.md`.

## Test plan

- [x] Docs-only change — spot-check rendering on GitHub.