### PR TITLE
feat(consensus): add CoordinatorProposal and Recruit/Propose/Inform proto definitions

### DIFF
--- a/go/pb/consensus/consensusservice.pb.go
+++ b/go/pb/consensus/consensusservice.pb.go
@@ -40,7 +40,7 @@ var File_consensusservice_proto protoreflect.FileDescriptor
 
 const file_consensusservice_proto_rawDesc = "" +
 	"\n" +
-	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xfb\x06\n" +
+	"\x16consensusservice.proto\x12\tconsensus\x1a\x13consensusdata.proto\x1a\x1cmultipoolermanagerdata.proto2\xd6\b\n" +
 	"\x14MultiPoolerConsensus\x12N\n" +
 	"\tBeginTerm\x12\x1f.consensusdata.BeginTermRequest\x1a .consensusdata.BeginTermResponse\x12E\n" +
 	"\x06Status\x12\x1c.consensusdata.StatusRequest\x1a\x1d.consensusdata.StatusResponse\x12r\n" +
@@ -49,7 +49,10 @@ const file_consensusservice_proto_rawDesc = "" +
 	"\x13UpdateConsensusRule\x12;.multipoolermanagerdata.UpdateSynchronousStandbyListRequest\x1a<.multipoolermanagerdata.UpdateSynchronousStandbyListResponse\x12{\n" +
 	"\x12DemoteStalePrimary\x121.multipoolermanagerdata.DemoteStalePrimaryRequest\x1a2.multipoolermanagerdata.DemoteStalePrimaryResponse\x12{\n" +
 	"\x12SetPrimaryConnInfo\x121.multipoolermanagerdata.SetPrimaryConnInfoRequest\x1a2.multipoolermanagerdata.SetPrimaryConnInfoResponse\x12o\n" +
-	"\x0eRewindToSource\x12-.multipoolermanagerdata.RewindToSourceRequest\x1a..multipoolermanagerdata.RewindToSourceResponseB0Z.github.com/multigres/multigres/go/pb/consensusb\x06proto3"
+	"\x0eRewindToSource\x12-.multipoolermanagerdata.RewindToSourceRequest\x1a..multipoolermanagerdata.RewindToSourceResponse\x12H\n" +
+	"\aRecruit\x12\x1d.consensusdata.RecruitRequest\x1a\x1e.consensusdata.RecruitResponse\x12H\n" +
+	"\aPropose\x12\x1d.consensusdata.ProposeRequest\x1a\x1e.consensusdata.ProposeResponse\x12E\n" +
+	"\x06Inform\x12\x1c.consensusdata.InformRequest\x1a\x1d.consensusdata.InformResponseB0Z.github.com/multigres/multigres/go/pb/consensusb\x06proto3"
 
 var file_consensusservice_proto_goTypes = []any{
 	(*consensusdata.BeginTermRequest)(nil),                              // 0: consensusdata.BeginTermRequest
@@ -60,14 +63,20 @@ var file_consensusservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.DemoteStalePrimaryRequest)(nil),            // 5: multipoolermanagerdata.DemoteStalePrimaryRequest
 	(*multipoolermanagerdata.SetPrimaryConnInfoRequest)(nil),            // 6: multipoolermanagerdata.SetPrimaryConnInfoRequest
 	(*multipoolermanagerdata.RewindToSourceRequest)(nil),                // 7: multipoolermanagerdata.RewindToSourceRequest
