### PR TITLE
feat(pgctld): add /ready probe that dials postgres and gRPC sockets

### DIFF
--- a/go/cmd/pgctld/command/ready.go
+++ b/go/cmd/pgctld/command/ready.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/multigres/multigres/go/common/timeouts"
+)
+
+// grpcAccepting verifies the gRPC server is accepting connections. Prefers
+// the Unix socket, and falls back to a TCP dial on the configured bind
+// address when only the port is configured.
+// When neither is configured, gRPC is not in use and the check is skipped.
+func grpcAccepting(socketPath, bindAddress string, port int) bool {
+	if socketPath != "" {
+		return unixSocketAccepting(socketPath)
+	}
+	if port != 0 {
+		return tcpAccepting(bindAddress, port)
+	}
+	return true
+}
+
+// unixSocketAccepting returns true if a process is currently accepting
+// connections on the given Unix socket path. A successful Dial means the
+// kernel handed off to a listener, distinguishing a live listener from a
+// stale socket file left behind (by a crash, for example).
+// Any dial error (e.g. ENOENT, ECONNREFUSED, EACCES, timeout) returns false.
+func unixSocketAccepting(path string) bool {
+	conn, err := net.DialTimeout("unix", path, timeouts.ReadyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// tcpAccepting returns true if a TCP listener is accepting on the given
+// bind address and port.
+// If bindAddress is a wildcard ("", "0.0.0.0", or "::"), we dial "localhost"
+// instead: Go's resolver picks 127.0.0.1 and/or ::1 based on the host's
+// stack, so the probe works on IPv4-only, IPv6-only, and dual-stack hosts.
+// If bindAddress is a specific address (e.g. "127.0.0.1", "::1", an
+// interface IP) we dial that address directly.
+// See unixSocketAccepting for the error-handling contract.
+func tcpAccepting(bindAddress string, port int) bool {
+	host := bindAddress
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeouts.ReadyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/go/cmd/pgctld/command/ready_test.go
+++ b/go/cmd/pgctld/command/ready_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortTempDir returns a tmp dir under /tmp rather than t.TempDir() to keep
+// Unix socket paths within sun_path's 104-byte limit on macOS.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "p")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenUnix starts a Unix socket listener at path and registers cleanup.
+func listenUnix(t *testing.T, path string) string {
+	t.Helper()
+	require.LessOrEqualf(t, len(path), 104, "unix socket path exceeds sun_path limit: %s", path)
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	return path
+}
+
+// listenTCP starts a TCP listener on the given host:0 and returns the
+// assigned port. t.Skip()s if the host can't be bound (e.g. "::1" on an
+// IPv4-only CI runner) so these tests don't flake by environment.
+func listenTCP(t *testing.T, host string) int {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on %s: %v", host, err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// closedTCPPort returns a port that was briefly bound and then closed, so
+// nothing is listening on it. Useful for "not accepting" assertions.
+func closedTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func TestGrpcAccepting(t *testing.T) {
+	t.Run("unix socket preferred over tcp", func(t *testing.T) {
+		dir := shortTempDir(t)
+		sock := listenUnix(t, filepath.Join(dir, "grpc.sock"))
+		port := closedTCPPort(t) // would fail if consulted
+		assert.True(t, grpcAccepting(sock, "", port))
+	})
+
+	t.Run("falls back to tcp when no socket", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, grpcAccepting("", "", port))
+	})
+
+	t.Run("neither configured skips check", func(t *testing.T) {
+		assert.True(t, grpcAccepting("", "", 0))
+	})
+}
+
+func TestTCPAccepting(t *testing.T) {
+	t.Run("wildcard bind dials localhost", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, tcpAccepting("", port))
+		assert.True(t, tcpAccepting("0.0.0.0", port))
+	})
+
+	t.Run("specific address dialled directly", func(t *testing.T) {
+		port := listenTCP(t, "127.0.0.1")
+		assert.True(t, tcpAccepting("127.0.0.1", port))
+	})
+
+	t.Run("ipv6 loopback", func(t *testing.T) {
+		port := listenTCP(t, "::1")
+		assert.True(t, tcpAccepting("::1", port))
+	})
+
+	t.Run("not listening returns false", func(t *testing.T) {
+		port := closedTCPPort(t)
+		assert.False(t, tcpAccepting("", port))
+	})
+}
+
+func TestUnixSocketAccepting(t *testing.T) {
+	t.Run("live listener returns true", func(t *testing.T) {
+		dir := shortTempDir(t)
+		path := listenUnix(t, filepath.Join(dir, "sock"))
+		assert.True(t, unixSocketAccepting(path))
+	})
+
+	t.Run("missing path returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		assert.False(t, unixSocketAccepting(filepath.Join(dir, "missing.sock")))
+	})
+
+	t.Run("stale regular file returns false", func(t *testing.T) {
+		dir := shortTempDir(t)
+		path := filepath.Join(dir, "stale.sock")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+		assert.False(t, unixSocketAccepting(path))
+	})
+}

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -164,6 +164,30 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Register /ready probe: postgres socket accepting + gRPC accepting.
+	// Replication health is intentionally excluded (see pgctldReadyHandler).
+	pgSocketPath := filepath.Join(
+		pgctld.PostgresSocketDir(poolerDir),
+		fmt.Sprintf(".s.PGSQL.%d", s.pgCtlCmd.pgPort.Get()),
+	)
+	s.senv.RegisterReadyCheck(func() error {
+		if !unixSocketAccepting(pgSocketPath) {
+			return errors.New("postgres socket not accepting")
+		}
+		return nil
+	})
+
+	grpcSocketPath := s.grpcServer.SocketFile()
+	grpcBindAddress := s.grpcServer.BindAddress()
+	grpcPort := s.grpcServer.Port()
+
+	s.senv.RegisterReadyCheck(func() error {
+		if !grpcAccepting(grpcSocketPath, grpcBindAddress, grpcPort) {
+			return errors.New("grpc not accepting")
+		}
+		return nil
+	})
+
 	s.senv.OnRun(func() {
 		logger.Info("pgctld server starting up",
 			"grpc_port", s.grpcServer.Port(),

--- a/go/common/servenv/grpc_server.go
+++ b/go/common/servenv/grpc_server.go
@@ -285,6 +285,11 @@ func (g *GrpcServer) BindAddress() string {
 	return g.bindAddress.Get()
 }
 
+// SocketFile returns the Unix socket file path, or empty string if not configured.
+func (g *GrpcServer) SocketFile() string {
+	return g.socketFile.Get()
+}
+
 // IsEnabled returns true if gRPC server is enabled
 func (g *GrpcServer) IsEnabled() bool {
 	if g.port.Get() != 0 {

--- a/go/common/servenv/pages.go
+++ b/go/common/servenv/pages.go
@@ -58,5 +58,19 @@ func (sv *ServEnv) RegisterCommonHTTPEndpoints() {
 		_ = web.Templates.ExecuteTemplate(w, "isok.html", true)
 	})
 
+	sv.HTTPHandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		sv.readyMu.RLock()
+		checks := sv.readyChecks
+		sv.readyMu.RUnlock()
+		for _, check := range checks {
+			if err := check(); err != nil {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_ = web.Templates.ExecuteTemplate(w, "isok.html", false)
+				return
+			}
+		}
+		_ = web.Templates.ExecuteTemplate(w, "isok.html", true)
+	})
+
 	sv.HTTPHandleFunc("/config", viperdebug.HandlerFunc(sv.reg))
 }

--- a/go/common/servenv/servenv.go
+++ b/go/common/servenv/servenv.go
@@ -98,6 +98,8 @@ type ServEnv struct {
 	mu           sync.Mutex
 	inited       bool
 	listeningURL url.URL
+	readyMu      sync.RWMutex
+	readyChecks  []func() error
 
 	mux          *http.ServeMux
 	onCloseHooks event.Hooks
@@ -207,6 +209,13 @@ func (se *ServEnv) PopulateListeningURL(port int32) {
 		Host:   netutil.JoinHostPort(hostname, port),
 		Path:   "/",
 	})
+}
+
+// RegisterReadyCheck adds a function called on each /ready request.
+func (se *ServEnv) RegisterReadyCheck(f func() error) {
+	se.readyMu.Lock()
+	defer se.readyMu.Unlock()
+	se.readyChecks = append(se.readyChecks, f)
 }
 
 // GetHTTPPort returns the HTTP port value

