### PR TITLE
test(pgregresstest): persist per-test residual diffs to artifact

### DIFF
--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -139,7 +139,7 @@ func TestPostgreSQLRegression(t *testing.T) {
 			// verification. Operates on the regress build directory, where
 			// pg_regress wrote expected/ and results/ files.
 			regressDir := filepath.Join(builder.BuildDir, "src", "test", "regress")
-			if verr := builder.VerifyWithPatches(t, suiteCtx, results, regressDir); verr != nil {
+			if verr := builder.VerifyWithPatches(t, suiteCtx, results, regressDir, builder.OutputDir); verr != nil {
 				t.Logf("Warning: patch verification failed: %v", verr)
 			}
 

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -408,7 +408,7 @@ func findExpectedFile(regressDir, name string) string {
 // Expected output lives in the source tree (prep_buildtree does not symlink
 // .out files into the build tree). Actual output is written by pg_regress
 // into the build tree's results/ directory.
-func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, results *TestResults, buildRegressDir string) error {
+func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, results *TestResults, buildRegressDir, outputDir string) error {
 	t.Helper()
 	mode := GetPatchMode()
 	patchDir := PatchesDir()
@@ -425,6 +425,14 @@ func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, 
 	t.Logf("Patch-based verification: mode=%s patches=%s", mode, patchDir)
 	t.Logf("  expected source: %s", sourceRegressDir)
 	t.Logf("  actual source:   %s", buildRegressDir)
+
+	// Per-test residual diffs are written under outputDir/diffs/ for inclusion
+	// in the CI artifact. Concatenated failures.diffs is written at the end.
+	diffsDir := ""
+	if outputDir != "" {
+		diffsDir = filepath.Join(outputDir, "diffs")
+	}
+	var aggregated bytes.Buffer
 
 	// Recompute aggregates from the per-test results after verification.
 	// We intentionally discard pg_regress's TAP-derived aggregates because
@@ -475,12 +483,35 @@ func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, 
 
 		if outcome.Status == "pass" {
 			passed++
+			continue
+		}
+		failed++
+		failures = append(failures, TestFailure{
+			TestName: test.Name,
+			Error:    outcome.Reason,
+		})
+
+		if outcome.Diff == "" || diffsDir == "" {
+			continue
+		}
+		if err := os.MkdirAll(diffsDir, 0o755); err != nil {
+			t.Logf("Warning: mkdir %s: %v", diffsDir, err)
+			continue
+		}
+		diffPath := filepath.Join(diffsDir, test.Name+".diff")
+		if err := os.WriteFile(diffPath, []byte(outcome.Diff), 0o644); err != nil {
+			t.Logf("Warning: write %s: %v", diffPath, err)
+			continue
+		}
+		fmt.Fprintf(&aggregated, "=== %s ===\n%s\n", test.Name, outcome.Diff)
+	}
+
+	if outputDir != "" && aggregated.Len() > 0 {
+		aggPath := filepath.Join(outputDir, "failures.diffs")
+		if err := os.WriteFile(aggPath, aggregated.Bytes(), 0o644); err != nil {
+			t.Logf("Warning: write %s: %v", aggPath, err)
 		} else {
-			failed++
-			failures = append(failures, TestFailure{
-				TestName: test.Name,
-				Error:    outcome.Reason,
-			})
+			t.Logf("Residual failure diffs: %s (per-test files in %s)", aggPath, diffsDir)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `VerifyWithPatches` already computes the patched-vs-actual residual diff per failing test (`outcome.Diff` in `patch_verify.go`), but the value is dropped on the floor — `results.json`, `compatibility-report.md`, and pg_regress's raw `regression.diffs` all lack it, so investigating a failure required re-running the suite locally.
- Write each failure's residual diff to `<outputDir>/diffs/<name>.diff` and a concatenated `<outputDir>/failures.diffs`. Both ride the existing artifact upload — downloading the CI artifact now gives the full set of residual diffs.

## Problem

After a CI run, the only diff data shipped is `regression.diffs` produced by pg_regress itself, which:

- Compares unpatched upstream `expected/` against `results/` directly, so it includes diffs for tests we mark as **passing** under our `.patch`-based verification (whitespace-only changes, error-message wording, etc.).
- Lacks any signal for which diffs are *real* residuals after patching.

`VerifyWithPatches` already produces the right artifact internally — `outcome.Diff` is the patched-vs-actual residual — but never persists it.

## Solution

In the per-test verification loop, on `outcome.Status == "fail"` and non-empty `outcome.Diff`, write `<outputDir>/diffs/<test>.diff`. After the loop, write a concatenated `failures.diffs` with `=== <name> ===` separators for one-shot grep.

`VerifyWithPatches` gains an `outputDir` parameter; the regression-suite call site passes `builder.OutputDir`. No table / report format changes — diffs are only on disk, picked up automatically by the existing `actions/upload-artifact` glob (`/tmp/multigres_pg_cache/results/**/*`).

## Validation

- `go build ./go/test/endtoend/pgregresstest/...` — clean.
- `go test -short ./go/test/endtoend/pgregresstest/...` — pass.
- Existing `patch_verify_test.go` exercises `VerifyTest` (unaffected); no harness-level tests changed signature.