### PR TITLE
refactor(consensus): derive primary_term from committed rule

### DIFF
--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -30,3 +30,14 @@ func IsPrimary(cs *clustermetadatapb.ConsensusStatus) bool {
 	}
 	return self.Cell == primary.Cell && self.Name == primary.Name
 }
+
+// PrimaryTerm returns the coordinator term of the pooler's current committed
+// rule if the pooler holds the primary role (per IsPrimary). Returns 0 when
+// the pooler is not the primary, when the consensus status is nil/empty, or
+// when the rule has no coordinator term.
+func PrimaryTerm(cs *clustermetadatapb.ConsensusStatus) int64 {
+	if !IsPrimary(cs) {
+		return 0
+	}
+	return cs.GetCurrentPosition().GetRule().GetRuleNumber().GetCoordinatorTerm()
+}

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -494,20 +494,14 @@ type StatusResponse struct {
 	Role PostgresRole `protobuf:"varint,9,opt,name=role,proto3,enum=consensusdata.PostgresRole" json:"role,omitempty"`
 	// Timeline information for divergence detection
 	TimelineInfo *TimelineInfo `protobuf:"bytes,10,opt,name=timeline_info,json=timelineInfo,proto3" json:"timeline_info,omitempty"`
-	// The term for which this multipooler was promoted to primary.
-	// Set during promotion (Promote).
-	// Preserved when consensus term increases (new elections).
-	// Cleared to 0 when demoted (DemoteStalePrimary) or restored from backup.
-	// 0 if never primary. For current primaries, must be non-zero.
-	PrimaryTerm int64 `protobuf:"varint,11,opt,name=primary_term,json=primaryTerm,proto3" json:"primary_term,omitempty"`
 	// The pooler's current consensus status: its term revocation, committed
 	// rule position, and highest known rule. Authoritative view of where this
 	// pooler stands in the distributed system.
-	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,12,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
+	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,11,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
 	// Best-effort operational fitness signals for this node. These signals are
 	// in-memory and may be absent after a process restart. Coordinators treat
 	// absence as "unknown," not "unfit."
-	AvailabilityStatus *clustermetadata.AvailabilityStatus `protobuf:"bytes,13,opt,name=availability_status,json=availabilityStatus,proto3" json:"availability_status,omitempty"`
+	AvailabilityStatus *clustermetadata.AvailabilityStatus `protobuf:"bytes,12,opt,name=availability_status,json=availabilityStatus,proto3" json:"availability_status,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -596,13 +590,6 @@ func (x *StatusResponse) GetTimelineInfo() *TimelineInfo {
 		return x.TimelineInfo
 	}
 	return nil
-}
-
-func (x *StatusResponse) GetPrimaryTerm() int64 {
-	if x != nil {
-		return x.PrimaryTerm
-	}
-	return 0
 }
 
 func (x *StatusResponse) GetConsensusStatus() *clustermetadata.ConsensusStatus {
@@ -694,7 +681,7 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x10consensus_status\x18\x05 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\">\n" +
 	"\rStatusRequest\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x03R\x04term\x12\x19\n" +
-	"\bshard_id\x18\x02 \x01(\tR\ashardId\"\x9c\x04\n" +
+	"\bshard_id\x18\x02 \x01(\tR\ashardId\"\xf9\x03\n" +
 	"\x0eStatusResponse\x12\x1b\n" +
 	"\tpooler_id\x18\x01 \x01(\tR\bpoolerId\x12!\n" +
 	"\fcurrent_term\x18\x02 \x01(\x03R\vcurrentTerm\x12=\n" +
@@ -706,10 +693,9 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x04cell\x18\a \x01(\tR\x04cell\x12/\n" +
 	"\x04role\x18\t \x01(\x0e2\x1b.consensusdata.PostgresRoleR\x04role\x12@\n" +
 	"\rtimeline_info\x18\n" +
-	" \x01(\v2\x1b.consensusdata.TimelineInfoR\ftimelineInfo\x12!\n" +
-	"\fprimary_term\x18\v \x01(\x03R\vprimaryTerm\x12K\n" +
-	"\x10consensus_status\x18\f \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\x12T\n" +
-	"\x13availability_status\x18\r \x01(\v2#.clustermetadata.AvailabilityStatusR\x12availabilityStatus\"/\n" +
+	" \x01(\v2\x1b.consensusdata.TimelineInfoR\ftimelineInfo\x12K\n" +
+	"\x10consensus_status\x18\v \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\x12T\n" +
+	"\x13availability_status\x18\f \x01(\v2#.clustermetadata.AvailabilityStatusR\x12availabilityStatus\"/\n" +
 	"\fTimelineInfo\x12\x1f\n" +
 	"\vtimeline_id\x18\x01 \x01(\x03R\n" +
 	"timelineId*s\n" +

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -1134,11 +1134,8 @@ type PrimaryStatus struct {
 	ConnectedFollowers []*clustermetadata.ID `protobuf:"bytes,3,rep,name=connected_followers,json=connectedFollowers,proto3" json:"connected_followers,omitempty"`
 	// Synchronous replication configuration (parsed from synchronous_standby_names and synchronous_commit)
 	SyncReplicationConfig *SynchronousReplicationConfiguration `protobuf:"bytes,4,opt,name=sync_replication_config,json=syncReplicationConfig,proto3" json:"sync_replication_config,omitempty"`
-	// The term for which this pooler was promoted to primary.
-	// Non-zero for current primaries. See ConsensusTerm.primary_term for full lifecycle details.
-	PrimaryTerm   int64 `protobuf:"varint,5,opt,name=primary_term,json=primaryTerm,proto3" json:"primary_term,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *PrimaryStatus) Reset() {
@@ -1197,13 +1194,6 @@ func (x *PrimaryStatus) GetSyncReplicationConfig() *SynchronousReplicationConfig
 		return x.SyncReplicationConfig
 	}
 	return nil
-}
-
-func (x *PrimaryStatus) GetPrimaryTerm() int64 {
-	if x != nil {
-		return x.PrimaryTerm
-	}
-	return 0
 }
 
 // Status provides unified status information that works for both PRIMARY and REPLICA poolers.
@@ -2588,13 +2578,7 @@ type ConsensusTerm struct {
 	// Timestamp of the last acceptance
 	LastAcceptanceTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=last_acceptance_time,json=lastAcceptanceTime,proto3" json:"last_acceptance_time,omitempty"`
 	// ID of the leader of the current term
-	LeaderId *clustermetadata.ID `protobuf:"bytes,4,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
-	// The term for which this pooler was promoted to primary.
-	// Set during promotion (Promote).
-	// Preserved when consensus term increases (new elections).
-	// Cleared to 0 when demoted (DemoteStalePrimary) or restored from backup.
-	// 0 if never primary.
-	PrimaryTerm   int64 `protobuf:"varint,5,opt,name=primary_term,json=primaryTerm,proto3" json:"primary_term,omitempty"`
+	LeaderId      *clustermetadata.ID `protobuf:"bytes,4,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2655,13 +2639,6 @@ func (x *ConsensusTerm) GetLeaderId() *clustermetadata.ID {
 		return x.LeaderId
 	}
 	return nil
-}
-
-func (x *ConsensusTerm) GetPrimaryTerm() int64 {
-	if x != nil {
-		return x.PrimaryTerm
-	}
-	return 0
 }
 
 // BackupRequest requests a backup
