### PR TITLE
fix: bump recovery timeouts to avoid test flakiness

### DIFF
--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -160,7 +160,9 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// Force multiorch to resolve all pending problems immediately (bypasses grace periods).
 		// This ensures StalePrimary for the killed node is fully resolved (pg_rewind + rejoin)
 		// before the next iteration begins — otherwise the grace period would carry over.
-		setup.RequireRecovery(t, "multiorch", 20*time.Second)
+		// 45s budget: DemoteStalePrimary is synchronous and includes a 5s drain +
+		// up to ~15s pg_rewind + ~5s postgres restart on slow CI.
+		setup.RequireRecovery(t, "multiorch", 45*time.Second)
 
 		// Get the new primary's consensus term to verify rejoining nodes are on correct term
 		newPrimary := setup.GetMultipoolerInstance(newPrimaryName)

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -115,7 +115,7 @@ func TestDemoteStalePrimary_SIGKILL(t *testing.T) {
 	// 4. Configure replication to the new primary
 	// 5. Start WAL receiver
 	t.Log("Waiting for multiorch to detect stale primary, run pg_rewind, and configure replication...")
-	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 20*time.Second)
+	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 45*time.Second)
 
 	// Step 6: Verify old primary is now replicating from new primary
 	t.Log("Verifying old primary is now a replica...")
@@ -217,7 +217,7 @@ func TestDemoteStalePrimary_GracefulShutdown(t *testing.T) {
 	// 4. Configure replication to the new primary
 	// 5. Start WAL receiver
 	t.Log("Waiting for multiorch to detect stale primary, run pg_rewind, and configure replication...")
-	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 20*time.Second)
+	waitForDivergenceRepaired(t, setup, oldPrimaryName, newPrimaryName, 45*time.Second)
 
 	// Step 6: Verify old primary is now replicating from new primary
 	t.Log("Verifying old primary is now a replica...")


### PR DESCRIPTION
Root cause: DemoteStalePrimary executes synchronously within the recovery cycle — 5s drain + up to ~15s pg_rewind + ~5s postgres restart = ~25s worst case on slow CI. Using a 20s timeout makes the tests to fail eventually.

Fix: Bump timeout to 45s.