-	(*consensusdata.BeginTermResponse)(nil),                             // 8: consensusdata.BeginTermResponse
-	(*consensusdata.StatusResponse)(nil),                                // 9: consensusdata.StatusResponse
-	(*multipoolermanagerdata.EmergencyDemoteResponse)(nil),              // 10: multipoolermanagerdata.EmergencyDemoteResponse
-	(*multipoolermanagerdata.PromoteResponse)(nil),                      // 11: multipoolermanagerdata.PromoteResponse
-	(*multipoolermanagerdata.UpdateSynchronousStandbyListResponse)(nil), // 12: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	(*multipoolermanagerdata.DemoteStalePrimaryResponse)(nil),           // 13: multipoolermanagerdata.DemoteStalePrimaryResponse
-	(*multipoolermanagerdata.SetPrimaryConnInfoResponse)(nil),           // 14: multipoolermanagerdata.SetPrimaryConnInfoResponse
-	(*multipoolermanagerdata.RewindToSourceResponse)(nil),               // 15: multipoolermanagerdata.RewindToSourceResponse
+	(*consensusdata.RecruitRequest)(nil),                                // 8: consensusdata.RecruitRequest
+	(*consensusdata.ProposeRequest)(nil),                                // 9: consensusdata.ProposeRequest
+	(*consensusdata.InformRequest)(nil),                                 // 10: consensusdata.InformRequest
+	(*consensusdata.BeginTermResponse)(nil),                             // 11: consensusdata.BeginTermResponse
+	(*consensusdata.StatusResponse)(nil),                                // 12: consensusdata.StatusResponse
+	(*multipoolermanagerdata.EmergencyDemoteResponse)(nil),              // 13: multipoolermanagerdata.EmergencyDemoteResponse
+	(*multipoolermanagerdata.PromoteResponse)(nil),                      // 14: multipoolermanagerdata.PromoteResponse
+	(*multipoolermanagerdata.UpdateSynchronousStandbyListResponse)(nil), // 15: multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	(*multipoolermanagerdata.DemoteStalePrimaryResponse)(nil),           // 16: multipoolermanagerdata.DemoteStalePrimaryResponse
+	(*multipoolermanagerdata.SetPrimaryConnInfoResponse)(nil),           // 17: multipoolermanagerdata.SetPrimaryConnInfoResponse
+	(*multipoolermanagerdata.RewindToSourceResponse)(nil),               // 18: multipoolermanagerdata.RewindToSourceResponse
+	(*consensusdata.RecruitResponse)(nil),                               // 19: consensusdata.RecruitResponse
+	(*consensusdata.ProposeResponse)(nil),                               // 20: consensusdata.ProposeResponse
+	(*consensusdata.InformResponse)(nil),                                // 21: consensusdata.InformResponse
 }
 var file_consensusservice_proto_depIdxs = []int32{
 	0,  // 0: consensus.MultiPoolerConsensus.BeginTerm:input_type -> consensusdata.BeginTermRequest
@@ -78,16 +87,22 @@ var file_consensusservice_proto_depIdxs = []int32{
 	5,  // 5: consensus.MultiPoolerConsensus.DemoteStalePrimary:input_type -> multipoolermanagerdata.DemoteStalePrimaryRequest
 	6,  // 6: consensus.MultiPoolerConsensus.SetPrimaryConnInfo:input_type -> multipoolermanagerdata.SetPrimaryConnInfoRequest
 	7,  // 7: consensus.MultiPoolerConsensus.RewindToSource:input_type -> multipoolermanagerdata.RewindToSourceRequest
-	8,  // 8: consensus.MultiPoolerConsensus.BeginTerm:output_type -> consensusdata.BeginTermResponse
-	9,  // 9: consensus.MultiPoolerConsensus.Status:output_type -> consensusdata.StatusResponse
-	10, // 10: consensus.MultiPoolerConsensus.EmergencyDemote:output_type -> multipoolermanagerdata.EmergencyDemoteResponse
-	11, // 11: consensus.MultiPoolerConsensus.Promote:output_type -> multipoolermanagerdata.PromoteResponse
-	12, // 12: consensus.MultiPoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateSynchronousStandbyListResponse
-	13, // 13: consensus.MultiPoolerConsensus.DemoteStalePrimary:output_type -> multipoolermanagerdata.DemoteStalePrimaryResponse
-	14, // 14: consensus.MultiPoolerConsensus.SetPrimaryConnInfo:output_type -> multipoolermanagerdata.SetPrimaryConnInfoResponse
-	15, // 15: consensus.MultiPoolerConsensus.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
-	8,  // [8:16] is the sub-list for method output_type
-	0,  // [0:8] is the sub-list for method input_type
+	8,  // 8: consensus.MultiPoolerConsensus.Recruit:input_type -> consensusdata.RecruitRequest
+	9,  // 9: consensus.MultiPoolerConsensus.Propose:input_type -> consensusdata.ProposeRequest
+	10, // 10: consensus.MultiPoolerConsensus.Inform:input_type -> consensusdata.InformRequest
+	11, // 11: consensus.MultiPoolerConsensus.BeginTerm:output_type -> consensusdata.BeginTermResponse
+	12, // 12: consensus.MultiPoolerConsensus.Status:output_type -> consensusdata.StatusResponse
+	13, // 13: consensus.MultiPoolerConsensus.EmergencyDemote:output_type -> multipoolermanagerdata.EmergencyDemoteResponse
+	14, // 14: consensus.MultiPoolerConsensus.Promote:output_type -> multipoolermanagerdata.PromoteResponse
+	15, // 15: consensus.MultiPoolerConsensus.UpdateConsensusRule:output_type -> multipoolermanagerdata.UpdateSynchronousStandbyListResponse
+	16, // 16: consensus.MultiPoolerConsensus.DemoteStalePrimary:output_type -> multipoolermanagerdata.DemoteStalePrimaryResponse
+	17, // 17: consensus.MultiPoolerConsensus.SetPrimaryConnInfo:output_type -> multipoolermanagerdata.SetPrimaryConnInfoResponse
+	18, // 18: consensus.MultiPoolerConsensus.RewindToSource:output_type -> multipoolermanagerdata.RewindToSourceResponse
+	19, // 19: consensus.MultiPoolerConsensus.Recruit:output_type -> consensusdata.RecruitResponse
+	20, // 20: consensus.MultiPoolerConsensus.Propose:output_type -> consensusdata.ProposeResponse
+	21, // 21: consensus.MultiPoolerConsensus.Inform:output_type -> consensusdata.InformResponse
+	11, // [11:22] is the sub-list for method output_type
+	0,  // [0:11] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/consensus/consensusservice.pb.gw.go
+++ b/go/pb/consensus/consensusservice.pb.gw.go
@@ -253,6 +253,87 @@ func local_request_MultiPoolerConsensus_RewindToSource_0(ctx context.Context, ma
 	return msg, metadata, err
 }
 
+func request_MultiPoolerConsensus_Recruit_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.RecruitRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Recruit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerConsensus_Recruit_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerConsensusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.RecruitRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Recruit(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MultiPoolerConsensus_Propose_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.ProposeRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Propose(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerConsensus_Propose_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerConsensusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.ProposeRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Propose(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_MultiPoolerConsensus_Inform_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerConsensusClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.InformRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.Inform(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerConsensus_Inform_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerConsensusServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq consensusdata.InformRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.Inform(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMultiPoolerConsensusHandlerServer registers the http handlers for service MultiPoolerConsensus to "mux".
 // UnaryRPC     :call MultiPoolerConsensusServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -418,6 +499,66 @@ func RegisterMultiPoolerConsensusHandlerServer(ctx context.Context, mux *runtime
 			return
 		}
 		forward_MultiPoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Recruit", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Recruit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerConsensus_Recruit_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Recruit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Propose_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Propose", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Propose"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerConsensus_Propose_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Propose_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Inform_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Inform", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Inform"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerConsensus_Inform_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Inform_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -595,6 +736,57 @@ func RegisterMultiPoolerConsensusHandlerClient(ctx context.Context, mux *runtime
 		}
 		forward_MultiPoolerConsensus_RewindToSource_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Recruit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Recruit", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Recruit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerConsensus_Recruit_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Recruit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Propose_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Propose", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Propose"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerConsensus_Propose_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Propose_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerConsensus_Inform_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/consensus.MultiPoolerConsensus/Inform", runtime.WithHTTPPathPattern("/consensus.MultiPoolerConsensus/Inform"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerConsensus_Inform_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerConsensus_Inform_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -607,6 +799,9 @@ var (
 	pattern_MultiPoolerConsensus_DemoteStalePrimary_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "DemoteStalePrimary"}, ""))
 	pattern_MultiPoolerConsensus_SetPrimaryConnInfo_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "SetPrimaryConnInfo"}, ""))
 	pattern_MultiPoolerConsensus_RewindToSource_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "RewindToSource"}, ""))
