### PR TITLE
fix(pgregresstest): pass EXTRA_REGRESS_OPTS to isolation installcheck

### DIFF
--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -872,7 +872,8 @@ func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, 
 		cmd = executil.Command(ctx, pgIsoRegress, args...).WithProcessGroup()
 		t.Logf("Running selective isolation tests: %s", testsEnv)
 	} else {
-		cmd = executil.Command(ctx, "make", "-C", isolationBuildDir, "installcheck").WithProcessGroup()
+		cmd = executil.Command(ctx, "make", "-C", isolationBuildDir, "installcheck",
+			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
 		t.Logf("Running full PostgreSQL isolation test suite (installcheck)")
 	}
 


### PR DESCRIPTION
## Summary

- Pass `EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres` to the isolation `installcheck` target so `pg_isolation_regress` stops trying to DROP/CREATE its own regression database through multigateway.

## Problem

Nightly pgregress runs on `main` fail because the isolation suite bails out immediately with:

```
ERROR:  DROP DATABASE is not supported through the connection pooler
# command failed: psql ... -c "DROP DATABASE IF EXISTS \"isolation_regression\"" "postgres"
Bail out!make: *** [installcheck] Error 2
```

PR #860 added `EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres` in two places (the regression suite's `make installcheck` invocation at `postgres_builder.go:381` and the isolation suite's *selective-tests* path at `:868`) but missed the third: the isolation *full-suite* path at `:875`. The CI workflow sets `RUN_PGISOLATION=1` without `PGISOLATION_TESTS`, so it hits the missed branch, and `pg_isolation_regress` tries to drop and recreate the scratch `isolation_regression` database. Since PR #849's unsafe-statement rejection blocks `DROP DATABASE` at multigateway, the suite bails before any tests run.

## Solution

Add `EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres` to the `make -C isolationBuildDir installcheck` args. PostgreSQL's `src/Makefile.global.in` propagates `EXTRA_REGRESS_OPTS` to `pg_isolation_regress` the same way it does for `pg_regress`, so this is the identical mechanism #860 already uses for the regression suite.

## Test plan

- [ ] Apply the `Run PgRegress Tests` label to trigger the pgregress workflow on this PR.
- [ ] Confirm the isolation suite no longer bails on `DROP DATABASE`.
- [ ] Confirm `results.json` and `compatibility-report.md` artifacts are produced.

## Note

This unblocks the isolation suite but does not fix all pgregress CI failures. A separate `ReinitializeCluster` / manager-ready issue surfaces after this fix on GHA runners (pooler-2 never reaches `PostgresReady` after restart). That needs a separate fix — likely clearing etcd topology state in `ReinitializeCluster` so the restarted primary doesn't resume with stale role info against an empty data dir. Will handle in a follow-up.