### PR TITLE
refactor: replace types.ShardKey struct with *clustermetadatapb.ShardKey

### DIFF
--- a/go/common/topoclient/backup_lock.go
+++ b/go/common/topoclient/backup_lock.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 // BackupsPath is the path component for backup locks in the topology hierarchy.
@@ -61,7 +62,7 @@ const BackupLeaseStealGracePeriod = 5 * time.Second
 const BackupLeaseCheckInterval = 10 * time.Second
 
 type backupLock struct {
-	types.ShardKey
+	shardKey *clustermetadatapb.ShardKey
 }
 
 var _ iTopoLock = (*backupLock)(nil)
@@ -71,17 +72,17 @@ func (b *backupLock) Type() string {
 }
 
 func (b *backupLock) ResourceName() string {
-	return b.ShardKey.String()
+	return string(types.FormatShardKey(b.shardKey))
 }
 
 func (b *backupLock) Path() string {
-	return fmt.Sprintf("%s/%s/%s/%s/lock", BackupsPath, b.Database, b.TableGroup, b.Shard)
+	return fmt.Sprintf("%s/%s/%s/%s/lock", BackupsPath, b.shardKey.Database, b.shardKey.TableGroup, b.shardKey.Shard)
 }
 
 // AssertBackupLockHeld checks that the backup lock is held for the given shard
 // in the provided context. Returns an error if it is not.