@@ -3523,13 +3500,12 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\bnum_sync\x18\x03 \x01(\x05R\anumSync\x124\n" +
 	"\vstandby_ids\x18\x04 \x03(\v2\x13.clustermetadata.IDR\n" +
 	"standbyIds\x12:\n" +
-	"\x19standby_application_names\x18\x05 \x03(\tR\x17standbyApplicationNames\"\x95\x02\n" +
+	"\x19standby_application_names\x18\x05 \x03(\tR\x17standbyApplicationNames\"\xf2\x01\n" +
 	"\rPrimaryStatus\x12\x10\n" +
 	"\x03lsn\x18\x01 \x01(\tR\x03lsn\x12\x14\n" +
 	"\x05ready\x18\x02 \x01(\bR\x05ready\x12D\n" +
 	"\x13connected_followers\x18\x03 \x03(\v2\x13.clustermetadata.IDR\x12connectedFollowers\x12s\n" +
-	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\x12!\n" +
-	"\fprimary_term\x18\x05 \x01(\x03R\vprimaryTerm\"\xaf\x06\n" +
+	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\"\xaf\x06\n" +
 	"\x06Status\x12<\n" +
 	"\vpooler_type\x18\x01 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
 	"poolerType\x12L\n" +
@@ -3616,14 +3592,13 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x0econsensus_term\x18\x04 \x01(\x03R\rconsensusTerm\x12\x14\n" +
 	"\x05force\x18\x05 \x01(\bR\x05force\x12:\n" +
 	"\x0ecoordinator_id\x18\x06 \x01(\v2\x13.clustermetadata.IDR\rcoordinatorId\"&\n" +
-	"$UpdateSynchronousStandbyListResponse\"\xb2\x02\n" +
+	"$UpdateSynchronousStandbyListResponse\"\x8f\x02\n" +
 	"\rConsensusTerm\x12\x1f\n" +
 	"\vterm_number\x18\x01 \x01(\x03R\n" +
 	"termNumber\x12]\n" +
 	"!accepted_term_from_coordinator_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\x1dacceptedTermFromCoordinatorId\x12L\n" +
 	"\x14last_acceptance_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x12lastAcceptanceTime\x120\n" +
-	"\tleader_id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\bleaderId\x12!\n" +
-	"\fprimary_term\x18\x05 \x01(\x03R\vprimaryTerm\"\xf1\x01\n" +
+	"\tleader_id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\bleaderId\"\xf1\x01\n" +
 	"\rBackupRequest\x12#\n" +
 	"\rforce_primary\x18\x01 \x01(\bR\fforcePrimary\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x15\n" +

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/timeouts"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/tools/pgutil"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
@@ -95,12 +96,19 @@ func (c *Coordinator) BeginTerm(ctx context.Context, shardID string, cohort []*m
 		return nil, nil, 0, mterrors.Wrapf(err, "candidacy validation failed for shard %s", shardID)
 	}
 
-	// Separate candidate from standbys
+	// Resigned poolers are excluded: they may still carry a stale primary rule
+	// that needs pg_rewind, which the stale-primary analyzer owns.
 	var standbys []*multiorchdatapb.PoolerHealthState
 	for _, pooler := range recruitedPoolers {
-		if pooler.MultiPooler.Id.Name != candidate.MultiPooler.Id.Name {
-			standbys = append(standbys, pooler)
+		if pooler.MultiPooler.Id.Name == candidate.MultiPooler.Id.Name {
+			continue
 		}
+		if types.PrimaryNeedsReplacement(pooler) {
+			c.logger.InfoContext(ctx, "Skipping resigned pooler from standbys",
+				"pooler", pooler.MultiPooler.Id.Name)
+			continue
+		}
+		standbys = append(standbys, pooler)
 	}
 
 	return candidate, standbys, proposedTerm, nil
@@ -226,7 +234,7 @@ func (c *Coordinator) selectCandidate(ctx context.Context, recruited []recruitme
 		// unconditionally avoids confusing re-elections of a node that just
 		// stepped down. If all candidates are resigned the election is deferred
 		// until a non-resigned candidate is available.
-		if poolerRequestingDemotion(r.pooler) {
+		if types.PrimaryNeedsReplacement(r.pooler) {
 			c.logger.InfoContext(ctx, "Skipping resigned candidate during selection",
 				"pooler", r.pooler.MultiPooler.Id.Name)
 			continue
@@ -284,18 +292,6 @@ func (c *Coordinator) selectCandidate(ctx context.Context, recruited []recruitme
 type recruitmentResult struct {
 	pooler      *multiorchdatapb.PoolerHealthState
 	walPosition *consensusdatapb.WALPosition
-}
-
-// poolerRequestingDemotion reports whether the pooler's cached health state shows it has
-// voluntarily requested to be replaced (REQUESTING_DEMOTION signal at its current primary term).
-// This duplicates the logic in recovery/types.PrimaryNeedsReplacement to avoid a circular import
-// (recovery imports consensus; consensus cannot import recovery).
-func poolerRequestingDemotion(pooler *multiorchdatapb.PoolerHealthState) bool {
-	ls := pooler.GetConsensusStatus().GetAvailabilityStatus().GetLeadershipStatus()
-	return ls != nil &&
-		ls.Signal == clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION &&
-		ls.PrimaryTerm != 0 &&
-		ls.PrimaryTerm == pooler.GetConsensusStatus().GetPrimaryTerm()
 }
 
 // recruitNodes sends BeginTerm RPC to all poolers in parallel and returns those that accepted.

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -98,6 +98,8 @@ func (c *Coordinator) BeginTerm(ctx context.Context, shardID string, cohort []*m
 
 	// Resigned poolers are excluded: they may still carry a stale primary rule
 	// that needs pg_rewind, which the stale-primary analyzer owns.
+	// TODO: once poolers self-rewind after emergency demotion, this exclusion
+	// becomes unnecessary — the resigned pooler can rejoin as a standby directly.
 	var standbys []*multiorchdatapb.PoolerHealthState
 	for _, pooler := range recruitedPoolers {
 		if pooler.MultiPooler.Id.Name == candidate.MultiPooler.Id.Name {

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -682,12 +682,21 @@ func TestSelectCandidate(t *testing.T) {
 			logger:        logger,
 		}
 
+		resignedPoolerID := &clustermetadatapb.ID{Name: "mp1-resigned"}
 		resignedPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id: &clustermetadatapb.ID{Name: "mp1-resigned"},
+				Id: resignedPoolerID,
 			},
 			ConsensusStatus: &consensusdatapb.StatusResponse{
-				PrimaryTerm: 4,
+				ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+					Id: resignedPoolerID,
+					CurrentPosition: &clustermetadatapb.PoolerPosition{
+						Rule: &clustermetadatapb.ShardRule{
+							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4},
+							PrimaryId:  resignedPoolerID,
+						},
+					},
+				},
 				AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
 					LeadershipStatus: &clustermetadatapb.LeadershipStatus{
 						PrimaryTerm: 4,
@@ -735,12 +744,21 @@ func TestSelectCandidate(t *testing.T) {
 			logger:        logger,
 		}
 
+		onlyNodeID := &clustermetadatapb.ID{Name: "only-node"}
 		resignedPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id: &clustermetadatapb.ID{Name: "only-node"},
+				Id: onlyNodeID,
 			},
 			ConsensusStatus: &consensusdatapb.StatusResponse{
-				PrimaryTerm: 3,
+				ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+					Id: onlyNodeID,
+					CurrentPosition: &clustermetadatapb.PoolerPosition{
+						Rule: &clustermetadatapb.ShardRule{
+							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3},
+							PrimaryId:  onlyNodeID,
+						},
+					},
+				},
 				AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
 					LeadershipStatus: &clustermetadatapb.LeadershipStatus{
 						PrimaryTerm: 3,
@@ -770,12 +788,21 @@ func TestSelectCandidate(t *testing.T) {
 			logger:        logger,
 		}
 
+		staleSignalID := &clustermetadatapb.ID{Name: "mp1-stale-signal"}
 		nodeWithStaleSignal := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id: &clustermetadatapb.ID{Name: "mp1-stale-signal"},
+				Id: staleSignalID,
 			},
 			ConsensusStatus: &consensusdatapb.StatusResponse{
-				PrimaryTerm: 5, // current term is 5
+				ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+					Id: staleSignalID,
+					CurrentPosition: &clustermetadatapb.PoolerPosition{
+						Rule: &clustermetadatapb.ShardRule{
+							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+							PrimaryId:  staleSignalID,
+						},
+					},
+				},
 				AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
 					LeadershipStatus: &clustermetadatapb.LeadershipStatus{
 						PrimaryTerm: 3, // signal from an old term — stale
@@ -1252,6 +1279,68 @@ func TestBeginTerm(t *testing.T) {
 		require.Equal(t, int64(0), term)
 		require.Contains(t, err.Error(), "recruitment validation failed",
 			"should fail recruitment validation when only 1 node recruited but need 2")
+	})
+
+	t.Run("excludes resigned pooler from standbys so stale-primary recovery can handle it", func(t *testing.T) {
+		// A pooler that emergency-demoted (REQUESTING_DEMOTION signal with a
+		// matching primary term) must not land in the standbys list returned by
+		// BeginTerm. If it did, the standby-config step would call
+		// SetPrimaryConnInfo on it directly, bypassing the stale-primary flow
+		// that runs pg_rewind. Instead we leave it alone so a later analysis
+		// pass observes its lingering stale rule and routes it through
+		// DemoteStalePrimary.
+		fakeClient := rpcclient.NewFakeClient()
+		c := &Coordinator{
+			coordinatorID: coordID,
+			logger:        logger,
+			rpcClient:     fakeClient,
+		}
+
+		mp1 := createMockNode(fakeClient, "mp1", 5, "0/5000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
+		mp2 := createMockNode(fakeClient, "mp2", 5, "0/3000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
+		mp3 := createMockNode(fakeClient, "mp3", 5, "0/2000000", true, consensusdatapb.PostgresRole_POSTGRES_ROLE_REPLICA)
+
+		// mp1 was the previous primary at term 4 and has emergency-demoted.
+		// Its cached health still shows rule=(primary=mp1, term=4) and the
+		// leadership status carries REQUESTING_DEMOTION at that same term —
+		// the shape types.PrimaryNeedsReplacement looks for.
+		mp1.ConsensusStatus = &consensusdatapb.StatusResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: mp1.MultiPooler.Id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4},
+						PrimaryId:  mp1.MultiPooler.Id,
+					},
+				},
+			},
+			AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
+				LeadershipStatus: &clustermetadatapb.LeadershipStatus{
+					PrimaryTerm: 4,
+					Signal:      clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
+				},
+			},
+		}
+
+		cohort := []*multiorchdatapb.PoolerHealthState{mp1, mp2, mp3}
+
+		quorumRule := &clustermetadatapb.DurabilityPolicy{
+			QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+			RequiredCount: 2,
+		}
+
+		candidate, standbys, term, err := c.BeginTerm(ctx, "shard0", cohort, mustPolicy(t, quorumRule), int64(6))
+		require.NoError(t, err)
+		require.NotNil(t, candidate)
+		require.NotEqual(t, "mp1", candidate.MultiPooler.Id.Name,
+			"resigned pooler must not be elected as candidate")
+		require.Equal(t, int64(6), term)
+
+		require.Len(t, standbys, 1, "resigned pooler must be excluded from standbys list")
+		for _, s := range standbys {
+			require.NotEqual(t, "mp1", s.MultiPooler.Id.Name,
+				"resigned pooler must not appear in standbys so stale-primary recovery owns it")
+		}
 	})
 }
 

--- a/go/services/multiorch/recovery/actions/demote_stale_primary.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_primary.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -203,11 +204,8 @@ func (a *DemoteStalePrimaryAction) findCorrectPrimary(shardKey commontypes.Shard
 		}
 
 		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-			// Get its PrimaryTerm (not consensus term)
-			var primaryTerm int64
-			if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
-				primaryTerm = ct.PrimaryTerm
-			}
+			// Get its PrimaryTerm (not consensus term) from its current rule.
+			primaryTerm := commonconsensus.PrimaryTerm(pooler.GetConsensusStatus().GetConsensusStatus())
 
 			if primaryTerm > maxPrimaryTerm {
 				maxPrimaryTerm = primaryTerm

--- a/go/services/multiorch/recovery/actions/demote_stale_primary.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_primary.go
@@ -30,7 +30,6 @@ import (
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
@@ -197,19 +196,15 @@ func (a *DemoteStalePrimaryAction) findCorrectPrimary(shardKey commontypes.Shard
 			return true // continue
 		}
 
-		// Check if this pooler is a PRIMARY
-		poolerType := pooler.GetStatus().GetPoolerType()
-		if poolerType == clustermetadatapb.PoolerType_UNKNOWN && pooler.MultiPooler != nil {
-			poolerType = pooler.MultiPooler.Type
+		if !commonconsensus.IsPrimary(pooler.GetConsensusStatus().GetConsensusStatus()) {
+			return true // continue
 		}
 
-		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-			primaryTerm := commonconsensus.PrimaryTerm(pooler.GetConsensusStatus().GetConsensusStatus())
+		primaryTerm := commonconsensus.PrimaryTerm(pooler.GetConsensusStatus().GetConsensusStatus())
 
-			if primaryTerm > maxPrimaryTerm {
-				maxPrimaryTerm = primaryTerm
-				correctPrimary = pooler
-			}
+		if primaryTerm > maxPrimaryTerm {
+			maxPrimaryTerm = primaryTerm
+			correctPrimary = pooler
 		}
 
 		return true // continue

--- a/go/services/multiorch/recovery/actions/demote_stale_primary.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_primary.go
@@ -204,7 +204,6 @@ func (a *DemoteStalePrimaryAction) findCorrectPrimary(shardKey commontypes.Shard
 		}
 
 		if poolerType == clustermetadatapb.PoolerType_PRIMARY {
-			// Get its PrimaryTerm (not consensus term) from its current rule.
 			primaryTerm := commonconsensus.PrimaryTerm(pooler.GetConsensusStatus().GetConsensusStatus())
 
 			if primaryTerm > maxPrimaryTerm {

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/topoclient"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -220,7 +221,7 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 		PoolerID:         pooler.MultiPooler.Id,
 		ShardKey:         shardKey,
 		PoolerType:       poolerType,
-		IsPrimary:        poolerType == clustermetadatapb.PoolerType_PRIMARY,
+		IsPrimary:        commonconsensus.IsPrimary(pooler.GetConsensusStatus().GetConsensusStatus()),
 		LastCheckValid:   pooler.IsLastCheckValid,
 		IsInitialized:    store.IsInitialized(pooler),
 		HasDataDirectory: pooler.GetStatus().GetHasDataDirectory(),
@@ -235,11 +236,6 @@ func (g *AnalysisGenerator) generateAnalysisForPooler(
 	if pooler.ConsensusStatus != nil {
 		analysis.ConsensusTerm = pooler.ConsensusStatus.CurrentTerm
 		analysis.ConsensusStatus = pooler.ConsensusStatus.ConsensusStatus
-	}
-
-	// Store primary term (term when this pooler was promoted to primary)
-	if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
-		analysis.PrimaryTerm = ct.PrimaryTerm
 	}
 
 	// If this is a REPLICA, populate replica-specific fields
@@ -272,10 +268,7 @@ func findHighestTermRawPooler(poolers map[string]*multiorchdatapb.PoolerHealthSt
 		if pooler.GetStatus().GetPoolerType() != clustermetadatapb.PoolerType_PRIMARY {
 			continue
 		}
-		var term int64
-		if ct := pooler.GetStatus().GetConsensusTerm(); ct != nil {
-			term = ct.PrimaryTerm
-		}
+		term := commonconsensus.PrimaryTerm(pooler.GetConsensusStatus().GetConsensusStatus())
 		if best == nil || term > bestTerm {
 			best = pooler
 			bestTerm = term
@@ -484,7 +477,7 @@ func findHighestTermPooler(primaries []*PoolerAnalysis) *PoolerAnalysis {
 	mostAdvanced := slices.MaxFunc(primaries, comparePrimaryTimeline)
 
 	// Defensive: should not happen in initialized shards, but guard against invalid state
-	if mostAdvanced.PrimaryTerm == 0 {
+	if commonconsensus.PrimaryTerm(mostAdvanced.ConsensusStatus) == 0 {
 		return nil
 	}
 

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
@@ -31,6 +32,25 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
+
+// primaryConsensusStatus builds a consensusdata.StatusResponse that names id as
+// the primary in its current rule with the given coordinator term. This is the
+// minimal fixture required for commonconsensus.IsPrimary to return true for a
+// given pooler.
+func primaryConsensusStatus(id *clustermetadatapb.ID, term int64) *consensusdatapb.StatusResponse {
+	return &consensusdatapb.StatusResponse{
+		CurrentTerm: term,
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			Id: id,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+					PrimaryId:  id,
+				},
+			},
+		},
+	}
+}
 
 func TestAnalysisGenerator_GenerateShardAnalyses_EmptyStore(t *testing.T) {
 	generator := NewAnalysisGenerator(store.NewPoolerStore(nil, slog.Default()), nil)
@@ -61,6 +81,7 @@ func TestAnalysisGenerator_GenerateShardAnalyses_SinglePrimary(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
+		ConsensusStatus:  primaryConsensusStatus(primaryID, 1),
 		Status: &multipoolermanagerdatapb.Status{
 			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
@@ -118,6 +139,7 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
+		ConsensusStatus:  primaryConsensusStatus(primaryID, 1),
 		Status: &multipoolermanagerdatapb.Status{
 			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 			PrimaryStatus: &multipoolermanagerdatapb.PrimaryStatus{
@@ -218,6 +240,7 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
 		LastSeen:         timestamppb.Now(),
+		ConsensusStatus:  primaryConsensusStatus(primaryID, 1),
 		Status: &multipoolermanagerdatapb.Status{
 			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
 			PostgresReady: true,
@@ -1425,11 +1448,22 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 		MultiPooler:      shardConfig(newPrimaryID),
 		IsLastCheckValid: true,
 		LastSeen:         timestamppb.Now(),
-		ConsensusStatus:  &consensusdatapb.StatusResponse{CurrentTerm: 11},
+		ConsensusStatus: &consensusdatapb.StatusResponse{
+			CurrentTerm: 11,
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: newPrimaryID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 6},
+						PrimaryId:  newPrimaryID,
+					},
+				},
+			},
+		},
 		Status: &multipoolermanagerdatapb.Status{
 			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
 			PostgresReady: true,
-			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 11, PrimaryTerm: 6},
+			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 11},
 		},
 	})
 
@@ -1438,11 +1472,22 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 		MultiPooler:      shardConfig(stalePrimaryID),
 		IsLastCheckValid: true,
 		LastSeen:         timestamppb.Now(),
-		ConsensusStatus:  &consensusdatapb.StatusResponse{CurrentTerm: 10},
+		ConsensusStatus: &consensusdatapb.StatusResponse{
+			CurrentTerm: 10,
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: stalePrimaryID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+						PrimaryId:  stalePrimaryID,
+					},
+				},
+			},
+		},
 		Status: &multipoolermanagerdatapb.Status{
 			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
 			PostgresReady: false,
-			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10, PrimaryTerm: 5},
+			ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 10},
 		},
 	})
 
