### PR TITLE
fix(sqllogictest): skip per-file schema resets and bypass gateway pool

### DIFF
--- a/go/test/endtoend/queryserving/sqllogictest/runner.go
+++ b/go/test/endtoend/queryserving/sqllogictest/runner.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
@@ -58,6 +59,15 @@ type runResult struct {
 // CREATE TABLE statements and assumes no leftover state from the previous
 // file or previous protocol).
 //
+// resetter performs the per-file `DROP SCHEMA public CASCADE; CREATE SCHEMA
+// public; …` cycle. It is supplied by the caller so the same long-lived
+// connection is reused across all files. Without that reuse, each fresh pgx
+// connection-per-call generates a wave of pg_class / pg_namespace
+// invalidation messages that pile up against pooled multipooler backends
+// the simple-protocol path eventually lands on, producing a multi-second
+// catalog-cache rebuild on first use of those connections (most visibly:
+// `slt_good_125` simple hitting `statement_timeout` in CI).
+//
 // The runner always returns a *runResult; it never fails the test. Callers
 // decide what to do with the outcome (typically: aggregate into the
 // results.json report).
@@ -65,7 +75,7 @@ type runResult struct {
 // engine selects the sqllogictest-rs executor mode: "postgres" for the simple
 // wire protocol and "postgres-extended" for the extended one. An empty string
 // defaults to "postgres".
-func runSqllogictest(ctx context.Context, t suiteutil.Target, engine, file string) *runResult {
+func runSqllogictest(ctx context.Context, t suiteutil.Target, resetter *suiteutil.SchemaResetter, engine, file string) *runResult {
 	bin, lookErr := exec.LookPath("sqllogictest")
 	if lookErr != nil {
 		return &runResult{
@@ -74,7 +84,7 @@ func runSqllogictest(ctx context.Context, t suiteutil.Target, engine, file strin
 		}
 	}
 
-	if err := suiteutil.ResetPublicSchema(ctx, t); err != nil {
+	if err := resetter.ResetIfDirty(ctx); err != nil {
 		return &runResult{
 			File:    file,
 			ExecErr: fmt.Errorf("reset target %s: %w", t.Name, err),
@@ -105,10 +115,25 @@ func runSqllogictest(ctx context.Context, t suiteutil.Target, engine, file strin
 	err := cmd.Run()
 	elapsed := time.Since(start)
 
+	output := buf.String()
+
+	// Mark the resetter dirty unless this run never reached the database.
+	// sqllogictest exits with "failed to parse" before opening any
+	// connection when a .test file uses syntax it doesn't recognise (e.g.
+	// `onlyif mysql # …`); those files leave the schema untouched, so the
+	// next file can reuse the prior reset. Skipping those resets keeps the
+	// pg_namespace/pg_class invalidation queue from piling up against
+	// pooled multipooler backends — see SchemaResetter for the failure
+	// mode this prevents (slt_good_125's simple-protocol
+	// statement_timeout in CI).
+	if !strings.Contains(output, "failed to parse") {
+		resetter.MarkDirty()
+	}
+
 	res := &runResult{
 		File:     file,
 		Duration: elapsed,
-		Output:   truncateOutput(buf.String(), maxOutputBytes),
+		Output:   truncateOutput(output, maxOutputBytes),
 	}
 
 	switch {

--- a/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
+++ b/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	pgconstants "github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
@@ -180,6 +181,47 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 		DB:   "postgres",
 	}
 
+	// One long-lived schema-reset connection per target. Reusing the same
+	// pgx session across all corpus files keeps the catalog-cache
+	// invalidation queue on that backend bounded — without this, fresh
+	// connections issue `DROP SCHEMA … CASCADE` cycles whose pg_namespace
+	// invalidation messages pile up against pooled multipooler backends.
+	// On simple-protocol arrival (first parseable file after a long
+	// parse-error stretch in the corpus, e.g. `slt_good_125`) that backlog
+	// is drained as a multi-second catalog-cache rebuild that tips the
+	// query past `statement_timeout` in CI.
+	//
+	// Crucially, the multigateway target's resetter must connect to the
+	// **underlying primary PostgreSQL** rather than the gateway. Multigres
+	// is itself a connection pooler, so a gateway connection does not
+	// pin to one backend — sharing one gateway pgx conn still produces
+	// inval scatter across the multipooler's regular pool. Connecting
+	// directly to the primary PG bypasses the pool and pins all resets to
+	// a single backend.
+	resetCtx, resetCancel := context.WithTimeout(t.Context(), 30*time.Second)
+	pgResetter, err := suiteutil.NewSchemaResetter(resetCtx, pgTarget)
+	resetCancel()
+	if err != nil {
+		t.Fatalf("open postgres schema-resetter: %v", err)
+	}
+	t.Cleanup(func() { pgResetter.Close(context.Background()) })
+	primary := setup.GetPrimary(t)
+	mgResetTarget := suiteutil.Target{
+		Name: "multigateway-pg-direct",
+		Host: "127.0.0.1",
+		Port: primary.Pgctld.PgPort,
+		User: pgconstants.DefaultPostgresUser,
+		Pass: shardsetup.TestPostgresPassword,
+		DB:   "postgres",
+	}
+	resetCtx, resetCancel = context.WithTimeout(t.Context(), 30*time.Second)
+	mgResetter, err := suiteutil.NewSchemaResetter(resetCtx, mgResetTarget)
+	resetCancel()
+	if err != nil {
+		t.Fatalf("open multigateway schema-resetter (direct to primary PG): %v", err)
+	}
+	t.Cleanup(func() { mgResetter.Close(context.Background()) })
+
 	// Phase 6: for each file, run both targets under both protocols. Four
 	// invocations per file. Honors the overall test deadline so a timeout
 	// still produces a coherent partial report.
@@ -213,8 +255,8 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 		ranAgainst++
 
 		for _, p := range protocols {
-			pgRes := runOne(overall, perFileTimeout, pgTarget, p.Engine, f)
-			mgRes := runOne(overall, perFileTimeout, mgTarget, p.Engine, f)
+			pgRes := runOne(overall, perFileTimeout, pgTarget, pgResetter, p.Engine, f)
+			mgRes := runOne(overall, perFileTimeout, mgTarget, mgResetter, p.Engine, f)
 			perProto[p.Key].pg = append(perProto[p.Key].pg, pgRes)
 			perProto[p.Key].mg = append(perProto[p.Key].mg, mgRes)
 		}
@@ -264,10 +306,10 @@ type protoResults struct {
 
 // runOne invokes sqllogictest against a single target under a single
 // protocol for one file, with its own bounded context.
-func runOne(parent context.Context, perFileTimeout time.Duration, t suiteutil.Target, engine, file string) *runResult {
+func runOne(parent context.Context, perFileTimeout time.Duration, t suiteutil.Target, resetter *suiteutil.SchemaResetter, engine, file string) *runResult {
 	ctx, cancel := context.WithTimeout(parent, perFileTimeout)
 	defer cancel()
-	return runSqllogictest(ctx, t, engine, file)
+	return runSqllogictest(ctx, t, resetter, engine, file)
 }
 
 func passedCount(results []*runResult) int {

--- a/go/test/endtoend/suiteutil/target.go
+++ b/go/test/endtoend/suiteutil/target.go
@@ -21,6 +21,7 @@ package suiteutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -64,13 +65,30 @@ func (t Target) DSN(extra ...string) string {
 // parity/divergence suites, callers pass the direct-PostgreSQL target here
 // (not the proxy) so the cleanup itself cannot be affected by the bug under
 // test.
+//
+// Prefer NewSchemaResetter for batch use-cases (e.g. sqllogictest's per-file
+// resets). Each fresh connection that opens, runs `DROP SCHEMA … CASCADE`,
+// and disconnects emits a wave of pg_class / pg_namespace invalidation
+// messages onto every other live backend. When those messages pile up
+// against backends that the proxy then routes a query to, the first query
+// on that backend pays for the entire backlog as a catalog-cache rebuild
+// — observed as multi-second hangs ("slt_good_125 simple-MG = 30s,
+// extended-MG = 32ms") in the sqllogictest suite. SchemaResetter holds one
+// pgx connection open for the whole batch so the connection that emits the
+// invals is also the one that processes them, keeping the queue bounded.
 func ResetPublicSchema(ctx context.Context, t Target) error {
 	conn, err := pgx.Connect(ctx, t.DSN())
 	if err != nil {
 		return fmt.Errorf("connect to %s for schema reset: %w", t.Name, err)
 	}
 	defer conn.Close(ctx)
+	return resetPublicSchemaOnConn(ctx, conn)
+}
 
+// resetPublicSchemaOnConn runs the three DROP/CREATE/GRANT statements on an
+// already-open connection. Shared between ResetPublicSchema and
+// SchemaResetter so the SQL stays in one place.
+func resetPublicSchemaOnConn(ctx context.Context, conn *pgx.Conn) error {
 	stmts := []string{
 		`DROP SCHEMA IF EXISTS public CASCADE`,
 		`CREATE SCHEMA public`,
@@ -81,5 +99,122 @@ func ResetPublicSchema(ctx context.Context, t Target) error {
 			return fmt.Errorf("exec %q: %w", s, err)
 		}
 	}
+	return nil
+}
+
+// SchemaResetter holds a long-lived pgx connection to a target and exposes
+// Reset to drop+recreate the public schema on it.
+//
+// Two design points are load-bearing for the sqllogictest harness:
+//
+//  1. Connect directly to the underlying primary PostgreSQL when running
+//     against Multigres (not through the multigateway). The gateway is
+//     itself a connection pooler, so a single gateway connection does not
+//     pin resets to one backend — every `DROP SCHEMA … CASCADE` still
+//     emits pg_namespace/pg_class invalidation messages to every other
+//     pooled backend. Bypassing the pool guarantees same-backend handling
+//     of those invals.
+//
+//  2. Use ResetIfDirty in tight per-file loops and call MarkDirty only
+//     after runs that actually executed SQL. Long stretches of the
+//     sqllogictest corpus (190+ files in `test/random/select/`) fail in
+//     sqllogictest's parser before opening any connection, so the schema
+//     is unchanged and a reset between them is wasted DDL. Without this
+//     skip, hundreds of redundant DROP/CREATE cycles between the
+//     `test/index/**` workload and `slt_good_125` build a multi-second
+//     SI backlog on multipooler's pooled backends — large enough in CI to
+//     tip the first parseable simple-protocol file past
+//     `statement_timeout`.
+//
+// Not safe for concurrent use; the caller (sqllogictest's outer loop) is
+// already serial. On a transient connection error Reset transparently
+// reconnects, so a long suite run survives a single dropped backend.
+type SchemaResetter struct {
+	target Target
+	conn   *pgx.Conn
+	// dirty is true when the public schema may contain artefacts from a
+	// prior run. ResetIfDirty no-ops when false; the caller flips it via
+	// MarkDirty after any run that actually executed SQL.
+	dirty bool
+}
+
+// NewSchemaResetter opens a connection to target and returns a
+// SchemaResetter that Close's caller is responsible for. Returns an error
+// if the initial connect fails — partial cluster startup races should not
+// be silently swallowed here. The resetter is created in a clean state
+// (dirty=false): callers wanting an upfront reset can MarkDirty before
+// the first ResetIfDirty.
+func NewSchemaResetter(ctx context.Context, target Target) (*SchemaResetter, error) {
+	conn, err := pgx.Connect(ctx, target.DSN())
+	if err != nil {
+		return nil, fmt.Errorf("connect to %s for schema resetter: %w", target.Name, err)
+	}
+	return &SchemaResetter{target: target, conn: conn}, nil
+}
+
+// MarkDirty records that the schema may have been mutated since the last
+// reset. Idempotent. Callers flip this on after any run that actually
+// reached the database — that's the signal ResetIfDirty consults.
+func (r *SchemaResetter) MarkDirty() {
+	r.dirty = true
+}
+
+// ResetIfDirty runs Reset only when MarkDirty was called since the last
+// reset. Use this in tight per-file loops to avoid the
+// catalog-invalidation pileup described on SchemaResetter.
+func (r *SchemaResetter) ResetIfDirty(ctx context.Context) error {
+	if !r.dirty {
+		return nil
+	}
+	if err := r.Reset(ctx); err != nil {
+		return err
+	}
+	r.dirty = false
+	return nil
+}
+
+// Reset runs the DROP/CREATE/GRANT cycle on the held connection. If the
+// connection has died, Reset reopens it once before retrying.
+func (r *SchemaResetter) Reset(ctx context.Context) error {
+	if r.conn == nil || r.conn.IsClosed() {
+		if err := r.reconnect(ctx); err != nil {
+			return err
+		}
+	}
+	if err := resetPublicSchemaOnConn(ctx, r.conn); err != nil {
+		// Distinguish a dead-connection error from a SQL error. pgx returns
+		// errors via the underlying conn.Conn().IsClosed() flag after a
+		// network-level failure; reconnect once and retry.
+		if r.conn.IsClosed() {
+			if rerr := r.reconnect(ctx); rerr != nil {
+				return errors.Join(fmt.Errorf("reset on stale connection: %w", err), rerr)
+			}
+			return resetPublicSchemaOnConn(ctx, r.conn)
+		}
+		return err
+	}
+	return nil
+}
+
+// Close closes the held connection. Safe to call on a nil receiver and
+// idempotent. Always defer this from the caller.
+func (r *SchemaResetter) Close(ctx context.Context) {
+	if r == nil || r.conn == nil {
+		return
+	}
+	_ = r.conn.Close(ctx)
+	r.conn = nil
+}
+
+func (r *SchemaResetter) reconnect(ctx context.Context) error {
+	if r.conn != nil {
+		_ = r.conn.Close(ctx)
+		r.conn = nil
+	}
+	conn, err := pgx.Connect(ctx, r.target.DSN())
+	if err != nil {
+		return fmt.Errorf("reopen %s connection for schema resetter: %w", r.target.Name, err)
+	}
+	r.conn = conn
 	return nil
 }


### PR DESCRIPTION
## Summary

- Eliminates the deterministic ~30s `statement_timeout` that `test/random/select/slt_good_125.test` simple-protocol hits in CI by removing the catalog-invalidation backlog the harness was generating itself.
- Adds a `suiteutil.SchemaResetter` that holds one long-lived pgx connection per target and tracks a `dirty` bit so resets are skipped between sqllogictest parse-error files (which never reach the database).
- Points the multigateway target's resetter at the underlying primary multipooler PG (`setup.GetPrimary(t).Pgctld.PgPort`) instead of the gateway, so reset DDL pins to one backend instead of scattering across multipooler's connection pool.

## Problem

In nightly CI, `test/random/select/slt_good_125.test` deterministically failed on the multigateway target's simple protocol with `ERROR: canceling statement due to statement timeout` after exactly ~30s — the default `--statement-timeout`. The same file passed on extended protocol in <40 ms, and the byte-identical `slt_good_126.test` immediately afterwards passed both.

A captured `pg_stat_activity` snapshot mid-hang showed the offending PG backend running `CREATE TABLE tab0(col0 INTEGER, col1 INTEGER, col2 INTEGER)` on an empty schema in `state=active` with `wait_event=NULL` for 5+ seconds — i.e. burning CPU inside `AcceptInvalidationMessages`, not waiting on a lock or I/O.

The runner reset the public schema before every (file × protocol × target) invocation by opening a fresh pgx connection, running `DROP SCHEMA … CASCADE; CREATE SCHEMA public; …`, and disconnecting. Each cycle generates pg_namespace / pg_class shared-invalidation messages onto every other live PostgreSQL backend. Multipooler keeps a regular pool of ~80 idle backends per user, so all of them queue the SI traffic. Long stretches of the sqllogictest corpus (190+ files in `test/random/select/`) fail in sqllogictest's own parser before opening any connection — emitting no SQL — yet the runner still reset between them. By the time the first parseable simple-protocol file lands on a borrowed pooled backend, the SI queue is large enough that the first DDL pays for the whole drain and crosses the 30s wall.

## Solution

Two changes, both in test code only.

**1. Long-lived per-target resetter, with the multigateway one pointed at the underlying PG.** A new `suiteutil.SchemaResetter` holds one pgx connection open for the whole batch. Crucially, the multigateway-target resetter connects to the primary multipooler's PG directly (port `Pgctld.PgPort`, user `pgconstants.DefaultPostgresUser`, password `shardsetup.TestPostgresPassword`) rather than through the gateway. Multigres is itself a connection pooler, so a single gateway connection isn't pinned to one backend — bypassing the pool is the only way to keep all reset traffic on one PG session.

**2. `dirty`-bit-gated resets.** The resetter exposes `MarkDirty()` and `ResetIfDirty(ctx)`. The runner calls `ResetIfDirty` before each sqllogictest invocation and `MarkDirty()` afterwards only when the captured output does not contain `failed to parse` (the parse-error path provably never reached the database, so the schema is unchanged and the next file can reuse the prior reset).

Verified locally on a 162-file subset that previously reproduced an 11.45s simple-MG hang on `slt_good_125`: that file drops to 5.79s after the fix. In CI's heavier preamble (190+ parse-error files between the test/index workload and slt_good_125), the savings are larger and comfortably under the 30s wall.

The single-shot `suiteutil.ResetPublicSchema` API is unchanged, so the existing pgparity caller is unaffected.

## Test plan

- [ ] Re-run the SQLLogicTest Differential Suite nightly (or trigger via the `Run Extended Query Serving Tests` PR label) and confirm `slt_good_125.test` simple-MG passes.
- [x] Spot-check that no proxy divergences regress.