### PR TITLE
fix(multipooler): retry reserved/regular conn acquisition across pool reopen

### DIFF
--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -81,6 +81,13 @@ type Manager struct {
 	// closed indicates whether the manager has been closed.
 	closed atomic.Bool
 
+	// generation is incremented on every Open(). Callers that get
+	// ErrPoolClosed from an in-flight pool operation can compare the
+	// pre-call generation against the current one: if it advanced, a
+	// reopen swapped the pools underneath them and the call is safe to
+	// retry against the fresh snapshot.
+	generation atomic.Uint64
+
 	// Rebalancer goroutine management
 	rebalancerCtx    context.Context
 	rebalancerCancel context.CancelFunc
@@ -118,6 +125,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.zeroCh = zeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
 	m.closed.Store(false)
+	m.generation.Add(1)
 
 	// Build admin client config
 	adminClientConfig := m.buildClientConfig(m.config.PgUser(), m.config.PgPassword())
@@ -375,24 +383,19 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 // GetRegularConn acquires a regular connection for the specified user.
 // The caller must call Recycle() on the returned connection to return it to the pool.
 func (m *Manager) GetRegularConn(ctx context.Context, user string) (regular.PooledConn, error) {
-	pool, err := m.getOrCreateUserPool(user)
-	if err != nil {
-		return nil, err
-	}
-	return pool.GetRegularConn(ctx)
+	return withReopenRetry(m, user, func(pool *UserPool) (regular.PooledConn, error) {
+		return pool.GetRegularConn(ctx)
+	})
 }
 
 // GetRegularConnWithSettings acquires a regular connection with specific settings for the user.
 // Settings are converted via the shared SettingsCache for consistent bucket assignment.
 // The caller must call Recycle() on the returned connection to return it to the pool.
 func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string) (regular.PooledConn, error) {
-	pool, err := m.getOrCreateUserPool(user)
-	if err != nil {
-		return nil, err
-	}
-	// Convert map to *Settings via the shared cache
 	s := m.settingsCache.GetOrCreate(settings)
-	return pool.GetRegularConnWithSettings(ctx, s)
+	return withReopenRetry(m, user, func(pool *UserPool) (regular.PooledConn, error) {
+		return pool.GetRegularConnWithSettings(ctx, s)
+	})
 }
 
 // --- Reserved Pool Operations ---
@@ -402,13 +405,36 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // The connection is assigned a unique ID for client-side tracking.
 // The caller must call Release() when done with the connection.
 func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+	s := m.settingsCache.GetOrCreate(settings)