@@ -1494,7 +1539,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// primary-2 has higher PrimaryTerm, so it's the most advanced
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-2", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(6), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(6), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 
 	t.Run("multiple other primaries detected", func(t *testing.T) {
@@ -1523,7 +1568,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// This verifies we're comparing on PrimaryTerm, not ConsensusTerm.
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-3", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(6), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(6), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 
 	t.Run("this primary is most advanced", func(t *testing.T) {
@@ -1543,7 +1588,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// This primary has highest PrimaryTerm (7), so it's the most advanced
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-1", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(7), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(7), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 
 	t.Run("tie in primary_term returns nil", func(t *testing.T) {
@@ -1600,7 +1645,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// primary-2 has non-zero PrimaryTerm (5), so it's the most advanced
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-2", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(5), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(5), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 
 	t.Run("no other primaries detected", func(t *testing.T) {
@@ -1618,7 +1663,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// Single primary is still the most advanced
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-1", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(5), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(5), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 
 	t.Run("unreachable primary not detected", func(t *testing.T) {
@@ -1637,7 +1682,7 @@ func TestDetectOtherPrimary(t *testing.T) {
 		// Only this primary is reachable, so it's the most advanced
 		require.NotNil(t, sa.HighestTermReachablePrimary)
 		assert.Equal(t, "primary-1", sa.HighestTermReachablePrimary.PoolerID.Name)
-		assert.Equal(t, int64(5), sa.HighestTermReachablePrimary.PrimaryTerm)
+		assert.Equal(t, int64(5), commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus))
 	})
 }
 
@@ -1670,13 +1715,14 @@ func setupMultiplePrimariesStoreWithReachability(t *testing.T, primaries []prima
 
 	for _, p := range primaries {
 		poolerID := "multipooler-cell1-" + p.id
+		id := &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "cell1",
+			Name:      p.id,
+		}
 		poolerState := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id: &clustermetadatapb.ID{
-					Component: clustermetadatapb.ID_MULTIPOOLER,
-					Cell:      "cell1",
-					Name:      p.id,
-				},
+				Id:         id,
 				Database:   "testdb",
 				TableGroup: "default",
 				Shard:      "0",
@@ -1687,13 +1733,19 @@ func setupMultiplePrimariesStoreWithReachability(t *testing.T, primaries []prima
 			IsUpToDate:       true,
 			ConsensusStatus: &consensusdatapb.StatusResponse{
 				CurrentTerm: p.consensusTerm,
+				ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+					Id: id,
+					CurrentPosition: &clustermetadatapb.PoolerPosition{
+						Rule: &clustermetadatapb.ShardRule{
+							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: p.primaryTerm},
+							PrimaryId:  id,
+						},
+					},
+				},
 			},
 			Status: &multipoolermanagerdatapb.Status{
-				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
-				ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{
-					TermNumber:  p.consensusTerm,
-					PrimaryTerm: p.primaryTerm,
-				},
+				PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+				ConsensusTerm: &multipoolermanagerdatapb.ConsensusTerm{TermNumber: p.consensusTerm},
 			},
 		}
 		ps.Set(poolerID, poolerState)

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
@@ -149,8 +150,6 @@ type PoolerAnalysis struct {
 	ReplicationStopped  bool
 	PrimaryConnInfoHost string
 
-	// Primary term and WAL position
-	PrimaryTerm   int64 // This pooler's primary term (term when promoted)
 	ConsensusTerm int64 // This node's consensus term (from health check)
 	// ConsensusStatus is the pooler's authoritative consensus state as of the last
 	// ConsensusStatus RPC.
@@ -158,12 +157,17 @@ type PoolerAnalysis struct {
 	ConsensusStatus *clustermetadatapb.ConsensusStatus
 }
 
-// comparePrimaryTimeline compares two primary PoolerAnalysis entries by PrimaryTerm only.
-// Returns negative if a is less advanced than b, 0 if equal, positive if a is more advanced.
-// LSN is intentionally excluded: for primaries, PrimaryTerm must be unique per promotion, so
-// equal PrimaryTerms indicate a consensus bug rather than a resolvable tie.
+// comparePrimaryTimeline compares two primary PoolerAnalysis entries by the
+// coordinator term of each pooler's current rule (via commonconsensus.PrimaryTerm).
+// Returns negative if a is less advanced than b, 0 if equal, positive if a is
+// more advanced. LSN is intentionally excluded: for primaries, the coordinator
+// term must be unique per promotion, so equal terms indicate a consensus bug
+// rather than a resolvable tie.
 func comparePrimaryTimeline(a, b *PoolerAnalysis) int {
-	return cmp.Compare(a.PrimaryTerm, b.PrimaryTerm)
+	return cmp.Compare(
+		commonconsensus.PrimaryTerm(a.ConsensusStatus),
+		commonconsensus.PrimaryTerm(b.ConsensusStatus),
+	)
 }
 
 // analyzeAllPoolers runs fn against each pooler analysis in sa, collecting all problems.

--- a/go/services/multiorch/recovery/analysis/stale_primary_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/stale_primary_analyzer.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 )
@@ -66,15 +67,14 @@ func (a *StalePrimaryAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, erro
 		return nil, nil
 	}
 
-	// Collect stale primaries: all in sa.Primaries that are not the highest-term primary
-	// and have a valid (non-zero) PrimaryTerm.
+	// Collect stale primaries: every topology-PRIMARY pooler that is not the
+	// highest-term primary is stale. This includes poolers whose own rule has
+	// caught up (PrimaryTerm == 0 because the rule now names a different
+	// primary) — exactly the post-emergency-demotion state we need to repair.
 	mostAdvancedIDStr := topoclient.MultiPoolerIDString(sa.HighestTermReachablePrimary.PoolerID)
 	var stalePrimaries []*PoolerAnalysis
 	for _, p := range sa.Primaries {
 		if topoclient.MultiPoolerIDString(p.PoolerID) == mostAdvancedIDStr {
-			continue
-		}
-		if p.PrimaryTerm == 0 {
 			continue
 		}
 		stalePrimaries = append(stalePrimaries, p)
@@ -84,12 +84,13 @@ func (a *StalePrimaryAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, erro
 		return nil, nil
 	}
 
-	// Sort most stale first (lowest PrimaryTerm first) so the recovery system
-	// processes the most out-of-date primary at highest priority.
+	// Sort most stale first (lowest rule coordinator term first) so the
+	// recovery system processes the most out-of-date primary at highest
+	// priority.
 	slices.SortFunc(stalePrimaries, comparePrimaryTimeline)
 
-	// Assign descending priorities so the most stale primary (lowest PrimaryTerm,
-	// sorted first) gets PriorityEmergency, the next gets PriorityEmergency-1, etc.
+	// Assign descending priorities so the most stale primary (sorted first)
+	// gets PriorityEmergency, the next gets PriorityEmergency-1, etc.
 	problems := make([]types.Problem, 0, len(stalePrimaries))
 	for i, stale := range stalePrimaries {
 		problems = append(problems, types.Problem{
@@ -99,9 +100,9 @@ func (a *StalePrimaryAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, erro
 			ShardKey:  sa.ShardKey,
 			Description: fmt.Sprintf("Stale primary detected: %s (stale_primary_term %d) is stale, most advanced primary %s (most_advanced_primary_term %d)",
 				stale.PoolerID.Name,
-				stale.PrimaryTerm,
+				commonconsensus.PrimaryTerm(stale.ConsensusStatus),
 				sa.HighestTermReachablePrimary.PoolerID.Name,
-				sa.HighestTermReachablePrimary.PrimaryTerm),
+				commonconsensus.PrimaryTerm(sa.HighestTermReachablePrimary.ConsensusStatus)),
 			Priority:       types.PriorityEmergency - types.Priority(i),
 			Scope:          types.ScopeShard,
 			DetectedAt:     time.Now(),

--- a/go/services/multiorch/recovery/analysis/stale_primary_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/stale_primary_analyzer_test.go
@@ -27,23 +27,40 @@ import (
 	"github.com/multigres/multigres/go/services/multiorch/store"
 )
 
+// primaryRuleStatus builds a ConsensusStatus that names id as the primary
+// with the given coordinator term — shorthand for wiring PoolerAnalysis so
+// commonconsensus.PrimaryTerm returns term.
+func primaryRuleStatus(id *clustermetadatapb.ID, term int64) *clustermetadatapb.ConsensusStatus {
+	return &clustermetadatapb.ConsensusStatus{
+		Id: id,
+		CurrentPosition: &clustermetadatapb.PoolerPosition{
+			Rule: &clustermetadatapb.ShardRule{
+				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: term},
+				PrimaryId:  id,
+			},
+		},
+	}
+}
+
 func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 	factory := &RecoveryActionFactory{poolerStore: store.NewPoolerStore(nil, slog.Default())}
 
 	t.Run("detects stale primary when this pooler has lower primary_term", func(t *testing.T) {
 		analyzer := &StalePrimaryAnalyzer{factory: factory}
+		staleID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary"}
+		newID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"}
 		stalePA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   5,
-			ConsensusTerm: 10,
+			PoolerID:        staleID,
+			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			IsPrimary:       true,
+			IsInitialized:   true,
+			ConsensusStatus: primaryRuleStatus(staleID, 5),
+			ConsensusTerm:   10,
 		}
 		newPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"},
-			PrimaryTerm:   6,
-			ConsensusTerm: 11,
+			PoolerID:        newID,
+			ConsensusStatus: primaryRuleStatus(newID, 6),
+			ConsensusTerm:   11,
 		}
 		sa := &ShardAnalysis{
 			ShardKey:                    stalePA.ShardKey,
@@ -67,18 +84,20 @@ func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 
 	t.Run("detects other primary as stale when this pooler has higher primary_term", func(t *testing.T) {
 		analyzer := &StalePrimaryAnalyzer{factory: factory}
+		newID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"}
+		staleID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary"}
 		newPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   6,
-			ConsensusTerm: 11,
+			PoolerID:        newID,
+			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			IsPrimary:       true,
+			IsInitialized:   true,
+			ConsensusStatus: primaryRuleStatus(newID, 6),
+			ConsensusTerm:   11,
 		}
 		stalePA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary"},
-			PrimaryTerm:   5,
-			ConsensusTerm: 10,
+			PoolerID:        staleID,
+			ConsensusStatus: primaryRuleStatus(staleID, 5),
+			ConsensusTerm:   10,
 		}
 		sa := &ShardAnalysis{
 			ShardKey:                    newPA.ShardKey,
@@ -103,17 +122,19 @@ func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 		// unique per primary). We skip automatic demotion to avoid making the situation worse.
 		// See generator.go findMostAdvancedPrimary() for details and potential future solutions.
 		analyzer := &StalePrimaryAnalyzer{factory: factory}
+		primaryAID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-a"}
+		primaryBID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-b"}
 		primaryAPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-a"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   5,
-			ConsensusTerm: 10,
+			PoolerID:        primaryAID,
+			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			IsPrimary:       true,
+			IsInitialized:   true,
+			ConsensusStatus: primaryRuleStatus(primaryAID, 5),
+			ConsensusTerm:   10,
 		}
 		primaryBPA := &PoolerAnalysis{
-			PoolerID:    &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-b"},
-			PrimaryTerm: 5,
+			PoolerID:        primaryBID,
+			ConsensusStatus: primaryRuleStatus(primaryBID, 5),
 		}
 		sa := &ShardAnalysis{
 			ShardKey:                    primaryAPA.ShardKey,
@@ -149,44 +170,20 @@ func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 
 	t.Run("ignores when no other primary detected", func(t *testing.T) {
 		analyzer := &StalePrimaryAnalyzer{factory: factory}
+		primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"}
 		pa := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   5,
-			ConsensusTerm: 10,
+			PoolerID:        primaryID,
+			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			IsPrimary:       true,
+			IsInitialized:   true,
+			ConsensusStatus: primaryRuleStatus(primaryID, 5),
+			ConsensusTerm:   10,
 		}
 		sa := &ShardAnalysis{
 			ShardKey:                    pa.ShardKey,
 			Analyses:                    []*PoolerAnalysis{pa},
 			Primaries:                   []*PoolerAnalysis{pa}, // Only one primary — no stale primary to detect
 			HighestTermReachablePrimary: pa,
-		}
-
-		problems, err := analyzer.Analyze(sa)
-
-		require.NoError(t, err)
-		require.Empty(t, problems)
-	})
-
-	t.Run("ignores uninitialized primary", func(t *testing.T) {
-		analyzer := &StalePrimaryAnalyzer{factory: factory}
-		uninitPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: false, // Not initialized
-		}
-		otherPA := &PoolerAnalysis{
-			PoolerID:    &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "other-primary"},
-			PrimaryTerm: 5,
-		}
-		sa := &ShardAnalysis{
-			ShardKey:                    uninitPA.ShardKey,
-			Analyses:                    []*PoolerAnalysis{uninitPA},
-			Primaries:                   []*PoolerAnalysis{uninitPA, otherPA},
-			HighestTermReachablePrimary: otherPA,
 		}
 
 		problems, err := analyzer.Analyze(sa)
@@ -207,21 +204,24 @@ func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 
 	t.Run("handles multiple other primaries", func(t *testing.T) {
 		analyzer := &StalePrimaryAnalyzer{factory: factory}
+		newID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"}
+		stale1ID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary-1"}
+		stale2ID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary-2"}
 		newPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   6,
-			ConsensusTerm: 11,
+			PoolerID:        newID,
+			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			IsPrimary:       true,
+			IsInitialized:   true,
+			ConsensusStatus: primaryRuleStatus(newID, 6),
+			ConsensusTerm:   11,
 		}
 		stale1PA := &PoolerAnalysis{
-			PoolerID:    &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary-1"},
-			PrimaryTerm: 4,
+			PoolerID:        stale1ID,
+			ConsensusStatus: primaryRuleStatus(stale1ID, 4),
 		}
 		stale2PA := &PoolerAnalysis{
-			PoolerID:    &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary-2"},
-			PrimaryTerm: 5,
+			PoolerID:        stale2ID,
+			ConsensusStatus: primaryRuleStatus(stale2ID, 5),
 		}
 		sa := &ShardAnalysis{
 			ShardKey:                    newPA.ShardKey,
@@ -239,35 +239,6 @@ func TestStalePrimaryAnalyzer_Analyze(t *testing.T) {
 		assert.Equal(t, types.PriorityEmergency, problems[0].Priority)
 		assert.Equal(t, "stale-primary-2", problems[1].PoolerID.Name)
 		assert.Equal(t, types.PriorityEmergency-1, problems[1].Priority)
-	})
-
-	t.Run("skips when this pooler has primary_term zero (invalid state)", func(t *testing.T) {
-		// Note: This tests the invariant check. In a properly initialized shard,
-		// PRIMARY poolers should never have PrimaryTerm=0.
-		analyzer := &StalePrimaryAnalyzer{factory: factory}
-		zeroTermPA := &PoolerAnalysis{
-			PoolerID:      &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-a"},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
-			IsPrimary:     true,
-			IsInitialized: true,
-			PrimaryTerm:   0, // Invalid: initialized PRIMARY should never have PrimaryTerm=0
-			ConsensusTerm: 10,
-		}
-		otherPA := &PoolerAnalysis{
-			PoolerID:    &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-b"},
-			PrimaryTerm: 5,
-		}
-		sa := &ShardAnalysis{
-			ShardKey:                    zeroTermPA.ShardKey,
-			Analyses:                    []*PoolerAnalysis{zeroTermPA},
-			Primaries:                   []*PoolerAnalysis{zeroTermPA, otherPA},
-			HighestTermReachablePrimary: otherPA,
-		}
-
-		problems, err := analyzer.Analyze(sa)
-
-		require.NoError(t, err)
-		require.Empty(t, problems, "should skip when this pooler's PrimaryTerm=0 (invalid state)")
 	})
 
 	t.Run("analyzer name is correct", func(t *testing.T) {

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -40,6 +40,7 @@ import (
 	commontypes "github.com/multigres/multigres/go/common/types"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
@@ -719,7 +720,10 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		})
 		t.Cleanup(analysis.ResetAnalyzers)
 
-		// Set up store state: dead primary, replica with replication stopped
+		// Set up store state: dead primary, replica with replication stopped.
+		// Even though IsLastCheckValid is false, ConsensusStatus carries the
+		// last-known state from before the primary went unreachable, and
+		// analysis.IsPrimary is rule-based.
 		primaryPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
 				Id:       primaryID,
@@ -730,6 +734,17 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 			IsLastCheckValid: false,
 			IsUpToDate:       true,
 			LastSeen:         timestamppb.Now(),
+			ConsensusStatus: &consensusdatapb.StatusResponse{
+				ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+					Id: primaryID,
+					CurrentPosition: &clustermetadatapb.PoolerPosition{
+						Rule: &clustermetadatapb.ShardRule{
+							RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+							PrimaryId:  primaryID,
+						},
+					},
+				},
+			},
 		}
 		engine.poolerStore.Set("multipooler-cell1-primary-pooler", primaryPooler)
 
@@ -1050,6 +1065,17 @@ func TestRecoveryLoop_PostRecoveryRefresh(t *testing.T) {
 		IsUpToDate:         true,
 		LastSeen:           timestamppb.New(time.Now().Add(-1 * time.Minute)),
 		LastCheckAttempted: timestamppb.New(initialPrimaryCheck),
+		ConsensusStatus: &consensusdatapb.StatusResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: primaryID,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Rule: &clustermetadatapb.ShardRule{
+						RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+						PrimaryId:  primaryID,
+					},
+				},
+			},
+		},
 	}
 	engine.poolerStore.Set("multipooler-cell1-primary-pooler", primaryPooler)
 

--- a/go/services/multiorch/recovery/types/pooler_signals.go
+++ b/go/services/multiorch/recovery/types/pooler_signals.go
@@ -47,6 +47,6 @@ func PrimaryNeedsReplacement(p *multiorchdatapb.PoolerHealthState) bool {
 		return false
 	}
 	// Verify the signal is for the current primary term, not a stale one.
-	currentTerm := commonconsensus.PrimaryTerm(p.GetConsensusStatus().GetConsensusStatus())
-	return leadershipStatus.PrimaryTerm != 0 && leadershipStatus.PrimaryTerm == currentTerm
+	primaryTerm := commonconsensus.PrimaryTerm(p.GetConsensusStatus().GetConsensusStatus())
+	return leadershipStatus.PrimaryTerm != 0 && leadershipStatus.PrimaryTerm == primaryTerm
 }

--- a/go/services/multiorch/recovery/types/pooler_signals.go
+++ b/go/services/multiorch/recovery/types/pooler_signals.go
@@ -20,6 +20,7 @@ package types
 // should move to go/common/consensus or a similar shared package.
 
 import (
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 )
@@ -46,5 +47,6 @@ func PrimaryNeedsReplacement(p *multiorchdatapb.PoolerHealthState) bool {
 		return false
 	}
 	// Verify the signal is for the current primary term, not a stale one.
-	return leadershipStatus.PrimaryTerm != 0 && leadershipStatus.PrimaryTerm == p.ConsensusStatus.GetPrimaryTerm()
+	currentTerm := commonconsensus.PrimaryTerm(p.GetConsensusStatus().GetConsensusStatus())
+	return leadershipStatus.PrimaryTerm != 0 && leadershipStatus.PrimaryTerm == currentTerm
 }

--- a/go/services/multipooler/manager/consensus_state.go
+++ b/go/services/multipooler/manager/consensus_state.go
@@ -24,9 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/multigres/multigres/go/common/mterrors"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
-	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
@@ -201,10 +199,8 @@ func (cs *ConsensusState) UpdateTermAndAcceptCandidate(ctx context.Context, newT
 	}
 
 	currentTerm := int64(0)
-	currentPrimaryTerm := int64(0)
 	if cs.term != nil {
 		currentTerm = cs.term.GetTermNumber()
-		currentPrimaryTerm = cs.term.GetPrimaryTerm()
 	}
 
 	if newTerm < currentTerm {
@@ -220,7 +216,6 @@ func (cs *ConsensusState) UpdateTermAndAcceptCandidate(ctx context.Context, newT
 			AcceptedTermFromCoordinatorId: proto.Clone(candidateID).(*clustermetadatapb.ID),
 			LastAcceptanceTime:            timestamppb.New(time.Now()),
 			LeaderId:                      nil,
-			PrimaryTerm:                   currentPrimaryTerm,
 		}
 	} else {
 		// Same term: just update acceptance (idempotent check first)
@@ -261,10 +256,8 @@ func (cs *ConsensusState) UpdateTermAndSave(ctx context.Context, newTerm int64) 
 	defer cs.mu.Unlock()
 
 	currentTerm := int64(0)
-	currentPrimaryTerm := int64(0)
 	if cs.term != nil {
 		currentTerm = cs.term.GetTermNumber()
-		currentPrimaryTerm = cs.term.GetPrimaryTerm()
 	}
 
 	if newTerm < currentTerm {
@@ -282,55 +275,10 @@ func (cs *ConsensusState) UpdateTermAndSave(ctx context.Context, newTerm int64) 
 		AcceptedTermFromCoordinatorId: nil,
 		LastAcceptanceTime:            nil,
 		LeaderId:                      nil,
-		PrimaryTerm:                   currentPrimaryTerm,
 	}
 
 	// Save and update under lock
 	return cs.saveAndUpdateLocked(term)
-}
-
-// SetPrimaryTerm updates the primary term in the consensus record.
-// This is called during propagation when a multipooler is promoted to primary.
-// The force parameter bypasses invariant validation for manual intervention (e.g., split-brain recovery).
-func (cs *ConsensusState) SetPrimaryTerm(ctx context.Context, primaryTerm int64, force bool) error {
-	if err := AssertActionLockHeld(ctx); err != nil {
-		return err
-	}
-
-	// Validation: negative values are never allowed
-	if primaryTerm < 0 {
-		return mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT,
-			fmt.Sprintf("primary_term cannot be negative: %d", primaryTerm))
-	}
-
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
-	if cs.term == nil {
-		return errors.New("consensus term not initialized")
-	}
-
-	// Invariant validation (unless force=true for manual intervention)
-	if !force {
-		// INVARIANT: When setting primary_term to a non-zero value, it must match the current consensus term.
-		// This ensures we record the exact term in which this pooler was promoted to primary.
-		// After promotion, term_number may increase (due to new elections) but primary_term remains fixed.
-		// Exception: clearing primary_term to 0 (during demotion or restore) is always allowed.
-		currentTermNumber := cs.term.GetTermNumber()
-		isSettingNonZeroTerm := primaryTerm != 0
-		termMismatch := primaryTerm != currentTermNumber
-
-		if isSettingNonZeroTerm && termMismatch {
-			return mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-				fmt.Sprintf("primary_term must match current term when setting: primary_term=%d, current_term=%d",
-					primaryTerm, currentTermNumber))
-		}
-	}
-
-	newTerm := cloneTerm(cs.term)
-	newTerm.PrimaryTerm = primaryTerm
-
-	return cs.saveAndUpdateLocked(newTerm)
 }
 
 // saveAndUpdateLocked saves the term to disk and updates memory.

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/backup"
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
@@ -715,12 +716,17 @@ func (pm *MultiPoolerManager) checkAndSetReady() {
 			close(pm.readyChan)
 		}
 
-		// Set initial primary observation from loaded consensus state.
-		if term, _ := pm.consensusState.GetInconsistentTerm(); term != nil && term.GetPrimaryTerm() > 0 {
-			pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
-				PrimaryID:   pm.serviceID,
-				PrimaryTerm: term.GetPrimaryTerm(),
-			})
+		// Set initial primary observation from the highest known rule.
+		// TODO: This publishes PrimaryID as ourselves without first verifying that
+		// the highest known rule actually has us as the primary. Address in a
+		// follow-up PR (check rule.PrimaryId before publishing).
+		if cs, err := pm.getInconsistentConsensusStatus(pm.ctx); err == nil {
+			if primaryTerm := commonconsensus.PrimaryTerm(cs); primaryTerm > 0 {
+				pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{
+					PrimaryID:   pm.serviceID,
+					PrimaryTerm: primaryTerm,
+				})
+			}
 		}
 	}
 }
