### PR TITLE
fix(tests): ensure cluster cleanup always runs and kills process groups

### DIFF
--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -29,6 +29,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -124,13 +125,20 @@ func getTestPortConfig(t *testing.T, numZones int) *testPortConfig {
 	return config
 }
 
-// killProcessByPID kills a process by PID using kill -9
+// killProcessByPID kills a process and its process group by PID using kill -9.
+// Sending SIGKILL to the process group (negative PID) ensures child processes
+// such as postgres under pgctld are also terminated.
 func killProcessByPID(pid int) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid PID: %d", pid)
 	}
 
-	// Use SIGKILL to forcefully terminate with a short timeout
+	// Kill the entire process group so children (e.g. postgres under pgctld)
+	// are terminated alongside the service. Services started with Setpgid: true
+	// have PGID == PID, so this kills the group leader and all its children.
+	// Ignore errors: the group may not exist if the process already exited.
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -869,8 +877,7 @@ func TestClusterLifecycle(t *testing.T) {
 	t.Run("cluster init and basic connectivity test", func(t *testing.T) {
 		t.Skip("TODO(sougou): Disabling this till we fix leader election after restart")
 		// Setup test directory
-		clusterSetup, cleanup := setupTestCluster(t)
-		t.Cleanup(cleanup)
+		clusterSetup := setupTestCluster(t)
 		tempDir := clusterSetup.TempDir
 		configFile := clusterSetup.ConfigFile
 		testPorts := clusterSetup.PortConfig
@@ -1408,8 +1415,7 @@ func TestTCPPasswordAuthentication(t *testing.T) {
 		t.Skip("etcd binary not found in PATH")
 	}
 
-	clusterSetup, cleanup := setupTestCluster(t)
-	defer cleanup()
+	clusterSetup := setupTestCluster(t)
 
 	pgPort := clusterSetup.PortConfig.Zones[0].PgctldPGPort
 
@@ -1628,7 +1634,7 @@ type testClusterSetup struct {
 // and verifying all services are up and responding. Returns a testClusterSetup
 // with resources and a cleanup function that must be called when done (typically
 // via t.Cleanup).
-func setupTestCluster(t *testing.T) (*testClusterSetup, func()) {
+func setupTestCluster(t *testing.T) *testClusterSetup {
 	t.Helper()
 
 	// Setup test directory
@@ -1638,8 +1644,11 @@ func setupTestCluster(t *testing.T) (*testClusterSetup, func()) {
 	// Track for log dumping on test failure
 	lastTestClusterTempDir = tempDir
 
-	// Create cleanup function
-	cleanup := func() {
+	// Register cleanup via t.Cleanup so it is guaranteed to run even when
+	// setupTestCluster exits early via t.FailNow() / runtime.Goexit(). A plain
+	// "defer cleanup()" in the caller would never be registered in that case,
+	// leaving services running and their ports returned to the pool.
+	t.Cleanup(func() {
 		if cleanupErr := cleanupTestProcesses(tempDir); cleanupErr != nil {
 			t.Logf("Warning: cleanup failed: %v", cleanupErr)
 		}
@@ -1650,7 +1659,7 @@ func setupTestCluster(t *testing.T) (*testClusterSetup, func()) {
 		} else {
 			os.RemoveAll(tempDir)
 		}
-	}
+	})
 
 	t.Logf("Testing cluster lifecycle in directory: %s", tempDir)
 
@@ -1733,5 +1742,5 @@ func setupTestCluster(t *testing.T) (*testClusterSetup, func()) {
 		ConfigFile:  configFile,
 		Database:    database,
 		ReadyPGPort: readyPort,
-	}, cleanup
+	}
 }


### PR DESCRIPTION
Register test cluster cleanup via t.Cleanup inside setupTestCluster so it is guaranteed to run even when the function exits early via t.FailNow() / runtime.Goexit(). Previously, the caller's defer cleanup() was never registered in that case, leaving services running while their ports were returned to the pool.

Also send SIGKILL to the entire process group (kill -pid) in addition to the individual service PID, so child processes such as postgres under pgctld are terminated alongside the service.