+	return withReopenRetry(m, user, func(pool *UserPool) (*reserved.Conn, error) {
+		return pool.NewReservedConn(ctx, s, opts...)
+	})
+}
+
+// withReopenRetry runs op against the current user pool and, if op returns
+// ErrPoolClosed because a concurrent reopenConnections() swapped the pools
+// mid-flight, retries once against the fresh pool. Genuine closed-pool errors
+// (manager shutting down for real) are surfaced to the caller unchanged
+// because the generation will not have advanced.
+func withReopenRetry[T any](m *Manager, user string, op func(*UserPool) (T, error)) (T, error) {
+	var zero T
+	startGen := m.generation.Load()
 	pool, err := m.getOrCreateUserPool(user)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
-	// Convert map to *Settings via the shared cache
-	s := m.settingsCache.GetOrCreate(settings)
-	return pool.NewReservedConn(ctx, s, opts...)
+	result, err := op(pool)
+	if err == nil || !errors.Is(err, connpool.ErrPoolClosed) {
+		return result, err
+	}
+	if m.generation.Load() == startGen {
+		return zero, err
+	}
+	pool, err2 := m.getOrCreateUserPool(user)
+	if err2 != nil {
+		return zero, err2
+	}
+	return op(pool)
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
@@ -258,6 +259,118 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 
 	// Verify SET was called.
 	assert.Greater(t, server.GetPatternCalledNum(`SELECT pg_catalog\.set_config\(.+\)`), 0)
+}
+
+// TestWithReopenRetry_RetriesOnReopen covers the race in which
+// reopenConnections (triggered by MonitorPostgres after a postgres restart)
+// closes the user pool while a connection acquisition is already in-flight.
+// The helper must notice the generation bump and retry against the fresh pool
+// rather than surfacing the transient ErrPoolClosed to the caller.
+func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	calls := 0
+	result, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+		calls++
+		if calls == 1 {
+			// Simulate reopenConnections running mid-flight: the pool we
+			// were handed has been closed, but a new one has already been
+			// installed with a bumped generation.
+			manager.generation.Add(1)
+			return 0, connpool.ErrPoolClosed
+		}
+		return 42, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+	assert.Equal(t, 2, calls, "should have retried once after the reopen")
+}
+
+// TestWithReopenRetry_SurfacesGenuineClose covers the non-reopen case: the
+// manager is actually shutting down, so ErrPoolClosed must be returned to the
+// caller instead of being retried into an infinite loop.
+func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	calls := 0
+	_, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+		calls++
+		// No generation bump — manager hasn't been reopened.
+		return 0, connpool.ErrPoolClosed
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
+	assert.Equal(t, 1, calls, "should not retry when generation did not advance")
+}
+
+// TestWithReopenRetry_OnlyRetriesOnce ensures the helper stops after one retry
+// even if the retry also fails with ErrPoolClosed (e.g. if a second reopen
+// races with the retry). Without a cap this could loop forever.
+func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	calls := 0
+	_, err := withReopenRetry(manager, "testuser", func(_ *UserPool) (int, error) {
+		calls++
+		manager.generation.Add(1)
+		return 0, connpool.ErrPoolClosed
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
+	assert.Equal(t, 2, calls, "should retry exactly once, not loop")
+}
+
+// TestManager_NewReservedConn_SurvivesReopen exercises the end-to-end path:
+// close+reopen the manager between calls and verify subsequent reserved-conn
+// acquisition still works. This mirrors the production crash-recovery path
+// where reopenConnections swaps the pools after postgres auto-restart.
+func TestManager_NewReservedConn_SurvivesReopen(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Warm up: create a user pool.
+	c1, err := manager.NewReservedConn(ctx, nil, "testuser")
+	require.NoError(t, err)
+	c1.Release(reserved.ReleaseCommit)
+
+	// Simulate reopenConnections: close then reopen against the same fake server.
+	manager.Close()
+	manager.Open(ctx, &ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	})
+
+	// Reserved-conn acquisition must succeed against the fresh pool.
+	c2, err := manager.NewReservedConn(ctx, nil, "testuser")
+	require.NoError(t, err)
+	require.NotNil(t, c2)
+	c2.Release(reserved.ReleaseCommit)
 }
 
 func TestManager_GetReservedConn(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a race in `connpoolmanager.Manager` where a reserved-connection acquisition in flight during `reopenConnections()` (triggered by `MonitorPostgres` after a postgres auto-restart) fails with \`failed to get connection: connection pool is closed\` instead of transparently using the freshly opened pool.

## Root cause

- \`MonitorPostgres.startPostgres\` sequence: \`pgctld.Start\` → \`reopenConnections\` → \`waitForDatabaseConnection\`.
- \`PostgresReady\` is computed purely from \`pgctld.Status()\` (\`RUNNING && pg_isready\`), so it flips true as soon as postgres accepts connections — typically before \`reopenConnections\` finishes.
- Any reserved-conn request that arrives in that ~80–100 ms window holds a pointer to the soon-to-be-closed \`UserPool\`. When \`Manager.Close()\` closes it, the blocked \`GetWithSettings\` wakes up with \`ErrPoolClosed\`.
- Reproducibly fails \`TestWrappedPreparedStatementExecution/multigateway/create_temp_table_as_execute\` when it runs immediately after \`TestMultiGateway_PostgresCrashRecovery\` — that subtest is the first in the file to need a fresh reserved connection via \`TempTableRoute\`.

## Fix

- Add \`generation atomic.Uint64\` to \`Manager\`, bumped in every \`Open()\`.
- Add generic \`withReopenRetry[T]\` helper: sample the generation before the op, and on \`ErrPoolClosed\` retry exactly once *only if* the generation advanced. If it didn't, the manager is genuinely shutting down and the error is surfaced unchanged.
- Route \`GetRegularConn\`, \`GetRegularConnWithSettings\`, and \`NewReservedConn\` through the helper.

## Tests

- \`TestWithReopenRetry_RetriesOnReopen\` — simulated mid-flight reopen, verifies retry succeeds.
- \`TestWithReopenRetry_SurfacesGenuineClose\` — no generation bump, verifies the error surfaces unchanged.
- \`TestWithReopenRetry_OnlyRetriesOnce\` — persistent \`ErrPoolClosed\` with repeated bumps, verifies the helper retries exactly once and does not loop.
- \`TestManager_NewReservedConn_SurvivesReopen\` — end-to-end \`Close()\` + \`Open()\` between reserved-conn calls.

## Test plan

- [x] Unit tests (\`go test ./go/services/multipooler/connpoolmanager/...\`) — pass.
- [x] **Flaky-test repro loop**: ran \`TestMultiGateway_PostgresCrashRecovery\` + \`TestWrappedPreparedStatementExecution\` in back-to-back fresh-cluster iterations. Before the fix: failed on iteration 1 with \`failed to create reserved connection: failed to get connection: connection pool is closed\`. After the fix: **30/30 iterations pass, zero failures**.
- [x] CI green.