### PR TITLE
test(pgregresstest): set vanilla planner GUCs via PGOPTIONS

### DIFF
--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -124,6 +124,18 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 	// grandchildren (e.g. psql) holding pipes open would cause a hang.
 	cmd.SetWaitDelay(10 * time.Second)
 
+	// pgctld provisions PostgreSQL with Supabase Pico-instance defaults
+	// (work_mem=1092kB, random_page_cost=1.1, effective_cache_size=192MB,
+	// max_parallel_workers_per_gather=1). pg_regress expected .out files were
+	// captured against vanilla PostgreSQL defaults, so the planner picks
+	// different shapes (e.g. Hash↔Merge, Bitmap↔Index) under our defaults.
+	// Override to vanilla values per session via PGOPTIONS so the harness
+	// matches upstream fixtures without changing production pgctld defaults.
+	pgOptions := "-c work_mem=4MB" +
+		" -c random_page_cost=4.0" +
+		" -c effective_cache_size=4GB" +
+		" -c max_parallel_workers_per_gather=2"
+
 	cmd.AddEnv(
 		"PGHOST=localhost",
 		fmt.Sprintf("PGPORT=%d", multigatewayPort),
@@ -131,6 +143,7 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 		"PGPASSWORD="+password,
 		"PGDATABASE=postgres",
 		"PGCONNECT_TIMEOUT=10",
+		"PGOPTIONS="+pgOptions,
 	)
 
 	// Capture stdout for result parsing while still printing to the terminal.

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -124,13 +124,11 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 	// grandchildren (e.g. psql) holding pipes open would cause a hang.
 	cmd.SetWaitDelay(10 * time.Second)
 
-	// pgctld provisions PostgreSQL with Supabase Pico-instance defaults
-	// (work_mem=1092kB, random_page_cost=1.1, effective_cache_size=192MB,
-	// max_parallel_workers_per_gather=1). pg_regress expected .out files were
-	// captured against vanilla PostgreSQL defaults, so the planner picks
-	// different shapes (e.g. Hash↔Merge, Bitmap↔Index) under our defaults.
-	// Override to vanilla values per session via PGOPTIONS so the harness
-	// matches upstream fixtures without changing production pgctld defaults.
+	// pg_regress expected .out files were captured against vanilla PostgreSQL
+	// defaults, so the planner picks different shapes (e.g. Hash↔Merge,
+	// Bitmap↔Index) when pgctld's tuned GUCs are in effect. Override to
+	// PostgreSQL defaults per session via PGOPTIONS so the harness matches
+	// upstream fixtures without changing pgctld defaults.
 	pgOptions := "-c work_mem=4MB" +
 		" -c random_page_cost=4.0" +
 		" -c effective_cache_size=4GB" +


### PR DESCRIPTION
## Summary

- pg_regress harness was reporting plan-shape diffs (Hash↔Merge, Bitmap↔Index) on EXPLAIN tests because pgctld provisions PostgreSQL with Supabase Pico-instance defaults while upstream `.out` fixtures were captured against vanilla PostgreSQL defaults.
- Inject `PGOPTIONS` in the harness env so pg_regress sessions run with vanilla planner GUCs. Production pgctld defaults are unchanged.

Closes [MUL-402](https://linear.app/supabase/issue/MUL-402/use-default-postgres-gucs-for-pg-regress).

## Problem

`pgctld` ships these defaults (`go/services/pgctld/postgresconfig_gen.go:86-105`):

| GUC | pgctld | vanilla PostgreSQL |
|---|---|---|
| `work_mem` | 1092kB | 4MB |
| `random_page_cost` | 1.1 | 4.0 |
| `effective_cache_size` | 192MB | 4GB |
| `max_parallel_workers_per_gather` | 1 | 2 |

Upstream `pg_regress` expected `.out` files were captured against vanilla defaults. The planner reacts to the GUC delta — small `work_mem` makes hash joins look expensive, low `random_page_cost` makes index scans look cheap — so EXPLAIN-bearing tests (e.g. `updatable_views`, `inherit`, `subselect`, `join`) fail purely on plan-shape diffs even though results are identical.

EXPLAIN bypasses multigateway's normalizer (`isCacheable()` excludes utility statements), so the diffs are not caused by query rewriting. They are produced by PostgreSQL's planner reacting to its own GUCs.

## Solution

Set `PGOPTIONS` in `runTestSuite`'s env block so libpq forwards `-c work_mem=4MB -c random_page_cost=4.0 -c effective_cache_size=4GB -c max_parallel_workers_per_gather=2` as startup options. multigateway already passes startup parameters through to the backend session, verified locally (`SHOW work_mem` returns `4MB` after connection). Production pgctld defaults stay intact — only the regress harness uses vanilla values.

## Validation

Three EXPLAIN MERGE statements from `updatable_views` (the diffs at lines 5302-5370 of the latest scheduled run) were re-run against a fresh local cluster:

- With pgctld defaults: plans matched the failing `+` lines (Nested Loop + Index Scan, Merge Left Join + Sort).
- With `PGOPTIONS` set to vanilla values: plans matched the upstream `-` lines exactly (Hash Join + Bitmap Heap Scan + Bitmap Index Scan).

Out of scope: parser/rewriter diffs such as `missing FROM-clause entry for table "foo"` in `join.out` — not caused by GUCs and tracked separately.