-func AssertBackupLockHeld(ctx context.Context, shardKey types.ShardKey) error {
-	return checkLocked(ctx, &backupLock{ShardKey: shardKey})
+func AssertBackupLockHeld(ctx context.Context, shardKey *clustermetadatapb.ShardKey) error {
+	return checkLocked(ctx, &backupLock{shardKey: shardKey})
 }
 
 // TryLockBackup attempts to acquire a backup lock on the specified shard without
@@ -90,8 +91,8 @@ func AssertBackupLockHeld(ctx context.Context, shardKey types.ShardKey) error {
 //
 // The lock uses a 30s TTL with KeepAlive as a safety net for crash recovery.
 // Normal release is done by calling the returned unlock function.
-func (ts *store) TryLockBackup(ctx context.Context, shardKey types.ShardKey, action string) (context.Context, func(*error), error) {
-	bl := &backupLock{ShardKey: shardKey}
+func (ts *store) TryLockBackup(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string) (context.Context, func(*error), error) {
+	bl := &backupLock{shardKey: shardKey}
 	// Use NamedNonBlocking semantics (fail-fast, creates path) with custom TTL
 	return ts.internalLock(ctx, bl, action,
 		WithType(NamedNonBlockingWithTTL),
@@ -105,8 +106,8 @@ func (ts *store) TryLockBackup(ctx context.Context, shardKey types.ShardKey, act
 // triggering process cleanup on their side.
 //
 // Returns nil if no lock exists.
-func (ts *store) RevokeBackup(ctx context.Context, shardKey types.ShardKey) error {
-	bl := &backupLock{ShardKey: shardKey}
+func (ts *store) RevokeBackup(ctx context.Context, shardKey *clustermetadatapb.ShardKey) error {
+	bl := &backupLock{shardKey: shardKey}
 	if ts.globalTopo == nil {
 		return errors.New("no global cell connection on the topo server")
 	}
@@ -121,7 +122,7 @@ func (ts *store) RevokeBackup(ctx context.Context, shardKey types.ShardKey) erro
 // to steal.
 func (ts *store) WithBackupLease(
 	ctx context.Context,
-	shardKey types.ShardKey,
+	shardKey *clustermetadatapb.ShardKey,
 	holderID string,
 	operation string,
 	logger *slog.Logger,
@@ -131,17 +132,17 @@ func (ts *store) WithBackupLease(
 	acquire, revoke, check := ts.backupLeaseOps(shardKey)
 
 	logger.InfoContext(ctx, "Acquiring backup lease",
-		"shard", shardKey.String(), "holder", holderID, "operation", operation)
+		"shard", types.FormatShardKey(shardKey), "holder", holderID, "operation", operation)
 
 	err := WithLease(ctx, action, acquire, revoke, check, fn,
 		WithLeaseCheckInterval(BackupLeaseCheckInterval),
 	)
 	if err != nil {
 		logger.InfoContext(ctx, "Backup lease operation completed with error",
-			"shard", shardKey.String(), "holder", holderID, "error", err)
+			"shard", types.FormatShardKey(shardKey), "holder", holderID, "error", err)
 	} else {
 		logger.InfoContext(ctx, "Backup lease operation completed",
-			"shard", shardKey.String(), "holder", holderID, "operation", operation)
+			"shard", types.FormatShardKey(shardKey), "holder", holderID, "operation", operation)
 	}
 	return err
 }
@@ -154,7 +155,7 @@ func (ts *store) WithBackupLease(
 // contenders for the lease, retries of steals would cause thrashing of the lease.
 func (ts *store) WithStolenBackupLease(
 	ctx context.Context,
-	shardKey types.ShardKey,
+	shardKey *clustermetadatapb.ShardKey,
 	stealerID string,
 	operation string,
 	logger *slog.Logger,
@@ -164,7 +165,7 @@ func (ts *store) WithStolenBackupLease(
 	acquire, revoke, check := ts.backupLeaseOps(shardKey)
 
 	logger.InfoContext(ctx, "Acquiring backup lease (steal-enabled)",
-		"shard", shardKey.String(), "stealer", stealerID, "operation", operation)
+		"shard", types.FormatShardKey(shardKey), "stealer", stealerID, "operation", operation)
 
 	err := WithLease(ctx, action, acquire, revoke, check, fn,
 		WithStealGracePeriod(BackupLeaseStealGracePeriod),
@@ -172,16 +173,16 @@ func (ts *store) WithStolenBackupLease(
 	)
 	if err != nil {
 		logger.InfoContext(ctx, "Backup lease operation completed with error",
-			"shard", shardKey.String(), "stealer", stealerID, "error", err)
+			"shard", types.FormatShardKey(shardKey), "stealer", stealerID, "error", err)
 	} else {
 		logger.InfoContext(ctx, "Backup lease operation completed",
-			"shard", shardKey.String(), "stealer", stealerID, "operation", operation)
+			"shard", types.FormatShardKey(shardKey), "stealer", stealerID, "operation", operation)
 	}
 	return err
 }
 
 // backupLeaseOps returns the acquire/revoke/check closures for backup lease operations.
-func (ts *store) backupLeaseOps(shardKey types.ShardKey) (LeaseAcquirer, LeaseRevoker, LeaseChecker) {
+func (ts *store) backupLeaseOps(shardKey *clustermetadatapb.ShardKey) (LeaseAcquirer, LeaseRevoker, LeaseChecker) {
 	return func(ctx context.Context, action string) (context.Context, func(*error), error) {
 			return ts.TryLockBackup(ctx, shardKey, action)
 		},

--- a/go/common/topoclient/backup_lock_test.go
+++ b/go/common/topoclient/backup_lock_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 func newTestStore(t *testing.T) topoclient.Store {
@@ -39,7 +39,7 @@ func newTestStore(t *testing.T) topoclient.Store {
 	return ts
 }
 
-var testShardKey = types.ShardKey{
+var testShardKey = &clustermetadatapb.ShardKey{
 	Database:   "testdb",
 	TableGroup: constants.DefaultTableGroup,
 	Shard:      "0",
@@ -54,7 +54,7 @@ func TestTryLockBackup(t *testing.T) {
 	ts, _ := memorytopo.NewServerAndFactoryWithConfig(ctx, config, "zone1")
 	defer ts.Close()
 
-	shardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
 
 	// Acquire backup lock
 	lockCtx, unlock, err := ts.TryLockBackup(ctx, shardKey, "backup by pooler-1")
@@ -69,7 +69,7 @@ func TestTryLockBackup(t *testing.T) {
 	require.Error(t, err)
 
 	// Different shard should succeed
-	shardKey2 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
+	shardKey2 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
 	_, unlock2, err := ts.TryLockBackup(ctx, shardKey2, "backup by pooler-1")
 	require.NoError(t, err)
 	var unlockErr error
@@ -96,7 +96,7 @@ func TestForceUnlockBackup(t *testing.T) {
 	ts, _ := memorytopo.NewServerAndFactoryWithConfig(ctx, config, "zone1")
 	defer ts.Close()
 
-	shardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
 
 	// Acquire backup lock
 	_, _, err := ts.TryLockBackup(ctx, shardKey, "backup by pooler-1")
@@ -127,7 +127,7 @@ func TestAssertBackupLockHeld(t *testing.T) {
 	ts, _ := memorytopo.NewServerAndFactoryWithConfig(ctx, config, "zone1")
 	defer ts.Close()
 
-	shardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
 
 	// Assert should fail when no lock is held
 	err := topoclient.AssertBackupLockHeld(ctx, shardKey)
@@ -258,7 +258,7 @@ func TestWithBackupLeaseDifferentShards(t *testing.T) {
 	ctx := t.Context()
 	logger := slog.Default()
 
-	shardKey2 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
+	shardKey2 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
 
 	err := ts.WithBackupLease(ctx, testShardKey, "pooler-1", "backup", logger, func(ctx context.Context) error {
 		return nil

--- a/go/common/topoclient/shard_init_claim.go
+++ b/go/common/topoclient/shard_init_claim.go
@@ -26,7 +26,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
-func shardInitClaimPath(shardKey types.ShardKey) string {
+func shardInitClaimPath(shardKey *clustermetadatapb.ShardKey) string {
 	return path.Join(DatabasesPath, shardKey.Database, shardKey.TableGroup, shardKey.Shard, ShardInitClaimFile)
 }
 
@@ -39,7 +39,7 @@ func shardInitClaimPath(shardKey types.ShardKey) string {
 // Returns won=true and the committed cohort if this caller created the claim or
 // is resuming its own prior claim. Returns won=false if a different coordinator
 // already owns the initialization.
-func (ts *store) ClaimShardInitialization(ctx context.Context, shardKey types.ShardKey, claimerID *clustermetadatapb.ID, proposedCohort []*clustermetadatapb.ID) (bool, []*clustermetadatapb.ID, error) {
+func (ts *store) ClaimShardInitialization(ctx context.Context, shardKey *clustermetadatapb.ShardKey, claimerID *clustermetadatapb.ID, proposedCohort []*clustermetadatapb.ID) (bool, []*clustermetadatapb.ID, error) {
 	claim := &clustermetadatapb.ShardInitClaim{
 		ClaimerId:     claimerID,
 		CohortMembers: proposedCohort,
@@ -47,7 +47,7 @@ func (ts *store) ClaimShardInitialization(ctx context.Context, shardKey types.Sh
 
 	data, err := proto.Marshal(claim)
 	if err != nil {
-		return false, nil, mterrors.Wrapf(err, "failed to marshal shard init claim for %s", shardKey)
+		return false, nil, mterrors.Wrapf(err, "failed to marshal shard init claim for %s", types.FormatShardKey(shardKey))
 	}
 
 	filePath := shardInitClaimPath(shardKey)
@@ -58,18 +58,18 @@ func (ts *store) ClaimShardInitialization(ctx context.Context, shardKey types.Sh
 	}
 
 	if !errors.Is(err, &TopoError{Code: NodeExists}) {
-		return false, nil, mterrors.Wrapf(err, "failed to claim shard initialization for %s", shardKey)
+		return false, nil, mterrors.Wrapf(err, "failed to claim shard initialization for %s", types.FormatShardKey(shardKey))
 	}
 
 	// Claim already exists — read it back and check ownership.
 	existing, _, err := ts.globalTopo.Get(ctx, filePath)
 	if err != nil {
-		return false, nil, mterrors.Wrapf(err, "failed to read shard init claim for %s", shardKey)
+		return false, nil, mterrors.Wrapf(err, "failed to read shard init claim for %s", types.FormatShardKey(shardKey))
 	}
 
 	committed := &clustermetadatapb.ShardInitClaim{}
 	if err := proto.Unmarshal(existing, committed); err != nil {
-		return false, nil, mterrors.Wrapf(err, "failed to unmarshal shard init claim for %s", shardKey)
+		return false, nil, mterrors.Wrapf(err, "failed to unmarshal shard init claim for %s", types.FormatShardKey(shardKey))
 	}
 
 	if ClusterIDString(committed.ClaimerId) == ClusterIDString(claimerID) {

--- a/go/common/topoclient/shard_init_claim_test.go
+++ b/go/common/topoclient/shard_init_claim_test.go
@@ -20,12 +20,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	"github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 func TestClaimShardInitialization(t *testing.T) {
-	shardKey := types.ShardKey{Database: "mydb", TableGroup: "tg0", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "mydb", TableGroup: "tg0", Shard: "0"}
 	coord := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "cell1", Name: "orch-1"}
 	cohort := []*clustermetadatapb.ID{
 		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "p1"},

--- a/go/common/topoclient/shard_lock.go
+++ b/go/common/topoclient/shard_lock.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 
 	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 // ShardsPath is the path component for shards in the topology hierarchy.
 const ShardsPath = "shards"
 
 type shardLock struct {
-	types.ShardKey
+	shardKey *clustermetadatapb.ShardKey
 }
 
 var _ iTopoLock = (*shardLock)(nil)
@@ -37,11 +38,11 @@ func (s *shardLock) Type() string {
 }
 
 func (s *shardLock) ResourceName() string {
-	return s.ShardKey.String()
+	return string(types.FormatShardKey(s.shardKey))
 }
 
 func (s *shardLock) Path() string {
-	return fmt.Sprintf("%s/%s/%s/%s", DatabasesPath, s.Database, s.TableGroup, s.Shard)
+	return fmt.Sprintf("%s/%s/%s/%s", DatabasesPath, s.shardKey.Database, s.shardKey.TableGroup, s.shardKey.Shard)
 }
 
 // LockShard will lock the shard, and return:
@@ -55,10 +56,10 @@ func (s *shardLock) Path() string {
 // Note: Shard locks use named locks (LockNameWithTTL) which create the lock path
 // if it doesn't exist. If no TTL is specified via WithTTL option, it defaults to
 // NamedLockTTL (24 hours).
-func (ts *store) LockShard(ctx context.Context, shardKey types.ShardKey, action string, opts ...LockOption) (context.Context, func(*error), error) {
+func (ts *store) LockShard(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string, opts ...LockOption) (context.Context, func(*error), error) {
 	// Prepend Named lock type - user-provided options can override this
 	opts = append([]LockOption{WithType(Named)}, opts...)
-	return ts.internalLock(ctx, &shardLock{ShardKey: shardKey}, action, opts...)
+	return ts.internalLock(ctx, &shardLock{shardKey: shardKey}, action, opts...)
 }
 
 // TryLockShard will lock the shard, and return:
@@ -76,12 +77,12 @@ func (ts *store) LockShard(ctx context.Context, shardKey types.ShardKey, action 
 // and acquiring is not under the same mutex in current implementation of `TryLockShard`.
 //
 // Note: Uses NamedNonBlocking lock type which creates the lock path if it doesn't exist.
-func (ts *store) TryLockShard(ctx context.Context, shardKey types.ShardKey, action string) (context.Context, func(*error), error) {
-	return ts.internalLock(ctx, &shardLock{ShardKey: shardKey}, action, WithType(NamedNonBlocking))
+func (ts *store) TryLockShard(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string) (context.Context, func(*error), error) {
+	return ts.internalLock(ctx, &shardLock{shardKey: shardKey}, action, WithType(NamedNonBlocking))
 }
 
 // CheckShardLocked can be called on a context to make sure we have the lock
 // for a given shard.
-func CheckShardLocked(ctx context.Context, shardKey types.ShardKey) error {
-	return checkLocked(ctx, &shardLock{ShardKey: shardKey})
+func CheckShardLocked(ctx context.Context, shardKey *clustermetadatapb.ShardKey) error {
+	return checkLocked(ctx, &shardLock{shardKey: shardKey})
 }

--- a/go/common/topoclient/shard_lock_integration_test.go
+++ b/go/common/topoclient/shard_lock_integration_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 const testLockTimeout = 100 * time.Millisecond
@@ -41,8 +41,8 @@ func TestTopoShardLock(t *testing.T) {
 	ts, _ := memorytopo.NewServerAndFactoryWithConfig(ctx, config, "zone1")
 	defer ts.Close()
 
-	shardKey1 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
-	shardKey2 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
+	shardKey1 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey2 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
 
 	origCtx := ctx
 	ctx, unlock, err := ts.LockShard(origCtx, shardKey1, "db/default/0")

--- a/go/common/topoclient/shard_lock_test.go
+++ b/go/common/topoclient/shard_lock_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/constants"
-	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 // fakeLockDescriptor implements the topoclient.LockDescriptor interface for testing.
@@ -43,9 +43,9 @@ var _ LockDescriptor = (*fakeLockDescriptor)(nil)
 
 // lockedShardContext returns a context that appears to have a lock on the given shard.
 // This is useful for testing code that requires a shard lock to be held.
-func lockedShardContext(shardKey types.ShardKey) context.Context {
+func lockedShardContext(shardKey *clustermetadatapb.ShardKey) context.Context {
 	ctx := context.Background()
-	resourceName := (&shardLock{ShardKey: shardKey}).ResourceName()
+	resourceName := (&shardLock{shardKey: shardKey}).ResourceName()
 	return context.WithValue(ctx, locksKey, &locksInfo{
 		info: map[string]*lockInfo{
 			resourceName: {
@@ -56,7 +56,7 @@ func lockedShardContext(shardKey types.ShardKey) context.Context {
 }
 
 func TestCheckShardLocked(t *testing.T) {
-	shardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
 
 	t.Run("returns error when no lock info in context", func(t *testing.T) {
 		ctx := context.Background()
@@ -67,7 +67,7 @@ func TestCheckShardLocked(t *testing.T) {
 
 	t.Run("returns error when shard is not locked", func(t *testing.T) {
 		// Create a context with lock info, but for a different shard
-		otherShardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "other-shard"}
+		otherShardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "other-shard"}
 		ctx := lockedShardContext(otherShardKey)
 		err := CheckShardLocked(ctx, shardKey)
 		require.Error(t, err)
@@ -83,7 +83,7 @@ func TestCheckShardLocked(t *testing.T) {
 
 func TestShardLockInterface(t *testing.T) {
 	lock := &shardLock{
-		ShardKey: types.ShardKey{Database: "mydb", TableGroup: constants.DefaultTableGroup, Shard: "0"},
+		shardKey: &clustermetadatapb.ShardKey{Database: "mydb", TableGroup: constants.DefaultTableGroup, Shard: "0"},
 	}
 
 	t.Run("Type returns shard", func(t *testing.T) {
@@ -101,10 +101,10 @@ func TestShardLockInterface(t *testing.T) {
 
 func TestShardLockResourceNameUniqueness(t *testing.T) {
 	// Test that different shards have different resource names
-	lock1 := &shardLock{ShardKey: types.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}}
-	lock2 := &shardLock{ShardKey: types.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}}
-	lock3 := &shardLock{ShardKey: types.ShardKey{Database: "db1", TableGroup: "tg2", Shard: "0"}}
-	lock4 := &shardLock{ShardKey: types.ShardKey{Database: "db2", TableGroup: "tg1", Shard: "0"}}
+	lock1 := &shardLock{shardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}}
+	lock2 := &shardLock{shardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}}
+	lock3 := &shardLock{shardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg2", Shard: "0"}}
+	lock4 := &shardLock{shardKey: &clustermetadatapb.ShardKey{Database: "db2", TableGroup: "tg1", Shard: "0"}}
 
 	require.NotEqual(t, lock1.ResourceName(), lock2.ResourceName())
 	require.NotEqual(t, lock1.ResourceName(), lock3.ResourceName())
@@ -116,14 +116,14 @@ func TestShardLockResourceNameUniqueness(t *testing.T) {
 
 func TestLockedShardContextMultipleShards(t *testing.T) {
 	// Test that we can have multiple shards locked in the same context
-	shardKey1 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
-	shardKey2 := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
+	shardKey1 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+	shardKey2 := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "1"}
 
 	// Create context with first shard locked
 	ctx := lockedShardContext(shardKey1)
 
 	// Add second shard to the same context
-	resourceName2 := (&shardLock{ShardKey: shardKey2}).ResourceName()
+	resourceName2 := (&shardLock{shardKey: shardKey2}).ResourceName()
 	locksInfoVal := ctx.Value(locksKey).(*locksInfo)
 	locksInfoVal.info[resourceName2] = &lockInfo{
 		lockDescriptor: fakeLockDescriptor{},
@@ -134,7 +134,7 @@ func TestLockedShardContextMultipleShards(t *testing.T) {
 	require.NoError(t, CheckShardLocked(ctx, shardKey2))
 
 	// A different shard should not be locked
-	otherShardKey := types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "other"}
+	otherShardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "other"}
 	err := CheckShardLocked(ctx, otherShardKey)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is not locked (no lockInfo in map)")

--- a/go/common/topoclient/store.go
+++ b/go/common/topoclient/store.go
@@ -74,7 +74,6 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
@@ -207,33 +206,33 @@ type Store interface {
 
 	// LockShard acquires a lock on the specified shard.
 	// See shard_lock.go for full documentation.
-	LockShard(ctx context.Context, shardKey types.ShardKey, action string, opts ...LockOption) (context.Context, func(*error), error)
+	LockShard(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string, opts ...LockOption) (context.Context, func(*error), error)
 
 	// TryLockShard attempts to acquire a lock on the specified shard without blocking.
 	// See shard_lock.go for full documentation.
-	TryLockShard(ctx context.Context, shardKey types.ShardKey, action string) (context.Context, func(*error), error)
+	TryLockShard(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string) (context.Context, func(*error), error)
 
 	// TryLockBackup attempts to acquire a backup lock on the specified shard without blocking.
 	// See backup_lock.go for full documentation.
-	TryLockBackup(ctx context.Context, shardKey types.ShardKey, action string) (context.Context, func(*error), error)
+	TryLockBackup(ctx context.Context, shardKey *clustermetadatapb.ShardKey, action string) (context.Context, func(*error), error)
 
 	// ClaimShardInitialization atomically claims the right to initialize a shard.
 	// Persists both the claimer ID and the proposed cohort. On crash-retry the
 	// committed cohort is returned so the caller reuses the same members.
 	// Returns won=false if a different coordinator already owns the claim.
-	ClaimShardInitialization(ctx context.Context, shardKey types.ShardKey, claimerID *clustermetadatapb.ID, proposedCohort []*clustermetadatapb.ID) (won bool, committedCohort []*clustermetadatapb.ID, err error)
+	ClaimShardInitialization(ctx context.Context, shardKey *clustermetadatapb.ShardKey, claimerID *clustermetadatapb.ID, proposedCohort []*clustermetadatapb.ID) (won bool, committedCohort []*clustermetadatapb.ID, err error)
 
 	// RevokeBackup forcefully removes the backup lock for the specified shard.
 	// See backup_lock.go for full documentation.
-	RevokeBackup(ctx context.Context, shardKey types.ShardKey) error
+	RevokeBackup(ctx context.Context, shardKey *clustermetadatapb.ShardKey) error
 
 	// WithBackupLease acquires a backup lease, runs fn, and releases the lease when fn returns.
 	// See backup_lock.go for full documentation.
-	WithBackupLease(ctx context.Context, shardKey types.ShardKey, holderID string, operation string, logger *slog.Logger, fn func(ctx context.Context) error) error
+	WithBackupLease(ctx context.Context, shardKey *clustermetadatapb.ShardKey, holderID string, operation string, logger *slog.Logger, fn func(ctx context.Context) error) error
 
 	// WithStolenBackupLease acquires a backup lease (stealing if necessary), runs fn, and releases.
 	// See backup_lock.go for full documentation.
-	WithStolenBackupLease(ctx context.Context, shardKey types.ShardKey, stealerID string, operation string, logger *slog.Logger, fn func(ctx context.Context) error) error
+	WithStolenBackupLease(ctx context.Context, shardKey *clustermetadatapb.ShardKey, stealerID string, operation string, logger *slog.Logger, fn func(ctx context.Context) error) error
 
 	// GetRemoteOperationTimeout returns the configured timeout for remote operations.
 	// This should be used for RPCs and database operations that should use a shorter timeout than the parent context.

--- a/go/common/topoclient/test/shard_init_claim.go
+++ b/go/common/topoclient/test/shard_init_claim.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/topoclient"
-	"github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
@@ -30,7 +29,7 @@ import (
 // first caller wins, different caller loses, same caller after crash wins
 // with the originally committed cohort.
 func checkShardInitClaim(t *testing.T, ctx context.Context, ts topoclient.Store) {
-	shardKey := types.ShardKey{Database: "claimdb", TableGroup: "tg0", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "claimdb", TableGroup: "tg0", Shard: "0"}
 
 	coord1 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "cell1", Name: "orch-1"}
 	coord2 := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIORCH, Cell: "cell2", Name: "orch-2"}
@@ -63,7 +62,7 @@ func checkShardInitClaim(t *testing.T, ctx context.Context, ts topoclient.Store)
 	assert.False(t, won, "different caller should lose")
 
 	t.Log("===      independent shard can be claimed separately")
-	shardKey2 := types.ShardKey{Database: "claimdb", TableGroup: "tg0", Shard: "1"}
+	shardKey2 := &clustermetadatapb.ShardKey{Database: "claimdb", TableGroup: "tg0", Shard: "1"}
 	won, committed, err = ts.ClaimShardInitialization(ctx, shardKey2, coord2, cohort)
 	require.NoError(t, err)
 	assert.True(t, won, "different shard should be claimable independently")

--- a/go/common/topoclient/with_lease_test.go
+++ b/go/common/topoclient/with_lease_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	"github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
-var withLeaseShardKey = types.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
+var withLeaseShardKey = &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: constants.DefaultTableGroup, Shard: "0"}
 
 // backupLeaseOps returns the acquire/revoke/check closures for backup lease tests.
-func backupLeaseOps(ts topoclient.Store, shardKey types.ShardKey) (topoclient.LeaseAcquirer, topoclient.LeaseRevoker, topoclient.LeaseChecker) {
+func backupLeaseOps(ts topoclient.Store, shardKey *clustermetadatapb.ShardKey) (topoclient.LeaseAcquirer, topoclient.LeaseRevoker, topoclient.LeaseChecker) {
 	return func(ctx context.Context, action string) (context.Context, func(*error), error) {
 			return ts.TryLockBackup(ctx, shardKey, action)
 		},

--- a/go/common/types/shard_key.go
+++ b/go/common/types/shard_key.go
@@ -14,16 +14,20 @@
 
 package types
 
-import "fmt"
+import (
+	"fmt"
 
-// ShardKey uniquely identifies a shard.
-type ShardKey struct {
-	Database   string
-	TableGroup string
-	Shard      string
-}
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+)
 
-// String returns a string representation of the ShardKey.
-func (s ShardKey) String() string {
-	return fmt.Sprintf("%s/%s/%s", s.Database, s.TableGroup, s.Shard)
+// ShardKeyString is the stable string representation of a shard key.
+// Use as map keys, log fields, and error context.
+type ShardKeyString string
+
+// FormatShardKey returns the ShardKeyString for a proto ShardKey.
+func FormatShardKey(k *clustermetadatapb.ShardKey) ShardKeyString {
+	if k == nil {
+		return ""
+	}
+	return ShardKeyString(fmt.Sprintf("%s/%s/%s", k.Database, k.TableGroup, k.Shard))
 }

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -325,7 +325,7 @@ func (x ID_ComponentType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ID_ComponentType.Descriptor instead.
 func (ID_ComponentType) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{10, 0}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{11, 0}
 }
 
 // TopoConfig defines the connection parameters for a topology service.
@@ -1026,6 +1026,71 @@ func (x *MultiGateway) GetPidPrefix() uint32 {
 	return 0
 }
 
+// ShardKey uniquely identifies a shard in the cluster.
+// This is a centralized message used across all services to identify shards.
+type ShardKey struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Database name.
+	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
+	// TableGroup name.
+	TableGroup string `protobuf:"bytes,2,opt,name=table_group,json=tableGroup,proto3" json:"table_group,omitempty"`
+	// Shard name. If range based sharding is used, it should match key_range.
+	Shard         string `protobuf:"bytes,3,opt,name=shard,proto3" json:"shard,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ShardKey) Reset() {
+	*x = ShardKey{}
+	mi := &file_clustermetadata_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ShardKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ShardKey) ProtoMessage() {}
+
+func (x *ShardKey) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ShardKey.ProtoReflect.Descriptor instead.
+func (*ShardKey) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ShardKey) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
+}
+
+func (x *ShardKey) GetTableGroup() string {
+	if x != nil {
+		return x.TableGroup
+	}
+	return ""
+}
+
+func (x *ShardKey) GetShard() string {
+	if x != nil {
+		return x.Shard
+	}
+	return ""
+}
+
 // MultiOrch represents information about a running instance of multiorch.
 type MultiOrch struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1041,7 +1106,7 @@ type MultiOrch struct {
 
 func (x *MultiOrch) Reset() {
 	*x = MultiOrch{}
-	mi := &file_clustermetadata_proto_msgTypes[9]
+	mi := &file_clustermetadata_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1053,7 +1118,7 @@ func (x *MultiOrch) String() string {
 func (*MultiOrch) ProtoMessage() {}
 
 func (x *MultiOrch) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[9]
+	mi := &file_clustermetadata_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1066,7 +1131,7 @@ func (x *MultiOrch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MultiOrch.ProtoReflect.Descriptor instead.
 func (*MultiOrch) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{9}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *MultiOrch) GetId() *ID {
@@ -1106,7 +1171,7 @@ type ID struct {
 
 func (x *ID) Reset() {
 	*x = ID{}
-	mi := &file_clustermetadata_proto_msgTypes[10]
+	mi := &file_clustermetadata_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1118,7 +1183,7 @@ func (x *ID) String() string {
 func (*ID) ProtoMessage() {}
 
 func (x *ID) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[10]
+	mi := &file_clustermetadata_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1131,7 +1196,7 @@ func (x *ID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ID.ProtoReflect.Descriptor instead.
 func (*ID) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{10}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ID) GetComponent() ID_ComponentType {
@@ -1168,7 +1233,7 @@ type KeyRange struct {
 
 func (x *KeyRange) Reset() {
 	*x = KeyRange{}
-	mi := &file_clustermetadata_proto_msgTypes[11]
+	mi := &file_clustermetadata_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1180,7 +1245,7 @@ func (x *KeyRange) String() string {
 func (*KeyRange) ProtoMessage() {}
 
 func (x *KeyRange) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[11]
+	mi := &file_clustermetadata_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1193,7 +1258,7 @@ func (x *KeyRange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyRange.ProtoReflect.Descriptor instead.
 func (*KeyRange) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{11}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *KeyRange) GetStart() []byte {
@@ -1234,7 +1299,7 @@ type DurabilityPolicy struct {
 
 func (x *DurabilityPolicy) Reset() {
 	*x = DurabilityPolicy{}
-	mi := &file_clustermetadata_proto_msgTypes[12]
+	mi := &file_clustermetadata_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1246,7 +1311,7 @@ func (x *DurabilityPolicy) String() string {
 func (*DurabilityPolicy) ProtoMessage() {}
 
 func (x *DurabilityPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[12]
+	mi := &file_clustermetadata_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1259,7 +1324,7 @@ func (x *DurabilityPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DurabilityPolicy.ProtoReflect.Descriptor instead.
 func (*DurabilityPolicy) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{12}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DurabilityPolicy) GetPolicyName() string {
@@ -1315,7 +1380,7 @@ type RuleNumber struct {
 
 func (x *RuleNumber) Reset() {
 	*x = RuleNumber{}
-	mi := &file_clustermetadata_proto_msgTypes[13]
+	mi := &file_clustermetadata_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1327,7 +1392,7 @@ func (x *RuleNumber) String() string {
 func (*RuleNumber) ProtoMessage() {}
 
 func (x *RuleNumber) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[13]
+	mi := &file_clustermetadata_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1340,7 +1405,7 @@ func (x *RuleNumber) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleNumber.ProtoReflect.Descriptor instead.
 func (*RuleNumber) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{13}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *RuleNumber) GetCoordinatorTerm() int64 {
@@ -1381,7 +1446,7 @@ type ShardRule struct {
 
 func (x *ShardRule) Reset() {
 	*x = ShardRule{}
-	mi := &file_clustermetadata_proto_msgTypes[14]
+	mi := &file_clustermetadata_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1393,7 +1458,7 @@ func (x *ShardRule) String() string {
 func (*ShardRule) ProtoMessage() {}
 
 func (x *ShardRule) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[14]
+	mi := &file_clustermetadata_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1406,7 +1471,7 @@ func (x *ShardRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardRule.ProtoReflect.Descriptor instead.
 func (*ShardRule) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{14}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ShardRule) GetRuleNumber() *RuleNumber {
@@ -1475,7 +1540,7 @@ type PoolerPosition struct {
 
 func (x *PoolerPosition) Reset() {
 	*x = PoolerPosition{}
-	mi := &file_clustermetadata_proto_msgTypes[15]
+	mi := &file_clustermetadata_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1487,7 +1552,7 @@ func (x *PoolerPosition) String() string {
 func (*PoolerPosition) ProtoMessage() {}
 
 func (x *PoolerPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[15]
+	mi := &file_clustermetadata_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1500,7 +1565,7 @@ func (x *PoolerPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PoolerPosition.ProtoReflect.Descriptor instead.
 func (*PoolerPosition) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{15}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PoolerPosition) GetRule() *ShardRule {
@@ -1541,7 +1606,7 @@ type HighestKnownRule struct {
 
 func (x *HighestKnownRule) Reset() {
 	*x = HighestKnownRule{}
-	mi := &file_clustermetadata_proto_msgTypes[16]
+	mi := &file_clustermetadata_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1618,7 @@ func (x *HighestKnownRule) String() string {
 func (*HighestKnownRule) ProtoMessage() {}
 
 func (x *HighestKnownRule) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[16]
+	mi := &file_clustermetadata_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1631,7 @@ func (x *HighestKnownRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HighestKnownRule.ProtoReflect.Descriptor instead.
 func (*HighestKnownRule) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{16}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *HighestKnownRule) GetRule() *ShardRule {
@@ -1614,7 +1679,7 @@ type TermRevocation struct {
 
 func (x *TermRevocation) Reset() {
 	*x = TermRevocation{}
-	mi := &file_clustermetadata_proto_msgTypes[17]
+	mi := &file_clustermetadata_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1626,7 +1691,7 @@ func (x *TermRevocation) String() string {
 func (*TermRevocation) ProtoMessage() {}
 
 func (x *TermRevocation) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[17]
+	mi := &file_clustermetadata_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1639,7 +1704,7 @@ func (x *TermRevocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TermRevocation.ProtoReflect.Descriptor instead.
 func (*TermRevocation) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{17}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TermRevocation) GetRevokedBelowTerm() int64 {
@@ -1698,7 +1763,7 @@ type ConsensusStatus struct {
 
 func (x *ConsensusStatus) Reset() {
 	*x = ConsensusStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[18]
+	mi := &file_clustermetadata_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1710,7 +1775,7 @@ func (x *ConsensusStatus) String() string {
 func (*ConsensusStatus) ProtoMessage() {}
 
 func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[18]
+	mi := &file_clustermetadata_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1723,7 +1788,7 @@ func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusStatus.ProtoReflect.Descriptor instead.
 func (*ConsensusStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{18}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ConsensusStatus) GetTermRevocation() *TermRevocation {
@@ -1769,7 +1834,7 @@ type LeadershipStatus struct {
 
 func (x *LeadershipStatus) Reset() {
 	*x = LeadershipStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[19]
+	mi := &file_clustermetadata_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1781,7 +1846,7 @@ func (x *LeadershipStatus) String() string {
 func (*LeadershipStatus) ProtoMessage() {}
 
 func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[19]
+	mi := &file_clustermetadata_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1794,7 +1859,7 @@ func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeadershipStatus.ProtoReflect.Descriptor instead.
 func (*LeadershipStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LeadershipStatus) GetLeaderTerm() int64 {
@@ -1835,7 +1900,7 @@ type AvailabilityStatus struct {
 
 func (x *AvailabilityStatus) Reset() {
 	*x = AvailabilityStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1847,7 +1912,7 @@ func (x *AvailabilityStatus) String() string {
 func (*AvailabilityStatus) ProtoMessage() {}
 
 func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1860,7 +1925,7 @@ func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AvailabilityStatus.ProtoReflect.Descriptor instead.
 func (*AvailabilityStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AvailabilityStatus) GetLeadershipStatus() *LeadershipStatus {
@@ -1934,7 +1999,12 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"pid_prefix\x18\x04 \x01(\rR\tpidPrefix\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xcc\x01\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"]\n" +
+	"\bShardKey\x12\x1a\n" +
+	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x1f\n" +
+	"\vtable_group\x18\x02 \x01(\tR\n" +
+	"tableGroup\x12\x14\n" +
+	"\x05shard\x18\x03 \x01(\tR\x05shard\"\xcc\x01\n" +
 	"\tMultiOrch\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12B\n" +
@@ -2029,7 +2099,7 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 }
 
 var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),               // 0: clustermetadata.PoolerType
 	(PoolerServingStatus)(0),      // 1: clustermetadata.PoolerServingStatus
@@ -2045,57 +2115,58 @@ var file_clustermetadata_proto_goTypes = []any{
 	(*S3Backup)(nil),              // 11: clustermetadata.S3Backup
 	(*MultiPooler)(nil),           // 12: clustermetadata.MultiPooler
 	(*MultiGateway)(nil),          // 13: clustermetadata.MultiGateway
-	(*MultiOrch)(nil),             // 14: clustermetadata.MultiOrch
-	(*ID)(nil),                    // 15: clustermetadata.ID
-	(*KeyRange)(nil),              // 16: clustermetadata.KeyRange
-	(*DurabilityPolicy)(nil),      // 17: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),            // 18: clustermetadata.RuleNumber
-	(*ShardRule)(nil),             // 19: clustermetadata.ShardRule
-	(*PoolerPosition)(nil),        // 20: clustermetadata.PoolerPosition
-	(*HighestKnownRule)(nil),      // 21: clustermetadata.HighestKnownRule
-	(*TermRevocation)(nil),        // 22: clustermetadata.TermRevocation
-	(*ConsensusStatus)(nil),       // 23: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),      // 24: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),    // 25: clustermetadata.AvailabilityStatus
-	nil,                           // 26: clustermetadata.MultiPooler.PortMapEntry
-	nil,                           // 27: clustermetadata.MultiGateway.PortMapEntry
-	nil,                           // 28: clustermetadata.MultiOrch.PortMapEntry
-	(*timestamppb.Timestamp)(nil), // 29: google.protobuf.Timestamp
+	(*ShardKey)(nil),              // 14: clustermetadata.ShardKey
+	(*MultiOrch)(nil),             // 15: clustermetadata.MultiOrch
+	(*ID)(nil),                    // 16: clustermetadata.ID
+	(*KeyRange)(nil),              // 17: clustermetadata.KeyRange
+	(*DurabilityPolicy)(nil),      // 18: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),            // 19: clustermetadata.RuleNumber
+	(*ShardRule)(nil),             // 20: clustermetadata.ShardRule
+	(*PoolerPosition)(nil),        // 21: clustermetadata.PoolerPosition
+	(*HighestKnownRule)(nil),      // 22: clustermetadata.HighestKnownRule
+	(*TermRevocation)(nil),        // 23: clustermetadata.TermRevocation
+	(*ConsensusStatus)(nil),       // 24: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),      // 25: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),    // 26: clustermetadata.AvailabilityStatus
+	nil,                           // 27: clustermetadata.MultiPooler.PortMapEntry
+	nil,                           // 28: clustermetadata.MultiGateway.PortMapEntry
+	nil,                           // 29: clustermetadata.MultiOrch.PortMapEntry
+	(*timestamppb.Timestamp)(nil), // 30: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
 	9,  // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	17, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	15, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	15, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	18, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	16, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	16, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
 	10, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
 	11, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	15, // 6: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	16, // 7: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	16, // 6: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
+	17, // 7: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 8: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
 	1,  // 9: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	26, // 10: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	15, // 11: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	27, // 12: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	15, // 13: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	28, // 14: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	27, // 10: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	16, // 11: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	28, // 12: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	16, // 13: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	29, // 14: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
 	4,  // 15: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
 	2,  // 16: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	18, // 17: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	15, // 18: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	15, // 19: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	17, // 20: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	15, // 21: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	29, // 22: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	19, // 23: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	19, // 24: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
-	15, // 25: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	29, // 26: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	22, // 27: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	20, // 28: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	21, // 29: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
-	15, // 30: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	19, // 17: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	16, // 18: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	16, // 19: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	18, // 20: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	16, // 21: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	30, // 22: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	20, // 23: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
+	20, // 24: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
+	16, // 25: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	30, // 26: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	23, // 27: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	21, // 28: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	22, // 29: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
+	16, // 30: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
 	3,  // 31: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	24, // 32: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	25, // 32: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
 	33, // [33:33] is the sub-list for method output_type
 	33, // [33:33] is the sub-list for method input_type
 	33, // [33:33] is the sub-list for extension type_name
@@ -2118,7 +2189,7 @@ func file_clustermetadata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multiorch/multiorchservice.pb.go
+++ b/go/pb/multiorch/multiorchservice.pb.go
@@ -40,9 +40,7 @@ const (
 type ShardStatusRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Shard to get status for
-	Database      string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
-	TableGroup    string `protobuf:"bytes,2,opt,name=table_group,json=tableGroup,proto3" json:"table_group,omitempty"`
-	Shard         string `protobuf:"bytes,3,opt,name=shard,proto3" json:"shard,omitempty"`
+	ShardKey      *clustermetadata.ShardKey `protobuf:"bytes,1,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -77,25 +75,11 @@ func (*ShardStatusRequest) Descriptor() ([]byte, []int) {
 	return file_multiorchservice_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *ShardStatusRequest) GetDatabase() string {
+func (x *ShardStatusRequest) GetShardKey() *clustermetadata.ShardKey {
 	if x != nil {
-		return x.Database
+		return x.ShardKey
 	}
-	return ""
-}
-
-func (x *ShardStatusRequest) GetTableGroup() string {
-	if x != nil {
-		return x.TableGroup
-	}
-	return ""
-}
-
-func (x *ShardStatusRequest) GetShard() string {
-	if x != nil {
-		return x.Shard
-	}
-	return ""
+	return nil
 }
 
 type ShardStatusResponse struct {
@@ -153,17 +137,15 @@ func (x *ShardStatusResponse) GetPoolerHealths() []*PoolerHealth {
 }
 
 type DetectedProblem struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Code          string                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`                            // e.g., "PrimaryIsDead"
-	CheckName     string                 `protobuf:"bytes,2,opt,name=check_name,json=checkName,proto3" json:"check_name,omitempty"` // Analyzer name
-	PoolerId      *clustermetadata.ID    `protobuf:"bytes,3,opt,name=pooler_id,json=poolerId,proto3" json:"pooler_id,omitempty"`    // Affected pooler
-	Database      string                 `protobuf:"bytes,4,opt,name=database,proto3" json:"database,omitempty"`
-	TableGroup    string                 `protobuf:"bytes,5,opt,name=table_group,json=tableGroup,proto3" json:"table_group,omitempty"`
-	Shard         string                 `protobuf:"bytes,6,opt,name=shard,proto3" json:"shard,omitempty"`
-	Description   string                 `protobuf:"bytes,7,opt,name=description,proto3" json:"description,omitempty"`
-	Priority      int32                  `protobuf:"varint,8,opt,name=priority,proto3" json:"priority,omitempty"`
-	Scope         string                 `protobuf:"bytes,9,opt,name=scope,proto3" json:"scope,omitempty"` // "Shard" or "Pooler"
-	DetectedAt    *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=detected_at,json=detectedAt,proto3" json:"detected_at,omitempty"`
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Code          string                    `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`                            // e.g., "PrimaryIsDead"
+	CheckName     string                    `protobuf:"bytes,2,opt,name=check_name,json=checkName,proto3" json:"check_name,omitempty"` // Analyzer name
+	PoolerId      *clustermetadata.ID       `protobuf:"bytes,3,opt,name=pooler_id,json=poolerId,proto3" json:"pooler_id,omitempty"`    // Affected pooler
+	ShardKey      *clustermetadata.ShardKey `protobuf:"bytes,4,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"`
+	Description   string                    `protobuf:"bytes,5,opt,name=description,proto3" json:"description,omitempty"`
+	Priority      int32                     `protobuf:"varint,6,opt,name=priority,proto3" json:"priority,omitempty"`
+	Scope         string                    `protobuf:"bytes,7,opt,name=scope,proto3" json:"scope,omitempty"` // "Shard" or "Pooler"
+	DetectedAt    *timestamppb.Timestamp    `protobuf:"bytes,8,opt,name=detected_at,json=detectedAt,proto3" json:"detected_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -219,25 +201,11 @@ func (x *DetectedProblem) GetPoolerId() *clustermetadata.ID {
 	return nil
 }
 
-func (x *DetectedProblem) GetDatabase() string {
+func (x *DetectedProblem) GetShardKey() *clustermetadata.ShardKey {
 	if x != nil {
-		return x.Database
+		return x.ShardKey
 	}
-	return ""
-}
-
-func (x *DetectedProblem) GetTableGroup() string {
-	if x != nil {
-		return x.TableGroup
-	}
-	return ""
-}
-
-func (x *DetectedProblem) GetShard() string {
-	if x != nil {
-		return x.Shard
-	}
-	return ""
+	return nil
 }
 
 func (x *DetectedProblem) GetDescription() string {
@@ -710,29 +678,22 @@ var File_multiorchservice_proto protoreflect.FileDescriptor
 
 const file_multiorchservice_proto_rawDesc = "" +
 	"\n" +
-	"\x16multiorchservice.proto\x12\tmultiorch\x1a\x15clustermetadata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"g\n" +
-	"\x12ShardStatusRequest\x12\x1a\n" +
-	"\bdatabase\x18\x01 \x01(\tR\bdatabase\x12\x1f\n" +
-	"\vtable_group\x18\x02 \x01(\tR\n" +
-	"tableGroup\x12\x14\n" +
-	"\x05shard\x18\x03 \x01(\tR\x05shard\"\x8d\x01\n" +
+	"\x16multiorchservice.proto\x12\tmultiorch\x1a\x15clustermetadata.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"L\n" +
+	"\x12ShardStatusRequest\x126\n" +
+	"\tshard_key\x18\x01 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\"\x8d\x01\n" +
 	"\x13ShardStatusResponse\x126\n" +
 	"\bproblems\x18\x01 \x03(\v2\x1a.multiorch.DetectedProblemR\bproblems\x12>\n" +
-	"\x0epooler_healths\x18\x02 \x03(\v2\x17.multiorch.PoolerHealthR\rpoolerHealths\"\xda\x02\n" +
+	"\x0epooler_healths\x18\x02 \x03(\v2\x17.multiorch.PoolerHealthR\rpoolerHealths\"\xbf\x02\n" +
 	"\x0fDetectedProblem\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x1d\n" +
 	"\n" +
 	"check_name\x18\x02 \x01(\tR\tcheckName\x120\n" +
-	"\tpooler_id\x18\x03 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12\x1a\n" +
-	"\bdatabase\x18\x04 \x01(\tR\bdatabase\x12\x1f\n" +
-	"\vtable_group\x18\x05 \x01(\tR\n" +
-	"tableGroup\x12\x14\n" +
-	"\x05shard\x18\x06 \x01(\tR\x05shard\x12 \n" +
-	"\vdescription\x18\a \x01(\tR\vdescription\x12\x1a\n" +
-	"\bpriority\x18\b \x01(\x05R\bpriority\x12\x14\n" +
-	"\x05scope\x18\t \x01(\tR\x05scope\x12;\n" +
-	"\vdetected_at\x18\n" +
-	" \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"\tpooler_id\x18\x03 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x126\n" +
+	"\tshard_key\x18\x04 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x12 \n" +
+	"\vdescription\x18\x05 \x01(\tR\vdescription\x12\x1a\n" +
+	"\bpriority\x18\x06 \x01(\x05R\bpriority\x12\x14\n" +
+	"\x05scope\x18\a \x01(\tR\x05scope\x12;\n" +
+	"\vdetected_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"detectedAt\"\x8c\x02\n" +
 	"\fPoolerHealth\x120\n" +
 	"\tpooler_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12\x1c\n" +
@@ -792,31 +753,34 @@ var file_multiorchservice_proto_goTypes = []any{
 	(*GetRecoveryStatusResponse)(nil),  // 9: multiorch.GetRecoveryStatusResponse
 	(*TriggerRecoveryNowRequest)(nil),  // 10: multiorch.TriggerRecoveryNowRequest
 	(*TriggerRecoveryNowResponse)(nil), // 11: multiorch.TriggerRecoveryNowResponse
-	(*clustermetadata.ID)(nil),         // 12: clustermetadata.ID
-	(*timestamppb.Timestamp)(nil),      // 13: google.protobuf.Timestamp
+	(*clustermetadata.ShardKey)(nil),   // 12: clustermetadata.ShardKey
+	(*clustermetadata.ID)(nil),         // 13: clustermetadata.ID
+	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
 }
 var file_multiorchservice_proto_depIdxs = []int32{
-	2,  // 0: multiorch.ShardStatusResponse.problems:type_name -> multiorch.DetectedProblem
-	3,  // 1: multiorch.ShardStatusResponse.pooler_healths:type_name -> multiorch.PoolerHealth
-	12, // 2: multiorch.DetectedProblem.pooler_id:type_name -> clustermetadata.ID
-	13, // 3: multiorch.DetectedProblem.detected_at:type_name -> google.protobuf.Timestamp
-	12, // 4: multiorch.PoolerHealth.pooler_id:type_name -> clustermetadata.ID
-	13, // 5: multiorch.PoolerHealth.last_check:type_name -> google.protobuf.Timestamp
-	0,  // 6: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
-	4,  // 7: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
-	6,  // 8: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
-	8,  // 9: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
-	10, // 10: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
-	1,  // 11: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
-	5,  // 12: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
-	7,  // 13: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
-	9,  // 14: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
-	11, // 15: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
-	11, // [11:16] is the sub-list for method output_type
-	6,  // [6:11] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	12, // 0: multiorch.ShardStatusRequest.shard_key:type_name -> clustermetadata.ShardKey
+	2,  // 1: multiorch.ShardStatusResponse.problems:type_name -> multiorch.DetectedProblem
+	3,  // 2: multiorch.ShardStatusResponse.pooler_healths:type_name -> multiorch.PoolerHealth
+	13, // 3: multiorch.DetectedProblem.pooler_id:type_name -> clustermetadata.ID
+	12, // 4: multiorch.DetectedProblem.shard_key:type_name -> clustermetadata.ShardKey
+	14, // 5: multiorch.DetectedProblem.detected_at:type_name -> google.protobuf.Timestamp
+	13, // 6: multiorch.PoolerHealth.pooler_id:type_name -> clustermetadata.ID
+	14, // 7: multiorch.PoolerHealth.last_check:type_name -> google.protobuf.Timestamp
+	0,  // 8: multiorch.MultiOrchService.GetShardStatus:input_type -> multiorch.ShardStatusRequest
+	4,  // 9: multiorch.MultiOrchService.DisableRecovery:input_type -> multiorch.DisableRecoveryRequest
+	6,  // 10: multiorch.MultiOrchService.EnableRecovery:input_type -> multiorch.EnableRecoveryRequest
+	8,  // 11: multiorch.MultiOrchService.GetRecoveryStatus:input_type -> multiorch.GetRecoveryStatusRequest
+	10, // 12: multiorch.MultiOrchService.TriggerRecoveryNow:input_type -> multiorch.TriggerRecoveryNowRequest
+	1,  // 13: multiorch.MultiOrchService.GetShardStatus:output_type -> multiorch.ShardStatusResponse
+	5,  // 14: multiorch.MultiOrchService.DisableRecovery:output_type -> multiorch.DisableRecoveryResponse
+	7,  // 15: multiorch.MultiOrchService.EnableRecovery:output_type -> multiorch.EnableRecoveryResponse
+	9,  // 16: multiorch.MultiOrchService.GetRecoveryStatus:output_type -> multiorch.GetRecoveryStatusResponse
+	11, // 17: multiorch.MultiOrchService.TriggerRecoveryNow:output_type -> multiorch.TriggerRecoveryNowResponse
+	13, // [13:18] is the sub-list for method output_type
+	8,  // [8:13] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_multiorchservice_proto_init() }

--- a/go/services/multigateway/buffer/buffer.go
+++ b/go/services/multigateway/buffer/buffer.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	commontypes "github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 // RetryDoneFunc must be called by the caller after the retry attempt completes.
@@ -52,7 +53,7 @@ type entry struct {
 	bufferCtx    context.Context
 	bufferCancel context.CancelFunc
 	// shardKey identifies which shard this entry belongs to.
-	shardKey commontypes.ShardKey
+	shardKey *clustermetadatapb.ShardKey
 	// createdAt records when the entry was enqueued for metrics.
 	createdAt time.Time
 }
@@ -88,7 +89,7 @@ type Buffer struct {
 	bufferSizeSema *semaphore.Weighted
 
 	mu      sync.Mutex
-	buffers map[commontypes.ShardKey]*shardBuffer
+	buffers map[commontypes.ShardKeyString]*shardBuffer
 	queue   []*entry // Global FIFO queue (all shards interleaved)
 	stopped bool
 
@@ -106,7 +107,7 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, opts ...Optio
 		ctx:            ctx,
 		cancel:         cancel,
 		bufferSizeSema: semaphore.NewWeighted(int64(config.Size.Get())),
-		buffers:        make(map[commontypes.ShardKey]*shardBuffer),
+		buffers:        make(map[commontypes.ShardKeyString]*shardBuffer),
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -120,7 +121,7 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, opts ...Optio
 // a failover. When the failover completes, the returned RetryDoneFunc must
 // be called after the retry attempt completes. Returns (nil, nil) if
 // buffering is not applicable (disabled, wrong target type, timing guard, etc).
-func (b *Buffer) WaitForFailoverEnd(ctx context.Context, key commontypes.ShardKey) (RetryDoneFunc, error) {
+func (b *Buffer) WaitForFailoverEnd(ctx context.Context, key *clustermetadatapb.ShardKey) (RetryDoneFunc, error) {
 	if !b.config.Enabled.Get() {
 		return nil, nil
 	}
@@ -134,14 +135,14 @@ func (b *Buffer) WaitForFailoverEnd(ctx context.Context, key commontypes.ShardKe
 // it does NOT start buffering for idle shards. This is used proactively before
 // sending a query to avoid a wasted round-trip to a pooler that is known to be
 // failing over.
-func (b *Buffer) WaitIfAlreadyBuffering(ctx context.Context, key commontypes.ShardKey) (RetryDoneFunc, error) {
+func (b *Buffer) WaitIfAlreadyBuffering(ctx context.Context, key *clustermetadatapb.ShardKey) (RetryDoneFunc, error) {
 	if !b.config.Enabled.Get() {
 		return nil, nil
 	}
 
 	// Lookup only — don't create a shardBuffer for a shard we've never seen.
 	b.mu.Lock()
-	sb, ok := b.buffers[key]
+	sb, ok := b.buffers[commontypes.FormatShardKey(key)]
 	b.mu.Unlock()
 	if !ok {
 		return nil, nil
@@ -152,9 +153,9 @@ func (b *Buffer) WaitIfAlreadyBuffering(ctx context.Context, key commontypes.Sha
 
 // StopBuffering is called when a new PRIMARY is discovered for the given shard.
 // It transitions the shard from BUFFERING to DRAINING.
-func (b *Buffer) StopBuffering(key commontypes.ShardKey) {
+func (b *Buffer) StopBuffering(key *clustermetadatapb.ShardKey) {
 	b.mu.Lock()
-	sb, ok := b.buffers[key]
+	sb, ok := b.buffers[commontypes.FormatShardKey(key)]
 	b.mu.Unlock()
 
 	if !ok {
@@ -207,14 +208,15 @@ func (b *Buffer) Shutdown() {
 	b.logger.Info("buffer shut down")
 }
 
-func (b *Buffer) getOrCreateShardBuffer(key commontypes.ShardKey) *shardBuffer {
+func (b *Buffer) getOrCreateShardBuffer(key *clustermetadatapb.ShardKey) *shardBuffer {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	sb, ok := b.buffers[key]
+	keyStr := commontypes.FormatShardKey(key)
+	sb, ok := b.buffers[keyStr]
 	if !ok {
 		sb = newShardBuffer(b, key)
-		b.buffers[key] = sb
+		b.buffers[keyStr] = sb
 	}
 	return sb
 }
@@ -225,7 +227,7 @@ func (b *Buffer) getOrCreateShardBuffer(key commontypes.ShardKey) *shardBuffer {
 // keeps the implementation simple and avoids per-shard capacity tracking. For the
 // common case (single-shard failover) there is no cross-shard interference.
 // Must NOT be called with b.mu held.
-func (b *Buffer) enqueue(shardKey commontypes.ShardKey) (*entry, error) {
+func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -247,7 +249,7 @@ func (b *Buffer) enqueue(shardKey commontypes.ShardKey) (*entry, error) {
 		b.queue = b.queue[1:]
 		oldest.err = mterrors.MTB01.New()
 		close(oldest.done)
-		b.stats.recordEvicted(b.ctx, oldest.shardKey.String(), "buffer_full")
+		b.stats.recordEvicted(b.ctx, string(commontypes.FormatShardKey(oldest.shardKey)), "buffer_full")
 		// The evicted entry's semaphore slot is conceptually transferred to us,
 		// so we don't need to acquire again.
 	}
@@ -263,7 +265,7 @@ func (b *Buffer) enqueue(shardKey commontypes.ShardKey) (*entry, error) {
 		createdAt:    now,
 	}
 	b.queue = append(b.queue, e)
-	b.stats.recordBuffered(b.ctx, shardKey.String())
+	b.stats.recordBuffered(b.ctx, string(commontypes.FormatShardKey(shardKey)))
 
 	// Notify timeout thread only when the queue transitions from empty to
 	// non-empty. Entries are always appended to the tail, and the timeout
@@ -298,14 +300,15 @@ func (b *Buffer) removeEntry(e *entry) {
 // drainEntriesForShard removes and returns all entries for the given shard
 // from the global queue.
 // Must NOT be called with b.mu held.
-func (b *Buffer) drainEntriesForShard(shardKey commontypes.ShardKey) []*entry {
+func (b *Buffer) drainEntriesForShard(shardKey *clustermetadatapb.ShardKey) []*entry {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	shardKeyStr := commontypes.FormatShardKey(shardKey)
 	var drained []*entry
 	remaining := b.queue[:0]
 	for _, e := range b.queue {
-		if e.shardKey == shardKey {
+		if commontypes.FormatShardKey(e.shardKey) == shardKeyStr {
 			drained = append(drained, e)
 		} else {
 			remaining = append(remaining, e)

--- a/go/services/multigateway/buffer/buffer_test.go
+++ b/go/services/multigateway/buffer/buffer_test.go
@@ -28,12 +28,13 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	commontypes "github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
 var (
-	shard1Key = commontypes.ShardKey{TableGroup: "tg1", Shard: "shard1"}
-	shard2Key = commontypes.ShardKey{TableGroup: "tg1", Shard: "shard2"}
+	shard1Key = &clustermetadatapb.ShardKey{TableGroup: "tg1", Shard: "shard1"}
+	shard2Key = &clustermetadatapb.ShardKey{TableGroup: "tg1", Shard: "shard2"}
 )
 
 func testConfig(t *testing.T, opts ...func(*Config)) *Config {
@@ -259,7 +260,7 @@ func TestBufferStaleMaxDurationTimer(t *testing.T) {
 
 	// Wait for max duration to fire and drain.
 	wg.Wait()
-	sb := buf.buffers[shard1Key]
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
 	sb.drainWg.Wait()
 
 	// Failover 2: start buffering again immediately.
@@ -351,7 +352,7 @@ func TestBufferTimingGuard(t *testing.T) {
 	buf.StopBuffering(shard1Key)
 	wg.Wait()
 
-	sb := buf.buffers[shard1Key]
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
 	sb.drainWg.Wait()
 
 	// Second failover: should be skipped (too soon).
@@ -404,13 +405,13 @@ func TestBufferMultipleShards(t *testing.T) {
 
 	// Stop buffering for shard1 only.
 	buf.StopBuffering(shard1Key)
-	sb := buf.buffers[shard1Key]
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
 	sb.drainWg.Wait()
 
 	// shard2 should still be buffered.
 	buf.mu.Lock()
 	assert.Len(t, buf.queue, 1)
-	assert.Equal(t, shard2Key, buf.queue[0].shardKey)
+	assert.Equal(t, commontypes.FormatShardKey(shard2Key), commontypes.FormatShardKey(buf.queue[0].shardKey))
 	buf.mu.Unlock()
 
 	// Stop buffering for shard2.
@@ -604,7 +605,7 @@ func TestBufferContextCancelDuringDrain(t *testing.T) {
 
 	// Wait for the shard buffer drain to complete. If the bug is present,
 	// this will hang because drainEntry blocks on <-e.bufferCtx.Done() forever.
-	sb := buf.buffers[shard1Key]
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
 	sb.drainWg.Wait()
 
 	wg.Wait()
@@ -628,7 +629,7 @@ func TestBufferProactiveBuffering(t *testing.T) {
 	assert.Nil(t, retryDone, "idle shard should not proactively buffer")
 
 	// WaitIfAlreadyBuffering on an unknown shard should return (nil, nil).
-	retryDone, err = buf.WaitIfAlreadyBuffering(ctx, commontypes.ShardKey{TableGroup: "unknown", Shard: "unknown"})
+	retryDone, err = buf.WaitIfAlreadyBuffering(ctx, &clustermetadatapb.ShardKey{TableGroup: "unknown", Shard: "unknown"})
 	assert.NoError(t, err)
 	assert.Nil(t, retryDone, "unknown shard should not proactively buffer")
 

--- a/go/services/multigateway/buffer/shard_buffer.go
+++ b/go/services/multigateway/buffer/shard_buffer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	commontypes "github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
 
 // bufferState represents the state of a per-shard buffer.
@@ -49,7 +50,7 @@ func (s bufferState) String() string {
 // State transitions: IDLE -> BUFFERING -> DRAINING -> IDLE
 type shardBuffer struct {
 	buf      *Buffer
-	shardKey commontypes.ShardKey
+	shardKey *clustermetadatapb.ShardKey
 	logger   *slog.Logger
 
 	mu               sync.Mutex
@@ -61,7 +62,7 @@ type shardBuffer struct {
 	drainWg          sync.WaitGroup
 }
 
-func newShardBuffer(buf *Buffer, key commontypes.ShardKey) *shardBuffer {
+func newShardBuffer(buf *Buffer, key *clustermetadatapb.ShardKey) *shardBuffer {
 	return &shardBuffer{
 		buf:      buf,
 		shardKey: key,
@@ -127,7 +128,7 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context) (RetryDoneFunc, e
 		gen := sb.generation
 		sb.lastStart = sb.buf.now()
 		sb.logger.InfoContext(ctx, "failover detected, starting buffering")
-		sb.buf.stats.recordFailover(ctx, sb.shardKey.String())
+		sb.buf.stats.recordFailover(ctx, string(commontypes.FormatShardKey(sb.shardKey)))
 
 		// Start max-duration timer. The generation is captured so that if
 		// the timer fires after this failover has already ended and a new
@@ -168,7 +169,7 @@ func (sb *shardBuffer) waitOnEntry(ctx context.Context, e *entry) (RetryDoneFunc
 		// <-e.bufferCtx.Done(). If the entry was still in the queue,
 		// this is harmless (nobody is watching bufferCtx).
 		e.bufferCancel()
-		sb.buf.stats.recordEvicted(sb.buf.ctx, sb.shardKey.String(), "context_canceled")
+		sb.buf.stats.recordEvicted(sb.buf.ctx, string(commontypes.FormatShardKey(sb.shardKey)), "context_canceled")
 		sb.buf.stats.recordWaitDuration(sb.buf.ctx, sb.buf.now().Sub(start).Seconds())
 		return nil, ctx.Err()
 	case <-e.done:
@@ -251,7 +252,7 @@ func (sb *shardBuffer) stopBuffering(reason string, gen uint64) {
 func (sb *shardBuffer) drainEntry(e *entry) {
 	// Signal the entry to retry by closing its done channel.
 	close(e.done)
-	sb.buf.stats.recordDrained(sb.buf.ctx, sb.shardKey.String())
+	sb.buf.stats.recordDrained(sb.buf.ctx, string(commontypes.FormatShardKey(sb.shardKey)))
 
 	// Wait for the retry to complete (caller invokes RetryDoneFunc which
 	// calls bufferCancel).

--- a/go/services/multigateway/buffer/timeout_thread.go
+++ b/go/services/multigateway/buffer/timeout_thread.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	commontypes "github.com/multigres/multigres/go/common/types"
 )
 
 // timeoutThread is a single goroutine that monitors the head of the global
@@ -135,6 +136,6 @@ func (tt *timeoutThread) evictHead() {
 	head.err = mterrors.MTB02.New()
 	close(head.done)
 	tt.buf.bufferSizeSema.Release(1)
-	tt.buf.stats.recordEvicted(tt.buf.ctx, head.shardKey.String(), "window_exceeded")
-	tt.buf.logger.Debug("evicted entry: window exceeded", "shard_key", head.shardKey)
+	tt.buf.stats.recordEvicted(tt.buf.ctx, string(commontypes.FormatShardKey(head.shardKey)), "window_exceeded")
+	tt.buf.logger.Debug("evicted entry: window exceeded", "shard_key", commontypes.FormatShardKey(head.shardKey))
 }

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -37,7 +37,6 @@ import (
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/servenv/toporeg"
 	"github.com/multigres/multigres/go/common/topoclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	querypb "github.com/multigres/multigres/go/pb/query"
@@ -334,7 +333,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		// This is a direct signal from the pooler's health stream — more reliable
 		// and lower latency than topology-based propagation via etcd.
 		loadBalancer.SetOnPrimaryServing(func(tableGroup, shard string) {
-			mg.buffer.StopBuffering(commontypes.ShardKey{
+			mg.buffer.StopBuffering(&clustermetadatapb.ShardKey{
 				TableGroup: tableGroup,
 				Shard:      shard,
 			})

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -32,7 +32,6 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/sqltypes"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
@@ -124,7 +123,7 @@ func (pg *PoolerGateway) withBuffering(
 	inner func(conn *PoolerConnection) error,
 ) error {
 	bufferedOnce := false
-	sk := commontypes.ShardKey{
+	sk := &clustermetadatapb.ShardKey{
 		TableGroup: target.TableGroup,
 		Shard:      target.Shard,
 	}

--- a/go/services/multiorch/grpcserver/server.go
+++ b/go/services/multiorch/grpcserver/server.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commontypes "github.com/multigres/multigres/go/common/types"
 	multiorchpb "github.com/multigres/multigres/go/pb/multiorch"
 	"github.com/multigres/multigres/go/services/multiorch/recovery"
 )
@@ -60,28 +61,28 @@ func (s *MultiOrchServer) GetShardStatus(
 	req *multiorchpb.ShardStatusRequest,
 ) (*multiorchpb.ShardStatusResponse, error) {
 	// Validate that this shard is in our watch targets
-	if !s.engine.IsWatchingShard(req.Database, req.TableGroup, req.Shard) {
+	if req.ShardKey == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "shard_key is required")
+	}
+	sk := req.ShardKey
+	if !s.engine.IsWatchingShard(sk.Database, sk.TableGroup, sk.Shard) {
 		return nil, status.Errorf(codes.NotFound,
-			"shard %s/%s/%s is not in watch targets for this multiorch instance",
-			req.Database, req.TableGroup, req.Shard)
+			"shard %s is not in watch targets for this multiorch instance", commontypes.FormatShardKey(sk))
 	}
 
 	// Get all detected problems from the engine
 	allProblems := s.engine.GetDetectedProblems()
 
 	// Filter problems for the requested shard
+	skStr := commontypes.FormatShardKey(sk)
 	var shardProblems []*multiorchpb.DetectedProblem
 	for _, p := range allProblems {
-		if p.ShardKey.Database == req.Database &&
-			p.ShardKey.TableGroup == req.TableGroup &&
-			p.ShardKey.Shard == req.Shard {
+		if commontypes.FormatShardKey(p.ShardKey) == skStr {
 			shardProblems = append(shardProblems, &multiorchpb.DetectedProblem{
 				Code:        string(p.Code),
 				CheckName:   string(p.CheckName),
 				PoolerId:    p.PoolerID,
-				Database:    p.ShardKey.Database,
-				TableGroup:  p.ShardKey.TableGroup,
-				Shard:       p.ShardKey.Shard,
+				ShardKey:    p.ShardKey,
 				Description: p.Description,
 				Priority:    int32(p.Priority),
 				Scope:       string(p.Scope),
@@ -162,7 +163,8 @@ func (s *MultiOrchServer) TriggerRecoveryNow(ctx context.Context, req *multiorch
 
 // buildPoolerHealthList creates pooler health snapshots for the requested shard.
 func (s *MultiOrchServer) buildPoolerHealthList(req *multiorchpb.ShardStatusRequest) []*multiorchpb.PoolerHealth {
-	poolers := s.engine.GetPoolerHealthForShard(req.Database, req.TableGroup, req.Shard)
+	sk := req.ShardKey
+	poolers := s.engine.GetPoolerHealthForShard(sk.Database, sk.TableGroup, sk.Shard)
 
 	healthList := make([]*multiorchpb.PoolerHealth, 0, len(poolers))
 	for _, p := range poolers {

--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -68,12 +68,12 @@ func NewAppointLeaderAction(
 // Execute performs leader appointment by running the coordinator's consensus protocol
 func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem) error {
 	a.logger.InfoContext(ctx, "executing appoint leader action",
-		"shard_key", problem.ShardKey.String())
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 
 	// Fetch cohort and recheck the problem
 	cohort := a.getCohort(problem.ShardKey)
 	if len(cohort) == 0 {
-		return fmt.Errorf("no poolers found for shard %s", problem.ShardKey)
+		return fmt.Errorf("no poolers found for shard %s", commontypes.FormatShardKey(problem.ShardKey))
 	}
 
 	// Check if a primary already exists and is healthy (problem resolved).
@@ -97,17 +97,17 @@ func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem
 		if types.LeaderNeedsReplacement(pooler) {
 			a.logger.InfoContext(ctx, "primary has requested replacement, proceeding with election",
 				"primary", pooler.MultiPooler.Id.Name,
-				"shard_key", problem.ShardKey.String())
+				"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 			continue
 		}
 		a.logger.InfoContext(ctx, "primary already exists, skipping leader appointment",
 			"primary", pooler.MultiPooler.Id.Name,
-			"shard_key", problem.ShardKey.String())
+			"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 		return nil
 	}
 
 	a.logger.InfoContext(ctx, "verified shard still needs leader appointment, proceeding",
-		"shard_key", problem.ShardKey.String(),
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey),
 		"cohort_size", len(cohort))
 
 	// Use the coordinator's AppointLeader to handle the election
@@ -122,13 +122,13 @@ func (a *AppointLeaderAction) Execute(ctx context.Context, problem types.Problem
 	}
 
 	a.logger.InfoContext(ctx, "appoint leader action completed successfully",
-		"shard_key", problem.ShardKey.String())
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 
 	return nil
 }
 
 // getCohort fetches all poolers in the shard from the pooler store.
-func (a *AppointLeaderAction) getCohort(shardKey commontypes.ShardKey) []*multiorchdatapb.PoolerHealthState {
+func (a *AppointLeaderAction) getCohort(shardKey *clustermetadatapb.ShardKey) []*multiorchdatapb.PoolerHealthState {
 	var cohort []*multiorchdatapb.PoolerHealthState
 
 	a.poolerStore.Range(func(key string, pooler *multiorchdatapb.PoolerHealthState) bool {

--- a/go/services/multiorch/recovery/actions/demote_stale_leader.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader.go
@@ -30,6 +30,7 @@ import (
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
@@ -105,7 +106,7 @@ func (a *DemoteStaleLeaderAction) Execute(ctx context.Context, problem types.Pro
 	poolerIDStr := topoclient.MultiPoolerIDString(problem.PoolerID)
 
 	a.logger.InfoContext(ctx, "executing demote stale leader action",
-		"shard_key", problem.ShardKey.String(),
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey),
 		"stale_leader", poolerIDStr)
 
 	// Get the stale leader from the store
@@ -164,7 +165,7 @@ func (a *DemoteStaleLeaderAction) Execute(ctx context.Context, problem types.Pro
 		"lsn_position", demoteResp.LsnPosition)
 
 	a.logger.InfoContext(ctx, "demote stale leader action completed",
-		"shard_key", problem.ShardKey.String(),
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey),
 		"demoted_leader", poolerIDStr)
 
 	return nil
@@ -172,7 +173,7 @@ func (a *DemoteStaleLeaderAction) Execute(ctx context.Context, problem types.Pro
 
 // findCorrectLeader finds the current leader in the shard and returns it along with its term.
 // The correct leader is the one with the highest LeaderTerm.
-func (a *DemoteStaleLeaderAction) findCorrectLeader(shardKey commontypes.ShardKey, stalePrimaryIDStr string) (*multiorchdatapb.PoolerHealthState, int64, error) {
+func (a *DemoteStaleLeaderAction) findCorrectLeader(shardKey *clustermetadatapb.ShardKey, stalePrimaryIDStr string) (*multiorchdatapb.PoolerHealthState, int64, error) {
 	var correctLeader *multiorchdatapb.PoolerHealthState
 	var maxLeaderTerm int64
 
@@ -211,7 +212,7 @@ func (a *DemoteStaleLeaderAction) findCorrectLeader(shardKey commontypes.ShardKe
 	})
 
 	if correctLeader == nil {
-		return nil, 0, fmt.Errorf("no current leader found in shard %s", shardKey.String())
+		return nil, 0, fmt.Errorf("no current leader found in shard %s", commontypes.FormatShardKey(shardKey))
 	}
 
 	consensusTerm := correctLeader.GetConsensusStatus().GetTermRevocation().GetRevokedBelowTerm()

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/services/multiorch/store"
 
@@ -71,7 +70,7 @@ func TestFixReplicationAction_ExecuteReplicaNotFound(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -117,7 +116,7 @@ func TestFixReplicationAction_ExecuteNoPrimary(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -192,7 +191,7 @@ func TestFixReplicationAction_ExecuteUnsupportedProblemCode(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaLagging, // Not yet supported
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -284,7 +283,7 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -374,7 +373,7 @@ func TestFixReplicationAction_ExecuteAlreadyConfigured(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -582,7 +581,7 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 
 	problem := types.Problem{
 		Code: types.ProblemReplicaNotReplicating,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -86,7 +86,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	initializedPoolers, cohortEstablished := a.getInitializedPoolers(problem.ShardKey)
 	if cohortEstablished {
 		a.logger.InfoContext(ctx, "cohort already established, skipping",
-			"shard_key", problem.ShardKey.String())
+			"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 		return nil
 	}
 	if len(initializedPoolers) == 0 {
@@ -117,7 +117,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	}
 
 	a.logger.InfoContext(ctx, "quorum of initialized poolers available",
-		"shard_key", problem.ShardKey.String(),
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey),
 		"initialized_count", len(initializedPoolers),
 		"policy", durabilityPolicy.Description())
 
@@ -129,12 +129,12 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	}
 	if !won {
 		a.logger.InfoContext(ctx, "shard initialization claimed by another coordinator, skipping",
-			"shard_key", problem.ShardKey.String())
+			"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 		return nil
 	}
 
 	a.logger.InfoContext(ctx, "shard initialization claimed",
-		"shard_key", problem.ShardKey.String(),
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey),
 		"committed_cohort_size", len(committedIDs))
 
 	// Resolve committed IDs to full PoolerHealthState entries from the pooler store.
@@ -154,7 +154,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 	}
 
 	a.logger.InfoContext(ctx, "shard init action completed successfully",
-		"shard_key", problem.ShardKey.String())
+		"shard_key", commontypes.FormatShardKey(problem.ShardKey))
 	return nil
 }
 
@@ -162,7 +162,7 @@ func (a *ShardInitAction) Execute(ctx context.Context, problem types.Problem) er
 // recovery loop before Execute is called). It returns the list of initialized poolers, plus
 // a bool indicating whether the cohort is already established (any pooler has CohortMembers).
 // If cohortEstablished is true the returned slice is nil and the caller should no-op.
-func (a *ShardInitAction) getInitializedPoolers(shardKey commontypes.ShardKey) (initialized []*multiorchdatapb.PoolerHealthState, cohortEstablished bool) {
+func (a *ShardInitAction) getInitializedPoolers(shardKey *clustermetadatapb.ShardKey) (initialized []*multiorchdatapb.PoolerHealthState, cohortEstablished bool) {
 	a.poolerStore.Range(func(_ string, pooler *multiorchdatapb.PoolerHealthState) bool {
 		if pooler == nil || pooler.MultiPooler == nil || pooler.MultiPooler.Id == nil {
 			return true

--- a/go/services/multiorch/recovery/actions/shard_init_action_test.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -72,7 +71,7 @@ func (m *mockCoordinator) GetCoordinatorID() *clustermetadatapb.ID {
 	return testCoordinatorID
 }
 
-var testShardInitShardKey = commontypes.ShardKey{
+var testShardInitShardKey = &clustermetadatapb.ShardKey{
 	Database:   "testdb",
 	TableGroup: "default",
 	Shard:      "0",

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -75,16 +75,16 @@ func NewAnalysisGenerator(poolerStore *store.PoolerStore, policyLookup func(data
 // GenerateShardAnalyses groups per-pooler analyses into one ShardAnalysis per shard.
 func (g *AnalysisGenerator) GenerateShardAnalyses() []*ShardAnalysis {
 	type shardEntry struct {
-		key     commontypes.ShardKey
+		key     *clustermetadatapb.ShardKey
 		poolers map[string]*multiorchdatapb.PoolerHealthState
 	}
-	byKey := make(map[commontypes.ShardKey]*shardEntry)
+	byKey := make(map[string]*shardEntry)
 
 	for database, tableGroups := range g.poolersByShard {
 		for tableGroup, shards := range tableGroups {
 			for shard, poolers := range shards {
-				key := commontypes.ShardKey{Database: database, TableGroup: tableGroup, Shard: shard}
-				byKey[key] = &shardEntry{key: key, poolers: poolers}
+				key := &clustermetadatapb.ShardKey{Database: database, TableGroup: tableGroup, Shard: shard}
+				byKey[string(commontypes.FormatShardKey(key))] = &shardEntry{key: key, poolers: poolers}
 			}
 		}
 	}
@@ -98,16 +98,16 @@ func (g *AnalysisGenerator) GenerateShardAnalyses() []*ShardAnalysis {
 
 // GenerateShardAnalysis returns a ShardAnalysis for a specific shard.
 // Returns an error if no poolers for that shard are found in the store.
-func (g *AnalysisGenerator) GenerateShardAnalysis(shardKey commontypes.ShardKey) (*ShardAnalysis, error) {
+func (g *AnalysisGenerator) GenerateShardAnalysis(shardKey *clustermetadatapb.ShardKey) (*ShardAnalysis, error) {
 	poolers, ok := g.poolersByShard[shardKey.Database][shardKey.TableGroup][shardKey.Shard]
 	if !ok || len(poolers) == 0 {
-		return nil, fmt.Errorf("shard not found: %s", shardKey)
+		return nil, fmt.Errorf("shard not found: %s", commontypes.FormatShardKey(shardKey))
 	}
 	return g.buildShardAnalysis(shardKey, poolers), nil
 }
 
 // buildShardAnalysis constructs a ShardAnalysis for a shard, including shard-level aggregates.
-func (g *AnalysisGenerator) buildShardAnalysis(shardKey commontypes.ShardKey, poolers map[string]*multiorchdatapb.PoolerHealthState) *ShardAnalysis {
+func (g *AnalysisGenerator) buildShardAnalysis(shardKey *clustermetadatapb.ShardKey, poolers map[string]*multiorchdatapb.PoolerHealthState) *ShardAnalysis {
 	sa := &ShardAnalysis{ShardKey: shardKey}
 	for _, pooler := range poolers {
 		sa.Analyses = append(sa.Analyses, g.generateAnalysisForPooler(pooler, shardKey))
@@ -201,14 +201,14 @@ func (g *AnalysisGenerator) GenerateAnalysisForPooler(poolerIDStr string) (*Shar
 		return nil, fmt.Errorf("shard not found for pooler: %s", poolerIDStr)
 	}
 
-	shardKey := commontypes.ShardKey{Database: database, TableGroup: tableGroup, Shard: shard}
+	shardKey := &clustermetadatapb.ShardKey{Database: database, TableGroup: tableGroup, Shard: shard}
 	return g.buildShardAnalysis(shardKey, poolers), nil
 }
 
 // generateAnalysisForPooler creates a ReplicationAnalysis for a single pooler.
 func (g *AnalysisGenerator) generateAnalysisForPooler(
 	pooler *multiorchdatapb.PoolerHealthState,
-	shardKey commontypes.ShardKey,
+	shardKey *clustermetadatapb.ShardKey,
 ) *PoolerAnalysis {
 	// Determine pooler type from health check (PoolerType).
 	// Nodes are never created with topology type PRIMARY, so health check is authoritative.

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -403,7 +402,7 @@ func TestPopulatePrimaryInfo_NoPrimaryInShard(t *testing.T) {
 	})
 
 	gen := NewAnalysisGenerator(ps, nil)
-	sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+	sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 	require.NoError(t, err)
 
 	// When no primary exists in the shard, topology primary fields should be nil/false
@@ -459,7 +458,7 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 	})
 
 	gen := NewAnalysisGenerator(ps, nil)
-	sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+	sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 	require.NoError(t, err)
 	analysis := findPoolerByName(sa, "replica")
 	require.NotNil(t, analysis)
@@ -494,7 +493,7 @@ func TestPopulatePrimaryInfo_DemotedViaBeginTermRevoke(t *testing.T) {
 		},
 	}
 
-	shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"}
 
 	t.Run("topology type PRIMARY, PoolerType REPLICA, primary term > 0 via ConsensusStatus", func(t *testing.T) {
 		// Former primary promoted at term 4; etcd topology updated to PRIMARY.
@@ -687,7 +686,7 @@ func TestIsInStandbyList(t *testing.T) {
 			})
 
 			generator := NewAnalysisGenerator(ps, nil)
-			sa, err := generator.GenerateShardAnalysis(commontypes.ShardKey{Database: "testdb", TableGroup: "testtg", Shard: "0"})
+			sa, err := generator.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "testtg", Shard: "0"})
 			require.NoError(t, err)
 
 			result := sa.IsInStandbyList(tt.replicaID)
@@ -745,7 +744,7 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.True(t, sa.LeaderPoolerReachable)
@@ -800,7 +799,7 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.False(t, sa.LeaderPoolerReachable)
@@ -894,7 +893,7 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.True(t, sa.ReplicasConnectedToLeader, "should be true when all replicas are connected")
@@ -976,7 +975,7 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.False(t, sa.ReplicasConnectedToLeader, "should be false when any replica is disconnected")
@@ -1027,7 +1026,7 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.False(t, sa.ReplicasConnectedToLeader, "should be false when replica is unreachable")
@@ -1060,7 +1059,7 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		// Primary-only shard: ReplicasConnectedToLeader should be false (no replicas)
@@ -1121,7 +1120,7 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		})
 
 		gen := NewAnalysisGenerator(ps, nil)
-		sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
+		sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "shard1"})
 		require.NoError(t, err)
 
 		assert.False(t, sa.ReplicasConnectedToLeader, "should be false when replica points to wrong primary")
@@ -1492,7 +1491,7 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 	})
 
 	generator := NewAnalysisGenerator(ps, nil)
-	shardKey := commontypes.ShardKey{Database: "testdb", TableGroup: "testtg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "testtg", Shard: "0"}
 
 	t.Run("replica in standby list", func(t *testing.T) {
 		sa, err := generator.GenerateShardAnalysis(shardKey)
@@ -1596,7 +1595,7 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 	})
 
 	generator := NewAnalysisGenerator(ps, nil)
-	sa, err := generator.GenerateShardAnalysis(commontypes.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"})
+	sa, err := generator.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"})
 	require.NoError(t, err)
 	analysis := findPoolerByName(sa, "replica-1")
 	require.NotNil(t, analysis)
@@ -1612,7 +1611,7 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 }
 
 func TestDetectOtherPrimary(t *testing.T) {
-	shardKey := commontypes.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"}
 
 	t.Run("single other primary detected", func(t *testing.T) {
 		store := setupMultiplePrimariesStore(t, []primaryConfig{
@@ -1882,7 +1881,7 @@ func TestGenerateShardAnalysis_ErrorOnMissingShard(t *testing.T) {
 	ps := store.NewPoolerStore(nil, slog.Default())
 	gen := NewAnalysisGenerator(ps, nil)
 
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
 	_, err := gen.GenerateShardAnalysis(shardKey)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shard not found")
@@ -1913,7 +1912,7 @@ func TestGenerateShardAnalysis_ReturnsAllPoolersInShard(t *testing.T) {
 	})
 
 	gen := NewAnalysisGenerator(ps, nil)
-	sa, err := gen.GenerateShardAnalysis(commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"})
+	sa, err := gen.GenerateShardAnalysis(&clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"})
 	require.NoError(t, err)
 	assert.Len(t, sa.Analyses, 2)
 }

--- a/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/leader_is_dead_analyzer_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/config"
 	"github.com/multigres/multigres/go/services/multiorch/consensus"
@@ -51,7 +50,7 @@ func TestLeaderIsDeadAnalyzer_Analyze(t *testing.T) {
 	analyzer := &LeaderIsDeadAnalyzer{factory: factory}
 
 	leaderID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "leader-1"}
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
 
 	// deadLeaderShardAnalysis builds a ShardAnalysis that has a dead leader and an
 	// initialized replica — the base case for LeaderIsDead detection.

--- a/go/services/multiorch/recovery/analysis/replica_not_in_standby_list_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_in_standby_list_analyzer_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/consensus"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
@@ -50,7 +49,7 @@ func TestReplicaNotInStandbyListAnalyzer_Analyze(t *testing.T) {
 
 	primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "primary1"}
 	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica1"}
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
 
 	tests := []struct {
 		name          string

--- a/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/replica_not_replicating_analyzer_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/consensus"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
@@ -49,7 +48,7 @@ func TestReplicaNotReplicatingAnalyzer_Analyze(t *testing.T) {
 
 	primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "primary1"}
 	replicaID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "replica1"}
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
 
 	t.Run("detects replica with no primary_conninfo", func(t *testing.T) {
 		sa := &ShardAnalysis{

--- a/go/services/multiorch/recovery/analysis/shard_analysis.go
+++ b/go/services/multiorch/recovery/analysis/shard_analysis.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 )
@@ -27,7 +26,7 @@ import (
 // ShardAnalysis groups all per-pooler analyses for a single shard.
 // It is the input type for the Analyzer interface.
 type ShardAnalysis struct {
-	ShardKey commontypes.ShardKey
+	ShardKey *clustermetadatapb.ShardKey
 	Analyses []*PoolerAnalysis
 
 	// NumInitialized is the count of reachable, initialized poolers in this shard.
@@ -137,7 +136,7 @@ func (sa *ShardAnalysis) Replicas() []*PoolerAnalysis {
 type PoolerAnalysis struct {
 	// Identity
 	PoolerID *clustermetadatapb.ID
-	ShardKey commontypes.ShardKey
+	ShardKey *clustermetadatapb.ShardKey
 
 	// Pooler properties
 	PoolerType clustermetadatapb.PoolerType

--- a/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/shard_needs_initialization_analyzer_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/consensus"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
@@ -46,7 +45,7 @@ func TestShardNeedsInitializationAnalyzer_Analyze(t *testing.T) {
 	factory := NewRecoveryActionFactory(nil, poolerStore, rpcClient, ts, coord, slog.Default())
 
 	analyzer := &ShardNeedsInitializationAnalyzer{factory: factory}
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"}
 	policy := topoclient.AtLeastN(2)
 
 	initialized := func(name string) *PoolerAnalysis {

--- a/go/services/multiorch/recovery/analysis/stale_leader_analyzer_test.go
+++ b/go/services/multiorch/recovery/analysis/stale_leader_analyzer_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 	"github.com/multigres/multigres/go/services/multiorch/store"
@@ -51,7 +50,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		newID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "new-primary"}
 		stalePA := &PoolerAnalysis{
 			PoolerID:        staleID,
-			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:        &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:        true,
 			IsInitialized:   true,
 			ConsensusStatus: primaryRuleStatus(staleID, 5),
@@ -88,7 +87,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		staleID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary"}
 		newPA := &PoolerAnalysis{
 			PoolerID:        newID,
-			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:        &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:        true,
 			IsInitialized:   true,
 			ConsensusStatus: primaryRuleStatus(newID, 6),
@@ -126,7 +125,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		primaryBID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary-b"}
 		primaryAPA := &PoolerAnalysis{
 			PoolerID:        primaryAID,
-			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:        &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:        true,
 			IsInitialized:   true,
 			ConsensusStatus: primaryRuleStatus(primaryAID, 5),
@@ -157,7 +156,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "replica1",
 			},
-			ShardKey:      commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:      &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:      false,
 			IsInitialized: true,
 		}
@@ -173,7 +172,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		primaryID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"}
 		pa := &PoolerAnalysis{
 			PoolerID:        primaryID,
-			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:        &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:        true,
 			IsInitialized:   true,
 			ConsensusStatus: primaryRuleStatus(primaryID, 5),
@@ -209,7 +208,7 @@ func TestStaleLeaderAnalyzer_Analyze(t *testing.T) {
 		stale2ID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "stale-primary-2"}
 		newPA := &PoolerAnalysis{
 			PoolerID:        newID,
-			ShardKey:        commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
+			ShardKey:        &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"},
 			IsLeader:        true,
 			IsInitialized:   true,
 			ConsensusStatus: primaryRuleStatus(newID, 6),

--- a/go/services/multiorch/recovery/bookkeeping.go
+++ b/go/services/multiorch/recovery/bookkeeping.go
@@ -69,7 +69,7 @@ func (re *Engine) forgetLongUnseenInstances() {
 		poolerID  string
 		id        *clustermetadatapb.ID
 		auditType string
-		shardKey  commontypes.ShardKey
+		shardKey  *clustermetadatapb.ShardKey
 		message   string
 	}
 	var toDelete []deleteEntry
@@ -88,7 +88,7 @@ func (re *Engine) forgetLongUnseenInstances() {
 			return true // continue iteration
 		}
 
-		shardKey := commontypes.ShardKey{
+		shardKey := &clustermetadatapb.ShardKey{
 			Database:   poolerInfo.MultiPooler.Database,
 			TableGroup: poolerInfo.MultiPooler.TableGroup,
 			Shard:      poolerInfo.MultiPooler.Shard,
@@ -157,11 +157,11 @@ func (re *Engine) forgetLongUnseenInstances() {
 
 // audit logs an audit message with consistent formatting.
 // This ensures important operations are logged in a structured way for compliance and debugging.
-func (re *Engine) audit(auditType, poolerID string, shardKey commontypes.ShardKey, message string) {
+func (re *Engine) audit(auditType, poolerID string, shardKey *clustermetadatapb.ShardKey, message string) {
 	re.logger.Info("audit",
 		"audit_type", auditType,
 		"pooler_id", poolerID,
-		"shard_key", shardKey.String(),
+		"shard_key", commontypes.FormatShardKey(shardKey),
 		"message", message,
 	)
 }

--- a/go/services/multiorch/recovery/bookkeeping_test.go
+++ b/go/services/multiorch/recovery/bookkeeping_test.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/constants"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	"github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 )
@@ -313,5 +312,5 @@ func TestAudit(t *testing.T) {
 	engine := newTestEngine(ctx, t)
 
 	// Just verify audit doesn't panic (output is logged)
-	engine.audit("test-type", "pooler-1", commontypes.ShardKey{Database: "db1", TableGroup: "default", Shard: "-"}, "test message")
+	engine.audit("test-type", "pooler-1", &clustermetadata.ShardKey{Database: "db1", TableGroup: "default", Shard: "-"}, "test message")
 }

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -25,7 +25,7 @@ import (
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	"github.com/multigres/multigres/go/services/multiorch/config"
 	"github.com/multigres/multigres/go/services/multiorch/consensus"
@@ -503,7 +503,7 @@ func (re *Engine) IsWatchingShard(database, tableGroup, shard string) bool {
 // GetPoolerHealthForShard returns health information for all poolers in a shard.
 // Thread-safe for concurrent access from gRPC handlers.
 func (re *Engine) GetPoolerHealthForShard(database, tableGroup, shard string) []*multiorchdatapb.PoolerHealthState {
-	return re.poolerStore.FindPoolersInShard(commontypes.ShardKey{
+	return re.poolerStore.FindPoolersInShard(&clustermetadatapb.ShardKey{
 		Database:   database,
 		TableGroup: tableGroup,
 		Shard:      shard,

--- a/go/services/multiorch/recovery/metrics_test.go
+++ b/go/services/multiorch/recovery/metrics_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
 	"github.com/multigres/multigres/go/services/multiorch/config"
@@ -59,7 +58,7 @@ func TestEngine_UpdateDetectedProblems(t *testing.T) {
 		{
 			CheckName: "PrimaryIsDead",
 			Scope:     types.ScopePooler,
-			ShardKey: commontypes.ShardKey{
+			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   "testdb",
 				TableGroup: "tg1",
 				Shard:      "shard1",
@@ -73,7 +72,7 @@ func TestEngine_UpdateDetectedProblems(t *testing.T) {
 		{
 			CheckName: "ReplicaNotReplicating",
 			Scope:     types.ScopePooler,
-			ShardKey: commontypes.ShardKey{
+			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   "testdb",
 				TableGroup: "tg1",
 				Shard:      "shard2",
@@ -122,7 +121,7 @@ func TestEngine_UpdateDetectedProblems_Replacement(t *testing.T) {
 		{
 			CheckName: "PrimaryIsDead",
 			Scope:     types.ScopePooler,
-			ShardKey: commontypes.ShardKey{
+			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   "testdb",
 				TableGroup: "tg1",
 				Shard:      "shard1",
@@ -141,7 +140,7 @@ func TestEngine_UpdateDetectedProblems_Replacement(t *testing.T) {
 		{
 			CheckName: "ReplicaNotReplicating",
 			Scope:     types.ScopePooler,
-			ShardKey: commontypes.ShardKey{
+			ShardKey: &clustermetadatapb.ShardKey{
 				Database:   "testdb",
 				TableGroup: "tg1",
 				Shard:      "shard2",
@@ -190,7 +189,7 @@ func TestEngine_DetectedProblems_ThreadSafety(t *testing.T) {
 				problems := []types.Problem{
 					{
 						CheckName: "PrimaryIsDead",
-						ShardKey: commontypes.ShardKey{
+						ShardKey: &clustermetadatapb.ShardKey{
 							Database:   "testdb",
 							TableGroup: "tg1",
 							Shard:      "shard1",

--- a/go/services/multiorch/recovery/recovery_grace_period_test.go
+++ b/go/services/multiorch/recovery/recovery_grace_period_test.go
@@ -230,7 +230,7 @@ func TestRecoveryGracePeriod_DeadlineNotExpired(t *testing.T) {
 		},
 	}
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: "default",
 		Shard:      "0",
@@ -250,7 +250,7 @@ func TestRecoveryGracePeriod_DeadlineNotExpired(t *testing.T) {
 	}
 
 	// Reset deadline (now + 10s)
-	tracker.Observe(types.ProblemLeaderIsDead, shardKey.String(), action, true)
+	tracker.Observe(types.ProblemLeaderIsDead, string(commontypes.FormatShardKey(shardKey)), action, true)
 
 	// Check immediately - should not be expired
 	expired := tracker.ShouldExecute(problem)
@@ -272,7 +272,7 @@ func TestRecoveryGracePeriod_DeadlineExpired(t *testing.T) {
 		},
 	}
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: "default",
 		Shard:      "0",
@@ -292,7 +292,7 @@ func TestRecoveryGracePeriod_DeadlineExpired(t *testing.T) {
 	}
 
 	// Reset deadline (now + 100ms)
-	tracker.Observe(types.ProblemLeaderIsDead, shardKey.String(), action, true)
+	tracker.Observe(types.ProblemLeaderIsDead, string(commontypes.FormatShardKey(shardKey)), action, true)
 
 	// Wait for deadline to expire
 	time.Sleep(150 * time.Millisecond)
@@ -315,7 +315,7 @@ func TestRecoveryGracePeriod_NoDeadlineTracked(t *testing.T) {
 		gracePeriod: nil,
 	}
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: "default",
 		Shard:      "0",
@@ -426,7 +426,7 @@ func TestRecoveryGracePeriod_FirstObserveUnhealthy(t *testing.T) {
 		},
 	}
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: "default",
 		Shard:      "0",
@@ -505,7 +505,7 @@ func TestRecoveryGracePeriod_NonTrackedProblemTypes(t *testing.T) {
 	problem := types.Problem{
 		Code:           types.ProblemReplicaNotReplicating,
 		RecoveryAction: action,
-		ShardKey: commontypes.ShardKey{
+		ShardKey: &clustermetadatapb.ShardKey{
 			Database:   "testdb",
 			TableGroup: "default",
 			Shard:      "0",
@@ -549,7 +549,7 @@ func TestRecoveryGracePeriod_ConcurrentAccess(t *testing.T) {
 		},
 	}
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: "default",
 		Shard:      "0",
@@ -610,7 +610,7 @@ func TestRecoveryGracePeriod_ForceExpireAll(t *testing.T) {
 	}
 
 	// Build problems the same way the recovery loop would.
-	shardKey := commontypes.ShardKey{Database: "db", TableGroup: "default", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db", TableGroup: "default", Shard: "0"}
 	poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c", Name: "pooler-1"}
 
 	problemA := types.Problem{
@@ -627,7 +627,7 @@ func TestRecoveryGracePeriod_ForceExpireAll(t *testing.T) {
 	}
 
 	// Observe both problems as unhealthy using the same entity IDs as the recovery loop
-	// (shardKey.String() for shard-wide, MultiPoolerIDString for pooler-scoped).
+	// (string(commontypes.FormatShardKey(shardKey) for shard-wide, MultiPoolerIDString for pooler-scoped).
 	tracker.Observe(types.ProblemLeaderIsDead, problemA.EntityID(), action, false)
 	tracker.Observe(types.ProblemStaleLeader, problemB.EntityID(), action, false)
 

--- a/go/services/multiorch/recovery/recovery_loop.go
+++ b/go/services/multiorch/recovery/recovery_loop.go
@@ -80,7 +80,7 @@ func (re *Engine) performRecoveryCycle(ctx context.Context) {
 					break
 				}
 			}
-			re.recoveryGracePeriodTracker.Observe(analyzer.ProblemCode(), shardAnalysis.ShardKey.String(), analyzer.RecoveryAction(), !shardHasProblem)
+			re.recoveryGracePeriodTracker.Observe(analyzer.ProblemCode(), string(commontypes.FormatShardKey(shardAnalysis.ShardKey)), analyzer.RecoveryAction(), !shardHasProblem)
 
 			problems = append(problems, detectedProblems...)
 		}
@@ -101,12 +101,12 @@ func (re *Engine) performRecoveryCycle(ctx context.Context) {
 
 	// Process each shard independently in parallel
 	var wg sync.WaitGroup
-	for shardKey, shardProblems := range problemsByShard {
+	for _, shardProblems := range problemsByShard {
 		wg.Add(1)
-		go func(key commontypes.ShardKey, problems []types.Problem) {
+		go func(problems []types.Problem) {
 			defer wg.Done()
-			re.processShardProblems(ctx, key, problems)
-		}(shardKey, shardProblems)
+			re.processShardProblems(ctx, problems[0].ShardKey, problems)
+		}(shardProblems)
 	}
 	wg.Wait()
 
@@ -115,19 +115,20 @@ func (re *Engine) performRecoveryCycle(ctx context.Context) {
 	re.recoveryRunner.UpdateInterval(newInterval)
 }
 
-// groupProblemsByShard groups problems by their shard.
-func (re *Engine) groupProblemsByShard(problems []types.Problem) map[commontypes.ShardKey][]types.Problem {
-	grouped := make(map[commontypes.ShardKey][]types.Problem)
+// groupProblemsByShard groups problems by their shard string key.
+func (re *Engine) groupProblemsByShard(problems []types.Problem) map[string][]types.Problem {
+	grouped := make(map[string][]types.Problem)
 
 	for _, problem := range problems {
-		grouped[problem.ShardKey] = append(grouped[problem.ShardKey], problem)
+		key := string(commontypes.FormatShardKey(problem.ShardKey))
+		grouped[key] = append(grouped[key], problem)
 	}
 
 	return grouped
 }
 
 // processShardProblems handles all problems for a single shard.
-func (re *Engine) processShardProblems(ctx context.Context, shardKey commontypes.ShardKey, problems []types.Problem) {
+func (re *Engine) processShardProblems(ctx context.Context, shardKey *clustermetadatapb.ShardKey, problems []types.Problem) {
 	re.logger.DebugContext(ctx, "processing shard problems",
 		"database", shardKey.Database,
 		"tablegroup", shardKey.TableGroup,

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -184,17 +184,17 @@ func TestGroupProblemsByShard(t *testing.T) {
 		{
 			Code:     types.ProblemLeaderIsDead,
 			PoolerID: poolerID1,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 		},
 		{
 			Code:     types.ProblemReplicaNotReplicating,
 			PoolerID: poolerID2,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 		},
 		{
 			Code:     types.ProblemLeaderIsDead,
 			PoolerID: poolerID3,
-			ShardKey: commontypes.ShardKey{Database: "db2", TableGroup: "tg2", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db2", TableGroup: "tg2", Shard: "0"},
 		},
 	}
 
@@ -204,11 +204,11 @@ func TestGroupProblemsByShard(t *testing.T) {
 	assert.Len(t, grouped, 2, "should have 2 shards")
 
 	// Check first shard
-	key1 := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	key1 := string(commontypes.FormatShardKey(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}))
 	assert.Len(t, grouped[key1], 2, "db1/tg1/0 should have 2 problems")
 
 	// Check second shard
-	key2 := commontypes.ShardKey{Database: "db2", TableGroup: "tg2", Shard: "0"}
+	key2 := string(commontypes.FormatShardKey(&clustermetadatapb.ShardKey{Database: "db2", TableGroup: "tg2", Shard: "0"}))
 	assert.Len(t, grouped[key2], 1, "db2/tg2/0 should have 1 problem")
 }
 
@@ -235,19 +235,19 @@ func TestPrioritySorting(t *testing.T) {
 		{
 			Code:     types.ProblemReplicaNotReplicating,
 			PoolerID: poolerID2,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Priority: types.PriorityHigh,
 		},
 		{
 			Code:     types.ProblemLeaderIsDead,
 			PoolerID: poolerID1,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Priority: types.PriorityEmergency,
 		},
 		{
 			Code:     "ConfigurationDrift",
 			PoolerID: poolerID3,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Priority: types.PriorityNormal,
 		},
 	}
@@ -270,22 +270,20 @@ func TestPrioritySorting(t *testing.T) {
 }
 
 func TestShardKey(t *testing.T) {
-	// Test that ShardKey works correctly as a map key
-	key1 := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	// Test that ShardKeyString provides value-equality semantics for proto shard keys.
+	key1 := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	key2 := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	key3 := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg2", Shard: "0"}
 
-	key2 := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	// Test string key map usage — proto pointers can't be map keys, so we use ShardKeyString.
+	m := make(map[commontypes.ShardKeyString]int)
+	m[commontypes.FormatShardKey(key1)] = 1
+	m[commontypes.FormatShardKey(key2)] = 2 // Should overwrite key1
+	m[commontypes.FormatShardKey(key3)] = 3
 
-	key3 := commontypes.ShardKey{Database: "db1", TableGroup: "tg2", Shard: "0"}
-
-	// Test map usage
-	m := make(map[commontypes.ShardKey]int)
-	m[key1] = 1
-	m[key2] = 2 // Should overwrite key1
-	m[key3] = 3
-
-	assert.Equal(t, 2, m[key1], "key1 and key2 should be equal")
-	assert.Equal(t, 2, m[key2], "key1 and key2 should be equal")
-	assert.Equal(t, 3, m[key3], "key3 should be different")
+	assert.Equal(t, 2, m[commontypes.FormatShardKey(key1)], "key1 and key2 should be equal")
+	assert.Equal(t, 2, m[commontypes.FormatShardKey(key2)], "key1 and key2 should be equal")
+	assert.Equal(t, 3, m[commontypes.FormatShardKey(key3)], "key3 should be different")
 	assert.Len(t, m, 2, "should have 2 unique keys")
 }
 
@@ -312,12 +310,12 @@ func TestGroupProblemsByShard_DifferentShards(t *testing.T) {
 		{
 			Code:     types.ProblemLeaderIsDead,
 			PoolerID: poolerID1,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 		},
 		{
 			Code:     types.ProblemLeaderIsDead,
 			PoolerID: poolerID2,
-			ShardKey: commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}, // Different shard
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}, // Different shard
 		},
 	}
 
@@ -326,8 +324,8 @@ func TestGroupProblemsByShard_DifferentShards(t *testing.T) {
 	// Should have 2 separate groups (different shards)
 	assert.Len(t, grouped, 2, "should have 2 separate groups for different shards")
 
-	key1 := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
-	key2 := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}
+	key1 := string(commontypes.FormatShardKey(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}))
+	key2 := string(commontypes.FormatShardKey(&clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "1"}))
 
 	assert.Len(t, grouped[key1], 1, "shard 0 should have 1 problem")
 	assert.Len(t, grouped[key2], 1, "shard 1 should have 1 problem")
@@ -353,7 +351,7 @@ func TestRecheckProblem_PoolerNotFound(t *testing.T) {
 		Code:      types.ProblemLeaderIsDead,
 		CheckName: "PrimaryDeadCheck",
 		PoolerID:  poolerID,
-		ShardKey:  commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
+		ShardKey:  &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 		Priority:  types.PriorityEmergency,
 	}
 
@@ -768,7 +766,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		problems := detectProblems(t, engine)
 		require.Len(t, problems, 2, "should detect both primary dead and replica not replicating")
 
-		shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+		shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
 
 		// Call processShardProblems - this exercises the full recovery flow
 		engine.processShardProblems(t.Context(), shardKey, problems)
@@ -830,7 +828,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		require.Len(t, problems, 1, "should detect only replica not replicating")
 		assert.Equal(t, types.ProblemReplicaNotReplicating, problems[0].Code)
 
-		shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+		shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
 
 		// Call processShardProblems
 		engine.processShardProblems(t.Context(), shardKey, problems)
@@ -1467,7 +1465,7 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 	problems := detectProblems(t, engine)
 	require.Len(t, problems, 3, "should detect 3 problems with different priorities")
 
-	shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+	shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
 
 	// Process problems - they should be attempted in priority order
 	engine.processShardProblems(t.Context(), shardKey, problems)

--- a/go/services/multiorch/recovery/types/types.go
+++ b/go/services/multiorch/recovery/types/types.go
@@ -106,15 +106,15 @@ const (
 
 // Problem represents a detected issue.
 type Problem struct {
-	Code           ProblemCode           // Category of problem
-	CheckName      CheckName             // Which check detected it
-	PoolerID       *clustermetadatapb.ID // Affected pooler; can be nil for shard-scoped problems
-	ShardKey       commontypes.ShardKey  // Identifies the affected shard
-	Description    string                // Human-readable description
-	Priority       Priority              // Priority of this problem
-	Scope          ProblemScope          // Whether this affects the whole cluster or just one pooler
-	DetectedAt     time.Time             // When the problem was detected
-	RecoveryAction RecoveryAction        // What to do about it
+	Code           ProblemCode                 // Category of problem
+	CheckName      CheckName                   // Which check detected it
+	PoolerID       *clustermetadatapb.ID       // Affected pooler; can be nil for shard-scoped problems
+	ShardKey       *clustermetadatapb.ShardKey // Identifies the affected shard
+	Description    string                      // Human-readable description
+	Priority       Priority                    // Priority of this problem
+	Scope          ProblemScope                // Whether this affects the whole cluster or just one pooler
+	DetectedAt     time.Time                   // When the problem was detected
+	RecoveryAction RecoveryAction              // What to do about it
 }
 
 // IsShardWide reports whether this problem affects the entire shard.
@@ -129,7 +129,7 @@ func (p Problem) EntityID() string {
 	if p.Scope == ScopePooler && p.PoolerID != nil {
 		return topoclient.MultiPoolerIDString(p.PoolerID)
 	}
-	return p.ShardKey.String()
+	return string(commontypes.FormatShardKey(p.ShardKey))
 }
 
 // GracePeriodConfig holds grace period settings for recovery actions.

--- a/go/services/multiorch/store/pooler_store.go
+++ b/go/services/multiorch/store/pooler_store.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/rpcclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -106,7 +105,7 @@ func (s *PoolerStore) DoUpdateRange(fn func(key string, value *multiorchdatapb.P
 
 // IsInitialized returns true if the pooler has been initialized.
 // FindPoolersInShard returns all poolers belonging to the given shard.
-func (s *PoolerStore) FindPoolersInShard(shardKey commontypes.ShardKey) []*multiorchdatapb.PoolerHealthState {
+func (s *PoolerStore) FindPoolersInShard(shardKey *clustermetadatapb.ShardKey) []*multiorchdatapb.PoolerHealthState {
 	var poolers []*multiorchdatapb.PoolerHealthState
 
 	s.health.rangeHealth(func(_ string, pooler *multiorchdatapb.PoolerHealthState) bool {

--- a/go/services/multiorch/store/pooler_store_test.go
+++ b/go/services/multiorch/store/pooler_store_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
@@ -61,7 +60,7 @@ func TestPoolerStore_FindPoolersInShard(t *testing.T) {
 	})
 
 	t.Run("finds poolers in shard", func(t *testing.T) {
-		shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+		shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
 		poolers := poolerStore.FindPoolersInShard(shardKey)
 
 		assert.Len(t, poolers, 2)
@@ -71,7 +70,7 @@ func TestPoolerStore_FindPoolersInShard(t *testing.T) {
 	})
 
 	t.Run("returns empty for non-existent shard", func(t *testing.T) {
-		shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "999"}
+		shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "999"}
 		poolers := poolerStore.FindPoolersInShard(shardKey)
 
 		assert.Empty(t, poolers)
@@ -81,7 +80,7 @@ func TestPoolerStore_FindPoolersInShard(t *testing.T) {
 		poolerStore.Set("nil-pooler", nil)
 		poolerStore.Set("nil-multipooler", &multiorchdatapb.PoolerHealthState{MultiPooler: nil})
 
-		shardKey := commontypes.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
+		shardKey := &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"}
 		poolers := poolerStore.FindPoolersInShard(shardKey)
 
 		// Should still find the 2 valid poolers

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -32,7 +32,6 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
-	commontypes "github.com/multigres/multigres/go/common/types"
 	"github.com/multigres/multigres/go/services/multipooler/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/executor"
 	"github.com/multigres/multigres/go/services/multipooler/heartbeat"
@@ -612,8 +611,8 @@ func (pm *MultiPoolerManager) getPoolerType() clustermetadatapb.PoolerType {
 }
 
 // shardKey returns a ShardKey identifying this pooler's shard.
-func (pm *MultiPoolerManager) shardKey() commontypes.ShardKey {
-	return commontypes.ShardKey{
+func (pm *MultiPoolerManager) shardKey() *clustermetadatapb.ShardKey {
+	return &clustermetadatapb.ShardKey{
 		Database:   pm.multipooler.Database,
 		TableGroup: pm.multipooler.TableGroup,
 		Shard:      pm.multipooler.Shard,

--- a/go/services/multipooler/manager/rpc_first_backup_test.go
+++ b/go/services/multipooler/manager/rpc_first_backup_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
-	commontypes "github.com/multigres/multigres/go/common/types"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -441,7 +440,7 @@ func TestWithBackupLease_ReturnsNodeExistsWhenHeld(t *testing.T) {
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "test-cell")
 	defer ts.Close()
 
-	shardKey := commontypes.ShardKey{
+	shardKey := &clustermetadatapb.ShardKey{
 		Database:   "testdb",
 		TableGroup: constants.DefaultTableGroup,
 		Shard:      constants.DefaultShard,

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -1925,9 +1925,11 @@ func logMultiOrchStatus(ctx context.Context, t *testing.T, setup *ShardSetup, la
 		// Query shard status for the default shard
 		// TODO: Handle multiple shards if needed
 		resp, err := client.GetShardStatus(ctx, &multiorchpb.ShardStatusRequest{
-			Database:   "postgres",
-			TableGroup: constants.DefaultTableGroup, // "default" - must match multipooler registration
-			Shard:      constants.DefaultShard,      // "0-inf" - must match multipooler registration
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "postgres",
+				TableGroup: constants.DefaultTableGroup, // "default" - must match multipooler registration
+				Shard:      constants.DefaultShard,      // "0-inf" - must match multipooler registration
+			},
 		})
 		if err != nil {
 			t.Logf("%s: multiorch %s: RPC failed: %v", label, name, err)

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -183,6 +183,19 @@ message MultiGateway {
   uint32 pid_prefix = 4;
 }
 
+// ShardKey uniquely identifies a shard in the cluster.
+// This is a centralized message used across all services to identify shards.
+message ShardKey {
+  // Database name.
+  string database = 1;
+
+  // TableGroup name.
+  string table_group = 2;
+
+  // Shard name. If range based sharding is used, it should match key_range.
+  string shard = 3;
+}
+
 // MultiOrch represents information about a running instance of multiorch.
 message MultiOrch {
   // id is the unique name of the MultiOrch in the cluster.

--- a/proto/multiorchservice.proto
+++ b/proto/multiorchservice.proto
@@ -53,9 +53,7 @@ service MultiOrchService {
 
 message ShardStatusRequest {
   // Shard to get status for
-  string database = 1;
-  string table_group = 2;
-  string shard = 3;
+  clustermetadata.ShardKey shard_key = 1;
 }
 
 message ShardStatusResponse {
@@ -70,13 +68,11 @@ message DetectedProblem {
   string code = 1; // e.g., "PrimaryIsDead"
   string check_name = 2; // Analyzer name
   clustermetadata.ID pooler_id = 3; // Affected pooler
-  string database = 4;
-  string table_group = 5;
-  string shard = 6;
-  string description = 7;
-  int32 priority = 8;
-  string scope = 9; // "Shard" or "Pooler"
-  google.protobuf.Timestamp detected_at = 10;
+  clustermetadata.ShardKey shard_key = 4;
+  string description = 5;
+  int32 priority = 6;
+  string scope = 7; // "Shard" or "Pooler"
+  google.protobuf.Timestamp detected_at = 8;
 }
 
 message PoolerHealth {


### PR DESCRIPTION
Remove the hand-rolled ShardKey struct from go/common/types and use the proto-generated *clustermetadatapb.ShardKey everywhere. Map keys that previously used the comparable struct directly now use commontypes.ShardKeyString (format: "db/tablegroup/shard") since proto pointers compare by address, not value.