### PR TITLE
feat(benchmarking): add sysbench oltp_point_select harness

### DIFF
--- a/go/test/endtoend/queryserving/benchmarking/SYSBENCH.md
+++ b/go/test/endtoend/queryserving/benchmarking/SYSBENCH.md
@@ -22,8 +22,9 @@ Output bundle:
 /tmp/multigres_sysbench_results/<utc-stamp>/
 ├── benchmark-report.md
 ├── results.json
-├── logs/sysbench-<scenario>.txt
-├── cpu/<scenario>/processes.json
+├── logs/prepare/<target>.txt
+├── logs/<scenario>/<target>.txt
+├── cpu/<scenario>/<target>/processes.json
 └── pprof/<scenario>/<target>/cpu-<service>.pb.gz
 ```
 

--- a/go/test/endtoend/queryserving/benchmarking/SYSBENCH.md
+++ b/go/test/endtoend/queryserving/benchmarking/SYSBENCH.md
@@ -1,0 +1,90 @@
+# TestSysBench — sysbench oltp_point_select harness
+
+`TestSysBench` (in `sysbench_test.go`) drives sysbench
+[`oltp_point_select`](https://github.com/akopytov/sysbench) over the pgsql
+driver against multigateway, while sampling per-process CPU and capturing
+CPU pprofs.
+
+This is a manual perf tool — like `TestPgBench`, it skips by default.
+
+## Quick start
+
+```bash
+RUN_BENCHMARKS=1 CAPTURE_PPROF=1 \
+SYSBENCH_CLIENTS=1,8,32 SYSBENCH_DURATION=60 \
+go test -v -timeout 30m -run TestSysBench \
+  ./go/test/endtoend/queryserving/benchmarking/
+```
+
+Output bundle:
+
+```text
+/tmp/multigres_sysbench_results/<utc-stamp>/
+├── benchmark-report.md
+├── results.json
+├── logs/sysbench-<scenario>.txt
+├── cpu/<scenario>/processes.json
+└── pprof/<scenario>/<target>/cpu-<service>.pb.gz
+```
+
+## Why `prepared` and `simple` ps modes
+
+`oltp_point_select` issues `SELECT c FROM sbtestN WHERE id = ?`. With
+`--db-ps-mode=auto` (the sysbench default — what we call `prepared` here),
+each worker prepares the statement once via `PQprepare` and re-executes it
+thousands of times. With `--db-ps-mode=disable` (`simple`) sysbench sends
+a fully-formatted SELECT every transaction, forcing the pgsql server (and
+multigateway, in our case) to re-parse it.
+
+Running both lets us isolate parser-per-query cost from everything else
+proxy/pooler do.
+
+## Environment variables
+
+| var                          | default                                       | notes                                                       |
+| ---------------------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| `RUN_BENCHMARKS`             | unset                                         | required — must be `1`                                      |
+| `CAPTURE_PPROF`              | unset                                         | when `1`, capture CPU pprof per scenario                    |
+| `CAPTURE_HEAP`               | unset                                         | when `1`, also capture heap/allocs/goroutine snapshots      |
+| `SYSBENCH_CLIENTS`           | `1,8,32`                                      | comma-separated thread counts                               |
+| `SYSBENCH_DURATION`          | `60`                                          | seconds per scenario                                        |
+| `SYSBENCH_PS_MODES`          | `prepared,simple`                             | subset of `{prepared,simple}`                               |
+| `SYSBENCH_TARGETS`           | `multigateway`                                | subset of `{multigateway,postgres,pgbouncer}`               |
+| `SYSBENCH_TABLES`            | `4`                                           | sysbench `--tables`                                         |
+| `SYSBENCH_TABLE_SIZE`        | `100000`                                      | sysbench `--table-size`                                     |
+| `SYSBENCH_QUIESCE_SECONDS`   | `5`                                           | sleep between scenarios                                     |
+| `SYSBENCH_RESULTS_DIR`       | `/tmp/multigres_sysbench_results/<utc-stamp>` | override output directory                                   |
+| `PGBENCH_PG_MAX_CONNECTIONS` | unset                                         | bump postgres `max_connections` (shared with `TestPgBench`) |
+
+## Skip behavior
+
+The test self-skips if any of:
+
+- `RUN_BENCHMARKS=1` is unset.
+- `sysbench` binary is missing on PATH.
+- `sysbench` is present but lacks the pgsql driver. The skip message tells
+  you exactly how to rebuild — sysbench needs `./configure --with-pgsql`.
+
+## Loud failures
+
+These are intentional `t.Errorf`/`t.Fatalf` rather than silent zeros, so a
+flaky run fails the test instead of producing misleading numbers:
+
+- Sysbench summary parse failure (missing `transactions:` or `99th
+percentile:` line).
+- Zero TPS or zero transactions in any scenario.
+- Empty (0-byte) CPU pprof file when `CAPTURE_PPROF=1` is set.
+
+## Caveats
+
+- Sysbench reports per-percentile latency in milliseconds with two decimals.
+  On point-select workloads the p99 frequently reads `0.00` because the
+  actual p99 is sub-millisecond. This is captured verbatim — interpret with
+  care.
+- The shared cluster setup (`getSharedSetup` in `main_test.go`) is reused
+  across `TestPgBench` and `TestSysBench`. Running both in the same `go
+test` invocation will share one multigres cluster.
+- Postgres has 4 sysbench tables (`sbtest1..sbtest4`) with 100k rows each
+  by default. They're left in place after the test — re-running
+  `TestSysBench` in the same cluster is fine; the cluster is torn down by
+  the package-level `TestMain`.

--- a/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
+++ b/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
@@ -222,12 +222,14 @@ func writeCPUStatsFile(t *testing.T, outputDir, scenario, target string, stats m
 }
 
 // writeSysBenchCPUStatsFile persists per-process CPU stats under
-// <outputDir>/cpu/<scenario>/processes.json. The filename matches the
-// vitess sysbench bundle's layout so cross-stack tools can read either.
-func writeSysBenchCPUStatsFile(t *testing.T, outputDir, scenario string, stats map[string]CPUStats) {
+// <outputDir>/cpu/<scenario>/<target>/processes.json. The "processes.json"
+// filename matches the vitess sysbench bundle's layout so cross-stack tools
+// can read either; the per-target directory keeps multi-target runs (e.g.
+// SYSBENCH_TARGETS=postgres,multigateway) from clobbering each other.
+func writeSysBenchCPUStatsFile(t *testing.T, outputDir, scenario, target string, stats map[string]CPUStats) {
 	t.Helper()
 
-	dir := filepath.Join(outputDir, "cpu", scenario)
+	dir := filepath.Join(outputDir, "cpu", scenario, target)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Logf("cpu stats: mkdir %s: %v", dir, err)
 		return

--- a/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
+++ b/go/test/endtoend/queryserving/benchmarking/cpu_sampler.go
@@ -220,3 +220,25 @@ func writeCPUStatsFile(t *testing.T, outputDir, scenario, target string, stats m
 		t.Logf("cpu stats: write %s: %v", path, err)
 	}
 }
+
+// writeSysBenchCPUStatsFile persists per-process CPU stats under
+// <outputDir>/cpu/<scenario>/processes.json. The filename matches the
+// vitess sysbench bundle's layout so cross-stack tools can read either.
+func writeSysBenchCPUStatsFile(t *testing.T, outputDir, scenario string, stats map[string]CPUStats) {
+	t.Helper()
+
+	dir := filepath.Join(outputDir, "cpu", scenario)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("cpu stats: mkdir %s: %v", dir, err)
+		return
+	}
+	path := filepath.Join(dir, "processes.json")
+	body, err := json.MarshalIndent(stats, "", "  ")
+	if err != nil {
+		t.Logf("cpu stats: marshal: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Logf("cpu stats: write %s: %v", path, err)
+	}
+}

--- a/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
+++ b/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
@@ -45,20 +45,22 @@ type ScenarioConfig struct {
 
 // ScenarioResult holds computed metrics from a pgbench or sysbench run.
 //
-// Protocol/ConnChurn are pgbench-only fields; PSMode is sysbench-only.
-// They're emitted as `omitempty` so each tool's results.json contains only
-// the fields relevant to that tool.
+// Protocol/ConnChurn/LatencyP50 are pgbench-specific but kept non-omitempty
+// so existing downstream tooling (e.g. the weekly pgbench workflow that
+// filters with `select(.connection_churn == false)`) keeps working — their
+// zero values for sysbench rows are harmless. PSMode is sysbench-only and
+// stays `omitempty` so it doesn't pollute pgbench output.
 type ScenarioResult struct {
 	Target       string  `json:"target"`
 	Scenario     string  `json:"scenario"`
 	TPS          float64 `json:"tps"`
 	LatencyAvg   float64 `json:"latency_avg_ms"`
-	LatencyP50   float64 `json:"latency_p50_ms,omitempty"`
+	LatencyP50   float64 `json:"latency_p50_ms"`
 	LatencyP99   float64 `json:"latency_p99_ms"`
 	Clients      int     `json:"clients"`
 	Duration     int     `json:"duration_seconds"`
-	Protocol     string  `json:"protocol,omitempty"`
-	ConnChurn    bool    `json:"connection_churn,omitempty"`
+	Protocol     string  `json:"protocol"`
+	ConnChurn    bool    `json:"connection_churn"`
 	PSMode       string  `json:"ps_mode,omitempty"`
 	Transactions int     `json:"transactions"`
 }

--- a/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
+++ b/go/test/endtoend/queryserving/benchmarking/pgbench_runner.go
@@ -43,34 +43,44 @@ type ScenarioConfig struct {
 	ConnChurn bool   // -C flag (new connection per transaction)
 }
 
-// ScenarioResult holds computed metrics from a pgbench run.
+// ScenarioResult holds computed metrics from a pgbench or sysbench run.
+//
+// Protocol/ConnChurn are pgbench-only fields; PSMode is sysbench-only.
+// They're emitted as `omitempty` so each tool's results.json contains only
+// the fields relevant to that tool.
 type ScenarioResult struct {
 	Target       string  `json:"target"`
 	Scenario     string  `json:"scenario"`
 	TPS          float64 `json:"tps"`
 	LatencyAvg   float64 `json:"latency_avg_ms"`
-	LatencyP50   float64 `json:"latency_p50_ms"`
+	LatencyP50   float64 `json:"latency_p50_ms,omitempty"`
 	LatencyP99   float64 `json:"latency_p99_ms"`
 	Clients      int     `json:"clients"`
 	Duration     int     `json:"duration_seconds"`
-	Protocol     string  `json:"protocol"`
-	ConnChurn    bool    `json:"connection_churn"`
+	Protocol     string  `json:"protocol,omitempty"`
+	ConnChurn    bool    `json:"connection_churn,omitempty"`
+	PSMode       string  `json:"ps_mode,omitempty"`
 	Transactions int     `json:"transactions"`
 }
 
 // BenchmarkReport is the top-level report containing all results.
 type BenchmarkReport struct {
 	Timestamp   string           `json:"timestamp"`
+	LoadTool    string           `json:"load_tool,omitempty"` // "pgbench" or "sysbench"
 	Results     []ScenarioResult `json:"results"`
 	Environment EnvironmentInfo  `json:"environment"`
 }
 
 // EnvironmentInfo captures the test environment for reproducibility.
 type EnvironmentInfo struct {
-	PostgresVersion string `json:"postgres_version"`
-	PgBenchVersion  string `json:"pgbench_version"`
-	OS              string `json:"os"`
-	GOMAXPROCS      int    `json:"gomaxprocs"`
+	PostgresVersion  string `json:"postgres_version,omitempty"`
+	PgBenchVersion   string `json:"pgbench_version,omitempty"`
+	SysBenchVersion  string `json:"sysbench_version,omitempty"`
+	MultigresVersion string `json:"multigres_version,omitempty"`
+	OS               string `json:"os"`
+	Arch             string `json:"arch,omitempty"`
+	GOMAXPROCS       int    `json:"gomaxprocs"`
+	PlanCacheBytes   int    `json:"plan_cache_bytes,omitempty"`
 }
 
 // PgBenchRunner wraps pgbench execution: initialization, scenario runs, and output parsing.

--- a/go/test/endtoend/queryserving/benchmarking/pgbench_test.go
+++ b/go/test/endtoend/queryserving/benchmarking/pgbench_test.go
@@ -185,6 +185,7 @@ func TestPgBench(t *testing.T) {
 	// Generate reports.
 	report := &BenchmarkReport{
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		LoadTool:    "pgbench",
 		Results:     allResults,
 		Environment: CaptureEnvironment(t, runner.pgbenchBinary),
 	}

--- a/go/test/endtoend/queryserving/benchmarking/report.go
+++ b/go/test/endtoend/queryserving/benchmarking/report.go
@@ -127,6 +127,66 @@ func WriteMarkdownReport(t *testing.T, outputDir string, report *BenchmarkReport
 	return suiteutil.WriteMarkdown(outputDir, "benchmark-report.md", sb.String())
 }
 
+// WriteSysBenchMarkdownReport renders a sysbench-shaped markdown report
+// (per-scenario rows with a ps_mode column) under <outputDir>/benchmark-report.md.
+//
+// Kept separate from WriteMarkdownReport because the sysbench harness has a
+// different scenario shape (ps_mode, no churn/protocol axis) and conflating
+// the two renderers obscures both.
+func WriteSysBenchMarkdownReport(t *testing.T, outputDir string, report *BenchmarkReport) (string, error) {
+	t.Helper()
+
+	var sb strings.Builder
+	sb.WriteString("# sysbench oltp_point_select — multigres\n\n")
+	fmt.Fprintf(&sb, "**Timestamp:** %s\n", report.Timestamp)
+	if report.Environment.SysBenchVersion != "" {
+		fmt.Fprintf(&sb, "**sysbench:** %s\n", report.Environment.SysBenchVersion)
+	}
+	if report.Environment.PostgresVersion != "" {
+		fmt.Fprintf(&sb, "**PostgreSQL:** %s\n", report.Environment.PostgresVersion)
+	}
+	if report.Environment.MultigresVersion != "" {
+		fmt.Fprintf(&sb, "**multigres:** %s\n", report.Environment.MultigresVersion)
+	}
+	fmt.Fprintf(&sb, "**OS/Arch:** %s/%s | **GOMAXPROCS:** %d\n",
+		report.Environment.OS, report.Environment.Arch, report.Environment.GOMAXPROCS)
+	if report.Environment.PlanCacheBytes > 0 {
+		fmt.Fprintf(&sb, "**multigateway plan cache:** %d bytes\n", report.Environment.PlanCacheBytes)
+	}
+	sb.WriteString("\n")
+
+	// Render one section per ps_mode, with a row per (target, scenario).
+	psModes := uniquePSModes(report.Results)
+	for _, mode := range psModes {
+		fmt.Fprintf(&sb, "## ps_mode = %s\n\n", mode)
+		sb.WriteString("| target | clients | TPS | avg ms | p99 ms | txns |\n")
+		sb.WriteString("|---|---|---|---|---|---|\n")
+		for _, r := range report.Results {
+			if r.PSMode != mode {
+				continue
+			}
+			fmt.Fprintf(&sb, "| %s | %d | %.0f | %.2f | %.2f | %d |\n",
+				r.Target, r.Clients, r.TPS, r.LatencyAvg, r.LatencyP99, r.Transactions)
+		}
+		sb.WriteString("\n")
+	}
+
+	return suiteutil.WriteMarkdown(outputDir, "benchmark-report.md", sb.String())
+}
+
+// uniquePSModes returns ps_mode values in the order they first appear.
+func uniquePSModes(results []ScenarioResult) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, r := range results {
+		if r.PSMode != "" && !seen[r.PSMode] {
+			seen[r.PSMode] = true
+			out = append(out, r.PSMode)
+		}
+	}
+	return out
+}
+
 // uniqueTargets returns deduplicated target names in the order they first appear.
 func uniqueTargets(results []ScenarioResult) []string {
 	seen := make(map[string]bool)

--- a/go/test/endtoend/queryserving/benchmarking/sysbench_runner.go
+++ b/go/test/endtoend/queryserving/benchmarking/sysbench_runner.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmarking
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+const (
+	sysbenchPSModePrepared = "prepared" // sysbench --db-ps-mode=auto
+	sysbenchPSModeSimple   = "simple"   // sysbench --db-ps-mode=disable
+)
+
+// SysBenchScenario defines a single sysbench oltp_point_select scenario.
+type SysBenchScenario struct {
+	Name     string // e.g. "sustained_32c_prepared"
+	Clients  int
+	Duration int    // seconds
+	PSMode   string // "prepared" or "simple"
+}
+
+// SysBenchRunner wraps the sysbench CLI: detection, prepare, scenario run,
+// and stdout parsing.
+type SysBenchRunner struct {
+	binary    string
+	OutputDir string
+
+	// Tables / table-size used by both prepare and run. They MUST match
+	// across phases — sysbench's run phase looks up the same sbtestN tables
+	// it created in prepare.
+	Tables    int
+	TableSize int
+}
+
+// NewSysBenchRunner locates the sysbench binary, verifies pgsql driver
+// support, and creates the output directory.
+//
+// If sysbench is missing or lacks pgsql, the test is skipped (not failed) —
+// this matches how TestPgBench handles a missing pgbench binary.
+func NewSysBenchRunner(t *testing.T) *SysBenchRunner {
+	t.Helper()
+
+	binary, err := exec.LookPath("sysbench")
+	if err != nil {
+		t.Skipf("sysbench binary not found: %v", err)
+	}
+
+	if err := checkSysBenchPgsqlDriver(binary); err != nil {
+		t.Skipf("%v", err)
+	}
+
+	outputDir := strings.TrimSpace(os.Getenv("SYSBENCH_RESULTS_DIR"))
+	if outputDir == "" {
+		outputDir = filepath.Join("/tmp", "multigres_sysbench_results", time.Now().UTC().Format("20060102-150405"))
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatalf("failed to create sysbench output directory: %v", err)
+	}
+
+	return &SysBenchRunner{
+		binary:    binary,
+		OutputDir: outputDir,
+		Tables:    parseSysBenchInt(t, "SYSBENCH_TABLES", 4),
+		TableSize: parseSysBenchInt(t, "SYSBENCH_TABLE_SIZE", 100000),
+	}
+}
+
+// checkSysBenchPgsqlDriver returns nil if the sysbench binary supports the
+// pgsql driver, otherwise returns an error with an actionable message.
+//
+// Detection probes by invoking sysbench with --db-driver=pgsql against an
+// unreachable host. If the driver isn't compiled in, sysbench fails fast
+// with "invalid database driver name". Any other failure (including the
+// expected "Connection refused") means the driver is present.
+func checkSysBenchPgsqlDriver(binary string) error {
+	out, _ := exec.Command(binary,
+		"--db-driver=pgsql",
+		"--pgsql-host=127.0.0.1", "--pgsql-port=1",
+		"oltp_point_select", "prepare",
+	).CombinedOutput()
+	if bytes.Contains(out, []byte("invalid database driver name")) {
+		return errors.New(`sysbench is missing the pgsql driver. Build sysbench from source with
+--with-pgsql, or install a distribution package that includes it
+(Ubuntu: sysbench from sysbench-pgsql, macOS: brew install sysbench --with-pgsql
+is unavailable; build from source: ./configure --with-pgsql).`)
+	}
+	return nil
+}
+
+// pgsqlConnArgs returns the --pgsql-* flags that identify a target.
+func (r *SysBenchRunner) pgsqlConnArgs(target suiteutil.Target) []string {
+	return []string{
+		"--db-driver=pgsql",
+		"--pgsql-host=" + target.Host,
+		"--pgsql-port=" + strconv.Itoa(target.Port),
+		"--pgsql-user=" + target.User,
+		"--pgsql-password=" + target.Pass,
+		"--pgsql-db=" + target.DB,
+	}
+}
+
+// commonOltpArgs returns the workload args that are constant across phases.
+func (r *SysBenchRunner) commonOltpArgs() []string {
+	return []string{
+		"oltp_point_select",
+		"--tables=" + strconv.Itoa(r.Tables),
+		"--table-size=" + strconv.Itoa(r.TableSize),
+	}
+}
+
+// Prepare creates the sbtestN tables on the given target. Idempotent across
+// runs only in the sense that we record stdout and surface errors loudly —
+// sysbench itself errors if the tables already exist, which the caller can
+// inspect in logs/sysbench-prepare.txt.
+func (r *SysBenchRunner) Prepare(ctx context.Context, t *testing.T, target suiteutil.Target) error {
+	t.Helper()
+
+	args := append(r.pgsqlConnArgs(target), r.commonOltpArgs()...)
+	args = append(args, "prepare")
+
+	logPath := filepath.Join(r.OutputDir, "logs", "sysbench-prepare.txt")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir logs: %w", err)
+	}
+
+	out, err := executil.Command(ctx, r.binary, args...).CombinedOutput()
+	_ = os.WriteFile(logPath, out, 0o644)
+	if err != nil {
+		t.Logf("sysbench prepare output:\n%s", string(out))
+		return fmt.Errorf("sysbench prepare failed: %w", err)
+	}
+	t.Logf("sysbench prepared %d table(s) of %d rows on %s:%d (log: %s)",
+		r.Tables, r.TableSize, target.Host, target.Port, logPath)
+	return nil
+}
+
+// RunScenario executes one sysbench oltp_point_select scenario and parses
+// the summary block from its stdout.
+func (r *SysBenchRunner) RunScenario(ctx context.Context, t *testing.T, target suiteutil.Target, sc SysBenchScenario) (*ScenarioResult, error) {
+	t.Helper()
+
+	psFlag := "auto"
+	if sc.PSMode == sysbenchPSModeSimple {
+		psFlag = "disable"
+	}
+
+	args := append(r.pgsqlConnArgs(target), r.commonOltpArgs()...)
+	args = append(args,
+		"--threads="+strconv.Itoa(sc.Clients),
+		"--time="+strconv.Itoa(sc.Duration),
+		"--report-interval=5",
+		// Force 99th-percentile reporting in the summary block. sysbench
+		// 1.0.x defaults to 95 (which then ends up labelled "95th
+		// percentile:" in the output and fails our regex).
+		"--percentile=99",
+		"--db-ps-mode="+psFlag,
+		"run",
+	)
+
+	out, err := executil.Command(ctx, r.binary, args...).CombinedOutput()
+
+	logPath := filepath.Join(r.OutputDir, "logs", "sysbench-"+sc.Name+".txt")
+	_ = os.MkdirAll(filepath.Dir(logPath), 0o755)
+	_ = os.WriteFile(logPath, out, 0o644)
+
+	if err != nil {
+		t.Logf("sysbench scenario %s output:\n%s", sc.Name, string(out))
+		return nil, fmt.Errorf("sysbench run failed: %w", err)
+	}
+
+	res, parseErr := parseSysBenchOutput(out)
+	if parseErr != nil {
+		t.Logf("sysbench scenario %s output:\n%s", sc.Name, string(out))
+		return nil, fmt.Errorf("parse sysbench output: %w", parseErr)
+	}
+	if res.TPS <= 0 || res.Transactions <= 0 {
+		return nil, fmt.Errorf("sysbench reported zero throughput (tps=%.2f txns=%d) — workload failed silently",
+			res.TPS, res.Transactions)
+	}
+
+	res.Target = target.Name
+	res.Scenario = sc.Name
+	res.Clients = sc.Clients
+	res.Duration = sc.Duration
+	res.PSMode = sc.PSMode
+	return res, nil
+}
+
+// Sysbench summary lines we parse out of the stdout block. Examples (from
+// sysbench 1.0.x and 1.1.x — both supported):
+//
+//	transactions:                        1940425 (32338.55 per sec.)
+//	    avg:                                    0.99
+//	    99th percentile:                        0.00
+var (
+	reTransactions = regexp.MustCompile(`transactions:\s+(\d+)\s+\(([\d.]+) per sec\.\)`)
+	reAvgLatency   = regexp.MustCompile(`(?m)^\s*avg:\s+([\d.]+)`)
+	reP99Latency   = regexp.MustCompile(`(?m)^\s*99th percentile:\s+([\d.]+)`)
+)
+
+// parseSysBenchOutput extracts TPS, transactions, avg latency and p99
+// latency from sysbench's summary block. Returns an error if any required
+// field is missing — we never want to silently record zero metrics.
+func parseSysBenchOutput(out []byte) (*ScenarioResult, error) {
+	res := &ScenarioResult{}
+
+	if m := reTransactions.FindSubmatch(out); m != nil {
+		txns, err := strconv.Atoi(string(m[1]))
+		if err != nil {
+			return nil, fmt.Errorf("parse transactions count %q: %w", m[1], err)
+		}
+		tps, err := strconv.ParseFloat(string(m[2]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse tps %q: %w", m[2], err)
+		}
+		res.Transactions = txns
+		res.TPS = tps
+	} else {
+		return nil, errors.New(`could not find "transactions: N (M per sec.)" line in sysbench output`)
+	}
+
+	if m := reAvgLatency.FindSubmatch(out); m != nil {
+		v, err := strconv.ParseFloat(string(m[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse avg latency %q: %w", m[1], err)
+		}
+		res.LatencyAvg = v
+	} else {
+		return nil, errors.New(`could not find "avg:" latency line in sysbench output`)
+	}
+
+	if m := reP99Latency.FindSubmatch(out); m != nil {
+		v, err := strconv.ParseFloat(string(m[1]), 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse p99 latency %q: %w", m[1], err)
+		}
+		res.LatencyP99 = v
+	} else {
+		return nil, errors.New(`could not find "99th percentile:" latency line in sysbench output`)
+	}
+
+	return res, nil
+}
+
+// DefaultSysBenchScenarios returns the cross-product of the env-driven
+// client list and ps-mode list. Naming convention:
+// `sustained_<clients>c_<ps_mode>` — distinct from the pgbench harness's
+// `sustained_<clients>c_simple` scenario name to avoid output-dir collisions
+// when both tests run in the same package.
+func DefaultSysBenchScenarios(duration int, clientCounts []int, psModes []string) []SysBenchScenario {
+	var out []SysBenchScenario
+	for _, ps := range psModes {
+		for _, c := range clientCounts {
+			out = append(out, SysBenchScenario{
+				Name:     fmt.Sprintf("sustained_%dc_%s", c, ps),
+				Clients:  c,
+				Duration: duration,
+				PSMode:   ps,
+			})
+		}
+	}
+	return out
+}
+
+// CaptureSysBenchEnvironment fills the EnvironmentInfo block for a sysbench
+// run. PlanCacheBytes is the multigateway --plan-cache-memory default; we
+// hardcode it because the shared cluster setup doesn't override it.
+func CaptureSysBenchEnvironment(t *testing.T, binary string) EnvironmentInfo {
+	t.Helper()
+
+	info := EnvironmentInfo{
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		GOMAXPROCS:     runtime.GOMAXPROCS(0),
+		PlanCacheBytes: 4 * 1024 * 1024, // multigateway default; see go/services/multigateway/init.go
+	}
+
+	if out, err := exec.Command(binary, "--version").Output(); err == nil {
+		info.SysBenchVersion = strings.TrimSpace(string(out))
+	}
+	if out, err := exec.Command("postgres", "--version").Output(); err == nil {
+		info.PostgresVersion = strings.TrimSpace(string(out))
+	}
+	if sha := gitHeadSha(); sha != "" {
+		info.MultigresVersion = "git-HEAD-" + sha
+	}
+	return info
+}
+
+// gitHeadSha returns the short HEAD sha of the repository the test binary
+// was built from, or "" if `git` isn't available.
+func gitHeadSha() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// parseSysBenchInt reads an optional positive int env var with a default.
+func parseSysBenchInt(t *testing.T, name string, def int) int {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		t.Fatalf("invalid %s=%q (must be positive int)", name, raw)
+	}
+	return n
+}
+
+// ParseSysBenchClients reads SYSBENCH_CLIENTS as a comma-separated list of
+// thread counts. Default: 1,8,32 — same as the handoff sweep.
+func ParseSysBenchClients(t *testing.T) []int {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("SYSBENCH_CLIENTS"))
+	if raw == "" {
+		return []int{1, 8, 32}
+	}
+	var out []int
+	for s := range strings.SplitSeq(raw, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil || n <= 0 {
+			t.Fatalf("invalid SYSBENCH_CLIENTS value %q: must be positive int", s)
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		t.Fatalf("SYSBENCH_CLIENTS=%q produced no client counts", raw)
+	}
+	return out
+}
+
+// ParseSysBenchDuration reads SYSBENCH_DURATION (seconds, default 60).
+func ParseSysBenchDuration(t *testing.T) int {
+	t.Helper()
+	return parseSysBenchInt(t, "SYSBENCH_DURATION", 60)
+}
+
+// ParseSysBenchPSModes reads SYSBENCH_PS_MODES; default is both
+// {prepared,simple}. Unknown values fail the test loudly.
+func ParseSysBenchPSModes(t *testing.T) []string {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("SYSBENCH_PS_MODES"))
+	if raw == "" {
+		return []string{sysbenchPSModePrepared, sysbenchPSModeSimple}
+	}
+	var out []string
+	for s := range strings.SplitSeq(raw, ",") {
+		s = strings.TrimSpace(s)
+		switch s {
+		case sysbenchPSModePrepared, sysbenchPSModeSimple:
+			out = append(out, s)
+		case "":
+		default:
+			t.Fatalf("invalid SYSBENCH_PS_MODES value %q (valid: prepared, simple)", s)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("SYSBENCH_PS_MODES=%q produced no ps modes", raw)
+	}
+	return out
+}
+
+// ParseSysBenchTargets reads SYSBENCH_TARGETS; default is multigateway only.
+func ParseSysBenchTargets(t *testing.T) (postgres, multigateway, pgbouncer bool) {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv("SYSBENCH_TARGETS"))
+	if raw == "" {
+		return false, true, false
+	}
+	for s := range strings.SplitSeq(raw, ",") {
+		switch strings.TrimSpace(s) {
+		case "postgres":
+			postgres = true
+		case "multigateway":
+			multigateway = true
+		case "pgbouncer":
+			pgbouncer = true
+		case "":
+		default:
+			t.Fatalf("SYSBENCH_TARGETS contains unknown target %q (valid: postgres, multigateway, pgbouncer)", s)
+		}
+	}
+	return postgres, multigateway, pgbouncer
+}
+
+// ParseSysBenchQuiesce reads SYSBENCH_QUIESCE_SECONDS (default 5).
+func ParseSysBenchQuiesce(t *testing.T) int {
+	t.Helper()
+	return parseSysBenchInt(t, "SYSBENCH_QUIESCE_SECONDS", 5)
+}

--- a/go/test/endtoend/queryserving/benchmarking/sysbench_runner.go
+++ b/go/test/endtoend/queryserving/benchmarking/sysbench_runner.go
@@ -145,7 +145,7 @@ func (r *SysBenchRunner) Prepare(ctx context.Context, t *testing.T, target suite
 	args := append(r.pgsqlConnArgs(target), r.commonOltpArgs()...)
 	args = append(args, "prepare")
 
-	logPath := filepath.Join(r.OutputDir, "logs", "sysbench-prepare.txt")
+	logPath := filepath.Join(r.OutputDir, "logs", "prepare", target.Name+".txt")
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return fmt.Errorf("mkdir logs: %w", err)
 	}
@@ -186,7 +186,7 @@ func (r *SysBenchRunner) RunScenario(ctx context.Context, t *testing.T, target s
 
 	out, err := executil.Command(ctx, r.binary, args...).CombinedOutput()
 
-	logPath := filepath.Join(r.OutputDir, "logs", "sysbench-"+sc.Name+".txt")
+	logPath := filepath.Join(r.OutputDir, "logs", sc.Name, target.Name+".txt")
 	_ = os.MkdirAll(filepath.Dir(logPath), 0o755)
 	_ = os.WriteFile(logPath, out, 0o644)
 

--- a/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
+++ b/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
@@ -131,18 +131,27 @@ func TestSysBench(t *testing.T) {
 	if capturePprof {
 		t.Logf("CAPTURE_PPROF=1: CPU profiles will be captured during each scenario")
 	}
+	if captureHeap {
+		t.Logf("CAPTURE_HEAP=1: heap/allocs/goroutine profiles will be captured before+after each scenario")
+	}
 
 	mgwPid := setup.Multigateway.Process.Process.Pid
 	pgPidEnum := postgresPidEnumerator(setup.GetPrimary(t).Pgctld.PoolerDir + "/pg_data")
 
+	// Quiesce between every (scenario, target) run, not just between
+	// scenarios — back-to-back targets within a scenario can otherwise
+	// inherit warm buffer cache, replication lag, or autovacuum activity
+	// from the previous run and bias later targets.
 	var allResults []ScenarioResult
-	for i, scenario := range scenarios {
-		if i > 0 && quiesce > 0 {
-			t.Logf("Quiesce %ds before next scenario", quiesce)
-			time.Sleep(time.Duration(quiesce) * time.Second)
-		}
+	first := true
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			for _, target := range targets {
+				if !first && quiesce > 0 {
+					t.Logf("Quiesce %ds before %s/%s", quiesce, scenario.Name, target.Name)
+					time.Sleep(time.Duration(quiesce) * time.Second)
+				}
+				first = false
 				t.Run(target.Name, func(t *testing.T) {
 					runSysBenchScenarioOnce(ctx, t, setup, runner, scenario, target,
 						mgwPid, pgPidEnum, capturePprof, captureHeap, &allResults)

--- a/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
+++ b/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
@@ -256,8 +256,10 @@ func runSysBenchScenarioOnce(
 		stats[st.Label] = st
 	}
 	// Match the vitess bundle's filename so cross-stack comparison tools can
-	// glob `cpu/<scenario>/processes.json` regardless of which stack wrote it.
-	writeSysBenchCPUStatsFile(t, runner.OutputDir, scenario.Name, stats)
+	// glob `cpu/<scenario>/<target>/processes.json` regardless of which
+	// stack wrote it. Nesting under <target> keeps multi-target runs from
+	// clobbering each other.
+	writeSysBenchCPUStatsFile(t, runner.OutputDir, scenario.Name, target.Name, stats)
 	for label, st := range stats {
 		t.Logf("CPU %s/%s/%s: mean=%.1f%% max=%.1f%% (n=%d)",
 			scenario.Name, target.Name, label,

--- a/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
+++ b/go/test/endtoend/queryserving/benchmarking/sysbench_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benchmarking
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestSysBench drives sysbench oltp_point_select against multigateway (and
+// optionally postgres / pgbouncer) under both prepared-statements-on
+// (--db-ps-mode=auto) and prepared-statements-off (--db-ps-mode=disable)
+// modes, capturing TPS / latency / per-process CPU / CPU pprofs.
+//
+// Skipped by default. Enable with:
+//
+//	RUN_BENCHMARKS=1 CAPTURE_PPROF=1 SYSBENCH_CLIENTS=1,8,32 SYSBENCH_DURATION=60 \
+//	  go test -v -timeout 30m -run TestSysBench ./go/test/endtoend/queryserving/benchmarking/
+//
+// See SYSBENCH.md in this directory for the env-var reference and output layout.
+func TestSysBench(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunBenchmarks)
+
+	runner := NewSysBenchRunner(t) // skips test if sysbench/pgsql missing
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	ctx := utils.WithTimeout(t, 2*time.Hour)
+
+	primary := setup.GetPrimary(t)
+	pgTarget := suiteutil.Target{
+		Name: "postgres",
+		Host: "127.0.0.1",
+		Port: primary.Pgctld.PgPort,
+		User: shardsetup.DefaultTestUser,
+		Pass: shardsetup.TestPostgresPassword,
+		DB:   "postgres",
+	}
+	mgwTarget := suiteutil.Target{
+		Name: "multigateway",
+		Host: "127.0.0.1",
+		Port: setup.MultigatewayPgPort,
+		User: shardsetup.DefaultTestUser,
+		Pass: shardsetup.TestPostgresPassword,
+		DB:   "postgres",
+	}
+
+	wantPostgres, wantMultigateway, wantPgbouncer := ParseSysBenchTargets(t)
+
+	// Bumping postgres max_connections is the same recipe pgbench uses; we
+	// reuse the same env var (PGBENCH_PG_MAX_CONNECTIONS) so a single sweep
+	// can flip both harnesses at once.
+	if raw := os.Getenv("PGBENCH_PG_MAX_CONNECTIONS"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("invalid PGBENCH_PG_MAX_CONNECTIONS=%q: %v", raw, err)
+		}
+		bumpPostgresMaxConnections(ctx, t, setup, n)
+		time.Sleep(2 * time.Second)
+	}
+
+	var targets []suiteutil.Target
+	if wantPostgres {
+		targets = append(targets, pgTarget)
+	}
+	if wantMultigateway {
+		targets = append(targets, mgwTarget)
+	}
+	if wantPgbouncer {
+		pgb, err := NewPgBouncerInstance(t, "127.0.0.1", primary.Pgctld.PgPort,
+			shardsetup.DefaultTestUser, shardsetup.TestPostgresPassword)
+		if err == nil && pgb != nil {
+			t.Cleanup(func() { pgb.Stop(t) })
+			targets = append(targets, suiteutil.Target{
+				Name: "pgbouncer",
+				Host: "127.0.0.1",
+				Port: pgb.Port(),
+				User: shardsetup.DefaultTestUser,
+				Pass: shardsetup.TestPostgresPassword,
+				DB:   "postgres",
+			})
+			t.Logf("pgbouncer available at port %d", pgb.Port())
+		} else {
+			t.Logf("pgbouncer requested but not available: %v", err)
+		}
+	}
+	if len(targets) == 0 {
+		t.Fatalf("no benchmark targets selected (SYSBENCH_TARGETS=%q)", os.Getenv("SYSBENCH_TARGETS"))
+	}
+	t.Logf("Sysbench targets: %s", targetNames(targets))
+
+	duration := ParseSysBenchDuration(t)
+	clients := ParseSysBenchClients(t)
+	psModes := ParseSysBenchPSModes(t)
+	quiesce := ParseSysBenchQuiesce(t)
+	scenarios := DefaultSysBenchScenarios(duration, clients, psModes)
+
+	// Prepare runs once against postgres directly — sbtestN tables are
+	// shared across all targets because the same backend serves them all.
+	t.Run("prepare", func(t *testing.T) {
+		if err := runner.Prepare(ctx, t, pgTarget); err != nil {
+			t.Fatalf("sysbench prepare failed: %v", err)
+		}
+	})
+
+	capturePprof := os.Getenv("CAPTURE_PPROF") == "1"
+	captureHeap := os.Getenv("CAPTURE_HEAP") == "1"
+	if capturePprof {
+		t.Logf("CAPTURE_PPROF=1: CPU profiles will be captured during each scenario")
+	}
+
+	mgwPid := setup.Multigateway.Process.Process.Pid
+	pgPidEnum := postgresPidEnumerator(setup.GetPrimary(t).Pgctld.PoolerDir + "/pg_data")
+
+	var allResults []ScenarioResult
+	for i, scenario := range scenarios {
+		if i > 0 && quiesce > 0 {
+			t.Logf("Quiesce %ds before next scenario", quiesce)
+			time.Sleep(time.Duration(quiesce) * time.Second)
+		}
+		t.Run(scenario.Name, func(t *testing.T) {
+			for _, target := range targets {
+				t.Run(target.Name, func(t *testing.T) {
+					runSysBenchScenarioOnce(ctx, t, setup, runner, scenario, target,
+						mgwPid, pgPidEnum, capturePprof, captureHeap, &allResults)
+				})
+			}
+		})
+	}
+
+	// Fail loudly if any scenario landed zero TPS — the parser explicitly
+	// guards against this, but defence in depth.
+	for _, r := range allResults {
+		if r.TPS <= 0 {
+			t.Fatalf("scenario %s/%s recorded zero TPS", r.Target, r.Scenario)
+		}
+	}
+
+	report := &BenchmarkReport{
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		LoadTool:    "sysbench",
+		Results:     allResults,
+		Environment: CaptureSysBenchEnvironment(t, "sysbench"),
+	}
+
+	if jsonPath, err := WriteJSONReport(t, runner.OutputDir, report); err == nil {
+		t.Logf("JSON report: %s", jsonPath)
+	} else {
+		t.Logf("Warning: failed to write JSON report: %v", err)
+	}
+	if mdPath, err := WriteSysBenchMarkdownReport(t, runner.OutputDir, report); err == nil {
+		t.Logf("Markdown report: %s", mdPath)
+	} else {
+		t.Logf("Warning: failed to write markdown report: %v", err)
+	}
+
+	t.Logf("Sysbench bundle: %s", runner.OutputDir)
+}
+
+// runSysBenchScenarioOnce executes one (scenario, target) tuple with CPU
+// sampling and optional pprof capture, mirroring runScenarioOnce for pgbench.
+func runSysBenchScenarioOnce(
+	ctx context.Context,
+	t *testing.T,
+	setup *shardsetup.ShardSetup,
+	runner *SysBenchRunner,
+	scenario SysBenchScenario,
+	target suiteutil.Target,
+	mgwPid int,
+	pgPidEnum pidEnumerator,
+	capturePprof bool,
+	captureHeap bool,
+	allResults *[]ScenarioResult,
+) {
+	t.Helper()
+
+	mpPid := setup.GetPrimary(t).Multipooler.Process.Process.Pid
+	samplers := []*cpuSampler{
+		newCPUSampler("postgres", pgPidEnum, time.Second),
+		newCPUSampler("multigateway", staticPidEnumerator(mgwPid), time.Second),
+		newCPUSampler("multipooler_primary", staticPidEnumerator(mpPid), time.Second),
+	}
+	for _, s := range samplers {
+		s.Start(ctx)
+	}
+
+	mgwAddr := fmt.Sprintf("127.0.0.1:%d", setup.Multigateway.HttpPort)
+	mpAddr := fmt.Sprintf("127.0.0.1:%d", setup.GetPrimary(t).Multipooler.HttpPort)
+	profileDir := filepath.Join(runner.OutputDir, "pprof", scenario.Name, target.Name)
+	services := map[string]string{
+		"multigateway":        mgwAddr,
+		"multipooler_primary": mpAddr,
+	}
+
+	if captureHeap {
+		captureSnapshots(ctx, t, services, profileDir, "before")
+	}
+
+	var wg sync.WaitGroup
+	if capturePprof {
+		profileDur := scenario.Duration - 4
+		if profileDur < 5 {
+			profileDur = scenario.Duration
+		}
+		wg.Add(len(services))
+		for label, addr := range services {
+			go func(label, addr string) {
+				defer wg.Done()
+				out := filepath.Join(profileDir, "cpu-"+shortServiceName(label)+".pb.gz")
+				if err := captureCPUProfile(ctx, addr, profileDur, out); err != nil {
+					t.Logf("%s CPU profile failed: %v", label, err)
+					return
+				}
+				if fi, err := os.Stat(out); err != nil || fi.Size() == 0 {
+					t.Errorf("%s CPU profile %s is empty (size=%d, err=%v)", label, out, sizeOrZero(fi), err)
+					return
+				}
+				t.Logf("%s CPU profile: %s", label, out)
+			}(label, addr)
+		}
+	}
+
+	result, err := runner.RunScenario(ctx, t, target, scenario)
+	wg.Wait()
+
+	if captureHeap {
+		captureSnapshots(ctx, t, services, profileDir, "after")
+	}
+
+	stats := make(map[string]CPUStats, len(samplers))
+	for _, s := range samplers {
+		st := s.Stop()
+		stats[st.Label] = st
+	}
+	// Match the vitess bundle's filename so cross-stack comparison tools can
+	// glob `cpu/<scenario>/processes.json` regardless of which stack wrote it.
+	writeSysBenchCPUStatsFile(t, runner.OutputDir, scenario.Name, stats)
+	for label, st := range stats {
+		t.Logf("CPU %s/%s/%s: mean=%.1f%% max=%.1f%% (n=%d)",
+			scenario.Name, target.Name, label,
+			st.MeanPercent, st.MaxPercent, st.Samples)
+	}
+
+	if err != nil {
+		t.Errorf("FAIL: sysbench failed for %s/%s: %v", target.Name, scenario.Name, err)
+		return
+	}
+	*allResults = append(*allResults, *result)
+	t.Logf("TPS=%.1f  AvgLatency=%.2fms  P99=%.2fms  Txns=%d  ps_mode=%s",
+		result.TPS, result.LatencyAvg, result.LatencyP99, result.Transactions, result.PSMode)
+}
+
+func sizeOrZero(fi os.FileInfo) int64 {
+	if fi == nil {
+		return 0
+	}
+	return fi.Size()
+}


### PR DESCRIPTION
## Summary

- Adds `TestSysBench`, a manual perf harness that drives sysbench `oltp_point_select` against multigateway (and optionally postgres/pgbouncer) over the pgsql driver.
- Reuses the shared cluster setup and reporting types from `TestPgBench`; emits per-scenario CPU stats, optional CPU pprofs, and a sysbench-shaped markdown report.
- Runs both `prepared` (`--db-ps-mode=auto`) and `simple` (`--db-ps-mode=disable`) modes so parser-per-query cost can be isolated from the rest of the proxy/pooler path.

## Description

`TestSysBench` lives next to `TestPgBench` in `go/test/endtoend/queryserving/benchmarking` and follows the same skip-by-default convention: it requires `RUN_BENCHMARKS=1`, and self-skips with an actionable message if `sysbench` is missing or was built without the pgsql driver.

`ScenarioResult` and `EnvironmentInfo` in `pgbench_runner.go` grew a few `omitempty` fields (`PSMode`, `SysBenchVersion`, `MultigresVersion`, `Arch`, `PlanCacheBytes`) so each tool's `results.json` only carries fields relevant to that tool. Reporting is split: `WriteSysBenchMarkdownReport` renders the sysbench-shaped table (per-scenario rows grouped by `ps_mode`) rather than overloading the pgbench renderer, since the scenario shapes don't line up.

`SYSBENCH.md` documents the env knobs (`SYSBENCH_CLIENTS`, `SYSBENCH_DURATION`, `SYSBENCH_PS_MODES`, `SYSBENCH_TARGETS`, etc.), the output bundle layout, the loud-failure conditions (zero TPS, missing summary lines, empty pprof), and known caveats around sub-millisecond p99 reporting.