@@ -1453,6 +1459,9 @@ type postgresState struct {
 	backupsAvailable         bool
 	isPrimary                bool
 	bootstrapSentinelPresent bool
+	// primaryTerm is the coordinator term at which this pooler is the primary
+	// per the highest known rule. 0 if we are not the primary for that rule.
+	primaryTerm int64
 }
 
 // remedialAction represents actions the postgres monitor can take
@@ -1544,7 +1553,7 @@ func (pm *MultiPoolerManager) monitorPostgresIteration(ctx context.Context) {
 	action = pm.determineRemedialAction(currentState)
 
 	// Take remedial action with lock held
-	pm.takeRemedialAction(lockCtx, action)
+	pm.takeRemedialAction(lockCtx, action, currentState)
 }
 
 // discoverPostgresState discovers the current state of PostgreSQL. Returns an
@@ -1581,6 +1590,11 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 		if err != nil {
 			pm.logger.ErrorContext(ctx, "Failed to determine primary status", "error", err)
 		}
+		// Lock-free first pass from the monitor: use the inconsistent read,
+		// which falls back to the cached rule when postgres is unreachable.
+		if cs, err := pm.getInconsistentConsensusStatus(ctx); err == nil {
+			state.primaryTerm = commonconsensus.PrimaryTerm(cs)
+		}
 	}
 
 	// Check if backups are available (only if directory not initialized)
