### PR TITLE
feat(consensus): add id to ConsensusStatus and IsPrimary helper

### DIFF
--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+
+// IsPrimary reports whether the pooler identified by cs is the designated
+// primary according to its highest committed rule. Returns false when cs, its
+// ID, or the current rule is absent.
+func IsPrimary(cs *clustermetadatapb.ConsensusStatus) bool {
+	if cs == nil {
+		return false
+	}
+	self := cs.GetId()
+	primary := cs.GetCurrentPosition().GetRule().GetPrimaryId()
+	if self == nil || primary == nil {
+		return false
+	}
+	return self.Cell == primary.Cell && self.Name == primary.Name
+}

--- a/go/common/consensus/pooler_test.go
+++ b/go/common/consensus/pooler_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
+
+func TestIsPrimary(t *testing.T) {
+	id := func(cell, name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{Cell: cell, Name: name}
+	}
+	statusWithRule := func(self, primary *clustermetadatapb.ID) *clustermetadatapb.ConsensusStatus {
+		return &clustermetadatapb.ConsensusStatus{
+			Id: self,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{PrimaryId: primary},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		cs   *clustermetadatapb.ConsensusStatus
+		want bool
+	}{
+		{
+			name: "nil status",
+			cs:   nil,
+			want: false,
+		},
+		{
+			name: "nil id",
+			cs:   statusWithRule(nil, id("zone1", "pooler-1")),
+			want: false,
+		},
+		{
+			name: "nil current_position",
+			cs:   &clustermetadatapb.ConsensusStatus{Id: id("zone1", "pooler-1")},
+			want: false,
+		},
+		{
+			name: "nil rule",
+			cs: &clustermetadatapb.ConsensusStatus{
+				Id:              id("zone1", "pooler-1"),
+				CurrentPosition: &clustermetadatapb.PoolerPosition{},
+			},
+			want: false,
+		},
+		{
+			name: "nil primary_id",
+			cs:   statusWithRule(id("zone1", "pooler-1"), nil),
+			want: false,
+		},
+		{
+			name: "self matches primary",
+			cs:   statusWithRule(id("zone1", "pooler-1"), id("zone1", "pooler-1")),
+			want: true,
+		},
+		{
+			name: "different name",
+			cs:   statusWithRule(id("zone1", "pooler-1"), id("zone1", "pooler-2")),
+			want: false,
+		},
+		{
+			name: "different cell",
+			cs:   statusWithRule(id("zone1", "pooler-1"), id("zone2", "pooler-1")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsPrimary(tt.cs))
+		})
+	}
+}

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1531,7 +1531,9 @@ type PoolerPosition struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The highest shard rule this pooler has committed to local WAL.
 	Rule *ShardRule `protobuf:"bytes,1,opt,name=rule,proto3" json:"rule,omitempty"`
-	// The latest WAL position.
+	// The current real-time WAL head at the time of reading. Note that this is likely
+	// beyond the LSN at which the rule was committed. For a primary: pg_current_wal_lsn().
+	// For a standby: pg_last_wal_receive_lsn() (or pg_last_wal_replay_lsn() if receive is null).
 	Lsn           string `protobuf:"bytes,2,opt,name=lsn,proto3" json:"lsn,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1753,8 +1755,11 @@ type ConsensusStatus struct {
 	// ahead of current_position when the pooler has forward knowledge of an
 	// upcoming rule that has not yet been replicated or written.
 	HighestKnownRule *HighestKnownRule `protobuf:"bytes,3,opt,name=highest_known_rule,json=highestKnownRule,proto3" json:"highest_known_rule,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// id identifies the pooler that produced this status. Makes ConsensusStatus