--- a/go/common/servenv/servenv_test.go
+++ b/go/common/servenv/servenv_test.go
@@ -15,9 +15,14 @@
 package servenv
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
 func TestGenerateRandomServiceID(t *testing.T) {
@@ -42,5 +47,57 @@ func TestGenerateRandomServiceID(t *testing.T) {
 			require.False(t, seen[id], "should not generate duplicate IDs")
 			seen[id] = true
 		}
+	})
+}
+
+func TestRegisterReadyCheck(t *testing.T) {
+	newSE := func() *ServEnv {
+		se := NewServEnv(viperutil.NewRegistry())
+		se.RegisterCommonHTTPEndpoints()
+		return se
+	}
+
+	t.Run("no checks returns 200", func(t *testing.T) {
+		se := newSE()
+		w := httptest.NewRecorder()
+		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+		require.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("failing check returns 503", func(t *testing.T) {
+		se := newSE()
+		se.RegisterReadyCheck(func() error { return errors.New("not ready") })
+		w := httptest.NewRecorder()
+		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+		require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+
+	t.Run("first check fails short-circuits", func(t *testing.T) {
+		se := newSE()
+		secondCalled := false
+		se.RegisterReadyCheck(func() error { return errors.New("first") })
+		se.RegisterReadyCheck(func() error { secondCalled = true; return nil })
+		w := httptest.NewRecorder()
+		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+		require.Equal(t, http.StatusServiceUnavailable, w.Code)
+		require.False(t, secondCalled)
+	})
+
+	t.Run("second check fails returns 503", func(t *testing.T) {
+		se := newSE()
+		se.RegisterReadyCheck(func() error { return nil })
+		se.RegisterReadyCheck(func() error { return errors.New("second") })
+		w := httptest.NewRecorder()
+		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+		require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+
+	t.Run("all checks pass returns 200", func(t *testing.T) {
+		se := newSE()
+		se.RegisterReadyCheck(func() error { return nil })
+		se.RegisterReadyCheck(func() error { return nil })
+		w := httptest.NewRecorder()
+		se.mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+		require.Equal(t, http.StatusOK, w.Code)
 	})
 }

--- a/go/common/timeouts/rpc.go
+++ b/go/common/timeouts/rpc.go
@@ -47,3 +47,8 @@ const DefaultSnapshotInterval = 5 * time.Second
 // sufficient for most network conditions and allows for some variability in
 // response times without causing undue delays in recovery.
 const PollResponseWait = 500 * time.Millisecond
+
+// readyDialTimeout bounds each probe dial. Local dials complete in microseconds,
+// 500ms stays well within Kubernetes' default probe timeoutSeconds: 1, leaving
+// headroom for HTTP overhead. It is a safety net for a kernel under extreme load.
+const ReadyDialTimeout = 500 * time.Millisecond

--- a/go/services/multiadmin/init.go
+++ b/go/services/multiadmin/init.go
@@ -139,7 +139,6 @@ func (ma *MultiAdmin) Init(ctx context.Context) error {
 
 	ma.senv.HTTPHandleFunc("/", ma.handleIndex)
 	ma.senv.HTTPHandleFunc("/proxy/", ma.handleProxy)
-	ma.senv.HTTPHandleFunc("/ready", ma.handleReady)
 	ma.senv.HTTPHandleFunc("/services", ma.handleServices)
 
 	ma.senv.OnClose(func() {

--- a/go/services/multiadmin/status.go
+++ b/go/services/multiadmin/status.go
@@ -74,11 +74,3 @@ func (ma *MultiAdmin) handleServices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-
-// handleReady serves the readiness check. For now, it's always ready.
-func (ma *MultiAdmin) handleReady(w http.ResponseWriter, r *http.Request) {
-	if err := web.Templates.ExecuteTemplate(w, "isok.html", true); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
-		return
-	}
-}

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -559,8 +559,22 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	)
 
 	mg.senv.HTTPHandleFunc("/", mg.handleIndex)
-	mg.senv.HTTPHandleFunc("/ready", mg.handleReady)
 	mg.senv.HTTPHandleFunc("/debug/consolidator", mg.handleConsolidatorDebug)
+
+	// The gateway is ready only when both conditions are met:
+	// 1. No init errors (topology registration succeeded)
+	// 2. At least one pooler has been discovered (can actually serve queries)
+	mg.senv.RegisterReadyCheck(func() error {
+		mg.serverStatus.mu.Lock()
+		defer mg.serverStatus.mu.Unlock()
+		if len(mg.serverStatus.InitError) > 0 {
+			return errors.New(mg.serverStatus.InitError)
+		}
+		if mg.poolerDiscovery.PoolerCount() == 0 {
+			return errors.New("no poolers discovered")
+		}
+		return nil
+	})
 	mg.senv.HTTPHandleFunc("/debug/queries", mg.handleQueriesDebug)
 
 	mg.senv.OnClose(func() {

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -102,26 +102,6 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleReady serves the readiness check.
-// The gateway is ready only when both conditions are met:
-// 1. No init errors (topology registration succeeded)
-// 2. At least one pooler has been discovered (can actually serve queries)
-func (mg *MultiGateway) handleReady(w http.ResponseWriter, r *http.Request) {
-	mg.serverStatus.mu.Lock()
-	defer mg.serverStatus.mu.Unlock()
-
-	hasNoInitError := len(mg.serverStatus.InitError) == 0
-	hasPoolers := mg.poolerDiscovery.PoolerCount() > 0
-	isReady := hasNoInitError && hasPoolers
-	if !isReady {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}
-	if err := web.Templates.ExecuteTemplate(w, "isok.html", isReady); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
-		return
-	}
-}
-
 // ConsolidatorDebugStatus contains data for the consolidator debug page.
 type ConsolidatorDebugStatus struct {
 	Title string

--- a/go/services/multiorch/init.go
+++ b/go/services/multiorch/init.go
@@ -158,7 +158,14 @@ func (mo *MultiOrch) Init() error {
 	)
 
 	mo.senv.HTTPHandleFunc("/", mo.handleIndex)
-	mo.senv.HTTPHandleFunc("/ready", mo.handleReady)
+	mo.senv.RegisterReadyCheck(func() error {
+		mo.serverStatus.mu.Lock()
+		defer mo.serverStatus.mu.Unlock()
+		if len(mo.serverStatus.InitError) > 0 {
+			return errors.New(mo.serverStatus.InitError)
+		}
+		return nil
+	})
 
 	// Create RPC client for recovery engine health checks
 	transportCreds, err := mo.connConfig.TransportCredentials(logger)

--- a/go/services/multiorch/status.go
+++ b/go/services/multiorch/status.go
@@ -56,18 +56,3 @@ func (mo *MultiOrch) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
-
-// handleReady serves the readiness check
-func (mo *MultiOrch) handleReady(w http.ResponseWriter, r *http.Request) {
-	mo.serverStatus.mu.Lock()
-	defer mo.serverStatus.mu.Unlock()
-
-	isReady := (len(mo.serverStatus.InitError) == 0)
-	if !isReady {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}
-	if err := web.Templates.ExecuteTemplate(w, "isok.html", isReady); err != nil {
-		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
-		return
-	}
-}


### PR DESCRIPTION
## Description

This PR implements the /ready endpoint for pgctld.

Ready means postgres is accepting connections on its unix socket and the gRPC server is accepting connections. Replication health is intentionally excluded, a pod with degraded replication must stay in DNS so
multiorch can reach it to initiate repair. 

The check uses an actual dial rather than a socket file-existence test.

## Changes

- Added /ready HTTP handler in pgctld that dials the postgres Unix socket and the gRPC endpoint on every request.
- Added SocketFile() accessor on GrpcServer so the server command can pass the socket path to the handler without reaching into unexported fields.
- Wired the handler in server.go with pgSocketPath, grpcSocketPath, grpcBindAddress, and grpcPort. Matching the two gRPC listener modes (--grpc-socket-file vs --grpc-port).
- gRPC check prefers the Unix socket when configured and falls back to a TCP dial on the configured bind address. When neither is configured the check is skipped (mirrors GrpcServer.IsEnabled()).
- Wildcard bind addresses ("", 0.0.0.0, ::) are mapped to "localhost" for the TCP probe so the dial works on IPv4-only, IPv6-only, and dual-stack hosts. Specific addresses (e.g. ::1) are dialed directly during the probe.

## Testing

ToDo: field tests.

Ran the new TestPgctldReadyHandler suite covering both sockets up, each socket missing independently, stale socket files with no listener, TCP wildcard bind, IPv6 loopback bind, and the socket-preferred-over-TCP
precedence rule. The IPv6 case is guarded with t.Skip so it doesn't flake on IPv4-only CI runners.