@@ -1597,6 +1611,25 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 	state.bootstrapSentinelPresent = sentinelPresent
 
 	return state, nil
+}
+
+// primaryTermLocked returns the coordinator term of the pooler's current
+// committed rule if this pooler is the primary per that rule. Uses a
+// consistent consensus status read and therefore requires the action lock.
+// Returns (0, nil) when the rule does not name this pooler as primary.
+// Returns (0, err) only when the consensus status cannot be read at all —
+// callers that need to distinguish "confirmed not primary" from "unknown"
+// must inspect the error.
+//
+// Callers that cannot hold the action lock should read
+// getInconsistentConsensusStatus themselves and pass the result to
+// consensus.PrimaryTerm.
+func (pm *MultiPoolerManager) primaryTermLocked(ctx context.Context) (int64, error) {
+	cs, err := pm.getConsensusStatus(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read consensus status: %w", err)
+	}
+	return commonconsensus.PrimaryTerm(cs), nil
 }
 
 // setMonitorReason sets the current monitor state reason and logs on state changes.
@@ -1628,11 +1661,10 @@ func (pm *MultiPoolerManager) determineRemedialAction(currentState postgresState
 		// signal needs to be (re-)published. This handles the case where the signal was
 		// lost after a process restart following EmergencyDemote.
 		if !currentState.isPrimary {
-			term, _ := pm.consensusState.GetInconsistentTerm()
 			pm.mu.Lock()
 			resigned := pm.resignedPrimaryAtTerm
 			pm.mu.Unlock()
-			if term.GetPrimaryTerm() != 0 && resigned == 0 {
+			if currentState.primaryTerm != 0 && resigned == 0 {
 				return remedialActionAdjustTypeToReplica
 			}
 		}
@@ -1661,7 +1693,7 @@ func (pm *MultiPoolerManager) determineRemedialAction(currentState postgresState
 
 // takeRemedialAction executes the specified remedial action.
 // Caller must hold the action lock.
-func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action remedialAction) {
+func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action remedialAction, state postgresState) {
 	// Assert that the action lock is held
 	if err := AssertActionLockHeld(ctx); err != nil {
 		pm.logger.ErrorContext(ctx, "takeRemedialAction called without action lock", "error", err)
@@ -1696,11 +1728,10 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// Signal voluntary resignation so the coordinator can trigger an immediate
 		// election. Use the primary_term (the term at which we were elected) since
 		// the coordinator uses this to decide whether the signal is still active.
-		// TODO: Once ConsensusStatus is populated in StatusResponse, use the
-		// consensus term from there for a more precise resignation signal.
-		if term, err := pm.consensusState.GetInconsistentTerm(); err == nil && term.GetPrimaryTerm() != 0 {
-			if err := pm.setResignedPrimaryAtTerm(ctx, term.GetPrimaryTerm()); err != nil {
+		if state.primaryTerm != 0 {
+			if err := pm.setResignedPrimaryAtTerm(ctx, state.primaryTerm); err != nil {
 				pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to set resigned primary term", "error", err)
+				return
 			}
 		}
 		if err := pm.changeTypeLocked(ctx, clustermetadatapb.PoolerType_REPLICA); err != nil {

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -717,9 +717,8 @@ func (pm *MultiPoolerManager) checkAndSetReady() {
 		}
 
 		// Set initial primary observation from the highest known rule.
-		// TODO: This publishes PrimaryID as ourselves without first verifying that
-		// the highest known rule actually has us as the primary. Address in a
-		// follow-up PR (check rule.PrimaryId before publishing).
+		// commonconsensus.PrimaryTerm returns 0 unless the rule names us as the
+		// primary, so publishing serviceID here is safe.
 		if cs, err := pm.getInconsistentConsensusStatus(pm.ctx); err == nil {
 			if primaryTerm := commonconsensus.PrimaryTerm(cs); primaryTerm > 0 {
 				pm.healthStreamer.UpdatePrimaryObservation(&poolerserver.PrimaryObservation{

--- a/go/services/multipooler/manager/manager_test.go
+++ b/go/services/multipooler/manager/manager_test.go
@@ -363,6 +363,8 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 			mockQueryService := mock.NewQueryService()
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 			manager.qsc = &mockPoolerController{queryService: mockQueryService}
+			manager.rules = newRuleStore(logger, mockQueryService)
+			manager.rules = newRuleStore(logger, mockQueryService)
 
 			// Start and wait for ready
 			senv := servenv.NewServEnv(viperutil.NewRegistry())

--- a/go/services/multipooler/manager/manager_test.go
+++ b/go/services/multipooler/manager/manager_test.go
@@ -364,7 +364,6 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 			manager.qsc = &mockPoolerController{queryService: mockQueryService}
 			manager.rules = newRuleStore(logger, mockQueryService)
-			manager.rules = newRuleStore(logger, mockQueryService)
 
 			// Start and wait for ready
 			senv := servenv.NewServEnv(viperutil.NewRegistry())

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -336,7 +336,9 @@ func (pm *MultiPoolerManager) getCachedConsensusStatus() (*clustermetadatapb.Con
 // BeginTerm, so it is suitable for observability (StatusResponse, health monitors) but not
 // for decisions that require a consistent view.
 //
-// Returns (nil, err) if postgres is unreachable; callers should log and continue.
+// Falls back to the ruleStore's cached position when postgres is unreachable, so
+// that callers can still derive the last-known primary term (e.g. for stale-
+// primary detection) after postgres has crashed.
 func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context) (*clustermetadatapb.ConsensusStatus, error) {
 	term, err := pm.consensusState.GetInconsistentTerm()
 	if err != nil {
@@ -345,7 +347,11 @@ func (pm *MultiPoolerManager) getInconsistentConsensusStatus(ctx context.Context
 
 	pos, err := pm.rules.observePosition(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read current rule position: %w", err)
+		// Postgres is unreachable — fall back to the last observed position
+		// cached in memory. May be stale, but preserves visibility into the
+		// most recent rule across postgres restarts and crashes.
+		pm.logger.DebugContext(ctx, "observePosition failed; falling back to cached rule position", "error", err)
+		pos = pm.rules.cachedPosition()
 	}
 	return buildConsensusStatus(pm.serviceID, term, pos), nil
 }
@@ -385,7 +391,7 @@ func (pm *MultiPoolerManager) setResignedPrimaryAtTerm(ctx context.Context, term
 }
 
 // clearResignedPrimaryAtTerm clears the leadership demotion request. Called by
-// coordinator-driven promotion (SetPrimaryTerm) when this node is explicitly
+// coordinator-driven promotion (Promote) when this node is explicitly
 // re-appointed as primary at a new term.
 // Requires the action lock (ctx must be an action-lock context).
 func (pm *MultiPoolerManager) clearResignedPrimaryAtTerm(ctx context.Context) error {
@@ -408,10 +414,6 @@ func (pm *MultiPoolerManager) ConsensusStatus(ctx context.Context, req *consensu
 	localCurrentTerm := int64(0)
 	if term != nil {
 		localCurrentTerm = term.GetTermNumber()
-	}
-	localPrimaryTerm := int64(0)
-	if term != nil {
-		localPrimaryTerm = term.GetPrimaryTerm()
 	}
 
 	// Check if database is healthy by attempting a simple query
@@ -473,7 +475,6 @@ func (pm *MultiPoolerManager) ConsensusStatus(ctx context.Context, req *consensu
 		Cell:               pm.serviceID.GetCell(),
 		Role:               role,
 		TimelineInfo:       timelineInfo,
-		PrimaryTerm:        localPrimaryTerm,
 		ConsensusStatus:    consensusStatus,
 		AvailabilityStatus: pm.buildAvailabilityStatus(),
 	}, nil

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -69,10 +69,14 @@ func expectObservePositionAsCurrentPrimary(m *mock.QueryService, appName string,
 	m.AddQueryPatternOnce("FROM multigres.current_rule", mock.MakeQueryResult(cols, row))
 }
 
-// expectObservePositionAsStalePrimary sets up a persistent mock so subsequent
-// calls to pm.primaryTermLocked return 0 for the original pooler:
-// observePosition reports primaryAppName (a different pooler) as the rule
-// primary. Useful for asserting state after DemoteStalePrimary has completed.
+// expectObservePositionAsStalePrimary installs a persistent mock that
+// simulates the rule-state convergence that replication will eventually
+// produce after DemoteStalePrimary completes. DemoteStalePrimary itself
+// does NOT rewrite the rule: pg_rewind overwrites multigres.current_rule
+// only when the timelines diverge; otherwise the rule converges via
+// streaming replication from the source primary. Tests use this helper
+// to assert the post-convergence primary_term without actually running
+// replication.
 func expectObservePositionAsStalePrimary(m *mock.QueryService, primaryAppName string, coordinatorTerm int64) {
 	cols, row := observePositionRow(primaryAppName, coordinatorTerm)
 	m.AddQueryPattern("FROM multigres.current_rule", mock.MakeQueryResult(cols, row))
@@ -1023,8 +1027,10 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// observePosition reports this pooler as the current primary, so
 				// the "already demoted" check does not short-circuit.
 				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
-				// After demotion, the rule names the source pooler as primary; this
-				// persistent mock lets the post-demotion assertion see primary_term=0.
+				// Simulates the post-replication rule state (source pooler as
+				// primary). DemoteStalePrimary doesn't rewrite the rule — this
+				// mock stands in for the streaming convergence that would make
+				// primary_term read back as 0 after DemoteStalePrimary returns.
 				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
 
 				// waitForDatabaseConnection after restart - health check
@@ -1058,7 +1064,8 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// observePosition reports this pooler as the current primary, so
 				// DemoteStalePrimary proceeds to term validation (which fails).
 				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 15)
-				// Demotion didn't happen, so the rule still names this pooler as
+				// Demotion short-circuited on term validation, so no replication
+				// was ever wired; the rule genuinely still names this pooler as
 				// primary for the post-error assertion.
 				expectObservePositionAsStalePrimary(m, "zone1_stale-primary", 15)
 			},
@@ -1085,8 +1092,10 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// observePosition reports this pooler as the current primary, so
 				// the "already demoted" check does not short-circuit.
 				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
-				// After demotion, the rule names the source pooler as primary; this
-				// persistent mock lets the post-demotion assertion see primary_term=0.
+				// Simulates the post-replication rule state (source pooler as
+				// primary). DemoteStalePrimary doesn't rewrite the rule — this
+				// mock stands in for the streaming convergence that would make
+				// primary_term read back as 0 after DemoteStalePrimary returns.
 				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
 
 				// waitForDatabaseConnection after restart - health check
@@ -1123,8 +1132,10 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// observePosition reports this pooler as the current primary, so
 				// the "already demoted" check does not short-circuit.
 				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
-				// After demotion, the rule names the source pooler as primary; this
-				// persistent mock lets the post-demotion assertion see primary_term=0.
+				// Simulates the post-replication rule state (source pooler as
+				// primary). DemoteStalePrimary doesn't rewrite the rule — this
+				// mock stands in for the streaming convergence that would make
+				// primary_term read back as 0 after DemoteStalePrimary returns.
 				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
 
 				// waitForDatabaseConnection after restart - health check

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
@@ -37,6 +38,45 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
+
+// observePositionRow builds a mock result row for the observePosition query
+// where the rule names primaryAppName (e.g. "zone1_stale-primary") as the
+// primary with the given coordinator term.
+func observePositionRow(primaryAppName string, coordinatorTerm int64) ([]string, [][]any) {
+	cols := []string{
+		"coordinator_term", "leader_subterm", "leader_id", "coordinator_id", "cohort_members",
+		"durability_policy_name", "durability_quorum_type", "durability_required_count",
+		"durability_async_fallback", "current_lsn",
+	}
+	row := [][]any{{
+		coordinatorTerm, int64(0), primaryAppName, primaryAppName, "{}",
+		nil, nil, nil, nil, "0/1",
+	}}
+	return cols, row
+}
+
+// expectObservePositionAsCurrentPrimary queues one-shot mocks so that the pre-
+// demotion observePosition calls (one from manager startup's checkAndSetReady
+// and one from DemoteStalePrimary's "already demoted" check) both report this
+// pooler as the primary of the current rule with the given coordinatorTerm.
+// A subsequent expectObservePositionAsStalePrimary call can install a persistent
+// post-demotion mock for the final assertion.
+func expectObservePositionAsCurrentPrimary(m *mock.QueryService, appName string, coordinatorTerm int64) {
+	cols, row := observePositionRow(appName, coordinatorTerm)
+	// Consumed by checkAndSetReady during manager startup.
+	m.AddQueryPatternOnce("FROM multigres.current_rule", mock.MakeQueryResult(cols, row))
+	// Consumed by DemoteStalePrimary's "already demoted" check.
+	m.AddQueryPatternOnce("FROM multigres.current_rule", mock.MakeQueryResult(cols, row))
+}
+
+// expectObservePositionAsStalePrimary sets up a persistent mock so subsequent
+// calls to pm.primaryTermLocked return 0 for the original pooler:
+// observePosition reports primaryAppName (a different pooler) as the rule
+// primary. Useful for asserting state after DemoteStalePrimary has completed.
+func expectObservePositionAsStalePrimary(m *mock.QueryService, primaryAppName string, coordinatorTerm int64) {
+	cols, row := observePositionRow(primaryAppName, coordinatorTerm)
+	m.AddQueryPattern("FROM multigres.current_rule", mock.MakeQueryResult(cols, row))
+}
 
 // expectStandbyRevokeMocks sets up mock expectations for the standby revoke path:
 // receiver disconnect, wait for disconnect, and replay stabilization.
@@ -968,8 +1008,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 		{
 			name: "SuccessfulDemotion_UpdatesTermFromLowerToHigher",
 			initialTerm: &multipoolermanagerdatapb.ConsensusTerm{
-				TermNumber:  5,
-				PrimaryTerm: 5, // Was primary in term 5
+				TermNumber: 5,
 			},
 			requestTerm: 10,
 			force:       false,
@@ -981,6 +1020,13 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				}
 			},
 			setupQueryMock: func(m *mock.QueryService) {
+				// observePosition reports this pooler as the current primary, so
+				// the "already demoted" check does not short-circuit.
+				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
+				// After demotion, the rule names the source pooler as primary; this
+				// persistent mock lets the post-demotion assertion see primary_term=0.
+				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
+
 				// waitForDatabaseConnection after restart - health check
 				m.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 
@@ -1001,8 +1047,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 		{
 			name: "OutdatedTerm_RejectedWithoutForce",
 			initialTerm: &multipoolermanagerdatapb.ConsensusTerm{
-				TermNumber:  15,
-				PrimaryTerm: 15,
+				TermNumber: 15,
 			},
 			requestTerm: 10,
 			force:       false,
@@ -1010,7 +1055,12 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// Should not reach pg_rewind since term validation fails
 			},
 			setupQueryMock: func(m *mock.QueryService) {
-				// No queries should execute
+				// observePosition reports this pooler as the current primary, so
+				// DemoteStalePrimary proceeds to term validation (which fails).
+				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 15)
+				// Demotion didn't happen, so the rule still names this pooler as
+				// primary for the post-error assertion.
+				expectObservePositionAsStalePrimary(m, "zone1_stale-primary", 15)
 			},
 			expectedFinalConsensusTerm: 15, // Term should remain unchanged
 			expectedPrimaryTerm:        15, // Primary term should remain unchanged
@@ -1021,8 +1071,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 		{
 			name: "OutdatedTerm_AcceptedWithForce",
 			initialTerm: &multipoolermanagerdatapb.ConsensusTerm{
-				TermNumber:  15,
-				PrimaryTerm: 15,
+				TermNumber: 15,
 			},
 			requestTerm: 10,
 			force:       true,
@@ -1033,6 +1082,13 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				}
 			},
 			setupQueryMock: func(m *mock.QueryService) {
+				// observePosition reports this pooler as the current primary, so
+				// the "already demoted" check does not short-circuit.
+				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
+				// After demotion, the rule names the source pooler as primary; this
+				// persistent mock lets the post-demotion assertion see primary_term=0.
+				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
+
 				// waitForDatabaseConnection after restart - health check
 				m.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 
@@ -1053,8 +1109,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 		{
 			name: "SameTerm_Idempotent",
 			initialTerm: &multipoolermanagerdatapb.ConsensusTerm{
-				TermNumber:  10,
-				PrimaryTerm: 10,
+				TermNumber: 10,
 			},
 			requestTerm: 10,
 			force:       false,
@@ -1065,6 +1120,13 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				}
 			},
 			setupQueryMock: func(m *mock.QueryService) {
+				// observePosition reports this pooler as the current primary, so
+				// the "already demoted" check does not short-circuit.
+				expectObservePositionAsCurrentPrimary(m, "zone1_stale-primary", 5)
+				// After demotion, the rule names the source pooler as primary; this
+				// persistent mock lets the post-demotion assertion see primary_term=0.
+				expectObservePositionAsStalePrimary(m, "zone1_correct-primary", 10)
+
 				// waitForDatabaseConnection after restart - health check
 				m.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
 
@@ -1142,6 +1204,7 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 
 			tt.setupQueryMock(mockQueryService)
 			pm.qsc = &mockPoolerController{queryService: mockQueryService}
+			pm.rules = newRuleStore(logger, mockQueryService)
 
 			senv := servenv.NewServEnv(viperutil.NewRegistry())
 			pm.Start(senv)
@@ -1190,8 +1253,11 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedFinalConsensusTerm, persistedTerm.TermNumber,
 				"Consensus term should be %d but got %d", tt.expectedFinalConsensusTerm, persistedTerm.TermNumber)
-			assert.Equal(t, tt.expectedPrimaryTerm, persistedTerm.PrimaryTerm,
-				"Primary term should be %d but got %d", tt.expectedPrimaryTerm, persistedTerm.PrimaryTerm)
+			cs, err := pm.getInconsistentConsensusStatus(ctx)
+			require.NoError(t, err)
+			primaryTerm := commonconsensus.PrimaryTerm(cs)
+			assert.Equal(t, tt.expectedPrimaryTerm, primaryTerm,
+				"Primary term should be %d but got %d", tt.expectedPrimaryTerm, primaryTerm)
 
 			// Verify topology was updated to REPLICA (only on success).
 			// The write is asynchronous so we poll until the publisher catches up.

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	"github.com/multigres/multigres/go/services/multipooler/executor/mock"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -54,6 +55,10 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 	}
 	pm, err := NewMultiPoolerManager(slog.Default(), mp, &Config{})
 	require.NoError(t, err)
+	// Replace the rule store's backing query service with a mock — the real
+	// one requires a running postgres, and tests that exercise rule reads
+	// (via observePosition) crash on nil otherwise.
+	pm.rules = newRuleStore(pm.logger, mock.NewQueryService())
 	return pm
 }
 
@@ -519,14 +524,9 @@ func TestDetermineRemedialAction(t *testing.T) {
 					Type: tt.poolerType,
 				},
 			}
-			cs := NewConsensusState("", nil)
-			if tt.primaryTerm != 0 {
-				cs.mu.Lock()
-				cs.term = &multipoolermanagerdatapb.ConsensusTerm{PrimaryTerm: tt.primaryTerm}
-				cs.mu.Unlock()
-			}
-			pm.consensusState = cs
+			pm.consensusState = NewConsensusState("", nil)
 			pm.resignedPrimaryAtTerm = tt.resignedPrimaryTerm
+			tt.state.primaryTerm = tt.primaryTerm
 
 			got := pm.determineRemedialAction(tt.state)
 			require.Equal(t, tt.expectedAction, got)
@@ -548,7 +548,7 @@ func TestTakeRemedialAction_PgctldUnavailable(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should log error and take no action
-	pm.takeRemedialAction(lockCtx, remedialActionNone)
+	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// Note: takeRemedialAction with remedialActionNone doesn't log
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -571,7 +571,7 @@ func TestTakeRemedialAction_PostgresReady(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should log info and take no action (no type mismatch)
-	pm.takeRemedialAction(lockCtx, remedialActionNone)
+	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// Note: takeRemedialAction with remedialActionNone doesn't log
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -594,7 +594,7 @@ func TestTakeRemedialAction_StartPostgres(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should attempt to start postgres
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
+	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 	assert.True(t, mockPgctld.startCalled, "Should have called Start()")
@@ -620,7 +620,7 @@ func TestTakeRemedialAction_StartPostgresFails(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Should handle error gracefully
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
+	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 
 	assert.True(t, mockPgctld.startCalled, "Should have attempted to call Start()")
 	// Reason stays the same since we're retrying
@@ -640,7 +640,7 @@ func TestTakeRemedialAction_WaitingForBackup(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// With no backups and uninitialized dir, action is None - doesn't do anything
-	pm.takeRemedialAction(lockCtx, remedialActionNone)
+	pm.takeRemedialAction(lockCtx, remedialActionNone, postgresState{})
 
 	// takeRemedialAction with None action doesn't modify last logged reason
 	assert.Equal(t, "", pm.pgMonitorLastLoggedReason)
@@ -668,17 +668,17 @@ func TestTakeRemedialAction_LogDeduplication(t *testing.T) {
 	defer pm.actionLock.Release(lockCtx)
 
 	// Call multiple times with same action - reason should stay the same (log deduplication)
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
+	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
+	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
-	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres)
+	pm.takeRemedialAction(lockCtx, remedialActionStartPostgres, postgresState{})
 	assert.Equal(t, "starting_postgres", pm.pgMonitorLastLoggedReason)
 
 	// Change action type - reason should change
-	pm.takeRemedialAction(lockCtx, remedialActionRestoreFromBackup)
+	pm.takeRemedialAction(lockCtx, remedialActionRestoreFromBackup, postgresState{})
 	assert.Equal(t, "restoring_from_backup", pm.pgMonitorLastLoggedReason)
 }
 
@@ -758,7 +758,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 
 			cs := NewConsensusState("", nil)
 			cs.mu.Lock()
-			cs.term = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 1, PrimaryTerm: tc.primaryTerm}
+			cs.term = &multipoolermanagerdatapb.ConsensusTerm{TermNumber: 1}
 			cs.mu.Unlock()
 			pm.consensusState = cs
 
@@ -770,7 +770,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				require.NoError(t, pm.setResignedPrimaryAtTerm(lockCtx, tc.resignedBefore))
 			}
 
-			pm.takeRemedialAction(lockCtx, tc.action)
+			pm.takeRemedialAction(lockCtx, tc.action, postgresState{primaryTerm: tc.primaryTerm})
 
 			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus())
 		})

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	"github.com/multigres/multigres/go/services/multipooler/executor/mock"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -55,10 +54,9 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 	}
 	pm, err := NewMultiPoolerManager(slog.Default(), mp, &Config{})
 	require.NoError(t, err)
-	// Replace the rule store's backing query service with a mock — the real
-	// one requires a running postgres, and tests that exercise rule reads
-	// (via observePosition) crash on nil otherwise.
-	pm.rules = newRuleStore(pm.logger, mock.NewQueryService())
+	// Swap in a fake rule store so tests that exercise observePosition /
+	// cachedPosition don't crash on the real store's nil query service.
+	pm.rules = &fakeRuleStore{}
 	return pm
 }
 

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -32,6 +32,7 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 )
 
@@ -659,15 +660,6 @@ func (pm *MultiPoolerManager) getPrimaryStatusInternal(ctx context.Context) (*mu
 	}
 	status.SyncReplicationConfig = syncConfig
 
-	// Include primary term from consensus state.
-	term, err := pm.consensusState.GetInconsistentTerm()
-	if err != nil {
-		return nil, err
-	}
-	if term != nil {
-		status.PrimaryTerm = term.GetPrimaryTerm()
-	}
-
 	return status, nil
 }
 
@@ -925,8 +917,8 @@ func (pm *MultiPoolerManager) emergencyDemoteLocked(ctx context.Context, consens
 	// election without waiting for a heartbeat timeout. Use this node's own
 	// primary_term (not the incoming consensusTerm) so the coordinator can
 	// correlate the signal with the term at which this node was elected.
-	if term, err := pm.consensusState.GetTerm(ctx); err == nil && term.GetPrimaryTerm() != 0 {
-		if err := pm.setResignedPrimaryAtTerm(ctx, term.GetPrimaryTerm()); err != nil {
+	if primaryTerm, err := pm.primaryTermLocked(ctx); err == nil && primaryTerm != 0 {
+		if err := pm.setResignedPrimaryAtTerm(ctx, primaryTerm); err != nil {
 			return nil, mterrors.Wrap(err, "failed to set resigned primary term")
 		}
 	}
@@ -1010,18 +1002,13 @@ func (pm *MultiPoolerManager) DemoteStalePrimary(
 	}
 	defer pm.actionLock.Release(ctx)
 
-	// Check if already demoted by reading primary_term from disk.
-	// Invariant: primary_term > 0 if and only if postgres is (or was) in primary state.
-	// We set primary_term before promotion and clear it after demotion.
-	// If primary_term is 0, this node was already demoted (either by a previous call
-	// or by another multiorch instance). Return early to avoid redundant work.
-	// TODO (@rafael): This information should come from pooler state, instead of checking this
-	// invariant.
-	term, err := pm.consensusState.GetTerm(ctx)
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to get current term")
-	}
-	if term.GetPrimaryTerm() == 0 {
+	// Check if already demoted by consulting the current rule. Only short-circuit
+	// when we can positively confirm this node is no longer the primary (err ==
+	// nil AND term == 0). On any error — e.g. postgres is down after a crash —
+	// we fall through and run the idempotent demotion flow, because we cannot
+	// tell the difference between "already demoted" and "primary with unreachable
+	// postgres" from local state alone.
+	if primaryTerm, err := pm.primaryTermLocked(ctx); err == nil && primaryTerm == 0 {
 		pm.logger.InfoContext(ctx, "Pooler already demoted, skipping DemoteStalePrimary")
 		// Return success with rewind_performed=false since node is already in correct state
 		finalLSN := ""
@@ -1083,12 +1070,6 @@ func (pm *MultiPoolerManager) DemoteStalePrimary(
 	// (calling SetPrimaryConnInfo would deadlock trying to acquire the same lock)
 	if err := pm.setPrimaryConnInfoLocked(ctx, source.Hostname, port, false, false); err != nil {
 		return nil, mterrors.Wrap(err, "failed to configure replication to source primary")
-	}
-
-	// Clear primary_term since this node is no longer primary for any term.
-	// Note: consensusState can't be nil here because validateTerm passed.
-	if err := pm.consensusState.SetPrimaryTerm(ctx, 0, false /* force */); err != nil {
-		return nil, mterrors.Wrap(err, "failed to clear primary term")
 	}
 
 	// Report the new primary (source) so the gateway can use this observation.
@@ -1211,19 +1192,6 @@ func (pm *MultiPoolerManager) Promote(ctx context.Context, consensusTerm int64, 
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "Failed to get final LSN", "error", err)
 		return nil, err
-	}
-
-	// ORDERING: Set primary_term BEFORE writing to history table.
-	// This ordering is intentional to avoid an inconsistent state:
-	// - If we set primary_term then history write fails: promotion fails, but primary_term is set.
-	//   This only means this primary doesn't have any committed transactions yet. On retry,
-	//   setting primary_term is idempotent and history write will succeed. This is safe.
-	// - On the contrary, if we write history then primary_term fails: history transaction is COMMITTED AND REPLICATED,
-	//   but the node doesn't know it's primary for this term. This creates inconsistent state with
-	//   a committed transaction that can't be easily rolled back.
-	// Therefore, we persist primary_term first, then commit the transaction.
-	if err := pm.consensusState.SetPrimaryTerm(ctx, consensusTerm, force); err != nil {
-		return nil, mterrors.Wrap(err, "failed to set primary term")
 	}
 
 	// Clear any outstanding resignation signal now that the coordinator has

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/servenv"
@@ -145,6 +146,7 @@ func TestPrimaryPosition(t *testing.T) {
 			isReplica := tt.poolerType == clustermetadatapb.PoolerType_REPLICA
 			mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{isReplica}}))
 			manager.qsc = &mockPoolerController{queryService: mockQueryService}
+			manager.rules = newRuleStore(logger, mockQueryService)
 
 			// Mark as initialized to skip auto-restore (not testing backup functionality)
 			err = manager.setInitialized()
@@ -220,6 +222,7 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	mockQueryService := mock.NewQueryService()
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = newRuleStore(logger, mockQueryService)
 
 	// Start and wait for ready
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -443,6 +446,7 @@ func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService, 
 	// Assign mock pooler controller and rule store BEFORE starting the manager
 	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = newRuleStore(logger, mockQueryService)
 	pm.rules = rules
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -989,9 +993,11 @@ func TestPromote_RuleHistoryErrorFailsPromotion(t *testing.T) {
 	pm.mu.Unlock()
 
 	// Verify primary_term is 0 before promotion
-	term, err := pm.consensusState.GetInconsistentTerm()
+	cs, err := pm.getInconsistentConsensusStatus(ctx)
 	require.NoError(t, err)
-	require.Equal(t, int64(0), term.GetPrimaryTerm(), "primary_term should be 0 before promotion")
+	require.Equal(t, int64(0),
+		commonconsensus.PrimaryTerm(cs),
+		"primary_term should be 0 before promotion")
 
 	// Call Promote - should FAIL because rule history write fails
 	resp, err := pm.Promote(ctx, 10, "0/9876543", nil, false /* force */, "test_reason", nil, nil, nil)
@@ -1001,15 +1007,13 @@ func TestPromote_RuleHistoryErrorFailsPromotion(t *testing.T) {
 	// Error message should indicate the rule history failure
 	assert.Contains(t, err.Error(), "rule history")
 
-	// CRITICAL: Verify that primary_term WAS set even though promotion failed.
-	// This is intentional - we set primary_term (local state) before writing to history table
-	// (committed transaction). If the order were reversed and history write succeeded but
-	// primary_term write failed, we'd have a committed transaction without local state.
-	// With this ordering, on retry the primary_term set is idempotent and history write will succeed.
-	term, err = pm.consensusState.GetInconsistentTerm()
+	// Primary term is derived from the highest known rule; since the rule history
+	// write failed, the rule was not updated and primary_term remains 0.
+	cs, err = pm.getInconsistentConsensusStatus(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int64(10), term.GetPrimaryTerm(),
-		"primary_term should be set to 10 even though promotion failed (set before history write)")
+	assert.Equal(t, int64(0),
+		commonconsensus.PrimaryTerm(cs),
+		"primary_term should be 0 because the rule history write failed")
 
 	// Note: PostgreSQL was promoted but we return error to indicate the promotion is incomplete.
 	// The coordinator should handle this partial promotion state (e.g., retry or repair).
@@ -1097,6 +1101,7 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 
 	fakeRules := &fakeRuleStore{}
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = newRuleStore(logger, mockQueryService)
 	pm.rules = fakeRules
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -1141,78 +1146,6 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 
 	fakeRules.assertPromoteRecorded(t)
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
-}
-
-func TestSetPrimaryTerm_InvariantValidation(t *testing.T) {
-	ctx := context.Background()
-	tmpDir := t.TempDir()
-
-	// Create pg_data directory structure
-	createPgDataDir(t, tmpDir)
-
-	serviceID := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test-pooler",
-	}
-
-	// Create consensus state and set initial term to 5
-	consensusState := NewConsensusState(tmpDir, serviceID)
-	initialTerm := &multipoolermanagerdatapb.ConsensusTerm{
-		TermNumber:  5,
-		PrimaryTerm: 0,
-	}
-	setTermForTest(t, tmpDir, initialTerm)
-	_, err := consensusState.Load()
-	require.NoError(t, err)
-
-	// Create action lock and acquire it
-	actionLock := NewActionLock()
-	lockCtx, err := actionLock.Acquire(ctx, "test-primary-term")
-	require.NoError(t, err)
-	defer actionLock.Release(lockCtx)
-
-	// Setting primary_term to match current term should succeed
-	err = consensusState.SetPrimaryTerm(lockCtx, 5, false /* force */)
-	require.NoError(t, err, "Should be able to set primary_term to current term value")
-
-	term, err := consensusState.GetInconsistentTerm()
-	require.NoError(t, err)
-	assert.Equal(t, int64(5), term.GetPrimaryTerm(), "primary_term should be set to 5")
-
-	// Setting primary_term to a different value should fail (invariant violation)
-	err = consensusState.SetPrimaryTerm(lockCtx, 7, false /* force */)
-	require.Error(t, err, "Should fail when primary_term doesn't match current term")
-
-	// Verify primary_term was not changed
-	term, err = consensusState.GetInconsistentTerm()
-	require.NoError(t, err)
-	assert.Equal(t, int64(5), term.GetPrimaryTerm(), "primary_term should still be 5")
-
-	// But with force=true, setting a mismatched term should succeed
-	err = consensusState.SetPrimaryTerm(lockCtx, 7, true /* force */)
-	require.NoError(t, err, "Should succeed with force=true even when terms don't match")
-
-	term, err = consensusState.GetInconsistentTerm()
-	require.NoError(t, err)
-	assert.Equal(t, int64(7), term.GetPrimaryTerm(), "primary_term should be updated to 7 with force")
-
-	// Clearing primary_term to 0 should always succeed (exception to invariant)
-	err = consensusState.SetPrimaryTerm(lockCtx, 0, false /* force */)
-	require.NoError(t, err, "Should be able to clear primary_term to 0 regardless of current term")
-
-	term, err = consensusState.GetInconsistentTerm()
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), term.GetPrimaryTerm(), "primary_term should be cleared to 0")
-
-	// Negative primary_term should fail even with force
-	err = consensusState.SetPrimaryTerm(lockCtx, -1, false /* force */)
-	require.Error(t, err, "Should fail with negative primary_term")
-	assert.Contains(t, err.Error(), "primary_term cannot be negative")
-
-	err = consensusState.SetPrimaryTerm(lockCtx, -1, true /* force */)
-	require.Error(t, err, "Should fail with negative primary_term even with force=true")
-	assert.Contains(t, err.Error(), "primary_term cannot be negative")
 }
 
 func TestSetPrimaryConnInfo_StoresPrimaryPoolerID(t *testing.T) {
@@ -1285,6 +1218,7 @@ func TestSetPrimaryConnInfo_StoresPrimaryPoolerID(t *testing.T) {
 	// SetPrimaryConnInfo executes pg_reload_conf()
 	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
+	pm.rules = newRuleStore(logger, mockQueryService)
 
 	senv := servenv.NewServEnv(viperutil.NewRegistry())
 	go pm.Start(senv)
@@ -1405,6 +1339,7 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
+		pm.rules = newRuleStore(logger, mockQueryService)
 		pm.rules = &fakeRuleStore{}
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -1493,6 +1428,7 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
+		pm.rules = newRuleStore(logger, mockQueryService)
 		pm.rules = &fakeRuleStore{}
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -1576,6 +1512,7 @@ func TestReplicationStatus(t *testing.T) {
 				[][]any{{"0/12345600", "0/12345678", "f", "not paused", "2025-01-01 00:00:00", "host=primary port=5432 user=repl application_name=test", "streaming", nil, nil, nil}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
+		pm.rules = newRuleStore(logger, mockQueryService)
 		pm.rules = &fakeRuleStore{}
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -1642,6 +1579,7 @@ func TestReplicationStatus(t *testing.T) {
 		mockQueryService.AddQueryPattern("SHOW synchronous_commit",
 			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
+		pm.rules = newRuleStore(logger, mockQueryService)
 		pm.rules = &fakeRuleStore{
 			pos: &clustermetadatapb.PoolerPosition{
 				Rule: &clustermetadatapb.ShardRule{
@@ -1726,6 +1664,7 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
+		pm.rules = newRuleStore(logger, mockQueryService)
 		pm.rules = &fakeRuleStore{}
 
 		senv := servenv.NewServEnv(viperutil.NewRegistry())
@@ -1786,7 +1725,7 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 
 	// Set consensus term
 	setTermForTest(t, poolerDir, &multipoolermanagerdatapb.ConsensusTerm{
-		PrimaryTerm: 1,
+		TermNumber: 1,
 	})
 
 	config := &Config{
@@ -1813,6 +1752,7 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = newRuleStore(logger, mockQueryService)
 	manager.rules = &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication")}
 
 	// Mark as initialized
@@ -1893,7 +1833,7 @@ func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing
 
 	// Set consensus term
 	setTermForTest(t, poolerDir, &multipoolermanagerdatapb.ConsensusTerm{
-		PrimaryTerm: 5,
+		TermNumber: 5,
 	})
 
 	config := &Config{
@@ -1920,6 +1860,7 @@ func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{false}}))
 
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = newRuleStore(logger, mockQueryService)
 	manager.rules = &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for sync replication")}
 
 	err = manager.setInitialized()
@@ -2022,6 +1963,7 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 
 	// Assign mock pooler controller BEFORE opening to avoid race conditions
 	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = newRuleStore(logger, mockQueryService)
 
 	// Simulate the manager being open and ready (set internal state without starting goroutines)
 	manager.mu.Lock()

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -32,10 +32,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
@@ -152,9 +154,13 @@ func TestBootstrapInitialization(t *testing.T) {
 		require.NoError(t, err, "Should be able to get status from primary")
 		require.NotNil(t, status.Status.ConsensusTerm, "Primary should have consensus term")
 		assert.Equal(t, int64(1), status.Status.ConsensusTerm.TermNumber, "Primary should be on term 1 after bootstrap")
-		assert.Equal(t, int64(1), status.Status.ConsensusTerm.PrimaryTerm, "Primary term should be set to 1 after bootstrap")
+		require.NotNil(t, status.Status.PrimaryStatus, "Primary should have primary status")
+		consensusResp, err := primaryClient.Consensus.Status(ctx, &consensusdatapb.StatusRequest{})
+		require.NoError(t, err, "Should be able to get consensus status from primary")
+		primaryTerm := commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus)
+		assert.Equal(t, int64(1), primaryTerm, "Primary term should be set to 1 after bootstrap")
 		t.Logf("Primary %s: term=%d, primary_term=%d", setup.PrimaryName,
-			status.Status.ConsensusTerm.TermNumber, status.Status.ConsensusTerm.PrimaryTerm)
+			status.Status.ConsensusTerm.TermNumber, primaryTerm)
 
 		// Verify multigres schema exists
 		resp, err := primaryClient.Pooler.ExecuteQuery(ctx,
@@ -175,20 +181,22 @@ func TestBootstrapInitialization(t *testing.T) {
 
 			ctx := utils.WithTimeout(t, 5*time.Second)
 			status, err := client.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
-			client.Close()
-
 			require.NoError(t, err)
 			if status.Status.IsInitialized && status.Status.PoolerType == clustermetadatapb.PoolerType_REPLICA {
 				standbyCount++
 
 				// Verify replica has primary_term = 0 (never been primary)
 				require.NotNil(t, status.Status.ConsensusTerm, "Standby %s should have consensus term", name)
-				assert.Equal(t, int64(0), status.Status.ConsensusTerm.PrimaryTerm,
+				consensusResp, err := client.Consensus.Status(ctx, &consensusdatapb.StatusRequest{})
+				require.NoError(t, err, "Standby %s: should be able to get consensus status", name)
+				primaryTerm := commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus)
+				assert.Equal(t, int64(0), primaryTerm,
 					"Standby %s should have primary_term=0 (never been primary)", name)
 
 				t.Logf("Standby node: %s (pooler_type=%s, primary_term=%d)",
-					name, status.Status.PoolerType, status.Status.ConsensusTerm.PrimaryTerm)
+					name, status.Status.PoolerType, primaryTerm)
 			}
+			client.Close()
 		}
 		// Should have at least 1 standby
 		assert.GreaterOrEqual(t, standbyCount, 1, "Should have at least one standby")

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -31,12 +31,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
-
-	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
-	"github.com/multigres/multigres/go/test/utils"
 )
 
 // TestDeadPrimaryRecovery tests multiorch's ability to detect a primary failure
@@ -164,10 +165,12 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		newPrimaryClient, err := shardsetup.NewMultipoolerClient(newPrimary.Multipooler.GrpcPort)
 		require.NoError(t, err)
 		status, err := newPrimaryClient.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
-		newPrimaryClient.Close()
 		require.NoError(t, err, "should be able to get status from new primary")
+		consensusResp, err := newPrimaryClient.Consensus.Status(utils.WithTimeout(t, 5*time.Second), &consensusdatapb.StatusRequest{})
+		newPrimaryClient.Close()
+		require.NoError(t, err, "should be able to get consensus status from new primary")
 		newPrimaryTerm := status.Status.ConsensusTerm.TermNumber
-		newPrimaryTermActual := status.Status.ConsensusTerm.PrimaryTerm
+		newPrimaryTermActual := commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus)
 		t.Logf("New primary %s is on term %d, primary_term=%d", newPrimaryName, newPrimaryTerm, newPrimaryTermActual)
 
 		// Verify primary_term is set and matches the consensus term
@@ -297,14 +300,15 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		require.NoError(t, err)
 
 		status, err := client.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
-		client.Close()
-
 		require.NoError(t, err)
 		if status.Status.PoolerType == clustermetadatapb.PoolerType_REPLICA {
 			require.NotNil(t, status.Status.ConsensusTerm, "Replica %s should have consensus term", name)
-			assert.Equal(t, int64(0), status.Status.ConsensusTerm.PrimaryTerm,
+			consensusResp, err := client.Consensus.Status(utils.WithTimeout(t, 5*time.Second), &consensusdatapb.StatusRequest{})
+			require.NoError(t, err, "Replica %s: should be able to get consensus status", name)
+			assert.Equal(t, int64(0), commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus),
 				"Replica %s should have primary_term=0 (never been primary)", name)
 		}
+		client.Close()
 	}
 
 	// Verify final primary is functional

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
-	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
-	"github.com/multigres/multigres/go/test/utils"
 )
 
 // TestDemoteStalePrimary_SIGKILL tests multiorch's ability to detect a stale primary
@@ -329,7 +331,9 @@ func verifyReplicaReplicating(t *testing.T, setup *shardsetup.ShardSetup, replic
 	status, err := client.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
 	require.NoError(t, err, "Should be able to get status from demoted replica")
 	require.NotNil(t, status.Status.ConsensusTerm, "Replica should have consensus term")
-	require.Equal(t, int64(0), status.Status.ConsensusTerm.PrimaryTerm,
+	consensusResp, err := client.Consensus.Status(ctx, &consensusdatapb.StatusRequest{})
+	require.NoError(t, err, "Should be able to get consensus status from demoted replica")
+	require.Equal(t, int64(0), commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus),
 		"Demoted stale primary %s should have primary_term=0 (cleared during DemoteStalePrimary)", replicaName)
 	t.Logf("Verified demoted stale primary %s has primary_term=0", replicaName)
 }

--- a/go/test/endtoend/multipooler/backup_test.go
+++ b/go/test/endtoend/multipooler/backup_test.go
@@ -29,11 +29,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
-	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
-	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	adminserver "github.com/multigres/multigres/go/services/multiadmin"
 	"github.com/multigres/multigres/go/test/utils"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
 // removeDataDirectory removes the pg_data directory for a given pgctld instance
@@ -240,7 +243,10 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 					statusResp, err = standbyBackupClient.Status(statusCtx, &multipoolermanagerdata.StatusRequest{})
 					require.NoError(t, err, "Should be able to get status after restore")
 					require.NotNil(t, statusResp.Status.ConsensusTerm, "ConsensusTerm should not be nil after restore")
-					assert.Equal(t, int64(0), statusResp.Status.ConsensusTerm.PrimaryTerm,
+					consensusStatusCtx := utils.WithShortDeadline(t)
+					consensusResp, err := standbyConsensusClient.Status(consensusStatusCtx, &consensusdatapb.StatusRequest{})
+					require.NoError(t, err, "Should be able to get consensus status after restore")
+					assert.Equal(t, int64(0), commonconsensus.PrimaryTerm(consensusResp.ConsensusStatus),
 						"primary_term should be 0 after restore")
 
 					// Configure replication after restore

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -151,22 +151,15 @@ message StatusResponse {
   // Timeline information for divergence detection
   TimelineInfo timeline_info = 10;
 
-  // The term for which this multipooler was promoted to primary.
-  // Set during promotion (Promote).
-  // Preserved when consensus term increases (new elections).
-  // Cleared to 0 when demoted (DemoteStalePrimary) or restored from backup.
-  // 0 if never primary. For current primaries, must be non-zero.
-  int64 primary_term = 11;
-
   // The pooler's current consensus status: its term revocation, committed
   // rule position, and highest known rule. Authoritative view of where this
   // pooler stands in the distributed system.
-  clustermetadata.ConsensusStatus consensus_status = 12;
+  clustermetadata.ConsensusStatus consensus_status = 11;
 
   // Best-effort operational fitness signals for this node. These signals are
   // in-memory and may be absent after a process restart. Coordinators treat
   // absence as "unknown," not "unfit."
-  clustermetadata.AvailabilityStatus availability_status = 13;
+  clustermetadata.AvailabilityStatus availability_status = 12;
 }
 
 // Timeline information from PostgreSQL

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -176,10 +176,6 @@ message PrimaryStatus {
 
   // Synchronous replication configuration (parsed from synchronous_standby_names and synchronous_commit)
   SynchronousReplicationConfiguration sync_replication_config = 4;
-
-  // The term for which this pooler was promoted to primary.
-  // Non-zero for current primaries. See ConsensusTerm.primary_term for full lifecycle details.
-  int64 primary_term = 5;
 }
 
 // Status provides unified status information that works for both PRIMARY and REPLICA poolers.
@@ -576,13 +572,6 @@ message ConsensusTerm {
 
   // ID of the leader of the current term
   clustermetadata.ID leader_id = 4;
-
-  // The term for which this pooler was promoted to primary.
-  // Set during promotion (Promote).
-  // Preserved when consensus term increases (new elections).
-  // Cleared to 0 when demoted (DemoteStalePrimary) or restored from backup.
-  // 0 if never primary.
-  int64 primary_term = 5;
 }
 
 // Backup operations


### PR DESCRIPTION
## Summary

- Removes the persisted `primary_term` field from `ConsensusTerm`, `PrimaryStatus`, and `StatusResponse`. Primary term is now derived from the committed rule at read time via `commonconsensus.PrimaryTerm(cs)`, which returns the rule's `coordinator_term` when the pooler holds the primary role per `IsPrimary(cs)` and 0 otherwise.
- Updates analyzers, recovery actions, and 4 end-to-end tests to read primary term through the helper instead of the removed proto field.

## Problem

Now that we have consensus_status rule, we are making that the canonical source of truth for everything consensus related. PrimaryTerm is not longer needed and can be derived from the consensus status. 

## Solution

`commonconsensus.PrimaryTerm(cs)` derives the term from the rule when the pooler is primary, returning 0 otherwise. Callers that previously read `ConsensusTerm.primary_term` or `PrimaryStatus.primary_term` now call this helper (or `primaryTermLocked` on the multipooler manager when an action lock is held for a consistent read).

In `BeginTerm`, standbys are built by filtering recruited poolers through `types.PrimaryNeedsReplacement` — the same predicate already used to skip resigned candidates in `selectCandidate`. Leaving the resigned pooler untouched lets the stale-primary analyzer detect the mismatched rule on the next pass and drive the proper recovery flow.

## Test plan

- I went through all the tests and updated them accordingly to the new changes. This is the part where I would like some extra eyes as these changes made some tests obsolete. 