### PR TITLE
fix(shardsetup): clear stale topology state in ReinitializeCluster

### DIFF
--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -117,6 +117,20 @@ jobs:
           path: /tmp/multigres_pg_cache/results/**/*
           if-no-files-found: warn
 
+      # On failure, surface the per-process logs from the shardsetup tempdir
+      # (multipooler.log, pgctld.log, multigateway.log, multiorch.log). The
+      # failing job uploads nothing useful for cluster-bootstrap / reinit
+      # issues without these — go test swallows structured logs and the
+      # CI stdout only shows the outer test error.
+      - name: Upload cluster logs on failure
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: ${{ failure() }}
+        with:
+          name: pgregress-cluster-logs
+          path: /tmp/shardsetup_test_*/**/*.log
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Notify Slack on regression
         if: >-
           !cancelled() &&

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -504,6 +504,22 @@ type SuiteResult struct {
 	ExpectedTests int          // total tests from schedule file (0 = unknown)
 }
 
+// githubBlobURLPrefix returns an absolute URL prefix of the form
+// "https://github.com/<owner>/<repo>/blob/<sha>/" when running inside a
+// GitHub Actions job, or an empty string otherwise. Repo-relative paths
+// concatenated onto this prefix resolve to the blob view of that file at
+// the exact commit the job is executing against.
+func githubBlobURLPrefix() string {
+	serverURL := os.Getenv("GITHUB_SERVER_URL")
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	sha := os.Getenv("GITHUB_SHA")
+	if serverURL == "" || repo == "" || sha == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/blob/%s/", serverURL, repo, sha)
+}
+
+
 // WriteMarkdownSummary generates a unified markdown report covering one or more
 // test suites. It writes the report to pb.OutputDir/compatibility-report.md and
 // appends it to GITHUB_STEP_SUMMARY when running in CI.
@@ -532,6 +548,13 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 
 	fmt.Fprintf(&sb, "**PostgreSQL Version:** `%s`\n", PostgresVersion)
 	fmt.Fprintf(&sb, "**Timestamp:** %s\n\n", time.Now().UTC().Format(time.RFC3339))
