### PR TITLE
fix: register missed plan-cache and backup-config flags with viper

### DIFF
--- a/go/cmd/multigres/command/cluster/check_backup_config.go
+++ b/go/cmd/multigres/command/cluster/check_backup_config.go
@@ -71,6 +71,7 @@ Examples:
 
 	cmd.Flags().String("backup-url", ccmd.backupURL.Default(), "S3 backup URL (format: s3://bucket/prefix)")
 	cmd.Flags().String("region", ccmd.region.Default(), "AWS region")
+	viperutil.BindFlags(cmd.Flags(), ccmd.backupURL, ccmd.region)
 
 	clusterCmd.AddCommand(cmd)
 }

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -221,6 +221,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
+	fs.Int("plan-cache-memory", mg.planCacheMemory.Default(), "maximum memory in bytes for the query plan cache; 0 disables caching")
 	viperutil.BindFlags(fs,
 		mg.cell,
 		mg.serviceID,
@@ -232,6 +233,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.pgReplicaPort,
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
+		mg.planCacheMemory,
 	)
 	mg.bufferConfig.RegisterFlags(fs)
 	mg.senv.RegisterFlags(fs)


### PR DESCRIPTION
## Summary

- Wire `--plan-cache-memory` (multigateway) through `pflag` and `viperutil.BindFlags` so the flag is actually exposed on the CLI and flows into viper.
- Wire `--backup-url` and `--region` (`multigres cluster check-backup-config`) through `viperutil.BindFlags` so values provided on the CLI actually reach `.Get()`.

## Problem

In both cases, values were created via `viperutil.Configure(...)` with a `FlagName` set, but the corresponding `RegisterFlags` path was incomplete:

- `plan-cache-memory` was never registered on the `pflag.FlagSet` and was missing from the `viperutil.BindFlags` list, so the flag did not exist on the CLI and only the hardcoded 4 MB default (or env var) ever reached `executor.NewExecutor`.
- `backup-url` / `region` were registered on `cmd.Flags()` but were never passed to `viperutil.BindFlags`, so `.Get()` would always return the default regardless of what the user passed.

## Solution

Add the missing `fs.Int("plan-cache-memory", ...)` registration and include each affected Value in the corresponding `viperutil.BindFlags(...)` call.