### PR TITLE
feat(benchmarking): make pgbench runner capture CPU/memory profiles and pick targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ demo/k8s/data/
 # Generated PR description
 pr-description.md
 
+docs/query_serving/benchmarking/results/*

--- a/docs/query_serving/benchmarking/pgbench.md
+++ b/docs/query_serving/benchmarking/pgbench.md
@@ -100,11 +100,17 @@ the test is skipped.
 
 ### Environment variables
 
-| Variable           | Default   | Description                                                                  |
-| ------------------ | --------- | ---------------------------------------------------------------------------- |
-| `RUN_BENCHMARKS`   | (unset)   | Set to `1` to enable benchmark tests. Matches the "Run Benchmarks" PR label. |
-| `PGBENCH_DURATION` | `30`      | Seconds per scenario                                                         |
-| `PGBENCH_CLIENTS`  | `1,10,50` | Comma-separated client counts                                                |
+| Variable                     | Default           | Description                                                                                      |
+| ---------------------------- | ----------------- | ------------------------------------------------------------------------------------------------ |
+| `RUN_BENCHMARKS`             | (unset)           | Set to `1` to enable benchmark tests. Matches the "Run Benchmarks" PR label.                     |
+| `PGBENCH_DURATION`           | `30`              | Seconds per scenario                                                                             |
+| `PGBENCH_CLIENTS`            | `1,10,50`         | Comma-separated client counts                                                                    |
+| `PGBENCH_PROTOCOLS`          | `simple,extended` | Comma-separated subset of `simple,extended`                                                      |
+| `PGBENCH_NO_CHURN`           | (unset)           | Set to `1` to skip the connection-churn (`-C`) variants                                          |
+| `PGBENCH_TARGETS`            | `multigateway`    | Comma-separated subset of `postgres,multigateway,pgbouncer`                                      |
+| `PGBENCH_PG_MAX_CONNECTIONS` | (unset)           | Bump postgres `max_connections` to this value and restart pgctld (needed for direct ≥ 60 client) |
+| `CAPTURE_PPROF`              | (unset)           | Set to `1` to capture CPU profiles from multigateway and primary multipooler during each run     |
+| `CAPTURE_HEAP`               | (unset)           | Set to `1` to capture heap, allocs and goroutine snapshots before+after each scenario            |
 
 ## How metrics are computed
 
@@ -128,11 +134,14 @@ gives us percentile data that the text summary does not include.
 
 Reports are written to `/tmp/multigres_pgbench_results/<timestamp>/`:
 
-| File                        | Format            | Purpose                                             |
-| --------------------------- | ----------------- | --------------------------------------------------- |
-| `results.json`              | JSON              | Machine-readable results for CI baseline comparison |
-| `benchmark-report.md`       | Markdown          | Human-readable comparison tables                    |
-| `logs/<scenario>/<target>/` | pgbench log files | Raw per-transaction data                            |
+| File                                                                       | Format            | Purpose                                                             |
+| -------------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------- |
+| `results.json`                                                             | JSON              | Machine-readable results for CI baseline comparison                 |
+| `benchmark-report.md`                                                      | Markdown          | Human-readable comparison tables                                    |
+| `logs/<scenario>/<target>/`                                                | pgbench log files | Raw per-transaction data                                            |
+| `cpu/<scenario>/<target>.json`                                             | JSON              | Per-process CPU usage samples (postgres, multigateway, multipooler) |
+| `pprof/<scenario>/<target>/cpu-*.pb.gz`                                    | pprof gzip        | CPU profiles (when `CAPTURE_PPROF=1`)                               |
+| `pprof/<scenario>/<target>/{heap,allocs,goroutine}-{before,after}-*.pb.gz` | pprof gzip        | Memory and goroutine snapshots (when `CAPTURE_HEAP=1`)              |
 
 ### Markdown report example
 

--- a/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
+++ b/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmarking
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// CPUStats summarizes CPU usage samples for a single process tree
+// across a scenario run. Values are in "percent of one core" — i.e.
+// 100.0 means 1 core fully busy. With many backends it can exceed 100.
+type CPUStats struct {
+	Label       string    `json:"label"`
+	Samples     int       `json:"samples"`
+	MeanPercent float64   `json:"mean_percent"`
+	MinPercent  float64   `json:"min_percent"`
+	MaxPercent  float64   `json:"max_percent"`
+	Series      []float64 `json:"series_percent"`
+}
+
+// pidEnumerator returns the set of PIDs to sample at a given moment.
+type pidEnumerator func() ([]int, error)
+
+// staticPidEnumerator returns a constant list of PIDs.
+func staticPidEnumerator(pids ...int) pidEnumerator {
+	return func() ([]int, error) { return pids, nil }
+}
+
+// postgresPidEnumerator returns the postmaster pid plus its direct children
+// (backends, bgworker, walwriter, etc.) on each call. The postmaster pid is
+// read from postmaster.pid in the data dir, so it's resilient to postgres
+// restarts mid-scenario.
+func postgresPidEnumerator(dataDir string) pidEnumerator {
+	pidFile := dataDir + "/postmaster.pid"
+	return func() ([]int, error) {
+		raw, err := os.ReadFile(pidFile)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", pidFile, err)
+		}
+		// First line is the postmaster PID.
+		firstLine := raw
+		if i := bytes.IndexByte(raw, '\n'); i > 0 {
+			firstLine = raw[:i]
+		}
+		pmPid, err := strconv.Atoi(strings.TrimSpace(string(firstLine)))
+		if err != nil {
+			return nil, fmt.Errorf("parse postmaster pid: %w", err)
+		}
+
+		// Children (one level is enough for postgres backends).
+		out, err := exec.Command("pgrep", "-P", strconv.Itoa(pmPid)).Output()
+		if err != nil {
+			// pgrep returns exit 1 when no children; treat as just the postmaster.
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				return []int{pmPid}, nil
+			}
+			return nil, fmt.Errorf("pgrep -P %d: %w", pmPid, err)
+		}
+		pids := []int{pmPid}
+		for s := range strings.FieldsSeq(string(out)) {
+			if pid, err := strconv.Atoi(s); err == nil {
+				pids = append(pids, pid)
+			}
+		}
+		return pids, nil
+	}
+}
+
+// readPSCPU returns the sum of %cpu across the given pids using a single
+// `ps` invocation. macOS ps reports "current" CPU% (decayed average).
+// On Linux ps reports cumulative-since-start which is less useful for
+// short windows, but we sample frequently enough that the per-sample
+// granularity matters more than the absolute scale.
+func readPSCPU(pids []int) (float64, error) {
+	if len(pids) == 0 {
+		return 0, nil
+	}
+	args := []string{"-o", "%cpu="}
+	for _, p := range pids {
+		args = append(args, "-p", strconv.Itoa(p))
+	}
+	// Errors are intentionally swallowed: pids may exit between
+	// enumeration and sampling, in which case `ps` returns non-zero but
+	// still emits %cpu lines for the survivors. Sum what we got.
+	out, _ := exec.Command("ps", args...).Output()
+	var total float64
+	for ln := range strings.SplitSeq(string(out), "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		v, perr := strconv.ParseFloat(ln, 64)
+		if perr != nil {
+			continue
+		}
+		total += v
+	}
+	return total, nil
+}
+
+// cpuSampler runs a goroutine sampling the given pidEnumerator at the
+// configured interval. Stop() returns the aggregated stats once the
+// goroutine has finished collecting.
+type cpuSampler struct {
+	label    string
+	enum     pidEnumerator
+	interval time.Duration
+
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+	mu     sync.Mutex
+	series []float64
+}
+
+func newCPUSampler(label string, enum pidEnumerator, interval time.Duration) *cpuSampler {
+	return &cpuSampler{label: label, enum: enum, interval: interval}
+}
+
+// Start begins sampling. Cancel ctx (or call Stop) to finish.
+func (s *cpuSampler) Start(parent context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	s.cancel = cancel
+
+	s.wg.Go(func() {
+		t := time.NewTicker(s.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				pids, err := s.enum()
+				if err != nil || len(pids) == 0 {
+					continue
+				}
+				v, err := readPSCPU(pids)
+				if err != nil {
+					continue
+				}
+				s.mu.Lock()
+				s.series = append(s.series, v)
+				s.mu.Unlock()
+			}
+		}
+	})
+}
+
+// Stop finalizes the sampler and returns aggregated stats.
+func (s *cpuSampler) Stop() CPUStats {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stats := CPUStats{Label: s.label, Samples: len(s.series), Series: s.series}
+	if len(s.series) == 0 {
+		return stats
+	}
+	var sum float64
+	stats.MinPercent = s.series[0]
+	stats.MaxPercent = s.series[0]
+	for _, v := range s.series {
+		sum += v
+		if v < stats.MinPercent {
+			stats.MinPercent = v
+		}
+		if v > stats.MaxPercent {
+			stats.MaxPercent = v
+		}
+	}
+	stats.MeanPercent = sum / float64(len(s.series))
+	return stats
+}
+
+// writeCPUStatsFile persists per-process CPU stats for one (scenario,target)
+// run as JSON under <outputDir>/cpu/<scenario>/<target>.json.
+func writeCPUStatsFile(t *testing.T, outputDir, scenario, target string, stats map[string]CPUStats) {
+	t.Helper()
+
+	dir := filepath.Join(outputDir, "cpu", scenario)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("cpu stats: mkdir %s: %v", dir, err)
+		return
+	}
+	path := filepath.Join(dir, target+".json")
+	body, err := json.MarshalIndent(stats, "", "  ")
+	if err != nil {
+		t.Logf("cpu stats: marshal: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Logf("cpu stats: write %s: %v", path, err)
+	}
+}

--- a/go/test/endtoend/queryserving/benchmarking/pg_config.go
+++ b/go/test/endtoend/queryserving/benchmarking/pg_config.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmarking
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// bumpPostgresMaxConnections rewrites postgresql.auto.conf on every pgctld
+// in the cluster to set max_connections=n, then restarts each postgres via
+// pgctld so the new value takes effect.
+//
+// Required when running pgbench with more clients than the default
+// postgres max_connections (60).
+func bumpPostgresMaxConnections(ctx context.Context, t *testing.T, setup *shardsetup.ShardSetup, n int) {
+	t.Helper()
+
+	for name, inst := range setup.Multipoolers {
+		if err := writeMaxConnectionsOverride(inst.Pgctld.PoolerDir, n); err != nil {
+			t.Fatalf("write max_connections override on %s: %v", name, err)
+		}
+		t.Logf("Wrote max_connections=%d override on %s (data dir: %s)", n, name, inst.Pgctld.PoolerDir)
+
+		// Disable the multipooler monitor's automatic postgres restart so it
+		// doesn't race with our pgctld Restart.
+		mp, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+		if err != nil {
+			t.Fatalf("connect to multipooler on %s: %v", name, err)
+		}
+		_, err = mp.Manager.SetPostgresRestartsEnabled(ctx,
+			&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: false})
+		mp.Close()
+		if err != nil {
+			t.Fatalf("disable monitor restarts on %s: %v", name, err)
+		}
+
+		pg, err := shardsetup.NewPgctldClient(inst.Pgctld.GrpcPort)
+		if err != nil {
+			t.Fatalf("connect to pgctld on %s: %v", name, err)
+		}
+
+		restartCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		_, err = pg.Restart(restartCtx, &pgctldpb.RestartRequest{Mode: "fast"})
+		cancel()
+		pg.Close()
+		if err != nil {
+			t.Fatalf("pgctld Restart on %s: %v", name, err)
+		}
+
+		// Re-enable the monitor.
+		mp2, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+		if err != nil {
+			t.Fatalf("re-connect to multipooler on %s: %v", name, err)
+		}
+		_, err = mp2.Manager.SetPostgresRestartsEnabled(ctx,
+			&multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest{Enabled: true})
+		mp2.Close()
+		if err != nil {
+			t.Fatalf("re-enable monitor restarts on %s: %v", name, err)
+		}
+
+		t.Logf("Restarted postgres on %s with max_connections=%d", name, n)
+	}
+}
+
+const maxConnectionsMarker = "# multigres_pgbench_override\n"
+
+// writeMaxConnectionsOverride appends (idempotently) the override to
+// postgresql.auto.conf inside the postgres data directory.
+func writeMaxConnectionsOverride(poolerDir string, n int) error {
+	autoConf := filepath.Join(poolerDir, "pg_data", "postgresql.auto.conf")
+
+	existing, err := os.ReadFile(autoConf)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", autoConf, err)
+	}
+
+	// If we already wrote the override, replace the line; otherwise append.
+	override := fmt.Sprintf("%smax_connections = %d\n", maxConnectionsMarker, n)
+	out := stripPriorOverride(string(existing)) + override
+
+	if err := os.WriteFile(autoConf, []byte(out), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", autoConf, err)
+	}
+	return nil
+}
+
+// stripPriorOverride removes the previous max_connections override block
+// (marker + immediate next line) so we can rewrite cleanly. Anything else
+// in postgresql.auto.conf is preserved.
+func stripPriorOverride(in string) string {
+	idx := -1
+	if i := indexOf(in, maxConnectionsMarker); i >= 0 {
+		idx = i
+	}
+	if idx < 0 {
+		return in
+	}
+	prefix := in[:idx]
+	rest := in[idx+len(maxConnectionsMarker):]
+	// drop the next line (the actual setting)
+	if nl := indexOf(rest, "\n"); nl >= 0 {
+		rest = rest[nl+1:]
+	} else {
+		rest = ""
+	}
+	return prefix + rest
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
+++ b/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
@@ -288,10 +288,26 @@ func CaptureEnvironment(t *testing.T, pgbenchBinary string) EnvironmentInfo {
 }
 
 // DefaultScenarios generates the cross-product of benchmark scenarios.
+//
+// PGBENCH_PROTOCOLS (comma-separated subset of "simple,extended", default
+// both) restricts which protocols are exercised. PGBENCH_NO_CHURN=1 skips
+// the churn variants — useful for scaling sweeps where churn is noise.
 func DefaultScenarios(duration int, clientCounts []int) []ScenarioConfig {
 	var scenarios []ScenarioConfig
 
-	for _, protocol := range []string{"simple", "extended"} {
+	protocols := []string{"simple", "extended"}
+	if raw := strings.TrimSpace(os.Getenv("PGBENCH_PROTOCOLS")); raw != "" {
+		protocols = nil
+		for s := range strings.SplitSeq(raw, ",") {
+			s = strings.TrimSpace(s)
+			if s == "simple" || s == "extended" {
+				protocols = append(protocols, s)
+			}
+		}
+	}
+	includeChurn := os.Getenv("PGBENCH_NO_CHURN") != "1"
+
+	for _, protocol := range protocols {
 		// Sustained load scenarios (all client counts)
 		for _, clients := range clientCounts {
 			scenarios = append(scenarios, ScenarioConfig{
@@ -302,6 +318,9 @@ func DefaultScenarios(duration int, clientCounts []int) []ScenarioConfig {
 			})
 		}
 
+		if !includeChurn {
+			continue
+		}
 		// Connection churn scenarios (limited client counts — churn with many clients is very slow)
 		for _, clients := range clientCounts {
 			if clients > 10 {

--- a/go/test/endtoend/queryserving/benchmarking/pgbench_test.go
+++ b/go/test/endtoend/queryserving/benchmarking/pgbench_test.go
@@ -15,7 +15,14 @@
 package benchmarking
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,15 +31,39 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestPgBench runs pgbench benchmarks against direct PostgreSQL, multigateway,
-// and optionally pgbouncer, then generates a comparison report.
+// TestPgBench runs pgbench against a configurable set of targets and
+// generates a comparison report.
 //
 // The test is skipped by default. Set RUN_BENCHMARKS=1 to run.
 //
-// Environment variables:
-//   - RUN_BENCHMARKS=1: enable benchmark tests
-//   - PGBENCH_DURATION: seconds per scenario (default: 30)
-//   - PGBENCH_CLIENTS: comma-separated client counts (default: "1,10,50")
+// Environment variables
+//
+//	RUN_BENCHMARKS=1               enable the test
+//	PGBENCH_DURATION               seconds per scenario (default: 30)
+//	PGBENCH_CLIENTS                comma-separated client counts
+//	                               (default: "1,10,50")
+//	PGBENCH_PROTOCOLS              comma-separated subset of
+//	                               "simple,extended" (default: both)
+//	PGBENCH_NO_CHURN=1             skip the churn (-C) scenarios
+//	PGBENCH_TARGETS                comma-separated subset of
+//	                               "multigateway,postgres,pgbouncer"
+//	                               (default: "multigateway")
+//	PGBENCH_PG_MAX_CONNECTIONS=N   bump postgres max_connections to N and
+//	                               restart pgctld (needed when running
+//	                               postgres or pgbouncer targets at
+//	                               client counts above the default 60).
+//	CAPTURE_PPROF=1                capture a CPU profile from
+//	                               multigateway and primary multipooler
+//	                               during each scenario
+//	CAPTURE_HEAP=1                 capture heap, allocs, and goroutine
+//	                               profiles before+after each scenario
+//
+// Outputs land under /tmp/multigres_pgbench_results/<timestamp>/:
+//
+//	results.json, benchmark-report.md   — pgbench TPS / latency
+//	cpu/<scenario>/<target>.json        — per-target CPU usage samples
+//	pprof/<scenario>/<target>/cpu.pb.gz — CPU profiles (when enabled)
+//	pprof/<scenario>/<target>/{heap,allocs,goroutine}-{before,after}.pb.gz
 func TestPgBench(t *testing.T) {
 	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunBenchmarks)
 
@@ -43,7 +74,9 @@ func TestPgBench(t *testing.T) {
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	ctx := utils.WithTimeout(t, 30*time.Minute)
+	// Generous timeout — long sweeps with 5-min runs across many client
+	// counts and several targets can take >2 hours.
+	ctx := utils.WithTimeout(t, 4*time.Hour)
 
 	primary := setup.GetPrimary(t)
 	pgTarget := suiteutil.Target{
@@ -63,56 +96,87 @@ func TestPgBench(t *testing.T) {
 		DB:   "postgres",
 	}
 
-	targets := []suiteutil.Target{pgTarget, mgwTarget}
+	wantPostgres, wantMultigateway, wantPgbouncer := parseTargets(t)
 
-	// Optional pgbouncer target
-	pgb, err := NewPgBouncerInstance(t, "localhost", primary.Pgctld.PgPort,
-		shardsetup.DefaultTestUser, shardsetup.TestPostgresPassword)
-	if err == nil && pgb != nil {
-		t.Cleanup(func() { pgb.Stop(t) })
-		targets = append(targets, suiteutil.Target{
-			Name: "pgbouncer",
-			Host: "localhost",
-			Port: pgb.Port(),
-			User: shardsetup.DefaultTestUser,
-			Pass: shardsetup.TestPostgresPassword,
-			DB:   "postgres",
-		})
-		t.Logf("pgbouncer available at port %d", pgb.Port())
-	} else {
-		t.Logf("pgbouncer not available, skipping comparison")
+	// Optionally bump postgres max_connections so high-client-count direct
+	// pgbench / pgbouncer runs don't exhaust the default of 60. This
+	// restarts every pgctld in the cluster, so do it before init.
+	if raw := os.Getenv("PGBENCH_PG_MAX_CONNECTIONS"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("invalid PGBENCH_PG_MAX_CONNECTIONS=%q: %v", raw, err)
+		}
+		bumpPostgresMaxConnections(ctx, t, setup, n)
+		// Wait briefly for multipooler to reconnect after pgctld restart.
+		time.Sleep(2 * time.Second)
 	}
+
+	var targets []suiteutil.Target
+	if wantPostgres {
+		targets = append(targets, pgTarget)
+	}
+	if wantMultigateway {
+		targets = append(targets, mgwTarget)
+	}
+	if wantPgbouncer {
+		pgb, err := NewPgBouncerInstance(t, "localhost", primary.Pgctld.PgPort,
+			shardsetup.DefaultTestUser, shardsetup.TestPostgresPassword)
+		if err == nil && pgb != nil {
+			t.Cleanup(func() { pgb.Stop(t) })
+			targets = append(targets, suiteutil.Target{
+				Name: "pgbouncer",
+				Host: "localhost",
+				Port: pgb.Port(),
+				User: shardsetup.DefaultTestUser,
+				Pass: shardsetup.TestPostgresPassword,
+				DB:   "postgres",
+			})
+			t.Logf("pgbouncer available at port %d", pgb.Port())
+		} else {
+			t.Logf("pgbouncer requested but not available: %v", err)
+		}
+	}
+	if len(targets) == 0 {
+		t.Fatalf("no benchmark targets selected (PGBENCH_TARGETS=%q)", os.Getenv("PGBENCH_TARGETS"))
+	}
+	t.Logf("Benchmarking targets: %s", targetNames(targets))
 
 	runner := NewPgBenchRunner(t)
 	duration := ParseDuration(t)
 	clients := ParseClients(t)
 	scenarios := DefaultScenarios(duration, clients)
 
-	// Initialize pgbench tables once through direct postgres.
-	// All targets route to the same backend so tables are shared.
+	// Initialize pgbench tables once via direct postgres. All routes share
+	// the same backend, so tables are visible from every target.
 	t.Run("init", func(t *testing.T) {
 		if err := runner.Initialize(ctx, t, pgTarget, 10); err != nil {
 			t.Fatalf("pgbench initialization failed: %v", err)
 		}
 	})
 
-	// Run all scenarios against all targets.
-	// Scenario failures are logged but do not fail the test — benchmarks are
-	// measurements, and some scenario/target combinations may legitimately not
-	// work yet (e.g. extended protocol edge cases through the proxy).
+	capturePprof := os.Getenv("CAPTURE_PPROF") == "1"
+	captureHeap := os.Getenv("CAPTURE_HEAP") == "1"
+	if capturePprof {
+		t.Logf("CAPTURE_PPROF=1: CPU profiles will be captured during each scenario")
+	}
+	if captureHeap {
+		t.Logf("CAPTURE_HEAP=1: heap/allocs/goroutine profiles will be captured before+after each scenario")
+	}
+
+	// CPU sampler PID enumerators for each long-lived service. Multigateway
+	// and multipooler PIDs are stable across the run; the postgres process
+	// tree changes as backends come and go, so we re-read postmaster.pid
+	// each tick.
+	mgwPid := setup.Multigateway.Process.Process.Pid
+	pgPidEnum := postgresPidEnumerator(setup.GetPrimary(t).Pgctld.PoolerDir + "/pg_data")
+
 	var allResults []ScenarioResult
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			for _, target := range targets {
 				t.Run(target.Name, func(t *testing.T) {
-					result, err := runner.RunScenario(ctx, t, target, scenario)
-					if err != nil {
-						t.Logf("SKIP: pgbench failed for %s/%s: %v", target.Name, scenario.Name, err)
-						return
-					}
-					allResults = append(allResults, *result)
-					t.Logf("TPS=%.1f  AvgLatency=%.2fms  P99=%.2fms  Txns=%d",
-						result.TPS, result.LatencyAvg, result.LatencyP99, result.Transactions)
+					runScenarioOnce(ctx, t, setup, runner, scenario, target,
+						mgwPid, pgPidEnum, capturePprof, captureHeap, &allResults)
 				})
 			}
 		})
@@ -135,4 +199,161 @@ func TestPgBench(t *testing.T) {
 	} else {
 		t.Logf("Warning: failed to write markdown report: %v", err)
 	}
+}
+
+// runScenarioOnce executes one (scenario, target) tuple with optional
+// CPU sampling, CPU profiling and heap/allocs/goroutine snapshots.
+func runScenarioOnce(
+	ctx context.Context,
+	t *testing.T,
+	setup *shardsetup.ShardSetup,
+	runner *PgBenchRunner,
+	scenario ScenarioConfig,
+	target suiteutil.Target,
+	mgwPid int,
+	pgPidEnum pidEnumerator,
+	capturePprof bool,
+	captureHeap bool,
+	allResults *[]ScenarioResult,
+) {
+	t.Helper()
+
+	// Per-process CPU sampling runs every (scenario, target) regardless of
+	// pprof flags — it's cheap and useful even on its own.
+	mpPid := setup.GetPrimary(t).Multipooler.Process.Process.Pid
+	samplers := []*cpuSampler{
+		newCPUSampler("postgres", pgPidEnum, 500*time.Millisecond),
+		newCPUSampler("multigateway", staticPidEnumerator(mgwPid), 500*time.Millisecond),
+		newCPUSampler("multipooler_primary", staticPidEnumerator(mpPid), 500*time.Millisecond),
+	}
+	for _, s := range samplers {
+		s.Start(ctx)
+	}
+
+	mgwAddr := fmt.Sprintf("localhost:%d", setup.Multigateway.HttpPort)
+	mpAddr := fmt.Sprintf("localhost:%d", setup.GetPrimary(t).Multipooler.HttpPort)
+	profileDir := filepath.Join(runner.OutputDir, "pprof", scenario.Name, target.Name)
+	services := map[string]string{
+		"multigateway":        mgwAddr,
+		"multipooler_primary": mpAddr,
+	}
+
+	// Heap/allocs/goroutine snapshot before the run (point-in-time samples).
+	if captureHeap {
+		captureSnapshots(ctx, t, services, profileDir, "before")
+	}
+
+	var wg sync.WaitGroup
+	if capturePprof {
+		// pprof CPU profile must be shorter than the pgbench run. Leave a
+		// 2-second margin on each side so the profile lands inside the
+		// steady-state window.
+		profileDur := scenario.Duration - 4
+		if profileDur < 5 {
+			profileDur = scenario.Duration
+		}
+		wg.Add(len(services))
+		for label, addr := range services {
+			go func(label, addr string) {
+				defer wg.Done()
+				out := filepath.Join(profileDir, "cpu-"+shortServiceName(label)+".pb.gz")
+				if err := captureCPUProfile(ctx, addr, profileDur, out); err != nil {
+					t.Logf("%s CPU profile failed: %v", label, err)
+					return
+				}
+				t.Logf("%s CPU profile: %s", label, out)
+			}(label, addr)
+		}
+	}
+
+	result, err := runner.RunScenario(ctx, t, target, scenario)
+	wg.Wait()
+
+	if captureHeap {
+		captureSnapshots(ctx, t, services, profileDir, "after")
+	}
+
+	// Stop samplers and persist CPU stats per (scenario, target).
+	stats := make(map[string]CPUStats, len(samplers))
+	for _, s := range samplers {
+		st := s.Stop()
+		stats[st.Label] = st
+	}
+	writeCPUStatsFile(t, runner.OutputDir, scenario.Name, target.Name, stats)
+	for label, st := range stats {
+		t.Logf("CPU %s/%s/%s: mean=%.1f%% max=%.1f%% (n=%d)",
+			scenario.Name, target.Name, label,
+			st.MeanPercent, st.MaxPercent, st.Samples)
+	}
+
+	if err != nil {
+		t.Logf("SKIP: pgbench failed for %s/%s: %v", target.Name, scenario.Name, err)
+		return
+	}
+	*allResults = append(*allResults, *result)
+	t.Logf("TPS=%.1f  AvgLatency=%.2fms  P99=%.2fms  Txns=%d",
+		result.TPS, result.LatencyAvg, result.LatencyP99, result.Transactions)
+}
+
+// captureSnapshots fetches heap, allocs, and goroutine profiles from each
+// service and writes them under profileDir with the given suffix
+// ("before" or "after"). Failures are logged, not fatal.
+func captureSnapshots(ctx context.Context, t *testing.T, services map[string]string, profileDir, suffix string) {
+	t.Helper()
+	for label, addr := range services {
+		short := shortServiceName(label)
+		for kind, fn := range map[string]func(context.Context, string, string) error{
+			"heap":      captureHeapProfile,
+			"allocs":    captureAllocsProfile,
+			"goroutine": captureGoroutineProfile,
+		} {
+			out := filepath.Join(profileDir, fmt.Sprintf("%s-%s-%s.pb.gz", short, kind, suffix))
+			if err := fn(ctx, addr, out); err != nil {
+				t.Logf("%s %s %s capture failed: %v", label, kind, suffix, err)
+			}
+		}
+	}
+}
+
+func shortServiceName(label string) string {
+	switch label {
+	case "multipooler_primary":
+		return "multipooler"
+	default:
+		return label
+	}
+}
+
+// parseTargets reads PGBENCH_TARGETS and returns flags for each known
+// target. Default is "multigateway" only. Unknown names are rejected.
+func parseTargets(t *testing.T) (postgres, multigateway, pgbouncer bool) {
+	t.Helper()
+
+	raw := strings.TrimSpace(os.Getenv("PGBENCH_TARGETS"))
+	if raw == "" {
+		return false, true, false
+	}
+	for name := range strings.SplitSeq(raw, ",") {
+		switch strings.TrimSpace(name) {
+		case "postgres":
+			postgres = true
+		case "multigateway":
+			multigateway = true
+		case "pgbouncer":
+			pgbouncer = true
+		case "":
+			// allow trailing commas
+		default:
+			t.Fatalf("PGBENCH_TARGETS contains unknown target %q (valid: postgres, multigateway, pgbouncer)", name)
+		}
+	}
+	return postgres, multigateway, pgbouncer
+}
+
+func targetNames(ts []suiteutil.Target) string {
+	names := make([]string, len(ts))
+	for i, t := range ts {
+		names[i] = t.Name
+	}
+	return strings.Join(names, ",")
 }

--- a/go/test/endtoend/queryserving/benchmarking/profile_capture.go
+++ b/go/test/endtoend/queryserving/benchmarking/profile_capture.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmarking
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// fetchProfile fetches a pprof endpoint at addr and writes the bytes to
+// outputPath. Endpoints that block for a window (e.g. CPU profile) are
+// supported via the timeout — pass it large enough to cover the
+// server-side window plus a small margin.
+func fetchProfile(ctx context.Context, addr, urlPath string, timeout time.Duration, outputPath string) error {
+	url := fmt.Sprintf("http://%s%s", addr, urlPath)
+
+	httpCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build pprof request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("%s returned %s: %s", url, resp.Status, string(body))
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir for profile: %w", err)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", outputPath, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("write profile body: %w", err)
+	}
+	return nil
+}
+
+// captureCPUProfile fetches a CPU profile of `seconds` duration from the
+// given servenv HTTP address. Blocks for ~seconds.
+func captureCPUProfile(ctx context.Context, addr string, seconds int, outputPath string) error {
+	urlPath := fmt.Sprintf("/debug/pprof/profile?seconds=%d", seconds)
+	return fetchProfile(ctx, addr, urlPath, time.Duration(seconds+30)*time.Second, outputPath)
+}
+
+// captureHeapProfile fetches a current heap (in-use space) profile snapshot.
+// Returns immediately — this is a sample of live allocations.
+func captureHeapProfile(ctx context.Context, addr, outputPath string) error {
+	return fetchProfile(ctx, addr, "/debug/pprof/heap", 30*time.Second, outputPath)
+}
+
+// captureAllocsProfile fetches a cumulative allocation profile (all
+// allocations since process start). Useful for spotting alloc hotspots.
+func captureAllocsProfile(ctx context.Context, addr, outputPath string) error {
+	return fetchProfile(ctx, addr, "/debug/pprof/allocs", 30*time.Second, outputPath)
+}
+
+// captureGoroutineProfile fetches the current goroutine stack dump.
+// Useful to see what's parked / contending.
+func captureGoroutineProfile(ctx context.Context, addr, outputPath string) error {
+	return fetchProfile(ctx, addr, "/debug/pprof/goroutine", 30*time.Second, outputPath)
+}


### PR DESCRIPTION
## Summary

- Make `TestPgBench` configurable: select any subset of `postgres,multigateway,pgbouncer` via `PGBENCH_TARGETS`, filter `simple`/`extended` via `PGBENCH_PROTOCOLS`, skip churn via `PGBENCH_NO_CHURN`.
- Capture CPU profiles from multigateway + primary multipooler during each scenario when `CAPTURE_PPROF=1`, and heap / allocs / goroutine snapshots before+after each scenario when `CAPTURE_HEAP=1`.
- Always sample per-process CPU usage (postgres process tree, multigateway, primary multipooler) for every scenario × target run and persist as JSON.
- Optionally bump postgres `max_connections` and restart pgctld via `PGBENCH_PG_MAX_CONNECTIONS` so we can drive direct-postgres or pgbouncer at high client counts without hitting the default 60-connection cap.

## Description

The existing pgbench suite ran a fixed cross-product of scenarios against postgres + multigateway + pgbouncer with no profiling hooks, which made it hard to drill into where multigateway's CPU goes. This PR adds the knobs needed to turn the suite into a usable perf workbench locally without changing what CI runs by default.

New env vars (all default to today's behavior except `PGBENCH_TARGETS`, which now defaults to `multigateway` so a quick local run only spins up what's actually under measurement):

| Variable | Default | Purpose |
| --- | --- | --- |
| `PGBENCH_TARGETS` | `multigateway` | subset of `postgres,multigateway,pgbouncer` |
| `PGBENCH_PROTOCOLS` | `simple,extended` | restrict to one protocol |
| `PGBENCH_NO_CHURN` | unset | skip the `-C` connection-churn variants |
| `PGBENCH_PG_MAX_CONNECTIONS` | unset | bump postgres `max_connections` and restart pgctld |
| `CAPTURE_PPROF` | unset | fetch `/debug/pprof/profile` from multigateway + primary multipooler during each scenario |
| `CAPTURE_HEAP` | unset | fetch `/debug/pprof/{heap,allocs,goroutine}` before+after each scenario |

New supporting files:

- `cpu_sampler.go` — `ps`-based CPU sampler. Postgres backends are enumerated each tick from `postmaster.pid` + `pgrep -P`, so the sampler is resilient to backend churn. multigateway and multipooler use static-pid enumerators.
- `profile_capture.go` — small HTTP fetcher for the four pprof endpoints we care about (CPU, heap, allocs, goroutine).
- `pg_config.go` — appends a `max_connections` override into each pgctld's `postgresql.auto.conf` and restarts via the pgctld gRPC `Restart` RPC. Disables the multipooler monitor's auto-restart for the duration so it doesn't race.

`pgbench.md` is updated with the new envs and the additional output paths.

Smoke-tested locally with all features on (`PGBENCH_TARGETS=postgres,multigateway,pgbouncer`, both protocols, sustained+churn, `CAPTURE_PPROF=1 CAPTURE_HEAP=1 PGBENCH_PG_MAX_CONNECTIONS=300`, 5s × 1,5 clients) — all 24 scenarios PASS, every artifact produced.