+	// self-describing when passed around without a surrounding envelope.
+	Id            *ID `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConsensusStatus) Reset() {
@@ -1804,6 +1809,13 @@ func (x *ConsensusStatus) GetCurrentPosition() *PoolerPosition {
 func (x *ConsensusStatus) GetHighestKnownRule() *HighestKnownRule {
 	if x != nil {
 		return x.HighestKnownRule
+	}
+	return nil
+}
+
+func (x *ConsensusStatus) GetId() *ID {
+	if x != nil {
+		return x.Id
 	}
 	return nil
 }
@@ -2038,11 +2050,12 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x0eTermRevocation\x12,\n" +
 	"\x12revoked_below_term\x18\x01 \x01(\x03R\x10revokedBelowTerm\x12K\n" +
 	"\x17accepted_coordinator_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\x15acceptedCoordinatorId\x12T\n" +
-	"\x18coordinator_initiated_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x16coordinatorInitiatedAt\"\xf8\x01\n" +
+	"\x18coordinator_initiated_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x16coordinatorInitiatedAt\"\x9d\x02\n" +
 	"\x0fConsensusStatus\x12H\n" +
 	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12J\n" +
 	"\x10current_position\x18\x02 \x01(\v2\x1f.clustermetadata.PoolerPositionR\x0fcurrentPosition\x12O\n" +
-	"\x12highest_known_rule\x18\x03 \x01(\v2!.clustermetadata.HighestKnownRuleR\x10highestKnownRule\"p\n" +
+	"\x12highest_known_rule\x18\x03 \x01(\v2!.clustermetadata.HighestKnownRuleR\x10highestKnownRule\x12#\n" +
+	"\x02id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\x02id\"p\n" +
 	"\x10LeadershipStatus\x12!\n" +
 	"\fprimary_term\x18\x01 \x01(\x03R\vprimaryTerm\x129\n" +
 	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"d\n" +
@@ -2153,13 +2166,14 @@ var file_clustermetadata_proto_depIdxs = []int32{
 	23, // 28: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
 	21, // 29: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
 	22, // 30: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
-	4,  // 31: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	25, // 32: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	33, // [33:33] is the sub-list for method output_type
-	33, // [33:33] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	16, // 31: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	4,  // 32: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	25, // 33: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	34, // [34:34] is the sub-list for method output_type
+	34, // [34:34] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -277,8 +277,8 @@ func (pm *MultiPoolerManager) executeRevoke(ctx context.Context, term int64, res
 // buildConsensusStatus constructs a ConsensusStatus from a pre-resolved term and position.
 // Both arguments may be nil; in that case the corresponding fields in the returned status
 // are left unset. Never performs I/O.
-func buildConsensusStatus(term *multipoolermanagerdatapb.ConsensusTerm, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
-	status := &clustermetadatapb.ConsensusStatus{}
+func buildConsensusStatus(id *clustermetadatapb.ID, term *multipoolermanagerdatapb.ConsensusTerm, pos *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
+	status := &clustermetadatapb.ConsensusStatus{Id: id}
 	if term != nil {
 		status.TermRevocation = &clustermetadatapb.TermRevocation{
 			RevokedBelowTerm:      term.TermNumber,
@@ -309,7 +309,7 @@ func (pm *MultiPoolerManager) getConsensusStatus(ctx context.Context) (*clusterm
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return buildConsensusStatus(term, pos), nil
+	return buildConsensusStatus(pm.serviceID, term, pos), nil
 }
 
 // getCachedConsensusStatus builds a ConsensusStatus using the in-memory term cache and
@@ -328,7 +328,7 @@ func (pm *MultiPoolerManager) getCachedConsensusStatus() (*clustermetadatapb.Con
 	if pos == nil {
 		return nil, nil
 	}
-	return buildConsensusStatus(term, pos), nil
+	return buildConsensusStatus(pm.serviceID, term, pos), nil
 }
 
 // getInconsistentConsensusStatus builds a ConsensusStatus without holding the action lock.
@@ -347,7 +347,7 @@ func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("failed to read current rule position: %w", err)
 	}
-	return buildConsensusStatus(term, pos), nil
+	return buildConsensusStatus(pm.serviceID, term, pos), nil
 }
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -384,7 +384,9 @@ message PoolerPosition {
   // The highest shard rule this pooler has committed to local WAL.
   ShardRule rule = 1;
 
-  // The latest WAL position.
+  // The current real-time WAL head at the time of reading. Note that this is likely
+  // beyond the LSN at which the rule was committed. For a primary: pg_current_wal_lsn().
+  // For a standby: pg_last_wal_receive_lsn() (or pg_last_wal_replay_lsn() if receive is null).
   string lsn = 2;
 }
 
@@ -469,6 +471,10 @@ message ConsensusStatus {
   // ahead of current_position when the pooler has forward knowledge of an
   // upcoming rule that has not yet been replicated or written.
   HighestKnownRule highest_known_rule = 3;
+
+  // id identifies the pooler that produced this status. Makes ConsensusStatus
+  // self-describing when passed around without a surrounding envelope.
+  ID id = 4;
 }
 
 // LeadershipSignal describes a leader's self-reported status for its current term.


### PR DESCRIPTION
## Summary

- Adds a top-level `id` field (`ID`) to `ConsensusStatus` so the message is self-describing when passed around without a surrounding envelope.
- Adds an `IsPrimary(cs *ConsensusStatus) bool` helper in `go/common/consensus` that checks whether a pooler holds the primary role according to its current committed rule (compares `cs.Id` against `cs.CurrentPosition.Rule.PrimaryId`).
- Populates the new `id` from `pm.serviceID` in all `buildConsensusStatus` call paths (`getConsensusStatus`, `getCachedConsensusStatus`, `getInconsistentConsensusStatus`).
- Clarifies the `PoolerPosition.lsn` comment: documents that it is the current real-time WAL head (likely ahead of the rule-committed LSN), and describes the primary vs standby semantics (`pg_current_wal_lsn()` vs `pg_last_wal_receive_lsn()` / `pg_last_wal_replay_lsn()`).

## Why

This is a minimal slice carved out of [#888](https://github.com/multigres/multigres/pull/888) so `IsPrimary` can be reused in another in-flight PR without pulling in the full `StatusResponse` field consolidation.

## Test plan

- [x] `make proto` regenerates cleanly
- [x] `make build` succeeds
- [x] `go test -short ./go/services/multipooler/manager/... ./go/common/consensus/...` passes
- [ ] CI green