### PR TITLE
fix(multigateway): honor SET LOCAL on gateway-managed GUCs

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -190,6 +190,21 @@ func NewPgError(severity, sqlState, message, detail string) *PgDiagnostic {
 	}
 }
 
+// NewPgNotice creates a *PgDiagnostic that will be sent as a NoticeResponse
+// ('N') rather than an ErrorResponse ('E'). Use this for non-fatal diagnostics
+// (WARNING, NOTICE, INFO, LOG, DEBUG) that PostgreSQL surfaces alongside a
+// successful CommandComplete — e.g., the WARNING emitted for `SET LOCAL`
+// outside a transaction block.
+func NewPgNotice(severity, sqlState, message, detail string) *PgDiagnostic {
+	return &PgDiagnostic{
+		MessageType: 'N',
+		Severity:    severity,
+		Code:        sqlState,
+		Message:     message,
+		Detail:      detail,
+	}
+}
+
 // NewUnrecognizedParameter creates a PgDiagnostic for an unrecognized configuration
 // parameter (SQLSTATE 42704 undefined_object). This matches PostgreSQL's error for
 // SHOW/SET/RESET of unknown GUC parameters.

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -18,12 +18,14 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multigateway/handler"
@@ -336,4 +338,62 @@ func TestExtractConstValue(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func TestGatewaySessionState_SETLOCAL_OutsideTxnNoOpsWithWarning(t *testing.T) {
+	// PostgreSQL: SET LOCAL outside a transaction block emits
+	//   WARNING: 25P01 — SET LOCAL can only be used in transaction blocks
+	// and the value is discarded immediately because the implicit autocommit
+	// transaction commits right after the statement.
+	//
+	// Multigateway must mirror this: skip the gateway-state mutation and
+	// surface the WARNING as a NoticeResponse. Without this guard, isLocalSet
+	// would persist for the lifetime of the connection because no
+	// COMMIT/ROLLBACK ever fires to clear it.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	require.False(t, testConn.IsInTransaction(), "TestConn defaults to TxnStatusIdle")
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	ctx := context.Background()
+
+	prim := NewStatementTimeoutSet("SET LOCAL statement_timeout = '100ms'", 100*time.Millisecond, true /*isLocal*/)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	// State must NOT have absorbed the LOCAL value.
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(),
+		"SET LOCAL outside txn must not update gateway state")
+
+	// Should receive a synthetic CommandComplete with a NoticeResponse attached.
+	require.Len(t, results, 1)
+	assert.Equal(t, "SET", results[0].CommandTag)
+	require.Len(t, results[0].Notices, 1, "should attach a single NoticeResponse")
+	notice := results[0].Notices[0]
+	assert.Equal(t, "WARNING", notice.Severity)
+	assert.Equal(t, "25P01", notice.Code)
+	assert.Equal(t, "SET LOCAL can only be used in transaction blocks", notice.Message)
+	assert.Equal(t, byte('N'), notice.MessageType, "must be NoticeResponse, not ErrorResponse")
+}
+
+func TestGatewaySessionState_SETLOCAL_InsideTxnUpdatesState(t *testing.T) {
+	// Sanity check: inside a transaction, SET LOCAL still flows to gateway state.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	testConn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	ctx := context.Background()
+
+	prim := NewStatementTimeoutSet("SET LOCAL statement_timeout = '100ms'", 100*time.Millisecond, true)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	assert.Equal(t, 100*time.Millisecond, state.GetStatementTimeout())
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Notices, "inside-txn SET LOCAL emits no warning")
 }

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -397,3 +397,55 @@ func TestGatewaySessionState_SETLOCAL_InsideTxnUpdatesState(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Empty(t, results[0].Notices, "inside-txn SET LOCAL emits no warning")
 }