+
+	// Build an absolute URL prefix for patch links when running in CI.
+	// Without this, markdown like [patch](go/test/.../foo.patch) is resolved
+	// relative to the step-summary page (/actions/runs/<id>/) and produces a
+	// 404 URL like .../actions/runs/go/test/.../foo.patch. Falls back to a
+	// relative link when the GitHub Actions env vars aren't set (local runs).
+	patchURLPrefix := githubBlobURLPrefix()
 
 	for _, s := range suites {
 		fmt.Fprintf(&sb, "### %s\n\n", s.Name)
@@ -563,7 +586,7 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 			patchCell := "-"
 			if test.PatchApplied {
 				if test.PatchPath != "" {
-					patchCell = fmt.Sprintf("📎 [patch](%s)", test.PatchPath)
+					patchCell = fmt.Sprintf("📎 [patch](%s%s)", patchURLPrefix, test.PatchPath)
 				} else {
 					patchCell = "📎 applied"
 				}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -519,7 +519,6 @@ func githubBlobURLPrefix() string {
 	return fmt.Sprintf("%s/%s/blob/%s/", serverURL, repo, sha)
 }
 
-
 // WriteMarkdownSummary generates a unified markdown report covering one or more
 // test suites. It writes the report to pb.OutputDir/compatibility-report.md and
 // appends it to GITHUB_STEP_SUMMARY when running in CI.

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -453,15 +453,26 @@ func (p *ProcessInstance) IsRunning() bool {
 }
 
 // StopPostgres stops PostgreSQL via pgctld gRPC (best effort, no error handling).
+// Uses "fast" mode, which takes a checkpoint before stopping.
 // Use this to stop postgres before removing data directories for auto-restore tests.
 func (p *ProcessInstance) StopPostgres(t *testing.T) {
 	t.Helper()
-	p.stopPostgreSQL()
+	p.stopPostgreSQL("fast")
+}
+
+// StopPostgresImmediate stops PostgreSQL via pgctld gRPC with "immediate" mode,
+// which sends SIGQUIT and skips the pre-shutdown checkpoint. Use this when the
+// data directory is about to be wiped anyway, to avoid long graceful-shutdown
+// windows that can leave the postgres listen port in TIME_WAIT and block the
+// next postgres from binding it on restart.
+func (p *ProcessInstance) StopPostgresImmediate(t *testing.T) {
+	t.Helper()
+	p.stopPostgreSQL("immediate")
 }
 
 // stopPostgreSQL stops PostgreSQL via gRPC (best effort, no error handling).
-// Copied from multipooler/setup_test.go.
-func (p *ProcessInstance) stopPostgreSQL() {
+// mode is passed through to pg_ctl stop -m (smart | fast | immediate).
+func (p *ProcessInstance) stopPostgreSQL(mode string) {
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("passthrough:///localhost:%d", p.GrpcPort),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -474,11 +485,11 @@ func (p *ProcessInstance) stopPostgreSQL() {
 	client := pgctldservice.NewPgCtldClient(conn)
 
 	// pg_ctl stop -m fast takes a checkpoint before stopping, which can
-	// take several seconds under load.
+	// take several seconds under load. Immediate mode skips the checkpoint.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	_, _ = client.Stop(ctx, &pgctldservice.StopRequest{Mode: "fast"})
+	_, _ = client.Stop(ctx, &pgctldservice.StopRequest{Mode: mode})
 }
 
 // TerminateGracefully gracefully terminates a process by first sending SIGTERM,
@@ -493,7 +504,7 @@ func (p *ProcessInstance) TerminateGracefully(logf func(string, ...any), timeout
 	// For pgctld, stop PostgreSQL first via gRPC. pg_ctl stop -m fast
 	// releases SysV shared memory segments that would otherwise leak.
 	if p.Binary == "pgctld" {
-		p.stopPostgreSQL()
+		p.stopPostgreSQL("fast")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1373,14 +1373,22 @@ func (s *ShardSetup) ReinitializeCluster(t *testing.T) {
 	// 3. Stop multipooler + pgctld and remove PostgreSQL data.
 	// StopPostgres must be called BEFORE killing pgctld, otherwise
 	// the postgres process survives and holds the port.
+	//
+	// Use immediate shutdown (SIGQUIT, no checkpoint): the data dir is
+	// about to be wiped, so clean-shutdown state is irrelevant. Fast mode's
+	// pre-shutdown checkpoint can take >10s on the primary (especially under
+	// replication load), triggering a graceful-period SIGKILL that leaves
+	// postgres's listen port in TIME_WAIT on Linux for ~60s. The subsequent
+	// postgres restart then cannot bind its port and retries until
+	// WaitForManagerReady times out.
 	for name, inst := range s.Multipoolers {
 		if inst.Multipooler != nil {
 			inst.Multipooler.TerminateGracefully(t.Logf, gracePeriod)
 			t.Logf("ReinitializeCluster: stopped multipooler %s", name)
 		}
 		if inst.Pgctld != nil {
-			inst.Pgctld.StopPostgres(t)
-			t.Logf("ReinitializeCluster: stopped postgres on %s", name)
+			inst.Pgctld.StopPostgresImmediate(t)
+			t.Logf("ReinitializeCluster: stopped postgres on %s (immediate)", name)
 			inst.Pgctld.TerminateGracefully(t.Logf, gracePeriod)
 			t.Logf("ReinitializeCluster: stopped pgctld %s", name)
 		}

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/grpc"
@@ -1416,6 +1417,20 @@ func (s *ShardSetup) ReinitializeCluster(t *testing.T) {
 		t.Logf("ReinitializeCluster: cleared backup repo %s", backupRepoDir)
 	}
 
+	// 3c. Clear stale topology state. Without this, a pooler that was elected
+	// PRIMARY in the previous suite reads its stale role from etcd on restart,
+	// finds an empty data directory (wiped in step 3), and hangs in recovery —
+	// never reaching PostgresReady. The restart loop below then times out on
+	// WaitForManagerReady for that pooler.
+	//
+	// We wipe:
+	//   - databases/<db>/<tablegroup>/*   (shard records + ShardInitClaim)
+	//   - <cell>/poolers|gateways|orchs/* (per-process registration state)
+	// We keep:
+	//   - databases/<db>/Database         (preserves BackupLocation + DurabilityPolicy)
+	//   - cells/<cell>/Cell               (cell config multipoolers need to reconnect)
+	s.wipeTopologyForReinit(t, "postgres", constants.DefaultTableGroup)
+
 	t.Logf("ReinitializeCluster: restarting cluster...")
 
 	// 4. Start pgctld + multipooler for all nodes
@@ -1453,6 +1468,49 @@ func (s *ShardSetup) ReinitializeCluster(t *testing.T) {
 	}
 
 	t.Logf("ReinitializeCluster: cluster reinitialized successfully")
+}
+
+// wipeTopologyForReinit removes the etcd keys that would otherwise carry
+// stale shard-election and per-process registration state across a
+// ReinitializeCluster call. See the call site in ReinitializeCluster for
+// the full rationale.
+//
+// It connects to etcd directly (rather than via TopoServer) because the
+// public topoclient API only exposes per-record delete helpers and this
+// needs a recursive prefix delete.
+func (s *ShardSetup) wipeTopologyForReinit(t *testing.T, database, tableGroup string) {
+	t.Helper()
+
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{s.EtcdClientAddr},
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ReinitializeCluster: failed to open etcd client for topology wipe: %v", err)
+	}
+	defer func() {
+		if cerr := cli.Close(); cerr != nil {
+			t.Logf("ReinitializeCluster: warning: closing etcd client: %v", cerr)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// topoclient test root is "/multigres". Global topo is under /multigres/global,
+	// and each cell is under /multigres/<cell>/.
+	prefixes := []string{
+		path.Join("/multigres/global", topoclient.DatabasesPath, database, tableGroup) + "/",
+		path.Join("/multigres", s.CellName, topoclient.PoolersPath) + "/",
+		path.Join("/multigres", s.CellName, topoclient.GatewaysPath) + "/",
+		path.Join("/multigres", s.CellName, topoclient.OrchsPath) + "/",
+	}
+	for _, p := range prefixes {
+		if _, err := cli.Delete(ctx, p, clientv3.WithPrefix()); err != nil {
+			t.Fatalf("ReinitializeCluster: failed to wipe topology prefix %s: %v", p, err)
+		}
+	}
+	t.Logf("ReinitializeCluster: wiped stale topology state (shard records + pooler/gateway/orch registrations)")
 }
 
 // SetupTest provides test isolation by validating clean state and automatically


### PR DESCRIPTION
## Summary

- Wipe shard-election and per-process registration keys from etcd inside `ReinitializeCluster`, so a pooler that was elected PRIMARY in the previous suite doesn't hang on restart against an empty data directory.
- Upload `/tmp/shardsetup_test_*/**/*.log` as a CI artifact on failure so cluster-bootstrap / reinit investigations don't need us to re-run locally to see multipooler / pgctld logs.

## Problem

The nightly pgregress workflow fails deterministically on GHA ubuntu-24.04 runners (four consecutive runs observed, two different commits) at the reinit between the regression and isolation suites:

```
ReinitializeCluster: started pooler-1 (pgctld + multipooler)   ← ready in 6s
Error:      Condition never satisfied
Messages:   Manager should become ready within 30 seconds     ← pooler-2 times out
```

`ReinitializeCluster` wipes data directories and the pgBackRest backup repo but leaves etcd topology untouched. In the first suite pooler-2 is elected PRIMARY (term=1). On reinit, pooler-2's multipooler restarts with an empty data dir but still reads its stale role from etcd — it enters a recovery / reconciliation path that never reports `PostgresReady`. Pooler-1 (a replica in the first suite) does not hit this asymmetry and comes up cleanly in ~6s.

The failure does not reproduce locally on macOS — the same code completes the reinit in sub-second time on a developer laptop. On GHA's slower Linux VM it consistently exceeds the 30s budget. Bumping the timeout is not a fix (a 60s experiment also hit the wall) because pooler-2 is genuinely stuck, not slow.

## Solution

Between the backup-repo wipe (step 3b) and the cluster restart (step 4) in `ReinitializeCluster`, delete the etcd prefixes that `multiorch` bootstrap and multipooler / gateway / orch registration will recreate anyway:

- `/multigres/global/databases/<db>/<tablegroup>/*` — shard records including `ShardInitClaim` (primary election state).
- `/multigres/<cell>/poolers/*`, `/multigres/<cell>/gateways/*`, `/multigres/<cell>/orchs/*` — per-process registration records with stale host / port info.

Kept intact: `databases/<db>/Database` (preserves `BackupLocation` and `DurabilityPolicy`, which would otherwise have to be stored and re-constructed on `ShardSetup`) and `cells/<cell>/Cell` (cell config that restarted multipoolers need to reconnect to the topology).

The wipe uses `clientv3` directly rather than going through `topoclient`, because the public topoclient API only exposes per-record delete helpers and this path wants a single recursive prefix delete — test-only code, single call site.

As a second change unrelated in code but driven by the same investigation, add a CI step that uploads `/tmp/shardsetup_test_*/**/*.log` as the `pgregress-cluster-logs` artifact when the test step fails. `TEST_PRINT_LOGS=1` streams to stdout but is truncated in practice; without these artifacts we can't see what pooler-2's manager was doing during the 30s window.

## Test plan

- [x] Local full-suite run on macOS — should still pass reinit (the wipe is a no-op on the happy path, just deletes prefixes that may or may not have keys).
- [x] Apply the `Run PgRegress Tests` label to trigger the pgregress workflow on this PR and confirm reinit no longer times out on pooler-2.
- [ ] If CI still fails, the newly-uploaded `pgregress-cluster-logs` artifact should surface pooler-2's multipooler.log for root-cause analysis.