### PR TITLE
fix(backup): inherit pg1-user in pgbackrest configs

### DIFF
--- a/config/pgbackrest/pgbackrest_server_template.conf
+++ b/config/pgbackrest/pgbackrest_server_template.conf
@@ -13,5 +13,5 @@ tls-server-auth=pgbackrest=*
 pg1-socket-path={{.Pg1SocketPath}}
 pg1-port={{.Pg1Port}}
 pg1-path={{.Pg1Path}}
-pg1-user=postgres
+pg1-user={{.Pg1User}}
 pg1-database=postgres

--- a/config/pgbackrest/pgbackrest_template.conf
+++ b/config/pgbackrest/pgbackrest_template.conf
@@ -29,7 +29,7 @@ process-max=8
 pg1-socket-path={{.Pg1SocketPath}}
 pg1-port={{.Pg1Port}}
 pg1-path={{.Pg1Path}}
-pg1-user=postgres
+pg1-user={{.Pg1User}}
 pg1-database=postgres
 
 # pg2 configuration is not included in this template because it varies by backup.

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -306,6 +306,7 @@ func NewPgCtldService(
 			Pg1Port:       cfg.Port,
 			Pg1SocketPath: pgctld.PostgresSocketDir(poolerDir),
 			Pg1Path:       pgctld.PostgresDataDir(),
+			Pg1User:       cfg.User,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate pgbackrest-server.conf: %w", err)

--- a/go/common/backup/clientconfig.go
+++ b/go/common/backup/clientconfig.go
@@ -30,6 +30,7 @@ type ClientConfigOpts struct {
 	Pg1Port       int    // Local PostgreSQL port
 	Pg1SocketPath string // Local PostgreSQL socket directory
 	Pg1Path       string // Local PostgreSQL data directory
+	Pg1User       string // PostgreSQL superuser for pgbackrest connections
 }
 
 // WriteClientConfig generates pgbackrest.conf for client operations (backup, restore, info).
@@ -78,6 +79,7 @@ func WriteClientConfig(opts ClientConfigOpts, backupCfg *Config) (string, error)
 		Pg1SocketPath string
 		Pg1Port       int
 		Pg1Path       string
+		Pg1User       string
 	}{
 		LogPath:   logPath,
 		SpoolPath: spoolPath,
@@ -90,6 +92,7 @@ func WriteClientConfig(opts ClientConfigOpts, backupCfg *Config) (string, error)
 		Pg1SocketPath: opts.Pg1SocketPath,
 		Pg1Port:       opts.Pg1Port,
 		Pg1Path:       opts.Pg1Path,
+		Pg1User:       opts.Pg1User,
 	}
 
 	// Execute template

--- a/go/common/backup/clientconfig_test.go
+++ b/go/common/backup/clientconfig_test.go
@@ -44,6 +44,7 @@ func TestWriteClientConfig_Filesystem(t *testing.T) {
 		Pg1Port:       5432,
 		Pg1SocketPath: "/tmp/socket",
 		Pg1Path:       "/var/lib/postgresql/data",
+		Pg1User:       "admin",
 	}
 
 	configPath, err := WriteClientConfig(opts, backupCfg)