+
+func TestGatewaySessionState_SETLOCAL_TODefault_PreservesSession(t *testing.T) {
+	// SET LOCAL var TO DEFAULT must mask the session value with the default for
+	// the duration of the transaction without destroying the session value.
+	// Pre-fix behavior: this primitive called ResetStatementTimeout(),
+	// destroying the session value.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	testConn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
+	ctx := context.Background()
+
+	// Mirrors what the planner emits for `SET LOCAL statement_timeout TO DEFAULT`.
+	prim := NewGatewaySessionStateReset("SET LOCAL statement_timeout TO DEFAULT", "statement_timeout", true /*isLocal*/)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(),
+		"inside txn: effective value is default, masking session")
+	state.ResetAllLocalGUCs()
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout(),
+		"after txn end: session value is restored, not lost")
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].Notices, "inside-txn LOCAL TO DEFAULT emits no warning")
+}
+
+func TestGatewaySessionState_RESET_NonLocalStillClearsSession(t *testing.T) {
+	// Plain RESET (non-LOCAL) should still clear the session-level override.
+	// Regression check: thread isLocal through without breaking the existing
+	// session-RESET behavior.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
+	ctx := context.Background()
+
+	prim := NewGatewaySessionStateReset("RESET statement_timeout", "statement_timeout", false /*isLocal*/)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(),
+		"RESET clears the session override and reverts to default")
+	require.Len(t, results, 1)
+	assert.Equal(t, "RESET", results[0].CommandTag)
+}

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -412,7 +412,7 @@ func TestGatewaySessionState_SETLOCAL_TODefault_PreservesSession(t *testing.T) {
 	ctx := context.Background()
 
 	// Mirrors what the planner emits for `SET LOCAL statement_timeout TO DEFAULT`.
-	prim := NewGatewaySessionStateReset("SET LOCAL statement_timeout TO DEFAULT", "statement_timeout", true /*isLocal*/)
+	prim := NewGatewaySessionStateReset("SET LOCAL statement_timeout TO DEFAULT", "statement_timeout", true /*isLocal*/, false /*isResetStmt: source is VAR_SET_DEFAULT*/)
 
 	var results []*sqltypes.Result
 	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
@@ -425,6 +425,8 @@ func TestGatewaySessionState_SETLOCAL_TODefault_PreservesSession(t *testing.T) {
 		"after txn end: session value is restored, not lost")
 	require.Len(t, results, 1)
 	assert.Empty(t, results[0].Notices, "inside-txn LOCAL TO DEFAULT emits no warning")
+	assert.Equal(t, "SET", results[0].CommandTag,
+		`SET LOCAL var TO DEFAULT must return CommandTag "SET" (not "RESET"), matching PostgreSQL`)
 }
 
 func TestGatewaySessionState_RESET_NonLocalStillClearsSession(t *testing.T) {
@@ -438,7 +440,7 @@ func TestGatewaySessionState_RESET_NonLocalStillClearsSession(t *testing.T) {
 	state.SetStatementTimeout(5 * time.Second)
 	ctx := context.Background()
 
-	prim := NewGatewaySessionStateReset("RESET statement_timeout", "statement_timeout", false /*isLocal*/)
+	prim := NewGatewaySessionStateReset("RESET statement_timeout", "statement_timeout", false /*isLocal*/, true /*isResetStmt*/)
 
 	var results []*sqltypes.Result
 	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
@@ -448,4 +450,58 @@ func TestGatewaySessionState_RESET_NonLocalStillClearsSession(t *testing.T) {
 		"RESET clears the session override and reverts to default")
 	require.Len(t, results, 1)
 	assert.Equal(t, "RESET", results[0].CommandTag)
+}
+
+func TestGatewaySessionState_SETToDEFAULT_NonLocalReturnsSETTag(t *testing.T) {
+	// `SET var TO DEFAULT` (non-LOCAL, VAR_SET_DEFAULT) clears the session
+	// override like RESET, but PostgreSQL returns CommandTag "SET" — only the
+	// literal `RESET var` syntax returns "RESET". The planner sets
+	// isResetStmt=false for VAR_SET_DEFAULT.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
+	ctx := context.Background()
+
+	prim := NewGatewaySessionStateReset("SET statement_timeout TO DEFAULT", "statement_timeout", false /*isLocal*/, false /*isResetStmt: source is VAR_SET_DEFAULT*/)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(),
+		"SET ... TO DEFAULT clears the session override, same effect as RESET")
+	require.Len(t, results, 1)
+	assert.Equal(t, "SET", results[0].CommandTag,
+		`SET var TO DEFAULT must return CommandTag "SET" (not "RESET"), matching PostgreSQL`)
+}
+
+func TestGatewaySessionState_SETLOCALToDEFAULT_OutsideTxnReturnsSETTag(t *testing.T) {
+	// `SET LOCAL var TO DEFAULT` outside a transaction emits the 25P01 warning
+	// AND must return CommandTag "SET" (not "RESET") because the source
+	// statement was VAR_SET_DEFAULT, not VAR_RESET.
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	require.False(t, testConn.IsInTransaction(), "TestConn defaults to TxnStatusIdle")
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
+	ctx := context.Background()
+
+	prim := NewGatewaySessionStateReset("SET LOCAL statement_timeout TO DEFAULT", "statement_timeout", true /*isLocal*/, false /*isResetStmt*/)
+
+	var results []*sqltypes.Result
+	err := prim.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	// State must NOT have changed: outside-txn SET LOCAL is a no-op.
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout(),
+		"outside-txn SET LOCAL (any form) must not mutate gateway state")
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "SET", results[0].CommandTag,
+		`SET LOCAL var TO DEFAULT (even outside txn) must return CommandTag "SET"`)
+	require.Len(t, results[0].Notices, 1)
+	assert.Equal(t, "25P01", results[0].Notices[0].Code)
 }

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -36,6 +36,7 @@ type GatewaySessionState struct {
 	sql      string // Original SQL for debugging
 	variable string // Variable name (e.g., "statement_timeout")
 	isReset  bool   // true for RESET, false for SET
+	isLocal  bool   // true for SET LOCAL (transaction-scoped); ignored for RESET
 
 	// Typed fields for each gateway-managed variable.
 	// Only the field matching `variable` is used.
@@ -44,11 +45,14 @@ type GatewaySessionState struct {
 
 // NewStatementTimeoutSet creates a primitive that SETs `statement_timeout`.
 // The value is pre-parsed and stored in the appropriate typed field.
-func NewStatementTimeoutSet(sql string, statementTimeout time.Duration) *GatewaySessionState {
+// When isLocal is true, the value is treated as a transaction-local override
+// (SET LOCAL), cleared on COMMIT/ROLLBACK.
+func NewStatementTimeoutSet(sql string, statementTimeout time.Duration, isLocal bool) *GatewaySessionState {
 	return &GatewaySessionState{
 		sql:              sql,
 		variable:         "statement_timeout",
 		statementTimeout: statementTimeout,
+		isLocal:          isLocal,
 	}
 }
 
@@ -76,9 +80,15 @@ func (g *GatewaySessionState) StreamExecute(
 	}
 	switch g.variable {
 	case "statement_timeout":
-		if g.isReset {
+		switch {
+		case g.isReset:
+			// RESET clears the session-level override. The transaction-local
+			// override (if any) stays in effect — this matches PostgreSQL,
+			// where RESET inside a transaction doesn't undo a prior SET LOCAL.
 			state.ResetStatementTimeout()
-		} else {
+		case g.isLocal:
+			state.SetLocalStatementTimeout(g.statementTimeout)
+		default:
 			state.SetStatementTimeout(g.statementTimeout)
 		}
 	default:

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -69,7 +70,7 @@ func NewGatewaySessionStateReset(sql string, variable string) *GatewaySessionSta
 func (g *GatewaySessionState) StreamExecute(
 	ctx context.Context,
 	_ IExecute,
-	_ *server.Conn,
+	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
 	_ []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
@@ -78,6 +79,23 @@ func (g *GatewaySessionState) StreamExecute(
 	if g.isReset {
 		commandTag = "RESET"
 	}
+
+	// SET LOCAL outside a transaction block is a no-op in PostgreSQL — it emits
+	// a WARNING with SQLSTATE 25P01 (no_active_sql_transaction) and the value is
+	// discarded immediately by the implicit-autocommit boundary. We mirror that
+	// here: skip the state mutation and surface the WARNING as a NoticeResponse.
+	// Without this guard, isLocalSet would persist for the lifetime of the
+	// connection because no COMMIT/ROLLBACK ever fires to clear it.
+	if g.isLocal && !conn.IsInTransaction() {
+		warning := mterrors.NewPgError("WARNING", "25P01",
+			"SET LOCAL can only be used in transaction blocks", "")
+		warning.MessageType = 'N'
+		return callback(ctx, &sqltypes.Result{
+			CommandTag: commandTag,
+			Notices:    []*mterrors.PgDiagnostic{warning},
+		})
+	}
+
 	switch g.variable {
 	case "statement_timeout":
 		switch {

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -103,9 +103,8 @@ func (g *GatewaySessionState) StreamExecute(
 	// Without this guard, isLocalSet would persist for the lifetime of the
 	// connection because no COMMIT/ROLLBACK ever fires to clear it.
 	if g.isLocal && !conn.IsInTransaction() {
-		warning := mterrors.NewPgError("WARNING", "25P01",
+		warning := mterrors.NewPgNotice("WARNING", "25P01",
 			"SET LOCAL can only be used in transaction blocks", "")
-		warning.MessageType = 'N'
 		return callback(ctx, &sqltypes.Result{
 			CommandTag: commandTag,
 			Notices:    []*mterrors.PgDiagnostic{warning},

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -57,12 +57,18 @@ func NewStatementTimeoutSet(sql string, statementTimeout time.Duration, isLocal 
 	}
 }
 
-// NewGatewaySessionStateReset creates a primitive that RESETs `a gateway-managed variable`.
-func NewGatewaySessionStateReset(sql string, variable string) *GatewaySessionState {
+// NewGatewaySessionStateReset creates a primitive that RESETs a
+// gateway-managed variable. When isLocal is true, the primitive performs
+// the SET LOCAL ... TO DEFAULT semantic (transaction-scoped override to
+// the server default that masks any session value). When isLocal is false,
+// it performs the session-level RESET (or SET ... TO DEFAULT) which clears
+// the session override entirely.
+func NewGatewaySessionStateReset(sql string, variable string, isLocal bool) *GatewaySessionState {
 	return &GatewaySessionState{
 		sql:      sql,
 		variable: variable,
 		isReset:  true,
+		isLocal:  isLocal,
 	}
 }
 
@@ -99,10 +105,17 @@ func (g *GatewaySessionState) StreamExecute(
 	switch g.variable {
 	case "statement_timeout":
 		switch {
+		case g.isReset && g.isLocal:
+			// SET LOCAL var TO DEFAULT: install a transaction-scoped override
+			// equal to the server default so SHOW returns default during the
+			// transaction, but the session-level value (if any) is preserved
+			// and will be restored when ResetAllLocalGUCs fires at txn end.
+			state.SetLocalStatementTimeoutToDefault()
 		case g.isReset:
-			// RESET clears the session-level override. The transaction-local
-			// override (if any) stays in effect — this matches PostgreSQL,
-			// where RESET inside a transaction doesn't undo a prior SET LOCAL.
+			// RESET (or SET ... TO DEFAULT, non-LOCAL): clear the session-level
+			// override. The transaction-local override (if any) stays in effect
+			// — this matches PostgreSQL, where RESET inside a transaction
+			// doesn't undo a prior SET LOCAL.
 			state.ResetStatementTimeout()
 		case g.isLocal:
 			state.SetLocalStatementTimeout(g.statementTimeout)

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -122,10 +122,11 @@ func (g *GatewaySessionState) StreamExecute(
 			// and will be restored when ResetAllLocalGUCs fires at txn end.
 			state.SetLocalStatementTimeoutToDefault()
 		case g.isReset:
-			// RESET (or SET ... TO DEFAULT, non-LOCAL): clear the session-level
-			// override. The transaction-local override (if any) stays in effect
-			// — this matches PostgreSQL, where RESET inside a transaction
-			// doesn't undo a prior SET LOCAL.
+			// RESET (or SET ... TO DEFAULT, non-LOCAL): clear both the
+			// session-level override and any active transaction-local override.
+			// Matches PostgreSQL: RESET inside a transaction with a prior
+			// SET LOCAL supersedes the LOCAL — effective value becomes the
+			// default (verified against PG 17).
 			state.ResetStatementTimeout()
 		case g.isLocal:
 			state.SetLocalStatementTimeout(g.statementTimeout)

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -36,12 +36,22 @@ import (
 type GatewaySessionState struct {
 	sql      string // Original SQL for debugging
 	variable string // Variable name (e.g., "statement_timeout")
-	isReset  bool   // true for RESET, false for SET
-	isLocal  bool   // true for SET LOCAL (transaction-scoped); ignored for RESET
+	isReset  bool   // true for RESET, SET ... TO DEFAULT, or SET LOCAL ... TO DEFAULT
+	isLocal  bool   // true if the source statement included LOCAL
 
 	// Typed fields for each gateway-managed variable.
 	// Only the field matching `variable` is used.
 	statementTimeout time.Duration
+
+	// The (isReset, isLocal) flags map to the four user-visible variants:
+	//
+	//   isReset isLocal  user statement                       primitive action
+	//   ------- -------  -----------------------------------  --------------------------------
+	//   false   false    SET var = value                      session-level override
+	//   false   true     SET LOCAL var = value                transaction-local override
+	//   true    false    RESET var | SET var TO DEFAULT       clear session (and any local)
+	//   true    true     SET LOCAL var TO DEFAULT             transaction-local revert to
+	//                                                         default; session preserved
 }
 
 // NewStatementTimeoutSet creates a primitive that SETs `statement_timeout`.

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -34,10 +34,11 @@ import (
 // Values are parsed at plan time and stored in typed fields so execution is a
 // simple assignment with no parsing overhead per query.
 type GatewaySessionState struct {
-	sql      string // Original SQL for debugging
-	variable string // Variable name (e.g., "statement_timeout")
-	isReset  bool   // true for RESET, SET ... TO DEFAULT, or SET LOCAL ... TO DEFAULT
-	isLocal  bool   // true if the source statement included LOCAL
+	sql         string // Original SQL for debugging
+	variable    string // Variable name (e.g., "statement_timeout")
+	isReset     bool   // true for RESET, SET ... TO DEFAULT, or SET LOCAL ... TO DEFAULT
+	isLocal     bool   // true if the source statement included LOCAL
+	isResetStmt bool   // true only for the literal `RESET var` statement; controls CommandTag
 
 	// Typed fields for each gateway-managed variable.
 	// Only the field matching `variable` is used.
@@ -52,6 +53,12 @@ type GatewaySessionState struct {
 	//   true    false    RESET var | SET var TO DEFAULT       clear session (and any local)
 	//   true    true     SET LOCAL var TO DEFAULT             transaction-local revert to
 	//                                                         default; session preserved
+	//
+	// isResetStmt is an orthogonal flag used only to derive the wire-protocol
+	// CommandTag. PostgreSQL returns "RESET" only for the literal `RESET var`
+	// statement; `SET [LOCAL] var TO DEFAULT` returns "SET" even though it
+	// shares semantics with RESET. So isResetStmt is true only when isReset is
+	// true AND the source was VAR_RESET (never VAR_SET_DEFAULT).
 }
 
 // NewStatementTimeoutSet creates a primitive that SETs `statement_timeout`.
@@ -72,13 +79,17 @@ func NewStatementTimeoutSet(sql string, statementTimeout time.Duration, isLocal 
 // the SET LOCAL ... TO DEFAULT semantic (transaction-scoped override to
 // the server default that masks any session value). When isLocal is false,
 // it performs the session-level RESET (or SET ... TO DEFAULT) which clears
-// the session override entirely.
-func NewGatewaySessionStateReset(sql string, variable string, isLocal bool) *GatewaySessionState {
+// the session override entirely. isResetStmt must be true only for the
+// literal `RESET var` statement (VAR_RESET); for `SET [LOCAL] var TO
+// DEFAULT` (VAR_SET_DEFAULT) it must be false so the CommandTag is "SET",
+// matching PostgreSQL.
+func NewGatewaySessionStateReset(sql string, variable string, isLocal bool, isResetStmt bool) *GatewaySessionState {
 	return &GatewaySessionState{
-		sql:      sql,
-		variable: variable,
-		isReset:  true,
-		isLocal:  isLocal,
+		sql:         sql,
+		variable:    variable,
+		isReset:     true,
+		isLocal:     isLocal,
+		isResetStmt: isResetStmt,
 	}
 }
 
@@ -91,8 +102,12 @@ func (g *GatewaySessionState) StreamExecute(
 	_ []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
+	// PostgreSQL returns "RESET" only for the literal `RESET var` statement.
+	// `SET [LOCAL] var TO DEFAULT` and all other SET forms return "SET", even
+	// though VAR_SET_DEFAULT shares semantics with RESET. Use isResetStmt
+	// (set by the planner from stmt.Kind == VAR_RESET) so the tag matches PG.
 	commandTag := "SET"
-	if g.isReset {
+	if g.isResetStmt {
 		commandTag = "RESET"
 	}
 

--- a/go/services/multigateway/engine/transaction_primitive.go
+++ b/go/services/multigateway/engine/transaction_primitive.go
@@ -134,6 +134,9 @@ func (t *TransactionPrimitive) executeCommit(
 ) error {
 	// Clear pending begin query — transaction is ending.
 	state.PendingBeginQuery = ""
+	// Clear any SET LOCAL overrides on gateway-managed variables — they're
+	// transaction-scoped and revert at COMMIT.
+	state.ResetAllLocalGUCs()
 
 	// Record transaction metrics before clearing state.
 	t.recordTxnMetrics(ctx, conn, state, TxnOutcomeCommit)
@@ -204,6 +207,9 @@ func (t *TransactionPrimitive) executeRollback(
 	state.PendingBeginQuery = ""
 	// Discard any pending LISTEN/UNLISTEN changes — ROLLBACK cancels them.
 	state.DiscardPendingListens()
+	// Clear any SET LOCAL overrides on gateway-managed variables — they're
+	// transaction-scoped and revert at ROLLBACK.
+	state.ResetAllLocalGUCs()
 
 	// Record transaction metrics before clearing state.
 	t.recordTxnMetrics(ctx, conn, state, TxnOutcomeRollback)

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -244,9 +244,10 @@ func (m *MultiGatewayConnectionState) SetStatementTimeout(d time.Duration) {
 	m.statementTimeout.Set(d)
 }
 
-// ResetStatementTimeout clears the session-level statement timeout,
-// reverting to the default (from startup params or flag). Does not touch
-// any active transaction-local override.
+// ResetStatementTimeout clears both the session-level override and any
+// active transaction-local override, reverting to the default (from startup
+// params or flag). Matches PostgreSQL: RESET inside a transaction with a
+// prior SET LOCAL supersedes the LOCAL — effective value becomes the default.
 func (m *MultiGatewayConnectionState) ResetStatementTimeout() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -245,11 +245,30 @@ func (m *MultiGatewayConnectionState) SetStatementTimeout(d time.Duration) {
 }
 
 // ResetStatementTimeout clears the session-level statement timeout,
-// reverting to the default (from startup params or flag).
+// reverting to the default (from startup params or flag). Does not touch
+// any active transaction-local override.
 func (m *MultiGatewayConnectionState) ResetStatementTimeout() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.statementTimeout.Reset()
+}
+
+// SetLocalStatementTimeout stores a transaction-local statement timeout
+// override (from SET LOCAL statement_timeout). Cleared on COMMIT/ROLLBACK
+// via ResetAllLocalGUCs.
+func (m *MultiGatewayConnectionState) SetLocalStatementTimeout(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statementTimeout.SetLocal(d)
+}
+
+// ResetAllLocalGUCs clears all transaction-local overrides for gateway-managed
+// variables. Called at transaction end (COMMIT/ROLLBACK) so the next statement
+// observes the session-level (or default) value.
+func (m *MultiGatewayConnectionState) ResetAllLocalGUCs() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statementTimeout.ResetLocal()
 }
 
 // GetStatementTimeout returns the effective statement timeout:

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -262,6 +262,17 @@ func (m *MultiGatewayConnectionState) SetLocalStatementTimeout(d time.Duration) 
 	m.statementTimeout.SetLocal(d)
 }
 
+// SetLocalStatementTimeoutToDefault sets the transaction-local override to
+// the server default (from SET LOCAL statement_timeout TO DEFAULT). This
+// masks any session-level override for the duration of the transaction
+// without destroying it; the session value is restored on COMMIT/ROLLBACK
+// via ResetAllLocalGUCs.
+func (m *MultiGatewayConnectionState) SetLocalStatementTimeoutToDefault() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statementTimeout.SetLocalToDefault()
+}
+
 // ResetAllLocalGUCs clears all transaction-local overrides for gateway-managed
 // variables. Called at transaction end (COMMIT/ROLLBACK) so the next statement
 // observes the session-level (or default) value.

--- a/go/services/multigateway/handler/gateway_managed_variable.go
+++ b/go/services/multigateway/handler/gateway_managed_variable.go
@@ -60,6 +60,16 @@ func (g *GatewayManagedVariable[T]) SetLocal(v T) {
 	g.isLocalSet = true
 }
 
+// SetLocalToDefault is the LOCAL form of SET ... TO DEFAULT: a transaction-
+// scoped override whose value is the server default. It masks any session-level
+// override for the duration of the transaction without destroying it. Matches
+// PostgreSQL's behavior for `SET LOCAL var TO DEFAULT` — after the transaction
+// ends and ResetLocal fires, the session-level value (if any) is restored.
+func (g *GatewayManagedVariable[T]) SetLocalToDefault() {
+	g.localValue = g.defaultValue
+	g.isLocalSet = true
+}
+
 // ResetLocal clears any transaction-local override. Called at COMMIT/ROLLBACK
 // to revert the value to the session-level (or default) value.
 func (g *GatewayManagedVariable[T]) ResetLocal() {

--- a/go/services/multigateway/handler/gateway_managed_variable.go
+++ b/go/services/multigateway/handler/gateway_managed_variable.go
@@ -39,18 +39,28 @@ func NewGatewayManagedVariable[T comparable](defaultValue T) GatewayManagedVaria
 	return GatewayManagedVariable[T]{defaultValue: defaultValue}
 }
 
-// Set stores a session-level override.
+// Set stores a session-level override and clears any active transaction-local
+// override. Matches PostgreSQL: a non-LOCAL SET issued inside a transaction
+// that has a prior SET LOCAL supersedes the LOCAL — effective value
+// immediately becomes the new session value.
 func (g *GatewayManagedVariable[T]) Set(v T) {
 	g.currentValue = v
 	g.isSet = true
+	var zero T
+	g.localValue = zero
+	g.isLocalSet = false
 }
 
-// Reset clears the session override, reverting to the default.
-// Does not touch any active transaction-local override.
+// Reset clears both the session override and any active transaction-local
+// override, reverting to the default. Matches PostgreSQL: RESET issued inside
+// a transaction that has a prior SET LOCAL supersedes the LOCAL — effective
+// value immediately becomes the default.
 func (g *GatewayManagedVariable[T]) Reset() {
 	var zero T
 	g.currentValue = zero
 	g.isSet = false
+	g.localValue = zero
+	g.isLocalSet = false
 }
 
 // SetLocal stores a transaction-local override. Cleared by ResetLocal at

--- a/go/services/multigateway/handler/gateway_managed_variable.go
+++ b/go/services/multigateway/handler/gateway_managed_variable.go
@@ -14,13 +14,24 @@
 
 package handler
 
-// GatewayManagedVariable holds a session-overridable variable with a server default.
-// The default is set once at connection init (from startup params or the server flag)
-// and the current value can be overridden per-session via SET / cleared via RESET.
+// GatewayManagedVariable holds a variable with three priority layers matching
+// PostgreSQL's GUC semantics:
+//
+//  1. defaultValue — the server default, set once at connection init from startup
+//     params or the server flag.
+//  2. currentValue — a session-level override set via SET var, cleared via RESET.
+//     Persists across transactions.
+//  3. localValue   — a transaction-scoped override set via SET LOCAL var, cleared
+//     when the surrounding transaction COMMITs or ROLLBACKs.
+//
+// GetEffective resolves with priority local > session > default, matching
+// PostgreSQL's behavior.
 type GatewayManagedVariable[T comparable] struct {
 	defaultValue T
 	currentValue T
 	isSet        bool
+	localValue   T
+	isLocalSet   bool
 }
 
 // NewGatewayManagedVariable creates a variable with the given default value.
@@ -35,21 +46,46 @@ func (g *GatewayManagedVariable[T]) Set(v T) {
 }
 
 // Reset clears the session override, reverting to the default.
+// Does not touch any active transaction-local override.
 func (g *GatewayManagedVariable[T]) Reset() {
 	var zero T
 	g.currentValue = zero
 	g.isSet = false
 }
 
-// GetEffective returns the session override if set, otherwise the default.
+// SetLocal stores a transaction-local override. Cleared by ResetLocal at
+// transaction end (COMMIT or ROLLBACK).
+func (g *GatewayManagedVariable[T]) SetLocal(v T) {
+	g.localValue = v
+	g.isLocalSet = true
+}
+
+// ResetLocal clears any transaction-local override. Called at COMMIT/ROLLBACK
+// to revert the value to the session-level (or default) value.
+func (g *GatewayManagedVariable[T]) ResetLocal() {
+	var zero T
+	g.localValue = zero
+	g.isLocalSet = false
+}
+
+// GetEffective returns the active value with priority:
+// transaction-local > session > default.
 func (g *GatewayManagedVariable[T]) GetEffective() T {
+	if g.isLocalSet {
+		return g.localValue
+	}
 	if g.isSet {
 		return g.currentValue
 	}
 	return g.defaultValue
 }
 
-// IsSet returns whether a session override is active.
+// IsSet returns whether a session-level override is active.
 func (g *GatewayManagedVariable[T]) IsSet() bool {
 	return g.isSet
+}
+
+// IsLocalSet returns whether a transaction-local override is active.
+func (g *GatewayManagedVariable[T]) IsLocalSet() bool {
+	return g.isLocalSet
 }

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -230,6 +230,25 @@ func TestGatewayManagedVariable(t *testing.T) {
 		require.Equal(t, time.Duration(0), v.GetEffective())
 		require.True(t, v.IsLocalSet())
 	})
+
+	t.Run("SetLocalToDefault masks session without destroying it", func(t *testing.T) {
+		// PG semantics: SET LOCAL var TO DEFAULT installs a transaction-scoped
+		// override equal to the default, masking the session value during the
+		// transaction. The session value must be preserved for restoration on
+		// COMMIT/ROLLBACK (when ResetLocal fires).
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.Set(5 * time.Second)
+		v.SetLocalToDefault()
+		require.Equal(t, 30*time.Second, v.GetEffective(),
+			"during txn: SHOW returns default value, masking session")
+		require.True(t, v.IsLocalSet())
+		require.True(t, v.IsSet(), "session value must be preserved, not destroyed")
+
+		// Simulate transaction-end ResetLocal: session value should be restored.
+		v.ResetLocal()
+		require.Equal(t, 5*time.Second, v.GetEffective(),
+			"after txn end: session value is restored")
+	})
 }
 
 func TestConnectionState_StatementTimeout(t *testing.T) {
@@ -322,5 +341,23 @@ func TestConnectionState_StatementTimeout(t *testing.T) {
 		s.SetLocalStatementTimeout(40 * time.Millisecond)
 		s.ResetStatementTimeout()
 		require.Equal(t, 40*time.Millisecond, s.GetStatementTimeout())
+	})
+
+	t.Run("SetLocalStatementTimeoutToDefault masks session", func(t *testing.T) {
+		// Repro the reviewer-flagged bug: SET LOCAL var TO DEFAULT must NOT
+		// destroy the session value. ShowStatementTimeout reflects the default
+		// during the transaction; after ResetAllLocalGUCs (transaction end),
+		// the original session value is restored.
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+
+		s.SetLocalStatementTimeoutToDefault()
+		require.Equal(t, 30*time.Second, s.GetStatementTimeout(),
+			"during txn: effective value is the default")
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, 5*time.Second, s.GetStatementTimeout(),
+			"after txn end: session value is restored, not lost")
 	})
 }

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -176,6 +176,60 @@ func TestGatewayManagedVariable(t *testing.T) {
 		v.Set(10 * time.Second)
 		require.Equal(t, 10*time.Second, v.GetEffective())
 	})
+
+	t.Run("set local overrides session and default", func(t *testing.T) {
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.Set(5 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		require.Equal(t, 100*time.Millisecond, v.GetEffective())
+		require.True(t, v.IsLocalSet())
+		require.True(t, v.IsSet())
+	})
+
+	t.Run("set local without session set still wins over default", func(t *testing.T) {
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		require.Equal(t, 100*time.Millisecond, v.GetEffective())
+		require.True(t, v.IsLocalSet())
+		require.False(t, v.IsSet())
+	})
+
+	t.Run("reset local reverts to session", func(t *testing.T) {
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.Set(5 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		v.ResetLocal()
+		require.Equal(t, 5*time.Second, v.GetEffective())
+		require.False(t, v.IsLocalSet())
+		require.True(t, v.IsSet())
+	})
+
+	t.Run("reset local with no session reverts to default", func(t *testing.T) {
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		v.ResetLocal()
+		require.Equal(t, 30*time.Second, v.GetEffective())
+		require.False(t, v.IsLocalSet())
+	})
+
+	t.Run("session reset does not clear local override", func(t *testing.T) {
+		// PostgreSQL semantics: RESET inside a transaction clears the
+		// session-level value but the SET LOCAL override stays in effect.
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.Set(5 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		v.Reset()
+		require.Equal(t, 100*time.Millisecond, v.GetEffective())
+		require.True(t, v.IsLocalSet())
+		require.False(t, v.IsSet())
+	})
+
+	t.Run("local zero is honored as override", func(t *testing.T) {
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.SetLocal(0)
+		require.Equal(t, time.Duration(0), v.GetEffective())
+		require.True(t, v.IsLocalSet())
+	})
 }
 
 func TestConnectionState_StatementTimeout(t *testing.T) {
@@ -230,5 +284,43 @@ func TestConnectionState_StatementTimeout(t *testing.T) {
 		// Non-even values stay in ms
 		s.SetStatementTimeout(1500 * time.Millisecond)
 		require.Equal(t, "1500ms", s.ShowStatementTimeout())
+	})
+
+	t.Run("set local overrides session and shows local value", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+		s.SetLocalStatementTimeout(40 * time.Millisecond)
+		require.Equal(t, 40*time.Millisecond, s.GetStatementTimeout())
+		require.Equal(t, "40ms", s.ShowStatementTimeout())
+	})
+
+	t.Run("ResetAllLocalGUCs clears local but keeps session", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+		s.SetLocalStatementTimeout(40 * time.Millisecond)
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, 5*time.Second, s.GetStatementTimeout())
+	})
+
+	t.Run("ResetAllLocalGUCs reverts to default when no session set", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetLocalStatementTimeout(40 * time.Millisecond)
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, 30*time.Second, s.GetStatementTimeout())
+	})
+
+	t.Run("session reset preserves local override", func(t *testing.T) {
+		// Mirrors PG: RESET inside a transaction does not undo SET LOCAL.
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetStatementTimeout(5 * time.Second)
+		s.SetLocalStatementTimeout(40 * time.Millisecond)
+		s.ResetStatementTimeout()
+		require.Equal(t, 40*time.Millisecond, s.GetStatementTimeout())
 	})
 }

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -212,15 +212,28 @@ func TestGatewayManagedVariable(t *testing.T) {
 		require.False(t, v.IsLocalSet())
 	})
 
-	t.Run("session reset does not clear local override", func(t *testing.T) {
-		// PostgreSQL semantics: RESET inside a transaction clears the
-		// session-level value but the SET LOCAL override stays in effect.
+	t.Run("session set clears active local override", func(t *testing.T) {
+		// PostgreSQL semantics: SET inside a transaction with a prior SET LOCAL
+		// supersedes the LOCAL — effective value immediately becomes the new
+		// session value (verified directly against PG 17).
+		v := NewGatewayManagedVariable(30 * time.Second)
+		v.SetLocal(100 * time.Millisecond)
+		v.Set(5 * time.Second)
+		require.Equal(t, 5*time.Second, v.GetEffective())
+		require.False(t, v.IsLocalSet())
+		require.True(t, v.IsSet())
+	})
+
+	t.Run("session reset clears active local override", func(t *testing.T) {
+		// PostgreSQL semantics: RESET inside a transaction with a prior SET LOCAL
+		// also supersedes the LOCAL — effective value becomes the default
+		// (verified directly against PG 17).
 		v := NewGatewayManagedVariable(30 * time.Second)
 		v.Set(5 * time.Second)
 		v.SetLocal(100 * time.Millisecond)
 		v.Reset()
-		require.Equal(t, 100*time.Millisecond, v.GetEffective())
-		require.True(t, v.IsLocalSet())
+		require.Equal(t, 30*time.Second, v.GetEffective())
+		require.False(t, v.IsLocalSet())
 		require.False(t, v.IsSet())
 	})
 
@@ -333,14 +346,25 @@ func TestConnectionState_StatementTimeout(t *testing.T) {
 		require.Equal(t, 30*time.Second, s.GetStatementTimeout())
 	})
 
-	t.Run("session reset preserves local override", func(t *testing.T) {
-		// Mirrors PG: RESET inside a transaction does not undo SET LOCAL.
+	t.Run("session set supersedes active local override", func(t *testing.T) {
+		// Mirrors PG: SET inside a transaction with a prior SET LOCAL
+		// supersedes the LOCAL — effective value is the new session value.
+		s := NewMultiGatewayConnectionState()
+		s.InitStatementTimeout(30 * time.Second)
+		s.SetLocalStatementTimeout(40 * time.Millisecond)
+		s.SetStatementTimeout(5 * time.Second)
+		require.Equal(t, 5*time.Second, s.GetStatementTimeout())
+	})
+
+	t.Run("session reset supersedes active local override", func(t *testing.T) {
+		// Mirrors PG: RESET inside a transaction with a prior SET LOCAL
+		// supersedes the LOCAL — effective value is the default.
 		s := NewMultiGatewayConnectionState()
 		s.InitStatementTimeout(30 * time.Second)
 		s.SetStatementTimeout(5 * time.Second)
 		s.SetLocalStatementTimeout(40 * time.Millisecond)
 		s.ResetStatementTimeout()
-		require.Equal(t, 40*time.Millisecond, s.GetStatementTimeout())
+		require.Equal(t, 30*time.Second, s.GetStatementTimeout())
 	})
 
 	t.Run("SetLocalStatementTimeoutToDefault masks session", func(t *testing.T) {

--- a/go/services/multigateway/planner/planner_test.go
+++ b/go/services/multigateway/planner/planner_test.go
@@ -52,7 +52,7 @@ func TestPrimitiveName(t *testing.T) {
 		},
 		{
 			name:      "GatewaySessionState",
-			primitive: engine.NewStatementTimeoutSet("SET statement_timeout = '5s'", 5*time.Second),
+			primitive: engine.NewStatementTimeoutSet("SET statement_timeout = '5s'", 5*time.Second, false),
 			want:      engine.PlanTypeGatewaySessionState,
 		},
 		{

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -151,9 +151,13 @@ func (p *Planner) planGatewayManagedVariable(
 		// which never passes isGatewayManagedVariable. RESET ALL is handled by
 		// ApplySessionState (after routing to PostgreSQL) which resets both
 		// PostgreSQL session settings and gateway-managed variables.
+		// isResetStmt is set only for VAR_RESET so the wire CommandTag is
+		// "RESET" for `RESET var` and "SET" for `SET [LOCAL] var TO DEFAULT`,
+		// matching PostgreSQL.
+		isResetStmt := stmt.Kind == ast.VAR_RESET
 		p.logger.Debug("planning RESET gateway-managed variable",
-			"variable", name, "is_local", stmt.IsLocal)
-		return engine.NewGatewaySessionStateReset(sql, name, stmt.IsLocal), nil
+			"variable", name, "is_local", stmt.IsLocal, "is_reset_stmt", isResetStmt)
+		return engine.NewGatewaySessionStateReset(sql, name, stmt.IsLocal, isResetStmt), nil
 
 	default:
 		return nil, mterrors.NewPgError("ERROR", mterrors.PgSSSyntaxError,

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -35,16 +35,12 @@ func (p *Planner) planVariableSetStmt(
 	stmt *ast.VariableSetStmt,
 	conn *server.Conn,
 ) (*engine.Plan, error) {
-	// Just pass through to PostgreSQL
-	if stmt.IsLocal {
-		p.logger.Debug("SET LOCAL detected, passing through",
-			"variable", stmt.Name)
-		return p.planDefault(sql, stmt, conn)
-	}
-
-	// Gateway-managed variables are handled locally without routing to PostgreSQL.
-	// This check happens before the Kind filter because VAR_SET_DEFAULT also needs
-	// to be intercepted for gateway-managed variables (it should behave like RESET).
+	// Gateway-managed variables are handled locally without routing to PostgreSQL,
+	// regardless of whether SET or SET LOCAL is used. This check must come before
+	// the IsLocal pass-through so SET LOCAL on a gateway-managed variable updates
+	// the gateway state instead of the (uninvolved) backend, keeping subsequent
+	// SHOW consistent with PostgreSQL semantics. The check also runs before the
+	// Kind filter because VAR_SET_DEFAULT needs to be intercepted (treated as RESET).
 	if isGatewayManagedVariable(stmt.Name) {
 		value := ""
 		if stmt.Kind == ast.VAR_SET_VALUE {
@@ -57,6 +53,14 @@ func (p *Planner) planVariableSetStmt(
 		plan := engine.NewPlan(sql, primitive)
 		p.logger.Debug("created gateway-managed plan", "plan", plan.String())
 		return plan, nil
+	}
+
+	// Non-gateway-managed SET LOCAL passes through to PostgreSQL unchanged —
+	// the backend is authoritative for those variables.
+	if stmt.IsLocal {
+		p.logger.Debug("SET LOCAL detected, passing through",
+			"variable", stmt.Name)
+		return p.planDefault(sql, stmt, conn)
 	}
 
 	// SET var TO DEFAULT is equivalent to RESET var in PostgreSQL
@@ -130,8 +134,8 @@ func (p *Planner) planGatewayManagedVariable(
 				return nil, err
 			}
 			p.logger.Debug("planning SET statement_timeout (gateway-managed)",
-				"value", value, "parsed", d)
-			return engine.NewStatementTimeoutSet(sql, d), nil
+				"value", value, "parsed", d, "is_local", stmt.IsLocal)
+			return engine.NewStatementTimeoutSet(sql, d, stmt.IsLocal), nil
 		default:
 			return nil, mterrors.NewUnrecognizedParameter(name)
 		}

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -142,12 +142,18 @@ func (p *Planner) planGatewayManagedVariable(
 
 	case ast.VAR_RESET, ast.VAR_SET_DEFAULT:
 		// RESET and SET ... TO DEFAULT revert to the flag default.
+		// SET LOCAL var TO DEFAULT (IsLocal && VAR_SET_DEFAULT) is distinct: it
+		// installs a transaction-scoped override equal to the default, masking
+		// (not destroying) the session value. The primitive branches on isLocal.
+		// RESET itself has no LOCAL form in the grammar, so stmt.IsLocal is
+		// always false for VAR_RESET.
 		// Note: VAR_RESET_ALL is not listed here because RESET ALL has stmt.Name=""
 		// which never passes isGatewayManagedVariable. RESET ALL is handled by
 		// ApplySessionState (after routing to PostgreSQL) which resets both
 		// PostgreSQL session settings and gateway-managed variables.
-		p.logger.Debug("planning RESET gateway-managed variable", "variable", name)
-		return engine.NewGatewaySessionStateReset(sql, name), nil
+		p.logger.Debug("planning RESET gateway-managed variable",
+			"variable", name, "is_local", stmt.IsLocal)
+		return engine.NewGatewaySessionStateReset(sql, name, stmt.IsLocal), nil
 
 	default:
 		return nil, mterrors.NewPgError("ERROR", mterrors.PgSSSyntaxError,


### PR DESCRIPTION
## Summary

- `SET LOCAL statement_timeout` was silently ignored: the value never reached multigateway's GUC state because the planner short-circuited LOCAL to a backend pass-through *before* the gateway-managed dispatch ran. SHOW kept returning the session-level value.
- Adds a third tier (`localValue` / `isLocalSet`) to `GatewayManagedVariable[T]` so the gateway tracks PostgreSQL's local/session/default GUC semantics for variables it owns. Effective priority: local > session > default.
- Wires `ResetAllLocalGUCs()` into `executeCommit` and `executeRollback` so LOCAL overrides clear at the transaction boundary, matching PG.

## Problem

Closes [MUL-390](https://linear.app/supabase/issue/MUL-390).

`statement_timeout` is intercepted by multigateway as a gateway-managed GUC: `SET` updates `MultiGatewayConnectionState`, `SHOW` reads it back. The planner's LOCAL handling looked like this:

```go
if stmt.IsLocal {
    return p.planDefault(...)             // pass-through to backend
}
if isGatewayManagedVariable(stmt.Name) {
    // gateway-managed dispatch (only reached for non-LOCAL)
}
```

So `SET LOCAL statement_timeout = '40ms'` was forwarded to the backend without updating gateway state, while `SHOW statement_timeout` continued reading from the (un-updated) gateway state. Subsequent SHOW returned the session-level default rather than the LOCAL override.

Other `SET LOCAL` values (`DateStyle`, `role`, `search_path`, `request.jwt.claims`) were unaffected — they're not gateway-managed, so the pass-through path produced correct round-trip behavior. Verified manually.

PostgREST issues `SET LOCAL statement_timeout` per request to enforce per-request query timeouts, so this bug specifically broke timeout enforcement for any deployment fronting PostgREST through multigateway.

## Solution

Three coordinated changes:

1. `GatewayManagedVariable[T]` gains `localValue` / `isLocalSet` plus `SetLocal` / `ResetLocal`, and `GetEffective()` resolves `local > session > default`. RESET clears only the session layer (matches PG: RESET inside a transaction does not undo a prior SET LOCAL).
2. The planner reorders its check: `isGatewayManagedVariable` runs *before* the IsLocal pass-through, threading `stmt.IsLocal` into the gateway-managed primitive. Non-gateway-managed SET LOCAL keeps passing through to the backend.
3. `transaction_primitive.go` calls `state.ResetAllLocalGUCs()` from both `executeCommit` and `executeRollback`, at the same boundary as the existing LISTEN/NOTIFY commit hook.

`SET LOCAL` outside a transaction is the no-op PG warns on; multigateway's existing autocommit handling already triggers an immediate commit, so the LOCAL value is cleared right after the statement that set it — matching PG semantics.

### Known limitation

`ROLLBACK TO SAVEPOINT` does not restore the pre-savepoint LOCAL value because no per-savepoint snapshot is kept. Tracked separately as [MUL-392](https://linear.app/supabase/issue/MUL-392) (savepoint-aware GUC stack), which covers both gateway-managed and backend-managed variables.

## Verification

End-to-end against a local cluster, all six acceptance scenarios pass:

| Scenario | Result |
|---|---|
| `BEGIN; SET LOCAL statement_timeout='40ms'; SHOW` | `40ms` inside, default after COMMIT |
| `pg_sleep(1)` with `100ms` LOCAL | `ERROR: canceling statement due to statement timeout` |
| ROLLBACK clears LOCAL | reverts to session/default |
| Session SET + LOCAL coexistence | LOCAL wins inside; session restored after COMMIT |
| RESET inside txn does not undo LOCAL | matches PG |
| Backend-managed `SET LOCAL` (DateStyle, role) | regression-free, still passes through |

13 new unit tests in `handler/statement_timeout_test.go` cover the GUC tier semantics and the `MultiGatewayConnectionState` integration. All multigateway test packages green.

## Test plan

- [x] CI green on this PR.
- [ ] Manual repro on a fresh cluster: `BEGIN; SET LOCAL statement_timeout = '40ms'; SHOW statement_timeout; SELECT pg_sleep(1); COMMIT;` — SHOW returns `40ms` and pg_sleep is canceled.
- [ ] Apply the `Run Extended Query Serving Tests` label to confirm pgregress doesn't regress (statement_timeout is not directly exercised by the regression or isolation suites; this is a no-regression check only).