### PR TITLE
fix(multigateway): forward bindVars through Sequence to children

### DIFF
--- a/go/services/multigateway/engine/sequence.go
+++ b/go/services/multigateway/engine/sequence.go
@@ -39,17 +39,25 @@ func NewSequence(primitives []Primitive) *Sequence {
 }
 
 // StreamExecute executes each primitive in order, stopping on first error.
+//
+// bindVars are forwarded to every child. The current Sequence shape used by
+// planSelectStmt is [silent ApplySessionState..., Route]: the silent steps
+// ignore bindVars (their VariableSetStmt is fully synthesized at plan time
+// from the literal set_config args), while the trailing Route uses bindVars
+// + its NormalizedAST to reconstruct the original literals before sending
+// the query to the backend. Dropping bindVars here breaks that
+// reconstruction — the normalized `$N` placeholders reach PG unbound and
+// fail with "there is no parameter $N".
 func (s *Sequence) StreamExecute(
 	ctx context.Context,
 	exec IExecute,
 	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
-	_ []*ast.A_Const,
+	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// Execute each primitive in order
 	for i, p := range s.Primitives {
-		if err := p.StreamExecute(ctx, exec, conn, state, nil, callback); err != nil {
+		if err := p.StreamExecute(ctx, exec, conn, state, bindVars, callback); err != nil {
 			return fmt.Errorf("primitive %d (%s) failed: %w", i, p.String(), err)
 		}
 	}

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -467,6 +467,39 @@ func TestPortalStreamExecute_RunsCacheableSequencePlan(t *testing.T) {
 		"portal must still be forwarded to the backend after silent prefix")
 }
 
+// TestStreamExecute_SetConfigWithSiblingLiteral covers the simple-protocol
+// shape `SELECT set_config(literal, literal, false), <other-literal>`. The
+// normalizer skips the set_config subtree but still parameterizes the
+// sibling literal; the planner emits a Sequence whose trailing Route holds
+// the normalized SQL + NormalizedAST. If Sequence.StreamExecute drops
+// bindVars on its way to children, Route can't reconstruct and the
+// `$N` placeholder reaches PG unbound — which surfaces as
+// `there is no parameter $1`. Verify the backend receives the literal,
+// not the placeholder.
+func TestStreamExecute_SetConfigWithSiblingLiteral(t *testing.T) {
+	mock := &mockExec{}
+	exec := newTestExecutor(mock)
+	defer exec.planCache.Close()
+	ctx := context.Background()
+	conn := testConn()
+	state := handler.NewMultiGatewayConnectionState()
+
+	sql := "SELECT set_config('work_mem', '256MB', false), 42 AS num"
+	_, err := exec.StreamExecute(ctx, conn, state, sql, parseOne(t, sql), noopCallback)
+	require.NoError(t, err)
+
+	backendSQL, _ := mock.lastStreamExecuteSQL.Load().(string)
+	assert.Contains(t, backendSQL, "42",
+		"sibling literal must be substituted back; backend SQL was %q", backendSQL)
+	assert.NotContains(t, backendSQL, "$1",
+		"normalized placeholder must not reach the backend; backend SQL was %q", backendSQL)
+
+	// Silent ApplySessionState prefix must still have updated the tracker.
+	got, ok := state.GetSessionVariable("work_mem")
+	require.True(t, ok)
+	assert.Equal(t, "256MB", got)
+}
+
 func TestCrossProtocol_CasingNormalization(t *testing.T) {
 	mock := &mockExec{}
 	exec := newTestExecutor(mock)

--- a/go/test/endtoend/queryserving/unsafe_funccall_test.go
+++ b/go/test/endtoend/queryserving/unsafe_funccall_test.go
@@ -205,6 +205,37 @@ func TestMultiGateway_SetConfigRoutedAsSET(t *testing.T) {
 		}
 	})
 
+	// Regression for the simple-protocol shape `SELECT set_config(...), <literal>`.
+	// The normalizer skips inside set_config but still parameterizes the
+	// sibling literal, and the planner emits a Sequence whose trailing Route
+	// reconstructs the SQL from bindVars. If Sequence.StreamExecute drops
+	// bindVars on its way to children, Route ships the normalized `$N`
+	// placeholder to PG and the backend errors with "there is no parameter
+	// $1". Verify both the row data the client sees and the tracker update
+	// for the set_config side effect.
+	t.Run("SELECT set_config alongside sibling literal", func(t *testing.T) {
+		_, err := db.ExecContext(ctx, "RESET ALL")
+		require.NoError(t, err)
+
+		var setConfigVal string
+		var num int
+		err = db.QueryRowContext(ctx,
+			"SELECT set_config('work_mem', '256MB', false), 42 AS num").
+			Scan(&setConfigVal, &num)
+		require.NoError(t, err, "sibling literal alongside set_config must not break SQL reconstruction")
+		assert.Equal(t, "256MB", setConfigVal)
+		assert.Equal(t, 42, num)
+
+		// Tracker must still reflect the set_config so the value persists
+		// across pool rotations.
+		for i := range 50 {
+			var got string
+			err = db.QueryRowContext(ctx, "SHOW work_mem").Scan(&got)
+			require.NoError(t, err, "iteration %d", i)
+			require.Equal(t, "256MB", got, "iteration %d", i)
+		}
+	})
+
 	// set_config(..., true) — transaction-scoped — is allowed but NOT tracked
 	// by the pooler (it's scoped to the backend transaction, so the pool
 	// shouldn't carry it forward). PG handles it directly.


### PR DESCRIPTION
## Summary

- Follow-up to #880 — we missed this while addressing the review comments on that PR.
- `Sequence.StreamExecute` was passing `nil` for `bindVars` to its children, so the trailing `Route` in a `[silent ApplySessionState..., Route]` plan couldn't reconstruct the original SQL from the normalized AST. The placeholder `$N` reached PG unbound and the backend errored with `there is no parameter $1`.
- Reproducer reported by @haritabh17 via psql: `SELECT set_config('work_mem','256MB',false), 42 AS num` — fails on simple protocol, works on plain PG.

## Problem

The cacheable simple-protocol path normalizes `42` to `$1` and stores the literal in `bindValues`. The planner emits a Sequence whose trailing Route holds the normalized SQL plus the `NormalizedAST` so it can substitute `bindVars` back at execution time. But Sequence.StreamExecute was iterating its children with `p.StreamExecute(ctx, exec, conn, state, nil, callback)` — dropping `bindVars`. Route then sent the normalized `$1` form to PG, which has no bind values for it.

The bug only fires when (a) the SELECT has at least one `set_config(..., false)` target and (b) some other target in the same SELECT is a literal that the normalizer would parameterize. A bare `SELECT set_config(...)` happens to work because there are no literals outside the (skipped) set_config subtree.

## Solution

Forward `bindVars` to every child in `Sequence.StreamExecute`. Silent `ApplySessionState` steps ignore them (their `VariableSetStmt` is fully synthesized at plan time from the literal set_config args), Route uses them.

Three layers of regression coverage:

- **Engine unit** — existing `TestSequence_PortalStreamExecute_*` covers the portal path; the StreamExecute path is now validated by the executor-level test below.
- **Executor unit** — new `TestStreamExecute_SetConfigWithSiblingLiteral` runs `SELECT set_config('work_mem','256MB',false), 42 AS num` through the executor and asserts the backend SQL contains `42` and not `$1`.
- **End-to-end** — new `SELECT set_config alongside sibling literal` subtest under `TestMultiGateway_SetConfigRoutedAsSET` runs the failing query through real psql against multigateway and verifies both the row data and the post-rotation tracker state (50 SHOW iterations).