+	pattern_MultiPoolerConsensus_Recruit_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "Recruit"}, ""))
+	pattern_MultiPoolerConsensus_Propose_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "Propose"}, ""))
+	pattern_MultiPoolerConsensus_Inform_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"consensus.MultiPoolerConsensus", "Inform"}, ""))
 )
 
 var (
@@ -618,4 +813,7 @@ var (
 	forward_MultiPoolerConsensus_DemoteStalePrimary_0  = runtime.ForwardResponseMessage
 	forward_MultiPoolerConsensus_SetPrimaryConnInfo_0  = runtime.ForwardResponseMessage
 	forward_MultiPoolerConsensus_RewindToSource_0      = runtime.ForwardResponseMessage
+	forward_MultiPoolerConsensus_Recruit_0             = runtime.ForwardResponseMessage
+	forward_MultiPoolerConsensus_Propose_0             = runtime.ForwardResponseMessage
+	forward_MultiPoolerConsensus_Inform_0              = runtime.ForwardResponseMessage
 )

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -82,16 +82,13 @@ type MultiPoolerConsensusClient interface {
 	// This is used to repair diverged timelines after failover.
 	RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
-	// record the coordinator's exclusive claim on that term. Replaces the
-	// "accept term" half of BeginTerm (without triggering a postgres action).
+	// record the coordinator's exclusive claim on that term.
 	Recruit(ctx context.Context, in *consensusdata.RecruitRequest, opts ...grpc.CallOption) (*consensusdata.RecruitResponse, error)
 	// Propose sends a complete shard-state proposal to a pooler. The designated
 	// leader promotes its postgres; all other cohort members point replication at
-	// the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+	// the new primary.
 	Propose(ctx context.Context, in *consensusdata.ProposeRequest, opts ...grpc.CallOption) (*consensusdata.ProposeResponse, error)
-	// Inform broadcasts the committed shard rule after a successful Propose
-	// round. Poolers update their highest_known_rule and repair replication
-	// settings if they are behind.
+	// Inform broadcasts a decided, durable rule.
 	Inform(ctx context.Context, in *consensusdata.InformRequest, opts ...grpc.CallOption) (*consensusdata.InformResponse, error)
 }
 
@@ -247,16 +244,13 @@ type MultiPoolerConsensusServer interface {
 	// This is used to repair diverged timelines after failover.
 	RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error)
 	// Recruit asks a pooler to revoke all terms below the one specified and
-	// record the coordinator's exclusive claim on that term. Replaces the
-	// "accept term" half of BeginTerm (without triggering a postgres action).
+	// record the coordinator's exclusive claim on that term.
 	Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error)
 	// Propose sends a complete shard-state proposal to a pooler. The designated
 	// leader promotes its postgres; all other cohort members point replication at
-	// the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+	// the new primary.
 	Propose(context.Context, *consensusdata.ProposeRequest) (*consensusdata.ProposeResponse, error)
-	// Inform broadcasts the committed shard rule after a successful Propose
-	// round. Poolers update their highest_known_rule and repair replication
-	// settings if they are behind.
+	// Inform broadcasts a decided, durable rule.
 	Inform(context.Context, *consensusdata.InformRequest) (*consensusdata.InformResponse, error)
 	mustEmbedUnimplementedMultiPoolerConsensusServer()
 }

--- a/go/pb/consensus/consensusservice_grpc.pb.go
+++ b/go/pb/consensus/consensusservice_grpc.pb.go
@@ -43,6 +43,9 @@ const (
 	MultiPoolerConsensus_DemoteStalePrimary_FullMethodName  = "/consensus.MultiPoolerConsensus/DemoteStalePrimary"
 	MultiPoolerConsensus_SetPrimaryConnInfo_FullMethodName  = "/consensus.MultiPoolerConsensus/SetPrimaryConnInfo"
 	MultiPoolerConsensus_RewindToSource_FullMethodName      = "/consensus.MultiPoolerConsensus/RewindToSource"
+	MultiPoolerConsensus_Recruit_FullMethodName             = "/consensus.MultiPoolerConsensus/Recruit"
+	MultiPoolerConsensus_Propose_FullMethodName             = "/consensus.MultiPoolerConsensus/Propose"
+	MultiPoolerConsensus_Inform_FullMethodName              = "/consensus.MultiPoolerConsensus/Inform"
 )
 
 // MultiPoolerConsensusClient is the client API for MultiPoolerConsensus service.