@@ -72,6 +73,7 @@ func TestWriteClientConfig_Filesystem(t *testing.T) {
 	assert.Equal(t, "/tmp/socket", stanza.Key("pg1-socket-path").String())
 	assert.Equal(t, "5432", stanza.Key("pg1-port").String())
 	assert.Equal(t, "/var/lib/postgresql/data", stanza.Key("pg1-path").String())
+	assert.Equal(t, "admin", stanza.Key("pg1-user").String())
 
 	// Must NOT contain TLS server settings
 	for _, key := range global.Keys() {
@@ -98,6 +100,7 @@ func TestWriteClientConfig_S3(t *testing.T) {
 		Pg1Port:       5432,
 		Pg1SocketPath: "/tmp/socket",
 		Pg1Path:       "/data",
+		Pg1User:       "admin",
 	}
 
 	configPath, err := WriteClientConfig(opts, backupCfg)
@@ -110,6 +113,7 @@ func TestWriteClientConfig_S3(t *testing.T) {
 	assert.Equal(t, "s3", stanza.Key("repo1-type").String())
 	assert.Equal(t, "test-bucket", stanza.Key("repo1-s3-bucket").String())
 	assert.Equal(t, "us-west-2", stanza.Key("repo1-s3-region").String())
+	assert.Equal(t, "admin", stanza.Key("pg1-user").String())
 }
 
 func TestWriteClientConfig_CreatesDirs(t *testing.T) {
@@ -128,6 +132,7 @@ func TestWriteClientConfig_CreatesDirs(t *testing.T) {
 		Pg1Port:       5432,
 		Pg1SocketPath: "/tmp/socket",
 		Pg1Path:       "/data",
+		Pg1User:       "admin",
 	}
 
 	_, err = WriteClientConfig(opts, backupCfg)

--- a/go/common/backup/serverconfig.go
+++ b/go/common/backup/serverconfig.go
@@ -32,6 +32,7 @@ type ServerConfigOpts struct {
 	Pg1Port       int    // Local PostgreSQL port
 	Pg1SocketPath string // Local PostgreSQL socket directory
 	Pg1Path       string // Local PostgreSQL data directory
+	Pg1User       string // PostgreSQL superuser for pgbackrest connections
 }
 
 // WriteServerConfig generates a minimal pgbackrest-server.conf for the TLS server.
@@ -62,6 +63,7 @@ func WriteServerConfig(opts ServerConfigOpts) (string, error) {
 		Pg1SocketPath  string
 		Pg1Port        int
 		Pg1Path        string
+		Pg1User        string
 	}{
 		LogPath:        logPath,
 		ServerCertFile: filepath.Join(opts.CertDir, "pgbackrest.crt"),
@@ -71,6 +73,7 @@ func WriteServerConfig(opts ServerConfigOpts) (string, error) {
 		Pg1SocketPath:  opts.Pg1SocketPath,
 		Pg1Port:        opts.Pg1Port,
 		Pg1Path:        opts.Pg1Path,
+		Pg1User:        opts.Pg1User,
 	}
 
 	var buf bytes.Buffer

--- a/go/common/backup/serverconfig_test.go
+++ b/go/common/backup/serverconfig_test.go
@@ -34,6 +34,7 @@ func TestWriteServerConfig(t *testing.T) {
 		Pg1Port:       5432,
 		Pg1SocketPath: "/tmp/socket",
 		Pg1Path:       "/var/lib/postgresql/data",
+		Pg1User:       "admin",
 	}
 
 	configPath, err := WriteServerConfig(opts)
@@ -57,7 +58,7 @@ func TestWriteServerConfig(t *testing.T) {
 	assert.Equal(t, "/tmp/socket", stanza.Key("pg1-socket-path").String())
 	assert.Equal(t, "5432", stanza.Key("pg1-port").String())
 	assert.Equal(t, "/var/lib/postgresql/data", stanza.Key("pg1-path").String())
-	assert.Equal(t, "postgres", stanza.Key("pg1-user").String())
+	assert.Equal(t, "admin", stanza.Key("pg1-user").String())
 	assert.Equal(t, "postgres", stanza.Key("pg1-database").String())
 
 	// Must NOT contain client-only settings
@@ -78,6 +79,7 @@ func TestWriteServerConfig_CreatesLogDir(t *testing.T) {
 		Pg1Port:       5432,
 		Pg1SocketPath: "/tmp/socket",
 		Pg1Path:       "/data",
+		Pg1User:       "admin",
 	}
 
 	_, err := WriteServerConfig(opts)

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -789,11 +789,16 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 		// Generate pgbackrest client config now that we have backup location
 		pgPort := int(pm.multipooler.PortMap["postgres"])
 		socketDir := filepath.Join(pm.multipooler.PoolerDir, "pg_sockets")
+		pg1User := constants.DefaultPostgresUser
+		if pm.connPoolMgr != nil {
+			pg1User = pm.connPoolMgr.PgUser()
+		}
 		configPath, err := backup.WriteClientConfig(backup.ClientConfigOpts{
 			PoolerDir:     pm.multipooler.PoolerDir,
 			Pg1Port:       pgPort,
 			Pg1SocketPath: socketDir,
 			Pg1Path:       postgresDataDir(),
+			Pg1User:       pg1User,
 		}, backupConfig)
 		if err != nil {
 			pm.setStateError(fmt.Errorf("failed to generate pgbackrest client config: %w", err))


### PR DESCRIPTION
pgbackrest configs had the `postgres` user hardcoded, but it should inherit user and password credentials from multipooler/pgctld. Replace the hardcoded user in pgbackrest client and server config templates with a configurable Pg1User field. In multipooler, resolve the user from the connection pool manager with a fallback to the default postgres user.

Closes MUL-378