### PR TITLE
fix: pass ctx to `filterAndPrioritize` for correct trace propagation

### DIFF
--- a/go/services/multiorch/recovery/recovery_loop.go
+++ b/go/services/multiorch/recovery/recovery_loop.go
@@ -137,7 +137,7 @@ func (re *Engine) processShardProblems(ctx context.Context, shardKey commontypes
 	)
 
 	// Sort by priority and apply filtering logic
-	filteredProblems := re.filterAndPrioritize(problems)
+	filteredProblems := re.filterAndPrioritize(ctx, problems)
 
 	// Check if there's a primary problem in this shard
 	hasPrimaryProblem := re.hasPrimaryProblem(filteredProblems)
@@ -172,7 +172,7 @@ func (re *Engine) hasPrimaryProblem(problems []types.Problem) bool {
 // - Sorts by priority (highest first)
 // - If there's a shard-wide problem, return only the highest priority shard-wide problem
 // - Otherwise, return all problems sorted by priority
-func (re *Engine) filterAndPrioritize(problems []types.Problem) []types.Problem {
+func (re *Engine) filterAndPrioritize(ctx context.Context, problems []types.Problem) []types.Problem {
 	if len(problems) == 0 {
 		return problems
 	}
@@ -193,7 +193,7 @@ func (re *Engine) filterAndPrioritize(problems []types.Problem) []types.Problem 
 	// If we have shard-wide problems, return only the highest priority one
 	// (since problems are now sorted by priority, the first one is highest)
 	if len(shardWideProblems) > 0 {
-		re.logger.DebugContext(re.shutdownCtx, "shard-wide problem detected, focusing on single recovery",
+		re.logger.DebugContext(ctx, "shard-wide problem detected, focusing on single recovery",
 			"problem_code", shardWideProblems[0].Code,
 			"priority", shardWideProblems[0].Priority,
 			"total_shard_wide", len(shardWideProblems),

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -422,7 +422,7 @@ func TestFilterAndPrioritize_ShardWideOnly(t *testing.T) {
 		},
 	}
 
-	filtered := engine.filterAndPrioritize(problems)
+	filtered := engine.filterAndPrioritize(context.Background(), problems)
 
 	// Should return only the shard-wide problem (PrimaryDead)
 	require.Len(t, filtered, 1)
@@ -489,7 +489,7 @@ func TestFilterAndPrioritize_NoShardWide(t *testing.T) {
 	}
 
 	// Problems are already sorted by priority
-	filtered := engine.filterAndPrioritize(problems)
+	filtered := engine.filterAndPrioritize(context.Background(), problems)
 
 	// Should keep only highest priority problem per pooler
 	require.Len(t, filtered, 3)
@@ -545,7 +545,7 @@ func TestFilterAndPrioritize_MultipleShardWide(t *testing.T) {
 		},
 	}
 
-	filtered := engine.filterAndPrioritize(problems)
+	filtered := engine.filterAndPrioritize(context.Background(), problems)
 
 	// Should return only the highest priority shard-wide problem
 	// PriorityShardBootstrap (10000) > PriorityEmergency (1000)


### PR DESCRIPTION
## Issue
- `filterAndPrioritize` was using `re.shutdownCtx` (the engine's root context) for a debug log call instead of the current recovery cycle context. This disconnected the log entry from the active `recovery/cycle` and `recovery/attempt` trace spans

## Proposed Solution
- Pass `ctx` through from `processShardProblems` to fix trace propagation