@@ -78,6 +81,18 @@ type MultiPoolerConsensusClient interface {
 	// RewindToSource performs pg_rewind to synchronize this server with a source.
 	// This is used to repair diverged timelines after failover.
 	RewindToSource(ctx context.Context, in *multipoolermanagerdata.RewindToSourceRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.RewindToSourceResponse, error)
+	// Recruit asks a pooler to revoke all terms below the one specified and
+	// record the coordinator's exclusive claim on that term. Replaces the
+	// "accept term" half of BeginTerm (without triggering a postgres action).
+	Recruit(ctx context.Context, in *consensusdata.RecruitRequest, opts ...grpc.CallOption) (*consensusdata.RecruitResponse, error)
+	// Propose sends a complete shard-state proposal to a pooler. The designated
+	// leader promotes its postgres; all other cohort members point replication at
+	// the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+	Propose(ctx context.Context, in *consensusdata.ProposeRequest, opts ...grpc.CallOption) (*consensusdata.ProposeResponse, error)
+	// Inform broadcasts the committed shard rule after a successful Propose
+	// round. Poolers update their highest_known_rule and repair replication
+	// settings if they are behind.
+	Inform(ctx context.Context, in *consensusdata.InformRequest, opts ...grpc.CallOption) (*consensusdata.InformResponse, error)
 }
 
 type multiPoolerConsensusClient struct {
@@ -168,6 +183,36 @@ func (c *multiPoolerConsensusClient) RewindToSource(ctx context.Context, in *mul
 	return out, nil
 }
 
+func (c *multiPoolerConsensusClient) Recruit(ctx context.Context, in *consensusdata.RecruitRequest, opts ...grpc.CallOption) (*consensusdata.RecruitResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(consensusdata.RecruitResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerConsensus_Recruit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *multiPoolerConsensusClient) Propose(ctx context.Context, in *consensusdata.ProposeRequest, opts ...grpc.CallOption) (*consensusdata.ProposeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(consensusdata.ProposeResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerConsensus_Propose_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *multiPoolerConsensusClient) Inform(ctx context.Context, in *consensusdata.InformRequest, opts ...grpc.CallOption) (*consensusdata.InformResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(consensusdata.InformResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerConsensus_Inform_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MultiPoolerConsensusServer is the server API for MultiPoolerConsensus service.
 // All implementations must embed UnimplementedMultiPoolerConsensusServer
 // for forward compatibility.
@@ -201,6 +246,18 @@ type MultiPoolerConsensusServer interface {
 	// RewindToSource performs pg_rewind to synchronize this server with a source.
 	// This is used to repair diverged timelines after failover.
 	RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error)
+	// Recruit asks a pooler to revoke all terms below the one specified and
+	// record the coordinator's exclusive claim on that term. Replaces the
+	// "accept term" half of BeginTerm (without triggering a postgres action).
+	Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error)
+	// Propose sends a complete shard-state proposal to a pooler. The designated
+	// leader promotes its postgres; all other cohort members point replication at
+	// the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+	Propose(context.Context, *consensusdata.ProposeRequest) (*consensusdata.ProposeResponse, error)
+	// Inform broadcasts the committed shard rule after a successful Propose
+	// round. Poolers update their highest_known_rule and repair replication
+	// settings if they are behind.
+	Inform(context.Context, *consensusdata.InformRequest) (*consensusdata.InformResponse, error)
 	mustEmbedUnimplementedMultiPoolerConsensusServer()
 }
 
@@ -234,6 +291,15 @@ func (UnimplementedMultiPoolerConsensusServer) SetPrimaryConnInfo(context.Contex
 }
 func (UnimplementedMultiPoolerConsensusServer) RewindToSource(context.Context, *multipoolermanagerdata.RewindToSourceRequest) (*multipoolermanagerdata.RewindToSourceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RewindToSource not implemented")
+}
+func (UnimplementedMultiPoolerConsensusServer) Recruit(context.Context, *consensusdata.RecruitRequest) (*consensusdata.RecruitResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Recruit not implemented")
+}
+func (UnimplementedMultiPoolerConsensusServer) Propose(context.Context, *consensusdata.ProposeRequest) (*consensusdata.ProposeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Propose not implemented")
+}
+func (UnimplementedMultiPoolerConsensusServer) Inform(context.Context, *consensusdata.InformRequest) (*consensusdata.InformResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Inform not implemented")
 }
 func (UnimplementedMultiPoolerConsensusServer) mustEmbedUnimplementedMultiPoolerConsensusServer() {}
 func (UnimplementedMultiPoolerConsensusServer) testEmbeddedByValue()                              {}
@@ -400,6 +466,60 @@ func _MultiPoolerConsensus_RewindToSource_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiPoolerConsensus_Recruit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(consensusdata.RecruitRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerConsensusServer).Recruit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerConsensus_Recruit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerConsensusServer).Recruit(ctx, req.(*consensusdata.RecruitRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MultiPoolerConsensus_Propose_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(consensusdata.ProposeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerConsensusServer).Propose(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerConsensus_Propose_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerConsensusServer).Propose(ctx, req.(*consensusdata.ProposeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MultiPoolerConsensus_Inform_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(consensusdata.InformRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerConsensusServer).Inform(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerConsensus_Inform_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerConsensusServer).Inform(ctx, req.(*consensusdata.InformRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MultiPoolerConsensus_ServiceDesc is the grpc.ServiceDesc for MultiPoolerConsensus service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -438,6 +558,18 @@ var MultiPoolerConsensus_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RewindToSource",
 			Handler:    _MultiPoolerConsensus_RewindToSource_Handler,
+		},
+		{
+			MethodName: "Recruit",
+			Handler:    _MultiPoolerConsensus_Recruit_Handler,
+		},
+		{
+			MethodName: "Propose",
+			Handler:    _MultiPoolerConsensus_Propose_Handler,
+		},
+		{
+			MethodName: "Inform",
+			Handler:    _MultiPoolerConsensus_Inform_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -730,25 +730,19 @@ func (x *ProposalLeader) GetPostgresPort() int32 {
 	return 0
 }
 
-// CoordinatorProposal is the coordinator's complete, self-describing proposal
-// for what the shard state should look like at a given term. Sent to every
-// cohort member via Propose: the designated leader promotes itself; all other
-// members point their replication at the new primary.
-//
-// The proposal is not persisted by the pooler (persistence is deferred until
-// the rule is committed and an Inform is received). The coordinator retries
-// Propose on failure and is responsible for detecting whether the promotion
-// already succeeded before retrying.
+// CoordinatorProposal is a coordinator-assisted rule proposal. It either reflects
+// a rule that's not yet in WAL that the coordinator wants to write, or it could
+// reflect a rule discovered in WAL that hasn't been propagated to the point of
+// becoming a decision.
 type CoordinatorProposal struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Which term this proposal is for. The pooler rejects the proposal if its
-	// persisted term_revocation does not match.
+	// The authority under which this proposal is made. Coordinators must revoke
+	// previous agents before making a proposal.
 	TermRevocation *clustermetadata.TermRevocation `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
-	// The node that should become primary.
+	// The node that should become primary to facilitate this proposal.
 	ProposalLeader *ProposalLeader `protobuf:"bytes,2,opt,name=proposal_leader,json=proposalLeader,proto3" json:"proposal_leader,omitempty"`
-	// The full proposed shard state, including cohort membership, durability
-	// policy, and rule number. The designated leader writes this to rule_history;
-	// replicas use it to configure synchronous standby names.
+	// The full proposed rule. This can either be an entirely new rule or an
+	// existing rule that hasn't yet finished propagating to durability.
 	ProposedRule  *clustermetadata.ShardRule `protobuf:"bytes,3,opt,name=proposed_rule,json=proposedRule,proto3" json:"proposed_rule,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -807,7 +801,7 @@ func (x *CoordinatorProposal) GetProposedRule() *clustermetadata.ShardRule {
 
 // RecruitRequest asks a pooler to revoke all terms below the one in the
 // enclosed term_revocation and record the coordinator's exclusive right to
-// act at that term. This is the "accept term" step of the appointment protocol.
+// propose at this term.
 type RecruitRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The revocation to accept. The pooler persists this to disk and responds

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -665,6 +665,428 @@ func (x *TimelineInfo) GetTimelineId() int64 {
 	return 0
 }
 
+// ProposalLeader identifies the node the coordinator intends to promote and
+// carries the connection information replicas need to stream WAL from it.
+type ProposalLeader struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Which pooler should become (or remain) primary.
+	Id *clustermetadata.ID `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Hostname replicas use to connect to the new primary's postgres.
+	Host string `protobuf:"bytes,2,opt,name=host,proto3" json:"host,omitempty"`
+	// Port of the new primary's postgres instance.
+	PostgresPort  int32 `protobuf:"varint,3,opt,name=postgres_port,json=postgresPort,proto3" json:"postgres_port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProposalLeader) Reset() {
+	*x = ProposalLeader{}
+	mi := &file_consensusdata_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProposalLeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProposalLeader) ProtoMessage() {}
+
+func (x *ProposalLeader) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProposalLeader.ProtoReflect.Descriptor instead.
+func (*ProposalLeader) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ProposalLeader) GetId() *clustermetadata.ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *ProposalLeader) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *ProposalLeader) GetPostgresPort() int32 {
+	if x != nil {
+		return x.PostgresPort
+	}
+	return 0
+}
+
+// CoordinatorProposal is the coordinator's complete, self-describing proposal
+// for what the shard state should look like at a given term. Sent to every
+// cohort member via Propose: the designated leader promotes itself; all other
+// members point their replication at the new primary.
+//
+// The proposal is not persisted by the pooler (persistence is deferred until
+// the rule is committed and an Inform is received). The coordinator retries
+// Propose on failure and is responsible for detecting whether the promotion
+// already succeeded before retrying.
+type CoordinatorProposal struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Which term this proposal is for. The pooler rejects the proposal if its
+	// persisted term_revocation does not match.
+	TermRevocation *clustermetadata.TermRevocation `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
+	// The node that should become primary.
+	ProposalLeader *ProposalLeader `protobuf:"bytes,2,opt,name=proposal_leader,json=proposalLeader,proto3" json:"proposal_leader,omitempty"`
+	// The full proposed shard state, including cohort membership, durability
+	// policy, and rule number. The designated leader writes this to rule_history;
+	// replicas use it to configure synchronous standby names.
+	ProposedRule  *clustermetadata.ShardRule `protobuf:"bytes,3,opt,name=proposed_rule,json=proposedRule,proto3" json:"proposed_rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CoordinatorProposal) Reset() {
+	*x = CoordinatorProposal{}
+	mi := &file_consensusdata_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CoordinatorProposal) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CoordinatorProposal) ProtoMessage() {}
+
+func (x *CoordinatorProposal) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CoordinatorProposal.ProtoReflect.Descriptor instead.
+func (*CoordinatorProposal) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CoordinatorProposal) GetTermRevocation() *clustermetadata.TermRevocation {
+	if x != nil {
+		return x.TermRevocation
+	}
+	return nil
+}
+
+func (x *CoordinatorProposal) GetProposalLeader() *ProposalLeader {
+	if x != nil {
+		return x.ProposalLeader
+	}
+	return nil
+}
+
+func (x *CoordinatorProposal) GetProposedRule() *clustermetadata.ShardRule {
+	if x != nil {
+		return x.ProposedRule
+	}
+	return nil
+}
+
+// RecruitRequest asks a pooler to revoke all terms below the one in the
+// enclosed term_revocation and record the coordinator's exclusive right to
+// act at that term. This is the "accept term" step of the appointment protocol.
+type RecruitRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The revocation to accept. The pooler persists this to disk and responds
+	// with its current ConsensusStatus (which includes the updated revocation).
+	TermRevocation *clustermetadata.TermRevocation `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RecruitRequest) Reset() {
+	*x = RecruitRequest{}
+	mi := &file_consensusdata_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecruitRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecruitRequest) ProtoMessage() {}
+
+func (x *RecruitRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecruitRequest.ProtoReflect.Descriptor instead.
+func (*RecruitRequest) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *RecruitRequest) GetTermRevocation() *clustermetadata.TermRevocation {
+	if x != nil {
+		return x.TermRevocation
+	}
+	return nil
+}
+
+// RecruitResponse carries the pooler's authoritative state after processing
+// a RecruitRequest. The coordinator uses current_position to select the best
+// promotion candidate.
+type RecruitResponse struct {
+	state           protoimpl.MessageState           `protogen:"open.v1"`
+	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,1,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RecruitResponse) Reset() {
+	*x = RecruitResponse{}
+	mi := &file_consensusdata_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecruitResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecruitResponse) ProtoMessage() {}
+
+func (x *RecruitResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecruitResponse.ProtoReflect.Descriptor instead.
+func (*RecruitResponse) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *RecruitResponse) GetConsensusStatus() *clustermetadata.ConsensusStatus {
+	if x != nil {
+		return x.ConsensusStatus
+	}
+	return nil
+}
+
+// ProposeRequest carries the coordinator's complete proposal for a new shard
+// state. Every cohort member receives this: the designated leader promotes
+// itself; all others configure replication toward the new primary.
+type ProposeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Proposal      *CoordinatorProposal   `protobuf:"bytes,1,opt,name=proposal,proto3" json:"proposal,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProposeRequest) Reset() {
+	*x = ProposeRequest{}
+	mi := &file_consensusdata_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProposeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProposeRequest) ProtoMessage() {}
+
+func (x *ProposeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProposeRequest.ProtoReflect.Descriptor instead.
+func (*ProposeRequest) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ProposeRequest) GetProposal() *CoordinatorProposal {
+	if x != nil {
+		return x.Proposal
+	}
+	return nil
+}
+
+// ProposeResponse carries the pooler's state after applying a ProposeRequest.
+type ProposeResponse struct {
+	state           protoimpl.MessageState           `protogen:"open.v1"`
+	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,1,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ProposeResponse) Reset() {
+	*x = ProposeResponse{}
+	mi := &file_consensusdata_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProposeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProposeResponse) ProtoMessage() {}
+
+func (x *ProposeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProposeResponse.ProtoReflect.Descriptor instead.
+func (*ProposeResponse) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ProposeResponse) GetConsensusStatus() *clustermetadata.ConsensusStatus {
+	if x != nil {
+		return x.ConsensusStatus
+	}
+	return nil
+}
+
+// InformRequest broadcasts the committed shard rule to a pooler so it can
+// update its highest_known_rule and fix replication settings if needed.
+// Sent by the coordinator after a successful Propose round.
+type InformRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The rule that was successfully committed (written to rule_history by the
+	// new primary and replicated). Poolers that are behind use this to reconnect.
+	CommittedRule *clustermetadata.ShardRule `protobuf:"bytes,1,opt,name=committed_rule,json=committedRule,proto3" json:"committed_rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InformRequest) Reset() {
+	*x = InformRequest{}
+	mi := &file_consensusdata_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InformRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InformRequest) ProtoMessage() {}
+
+func (x *InformRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InformRequest.ProtoReflect.Descriptor instead.
+func (*InformRequest) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *InformRequest) GetCommittedRule() *clustermetadata.ShardRule {
+	if x != nil {
+		return x.CommittedRule
+	}
+	return nil
+}
+
+// InformResponse carries the pooler's state after processing an InformRequest.
+type InformResponse struct {
+	state           protoimpl.MessageState           `protogen:"open.v1"`
+	ConsensusStatus *clustermetadata.ConsensusStatus `protobuf:"bytes,1,opt,name=consensus_status,json=consensusStatus,proto3" json:"consensus_status,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *InformResponse) Reset() {
+	*x = InformResponse{}
+	mi := &file_consensusdata_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InformResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InformResponse) ProtoMessage() {}
+
+func (x *InformResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_consensusdata_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InformResponse.ProtoReflect.Descriptor instead.
+func (*InformResponse) Descriptor() ([]byte, []int) {
+	return file_consensusdata_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *InformResponse) GetConsensusStatus() *clustermetadata.ConsensusStatus {
+	if x != nil {
+		return x.ConsensusStatus
+	}
+	return nil
+}
+
 var File_consensusdata_proto protoreflect.FileDescriptor
 
 const file_consensusdata_proto_rawDesc = "" +
@@ -712,7 +1134,27 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x13availability_status\x18\r \x01(\v2#.clustermetadata.AvailabilityStatusR\x12availabilityStatus\"/\n" +
 	"\fTimelineInfo\x12\x1f\n" +
 	"\vtimeline_id\x18\x01 \x01(\x03R\n" +
-	"timelineId*s\n" +
+	"timelineId\"n\n" +
+	"\x0eProposalLeader\x12#\n" +
+	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x12\n" +
+	"\x04host\x18\x02 \x01(\tR\x04host\x12#\n" +
+	"\rpostgres_port\x18\x03 \x01(\x05R\fpostgresPort\"\xe8\x01\n" +
+	"\x13CoordinatorProposal\x12H\n" +
+	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12F\n" +
+	"\x0fproposal_leader\x18\x02 \x01(\v2\x1d.consensusdata.ProposalLeaderR\x0eproposalLeader\x12?\n" +
+	"\rproposed_rule\x18\x03 \x01(\v2\x1a.clustermetadata.ShardRuleR\fproposedRule\"Z\n" +
+	"\x0eRecruitRequest\x12H\n" +
+	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\"^\n" +
+	"\x0fRecruitResponse\x12K\n" +
+	"\x10consensus_status\x18\x01 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\"P\n" +
+	"\x0eProposeRequest\x12>\n" +
+	"\bproposal\x18\x01 \x01(\v2\".consensusdata.CoordinatorProposalR\bproposal\"^\n" +
+	"\x0fProposeResponse\x12K\n" +
+	"\x10consensus_status\x18\x01 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\"R\n" +
+	"\rInformRequest\x12A\n" +
+	"\x0ecommitted_rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\rcommittedRule\"]\n" +
+	"\x0eInformResponse\x12K\n" +
+	"\x10consensus_status\x18\x01 \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus*s\n" +
 	"\x0fBeginTermAction\x12!\n" +
 	"\x1dBEGIN_TERM_ACTION_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bBEGIN_TERM_ACTION_NO_ACTION\x10\x01\x12\x1c\n" +
@@ -735,7 +1177,7 @@ func file_consensusdata_proto_rawDescGZIP() []byte {
 }
 
 var file_consensusdata_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_consensusdata_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_consensusdata_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_consensusdata_proto_goTypes = []any{
 	(BeginTermAction)(0),                       // 0: consensusdata.BeginTermAction
 	(PostgresRole)(0),                          // 1: consensusdata.PostgresRole
@@ -745,27 +1187,47 @@ var file_consensusdata_proto_goTypes = []any{
 	(*StatusRequest)(nil),                      // 5: consensusdata.StatusRequest
 	(*StatusResponse)(nil),                     // 6: consensusdata.StatusResponse
 	(*TimelineInfo)(nil),                       // 7: consensusdata.TimelineInfo
-	(*timestamppb.Timestamp)(nil),              // 8: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),                 // 9: clustermetadata.ID
-	(*clustermetadata.ConsensusStatus)(nil),    // 10: clustermetadata.ConsensusStatus
-	(*clustermetadata.AvailabilityStatus)(nil), // 11: clustermetadata.AvailabilityStatus
+	(*ProposalLeader)(nil),                     // 8: consensusdata.ProposalLeader
+	(*CoordinatorProposal)(nil),                // 9: consensusdata.CoordinatorProposal
+	(*RecruitRequest)(nil),                     // 10: consensusdata.RecruitRequest
+	(*RecruitResponse)(nil),                    // 11: consensusdata.RecruitResponse
+	(*ProposeRequest)(nil),                     // 12: consensusdata.ProposeRequest
+	(*ProposeResponse)(nil),                    // 13: consensusdata.ProposeResponse
+	(*InformRequest)(nil),                      // 14: consensusdata.InformRequest
+	(*InformResponse)(nil),                     // 15: consensusdata.InformResponse
+	(*timestamppb.Timestamp)(nil),              // 16: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),                 // 17: clustermetadata.ID
+	(*clustermetadata.ConsensusStatus)(nil),    // 18: clustermetadata.ConsensusStatus
+	(*clustermetadata.AvailabilityStatus)(nil), // 19: clustermetadata.AvailabilityStatus
+	(*clustermetadata.TermRevocation)(nil),     // 20: clustermetadata.TermRevocation
+	(*clustermetadata.ShardRule)(nil),          // 21: clustermetadata.ShardRule
 }
 var file_consensusdata_proto_depIdxs = []int32{
-	8,  // 0: consensusdata.WALPosition.timestamp:type_name -> google.protobuf.Timestamp
-	9,  // 1: consensusdata.BeginTermRequest.candidate_id:type_name -> clustermetadata.ID
+	16, // 0: consensusdata.WALPosition.timestamp:type_name -> google.protobuf.Timestamp
+	17, // 1: consensusdata.BeginTermRequest.candidate_id:type_name -> clustermetadata.ID
 	0,  // 2: consensusdata.BeginTermRequest.action:type_name -> consensusdata.BeginTermAction
 	2,  // 3: consensusdata.BeginTermResponse.wal_position:type_name -> consensusdata.WALPosition
-	10, // 4: consensusdata.BeginTermResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	18, // 4: consensusdata.BeginTermResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	2,  // 5: consensusdata.StatusResponse.wal_position:type_name -> consensusdata.WALPosition
 	1,  // 6: consensusdata.StatusResponse.role:type_name -> consensusdata.PostgresRole
 	7,  // 7: consensusdata.StatusResponse.timeline_info:type_name -> consensusdata.TimelineInfo
-	10, // 8: consensusdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	11, // 9: consensusdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	18, // 8: consensusdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	19, // 9: consensusdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	17, // 10: consensusdata.ProposalLeader.id:type_name -> clustermetadata.ID
+	20, // 11: consensusdata.CoordinatorProposal.term_revocation:type_name -> clustermetadata.TermRevocation
+	8,  // 12: consensusdata.CoordinatorProposal.proposal_leader:type_name -> consensusdata.ProposalLeader
+	21, // 13: consensusdata.CoordinatorProposal.proposed_rule:type_name -> clustermetadata.ShardRule
+	20, // 14: consensusdata.RecruitRequest.term_revocation:type_name -> clustermetadata.TermRevocation
+	18, // 15: consensusdata.RecruitResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	9,  // 16: consensusdata.ProposeRequest.proposal:type_name -> consensusdata.CoordinatorProposal
+	18, // 17: consensusdata.ProposeResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	21, // 18: consensusdata.InformRequest.committed_rule:type_name -> clustermetadata.ShardRule
+	18, // 19: consensusdata.InformResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_consensusdata_proto_init() }
@@ -779,7 +1241,7 @@ func file_consensusdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_consensusdata_proto_rawDesc), len(file_consensusdata_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   6,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -174,3 +174,81 @@ message TimelineInfo {
   // Current timeline ID (from pg_control_checkpoint())
   int64 timeline_id = 1;
 }
+
+// ProposalLeader identifies the node the coordinator intends to promote and
+// carries the connection information replicas need to stream WAL from it.
+message ProposalLeader {
+  // Which pooler should become (or remain) primary.
+  clustermetadata.ID id = 1;
+
+  // Hostname replicas use to connect to the new primary's postgres.
+  string host = 2;
+
+  // Port of the new primary's postgres instance.
+  int32 postgres_port = 3;
+}
+
+// CoordinatorProposal is the coordinator's complete, self-describing proposal
+// for what the shard state should look like at a given term. Sent to every
+// cohort member via Propose: the designated leader promotes itself; all other
+// members point their replication at the new primary.
+//
+// The proposal is not persisted by the pooler (persistence is deferred until
+// the rule is committed and an Inform is received). The coordinator retries
+// Propose on failure and is responsible for detecting whether the promotion
+// already succeeded before retrying.
+message CoordinatorProposal {
+  // Which term this proposal is for. The pooler rejects the proposal if its
+  // persisted term_revocation does not match.
+  clustermetadata.TermRevocation term_revocation = 1;
+
+  // The node that should become primary.
+  ProposalLeader proposal_leader = 2;
+
+  // The full proposed shard state, including cohort membership, durability
+  // policy, and rule number. The designated leader writes this to rule_history;
+  // replicas use it to configure synchronous standby names.
+  clustermetadata.ShardRule proposed_rule = 3;
+}
+
+// RecruitRequest asks a pooler to revoke all terms below the one in the
+// enclosed term_revocation and record the coordinator's exclusive right to
+// act at that term. This is the "accept term" step of the appointment protocol.
+message RecruitRequest {
+  // The revocation to accept. The pooler persists this to disk and responds
+  // with its current ConsensusStatus (which includes the updated revocation).
+  clustermetadata.TermRevocation term_revocation = 1;
+}
+
+// RecruitResponse carries the pooler's authoritative state after processing
+// a RecruitRequest. The coordinator uses current_position to select the best
+// promotion candidate.
+message RecruitResponse {
+  clustermetadata.ConsensusStatus consensus_status = 1;
+}
+
+// ProposeRequest carries the coordinator's complete proposal for a new shard
+// state. Every cohort member receives this: the designated leader promotes
+// itself; all others configure replication toward the new primary.
+message ProposeRequest {
+  CoordinatorProposal proposal = 1;
+}
+
+// ProposeResponse carries the pooler's state after applying a ProposeRequest.
+message ProposeResponse {
+  clustermetadata.ConsensusStatus consensus_status = 1;
+}
+
+// InformRequest broadcasts the committed shard rule to a pooler so it can
+// update its highest_known_rule and fix replication settings if needed.
+// Sent by the coordinator after a successful Propose round.
+message InformRequest {
+  // The rule that was successfully committed (written to rule_history by the
+  // new primary and replicated). Poolers that are behind use this to reconnect.
+  clustermetadata.ShardRule committed_rule = 1;
+}
+
+// InformResponse carries the pooler's state after processing an InformRequest.
+message InformResponse {
+  clustermetadata.ConsensusStatus consensus_status = 1;
+}

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -188,32 +188,26 @@ message ProposalLeader {
   int32 postgres_port = 3;
 }
 
-// CoordinatorProposal is the coordinator's complete, self-describing proposal
-// for what the shard state should look like at a given term. Sent to every
-// cohort member via Propose: the designated leader promotes itself; all other
-// members point their replication at the new primary.
-//
-// The proposal is not persisted by the pooler (persistence is deferred until
-// the rule is committed and an Inform is received). The coordinator retries
-// Propose on failure and is responsible for detecting whether the promotion
-// already succeeded before retrying.
+// CoordinatorProposal is a coordinator-assisted rule proposal. It either reflects
+// a rule that's not yet in WAL that the coordinator wants to write, or it could
+// reflect a rule discovered in WAL that hasn't been propagated to the point of
+// becoming a decision.
 message CoordinatorProposal {
-  // Which term this proposal is for. The pooler rejects the proposal if its
-  // persisted term_revocation does not match.
+  // The authority under which this proposal is made. Coordinators must revoke
+  // previous agents before making a proposal.
   clustermetadata.TermRevocation term_revocation = 1;
 
-  // The node that should become primary.
+  // The node that should become primary to facilitate this proposal.
   ProposalLeader proposal_leader = 2;
 
-  // The full proposed shard state, including cohort membership, durability
-  // policy, and rule number. The designated leader writes this to rule_history;
-  // replicas use it to configure synchronous standby names.
+  // The full proposed rule. This can either be an entirely new rule or an
+  // existing rule that hasn't yet finished propagating to durability.
   clustermetadata.ShardRule proposed_rule = 3;
 }
 
 // RecruitRequest asks a pooler to revoke all terms below the one in the
 // enclosed term_revocation and record the coordinator's exclusive right to
-// act at that term. This is the "accept term" step of the appointment protocol.
+// propose at this term.
 message RecruitRequest {
   // The revocation to accept. The pooler persists this to disk and responds
   // with its current ConsensusStatus (which includes the updated revocation).

--- a/proto/consensusservice.proto
+++ b/proto/consensusservice.proto
@@ -74,4 +74,23 @@ service MultiPoolerConsensus {
   // This is used to repair diverged timelines after failover.
   rpc RewindToSource(multipoolermanagerdata.RewindToSourceRequest)
     returns (multipoolermanagerdata.RewindToSourceResponse);
+
+  // New Recruit → Propose → Inform appointment protocol.
+  // These RPCs replace BeginTerm + Promote + SetPrimaryConnInfo and will be
+  // wired up to handlers in subsequent PRs.
+
+  // Recruit asks a pooler to revoke all terms below the one specified and
+  // record the coordinator's exclusive claim on that term. Replaces the
+  // "accept term" half of BeginTerm (without triggering a postgres action).
+  rpc Recruit(consensusdata.RecruitRequest) returns (consensusdata.RecruitResponse);
+
+  // Propose sends a complete shard-state proposal to a pooler. The designated
+  // leader promotes its postgres; all other cohort members point replication at
+  // the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+  rpc Propose(consensusdata.ProposeRequest) returns (consensusdata.ProposeResponse);
+
+  // Inform broadcasts the committed shard rule after a successful Propose
+  // round. Poolers update their highest_known_rule and repair replication
+  // settings if they are behind.
+  rpc Inform(consensusdata.InformRequest) returns (consensusdata.InformResponse);
 }

--- a/proto/consensusservice.proto
+++ b/proto/consensusservice.proto
@@ -80,17 +80,14 @@ service MultiPoolerConsensus {
   // wired up to handlers in subsequent PRs.
 
   // Recruit asks a pooler to revoke all terms below the one specified and
-  // record the coordinator's exclusive claim on that term. Replaces the
-  // "accept term" half of BeginTerm (without triggering a postgres action).
+  // record the coordinator's exclusive claim on that term.
   rpc Recruit(consensusdata.RecruitRequest) returns (consensusdata.RecruitResponse);
 
   // Propose sends a complete shard-state proposal to a pooler. The designated
   // leader promotes its postgres; all other cohort members point replication at
-  // the new primary. Replaces the Promote + SetPrimaryConnInfo pair.
+  // the new primary.
   rpc Propose(consensusdata.ProposeRequest) returns (consensusdata.ProposeResponse);
 
-  // Inform broadcasts the committed shard rule after a successful Propose
-  // round. Poolers update their highest_known_rule and repair replication
-  // settings if they are behind.
+  // Inform broadcasts a decided, durable rule.
   rpc Inform(consensusdata.InformRequest) returns (consensusdata.InformResponse);
 }


### PR DESCRIPTION
Add the data types and gRPC stubs for the new appointment protocol to consensusdata.proto and consensusservice.proto. No handlers are wired up yet.

New messages:
- ProposalLeader: identifies the proposed primary and its connection info
- CoordinatorProposal: complete shard-state proposal sent during Propose
- RecruitRequest/Response: "accept term" step (replaces BeginTerm NO_ACTION)
- ProposeRequest/Response: promote-or-follow step (replaces Promote + SetPrimaryConnInfo)
- InformRequest/Response: broadcast committed rule (enables autonomous replication repair)

New RPCs on MultiPoolerConsensus service: Recruit, Propose, Inform.