### PR TITLE
feat(multiorch,multipooler): graceful primary shutdown and Shutdown RPC

### DIFF
--- a/go/common/constants/pooler.go
+++ b/go/common/constants/pooler.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "time"
+
+const (
+	// PrimaryShutdownSignalTimeout is how long we wait for multiorch to call
+	// EmergencyDemote after we signal STOPPING. If it doesn't arrive in time we
+	// stop postgres ourselves so the process always exits cleanly.
+	PrimaryShutdownSignalTimeout = 45 * time.Second
+
+	// PrimaryShutdownPollInterval is how often we check whether postgres has stopped
+	// while waiting for EmergencyDemote.
+	PrimaryShutdownPollInterval = 500 * time.Millisecond
+)

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -81,6 +81,9 @@ type FakeClient struct {
 	// Errors to return - keyed by pooler ID
 	Errors map[string]error
 
+	// WaitForLSNErrors to return - keyed by pooler ID (overrides Errors for WaitForLSN only)
+	WaitForLSNErrors map[string]error
+
 	// CallLog tracks which methods were called for verification in tests
 	CallLog []string
 
@@ -115,6 +118,7 @@ func NewFakeClient() *FakeClient {
 		RewindToSourceResponses:             make(map[string]*multipoolermanagerdatapb.RewindToSourceResponse),
 		SetPostgresRestartsEnabledResponses: make(map[string]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		Errors:                              make(map[string]error),
+		WaitForLSNErrors:                    make(map[string]error),
 		CallLog:                             make([]string, 0),
 		PromoteRequests:                     make(map[string]*multipoolermanagerdatapb.PromoteRequest),
 		ProposeRequests:                     make(map[string]*consensusdatapb.ProposeRequest),
@@ -376,6 +380,12 @@ func (f *FakeClient) WaitForLSN(ctx context.Context, pooler *clustermetadatapb.M
 	poolerID := f.getPoolerID(pooler)
 	f.logCall("WaitForLSN", poolerID)
 
+	f.mu.RLock()
+	lsnErr := f.WaitForLSNErrors[poolerID]
+	f.mu.RUnlock()
+	if lsnErr != nil {
+		return nil, lsnErr
+	}
 	if err := f.checkError(poolerID); err != nil {
 		return nil, err
 	}

--- a/go/common/servenv/grpc_server.go
+++ b/go/common/servenv/grpc_server.go
@@ -457,7 +457,17 @@ func (g *GrpcServer) Serve(sv *ServEnv) error {
 		}
 	}()
 
-	sv.OnTermSync(func() {
+	// We use OnClose instead of OnTermSync because gRPC's GracefulStop() can
+	// block until all connections are closed, which may take some time. Using
+	// OnClose allows the server to begin shutting down immediately when the
+	// process receives a termination signal, while still allowing for a
+	// graceful shutdown of gRPC connections.
+	//
+	// If we used OnTermSync, the process would block waiting for all in-flight
+	// gRPC requests to finish before it could begin shutting down, including
+	// the health streams. However, multiorch needs the health stream to finish
+	// the shutdown.
+	sv.OnClose(func() {
 		slog.Info("Initiated graceful stop of gRPC server")
 		g.Server.GracefulStop()
 		slog.Info("gRPC server stopped")

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -47,8 +47,16 @@ const (
 	PoolerType_PRIMARY PoolerType = 1
 	// REPLICA replicates from leader. It is used to read only traffic
 	PoolerType_REPLICA PoolerType = 2
-	// DRAINED is used for poolers that are temporarily removed from serving traffic
+	// DRAINED is used for poolers that are no longer serving traffic and should
+	// be removed from the cluster. This is set when a pooler is permanently
+	// removed from consideration, for example, if pg_rewind fails and the server
+	// can no longer be part of the cluster. Analyzers skip DRAINED poolers to
+	// prevent spurious recovery attempts.
 	PoolerType_DRAINED PoolerType = 3
+	// STOPPING is used for a primary that is in the process of being gracefully
+	// shut down. The primary has been demoted and a new primary is being elected.
+	// Analyzers skip STOPPING poolers to prevent spurious recovery attempts.
+	PoolerType_STOPPING PoolerType = 4
 )
 
 // Enum value maps for PoolerType.
@@ -58,12 +66,14 @@ var (
 		1: "PRIMARY",
 		2: "REPLICA",
 		3: "DRAINED",
+		4: "STOPPING",
 	}
 	PoolerType_value = map[string]int32{
-		"UNKNOWN": 0,
-		"PRIMARY": 1,
-		"REPLICA": 2,
-		"DRAINED": 3,
+		"UNKNOWN":  0,
+		"PRIMARY":  1,
+		"REPLICA":  2,
+		"DRAINED":  3,
+		"STOPPING": 4,
 	}
 )
 
@@ -2063,13 +2073,14 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"leaderTerm\x129\n" +
 	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"d\n" +
 	"\x12AvailabilityStatus\x12N\n" +
-	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus*@\n" +
+	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus*N\n" +
 	"\n" +
 	"PoolerType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aPRIMARY\x10\x01\x12\v\n" +
 	"\aREPLICA\x10\x02\x12\v\n" +
-	"\aDRAINED\x10\x03*L\n" +
+	"\aDRAINED\x10\x03\x12\f\n" +
+	"\bSTOPPING\x10\x04*L\n" +
 	"\x13PoolerServingStatus\x12\v\n" +
 	"\aSERVING\x10\x00\x12\x0f\n" +
 	"\vNOT_SERVING\x10\x01\x12\n" +

--- a/go/pb/multiorch/multiorchservice.pb.go
+++ b/go/pb/multiorch/multiorchservice.pb.go
@@ -24,6 +24,7 @@ import (
 	clustermetadata "github.com/multigres/multigres/go/pb/clustermetadata"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -674,11 +675,158 @@ func (x *TriggerRecoveryNowResponse) GetRemainingProblemCodes() []string {
 	return nil
 }
 
+type ShutdownPrimaryRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shard to perform the switchover on
+	Database   string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	TableGroup string `protobuf:"bytes,2,opt,name=table_group,json=tableGroup,proto3" json:"table_group,omitempty"`
+	Shard      string `protobuf:"bytes,3,opt,name=shard,proto3" json:"shard,omitempty"`
+	// Identity of the primary requesting shutdown.
+	// Used to validate that the caller is the current primary and to exclude
+	// it from the new election cohort.
+	PrimaryId *clustermetadata.ID `protobuf:"bytes,4,opt,name=primary_id,json=primaryId,proto3" json:"primary_id,omitempty"`
+	// How long to wait for in-flight write transactions to drain on the primary.
+	// Required: must be a positive duration.
+	DrainTimeout *durationpb.Duration `protobuf:"bytes,5,opt,name=drain_timeout,json=drainTimeout,proto3" json:"drain_timeout,omitempty"`
+	// How long to wait for standbys to replay to the primary's final LSN.
+	// Required: must be a positive duration.
+	StandbyCatchupTimeout *durationpb.Duration `protobuf:"bytes,6,opt,name=standby_catchup_timeout,json=standbyCatchupTimeout,proto3" json:"standby_catchup_timeout,omitempty"`
+	// Human-readable reason for the shutdown (e.g. "SIGTERM", "operator request").
+	// Used for logging and audit trails only.
+	Reason        string `protobuf:"bytes,7,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownPrimaryRequest) Reset() {
+	*x = ShutdownPrimaryRequest{}
+	mi := &file_multiorchservice_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownPrimaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownPrimaryRequest) ProtoMessage() {}
+
+func (x *ShutdownPrimaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multiorchservice_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownPrimaryRequest.ProtoReflect.Descriptor instead.
+func (*ShutdownPrimaryRequest) Descriptor() ([]byte, []int) {
+	return file_multiorchservice_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ShutdownPrimaryRequest) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
+}
+
+func (x *ShutdownPrimaryRequest) GetTableGroup() string {
+	if x != nil {
+		return x.TableGroup
+	}
+	return ""
+}
+
+func (x *ShutdownPrimaryRequest) GetShard() string {
+	if x != nil {
+		return x.Shard
+	}
+	return ""
+}
+
+func (x *ShutdownPrimaryRequest) GetPrimaryId() *clustermetadata.ID {
+	if x != nil {
+		return x.PrimaryId
+	}
+	return nil
+}
+
+func (x *ShutdownPrimaryRequest) GetDrainTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.DrainTimeout
+	}
+	return nil
+}
+
+func (x *ShutdownPrimaryRequest) GetStandbyCatchupTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.StandbyCatchupTimeout
+	}
+	return nil
+}
+
+func (x *ShutdownPrimaryRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type ShutdownPrimaryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The newly elected primary after the switchover.
+	NewPrimaryId  *clustermetadata.ID `protobuf:"bytes,1,opt,name=new_primary_id,json=newPrimaryId,proto3" json:"new_primary_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownPrimaryResponse) Reset() {
+	*x = ShutdownPrimaryResponse{}
+	mi := &file_multiorchservice_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownPrimaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownPrimaryResponse) ProtoMessage() {}
+
+func (x *ShutdownPrimaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multiorchservice_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownPrimaryResponse.ProtoReflect.Descriptor instead.
+func (*ShutdownPrimaryResponse) Descriptor() ([]byte, []int) {
+	return file_multiorchservice_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ShutdownPrimaryResponse) GetNewPrimaryId() *clustermetadata.ID {
+	if x != nil {
+		return x.NewPrimaryId
+	}
+	return nil
+}
+
 var File_multiorchservice_proto protoreflect.FileDescriptor
 
 const file_multiorchservice_proto_rawDesc = "" +
 	"\n" +
-	"\x16multiorchservice.proto\x12\tmultiorch\x1a\x15clustermetadata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n" +
+	"\x16multiorchservice.proto\x12\tmultiorch\x1a\x15clustermetadata.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n" +
 	"\x12ShardStatusRequest\x126\n" +
 	"\tshard_key\x18\x01 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\"\x8d\x01\n" +
 	"\x13ShardStatusResponse\x126\n" +
@@ -719,13 +867,26 @@ const file_multiorchservice_proto_rawDesc = "" +
 	"\n" +
 	"max_cycles\x18\x01 \x01(\rR\tmaxCycles\"T\n" +
 	"\x1aTriggerRecoveryNowResponse\x126\n" +
-	"\x17remaining_problem_codes\x18\x04 \x03(\tR\x15remainingProblemCodes2\xe1\x03\n" +
+	"\x17remaining_problem_codes\x18\x04 \x03(\tR\x15remainingProblemCodes\"\xca\x02\n" +
+	"\x16ShutdownPrimaryRequest\x12\x1a\n" +
+	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x1f\n" +
+	"\vtable_group\x18\x02 \x01(\tR\n" +
+	"tableGroup\x12\x14\n" +
+	"\x05shard\x18\x03 \x01(\tR\x05shard\x122\n" +
+	"\n" +
+	"primary_id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\tprimaryId\x12>\n" +
+	"\rdrain_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\fdrainTimeout\x12Q\n" +
+	"\x17standby_catchup_timeout\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x15standbyCatchupTimeout\x12\x16\n" +
+	"\x06reason\x18\a \x01(\tR\x06reason\"T\n" +
+	"\x17ShutdownPrimaryResponse\x129\n" +
+	"\x0enew_primary_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\fnewPrimaryId2\xbd\x04\n" +
 	"\x10MultiOrchService\x12Q\n" +
 	"\x0eGetShardStatus\x12\x1d.multiorch.ShardStatusRequest\x1a\x1e.multiorch.ShardStatusResponse\"\x00\x12Z\n" +
 	"\x0fDisableRecovery\x12!.multiorch.DisableRecoveryRequest\x1a\".multiorch.DisableRecoveryResponse\"\x00\x12W\n" +
 	"\x0eEnableRecovery\x12 .multiorch.EnableRecoveryRequest\x1a!.multiorch.EnableRecoveryResponse\"\x00\x12`\n" +
 	"\x11GetRecoveryStatus\x12#.multiorch.GetRecoveryStatusRequest\x1a$.multiorch.GetRecoveryStatusResponse\"\x00\x12c\n" +
-	"\x12TriggerRecoveryNow\x12$.multiorch.TriggerRecoveryNowRequest\x1a%.multiorch.TriggerRecoveryNowResponse\"\x00B0Z.github.com/multigres/multigres/go/pb/multiorchb\x06proto3"
+	"\x12TriggerRecoveryNow\x12$.multiorch.TriggerRecoveryNowRequest\x1a%.multiorch.TriggerRecoveryNowResponse\"\x00\x12Z\n" +
+	"\x0fShutdownPrimary\x12!.multiorch.ShutdownPrimaryRequest\x1a\".multiorch.ShutdownPrimaryResponse\"\x00B0Z.github.com/multigres/multigres/go/pb/multiorchb\x06proto3"
 
 var (
 	file_multiorchservice_proto_rawDescOnce sync.Once
@@ -739,7 +900,7 @@ func file_multiorchservice_proto_rawDescGZIP() []byte {
 	return file_multiorchservice_proto_rawDescData
 }
 
-var file_multiorchservice_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_multiorchservice_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_multiorchservice_proto_goTypes = []any{
 	(*ShardStatusRequest)(nil),         // 0: multiorch.ShardStatusRequest
 	(*ShardStatusResponse)(nil),        // 1: multiorch.ShardStatusResponse
@@ -753,34 +914,43 @@ var file_multiorchservice_proto_goTypes = []any{
 	(*GetRecoveryStatusResponse)(nil),  // 9: multiorch.GetRecoveryStatusResponse
 	(*TriggerRecoveryNowRequest)(nil),  // 10: multiorch.TriggerRecoveryNowRequest
 	(*TriggerRecoveryNowResponse)(nil), // 11: multiorch.TriggerRecoveryNowResponse
-	(*clustermetadata.ShardKey)(nil),   // 12: clustermetadata.ShardKey
-	(*clustermetadata.ID)(nil),         // 13: clustermetadata.ID
-	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
+	(*ShutdownPrimaryRequest)(nil),     // 12: multiorch.ShutdownPrimaryRequest
+	(*ShutdownPrimaryResponse)(nil),    // 13: multiorch.ShutdownPrimaryResponse
+	(*clustermetadata.ShardKey)(nil),   // 14: clustermetadata.ShardKey
+	(*clustermetadata.ID)(nil),         // 15: clustermetadata.ID
+	(*timestamppb.Timestamp)(nil),      // 16: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),        // 17: google.protobuf.Duration
 }
 var file_multiorchservice_proto_depIdxs = []int32{
-	12, // 0: multiorch.ShardStatusRequest.shard_key:type_name -> clustermetadata.ShardKey
+	14, // 0: multiorch.ShardStatusRequest.shard_key:type_name -> clustermetadata.ShardKey
 	2,  // 1: multiorch.ShardStatusResponse.problems:type_name -> multiorch.DetectedProblem
 	3,  // 2: multiorch.ShardStatusResponse.pooler_healths:type_name -> multiorch.PoolerHealth
-	13, // 3: multiorch.DetectedProblem.pooler_id:type_name -> clustermetadata.ID
-	12, // 4: multiorch.DetectedProblem.shard_key:type_name -> clustermetadata.ShardKey
-	14, // 5: multiorch.DetectedProblem.detected_at:type_name -> google.protobuf.Timestamp
-	13, // 6: multiorch.PoolerHealth.pooler_id:type_name -> clustermetadata.ID
-	14, // 7: multiorch.PoolerHealth.last_check:type_name -> google.protobuf.Timestamp
-	0,  // 8: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
-	4,  // 9: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
-	6,  // 10: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
-	8,  // 11: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
-	10, // 12: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
-	1,  // 13: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
-	5,  // 14: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
-	7,  // 15: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
-	9,  // 16: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
-	11, // 17: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	15, // 3: multiorch.DetectedProblem.pooler_id:type_name -> clustermetadata.ID
+	14, // 4: multiorch.DetectedProblem.shard_key:type_name -> clustermetadata.ShardKey
+	16, // 5: multiorch.DetectedProblem.detected_at:type_name -> google.protobuf.Timestamp
+	15, // 6: multiorch.PoolerHealth.pooler_id:type_name -> clustermetadata.ID
+	16, // 7: multiorch.PoolerHealth.last_check:type_name -> google.protobuf.Timestamp
+	15, // 8: multiorch.ShutdownPrimaryRequest.primary_id:type_name -> clustermetadata.ID
+	17, // 9: multiorch.ShutdownPrimaryRequest.drain_timeout:type_name -> google.protobuf.Duration
+	17, // 10: multiorch.ShutdownPrimaryRequest.standby_catchup_timeout:type_name -> google.protobuf.Duration
+	15, // 11: multiorch.ShutdownPrimaryResponse.new_primary_id:type_name -> clustermetadata.ID
+	0,  // 12: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
+	4,  // 13: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
+	6,  // 14: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
+	8,  // 15: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
+	10, // 16: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
+	12, // 17: multiorch.MultiOrchService.ShutdownPrimary:input_type -> multiorch.ShutdownPrimaryRequest
+	1,  // 18: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
+	5,  // 19: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
+	7,  // 20: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
+	9,  // 21: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
+	11, // 22: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
+	13, // 23: multiorch.MultiOrchService.ShutdownPrimary:output_type -> multiorch.ShutdownPrimaryResponse
+	18, // [18:24] is the sub-list for method output_type
+	12, // [12:18] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_multiorchservice_proto_init() }
@@ -794,7 +964,7 @@ func file_multiorchservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multiorchservice_proto_rawDesc), len(file_multiorchservice_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/pb/multiorch/multiorchservice.pb.go
+++ b/go/pb/multiorch/multiorchservice.pb.go
@@ -688,9 +688,6 @@ type ShutdownPrimaryRequest struct {
 	// How long to wait for in-flight write transactions to drain on the primary.
 	// Required: must be a positive duration.
 	DrainTimeout *durationpb.Duration `protobuf:"bytes,5,opt,name=drain_timeout,json=drainTimeout,proto3" json:"drain_timeout,omitempty"`
-	// How long to wait for standbys to replay to the primary's final LSN.
-	// Required: must be a positive duration.
-	StandbyCatchupTimeout *durationpb.Duration `protobuf:"bytes,6,opt,name=standby_catchup_timeout,json=standbyCatchupTimeout,proto3" json:"standby_catchup_timeout,omitempty"`
 	// Human-readable reason for the shutdown (e.g. "SIGTERM", "operator request").
 	// Used for logging and audit trails only.
 	Reason        string `protobuf:"bytes,7,opt,name=reason,proto3" json:"reason,omitempty"`
@@ -759,13 +756,6 @@ func (x *ShutdownPrimaryRequest) GetPrimaryId() *clustermetadata.ID {
 func (x *ShutdownPrimaryRequest) GetDrainTimeout() *durationpb.Duration {
 	if x != nil {
 		return x.DrainTimeout
-	}
-	return nil
-}
-
-func (x *ShutdownPrimaryRequest) GetStandbyCatchupTimeout() *durationpb.Duration {
-	if x != nil {
-		return x.StandbyCatchupTimeout
 	}
 	return nil
 }
@@ -867,7 +857,7 @@ const file_multiorchservice_proto_rawDesc = "" +
 	"\n" +
 	"max_cycles\x18\x01 \x01(\rR\tmaxCycles\"T\n" +
 	"\x1aTriggerRecoveryNowResponse\x126\n" +
-	"\x17remaining_problem_codes\x18\x04 \x03(\tR\x15remainingProblemCodes\"\xca\x02\n" +
+	"\x17remaining_problem_codes\x18\x04 \x03(\tR\x15remainingProblemCodes\"\xf7\x01\n" +
 	"\x16ShutdownPrimaryRequest\x12\x1a\n" +
 	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x1f\n" +
 	"\vtable_group\x18\x02 \x01(\tR\n" +
@@ -875,8 +865,7 @@ const file_multiorchservice_proto_rawDesc = "" +
 	"\x05shard\x18\x03 \x01(\tR\x05shard\x122\n" +
 	"\n" +
 	"primary_id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\tprimaryId\x12>\n" +
-	"\rdrain_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\fdrainTimeout\x12Q\n" +
-	"\x17standby_catchup_timeout\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x15standbyCatchupTimeout\x12\x16\n" +
+	"\rdrain_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\fdrainTimeout\x12\x16\n" +
 	"\x06reason\x18\a \x01(\tR\x06reason\"T\n" +
 	"\x17ShutdownPrimaryResponse\x129\n" +
 	"\x0enew_primary_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\fnewPrimaryId2\xbd\x04\n" +
@@ -932,25 +921,24 @@ var file_multiorchservice_proto_depIdxs = []int32{
 	16, // 7: multiorch.PoolerHealth.last_check:type_name -> google.protobuf.Timestamp
 	15, // 8: multiorch.ShutdownPrimaryRequest.primary_id:type_name -> clustermetadata.ID
 	17, // 9: multiorch.ShutdownPrimaryRequest.drain_timeout:type_name -> google.protobuf.Duration
-	17, // 10: multiorch.ShutdownPrimaryRequest.standby_catchup_timeout:type_name -> google.protobuf.Duration
-	15, // 11: multiorch.ShutdownPrimaryResponse.new_primary_id:type_name -> clustermetadata.ID
-	0,  // 12: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
-	4,  // 13: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
-	6,  // 14: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
-	8,  // 15: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
-	10, // 16: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
-	12, // 17: multiorch.MultiOrchService.ShutdownPrimary:input_type -> multiorch.ShutdownPrimaryRequest
-	1,  // 18: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
-	5,  // 19: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
-	7,  // 20: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
-	9,  // 21: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
-	11, // 22: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
-	13, // 23: multiorch.MultiOrchService.ShutdownPrimary:output_type -> multiorch.ShutdownPrimaryResponse
-	18, // [18:24] is the sub-list for method output_type
-	12, // [12:18] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	15, // 10: multiorch.ShutdownPrimaryResponse.new_primary_id:type_name -> clustermetadata.ID
+	0,  // 11: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
+	4,  // 12: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
+	6,  // 13: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
+	8,  // 14: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
+	10, // 15: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
+	12, // 16: multiorch.MultiOrchService.ShutdownPrimary:input_type -> multiorch.ShutdownPrimaryRequest
+	1,  // 17: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
+	5,  // 18: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
+	7,  // 19: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
+	9,  // 20: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
+	11, // 21: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
+	13, // 22: multiorch.MultiOrchService.ShutdownPrimary:output_type -> multiorch.ShutdownPrimaryResponse
+	17, // [17:23] is the sub-list for method output_type
+	11, // [11:17] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_multiorchservice_proto_init() }

--- a/go/pb/multiorch/multiorchservice.pb.gw.go
+++ b/go/pb/multiorch/multiorchservice.pb.gw.go
@@ -170,6 +170,33 @@ func local_request_MultiOrchService_TriggerRecoveryNow_0(ctx context.Context, ma
 	return msg, metadata, err
 }
 
+func request_MultiOrchService_ShutdownPrimary_0(ctx context.Context, marshaler runtime.Marshaler, client MultiOrchServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ShutdownPrimaryRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ShutdownPrimary(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiOrchService_ShutdownPrimary_0(ctx context.Context, marshaler runtime.Marshaler, server MultiOrchServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ShutdownPrimaryRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ShutdownPrimary(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMultiOrchServiceHandlerServer registers the http handlers for service MultiOrchService to "mux".
 // UnaryRPC     :call MultiOrchServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -275,6 +302,26 @@ func RegisterMultiOrchServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 			return
 		}
 		forward_MultiOrchService_TriggerRecoveryNow_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiOrchService_ShutdownPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multiorch.MultiOrchService/ShutdownPrimary", runtime.WithHTTPPathPattern("/multiorch.MultiOrchService/ShutdownPrimary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiOrchService_ShutdownPrimary_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiOrchService_ShutdownPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -401,6 +448,23 @@ func RegisterMultiOrchServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_MultiOrchService_TriggerRecoveryNow_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiOrchService_ShutdownPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multiorch.MultiOrchService/ShutdownPrimary", runtime.WithHTTPPathPattern("/multiorch.MultiOrchService/ShutdownPrimary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiOrchService_ShutdownPrimary_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiOrchService_ShutdownPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -410,6 +474,7 @@ var (
 	pattern_MultiOrchService_EnableRecovery_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multiorch.MultiOrchService", "EnableRecovery"}, ""))
 	pattern_MultiOrchService_GetRecoveryStatus_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multiorch.MultiOrchService", "GetRecoveryStatus"}, ""))
 	pattern_MultiOrchService_TriggerRecoveryNow_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multiorch.MultiOrchService", "TriggerRecoveryNow"}, ""))
+	pattern_MultiOrchService_ShutdownPrimary_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multiorch.MultiOrchService", "ShutdownPrimary"}, ""))
 )
 
 var (
@@ -418,4 +483,5 @@ var (
 	forward_MultiOrchService_EnableRecovery_0     = runtime.ForwardResponseMessage
 	forward_MultiOrchService_GetRecoveryStatus_0  = runtime.ForwardResponseMessage
 	forward_MultiOrchService_TriggerRecoveryNow_0 = runtime.ForwardResponseMessage
+	forward_MultiOrchService_ShutdownPrimary_0    = runtime.ForwardResponseMessage
 )

--- a/go/pb/multiorch/multiorchservice_grpc.pb.go
+++ b/go/pb/multiorch/multiorchservice_grpc.pb.go
@@ -76,23 +76,23 @@ type MultiOrchServiceClient interface {
 	//
 	// Sequence:
 	//  1. Validates that the pooler is currently PRIMARY or STOPPING.
-	//  2. Reads the primary's current WAL LSN. The multipooler has already set
-	//     PoolerType_STOPPING on the health stream before calling this RPC,
-	//     which causes the gateway to stop routing new writes — so this LSN is
-	//     a stable target for standby catchup.
-	//  3. Waits for all standbys to replay to that LSN. The primary is still
-	//     running and streaming WAL during this window. If the timeout expires
-	//     the switchover proceeds anyway to avoid hanging indefinitely.
-	//  4. Calls EmergencyDemote to stop the primary. Standbys have caught up
-	//     (or timed out), so there are few or no active writes left to drain.
-	//     Then marks the old primary as DRAINED in topology so that the
-	//     topology never shows two PRIMARY nodes simultaneously and the node
-	//     is excluded from future elections.
-	//  5. Builds the election cohort from shard poolers, excluding STOPPING and
-	//     DRAINED poolers. This prevents the old primary from being re-elected
-	//     and prevents irreparable replicas from becoming candidates.
-	//  6. Elects a new primary via AppointLeader.
-	//  7. Polls shard poolers to confirm the new primary and returns its ID.
+	//  2. Calls EmergencyDemote with restart_server_as_standby=false. This
+	//     drains in-flight writes (with sync replication, each commit waits
+	//     for sync standby ACK before returning, so committed WAL is durable
+	//     on sync standbys when drain completes), captures the final LSN, and
+	//     signals voluntary resignation. PostgreSQL is left running in
+	//     NOT_SERVING state — the caller stops it after the RPC returns.
+	//     2b. Marks the old primary as DRAINED in topology so getpoolers never
+	//     shows two PRIMARY nodes simultaneously and the node is excluded
+	//     from future elections.
+	//  3. Builds the election cohort from shard poolers, excluding STOPPING
+	//     and DRAINED poolers. This prevents the old primary from being
+	//     re-elected and prevents irreparable replicas from becoming
+	//     candidates.
+	//  4. Elects a new primary via AppointLeader. Recruit returns each
+	//     candidate's last_receive_lsn and Propose makes the chosen leader
+	//     replay any received-but-unapplied WAL before opening for writes.
+	//  5. Polls shard poolers to confirm the new primary and returns its ID.
 	//
 	// Returns once a new primary has been elected. The caller can then shut down
 	// PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed
@@ -203,23 +203,23 @@ type MultiOrchServiceServer interface {
 	//
 	// Sequence:
 	//  1. Validates that the pooler is currently PRIMARY or STOPPING.
-	//  2. Reads the primary's current WAL LSN. The multipooler has already set
-	//     PoolerType_STOPPING on the health stream before calling this RPC,
-	//     which causes the gateway to stop routing new writes — so this LSN is
-	//     a stable target for standby catchup.
-	//  3. Waits for all standbys to replay to that LSN. The primary is still
-	//     running and streaming WAL during this window. If the timeout expires
-	//     the switchover proceeds anyway to avoid hanging indefinitely.
-	//  4. Calls EmergencyDemote to stop the primary. Standbys have caught up
-	//     (or timed out), so there are few or no active writes left to drain.
-	//     Then marks the old primary as DRAINED in topology so that the
-	//     topology never shows two PRIMARY nodes simultaneously and the node
-	//     is excluded from future elections.
-	//  5. Builds the election cohort from shard poolers, excluding STOPPING and
-	//     DRAINED poolers. This prevents the old primary from being re-elected
-	//     and prevents irreparable replicas from becoming candidates.
-	//  6. Elects a new primary via AppointLeader.
-	//  7. Polls shard poolers to confirm the new primary and returns its ID.
+	//  2. Calls EmergencyDemote with restart_server_as_standby=false. This
+	//     drains in-flight writes (with sync replication, each commit waits
+	//     for sync standby ACK before returning, so committed WAL is durable
+	//     on sync standbys when drain completes), captures the final LSN, and
+	//     signals voluntary resignation. PostgreSQL is left running in
+	//     NOT_SERVING state — the caller stops it after the RPC returns.
+	//     2b. Marks the old primary as DRAINED in topology so getpoolers never
+	//     shows two PRIMARY nodes simultaneously and the node is excluded
+	//     from future elections.
+	//  3. Builds the election cohort from shard poolers, excluding STOPPING
+	//     and DRAINED poolers. This prevents the old primary from being
+	//     re-elected and prevents irreparable replicas from becoming
+	//     candidates.
+	//  4. Elects a new primary via AppointLeader. Recruit returns each
+	//     candidate's last_receive_lsn and Propose makes the chosen leader
+	//     replay any received-but-unapplied WAL before opening for writes.
+	//  5. Polls shard poolers to confirm the new primary and returns its ID.
 	//
 	// Returns once a new primary has been elected. The caller can then shut down
 	// PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed

--- a/go/pb/multiorch/multiorchservice_grpc.pb.go
+++ b/go/pb/multiorch/multiorchservice_grpc.pb.go
@@ -38,6 +38,7 @@ const (
 	MultiOrchService_EnableRecovery_FullMethodName     = "/multiorch.MultiOrchService/EnableRecovery"
 	MultiOrchService_GetRecoveryStatus_FullMethodName  = "/multiorch.MultiOrchService/GetRecoveryStatus"
 	MultiOrchService_TriggerRecoveryNow_FullMethodName = "/multiorch.MultiOrchService/TriggerRecoveryNow"
+	MultiOrchService_ShutdownPrimary_FullMethodName    = "/multiorch.MultiOrchService/ShutdownPrimary"
 )
 
 // MultiOrchServiceClient is the client API for MultiOrchService service.
@@ -68,6 +69,35 @@ type MultiOrchServiceClient interface {
 	// - Returns when either: (1) no problems remain, or (2) context times out
 	// - If recovery is disabled, this temporarily enables it during this operation
 	TriggerRecoveryNow(ctx context.Context, in *TriggerRecoveryNowRequest, opts ...grpc.CallOption) (*TriggerRecoveryNowResponse, error)
+	// ShutdownPrimary orchestrates a planned primary switchover.
+	//
+	// Normally called by the primary multipooler during graceful shutdown on the
+	// reception of a SIGTERM signal, but this is not a requirement.
+	//
+	// Sequence:
+	//  1. Validates that the pooler is currently PRIMARY or STOPPING.
+	//  2. Reads the primary's current WAL LSN. The multipooler has already set
+	//     PoolerType_STOPPING on the health stream before calling this RPC,
+	//     which causes the gateway to stop routing new writes — so this LSN is
+	//     a stable target for standby catchup.
+	//  3. Waits for all standbys to replay to that LSN. The primary is still
+	//     running and streaming WAL during this window. If the timeout expires
+	//     the switchover proceeds anyway to avoid hanging indefinitely.
+	//  4. Calls EmergencyDemote to stop the primary. Standbys have caught up
+	//     (or timed out), so there are few or no active writes left to drain.
+	//     Then marks the old primary as DRAINED in topology so that the
+	//     topology never shows two PRIMARY nodes simultaneously and the node
+	//     is excluded from future elections.
+	//  5. Builds the election cohort from shard poolers, excluding STOPPING and
+	//     DRAINED poolers. This prevents the old primary from being re-elected
+	//     and prevents irreparable replicas from becoming candidates.
+	//  6. Elects a new primary via AppointLeader.
+	//  7. Polls shard poolers to confirm the new primary and returns its ID.
+	//
+	// Returns once a new primary has been elected. The caller can then shut down
+	// PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed
+	// with shutdown regardless.
+	ShutdownPrimary(ctx context.Context, in *ShutdownPrimaryRequest, opts ...grpc.CallOption) (*ShutdownPrimaryResponse, error)
 }
 
 type multiOrchServiceClient struct {
@@ -128,6 +158,16 @@ func (c *multiOrchServiceClient) TriggerRecoveryNow(ctx context.Context, in *Tri
 	return out, nil
 }
 
+func (c *multiOrchServiceClient) ShutdownPrimary(ctx context.Context, in *ShutdownPrimaryRequest, opts ...grpc.CallOption) (*ShutdownPrimaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ShutdownPrimaryResponse)
+	err := c.cc.Invoke(ctx, MultiOrchService_ShutdownPrimary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MultiOrchServiceServer is the server API for MultiOrchService service.
 // All implementations must embed UnimplementedMultiOrchServiceServer
 // for forward compatibility.
@@ -156,6 +196,35 @@ type MultiOrchServiceServer interface {
 	// - Returns when either: (1) no problems remain, or (2) context times out
 	// - If recovery is disabled, this temporarily enables it during this operation
 	TriggerRecoveryNow(context.Context, *TriggerRecoveryNowRequest) (*TriggerRecoveryNowResponse, error)
+	// ShutdownPrimary orchestrates a planned primary switchover.
+	//
+	// Normally called by the primary multipooler during graceful shutdown on the
+	// reception of a SIGTERM signal, but this is not a requirement.
+	//
+	// Sequence:
+	//  1. Validates that the pooler is currently PRIMARY or STOPPING.
+	//  2. Reads the primary's current WAL LSN. The multipooler has already set
+	//     PoolerType_STOPPING on the health stream before calling this RPC,
+	//     which causes the gateway to stop routing new writes — so this LSN is
+	//     a stable target for standby catchup.
+	//  3. Waits for all standbys to replay to that LSN. The primary is still
+	//     running and streaming WAL during this window. If the timeout expires
+	//     the switchover proceeds anyway to avoid hanging indefinitely.
+	//  4. Calls EmergencyDemote to stop the primary. Standbys have caught up
+	//     (or timed out), so there are few or no active writes left to drain.
+	//     Then marks the old primary as DRAINED in topology so that the
+	//     topology never shows two PRIMARY nodes simultaneously and the node
+	//     is excluded from future elections.
+	//  5. Builds the election cohort from shard poolers, excluding STOPPING and
+	//     DRAINED poolers. This prevents the old primary from being re-elected
+	//     and prevents irreparable replicas from becoming candidates.
+	//  6. Elects a new primary via AppointLeader.
+	//  7. Polls shard poolers to confirm the new primary and returns its ID.
+	//
+	// Returns once a new primary has been elected. The caller can then shut down
+	// PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed
+	// with shutdown regardless.
+	ShutdownPrimary(context.Context, *ShutdownPrimaryRequest) (*ShutdownPrimaryResponse, error)
 	mustEmbedUnimplementedMultiOrchServiceServer()
 }
 
@@ -180,6 +249,9 @@ func (UnimplementedMultiOrchServiceServer) GetRecoveryStatus(context.Context, *G
 }
 func (UnimplementedMultiOrchServiceServer) TriggerRecoveryNow(context.Context, *TriggerRecoveryNowRequest) (*TriggerRecoveryNowResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method TriggerRecoveryNow not implemented")
+}
+func (UnimplementedMultiOrchServiceServer) ShutdownPrimary(context.Context, *ShutdownPrimaryRequest) (*ShutdownPrimaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ShutdownPrimary not implemented")
 }
 func (UnimplementedMultiOrchServiceServer) mustEmbedUnimplementedMultiOrchServiceServer() {}
 func (UnimplementedMultiOrchServiceServer) testEmbeddedByValue()                          {}
@@ -292,6 +364,24 @@ func _MultiOrchService_TriggerRecoveryNow_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiOrchService_ShutdownPrimary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ShutdownPrimaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiOrchServiceServer).ShutdownPrimary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiOrchService_ShutdownPrimary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiOrchServiceServer).ShutdownPrimary(ctx, req.(*ShutdownPrimaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MultiOrchService_ServiceDesc is the grpc.ServiceDesc for MultiOrchService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -318,6 +408,10 @@ var MultiOrchService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "TriggerRecoveryNow",
 			Handler:    _MultiOrchService_TriggerRecoveryNow_Handler,
+		},
+		{
+			MethodName: "ShutdownPrimary",
+			Handler:    _MultiOrchService_ShutdownPrimary_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,7 +39,8 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xfb\t\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xda\n" +
+	"\n" +
 	"\x12MultiPoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
@@ -52,7 +53,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"GetBackups\x12).multipoolermanagerdata.GetBackupsRequest\x1a*.multipoolermanagerdata.GetBackupsResponse\x12u\n" +
 	"\x10GetBackupByJobId\x12/.multipoolermanagerdata.GetBackupByJobIdRequest\x1a0.multipoolermanagerdata.GetBackupByJobIdResponse\x12l\n" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12\x93\x01\n" +
-	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12\x88\x01\n" +
+	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12]\n" +
+	"\bShutdown\x12'.multipoolermanagerdata.ShutdownRequest\x1a(.multipoolermanagerdata.ShutdownResponse\x12\x88\x01\n" +
 	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
 
 var file_multipoolermanagerservice_proto_goTypes = []any{
@@ -66,18 +68,20 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.GetBackupByJobIdRequest)(nil),            // 7: multipoolermanagerdata.GetBackupByJobIdRequest
 	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 8: multipoolermanagerdata.ExpireBackupsRequest
 	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 9: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 10: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 11: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 12: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 13: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 14: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 15: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 16: multipoolermanagerdata.RestoreFromBackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 17: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 18: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 19: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 20: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 21: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.ShutdownRequest)(nil),                    // 10: multipoolermanagerdata.ShutdownRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 11: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 12: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 13: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 14: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 15: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 16: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 17: multipoolermanagerdata.RestoreFromBackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 18: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 19: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 20: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 21: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ShutdownResponse)(nil),                   // 22: multipoolermanagerdata.ShutdownResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 23: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultiPoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -90,20 +94,22 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	7,  // 7: multipoolermanager.MultiPoolerManager.GetBackupByJobId:input_type -> multipoolermanagerdata.GetBackupByJobIdRequest
 	8,  // 8: multipoolermanager.MultiPoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
 	9,  // 9: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	10, // 10: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	11, // 11: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	12, // 12: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	13, // 13: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	14, // 14: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	15, // 15: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	16, // 16: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
-	17, // 17: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	18, // 18: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	19, // 19: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	20, // 20: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	21, // 21: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	11, // [11:22] is the sub-list for method output_type
-	0,  // [0:11] is the sub-list for method input_type
+	10, // 10: multipoolermanager.MultiPoolerManager.Shutdown:input_type -> multipoolermanagerdata.ShutdownRequest
+	11, // 11: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	12, // 12: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	13, // 13: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	14, // 14: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	15, // 15: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	16, // 16: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	17, // 17: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
+	18, // 18: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	19, // 19: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	20, // 20: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	21, // 21: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	22, // 22: multipoolermanager.MultiPoolerManager.Shutdown:output_type -> multipoolermanagerdata.ShutdownResponse
+	23, // 23: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	12, // [12:24] is the sub-list for method output_type
+	0,  // [0:12] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -306,6 +306,33 @@ func local_request_MultiPoolerManager_SetPostgresRestartsEnabled_0(ctx context.C
 	return msg, metadata, err
 }
 
+func request_MultiPoolerManager_Shutdown_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ShutdownRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Shutdown(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerManager_Shutdown_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ShutdownRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Shutdown(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultiPoolerManager_ManagerHealthStream_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (MultiPoolerManager_ManagerHealthStreamClient, runtime.ServerMetadata, error) {
 	var metadata runtime.ServerMetadata
 	stream, err := client.ManagerHealthStream(ctx)
@@ -555,6 +582,26 @@ func RegisterMultiPoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Shutdown_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/Shutdown", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/Shutdown"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerManager_Shutdown_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_Shutdown_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
@@ -772,6 +819,23 @@ func RegisterMultiPoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_SetPostgresRestartsEnabled_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_Shutdown_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/Shutdown", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/Shutdown"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerManager_Shutdown_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_Shutdown_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ManagerHealthStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -803,6 +867,7 @@ var (
 	pattern_MultiPoolerManager_GetBackupByJobId_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "GetBackupByJobId"}, ""))
 	pattern_MultiPoolerManager_ExpireBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ExpireBackups"}, ""))
 	pattern_MultiPoolerManager_SetPostgresRestartsEnabled_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "SetPostgresRestartsEnabled"}, ""))
+	pattern_MultiPoolerManager_Shutdown_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "Shutdown"}, ""))
 	pattern_MultiPoolerManager_ManagerHealthStream_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ManagerHealthStream"}, ""))
 )
 
@@ -817,5 +882,6 @@ var (
 	forward_MultiPoolerManager_GetBackupByJobId_0           = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_ExpireBackups_0              = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_SetPostgresRestartsEnabled_0 = runtime.ForwardResponseMessage
+	forward_MultiPoolerManager_Shutdown_0                   = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_ManagerHealthStream_0        = runtime.ForwardResponseStream
 )

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	MultiPoolerManager_GetBackupByJobId_FullMethodName           = "/multipoolermanager.MultiPoolerManager/GetBackupByJobId"
 	MultiPoolerManager_ExpireBackups_FullMethodName              = "/multipoolermanager.MultiPoolerManager/ExpireBackups"
 	MultiPoolerManager_SetPostgresRestartsEnabled_FullMethodName = "/multipoolermanager.MultiPoolerManager/SetPostgresRestartsEnabled"
+	MultiPoolerManager_Shutdown_FullMethodName                   = "/multipoolermanager.MultiPoolerManager/Shutdown"
 	MultiPoolerManager_ManagerHealthStream_FullMethodName        = "/multipoolermanager.MultiPoolerManager/ManagerHealthStream"
 )
 
@@ -79,6 +80,18 @@ type MultiPoolerManagerClient interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// Shutdown initiates a graceful pooler shutdown identical to receiving SIGTERM.
+	//
+	// For PRIMARY poolers: signals PoolerType_STOPPING so multiorch can orchestrate
+	// a controlled failover (EmergencyDemote + AppointLeader) before the process
+	// exits. The pooler waits up to 45 s for multiorch to call EmergencyDemote and
+	// stop postgres; it stops postgres directly on timeout.
+	//
+	// For REPLICA poolers: stops postgres directly and exits.
+	//
+	// The response is delivered before the shutdown sequence starts, so callers
+	// will always receive a response. The process exit happens asynchronously.
+	Shutdown(ctx context.Context, in *multipoolermanagerdata.ShutdownRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ShutdownResponse, error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -204,6 +217,16 @@ func (c *multiPoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Contex
 	return out, nil
 }
 
+func (c *multiPoolerManagerClient) Shutdown(ctx context.Context, in *multipoolermanagerdata.ShutdownRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ShutdownResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.ShutdownResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerManager_Shutdown_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *multiPoolerManagerClient) ManagerHealthStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &MultiPoolerManager_ServiceDesc.Streams[0], MultiPoolerManager_ManagerHealthStream_FullMethodName, cOpts...)
@@ -249,6 +272,18 @@ type MultiPoolerManagerServer interface {
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
 	// controlled failovers.
 	SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error)
+	// Shutdown initiates a graceful pooler shutdown identical to receiving SIGTERM.
+	//
+	// For PRIMARY poolers: signals PoolerType_STOPPING so multiorch can orchestrate
+	// a controlled failover (EmergencyDemote + AppointLeader) before the process
+	// exits. The pooler waits up to 45 s for multiorch to call EmergencyDemote and
+	// stop postgres; it stops postgres directly on timeout.
+	//
+	// For REPLICA poolers: stops postgres directly and exits.
+	//
+	// The response is delivered before the shutdown sequence starts, so callers
+	// will always receive a response. The process exit happens asynchronously.
+	Shutdown(context.Context, *multipoolermanagerdata.ShutdownRequest) (*multipoolermanagerdata.ShutdownResponse, error)
 	// ManagerHealthStream is a bidirectional health stream between orchestrator
 	// and pooler.
 	//
@@ -303,6 +338,9 @@ func (UnimplementedMultiPoolerManagerServer) ExpireBackups(context.Context, *mul
 }
 func (UnimplementedMultiPoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
+}
+func (UnimplementedMultiPoolerManagerServer) Shutdown(context.Context, *multipoolermanagerdata.ShutdownRequest) (*multipoolermanagerdata.ShutdownResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Shutdown not implemented")
 }
 func (UnimplementedMultiPoolerManagerServer) ManagerHealthStream(grpc.BidiStreamingServer[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method ManagerHealthStream not implemented")
@@ -508,6 +546,24 @@ func _MultiPoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiPoolerManager_Shutdown_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.ShutdownRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerManagerServer).Shutdown(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerManager_Shutdown_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerManagerServer).Shutdown(ctx, req.(*multipoolermanagerdata.ShutdownRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MultiPoolerManager_ManagerHealthStream_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(MultiPoolerManagerServer).ManagerHealthStream(&grpc.GenericServerStream[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]{ServerStream: stream})
 }
@@ -561,6 +617,10 @@ var MultiPoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetPostgresRestartsEnabled",
 			Handler:    _MultiPoolerManager_SetPostgresRestartsEnabled_Handler,
+		},
+		{
+			MethodName: "Shutdown",
+			Handler:    _MultiPoolerManager_Shutdown_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -3440,6 +3440,93 @@ func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
 	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{45}
 }
 
+// ShutdownRequest requests a graceful pooler shutdown identical to SIGTERM.
+// The pooler signals STOPPING (if PRIMARY), waits for multiorch to orchestrate
+// failover, then exits the process.
+type ShutdownRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Human-readable reason for the shutdown (e.g. "operator request", "rolling restart").
+	// Used for logging and audit trails only.
+	Reason        string `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownRequest) Reset() {
+	*x = ShutdownRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownRequest) ProtoMessage() {}
+
+func (x *ShutdownRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownRequest.ProtoReflect.Descriptor instead.
+func (*ShutdownRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ShutdownRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+// ShutdownResponse confirms that the graceful shutdown sequence has been initiated.
+// The pooler process will exit shortly after this response is delivered.
+type ShutdownResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShutdownResponse) Reset() {
+	*x = ShutdownResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShutdownResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShutdownResponse) ProtoMessage() {}
+
+func (x *ShutdownResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShutdownResponse.ProtoReflect.Descriptor instead.
+func (*ShutdownResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{47}
+}
+
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerdata_proto_rawDesc = "" +
@@ -3637,7 +3724,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x10rewind_performed\x18\x03 \x01(\bR\x0frewindPerformed\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
-	"\"SetPostgresRestartsEnabledResponse*\xa4\x01\n" +
+	"\"SetPostgresRestartsEnabledResponse\")\n" +
+	"\x0fShutdownRequest\x12\x16\n" +
+	"\x06reason\x18\x01 \x01(\tR\x06reason\"\x12\n" +
+	"\x10ShutdownResponse*\xa4\x01\n" +
 	"\x0ePostgresStatus\x12\x1b\n" +
 	"\x17POSTGRES_STATUS_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18POSTGRES_STATUS_STARTING\x10\x01\x12\x1b\n" +
@@ -3687,7 +3777,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                             // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                             // 1: multipoolermanagerdata.PostgresAction
@@ -3743,71 +3833,73 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*RewindToSourceResponse)(nil),                  // 51: multipoolermanagerdata.RewindToSourceResponse
 	(*SetPostgresRestartsEnabledRequest)(nil),       // 52: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
 	(*SetPostgresRestartsEnabledResponse)(nil),      // 53: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                                 // 54: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                 // 55: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),         // 56: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),       // 57: google.protobuf.Timestamp
-	(*clustermetadata.MultiPooler)(nil), // 58: clustermetadata.MultiPooler
-	(*clustermetadata.ID)(nil),          // 59: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),     // 60: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil), // 61: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),    // 62: clustermetadata.ConsensusStatus
+	(*ShutdownRequest)(nil),                         // 54: multipoolermanagerdata.ShutdownRequest
+	(*ShutdownResponse)(nil),                        // 55: multipoolermanagerdata.ShutdownResponse
+	nil,                                             // 56: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                             // 57: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),                     // 58: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                   // 59: google.protobuf.Timestamp
+	(*clustermetadata.MultiPooler)(nil),             // 60: clustermetadata.MultiPooler
+	(*clustermetadata.ID)(nil),                      // 61: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),                 // 62: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil),      // 63: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),         // 64: clustermetadata.ConsensusStatus
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	56, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	58, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	57, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	56, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	56, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	56, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
-	58, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
+	59, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	58, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	58, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	58, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	60, // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest.primary:type_name -> clustermetadata.MultiPooler
 	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	59, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	59, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	61, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	61, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	18, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	60, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	62, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	19, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	56, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	59, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
+	58, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	61, // 20: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
 	20, // 21: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	61, // 22: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	62, // 23: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	63, // 22: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	64, // 23: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	24, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	25, // 25: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	56, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	56, // 27: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	56, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	56, // 29: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	58, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	58, // 27: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	58, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	58, // 29: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	28, // 31: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	22, // 32: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	56, // 33: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	58, // 33: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 34: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	56, // 35: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
-	58, // 36: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
+	58, // 35: multipoolermanagerdata.EmergencyDemoteRequest.drain_timeout:type_name -> google.protobuf.Duration
+	60, // 36: multipoolermanagerdata.DemoteStalePrimaryRequest.source:type_name -> clustermetadata.MultiPooler
 	35, // 37: multipoolermanagerdata.PromoteRequest.sync_replication_config:type_name -> multipoolermanagerdata.ConfigureSynchronousReplicationRequest
-	59, // 38: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
-	59, // 39: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
-	59, // 40: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
+	61, // 38: multipoolermanagerdata.PromoteRequest.coordinator_id:type_name -> clustermetadata.ID
+	61, // 39: multipoolermanagerdata.PromoteRequest.cohort_members:type_name -> clustermetadata.ID
+	61, // 40: multipoolermanagerdata.PromoteRequest.accepted_members:type_name -> clustermetadata.ID
 	6,  // 41: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 42: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	59, // 43: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
+	61, // 43: multipoolermanagerdata.ConfigureSynchronousReplicationRequest.standby_ids:type_name -> clustermetadata.ID
 	5,  // 44: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.operation:type_name -> multipoolermanagerdata.StandbyUpdateOperation
-	59, // 45: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
-	59, // 46: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
-	54, // 47: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	61, // 45: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.standby_ids:type_name -> clustermetadata.ID
+	61, // 46: multipoolermanagerdata.UpdateSynchronousStandbyListRequest.coordinator_id:type_name -> clustermetadata.ID
+	56, // 47: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	49, // 48: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	49, // 49: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	55, // 50: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	57, // 50: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
 	7,  // 51: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	60, // 52: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	58, // 53: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	62, // 52: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	60, // 53: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
 	54, // [54:54] is the sub-list for method output_type
 	54, // [54:54] is the sub-list for method input_type
 	54, // [54:54] is the sub-list for extension type_name
@@ -3834,7 +3926,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -1947,9 +1947,15 @@ type EmergencyDemoteRequest struct {
 	// Drain timeout - how long to wait for in-flight queries (default: 5s)
 	DrainTimeout *durationpb.Duration `protobuf:"bytes,2,opt,name=drain_timeout,json=drainTimeout,proto3" json:"drain_timeout,omitempty"`
 	// Force the operation even if term validation fails
-	Force         bool `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Force bool `protobuf:"varint,3,opt,name=force,proto3" json:"force,omitempty"`
+	// If true, restart postgres as standby after demotion so the node stays
+	// in the cluster as a replication target. If false, postgres is left
+	// running as primary in NOT_SERVING state — the caller is responsible for
+	// stopping it (used by ShutdownPrimary, where the multipooler is exiting
+	// and will stop postgres directly).
+	RestartServerAsStandby bool `protobuf:"varint,4,opt,name=restart_server_as_standby,json=restartServerAsStandby,proto3" json:"restart_server_as_standby,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *EmergencyDemoteRequest) Reset() {
@@ -2003,6 +2009,13 @@ func (x *EmergencyDemoteRequest) GetForce() bool {
 	return false
 }
 
+func (x *EmergencyDemoteRequest) GetRestartServerAsStandby() bool {
+	if x != nil {
+		return x.RestartServerAsStandby
+	}
+	return false
+}
+
 type EmergencyDemoteResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Whether the pooler was already demoted (idempotent check)
@@ -2011,8 +2024,12 @@ type EmergencyDemoteResponse struct {
 	LsnPosition string `protobuf:"bytes,3,opt,name=lsn_position,json=lsnPosition,proto3" json:"lsn_position,omitempty"`
 	// Number of connections that were terminated
 	ConnectionsTerminated int32 `protobuf:"varint,4,opt,name=connections_terminated,json=connectionsTerminated,proto3" json:"connections_terminated,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Whether postgres was restarted as a standby. Mirrors the request's
+	// restart_server flag — false means postgres is left running as primary
+	// in NOT_SERVING state and the caller must stop it.
+	ServerRestartedAsStandby bool `protobuf:"varint,5,opt,name=server_restarted_as_standby,json=serverRestartedAsStandby,proto3" json:"server_restarted_as_standby,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *EmergencyDemoteResponse) Reset() {
@@ -2064,6 +2081,13 @@ func (x *EmergencyDemoteResponse) GetConnectionsTerminated() int32 {
 		return x.ConnectionsTerminated
 	}
 	return 0
+}
+
+func (x *EmergencyDemoteResponse) GetServerRestartedAsStandby() bool {
+	if x != nil {
+		return x.ServerRestartedAsStandby
+	}
+	return false
 }
 
 // DemoteStalePrimary demotes a stale primary that came back online after failover.
@@ -3621,15 +3645,17 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x15ManagerHealthSnapshot\x12>\n" +
 	"\x06status\x18\x01 \x01(\v2&.multipoolermanagerdata.StatusResponseR\x06status\x123\n" +
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x12A\n" +
-	"\atrigger\x18\x03 \x01(\x0e2'.multipoolermanagerdata.SnapshotTriggerR\atrigger\"\x95\x01\n" +
+	"\atrigger\x18\x03 \x01(\x0e2'.multipoolermanagerdata.SnapshotTriggerR\atrigger\"\xd0\x01\n" +
 	"\x16EmergencyDemoteRequest\x12%\n" +
 	"\x0econsensus_term\x18\x01 \x01(\x03R\rconsensusTerm\x12>\n" +
 	"\rdrain_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\fdrainTimeout\x12\x14\n" +
-	"\x05force\x18\x03 \x01(\bR\x05force\"\xa3\x01\n" +
+	"\x05force\x18\x03 \x01(\bR\x05force\x129\n" +
+	"\x19restart_server_as_standby\x18\x04 \x01(\bR\x16restartServerAsStandby\"\xe2\x01\n" +
 	"\x17EmergencyDemoteResponse\x12.\n" +
 	"\x13was_already_demoted\x18\x01 \x01(\bR\x11wasAlreadyDemoted\x12!\n" +
 	"\flsn_position\x18\x03 \x01(\tR\vlsnPosition\x125\n" +
-	"\x16connections_terminated\x18\x04 \x01(\x05R\x15connectionsTerminated\"\x8e\x01\n" +
+	"\x16connections_terminated\x18\x04 \x01(\x05R\x15connectionsTerminated\x12=\n" +
+	"\x1bserver_restarted_as_standby\x18\x05 \x01(\bR\x18serverRestartedAsStandby\"\x8e\x01\n" +
 	"\x19DemoteStalePrimaryRequest\x124\n" +
 	"\x06source\x18\x01 \x01(\v2\x1c.clustermetadata.MultiPoolerR\x06source\x12%\n" +
 	"\x0econsensus_term\x18\x02 \x01(\x03R\rconsensusTerm\x12\x14\n" +

--- a/go/provisioner/local/config.go
+++ b/go/provisioner/local/config.go
@@ -80,10 +80,11 @@ type LocalProvisionerConfig struct {
 
 // EtcdConfig holds etcd service configuration
 type EtcdConfig struct {
-	Version  string `yaml:"version"`
-	DataDir  string `yaml:"data-dir"`
-	Port     int    `yaml:"port"`                // Client port
-	PeerPort int    `yaml:"peer-port,omitempty"` // Optional peer port, defaults to Port+1
+	Version     string `yaml:"version"`
+	DataDir     string `yaml:"data-dir"`
+	Port        int    `yaml:"port"`                   // Client port
+	PeerPort    int    `yaml:"peer-port,omitempty"`    // Optional peer port, defaults to Port+1
+	MetricsPort int    `yaml:"metrics-port,omitempty"` // Optional metrics port, defaults to Port+2
 }
 
 // MultigatewayConfig holds multigateway service configuration

--- a/go/services/multigateway/buffer/shard_buffer.go
+++ b/go/services/multigateway/buffer/shard_buffer.go
@@ -190,6 +190,14 @@ func (sb *shardBuffer) waitOnEntry(ctx context.Context, e *entry) (RetryDoneFunc
 func (sb *shardBuffer) stopBuffering(reason string, gen uint64) {
 	sb.mu.Lock()
 	if sb.state != stateBuffering {
+		// Phantom stop: new primary detected while buffer was idle (gen=0 means
+		// called from the public StopBuffering, not from the max-duration timer).
+		// Record lastEnd so the MinTimeBetweenFailovers guard blocks unnecessary
+		// buffer cycles from late in-flight requests after the fast re-election.
+		if gen == 0 && sb.state == stateIdle {
+			sb.lastEnd = sb.buf.now()
+			sb.logger.Debug("phantom stop: primary elected while buffer was idle")
+		}
 		sb.mu.Unlock()
 		return
 	}

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -1577,12 +1577,14 @@ func TestAppointInitialLeader(t *testing.T) {
 		// Fresh standbys at term 0 (brand new nodes, just restored from backup)
 		mp1 := createMockNode(fakeClient, "mp1", 0, "0/2000000", true, nil)
 		mp1.Status.IsInitialized = true
+		mp1.Status.PostgresRunning = true
 		mp1.Status.PostgresReady = true
 		mp1.Status.PostgresRunning = true
 		mp1.ConsensusStatus = &clustermetadatapb.ConsensusStatus{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 0}}
 
 		mp2 := createMockNode(fakeClient, "mp2", 0, "0/1000000", true, nil)
 		mp2.Status.IsInitialized = true
+		mp2.Status.PostgresRunning = true
 		mp2.Status.PostgresReady = true
 		mp2.Status.PostgresRunning = true
 		mp2.ConsensusStatus = &clustermetadatapb.ConsensusStatus{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 0}}

--- a/go/services/multiorch/recovery/actions/shutdown_primary.go
+++ b/go/services/multiorch/recovery/actions/shutdown_primary.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+)
+
+// Compile-time assertion that ShutdownPrimaryAction implements types.RecoveryAction.
+var _ types.RecoveryAction = (*ShutdownPrimaryAction)(nil)
+
+// ShutdownPrimaryCallback is called by ShutdownPrimaryAction to execute the switchover.
+// It is implemented by Engine.ShutdownPrimary and injected via the factory to avoid a
+// circular import between recovery/actions and recovery.
+type ShutdownPrimaryCallback func(
+	ctx context.Context,
+	primaryID *clustermetadatapb.ID,
+	database, tableGroup, shard string,
+) error
+
+// ShutdownPrimaryAction orchestrates a graceful leader switchover when the leader
+// multipooler signals PoolerType_STOPPING (e.g. on SIGTERM). It delegates to the
+// Engine.ShutdownPrimary method via an injected callback.
+type ShutdownPrimaryAction struct {
+	fn     ShutdownPrimaryCallback
+	logger *slog.Logger
+}
+
+// NewShutdownPrimaryAction creates a ShutdownPrimaryAction backed by the given callback.
+// fn may be nil when the factory is constructed; Execute will return an error if called
+// before SetShutdownPrimary wires it up.
+func NewShutdownPrimaryAction(fn ShutdownPrimaryCallback, logger *slog.Logger) *ShutdownPrimaryAction {
+	return &ShutdownPrimaryAction{fn: fn, logger: logger}
+}
+
+func (a *ShutdownPrimaryAction) Execute(ctx context.Context, problem types.Problem) error {
+	if a.fn == nil {
+		return mterrors.New(0, "ShutdownPrimaryAction: shutdown callback not wired up")
+	}
+	if problem.PoolerID == nil {
+		return mterrors.New(0, "ShutdownPrimaryAction: problem.PoolerID is nil")
+	}
+	a.logger.InfoContext(ctx, "ShutdownPrimaryAction: graceful leader switchover triggered",
+		"leader", problem.PoolerID.Name,
+		"shard", problem.ShardKey.String())
+
+	return a.fn(ctx, problem.PoolerID, problem.ShardKey.Database, problem.ShardKey.TableGroup, problem.ShardKey.Shard)
+}
+
+func (a *ShutdownPrimaryAction) RequiresHealthyLeader() bool { return false }
+
+func (a *ShutdownPrimaryAction) Metadata() types.RecoveryMetadata {
+	return types.RecoveryMetadata{
+		Name:      "ShutdownPrimary",
+		Timeout:   90 * time.Second,
+		Retryable: false,
+	}
+}
+
+func (a *ShutdownPrimaryAction) Priority() types.Priority {
+	return types.PriorityEmergency
+}
+
+func (a *ShutdownPrimaryAction) GracePeriod() *types.GracePeriodConfig {
+	return nil
+}

--- a/go/services/multiorch/recovery/analysis/action_factory.go
+++ b/go/services/multiorch/recovery/analysis/action_factory.go
@@ -26,14 +26,20 @@ import (
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
+// ShutdownPrimaryFunc is the callback type used by ShutdownPrimaryAction to trigger
+// a graceful leader switchover. It is an alias for actions.ShutdownPrimaryCallback so
+// callers in the recovery package can reference it without importing recovery/actions directly.
+type ShutdownPrimaryFunc = actions.ShutdownPrimaryCallback
+
 // RecoveryActionFactory creates recovery actions with all necessary dependencies.
 type RecoveryActionFactory struct {
-	config      *config.Config
-	poolerStore *store.PoolerStore
-	rpcClient   rpcclient.MultiPoolerClient
-	topoStore   topoclient.Store
-	coordinator *consensus.Coordinator
-	logger      *slog.Logger
+	config          *config.Config
+	poolerStore     *store.PoolerStore
+	rpcClient       rpcclient.MultiPoolerClient
+	topoStore       topoclient.Store
+	coordinator     *consensus.Coordinator
+	logger          *slog.Logger
+	shutdownPrimary ShutdownPrimaryFunc
 }
 
 // NewRecoveryActionFactory creates a factory for recovery actions.
@@ -73,9 +79,21 @@ func (f *RecoveryActionFactory) NewFixReplicationAction() types.RecoveryAction {
 	return actions.NewFixReplicationAction(f.config, f.rpcClient, f.poolerStore, f.topoStore, f.logger)
 }
 
-// NewDemoteStaleLeaderAction creates an action to demote a stale primary.
+// NewDemoteStaleLeaderAction creates an action to demote a stale leader.
 func (f *RecoveryActionFactory) NewDemoteStaleLeaderAction() types.RecoveryAction {
 	return actions.NewDemoteStaleLeaderAction(f.config, f.rpcClient, f.poolerStore, f.topoStore, f.logger)
+}
+
+// NewShutdownPrimaryAction creates an action that triggers a graceful leader switchover.
+func (f *RecoveryActionFactory) NewShutdownPrimaryAction() types.RecoveryAction {
+	return actions.NewShutdownPrimaryAction(f.shutdownPrimary, f.logger)
+}
+
+// SetShutdownPrimary sets the callback used by ShutdownPrimaryAction. Called after
+// the factory is constructed to break the circular dependency between the factory
+// and the Engine (which implements ShutdownPrimary).
+func (f *RecoveryActionFactory) SetShutdownPrimary(fn ShutdownPrimaryFunc) {
+	f.shutdownPrimary = fn
 }
 
 // Logger returns the factory's logger for use by analyzers.

--- a/go/services/multiorch/recovery/analysis/analyzer.go
+++ b/go/services/multiorch/recovery/analysis/analyzer.go
@@ -45,6 +45,7 @@ func DefaultAnalyzers(factory *RecoveryActionFactory) []Analyzer {
 		return []Analyzer{
 			&ShardNeedsInitializationAnalyzer{factory: factory},
 			&StaleLeaderAnalyzer{factory: factory},
+			&LeaderIsStoppingAnalyzer{factory: factory},
 			&LeaderIsDeadAnalyzer{factory: factory},
 			&ReplicaNotReplicatingAnalyzer{factory: factory},
 			&ReplicaNotInStandbyListAnalyzer{factory: factory},

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -475,6 +475,13 @@ func (g *AnalysisGenerator) computeShardLevelFields(sa *ShardAnalysis, poolers m
 		if topologyPrimary.GetStatus().GetPostgresStatus() == multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PROMOTING {
 			sa.PromotingPrimaryID = topologyPrimary.MultiPooler.Id
 		}
+
+		// Detect graceful primary shutdown: pooler reports STOPPING while it is the
+		// highest-term primary. ShutdownPrimary will handle the election, so
+		// LeaderIsDeadAnalyzer should not trigger a second concurrent failover.
+		if topologyPrimary.GetStatus().GetPoolerType() == clustermetadatapb.PoolerType_STOPPING {
+			sa.LeaderIsStopping = true
+		}
 	}
 
 	// HasInitializedReplica: any non-primary, reachable, initialized pooler.

--- a/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer.go
@@ -57,6 +57,15 @@ func (a *LeaderIsDeadAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, erro
 		return nil, nil
 	}
 
+	// Leader is gracefully stopping and is reachable. LeaderIsStoppingAnalyzer
+	// handles the election of a new leader and will suppress LeaderIsDead until
+	// the old leader is fully stopped. If the leader is not reachable, we will
+	// fall through to the code below and treat it as unreachable, which might
+	// mark it as dead if enough time passes.
+	if sa.LeaderIsStopping && sa.LeaderReachable {
+		return nil, nil
+	}
+
 	// No initialized replica to confirm the leader is dead — skip to avoid false positives
 	// when the shard has no postgres standby that has joined the cluster yet.
 	if !sa.HasInitializedReplica {

--- a/go/services/multiorch/recovery/analysis/leader_is_stopping_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/leader_is_stopping_analyzer.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
+)
+
+// LeaderIsStoppingAnalyzer detects when the highest-term leader has signalled
+// PoolerType_STOPPING, indicating a graceful shutdown is in progress. It triggers
+// ShutdownPrimaryAction to orchestrate the controlled failover (EmergencyDemote +
+// AppointLeader) instead of letting LeaderIsDeadAnalyzer run an uncontrolled election.
+type LeaderIsStoppingAnalyzer struct {
+	factory *RecoveryActionFactory
+}
+
+func (a *LeaderIsStoppingAnalyzer) Name() types.CheckName {
+	return "LeaderIsStopping"
+}
+
+func (a *LeaderIsStoppingAnalyzer) ProblemCode() types.ProblemCode {
+	return types.ProblemLeaderIsStopping
+}
+
+func (a *LeaderIsStoppingAnalyzer) RecoveryAction() types.RecoveryAction {
+	return a.factory.NewShutdownPrimaryAction()
+}
+
+func (a *LeaderIsStoppingAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, error) {
+	if a.factory == nil {
+		return nil, errors.New("recovery action factory not initialized")
+	}
+
+	if !sa.LeaderIsStopping {
+		return nil, nil
+	}
+
+	if sa.HighestTermDiscoveredLeaderID == nil {
+		return nil, nil
+	}
+
+	// Only trigger if the pooler is reachable — we need to be able to call
+	// EmergencyDemote on it. If unreachable, fall through to LeaderIsDeadAnalyzer.
+	if !sa.LeaderPoolerReachable {
+		return nil, nil
+	}
+
+	return []types.Problem{{
+		Code:           types.ProblemLeaderIsStopping,
+		CheckName:      "LeaderIsStopping",
+		PoolerID:       sa.HighestTermDiscoveredLeaderID,
+		ShardKey:       sa.ShardKey,
+		Description:    fmt.Sprintf("Leader for shard %s is gracefully stopping", sa.ShardKey),
+		Priority:       types.PriorityEmergency,
+		Scope:          types.ScopeShard,
+		DetectedAt:     time.Now(),
+		RecoveryAction: a.factory.NewShutdownPrimaryAction(),
+	}}, nil
+}

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -106,6 +106,12 @@ type ShardAnalysis struct {
 	// Used by LeaderIsDeadAnalyzer to suppress spurious failover detection during the
 	// brief window (~5–10s) when the newly promoted node's postgres is not yet ready.
 	PromotingPrimaryID *clustermetadatapb.ID
+
+	// LeaderIsStopping is true when the topology leader has signalled
+	// PoolerType_STOPPING, indicating a graceful shutdown is in progress. When
+	// true, LeaderIsDeadAnalyzer suppresses its failover because the
+	// ShutdownPrimary flow handles the election.
+	LeaderIsStopping bool
 }
 
 // IsInStandbyList reports whether the given pooler ID appears in the leader's

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -217,6 +217,7 @@ type Engine struct {
 	// Action factory for creating recovery actions
 	actionFactory *analysis.RecoveryActionFactory
 
+	// Consensus coordinator for leader election
 	coordinator *consensus.Coordinator
 
 	// recoveryGracePeriodTracker tracker for grace periods before recovery actions
@@ -296,6 +297,10 @@ func NewEngine(
 		coordinator,
 		logger,
 	)
+	// Wire the ShutdownPrimary callback after the factory is constructed.
+	// This breaks the circular dependency: factory is in a sub-package of recovery
+	// and cannot import Engine directly.
+	engine.actionFactory.SetShutdownPrimary(engine.shutdownPrimaryCallback)
 
 	// Create deadline tracker for grace periods
 	engine.recoveryGracePeriodTracker = NewRecoveryGracePeriodTracker(engine.shutdownCtx, config,
@@ -552,7 +557,7 @@ func (re *Engine) TriggerRecoveryNow(ctx context.Context, maxCycles uint32) ([]D
 	// recovery cycle. Without the wait, the cycle would run against stale store
 	// data because Poll() is asynchronous — snapshots arrive after the RPC returns.
 	re.logger.DebugContext(ctx, "TriggerRecoveryNow: polling all poolers and waiting for snapshots")
-	re.pollAndWaitForNewSnapshots(ctx)
+	re.pollAndWaitForNewSnapshots(ctx, nil)
 
 	// Expire all grace period deadlines so the next recovery cycle acts on
 	// detected problems immediately instead of waiting. This matches the
@@ -624,14 +629,36 @@ func (re *Engine) pollAllPoolers() {
 	})
 }
 
-// pollAndWaitForNewSnapshots sends poll requests to all poolers and blocks
-// until each pooler that had an active stream delivers at least one new
-// snapshot, or until pollResponseWait elapses or the context is cancelled.
+// pollShardPoolers sends a poll request on the active health stream for every
+// pooler in the given shard. Fire-and-forget; snapshots arrive asynchronously.
+func (re *Engine) pollShardPoolers(shardKey *clustermetadatapb.ShardKey) {
+	re.poolerStore.Range(func(poolerID string, p *multiorchdatapb.PoolerHealthState) bool {
+		// This should never happen since we only track poolers with metadata,
+		// but guard against nil just in case. If we encounter a nil entry, we
+		// return true to keep iterating rather than stopping the loop.
+		if p == nil || p.MultiPooler == nil {
+			return true
+		}
+		if p.MultiPooler.Database == shardKey.Database &&
+			p.MultiPooler.TableGroup == shardKey.TableGroup &&
+			p.MultiPooler.Shard == shardKey.Shard {
+			_ = re.healthStream.Poll(p.MultiPooler.Id)
+		}
+		return true
+	})
+}
+
+// pollAndWaitForNewSnapshots sends poll requests and blocks until each pooler
+// that had an active stream delivers at least one new snapshot, or until
+// pollResponseWait elapses or the context is cancelled.
+//
+// If shardKey is non-nil, only poolers in that shard are polled and waited on.
+// If nil, all poolers are polled (used by TriggerRecoveryNow).
 //
 // This bridges the gap between the asynchronous Poll() call and the recovery
 // cycle that follows: without the wait, the cycle would run against store data
 // that predates the poll.
-func (re *Engine) pollAndWaitForNewSnapshots(ctx context.Context) {
+func (re *Engine) pollAndWaitForNewSnapshots(ctx context.Context, shardKey *clustermetadatapb.ShardKey) {
 	type poolerBaseline struct {
 		id       string
 		baseline int64
@@ -640,13 +667,24 @@ func (re *Engine) pollAndWaitForNewSnapshots(ctx context.Context) {
 	// Capture snapshot counters for poolers with active streams before polling.
 	var baselines []poolerBaseline
 	re.poolerStore.Range(func(poolerID string, ph *multiorchdatapb.PoolerHealthState) bool {
-		if ph != nil && ph.StreamConnected {
-			baselines = append(baselines, poolerBaseline{poolerID, ph.StreamSnapshotsReceived})
+		if ph == nil || !ph.StreamConnected {
+			return true
 		}
+		if shardKey != nil && (ph.MultiPooler == nil ||
+			ph.MultiPooler.Database != shardKey.Database ||
+			ph.MultiPooler.TableGroup != shardKey.TableGroup ||
+			ph.MultiPooler.Shard != shardKey.Shard) {
+			return true
+		}
+		baselines = append(baselines, poolerBaseline{poolerID, ph.StreamSnapshotsReceived})
 		return true
 	})
 
-	re.pollAllPoolers()
+	if shardKey != nil {
+		re.pollShardPoolers(shardKey)
+	} else {
+		re.pollAllPoolers()
+	}
 
 	if len(baselines) == 0 {
 		return

--- a/go/services/multiorch/recovery/shutdown_primary.go
+++ b/go/services/multiorch/recovery/shutdown_primary.go
@@ -1,0 +1,377 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/multigres/multigres/go/common/eventlog"
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/topoclient"
+	commontypes "github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	multiorchpb "github.com/multigres/multigres/go/pb/multiorch"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// shutdownPrimaryCallback wraps ShutdownPrimary with the signature expected by
+// analysis.ShutdownPrimaryFunc so it can be injected into the action factory without
+// exposing the full proto request type to the analysis sub-package.
+func (re *Engine) shutdownPrimaryCallback(
+	ctx context.Context,
+	primaryID *clustermetadatapb.ID,
+	database, tableGroup, shard string,
+) error {
+	_, err := re.ShutdownPrimary(ctx, &multiorchpb.ShutdownPrimaryRequest{
+		Database:              database,
+		TableGroup:            tableGroup,
+		Shard:                 shard,
+		PrimaryId:             primaryID,
+		DrainTimeout:          durationpb.New(10 * time.Second),
+		StandbyCatchupTimeout: durationpb.New(30 * time.Second),
+		Reason:                "SIGTERM",
+	})
+	return err
+}
+
+// isPrimaryCandidate returns true if the pooler type is currently reported to
+// be in PRIMARY or REPLICA state. Both types are valid candidates for promotion
+// to PRIMARY during the ShutdownPrimary flow, which excludes the old primary
+// from consideration (since the pooler type is STOPPING).
+//
+// We deliberately exclude UNKNOWN (or any other unknown types that we don't know
+// are valid) to be conservative in the face of missing or stale health data. If
+// a pooler has no health status, we don't want to risk electing it as the new
+// primary only to discover it's unhealthy when we try to promote it.
+func (re *Engine) isPrimaryCandidate(pooler *multiorchdatapb.PoolerHealthState) bool {
+	if pooler.MultiPooler == nil {
+		return false
+	}
+
+	switch pooler.GetStatus().GetPoolerType() {
+	case clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerType_REPLICA:
+		return true
+	case clustermetadatapb.PoolerType_STOPPING, clustermetadatapb.PoolerType_DRAINED:
+		return false
+	default:
+		re.logger.Warn("isPrimaryCandidate: unknown pooler type, skipping",
+			"pooler_id", topoclient.MultiPoolerIDString(pooler.MultiPooler.Id),
+			"pooler_type", pooler.GetStatus().GetPoolerType())
+		return false
+	}
+}
+
+// ShutdownPrimary orchestrates a graceful primary switchover for the given shard.
+//
+// Triggered when a primary multipooler signals PoolerType_STOPPING on the health
+// stream (e.g. on SIGTERM). The pooler has already stopped accepting writes by
+// the time this runs; EmergencyDemote drains remaining connections and stops
+// PostgreSQL. After stopping the primary, it is marked DRAINED in topology so
+// getpoolers never shows two PRIMARY nodes simultaneously and the node is
+// excluded from future elections.
+//
+// See the ShutdownPrimary RPC in multiorchservice.proto for the full sequence.
+func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.ShutdownPrimaryRequest) (_ *multiorchpb.ShutdownPrimaryResponse, retErr error) {
+	shardKey := &clustermetadatapb.ShardKey{
+		Database:   req.Database,
+		TableGroup: req.TableGroup,
+		Shard:      req.Shard,
+	}
+	primaryIDStr := topoclient.MultiPoolerIDString(req.PrimaryId)
+	start := time.Now()
+
+	re.logger.InfoContext(ctx, "ShutdownPrimary: starting graceful switchover",
+		"shard_key", commontypes.FormatShardKey(shardKey),
+		"primary", primaryIDStr,
+		"drain_timeout", req.DrainTimeout.AsDuration(),
+		"standby_catchup_timeout", req.StandbyCatchupTimeout.AsDuration(),
+		"reason", req.Reason)
+
+	// Step 1: Validate that the given pooler is currently PRIMARY or STOPPING.
+	primary, err := re.shutdownValidatePrimary(shardKey, req.PrimaryId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Telemetry: record duration and emit demotion events.
+	eventlog.Emit(ctx, re.logger, eventlog.Started, eventlog.PrimaryDemotion{
+		NodeName: primaryIDStr,
+		Reason:   "shutdown",
+	})
+	defer func() {
+		duration := time.Since(start)
+		status := RecoveryActionStatusSuccess
+		if retErr != nil {
+			status = RecoveryActionStatusFailure
+			eventlog.Emit(ctx, re.logger, eventlog.Failed, eventlog.PrimaryDemotion{
+				NodeName: primaryIDStr,
+				Reason:   "shutdown",
+			}, "error", retErr)
+		} else {
+			eventlog.Emit(ctx, re.logger, eventlog.Success, eventlog.PrimaryDemotion{
+				NodeName: primaryIDStr,
+				Reason:   "shutdown",
+			})
+		}
+		re.metrics.recoveryActionDuration.Record(ctx,
+			float64(duration.Milliseconds()),
+			"ShutdownPrimary", "ShutdownPrimary",
+			status,
+			shardKey.Database, shardKey.Shard)
+	}()
+
+	// Step 2: Read the primary's current WAL LSN while it is still running.
+	// The gateway has already stopped routing new writes (STOPPING signal), so
+	// this LSN is a safe target for standby catchup. If the Status call fails
+	// we skip the standby wait and proceed directly to EmergencyDemote.
+	currentLSN := re.shutdownGetPrimaryLSN(ctx, primary.MultiPooler, primaryIDStr)
+
+	// Step 3: Wait for standbys to replay up to the primary's current LSN.
+	// The primary is still up and streaming WAL during this window, so standbys
+	// should catch up quickly. AppointLeader picks the most-advanced node if
+	// any standby times out.
+	if currentLSN != "" {
+		re.shutdownWaitForStandbys(ctx, shardKey, primaryIDStr, currentLSN, req.StandbyCatchupTimeout)
+	}
+
+	// Step 4: Stop the primary. Standbys have caught up (or timed out), so
+	// EmergencyDemote is fast: few or no active writes to drain.
+	re.logger.InfoContext(ctx, "ShutdownPrimary: stopping primary via EmergencyDemote",
+		"primary", primaryIDStr)
+	demoteResp, err := re.rpcClient.EmergencyDemote(ctx, primary.MultiPooler,
+		&multipoolermanagerdatapb.EmergencyDemoteRequest{
+			// force=true bypasses term validation: we are initiating this demotion
+			// deliberately, not responding to a detected failure.
+			Force:        true,
+			DrainTimeout: req.DrainTimeout,
+		})
+	if err != nil {
+		return nil, mterrors.Wrap(err, "EmergencyDemote failed")
+	}
+	re.logger.InfoContext(ctx, "ShutdownPrimary: primary stopped",
+		"primary", primaryIDStr,
+		"final_lsn", demoteResp.LsnPosition,
+		"connections_terminated", demoteResp.ConnectionsTerminated)
+
+	// Step 4b: Mark the old primary as DRAINED in topology so that getpoolers
+	// does not show two PRIMARYs and the node is excluded from future elections.
+	// The pooler sets STOPPING only on its in-memory health stream; it exits
+	// before its monitor loop can rewrite the etcd record.
+	if _, err := re.ts.UpdateMultiPoolerFields(ctx, req.PrimaryId, func(mp *clustermetadatapb.MultiPooler) error {
+		mp.Type = clustermetadatapb.PoolerType_DRAINED
+		return nil
+	}); err != nil {
+		re.logger.WarnContext(ctx, "ShutdownPrimary: failed to mark old primary as DRAINED in topology (non-fatal)",
+			"primary", primaryIDStr, "error", err)
+	}
+
+	// Step 5: Build the election cohort, excluding STOPPING and DRAINED poolers.
+	cohort := re.poolerStore.FindPoolersInShard(shardKey)
+	filteredCohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohort))
+	for _, p := range cohort {
+		if re.isPrimaryCandidate(p) {
+			filteredCohort = append(filteredCohort, p)
+		}
+	}
+	// Step 6: Elect a new primary from the cohort.
+	re.logger.InfoContext(ctx, "ShutdownPrimary: electing new primary",
+		"shard_key", commontypes.FormatShardKey(shardKey),
+		"cohort_size", len(filteredCohort))
+	if err := re.coordinator.AppointLeader(ctx, shardKey.Shard, filteredCohort, shardKey.Database, "ShutdownPrimary"); err != nil {
+		return nil, mterrors.Wrap(err, "AppointLeader failed")
+	}
+
+	// Step 7: Find the newly elected primary and return its ID.
+	newPrimary, err := re.shutdownFindNewPrimary(ctx, shardKey, primaryIDStr)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to find new primary after election")
+	}
+
+	newPrimaryIDStr := topoclient.MultiPoolerIDString(newPrimary.MultiPooler.Id)
+	re.logger.InfoContext(ctx, "ShutdownPrimary: switchover complete",
+		"old_primary", primaryIDStr,
+		"new_primary", newPrimaryIDStr)
+
+	return &multiorchpb.ShutdownPrimaryResponse{
+		NewPrimaryId: newPrimary.MultiPooler.Id,
+	}, nil
+}
+
+// shutdownValidatePrimary looks up the pooler in the store and validates that it
+// is currently acting as PRIMARY or STOPPING in the given shard.
+func (re *Engine) shutdownValidatePrimary(shardKey *clustermetadatapb.ShardKey, id *clustermetadatapb.ID) (*multiorchdatapb.PoolerHealthState, error) {
+	if id == nil {
+		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT, "primary_id is required")
+	}
+	idStr := topoclient.MultiPoolerIDString(id)
+	pooler, ok := re.poolerStore.Get(idStr)
+	if !ok {
+		return nil, mterrors.Errorf(mtrpcpb.Code_NOT_FOUND, "pooler %s not found in store", idStr)
+	}
+	if pooler.MultiPooler == nil {
+		return nil, mterrors.Errorf(mtrpcpb.Code_NOT_FOUND, "pooler %s has no metadata", idStr)
+	}
+	if pooler.MultiPooler.Database != shardKey.Database ||
+		pooler.MultiPooler.TableGroup != shardKey.TableGroup ||
+		pooler.MultiPooler.Shard != shardKey.Shard {
+		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+			"pooler %s does not belong to shard %s", idStr, commontypes.FormatShardKey(shardKey))
+	}
+	// Observed type from streaming; fall back to topology type if not yet seen.
+	poolerType := pooler.GetStatus().GetPoolerType()
+	if poolerType == clustermetadatapb.PoolerType_UNKNOWN {
+		poolerType = pooler.MultiPooler.Type
+	}
+	// Accept PRIMARY or STOPPING — the pooler may have already set STOPPING before
+	// we received the request.
+	if poolerType != clustermetadatapb.PoolerType_PRIMARY && poolerType != clustermetadatapb.PoolerType_STOPPING {
+		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+			"pooler %s is not PRIMARY or STOPPING (current type: %s)", idStr, poolerType)
+	}
+	return pooler, nil
+}
+
+// shutdownWaitForStandbys calls WaitForLSN on each REPLICA in the shard in
+// parallel. Timeouts and errors are logged as warnings but do not abort the
+// switchover — catchup is best-effort per the ShutdownPrimary contract.
+func (re *Engine) shutdownWaitForStandbys(
+	ctx context.Context,
+	shardKey *clustermetadatapb.ShardKey,
+	excludeIDStr string,
+	targetLSN string,
+	timeout *durationpb.Duration,
+) {
+	var standbys []*multiorchdatapb.PoolerHealthState
+	re.poolerStore.Range(func(_ string, p *multiorchdatapb.PoolerHealthState) bool {
+		if p == nil || p.MultiPooler == nil || p.MultiPooler.Id == nil {
+			return true
+		}
+		if p.MultiPooler.Database != shardKey.Database ||
+			p.MultiPooler.TableGroup != shardKey.TableGroup ||
+			p.MultiPooler.Shard != shardKey.Shard {
+			return true
+		}
+		if topoclient.MultiPoolerIDString(p.MultiPooler.Id) == excludeIDStr {
+			return true
+		}
+		t := p.GetStatus().GetPoolerType()
+		if t == clustermetadatapb.PoolerType_UNKNOWN {
+			t = p.MultiPooler.Type
+		}
+		if t == clustermetadatapb.PoolerType_REPLICA {
+			standbys = append(standbys, p)
+		}
+		return true
+	})
+
+	if len(standbys) == 0 {
+		re.logger.WarnContext(ctx, "ShutdownPrimary: no standbys found, skipping catchup wait",
+			"shard_key", commontypes.FormatShardKey(shardKey))
+		return
+	}
+
+	re.logger.InfoContext(ctx, "ShutdownPrimary: waiting for standbys to catch up",
+		"shard_key", commontypes.FormatShardKey(shardKey),
+		"standbys", len(standbys),
+		"target_lsn", targetLSN)
+
+	// Enforce the catchup deadline via context so WaitForLSN calls are
+	// cancelled when the window expires — even if the primary has died and
+	// WAL replay on standbys has stalled.
+	waitCtx, cancel := context.WithTimeout(ctx, timeout.AsDuration())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, s := range standbys {
+		wg.Add(1)
+		go func(standby *multiorchdatapb.PoolerHealthState) {
+			defer wg.Done()
+			standbyIDStr := topoclient.MultiPoolerIDString(standby.MultiPooler.Id)
+			_, err := re.rpcClient.WaitForLSN(waitCtx, standby.MultiPooler,
+				&multipoolermanagerdatapb.WaitForLSNRequest{
+					TargetLsn: targetLSN,
+					Timeout:   timeout,
+				})
+			if err != nil {
+				re.logger.WarnContext(ctx, "ShutdownPrimary: standby did not catch up in time (proceeding anyway)",
+					"standby", standbyIDStr, "error", err)
+			} else {
+				re.logger.InfoContext(ctx, "ShutdownPrimary: standby caught up",
+					"standby", standbyIDStr, "lsn", targetLSN)
+			}
+		}(s)
+	}
+	wg.Wait()
+}
+
+// shutdownGetPrimaryLSN calls Status on the primary to get its current WAL LSN
+// while it is still running. Returns an empty string (and logs a warning) if
+// the call fails — callers skip the standby wait in that case.
+func (re *Engine) shutdownGetPrimaryLSN(ctx context.Context, mp *clustermetadatapb.MultiPooler, primaryIDStr string) string {
+	resp, err := re.rpcClient.Status(ctx, mp, &multipoolermanagerdatapb.StatusRequest{})
+	if err != nil {
+		re.logger.WarnContext(ctx, "ShutdownPrimary: could not read primary LSN, skipping standby wait",
+			"primary", primaryIDStr, "error", err)
+		return ""
+	}
+	lsn := resp.GetStatus().GetPrimaryStatus().GetLsn()
+	if lsn == "" {
+		re.logger.WarnContext(ctx, "ShutdownPrimary: primary LSN is empty, skipping standby wait",
+			"primary", primaryIDStr)
+	}
+	return lsn
+}
+
+// shutdownFindNewPrimary polls shard poolers for fresh state and returns the
+// pooler in the shard that is now PRIMARY, excluding the old primary.
+func (re *Engine) shutdownFindNewPrimary(ctx context.Context, shardKey *clustermetadatapb.ShardKey, oldPrimaryIDStr string) (*multiorchdatapb.PoolerHealthState, error) {
+	re.pollAndWaitForNewSnapshots(ctx, shardKey)
+
+	var newPrimary *multiorchdatapb.PoolerHealthState
+	re.poolerStore.Range(func(_ string, p *multiorchdatapb.PoolerHealthState) bool {
+		if p == nil || p.MultiPooler == nil || p.MultiPooler.Id == nil {
+			return true
+		}
+		if p.MultiPooler.Database != shardKey.Database ||
+			p.MultiPooler.TableGroup != shardKey.TableGroup ||
+			p.MultiPooler.Shard != shardKey.Shard {
+			return true
+		}
+		if topoclient.MultiPoolerIDString(p.MultiPooler.Id) == oldPrimaryIDStr {
+			return true
+		}
+		t := p.GetStatus().GetPoolerType()
+		if t == clustermetadatapb.PoolerType_UNKNOWN {
+			t = p.MultiPooler.Type
+		}
+		if t == clustermetadatapb.PoolerType_PRIMARY {
+			newPrimary = p
+			return false
+		}
+		return true
+	})
+
+	if newPrimary == nil {
+		return nil, mterrors.Errorf(mtrpcpb.Code_NOT_FOUND,
+			"no new primary found in shard %s after election", commontypes.FormatShardKey(shardKey))
+	}
+	return newPrimary, nil
+}

--- a/go/services/multiorch/recovery/shutdown_primary.go
+++ b/go/services/multiorch/recovery/shutdown_primary.go
@@ -16,7 +16,6 @@ package recovery
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -41,13 +40,12 @@ func (re *Engine) shutdownPrimaryCallback(
 	database, tableGroup, shard string,
 ) error {
 	_, err := re.ShutdownPrimary(ctx, &multiorchpb.ShutdownPrimaryRequest{
-		Database:              database,
-		TableGroup:            tableGroup,
-		Shard:                 shard,
-		PrimaryId:             primaryID,
-		DrainTimeout:          durationpb.New(10 * time.Second),
-		StandbyCatchupTimeout: durationpb.New(30 * time.Second),
-		Reason:                "SIGTERM",
+		Database:     database,
+		TableGroup:   tableGroup,
+		Shard:        shard,
+		PrimaryId:    primaryID,
+		DrainTimeout: durationpb.New(10 * time.Second),
+		Reason:       "SIGTERM",
 	})
 	return err
 }
@@ -83,10 +81,11 @@ func (re *Engine) isPrimaryCandidate(pooler *multiorchdatapb.PoolerHealthState) 
 //
 // Triggered when a primary multipooler signals PoolerType_STOPPING on the health
 // stream (e.g. on SIGTERM). The pooler has already stopped accepting writes by
-// the time this runs; EmergencyDemote drains remaining connections and stops
-// PostgreSQL. After stopping the primary, it is marked DRAINED in topology so
-// getpoolers never shows two PRIMARY nodes simultaneously and the node is
-// excluded from future elections.
+// the time this runs; EmergencyDemote drains remaining connections and leaves
+// PostgreSQL running in NOT_SERVING state — the multipooler stops PostgreSQL
+// itself after this RPC returns. The old primary is then marked DRAINED in
+// topology so getpoolers never shows two PRIMARY nodes simultaneously and the
+// node is excluded from future elections.
 //
 // See the ShutdownPrimary RPC in multiorchservice.proto for the full sequence.
 func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.ShutdownPrimaryRequest) (_ *multiorchpb.ShutdownPrimaryResponse, retErr error) {
@@ -102,7 +101,6 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 		"shard_key", commontypes.FormatShardKey(shardKey),
 		"primary", primaryIDStr,
 		"drain_timeout", req.DrainTimeout.AsDuration(),
-		"standby_catchup_timeout", req.StandbyCatchupTimeout.AsDuration(),
 		"reason", req.Reason)
 
 	// Step 1: Validate that the given pooler is currently PRIMARY or STOPPING.
@@ -138,23 +136,16 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 			shardKey.Database, shardKey.Shard)
 	}()
 
-	// Step 2: Read the primary's current WAL LSN while it is still running.
-	// The gateway has already stopped routing new writes (STOPPING signal), so
-	// this LSN is a safe target for standby catchup. If the Status call fails
-	// we skip the standby wait and proceed directly to EmergencyDemote.
-	currentLSN := re.shutdownGetPrimaryLSN(ctx, primary.MultiPooler, primaryIDStr)
-
-	// Step 3: Wait for standbys to replay up to the primary's current LSN.
-	// The primary is still up and streaming WAL during this window, so standbys
-	// should catch up quickly. AppointLeader picks the most-advanced node if
-	// any standby times out.
-	if currentLSN != "" {
-		re.shutdownWaitForStandbys(ctx, shardKey, primaryIDStr, currentLSN, req.StandbyCatchupTimeout)
-	}
-
-	// Step 4: Stop the primary. Standbys have caught up (or timed out), so
-	// EmergencyDemote is fast: few or no active writes to drain.
-	re.logger.InfoContext(ctx, "ShutdownPrimary: stopping primary via EmergencyDemote",
+	// Step 2: Drain the primary via EmergencyDemote. With sync replication,
+	// drain blocks until in-flight commits are ACK'd by sync standbys, so the
+	// committed WAL is durable on sync standbys when this returns.
+	//
+	// EmergencyDemote is best-effort here: if it fails (e.g. the dying pooler's
+	// hard-stop timer fired and the process exited mid-RPC) we log and proceed.
+	// The cohort filter excludes STOPPING/DRAINED so the dying primary cannot be
+	// re-elected, and AppointLeader operates against the standbys regardless of
+	// whether the drain succeeded.
+	re.logger.InfoContext(ctx, "ShutdownPrimary: draining primary via EmergencyDemote",
 		"primary", primaryIDStr)
 	demoteResp, err := re.rpcClient.EmergencyDemote(ctx, primary.MultiPooler,
 		&multipoolermanagerdatapb.EmergencyDemoteRequest{
@@ -162,16 +153,22 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 			// deliberately, not responding to a detected failure.
 			Force:        true,
 			DrainTimeout: req.DrainTimeout,
+			// restart_server_as_standby=false: the multipooler is exiting on SIGTERM
+			// and will stop postgres directly. Restarting as standby would just be
+			// undone moments later.
+			RestartServerAsStandby: false,
 		})
 	if err != nil {
-		return nil, mterrors.Wrap(err, "EmergencyDemote failed")
+		re.logger.WarnContext(ctx, "ShutdownPrimary: EmergencyDemote failed; proceeding with election",
+			"primary", primaryIDStr, "error", err)
+	} else {
+		re.logger.InfoContext(ctx, "ShutdownPrimary: primary drained",
+			"primary", primaryIDStr,
+			"final_lsn", demoteResp.LsnPosition,
+			"connections_terminated", demoteResp.ConnectionsTerminated)
 	}
-	re.logger.InfoContext(ctx, "ShutdownPrimary: primary stopped",
-		"primary", primaryIDStr,
-		"final_lsn", demoteResp.LsnPosition,
-		"connections_terminated", demoteResp.ConnectionsTerminated)
 
-	// Step 4b: Mark the old primary as DRAINED in topology so that getpoolers
+	// Step 2b: Mark the old primary as DRAINED in topology so that getpoolers
 	// does not show two PRIMARYs and the node is excluded from future elections.
 	// The pooler sets STOPPING only on its in-memory health stream; it exits
 	// before its monitor loop can rewrite the etcd record.
@@ -183,7 +180,7 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 			"primary", primaryIDStr, "error", err)
 	}
 
-	// Step 5: Build the election cohort, excluding STOPPING and DRAINED poolers.
+	// Step 3: Build the election cohort, excluding STOPPING and DRAINED poolers.
 	cohort := re.poolerStore.FindPoolersInShard(shardKey)
 	filteredCohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohort))
 	for _, p := range cohort {
@@ -191,7 +188,7 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 			filteredCohort = append(filteredCohort, p)
 		}
 	}
-	// Step 6: Elect a new primary from the cohort.
+	// Step 4: Elect a new primary from the cohort.
 	re.logger.InfoContext(ctx, "ShutdownPrimary: electing new primary",
 		"shard_key", commontypes.FormatShardKey(shardKey),
 		"cohort_size", len(filteredCohort))
@@ -199,7 +196,7 @@ func (re *Engine) ShutdownPrimary(ctx context.Context, req *multiorchpb.Shutdown
 		return nil, mterrors.Wrap(err, "AppointLeader failed")
 	}
 
-	// Step 7: Find the newly elected primary and return its ID.
+	// Step 5: Find the newly elected primary and return its ID.
 	newPrimary, err := re.shutdownFindNewPrimary(ctx, shardKey, primaryIDStr)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to find new primary after election")
@@ -247,97 +244,6 @@ func (re *Engine) shutdownValidatePrimary(shardKey *clustermetadatapb.ShardKey, 
 			"pooler %s is not PRIMARY or STOPPING (current type: %s)", idStr, poolerType)
 	}
 	return pooler, nil
-}
-
-// shutdownWaitForStandbys calls WaitForLSN on each REPLICA in the shard in
-// parallel. Timeouts and errors are logged as warnings but do not abort the
-// switchover — catchup is best-effort per the ShutdownPrimary contract.
-func (re *Engine) shutdownWaitForStandbys(
-	ctx context.Context,
-	shardKey *clustermetadatapb.ShardKey,
-	excludeIDStr string,
-	targetLSN string,
-	timeout *durationpb.Duration,
-) {
-	var standbys []*multiorchdatapb.PoolerHealthState
-	re.poolerStore.Range(func(_ string, p *multiorchdatapb.PoolerHealthState) bool {
-		if p == nil || p.MultiPooler == nil || p.MultiPooler.Id == nil {
-			return true
-		}
-		if p.MultiPooler.Database != shardKey.Database ||
-			p.MultiPooler.TableGroup != shardKey.TableGroup ||
-			p.MultiPooler.Shard != shardKey.Shard {
-			return true
-		}
-		if topoclient.MultiPoolerIDString(p.MultiPooler.Id) == excludeIDStr {
-			return true
-		}
-		t := p.GetStatus().GetPoolerType()
-		if t == clustermetadatapb.PoolerType_UNKNOWN {
-			t = p.MultiPooler.Type
-		}
-		if t == clustermetadatapb.PoolerType_REPLICA {
-			standbys = append(standbys, p)
-		}
-		return true
-	})
-
-	if len(standbys) == 0 {
-		re.logger.WarnContext(ctx, "ShutdownPrimary: no standbys found, skipping catchup wait",
-			"shard_key", commontypes.FormatShardKey(shardKey))
-		return
-	}
-
-	re.logger.InfoContext(ctx, "ShutdownPrimary: waiting for standbys to catch up",
-		"shard_key", commontypes.FormatShardKey(shardKey),
-		"standbys", len(standbys),
-		"target_lsn", targetLSN)
-
-	// Enforce the catchup deadline via context so WaitForLSN calls are
-	// cancelled when the window expires — even if the primary has died and
-	// WAL replay on standbys has stalled.
-	waitCtx, cancel := context.WithTimeout(ctx, timeout.AsDuration())
-	defer cancel()
-
-	var wg sync.WaitGroup
-	for _, s := range standbys {
-		wg.Add(1)
-		go func(standby *multiorchdatapb.PoolerHealthState) {
-			defer wg.Done()
-			standbyIDStr := topoclient.MultiPoolerIDString(standby.MultiPooler.Id)
-			_, err := re.rpcClient.WaitForLSN(waitCtx, standby.MultiPooler,
-				&multipoolermanagerdatapb.WaitForLSNRequest{
-					TargetLsn: targetLSN,
-					Timeout:   timeout,
-				})
-			if err != nil {
-				re.logger.WarnContext(ctx, "ShutdownPrimary: standby did not catch up in time (proceeding anyway)",
-					"standby", standbyIDStr, "error", err)
-			} else {
-				re.logger.InfoContext(ctx, "ShutdownPrimary: standby caught up",
-					"standby", standbyIDStr, "lsn", targetLSN)
-			}
-		}(s)
-	}
-	wg.Wait()
-}
-
-// shutdownGetPrimaryLSN calls Status on the primary to get its current WAL LSN
-// while it is still running. Returns an empty string (and logs a warning) if
-// the call fails — callers skip the standby wait in that case.
-func (re *Engine) shutdownGetPrimaryLSN(ctx context.Context, mp *clustermetadatapb.MultiPooler, primaryIDStr string) string {
-	resp, err := re.rpcClient.Status(ctx, mp, &multipoolermanagerdatapb.StatusRequest{})
-	if err != nil {
-		re.logger.WarnContext(ctx, "ShutdownPrimary: could not read primary LSN, skipping standby wait",
-			"primary", primaryIDStr, "error", err)
-		return ""
-	}
-	lsn := resp.GetStatus().GetPrimaryStatus().GetLsn()
-	if lsn == "" {
-		re.logger.WarnContext(ctx, "ShutdownPrimary: primary LSN is empty, skipping standby wait",
-			"primary", primaryIDStr)
-	}
-	return lsn
 }
 
 // shutdownFindNewPrimary polls shard poolers for fresh state and returns the

--- a/go/services/multiorch/recovery/shutdown_primary_test.go
+++ b/go/services/multiorch/recovery/shutdown_primary_test.go
@@ -241,12 +241,11 @@ func TestShutdownPrimary_HappyPath(t *testing.T) {
 	engine, fakeClient, primary, standbys := shutdownTestFixture(t)
 
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              primary.Database,
-		TableGroup:            primary.TableGroup,
-		Shard:                 primary.Shard,
-		PrimaryId:             primary.Id,
-		DrainTimeout:          durationpb.New(5e9),  // 5s
-		StandbyCatchupTimeout: durationpb.New(30e9), // 30s
+		Database:     primary.Database,
+		TableGroup:   primary.TableGroup,
+		Shard:        primary.Shard,
+		PrimaryId:    primary.Id,
+		DrainTimeout: durationpb.New(5e9), // 5s // 30s
 	}
 
 	resp, err := engine.ShutdownPrimary(ctx, req)
@@ -263,11 +262,9 @@ func TestShutdownPrimary_HappyPath(t *testing.T) {
 	assert.True(t, standbyNames[newPrimaryName],
 		"new primary %q should be one of the standbys", newPrimaryName)
 
-	// Status must be called on the primary to read the LSN, then EmergencyDemote
-	// to stop it after standbys have caught up.
+	// EmergencyDemote must be called on the primary to drain it.
 	primaryKey := topoclient.MultiPoolerIDString(primary.Id)
 	callLog := fakeClient.GetCallLog()
-	assert.Contains(t, callLog, fmt.Sprintf("Status(%s)", primaryKey))
 	assert.Contains(t, callLog, fmt.Sprintf("EmergencyDemote(%s)", primaryKey))
 }
 
@@ -280,12 +277,11 @@ func TestShutdownPrimary_RejectsNonPrimary(t *testing.T) {
 	// standbys[1] is standby2, which is stored as REPLICA in the fixture.
 	replica := standbys[1]
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              replica.Database,
-		TableGroup:            replica.TableGroup,
-		Shard:                 replica.Shard,
-		PrimaryId:             replica.Id,
-		DrainTimeout:          durationpb.New(5e9),
-		StandbyCatchupTimeout: durationpb.New(30e9),
+		Database:     replica.Database,
+		TableGroup:   replica.TableGroup,
+		Shard:        replica.Shard,
+		PrimaryId:    replica.Id,
+		DrainTimeout: durationpb.New(5e9),
 	}
 
 	_, err := engine.ShutdownPrimary(ctx, req)
@@ -306,12 +302,11 @@ func TestShutdownPrimary_OldPrimaryExcludedFromElection(t *testing.T) {
 	primaryIDStr := topoclient.MultiPoolerIDString(primary.Id)
 
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              primary.Database,
-		TableGroup:            primary.TableGroup,
-		Shard:                 primary.Shard,
-		PrimaryId:             primary.Id,
-		DrainTimeout:          durationpb.New(5e9),
-		StandbyCatchupTimeout: durationpb.New(30e9),
+		Database:     primary.Database,
+		TableGroup:   primary.TableGroup,
+		Shard:        primary.Shard,
+		PrimaryId:    primary.Id,
+		DrainTimeout: durationpb.New(5e9),
 	}
 
 	resp, err := engine.ShutdownPrimary(ctx, req)
@@ -322,15 +317,17 @@ func TestShutdownPrimary_OldPrimaryExcludedFromElection(t *testing.T) {
 		"old primary should not be re-elected")
 }
 
-// TestShutdownPrimary_RecoveryUnaffectedOnError verifies that a fatal step
-// (EmergencyDemote) failing does not stop the recovery loop. ShutdownPrimary
-// no longer disables/re-enables the recovery runner — it stays running
-// throughout, so a failure must leave it in whatever state it was in before.
-func TestShutdownPrimary_RecoveryUnaffectedOnError(t *testing.T) {
+// TestShutdownPrimary_ProceedsWhenEmergencyDemoteFails verifies that an
+// EmergencyDemote failure (e.g. the dying pooler exiting via the hard-stop
+// timer mid-RPC) does not abort the switchover. ShutdownPrimary logs and
+// proceeds with the election against the standbys; the cohort filter excludes
+// STOPPING/DRAINED so the dying primary cannot be re-elected. Recovery must
+// also remain running throughout.
+func TestShutdownPrimary_ProceedsWhenEmergencyDemoteFails(t *testing.T) {
 	ctx := context.Background()
-	engine, fakeClient, primary, _ := shutdownTestFixture(t)
+	engine, fakeClient, primary, standbys := shutdownTestFixture(t)
 
-	// Start recovery so we can verify it remains running after a failure.
+	// Start recovery so we can verify it remains running after the call.
 	engine.EnableRecovery()
 	t.Cleanup(func() { engine.DisableRecovery() })
 
@@ -339,19 +336,29 @@ func TestShutdownPrimary_RecoveryUnaffectedOnError(t *testing.T) {
 	fakeClient.Errors[primaryKey] = errors.New("simulated RPC failure")
 
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              primary.Database,
-		TableGroup:            primary.TableGroup,
-		Shard:                 primary.Shard,
-		PrimaryId:             primary.Id,
-		DrainTimeout:          durationpb.New(5e9),
-		StandbyCatchupTimeout: durationpb.New(30e9),
+		Database:     primary.Database,
+		TableGroup:   primary.TableGroup,
+		Shard:        primary.Shard,
+		PrimaryId:    primary.Id,
+		DrainTimeout: durationpb.New(5e9),
 	}
 
-	_, err := engine.ShutdownPrimary(ctx, req)
-	require.Error(t, err)
+	resp, err := engine.ShutdownPrimary(ctx, req)
+	require.NoError(t, err, "ShutdownPrimary must proceed past EmergencyDemote failure")
+	require.NotNil(t, resp)
 
-	// Recovery must still be running — ShutdownPrimary must not stop it.
-	assert.True(t, engine.IsRecoveryEnabled(), "recovery must remain running after ShutdownPrimary failure")
+	// The election must still pick a standby — never the dying primary.
+	assert.NotEqual(t, primary.Id.Name, resp.NewPrimaryId.Name,
+		"old primary must not be re-elected")
+	standbyNames := make(map[string]bool)
+	for _, s := range standbys {
+		standbyNames[s.Id.Name] = true
+	}
+	assert.True(t, standbyNames[resp.NewPrimaryId.Name],
+		"new primary %q must be one of the standbys", resp.NewPrimaryId.Name)
+
+	// Recovery must still be running.
+	assert.True(t, engine.IsRecoveryEnabled(), "recovery must remain running after ShutdownPrimary")
 }
 
 // TestShutdownPrimary_StandbyTimeoutDoesNotAbort verifies that a WaitForLSN
@@ -365,12 +372,11 @@ func TestShutdownPrimary_StandbyTimeoutDoesNotAbort(t *testing.T) {
 	fakeClient.WaitForLSNErrors[standby2Key] = errors.New("context deadline exceeded")
 
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              primary.Database,
-		TableGroup:            primary.TableGroup,
-		Shard:                 primary.Shard,
-		PrimaryId:             primary.Id,
-		DrainTimeout:          durationpb.New(5e9),
-		StandbyCatchupTimeout: durationpb.New(30e9),
+		Database:     primary.Database,
+		TableGroup:   primary.TableGroup,
+		Shard:        primary.Shard,
+		PrimaryId:    primary.Id,
+		DrainTimeout: durationpb.New(5e9),
 	}
 
 	// Should still succeed despite one standby timing out.
@@ -392,12 +398,11 @@ func TestShutdownPrimary_UnknownPooler(t *testing.T) {
 		Name:      "does-not-exist",
 	}
 	req := &multiorchpb.ShutdownPrimaryRequest{
-		Database:              primary.Database,
-		TableGroup:            primary.TableGroup,
-		Shard:                 primary.Shard,
-		PrimaryId:             unknownID,
-		DrainTimeout:          durationpb.New(5e9),
-		StandbyCatchupTimeout: durationpb.New(30e9),
+		Database:     primary.Database,
+		TableGroup:   primary.TableGroup,
+		Shard:        primary.Shard,
+		PrimaryId:    unknownID,
+		DrainTimeout: durationpb.New(5e9),
 	}
 
 	_, err := engine.ShutdownPrimary(ctx, req)

--- a/go/services/multiorch/recovery/shutdown_primary_test.go
+++ b/go/services/multiorch/recovery/shutdown_primary_test.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multiorchpb "github.com/multigres/multigres/go/pb/multiorch"
+	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// makePoolerID returns an ID for a multipooler in cell1.
+func makePoolerID(name string) *clustermetadatapb.ID {
+	return &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      name,
+	}
+}
+
+// makeMultiPooler creates a MultiPooler for the given shard and type.
+func makeMultiPooler(name string, t clustermetadatapb.PoolerType) *clustermetadatapb.MultiPooler {
+	return &clustermetadatapb.MultiPooler{
+		Id:         makePoolerID(name),
+		Database:   "db1",
+		TableGroup: "default",
+		Shard:      "0",
+		Type:       t,
+		Hostname:   "host-" + name,
+	}
+}
+
+// shutdownTestFixture sets up a test engine pre-populated with one primary and
+// some standbys. It also configures the fake client so that:
+//   - Status on the primary returns finalLSN so ShutdownPrimary can read it
+//     before waiting for standbys to catch up.
+//   - EmergencyDemote on the primary succeeds (called after standbys catch up).
+//   - Status polls for standbys report REPLICA unless overridden.
+//   - Status poll for standby1 reports PRIMARY after promotion so that
+//     shutdownFindNewPrimary finds it.
+func shutdownTestFixture(t *testing.T) (*Engine, *rpcclient.FakeClient, *clustermetadatapb.MultiPooler, []*clustermetadatapb.MultiPooler) {
+	t.Helper()
+	const finalLSN = "0/ABC123"
+
+	fakeClient := rpcclient.NewFakeClient()
+
+	primary := makeMultiPooler("primary", clustermetadatapb.PoolerType_PRIMARY)
+	standby1 := makeMultiPooler("standby1", clustermetadatapb.PoolerType_REPLICA)
+	standby2 := makeMultiPooler("standby2", clustermetadatapb.PoolerType_REPLICA)
+
+	primaryKey := topoclient.MultiPoolerIDString(primary.Id)
+	standby1Key := topoclient.MultiPoolerIDString(standby1.Id)
+	standby2Key := topoclient.MultiPoolerIDString(standby2.Id)
+
+	// Status on the primary returns the current LSN so ShutdownPrimary can wait
+	// for standbys to catch up before stopping the primary.
+	fakeClient.SetStatusResponse(primaryKey, &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_PRIMARY,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
+				Lsn:   finalLSN,
+				Ready: true,
+			},
+		},
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+		},
+	})
+	// EmergencyDemote is called after standbys have caught up.
+	fakeClient.EmergencyDemoteResponses[primaryKey] = &multipoolermanagerdatapb.EmergencyDemoteResponse{}
+
+	// WaitForLSN succeeds for both standbys.
+	fakeClient.WaitForLSNResponses[standby1Key] = &multipoolermanagerdatapb.WaitForLSNResponse{}
+	fakeClient.WaitForLSNResponses[standby2Key] = &multipoolermanagerdatapb.WaitForLSNResponse{}
+
+	// AppointLeader requires a complete set of fake responses per standby:
+	//
+	//  1. Status — forceHealthCheckShardPoolers (step 3) calls this and populates
+	//     IsLastCheckValid, IsInitialized, IsPostgresReady, ConsensusTerm in the store.
+	//     Pre-vote checks all four fields. After promotion standby1 reports PRIMARY so
+	//     shutdownFindNewPrimary can identify the new leader.
+	//
+	//  2. ConsensusStatus — used by the BeginTerm phase to read current term and WAL position.
+	//
+	//  3. BeginTermResponse — must have Accepted:true plus a WalPosition so the candidate
+	//     selector can rank nodes by LSN.
+	//
+	//  4. PromoteResponse — called on the winning candidate.
+	//
+	//  5. SetPrimaryConnInfo — called on standbys after promotion to reconfigure replication.
+
+	for _, key := range []string{standby1Key, standby2Key} {
+		fakeClient.ConsensusStatusResponses[key] = &consensusdatapb.StatusResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn: finalLSN,
+				},
+			},
+		}
+		fakeClient.BeginTermResponses[key] = &consensusdatapb.BeginTermResponse{
+			Accepted: true,
+			WalPosition: &consensusdatapb.WALPosition{
+				LastReceiveLsn: finalLSN,
+				LastReplayLsn:  finalLSN,
+			},
+		}
+		fakeClient.PromoteResponses[key] = &multipoolermanagerdatapb.PromoteResponse{}
+		fakeClient.SetPrimaryConnInfoResponses[key] = &multipoolermanagerdatapb.SetPrimaryConnInfoResponse{}
+	}
+	// Give standby1 a strictly higher LSN so it consistently wins the election.
+	// This ensures EstablishLeadership calls WaitForLSN on standby1 (which succeeds),
+	// not standby2 (which may have a per-test injected error).
+	const standby1LSN = "0/FFFFFF"
+	fakeClient.ConsensusStatusResponses[standby1Key] = &consensusdatapb.StatusResponse{
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Lsn: standby1LSN,
+			},
+		},
+	}
+	fakeClient.BeginTermResponses[standby1Key] = &consensusdatapb.BeginTermResponse{
+		Accepted: true,
+		WalPosition: &consensusdatapb.WALPosition{
+			LastReceiveLsn: standby1LSN,
+			LastReplayLsn:  standby1LSN,
+		},
+	}
+	// Status RPC responses used by AppointLeader's pre-vote health checks.
+	// standby1 reports PRIMARY because pollShardPoolers is fire-and-forget in
+	// tests (no real stream), so we pre-populate its post-promotion state here.
+	consensusStatus := &clustermetadatapb.ConsensusStatus{
+		TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+	}
+	fakeClient.SetStatusResponse(standby1Key, &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_PRIMARY,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+		},
+		ConsensusStatus: consensusStatus,
+	})
+	fakeClient.SetStatusResponse(standby2Key, &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_REPLICA,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+		},
+		ConsensusStatus: consensusStatus,
+	})
+
+	engine := newTestEngine(context.Background(), t, WithFakeClient(fakeClient))
+
+	// AppointLeader loads the durability policy from topology; create the database first.
+	err := engine.ts.CreateDatabase(context.Background(), "db1", &clustermetadatapb.Database{
+		Name:                      "db1",
+		BootstrapDurabilityPolicy: topoclient.AtLeastN(1),
+	})
+	require.NoError(t, err)
+
+	// Pre-populate the store so AppointLeader and shutdownFindNewPrimary work without
+	// a live health stream. IsLastCheckValid + ConsensusStatus satisfy discoverMaxTerm
+	// and preVote. standby1 is set to PRIMARY (its post-promotion state) so that
+	// shutdownFindNewPrimary can locate it.
+	// The primary is stored as STOPPING: in real operation the multipooler sets
+	// PoolerType_STOPPING on the health stream before ShutdownPrimary is called
+	// (that STOPPING signal is what triggers ShutdownPrimary). isPrimaryCandidate
+	// relies on this to exclude the old leader from the election cohort.
+	engine.poolerStore.Set(primaryKey, &multiorchdatapb.PoolerHealthState{
+		MultiPooler:      primary,
+		IsLastCheckValid: true,
+		ConsensusStatus:  consensusStatus,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_STOPPING,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+		},
+	})
+	// standby1 is pre-populated as PRIMARY (its post-promotion state) so that
+	// shutdownFindNewPrimary can locate it without a real snapshot arriving.
+	engine.poolerStore.Set(standby1Key, &multiorchdatapb.PoolerHealthState{
+		MultiPooler:      standby1,
+		IsLastCheckValid: true,
+		ConsensusStatus:  consensusStatus,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_PRIMARY,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+		},
+	})
+	engine.poolerStore.Set(standby2Key, &multiorchdatapb.PoolerHealthState{
+		MultiPooler:      standby2,
+		IsLastCheckValid: true,
+		ConsensusStatus:  consensusStatus,
+		Status: &multipoolermanagerdatapb.Status{
+			PoolerType:      clustermetadatapb.PoolerType_REPLICA,
+			PostgresRunning: true,
+			PostgresReady:   true,
+			IsInitialized:   true,
+		},
+	})
+
+	return engine, fakeClient, primary, []*clustermetadatapb.MultiPooler{standby1, standby2}
+}
+
+// TestShutdownPrimary_HappyPath verifies the full switchover sequence:
+// EmergencyDemote is called, standbys are waited on, and a new primary is
+// returned in the response.
+func TestShutdownPrimary_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	engine, fakeClient, primary, standbys := shutdownTestFixture(t)
+
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              primary.Database,
+		TableGroup:            primary.TableGroup,
+		Shard:                 primary.Shard,
+		PrimaryId:             primary.Id,
+		DrainTimeout:          durationpb.New(5e9),  // 5s
+		StandbyCatchupTimeout: durationpb.New(30e9), // 30s
+	}
+
+	resp, err := engine.ShutdownPrimary(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.NewPrimaryId)
+
+	// The new primary must be one of the original standbys.
+	newPrimaryName := resp.NewPrimaryId.Name
+	standbyNames := make(map[string]bool)
+	for _, s := range standbys {
+		standbyNames[s.Id.Name] = true
+	}
+	assert.True(t, standbyNames[newPrimaryName],
+		"new primary %q should be one of the standbys", newPrimaryName)
+
+	// Status must be called on the primary to read the LSN, then EmergencyDemote
+	// to stop it after standbys have caught up.
+	primaryKey := topoclient.MultiPoolerIDString(primary.Id)
+	callLog := fakeClient.GetCallLog()
+	assert.Contains(t, callLog, fmt.Sprintf("Status(%s)", primaryKey))
+	assert.Contains(t, callLog, fmt.Sprintf("EmergencyDemote(%s)", primaryKey))
+}
+
+// TestShutdownPrimary_RejectsNonPrimary verifies that calling ShutdownPrimary
+// with a pooler that is not PRIMARY returns an error without touching the cluster.
+func TestShutdownPrimary_RejectsNonPrimary(t *testing.T) {
+	ctx := context.Background()
+	engine, fakeClient, _, standbys := shutdownTestFixture(t)
+
+	// standbys[1] is standby2, which is stored as REPLICA in the fixture.
+	replica := standbys[1]
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              replica.Database,
+		TableGroup:            replica.TableGroup,
+		Shard:                 replica.Shard,
+		PrimaryId:             replica.Id,
+		DrainTimeout:          durationpb.New(5e9),
+		StandbyCatchupTimeout: durationpb.New(30e9),
+	}
+
+	_, err := engine.ShutdownPrimary(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not PRIMARY")
+
+	// No RPCs should have been issued.
+	assert.Empty(t, fakeClient.GetCallLog())
+}
+
+// TestShutdownPrimary_OldPrimaryExcludedFromElection verifies that the pooler
+// requesting shutdown is excluded from the AppointLeader cohort.
+func TestShutdownPrimary_OldPrimaryExcludedFromElection(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a tracking fake that records AppointLeader cohorts.
+	engine, _, primary, _ := shutdownTestFixture(t)
+	primaryIDStr := topoclient.MultiPoolerIDString(primary.Id)
+
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              primary.Database,
+		TableGroup:            primary.TableGroup,
+		Shard:                 primary.Shard,
+		PrimaryId:             primary.Id,
+		DrainTimeout:          durationpb.New(5e9),
+		StandbyCatchupTimeout: durationpb.New(30e9),
+	}
+
+	resp, err := engine.ShutdownPrimary(ctx, req)
+	require.NoError(t, err)
+
+	// Verify the old primary is not returned as the new primary.
+	assert.NotEqual(t, primaryIDStr, topoclient.MultiPoolerIDString(resp.NewPrimaryId),
+		"old primary should not be re-elected")
+}
+
+// TestShutdownPrimary_RecoveryUnaffectedOnError verifies that a fatal step
+// (EmergencyDemote) failing does not stop the recovery loop. ShutdownPrimary
+// no longer disables/re-enables the recovery runner — it stays running
+// throughout, so a failure must leave it in whatever state it was in before.
+func TestShutdownPrimary_RecoveryUnaffectedOnError(t *testing.T) {
+	ctx := context.Background()
+	engine, fakeClient, primary, _ := shutdownTestFixture(t)
+
+	// Start recovery so we can verify it remains running after a failure.
+	engine.EnableRecovery()
+	t.Cleanup(func() { engine.DisableRecovery() })
+
+	// Make EmergencyDemote fail.
+	primaryKey := topoclient.MultiPoolerIDString(primary.Id)
+	fakeClient.Errors[primaryKey] = errors.New("simulated RPC failure")
+
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              primary.Database,
+		TableGroup:            primary.TableGroup,
+		Shard:                 primary.Shard,
+		PrimaryId:             primary.Id,
+		DrainTimeout:          durationpb.New(5e9),
+		StandbyCatchupTimeout: durationpb.New(30e9),
+	}
+
+	_, err := engine.ShutdownPrimary(ctx, req)
+	require.Error(t, err)
+
+	// Recovery must still be running — ShutdownPrimary must not stop it.
+	assert.True(t, engine.IsRecoveryEnabled(), "recovery must remain running after ShutdownPrimary failure")
+}
+
+// TestShutdownPrimary_StandbyTimeoutDoesNotAbort verifies that a WaitForLSN
+// timeout on one standby does not abort the switchover — it is best-effort.
+func TestShutdownPrimary_StandbyTimeoutDoesNotAbort(t *testing.T) {
+	ctx := context.Background()
+	engine, fakeClient, primary, standbys := shutdownTestFixture(t)
+
+	// Make WaitForLSN fail for standby2 only (not BeginTerm).
+	standby2Key := topoclient.MultiPoolerIDString(standbys[1].Id)
+	fakeClient.WaitForLSNErrors[standby2Key] = errors.New("context deadline exceeded")
+
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              primary.Database,
+		TableGroup:            primary.TableGroup,
+		Shard:                 primary.Shard,
+		PrimaryId:             primary.Id,
+		DrainTimeout:          durationpb.New(5e9),
+		StandbyCatchupTimeout: durationpb.New(30e9),
+	}
+
+	// Should still succeed despite one standby timing out.
+	resp, err := engine.ShutdownPrimary(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotNil(t, resp.NewPrimaryId)
+}
+
+// TestShutdownPrimary_UnknownPooler verifies that an unknown primary_id returns
+// NOT_FOUND.
+func TestShutdownPrimary_UnknownPooler(t *testing.T) {
+	ctx := context.Background()
+	engine, _, primary, _ := shutdownTestFixture(t)
+
+	unknownID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      "does-not-exist",
+	}
+	req := &multiorchpb.ShutdownPrimaryRequest{
+		Database:              primary.Database,
+		TableGroup:            primary.TableGroup,
+		Shard:                 primary.Shard,
+		PrimaryId:             unknownID,
+		DrainTimeout:          durationpb.New(5e9),
+		StandbyCatchupTimeout: durationpb.New(30e9),
+	}
+
+	_, err := engine.ShutdownPrimary(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/go/services/multiorch/recovery/types/types.go
+++ b/go/services/multiorch/recovery/types/types.go
@@ -39,6 +39,7 @@ const (
 
 	// Leader problems (catastrophic - block everything else).
 	ProblemLeaderIsDead      ProblemCode = "LeaderIsDead"
+	ProblemLeaderIsStopping  ProblemCode = "LeaderIsStopping"
 	ProblemLeaderDiskStalled ProblemCode = "LeaderDiskStalled"
 	ProblemStaleLeader       ProblemCode = "StaleLeader"
 

--- a/go/services/multipooler/grpcconsensusservice/service.go
+++ b/go/services/multipooler/grpcconsensusservice/service.go
@@ -89,7 +89,7 @@ func (s *consensusService) EmergencyDemote(ctx context.Context, req *multipooler
 	if req.DrainTimeout != nil {
 		drainTimeout = req.DrainTimeout.AsDuration()
 	}
-	resp, err := s.manager.EmergencyDemote(ctx, req.ConsensusTerm, drainTimeout, req.Force)
+	resp, err := s.manager.EmergencyDemote(ctx, req.ConsensusTerm, drainTimeout, req.Force, req.RestartServerAsStandby)
 	if err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -17,6 +17,7 @@ package grpcmanagerservice
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -146,6 +147,12 @@ func (s *managerService) ExpireBackups(ctx context.Context, req *multipoolermana
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor
 func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)
+}
+
+// Shutdown initiates a graceful pooler shutdown identical to SIGTERM.
+func (s *managerService) Shutdown(ctx context.Context, req *multipoolermanagerdatapb.ShutdownRequest) (*multipoolermanagerdatapb.ShutdownResponse, error) {
+	s.manager.InitiateGracefulShutdown(ctx, slog.String("reason", req.Reason))
+	return &multipoolermanagerdatapb.ShutdownResponse{}, nil
 }
 
 // ManagerHealthStream is the bidirectional health stream implementation.

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -209,6 +209,14 @@ func (mp *MultiPooler) RegisterFlags(flags *pflag.FlagSet) {
 	mp.senv.RegisterFlags(flags)
 	mp.topoConfig.RegisterFlags(flags)
 	mp.connPoolConfig.RegisterFlags(flags)
+
+	// The graceful-shutdown sequence for a PRIMARY must complete before the
+	// process exits: drain (10s) + standby catchup (30s) + postgres stop.
+	// Override the servenv default of 10s so OnTermSync isn't abandoned early.
+	if f := flags.Lookup("onterm-timeout"); f != nil {
+		_ = f.Value.Set("120s")
+		f.DefValue = "120s"
+	}
 }
 
 // Init initializes the multipooler. If any services fail to start,

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/heartbeat"
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 	"github.com/multigres/multigres/go/services/multipooler/pubsub"
+	"github.com/multigres/multigres/go/tools/ctxutil"
 	"github.com/multigres/multigres/go/tools/grpccommon"
 	"github.com/multigres/multigres/go/tools/retry"
 	"github.com/multigres/multigres/go/tools/telemetry"
@@ -156,6 +157,10 @@ type MultiPoolerManager struct {
 	// When set, the monitor continues to run and detect problems but skips the start action.
 	// False by default (restarts enabled); tests and demos set it during controlled failovers.
 	postgresRestartsDisabled atomic.Bool
+
+	// shutdownOnce ensures performGracefulShutdown runs at most once, even when both
+	// SIGTERM and the Shutdown RPC race to trigger it.
+	shutdownOnce sync.Once
 
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
@@ -380,7 +385,7 @@ func (pm *MultiPoolerManager) Open() {
 			// Broadcast postgres health transitions so orchestrators learn
 			// about changes immediately without waiting for the next 30-second
 			// heartbeat. This is especially important for:
-			//   - postgres going down: allows PrimaryIsDeadAnalyzer to detect failure promptly
+			//   - postgres going down: allows LeaderIsDeadAnalyzer to detect failure promptly
 			//   - postgres coming back up: allows FixReplication to see IsInitialized=true quickly
 			if !postgresStateEqual(newState, prevState) {
 				pm.logger.InfoContext(ctx, "MonitorPostgres: postgres state changed, broadcasting health",
@@ -1338,7 +1343,7 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 // is accepting connections. Both conditions are required: pg_is_in_recovery()=false
 // confirms the WAL-level promotion, and postgres_ready=true confirms clients can
 // connect. Clearing promotionInProgress only when both are true ensures multiorch's
-// PrimaryIsDeadAnalyzer suppression window matches the full visibility gap.
+// LeaderIsDeadAnalyzer suppression window matches the full visibility gap.
 func (pm *MultiPoolerManager) waitForPromotionComplete(ctx context.Context) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -1475,6 +1480,23 @@ func (pm *MultiPoolerManager) Start(senv *servenv.ServEnv) {
 		pm.registerGRPCServices()
 		pm.logger.Info("MultiPoolerManager gRPC services registered")
 		return nil
+	})
+
+	// OnTermSync: signal graceful shutdown via the health stream so multiorch can
+	// orchestrate a controlled failover before postgres stops.
+	//
+	// PRIMARY path: signal STOPPING (multiorch will call EmergencyDemote, which stops
+	// postgres). Wait up to 45 s for postgres to stop; stop it ourselves on timeout
+	// so the process always exits cleanly.
+	//
+	// REPLICA path: stop postgres directly — no failover coordination needed.
+	//
+	// If the Shutdown RPC already called performGracefulShutdown, the sync.Once
+	// makes this a no-op (postgres is already stopped before SIGTERM fires).
+	senv.OnTermSync(func() {
+		// pm.ctx may already be cancelled when OnTermSync fires. Detach so shutdown
+		// work is not skipped due to cancellation, while preserving trace context.
+		pm.performGracefulShutdown(ctxutil.Detach(pm.ctx))
 	})
 }
 
@@ -1725,10 +1747,14 @@ func (pm *MultiPoolerManager) determineRemedialAction(currentState postgresState
 
 	// Postgres is running: Check if pooler type needs adjustment
 	if currentState.postgresRunning {
-		if currentState.isPrimary && pm.getPoolerType() != clustermetadatapb.PoolerType_PRIMARY {
+		currentType := pm.getPoolerType()
+		// STOPPING is an intentional transient state set by OnTermSync to signal
+		// multiorch. Do not overwrite it — the monitor would otherwise race against
+		// the shutdown path and restore PRIMARY before EmergencyDemote can run.
+		if currentState.isPrimary && currentType != clustermetadatapb.PoolerType_PRIMARY && currentType != clustermetadatapb.PoolerType_STOPPING {
 			return remedialActionAdjustTypeToPrimary
 		}
-		if !currentState.isPrimary && pm.getPoolerType() == clustermetadatapb.PoolerType_PRIMARY {
+		if !currentState.isPrimary && currentType == clustermetadatapb.PoolerType_PRIMARY {
 			return remedialActionAdjustTypeToReplica
 		}
 		// Postgres is standby and type is already REPLICA, but check if the resignation

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -162,6 +162,13 @@ type MultiPoolerManager struct {
 	// SIGTERM and the Shutdown RPC race to trigger it.
 	shutdownOnce sync.Once
 
+	// demotedC is closed exactly once, when this pooler completes an emergency
+	// demotion (the local resignation signal). performGracefulShutdown selects on
+	// this so it can exit as soon as multiorch's EmergencyDemote returns, instead
+	// of waiting for the hard-stop timer.
+	demotedC    chan struct{}
+	demotedOnce sync.Once
+
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
 
@@ -270,6 +277,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		pgctldClient:           pgctldClient,
 		connPoolMgr:            connPoolMgr,
 		readyChan:              make(chan struct{}),
+		demotedC:               make(chan struct{}),
 		pgMonitor:              monitorRunner,
 		healthStreamer:         newHealthStreamer(logger, multiPooler.Id, multiPooler.TableGroup, multiPooler.Shard),
 		// We create a dummy context because some unit tests need them.

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -199,7 +199,7 @@ func (pm *MultiPoolerManager) executeRevoke(ctx context.Context, term int64, res
 		// This emergency demote path will remain for BeginTerm REVOKE actions.
 		pm.logger.InfoContext(ctx, "Revoking primary", "term", term)
 		drainTimeout := 5 * time.Second
-		demoteResp, err := pm.emergencyDemoteLocked(ctx, term, drainTimeout)
+		demoteResp, err := pm.emergencyDemoteLocked(ctx, term, drainTimeout, true)
 		if err != nil {
 			return mterrors.Wrap(err, "failed to demote primary during revoke")
 		}
@@ -474,7 +474,7 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 	if isPrimary {
 		pm.logger.InfoContext(ctx, "Recruiting primary: demoting and restarting as standby",
 			"revoked_below_term", revokedBelowTerm)
-		if _, err := pm.emergencyDemoteLocked(ctx, revokedBelowTerm, recruitDrainTimeout); err != nil {
+		if _, err := pm.emergencyDemoteLocked(ctx, revokedBelowTerm, recruitDrainTimeout, true); err != nil {
 			eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
 			return nil, mterrors.Wrap(err, "failed to demote primary during recruit")
 		}

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -467,6 +467,19 @@ func TestDetermineRemedialAction(t *testing.T) {
 			expectedAction:     remedialActionNone,
 		},
 		{
+			// STOPPING is intentional: OnTermSync set it so multiorch can call EmergencyDemote.
+			// The monitor must not overwrite it back to PRIMARY even though postgres is still
+			// running as primary — doing so would block the graceful-shutdown path.
+			name: "postgres_ready_primary_type_is_stopping_no_action",
+			state: postgresState{
+				pgctldAvailable: true,
+				postgresRunning: true,
+				isPrimary:       true,
+			},
+			poolerType:     clustermetadatapb.PoolerType_STOPPING,
+			expectedAction: remedialActionNone,
+		},
+		{
 			name: "postgres_stopped_start",
 			state: postgresState{
 				pgctldAvailable: true,

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -822,7 +822,7 @@ func (pm *MultiPoolerManager) ChangeType(ctx context.Context, poolerType string)
 // - By orchestrator when fixing a broken shard.
 // - When performing a Planned demotion.
 // - When receiving a SIGTERM and the pooler needs to shutdown.
-func (pm *MultiPoolerManager) EmergencyDemote(ctx context.Context, consensusTerm int64, drainTimeout time.Duration, force bool) (_ *multipoolermanagerdatapb.EmergencyDemoteResponse, retErr error) {
+func (pm *MultiPoolerManager) EmergencyDemote(ctx context.Context, consensusTerm int64, drainTimeout time.Duration, force bool, restartServerAsStandby bool) (_ *multipoolermanagerdatapb.EmergencyDemoteResponse, retErr error) {
 	if err := pm.checkReady(); err != nil {
 		return nil, err
 	}
@@ -853,7 +853,7 @@ func (pm *MultiPoolerManager) EmergencyDemote(ctx context.Context, consensusTerm
 	}()
 
 	// Perform the actual demotion
-	resp, err := pm.emergencyDemoteLocked(ctx, consensusTerm, drainTimeout)
+	resp, err := pm.emergencyDemoteLocked(ctx, consensusTerm, drainTimeout, restartServerAsStandby)
 	if err != nil {
 		return nil, err
 	}
@@ -880,7 +880,7 @@ func (pm *MultiPoolerManager) EmergencyDemote(ctx context.Context, consensusTerm
 // MultiOrch will try to contact all nodes in the cohort.
 // In the case that the dead primary received the RPC, it should just
 // shut down itself.
-func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consensusTerm int64, drainTimeout time.Duration) (*multipoolermanagerdatapb.EmergencyDemoteResponse, error) {
+func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consensusTerm int64, drainTimeout time.Duration, restartServerAsStandby bool) (*multipoolermanagerdatapb.EmergencyDemoteResponse, error) {
 	// Verify action lock is held
 	if err := AssertActionLockHeld(ctx); err != nil {
 		return nil, err
@@ -949,18 +949,27 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 		pm.broadcastHealth()
 	}
 
-	// Restart PostgreSQL as standby. Unlike the old stop-only path, this keeps
-	// the node in the cluster as a replication target, avoiding timeline divergence
-	// in most cases. The coordinator still uses pg_rewind for nodes that diverged.
-	if err := pm.restartPostgresAsStandby(ctx, state); err != nil {
-		return nil, err
+	// Signal local listeners (the graceful-shutdown goroutine) that demotion has
+	// completed. Closed at most once per manager lifetime; subsequent demote calls
+	// are no-ops on the channel.
+	pm.demotedOnce.Do(func() { close(pm.demotedC) })
+
+	// Restart PostgreSQL as standby if requested.
+	//
+	// Unlike the old stop-only path, this keeps the node in the cluster as a
+	// replication target, avoiding timeline divergence in most cases. The
+	// coordinator still uses pg_rewind for nodes that diverged.
+	if restartServerAsStandby {
+		if err := pm.restartPostgresAsStandby(ctx, state); err != nil {
+			return nil, err
+		}
+
+		pm.healthStreamer.UpdateLeaderObservation(nil)
+
+		// Suppress the postgres monitor until a rewind completes; the monitor would
+		// otherwise restart postgres on this demoted node.
+		pm.rewindPending.Store(true)
 	}
-
-	pm.healthStreamer.UpdateLeaderObservation(nil)
-
-	// Suppress the postgres monitor until a rewind completes; the monitor would
-	// otherwise restart postgres on this demoted node.
-	pm.rewindPending.Store(true)
 
 	pm.logger.InfoContext(ctx, "Demote completed successfully",
 		"final_lsn", finalLSN,
@@ -968,9 +977,10 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 		"connections_terminated", connectionsTerminated)
 
 	return &multipoolermanagerdatapb.EmergencyDemoteResponse{
-		WasAlreadyDemoted:     false,
-		LsnPosition:           finalLSN,
-		ConnectionsTerminated: connectionsTerminated,
+		WasAlreadyDemoted:        false,
+		LsnPosition:              finalLSN,
+		ConnectionsTerminated:    connectionsTerminated,
+		ServerRestartedAsStandby: restartServerAsStandby,
 	}, nil
 }
 

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -318,7 +318,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 			name:       "EmergencyDemote times out when lock is held",
 			poolerType: clustermetadatapb.PoolerType_PRIMARY,
 			callMethod: func(ctx context.Context) error {
-				_, err := manager.EmergencyDemote(ctx, 1, 5*time.Second, false)
+				_, err := manager.EmergencyDemote(ctx, 1, 5*time.Second, false, true)
 				return err
 			},
 		},

--- a/go/services/multipooler/manager/rpc_shutdown.go
+++ b/go/services/multipooler/manager/rpc_shutdown.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"syscall"
+
+	"github.com/multigres/multigres/go/tools/ctxutil"
+)
+
+// InitiateGracefulShutdown runs the graceful shutdown sequence and then sends
+// SIGTERM to trigger the normal servenv exit path. Both steps happen in a
+// goroutine so the RPC response is returned to the caller first.
+//
+// performGracefulShutdown is protected by sync.Once: if OnTermSync fires
+// concurrently (because SIGTERM arrives before performGracefulShutdown
+// completes), the second call is a no-op.
+func (pm *MultiPoolerManager) InitiateGracefulShutdown(ctx context.Context, attr slog.Attr) {
+	pm.logger.InfoContext(ctx, "Shutdown RPC received. Initiating graceful shutdown", attr)
+	go func() {
+		pm.performGracefulShutdown(ctxutil.Detach(ctx))
+		if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+			// Kill(self, SIGTERM) should never fail in practice. Panic so the
+			// process terminates rather than staying alive in an unexpected state.
+			panic("Shutdown RPC: failed to send SIGTERM to self: " + err.Error())
+		}
+	}()
+}

--- a/go/services/multipooler/manager/shutdown.go
+++ b/go/services/multipooler/manager/shutdown.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/multigres/multigres/go/common/constants"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+)
+
+// performGracefulShutdown runs the graceful shutdown sequence exactly once (sync.Once).
+// It may be called concurrently from OnTermSync and from InitiateGracefulShutdown; the
+// second caller returns immediately without re-running the shutdown logic.
+//
+// PRIMARY path: signal STOPPING so multiorch can orchestrate EmergencyDemote, then wait
+// for postgres to stop (or fall back to stopping it directly on timeout).
+// REPLICA path: stop postgres directly — no failover coordination needed.
+func (pm *MultiPoolerManager) performGracefulShutdown(ctx context.Context) {
+	pm.shutdownOnce.Do(func() {
+		poolerType := pm.getPoolerType()
+		pm.logger.InfoContext(ctx, "graceful shutdown: beginning", "pooler_type", poolerType.String())
+		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
+			if msg, attr := pm.awaitEmergencyDemote(ctx); msg != "" {
+				pm.logger.WarnContext(ctx, fmt.Sprintf("graceful shutdown: %s; stopping postgres directly", msg), attr)
+			}
+		}
+		pm.stopPostgresDirectly(ctx)
+	})
+}
+
+// awaitEmergencyDemote is called on SIGTERM when this pooler is a PRIMARY.
+// It signals PoolerType_STOPPING via the health stream so multiorch can orchestrate
+// a controlled failover (EmergencyDemote + AppointLeader), then waits for postgres
+// to stop. The caller is responsible for stopping postgres afterwards (directly on
+// timeout or when the signal fails).
+func (pm *MultiPoolerManager) awaitEmergencyDemote(ctx context.Context) (string, slog.Attr) {
+	// Signal STOPPING so the health stream snapshot delivered to multiorch
+	// triggers LeaderIsStoppingAnalyzer → ShutdownPrimaryAction → EmergencyDemote.
+	if err := pm.servingState.SetState(ctx,
+		clustermetadatapb.PoolerType_STOPPING,
+		clustermetadatapb.PoolerServingStatus_NOT_SERVING,
+	); err != nil {
+		return "failed to signal STOPPING", slog.String("error", err.Error())
+	}
+	pm.logger.InfoContext(ctx, "OnTermSync: signalled STOPPING; waiting for multiorch to call EmergencyDemote",
+		"timeout", constants.PrimaryShutdownSignalTimeout)
+
+	// Poll until postgres stops (EmergencyDemote will do this) or timeout.
+	deadline := time.Now().Add(constants.PrimaryShutdownSignalTimeout)
+	for time.Now().Before(deadline) {
+		if !pm.isPostgresRunning(ctx) {
+			// EmergencyDemote already stopped postgres — caller's stopPostgresDirectly
+			// will be a harmless no-op.
+			return "", slog.Attr{}
+		}
+		select {
+		case <-ctx.Done():
+			return "context cancelled", slog.Attr{}
+		case <-time.After(constants.PrimaryShutdownPollInterval):
+		}
+	}
+
+	return "timed out waiting for EmergencyDemote",
+		slog.Duration("timeout", constants.PrimaryShutdownSignalTimeout)
+}
+
+// stopPostgresDirectly asks pgctld to stop postgres with a "fast" shutdown.
+// Errors are logged but not returned — callers proceed regardless.
+func (pm *MultiPoolerManager) stopPostgresDirectly(ctx context.Context) {
+	if pm.pgctldClient == nil {
+		pm.logger.WarnContext(ctx, "OnTermSync: pgctld client not available; cannot stop postgres")
+		return
+	}
+	if _, err := pm.pgctldClient.Stop(ctx, &pgctldpb.StopRequest{Mode: "fast"}); err != nil {
+		pm.logger.WarnContext(ctx, "OnTermSync: failed to stop postgres", "error", err)
+		return
+	}
+	pm.logger.InfoContext(ctx, "OnTermSync: postgres stopped")
+}

--- a/go/services/multipooler/manager/shutdown.go
+++ b/go/services/multipooler/manager/shutdown.go
@@ -16,8 +16,6 @@ package manager
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/multigres/multigres/go/common/constants"
@@ -30,68 +28,69 @@ import (
 // It may be called concurrently from OnTermSync and from InitiateGracefulShutdown; the
 // second caller returns immediately without re-running the shutdown logic.
 //
-// PRIMARY path: signal STOPPING so multiorch can orchestrate EmergencyDemote, then wait
-// for postgres to stop (or fall back to stopping it directly on timeout).
+// PRIMARY path: signal STOPPING via the health stream so multiorch can run the
+// LeaderIsStopping recovery (EmergencyDemote + AppointLeader). Wait until either
+// EmergencyDemote returns locally (demotedC closed) or the hard-stop timer fires,
+// then stop postgres directly.
+//
 // REPLICA path: stop postgres directly — no failover coordination needed.
 func (pm *MultiPoolerManager) performGracefulShutdown(ctx context.Context) {
 	pm.shutdownOnce.Do(func() {
 		poolerType := pm.getPoolerType()
 		pm.logger.InfoContext(ctx, "graceful shutdown: beginning", "pooler_type", poolerType.String())
 		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-			if msg, attr := pm.awaitEmergencyDemote(ctx); msg != "" {
-				pm.logger.WarnContext(ctx, fmt.Sprintf("graceful shutdown: %s; stopping postgres directly", msg), attr)
-			}
+			pm.awaitPrimaryDemotion(ctx)
 		}
 		pm.stopPostgresDirectly(ctx)
 	})
 }
 
-// awaitEmergencyDemote is called on SIGTERM when this pooler is a PRIMARY.
+// awaitPrimaryDemotion is called on graceful shutdown when this pooler is a PRIMARY.
 // It signals PoolerType_STOPPING via the health stream so multiorch can orchestrate
-// a controlled failover (EmergencyDemote + AppointLeader), then waits for postgres
-// to stop. The caller is responsible for stopping postgres afterwards (directly on
-// timeout or when the signal fails).
-func (pm *MultiPoolerManager) awaitEmergencyDemote(ctx context.Context) (string, slog.Attr) {
-	// Signal STOPPING so the health stream snapshot delivered to multiorch
+// the controlled failover (EmergencyDemote + AppointLeader), then waits for either
+// the demotion to complete locally or the hard-stop timer to fire — whichever comes
+// first. The caller stops postgres afterwards in either case.
+//
+// In the happy path (multiorch is healthy, drain is fast), demotedC is closed at
+// the end of emergencyDemoteLocked and we exit within drain-time + small margin.
+// If multiorch is slow/dead/partitioned, the timer bounds the wait; postgres is
+// stopped, the health stream closes when this process exits, and multiorch's
+// LeaderIsDeadAnalyzer takes over to elect a new primary via the dead-leader path.
+func (pm *MultiPoolerManager) awaitPrimaryDemotion(ctx context.Context) {
+	// Signal STOPPING so the next health-stream snapshot delivered to multiorch
 	// triggers LeaderIsStoppingAnalyzer → ShutdownPrimaryAction → EmergencyDemote.
 	if err := pm.servingState.SetState(ctx,
 		clustermetadatapb.PoolerType_STOPPING,
 		clustermetadatapb.PoolerServingStatus_NOT_SERVING,
 	); err != nil {
-		return "failed to signal STOPPING", slog.String("error", err.Error())
+		pm.logger.WarnContext(ctx, "graceful shutdown: failed to signal STOPPING; stopping postgres directly",
+			"error", err)
+		return
 	}
-	pm.logger.InfoContext(ctx, "OnTermSync: signalled STOPPING; waiting for multiorch to call EmergencyDemote",
+	pm.logger.InfoContext(ctx, "graceful shutdown: signalled STOPPING; waiting for EmergencyDemote",
 		"timeout", constants.PrimaryShutdownSignalTimeout)
 
-	// Poll until postgres stops (EmergencyDemote will do this) or timeout.
-	deadline := time.Now().Add(constants.PrimaryShutdownSignalTimeout)
-	for time.Now().Before(deadline) {
-		if !pm.isPostgresRunning(ctx) {
-			// EmergencyDemote already stopped postgres — caller's stopPostgresDirectly
-			// will be a harmless no-op.
-			return "", slog.Attr{}
-		}
-		select {
-		case <-ctx.Done():
-			return "context cancelled", slog.Attr{}
-		case <-time.After(constants.PrimaryShutdownPollInterval):
-		}
+	select {
+	case <-pm.demotedC:
+		pm.logger.InfoContext(ctx, "graceful shutdown: EmergencyDemote completed locally")
+	case <-time.After(constants.PrimaryShutdownSignalTimeout):
+		pm.logger.WarnContext(ctx, "graceful shutdown: timed out waiting for EmergencyDemote",
+			"timeout", constants.PrimaryShutdownSignalTimeout)
+	case <-ctx.Done():
+		pm.logger.WarnContext(ctx, "graceful shutdown: context cancelled while waiting for EmergencyDemote")
 	}
-
-	return "timed out waiting for EmergencyDemote",
-		slog.Duration("timeout", constants.PrimaryShutdownSignalTimeout)
 }
 
 // stopPostgresDirectly asks pgctld to stop postgres with a "fast" shutdown.
 // Errors are logged but not returned — callers proceed regardless.
 func (pm *MultiPoolerManager) stopPostgresDirectly(ctx context.Context) {
 	if pm.pgctldClient == nil {
-		pm.logger.WarnContext(ctx, "OnTermSync: pgctld client not available; cannot stop postgres")
+		pm.logger.WarnContext(ctx, "graceful shutdown: pgctld client not available; cannot stop postgres")
 		return
 	}
 	if _, err := pm.pgctldClient.Stop(ctx, &pgctldpb.StopRequest{Mode: "fast"}); err != nil {
-		pm.logger.WarnContext(ctx, "OnTermSync: failed to stop postgres", "error", err)
+		pm.logger.WarnContext(ctx, "graceful shutdown: failed to stop postgres", "error", err)
 		return
 	}
-	pm.logger.InfoContext(ctx, "OnTermSync: postgres stopped")
+	pm.logger.InfoContext(ctx, "graceful shutdown: postgres stopped")
 }

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -90,6 +90,7 @@ type testPortConfig struct {
 	// Global services (shared across zones)
 	EtcdClientPort     int
 	EtcdPeerPort       int
+	EtcdMetricsPort    int
 	MultiadminHTTPPort int
 	MultiadminGRPCPort int
 
@@ -102,6 +103,7 @@ func getTestPortConfig(t *testing.T, numZones int) *testPortConfig {
 	config := &testPortConfig{
 		EtcdClientPort:     utils.GetFreePort(t),
 		EtcdPeerPort:       utils.GetFreePort(t),
+		EtcdMetricsPort:    utils.GetFreePort(t),
 		MultiadminHTTPPort: utils.GetFreePort(t),
 		MultiadminGRPCPort: utils.GetFreePort(t),
 		Zones:              make([]zonePortConfig, numZones),
@@ -202,10 +204,11 @@ func createTestConfigWithDatabase(tempDir string, portConfig *testPortConfig, db
 		RootWorkingDir: tempDir,
 		DefaultDbName:  dbName,
 		Etcd: local.EtcdConfig{
-			Version:  "3.5.9",
-			DataDir:  filepath.Join(tempDir, "data", "etcd-data"),
-			Port:     portConfig.EtcdClientPort,
-			PeerPort: portConfig.EtcdPeerPort,
+			Version:     "3.5.9",
+			DataDir:     filepath.Join(tempDir, "data", "etcd-data"),
+			Port:        portConfig.EtcdClientPort,
+			PeerPort:    portConfig.EtcdPeerPort,
+			MetricsPort: portConfig.EtcdMetricsPort,
 		},
 		Topology: local.TopologyConfig{
 			GlobalRootPath: "/multigres/global",

--- a/go/test/endtoend/multipooler/rpc_consensus_test.go
+++ b/go/test/endtoend/multipooler/rpc_consensus_test.go
@@ -563,8 +563,9 @@ func TestBeginTermEmergencyDemotesPrimary(t *testing.T) {
 		// Now demote the new primary (standby) and promote original primary back
 		// Use Force=true since we're testing BeginTerm auto-demote, not term validation
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		_, err = standbyConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.NoError(t, err, "Demote should succeed on new primary")

--- a/go/test/endtoend/multipooler/rpc_manager_promotion_demotion_test.go
+++ b/go/test/endtoend/multipooler/rpc_manager_promotion_demotion_test.go
@@ -92,9 +92,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Perform demotion with Force=true (testing demote functionality, not term validation)
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: primaryTerm,
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          primaryTerm,
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		demoteResp, err := primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.NoError(t, err, "Demote should succeed")
@@ -196,9 +197,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Demote the new primary (original standby) with Force=true
 		demoteReq2 := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		demoteResp2, err := standbyConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq2)
 		require.NoError(t, err, "Demote should succeed on new primary")
@@ -267,9 +269,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// First demotion with Force=true (testing demote behavior, not term validation)
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		demoteResp1, err := primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 20*time.Second), demoteReq)
 		require.NoError(t, err, "First demote should succeed")
@@ -313,9 +316,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// First demote the primary so we can test promote idempotency
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		_, err = primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.NoError(t, err, "Demote should succeed")
@@ -391,9 +395,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 		}
 
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: staleTerm, // Less than current term
-			DrainTimeout:  nil,
-			Force:         false,
+			ConsensusTerm:          staleTerm, // Less than current term
+			DrainTimeout:           nil,
+			Force:                  false,
+			RestartServerAsStandby: true,
 		}
 		_, err = primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.Error(t, err, "EmergencyDemote with stale term should fail")
@@ -423,9 +428,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 		// First demote the primary so we can test promote term validation
 		// Use Force=true since we're testing promote validation, not demote
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		_, err = primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.NoError(t, err, "Demote should succeed")
@@ -490,9 +496,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 
 		// Demote primary first - use Force=true since we're testing LSN validation, not term
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		_, err = primaryConsensusClient.EmergencyDemote(utils.WithTimeout(t, 10*time.Second), demoteReq)
 		require.NoError(t, err)
@@ -562,9 +569,10 @@ func TestEmergencyDemoteAndPromote(t *testing.T) {
 		// Use Force=true since we're testing error behavior for demote on standby,
 		// not term validation. The demote should fail because PostgreSQL is in standby mode.
 		demoteReq := &multipoolermanagerdatapb.EmergencyDemoteRequest{
-			ConsensusTerm: 0, // Ignored when Force=true
-			DrainTimeout:  nil,
-			Force:         true,
+			ConsensusTerm:          0, // Ignored when Force=true
+			DrainTimeout:           nil,
+			Force:                  true,
+			RestartServerAsStandby: true,
 		}
 		_, err = standbyConsensusClient.EmergencyDemote(context.Background(), demoteReq)
 		require.Error(t, err, "EmergencyDemote should fail on standby")

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -261,8 +261,17 @@ enum PoolerType {
   // REPLICA replicates from leader. It is used to read only traffic
   REPLICA = 2;
 
-  // DRAINED is used for poolers that are temporarily removed from serving traffic
+  // DRAINED is used for poolers that are no longer serving traffic and should
+  // be removed from the cluster. This is set when a pooler is permanently
+  // removed from consideration, for example, if pg_rewind fails and the server
+  // can no longer be part of the cluster. Analyzers skip DRAINED poolers to
+  // prevent spurious recovery attempts.
   DRAINED = 3;
+
+  // STOPPING is used for a primary that is in the process of being gracefully
+  // shut down. The primary has been demoted and a new primary is being elected.
+  // Analyzers skip STOPPING poolers to prevent spurious recovery attempts.
+  STOPPING = 4;
 }
 
 // PoolerServingStatus represents the serving status of the given MultiPooler.

--- a/proto/multiorchservice.proto
+++ b/proto/multiorchservice.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package multiorch;
 
 import "clustermetadata.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/multigres/multigres/go/pb/multiorch";
@@ -49,6 +50,36 @@ service MultiOrchService {
   // - Returns when either: (1) no problems remain, or (2) context times out
   // - If recovery is disabled, this temporarily enables it during this operation
   rpc TriggerRecoveryNow(TriggerRecoveryNowRequest) returns (TriggerRecoveryNowResponse) {}
+
+  // ShutdownPrimary orchestrates a planned primary switchover.
+  //
+  // Normally called by the primary multipooler during graceful shutdown on the
+  // reception of a SIGTERM signal, but this is not a requirement.
+  //
+  // Sequence:
+  //   1. Validates that the pooler is currently PRIMARY or STOPPING.
+  //   2. Reads the primary's current WAL LSN. The multipooler has already set
+  //      PoolerType_STOPPING on the health stream before calling this RPC,
+  //      which causes the gateway to stop routing new writes — so this LSN is
+  //      a stable target for standby catchup.
+  //   3. Waits for all standbys to replay to that LSN. The primary is still
+  //      running and streaming WAL during this window. If the timeout expires
+  //      the switchover proceeds anyway to avoid hanging indefinitely.
+  //   4. Calls EmergencyDemote to stop the primary. Standbys have caught up
+  //      (or timed out), so there are few or no active writes left to drain.
+  //      Then marks the old primary as DRAINED in topology so that the
+  //      topology never shows two PRIMARY nodes simultaneously and the node
+  //      is excluded from future elections.
+  //   5. Builds the election cohort from shard poolers, excluding STOPPING and
+  //      DRAINED poolers. This prevents the old primary from being re-elected
+  //      and prevents irreparable replicas from becoming candidates.
+  //   6. Elects a new primary via AppointLeader.
+  //   7. Polls shard poolers to confirm the new primary and returns its ID.
+  //
+  // Returns once a new primary has been elected. The caller can then shut down
+  // PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed
+  // with shutdown regardless.
+  rpc ShutdownPrimary(ShutdownPrimaryRequest) returns (ShutdownPrimaryResponse) {}
 }
 
 message ShardStatusRequest {
@@ -126,4 +157,33 @@ message TriggerRecoveryNowRequest {
 message TriggerRecoveryNowResponse {
   // remaining_problem_codes lists problem codes still detected (e.g., "REPLICA_NOT_REPLICATING")
   repeated string remaining_problem_codes = 4;
+}
+
+message ShutdownPrimaryRequest {
+  // Shard to perform the switchover on
+  string database = 1;
+  string table_group = 2;
+  string shard = 3;
+
+  // Identity of the primary requesting shutdown.
+  // Used to validate that the caller is the current primary and to exclude
+  // it from the new election cohort.
+  clustermetadata.ID primary_id = 4;
+
+  // How long to wait for in-flight write transactions to drain on the primary.
+  // Required: must be a positive duration.
+  google.protobuf.Duration drain_timeout = 5;
+
+  // How long to wait for standbys to replay to the primary's final LSN.
+  // Required: must be a positive duration.
+  google.protobuf.Duration standby_catchup_timeout = 6;
+
+  // Human-readable reason for the shutdown (e.g. "SIGTERM", "operator request").
+  // Used for logging and audit trails only.
+  string reason = 7;
+}
+
+message ShutdownPrimaryResponse {
+  // The newly elected primary after the switchover.
+  clustermetadata.ID new_primary_id = 1;
 }

--- a/proto/multiorchservice.proto
+++ b/proto/multiorchservice.proto
@@ -58,23 +58,23 @@ service MultiOrchService {
   //
   // Sequence:
   //   1. Validates that the pooler is currently PRIMARY or STOPPING.
-  //   2. Reads the primary's current WAL LSN. The multipooler has already set
-  //      PoolerType_STOPPING on the health stream before calling this RPC,
-  //      which causes the gateway to stop routing new writes — so this LSN is
-  //      a stable target for standby catchup.
-  //   3. Waits for all standbys to replay to that LSN. The primary is still
-  //      running and streaming WAL during this window. If the timeout expires
-  //      the switchover proceeds anyway to avoid hanging indefinitely.
-  //   4. Calls EmergencyDemote to stop the primary. Standbys have caught up
-  //      (or timed out), so there are few or no active writes left to drain.
-  //      Then marks the old primary as DRAINED in topology so that the
-  //      topology never shows two PRIMARY nodes simultaneously and the node
-  //      is excluded from future elections.
-  //   5. Builds the election cohort from shard poolers, excluding STOPPING and
-  //      DRAINED poolers. This prevents the old primary from being re-elected
-  //      and prevents irreparable replicas from becoming candidates.
-  //   6. Elects a new primary via AppointLeader.
-  //   7. Polls shard poolers to confirm the new primary and returns its ID.
+  //   2. Calls EmergencyDemote with restart_server_as_standby=false. This
+  //      drains in-flight writes (with sync replication, each commit waits
+  //      for sync standby ACK before returning, so committed WAL is durable
+  //      on sync standbys when drain completes), captures the final LSN, and
+  //      signals voluntary resignation. PostgreSQL is left running in
+  //      NOT_SERVING state — the caller stops it after the RPC returns.
+  //   2b. Marks the old primary as DRAINED in topology so getpoolers never
+  //      shows two PRIMARY nodes simultaneously and the node is excluded
+  //      from future elections.
+  //   3. Builds the election cohort from shard poolers, excluding STOPPING
+  //      and DRAINED poolers. This prevents the old primary from being
+  //      re-elected and prevents irreparable replicas from becoming
+  //      candidates.
+  //   4. Elects a new primary via AppointLeader. Recruit returns each
+  //      candidate's last_receive_lsn and Propose makes the chosen leader
+  //      replay any received-but-unapplied WAL before opening for writes.
+  //   5. Polls shard poolers to confirm the new primary and returns its ID.
   //
   // Returns once a new primary has been elected. The caller can then shut down
   // PostgreSQL cleanly. Errors are non-fatal: the caller should log and proceed
@@ -173,10 +173,6 @@ message ShutdownPrimaryRequest {
   // How long to wait for in-flight write transactions to drain on the primary.
   // Required: must be a positive duration.
   google.protobuf.Duration drain_timeout = 5;
-
-  // How long to wait for standbys to replay to the primary's final LSN.
-  // Required: must be a positive duration.
-  google.protobuf.Duration standby_catchup_timeout = 6;
 
   // Human-readable reason for the shutdown (e.g. "SIGTERM", "operator request").
   // Used for logging and audit trails only.

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -737,3 +737,18 @@ message SetPostgresRestartsEnabledRequest {
 message SetPostgresRestartsEnabledResponse {
   // Empty - success indicated by no error
 }
+
+// ShutdownRequest requests a graceful pooler shutdown identical to SIGTERM.
+// The pooler signals STOPPING (if PRIMARY), waits for multiorch to orchestrate
+// failover, then exits the process.
+message ShutdownRequest {
+  // Human-readable reason for the shutdown (e.g. "operator request", "rolling restart").
+  // Used for logging and audit trails only.
+  string reason = 1;
+}
+
+// ShutdownResponse confirms that the graceful shutdown sequence has been initiated.
+// The pooler process will exit shortly after this response is delivered.
+message ShutdownResponse {
+  // Empty - success indicated by no error
+}

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -390,6 +390,13 @@ message EmergencyDemoteRequest {
 
   // Force the operation even if term validation fails
   bool force = 3;
+
+  // If true, restart postgres as standby after demotion so the node stays
+  // in the cluster as a replication target. If false, postgres is left
+  // running as primary in NOT_SERVING state — the caller is responsible for
+  // stopping it (used by ShutdownPrimary, where the multipooler is exiting
+  // and will stop postgres directly).
+  bool restart_server_as_standby = 4;
 }
 
 message EmergencyDemoteResponse {
@@ -401,6 +408,11 @@ message EmergencyDemoteResponse {
 
   // Number of connections that were terminated
   int32 connections_terminated = 4;
+
+  // Whether postgres was restarted as a standby. Mirrors the request's
+  // restart_server flag — false means postgres is left running as primary
+  // in NOT_SERVING state and the caller must stop it.
+  bool server_restarted_as_standby = 5;
 }
 
 // DemoteStalePrimary demotes a stale primary that came back online after failover.

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -83,6 +83,19 @@ service MultiPoolerManager {
   rpc SetPostgresRestartsEnabled(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
       returns (multipoolermanagerdata.SetPostgresRestartsEnabledResponse);
 
+  // Shutdown initiates a graceful pooler shutdown identical to receiving SIGTERM.
+  //
+  // For PRIMARY poolers: signals PoolerType_STOPPING so multiorch can orchestrate
+  // a controlled failover (EmergencyDemote + AppointLeader) before the process
+  // exits. The pooler waits up to 45 s for multiorch to call EmergencyDemote and
+  // stop postgres; it stops postgres directly on timeout.
+  //
+  // For REPLICA poolers: stops postgres directly and exits.
+  //
+  // The response is delivered before the shutdown sequence starts, so callers
+  // will always receive a response. The process exit happens asynchronously.
+  rpc Shutdown(multipoolermanagerdata.ShutdownRequest) returns (multipoolermanagerdata.ShutdownResponse);
+
   // ManagerHealthStream is a bidirectional health stream between orchestrator
   // and pooler.
   //


### PR DESCRIPTION
On SIGTERM, a PRIMARY multipooler now signals PoolerType_STOPPING via the health stream so multiorch can orchestrate a controlled failover (PrimaryIsStoppingAnalyzer → ShutdownPrimaryAction → EmergencyDemote + AppointLeader) before the process exits. It waits up to 45 s for postgres to stop and falls back to a direct stop on timeout. REPLICA poolers stop postgres directly with no failover coordination.

A new Shutdown RPC on MultiPoolerManager triggers the same sequence programmatically by sending SIGTERM to the process, reusing the existing OnTermSync handler with no code duplication.

Also fix a port collision in the localprovisioner integration test: etcd was launching with --listen-metrics-urls on client-port+2, colliding with the MultiadminHTTPPort allocation. EtcdMetricsPort is now allocated independently via the port pool server.

Closes MUL-36