### PR TITLE
ci: detect flaky tests, auto-retry on failure, weekly Slack report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,8 +43,36 @@ jobs:
           echo "PORT_POOL_PID=$!" >> "$GITHUB_ENV"
           echo "MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock" >> "$GITHUB_ENV"
 
+      # Coverage jobs cannot use gotestsum's --rerun-fails: a retry would
+      # re-invoke `go test` against the failing package and overwrite the
+      # single -coverprofile file, truncating coverage for packages that
+      # passed the first time. We instead retry the whole suite on failure,
+      # which preserves coverage correctness at the cost of one extra full
+      # pass on a flake. test-short / test-race / test-integration handle
+      # per-package retries and feed the flake aggregator; coverage just
+      # needs to converge on a clean profile without manual restarts.
       - name: Run tests with direct coverage
-        run: go test -json -v -skip TestPostgreSQLRegression -cover -covermode=atomic -coverprofile=coverage-direct.txt -coverpkg=./... ./... | tee coverage-direct-test-results.jsonl | go tool tparse -follow
+        shell: bash
+        run: |
+          set -o pipefail
+          attempt=1
+          max_attempts=3
+          while [ $attempt -le $max_attempts ]; do
+            if go test -json -v -skip TestPostgreSQLRegression \
+                -cover -covermode=atomic \
+                -coverprofile=coverage-direct.txt \
+                -coverpkg=./... ./... \
+                | tee coverage-direct-test-results.jsonl \
+                | go tool tparse -follow ; then
+              break
+            fi
+            if [ $attempt -ge $max_attempts ]; then
+              echo "::error::coverage tests failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "::warning::coverage attempt $attempt failed; retrying"
+            attempt=$((attempt + 1))
+          done
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
@@ -86,11 +114,33 @@ jobs:
           echo "PORT_POOL_PID=$!" >> "$GITHUB_ENV"
           echo "MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock" >> "$GITHUB_ENV"
 
+      # See note in coverage-direct: we retry the whole suite on failure
+      # rather than per-package, because per-package retry would corrupt
+      # the GOCOVERDIR output (a clean dir is the simplest invariant).
       - name: Run tests with subprocess coverage
+        shell: bash
         run: |
+          set -o pipefail
           mkdir -p coverage-subprocess-raw
           export GOCOVERDIR="$PWD/coverage-subprocess-raw"
-          go test -json -v -skip TestPostgreSQLRegression ./... | tee coverage-subprocess-test-results.jsonl | go tool tparse -follow
+          attempt=1
+          max_attempts=3
+          while [ $attempt -le $max_attempts ]; do
+            # Wipe the coverage dir before each attempt so the final
+            # profile reflects only the successful pass.
+            rm -rf "$GOCOVERDIR"/*
+            if go test -json -v -skip TestPostgreSQLRegression ./... \
+                | tee coverage-subprocess-test-results.jsonl \
+                | go tool tparse -follow ; then
+              break
+            fi
+            if [ $attempt -ge $max_attempts ]; then
+              echo "::error::subprocess coverage tests failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "::warning::subprocess coverage attempt $attempt failed; retrying"
+            attempt=$((attempt + 1))
+          done
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -127,8 +127,10 @@ jobs:
           max_attempts=3
           while [ $attempt -le $max_attempts ]; do
             # Wipe the coverage dir before each attempt so the final
-            # profile reflects only the successful pass.
-            rm -rf "$GOCOVERDIR"/*
+            # profile reflects only the successful pass. The :? guard
+            # forces the script to abort if GOCOVERDIR ever ends up
+            # empty, so we can never accidentally rm -rf /*.
+            rm -rf "${GOCOVERDIR:?}"/*
             if go test -json -v -skip TestPostgreSQLRegression ./... \
                 | tee coverage-subprocess-test-results.jsonl \
                 | go tool tparse -follow ; then

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -43,6 +43,7 @@ jobs:
   report:
     name: Aggregate flaky tests and post to Slack
     runs-on: ubuntu-24.04
+    environment: ci
     permissions:
       actions: read
     steps:

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -1,0 +1,67 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Flaky Test Report
+
+on:
+  schedule:
+    # Mondays at 14:00 UTC.
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Lookback window in days"
+        required: false
+        default: "7"
+      threshold:
+        description: "Report tests with strictly more failures than this"
+        required: false
+        default: "3"
+      dry_run:
+        description: "Print Slack payload to logs instead of posting"
+        required: false
+        default: "false"
+
+permissions: {}
+
+jobs:
+  report:
+    name: Aggregate flaky tests and post to Slack
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run aggregator
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DAYS: ${{ github.event.inputs.days || '7' }}
+          THRESHOLD: ${{ github.event.inputs.threshold || '3' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          args=(--days="$DAYS" --threshold="$THRESHOLD")
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          go run ./go/tools/flakyaggregator "${args[@]}"

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     # Mondays at 14:00 UTC.
     - cron: "0 14 * * 1"
+  # checkov:skip=CKV_GHA_7: inputs are read-only flags that gate aggregator
+  # behavior (lookback window, threshold, dry-run); they do not influence any
+  # build artifact, so the "build output cannot be affected by user
+  # parameters" rule does not apply.
   workflow_dispatch:
     inputs:
       days:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.1
+
       - name: Start port pool server
         run: |
           ./bin/portpoolserver --socket /tmp/multigres-port-pool.sock &
@@ -54,7 +57,15 @@ jobs:
           TEST_PRINT_LOGS: "1"
           AWS_ACCESS_KEY_ID: test-access-key
           AWS_SECRET_ACCESS_KEY: test-secret-key
-        run: go test -json -v -skip TestPostgreSQLRegression ./go/test/endtoend/... | tee integration-test-results.jsonl | go tool tparse -follow
+        run: |
+          gotestsum \
+            --format=testname \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=10 \
+            --packages="./go/test/endtoend/..." \
+            --jsonfile=integration-test-results.jsonl \
+            -- \
+            -skip TestPostgreSQLRegression -timeout=30m
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
@@ -65,7 +76,7 @@ jobs:
         with:
           name: integration-test-logs
           path: integration-test-results.jsonl
-          retention-days: 7
+          retention-days: 14
 
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -44,7 +44,7 @@ jobs:
         run: make build
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Start port pool server
         run: |

--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -40,8 +40,19 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.1
+
       - name: Run race detection tests
-        run: go test -json -short -v -race ./... | tee race-test-results.jsonl | go tool tparse -follow
+        run: |
+          gotestsum \
+            --format=testname \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=10 \
+            --packages="./..." \
+            --jsonfile=race-test-results.jsonl \
+            -- \
+            -short -race -timeout=20m
 
       - name: Upload test logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -49,7 +60,7 @@ jobs:
         with:
           name: race-test-logs
           path: race-test-results.jsonl
-          retention-days: 7
+          retention-days: 14
 
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/test-race.yml
+++ b/.github/workflows/test-race.yml
@@ -41,7 +41,7 @@ jobs:
         run: make build
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run race detection tests
         run: |

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -40,8 +40,19 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.1
+
       - name: Run short tests
-        run: go test -json -short -v ./... | tee short-test-results.jsonl | go tool tparse -follow
+        run: |
+          gotestsum \
+            --format=testname \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=10 \
+            --packages="./..." \
+            --jsonfile=short-test-results.jsonl \
+            -- \
+            -short -timeout=20m
 
       - name: Upload test logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -49,7 +60,7 @@ jobs:
         with:
           name: short-test-logs
           path: short-test-results.jsonl
-          retention-days: 7
+          retention-days: 14
 
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -41,7 +41,7 @@ jobs:
         run: make build
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.1
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run short tests
         run: |

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gammazero/deque v1.2.1
 	github.com/google/go-cmp v0.7.0
+	github.com/google/go-github/v68 v68.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
@@ -93,6 +94,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,15 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
+github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/go/tools/flakyaggregator/main.go
+++ b/go/tools/flakyaggregator/main.go
@@ -35,6 +35,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-github/v68/github"
@@ -43,6 +44,7 @@ import (
 const (
 	defaultDays       = 7
 	defaultThreshold  = 3
+	defaultWorkers    = 8 // per-run fetch parallelism; well below GitHub's secondary concurrency limits
 	httpTimeoutSec    = 60
 	maxRunsToInspect  = 2000 // safety cap (covers main + all PR branches over a week)
 	maxRetries        = 3
@@ -68,8 +70,13 @@ var testWorkflowFiles = []string{
 func main() {
 	days := flag.Int("days", defaultDays, "lookback window in days")
 	threshold := flag.Int("threshold", defaultThreshold, "report tests with strictly more failures than this")
+	workers := flag.Int("workers", defaultWorkers, "per-run fetch parallelism")
 	dryRun := flag.Bool("dry-run", false, "print Slack payload to stdout instead of posting")
 	flag.Parse()
+
+	if *workers < 1 {
+		log.Fatalf("--workers must be >= 1, got %d", *workers)
+	}
 
 	repo := os.Getenv("GITHUB_REPOSITORY")
 	token := os.Getenv("GITHUB_TOKEN")
@@ -106,29 +113,11 @@ func main() {
 	log.Printf("found %d completed-success runs (flake-candidate scope)", len(runs))
 
 	stats := newAggregator()
-	for _, run := range runs {
-		artifacts, err := listRunArtifacts(ctx, gh, owner, name, run.GetID())
-		if err != nil {
-			log.Printf("WARN: list artifacts for run %d: %v", run.GetID(), err)
-			continue
-		}
-		for _, art := range artifacts {
-			if !isTestArtifact(art.GetName()) {
-				continue
-			}
-			body, err := downloadArtifact(ctx, gh, owner, name, art.GetID())
-			if err != nil {
-				log.Printf("WARN: download artifact %d (%s): %v", art.GetID(), art.GetName(), err)
-				continue
-			}
-			if err := stats.ingestArtifactZip(run, body); err != nil {
-				log.Printf("WARN: parse artifact %d (%s): %v", art.GetID(), art.GetName(), err)
-			}
-		}
-	}
+	processRunsConcurrently(ctx, gh, owner, name, runs, stats, *workers)
 
 	flaky := stats.filter(*threshold)
 	payload := formatSlackPayload(flaky, *days, *threshold)
+	logRateLimit(ctx, gh, "end")
 
 	if *dryRun {
 		buf, _ := json.MarshalIndent(payload, "", "  ")
@@ -140,7 +129,54 @@ func main() {
 		log.Fatalf("post slack: %v", err)
 	}
 	log.Printf("posted Slack message with %d flaky test(s)", len(flaky))
-	logRateLimit(ctx, gh, "end")
+}
+
+// processRunsConcurrently fans out per-run artifact fetch+parse work across
+// a small worker pool. The aggregator is shared across workers; recordFailure
+// is mutex-guarded so concurrent ingest is safe. Per-run errors are logged
+// and skipped — they're independent and should not abort the whole run.
+func processRunsConcurrently(ctx context.Context, gh *github.Client, owner, repo string, runs []*github.WorkflowRun, stats *aggregator, workers int) {
+	runCh := make(chan *github.WorkflowRun)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for run := range runCh {
+				processRun(ctx, gh, owner, repo, run, stats)
+			}
+		})
+	}
+	for _, run := range runs {
+		select {
+		case runCh <- run:
+		case <-ctx.Done():
+			close(runCh)
+			wg.Wait()
+			return
+		}
+	}
+	close(runCh)
+	wg.Wait()
+}
+
+func processRun(ctx context.Context, gh *github.Client, owner, repo string, run *github.WorkflowRun, stats *aggregator) {
+	artifacts, err := listRunArtifacts(ctx, gh, owner, repo, run.GetID())
+	if err != nil {
+		log.Printf("WARN: list artifacts for run %d: %v", run.GetID(), err)
+		return
+	}
+	for _, art := range artifacts {
+		if !isTestArtifact(art.GetName()) {
+			continue
+		}
+		body, err := downloadArtifact(ctx, gh, owner, repo, art.GetID())
+		if err != nil {
+			log.Printf("WARN: download artifact %d (%s): %v", art.GetID(), art.GetName(), err)
+			continue
+		}
+		if err := stats.ingestArtifactZip(run, body); err != nil {
+			log.Printf("WARN: parse artifact %d (%s): %v", art.GetID(), art.GetName(), err)
+		}
+	}
 }
 
 // --- Rate-limit handling ---
@@ -317,6 +353,7 @@ type testStats struct {
 }
 
 type aggregator struct {
+	mu    sync.Mutex
 	tests map[testKey]*testStats
 }
 
@@ -324,7 +361,11 @@ func newAggregator() *aggregator {
 	return &aggregator{tests: map[testKey]*testStats{}}
 }
 
+// recordFailure is safe for concurrent use; ingestArtifactZip is called from
+// multiple worker goroutines.
 func (a *aggregator) recordFailure(run *github.WorkflowRun, key testKey) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	s := a.tests[key]
 	if s == nil {
 		s = &testStats{runIDs: map[int64]struct{}{}}
@@ -346,6 +387,8 @@ type flakyEntry struct {
 }
 
 func (a *aggregator) filter(threshold int) []flakyEntry {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	var out []flakyEntry
 	for k, s := range a.tests {
 		if len(s.runIDs) > threshold {

--- a/go/tools/flakyaggregator/main.go
+++ b/go/tools/flakyaggregator/main.go
@@ -1,0 +1,514 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command flakyaggregator collects JUnit test artifacts produced by recent
+// CI runs on main, counts failure occurrences per test, and posts a Slack
+// summary of tests with more than --threshold failures in the last
+// --days days.
+package main
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+)
+
+const (
+	defaultDays       = 7
+	defaultThreshold  = 3
+	httpTimeoutSec    = 60
+	maxRunsToInspect  = 2000 // safety cap (covers main + all PR branches over a week)
+	maxRetries        = 3
+	maxBackoff        = 5 * time.Minute
+	testArtifactGlob1 = "-test-logs"
+)
+
+// testWorkflowFiles enumerates the workflow files that run gotestsum with
+// --rerun-fails and can therefore produce flake signal. Listing runs scoped
+// per-file (instead of across the whole repo) is the largest single rate-
+// limit saver: it skips lint, docker-build, pgbench, etc. runs that have
+// nothing for us. coverage.yml is intentionally excluded because it
+// deliberately omits --rerun-fails (a retry would truncate -coverprofile),
+// so its event stream contains no fail-then-pass pairs to detect.
+//
+// Update this list when a new test workflow with --rerun-fails is added.
+var testWorkflowFiles = []string{
+	"test-short.yml",
+	"test-race.yml",
+	"test-integration.yml",
+}
+
+func main() {
+	days := flag.Int("days", defaultDays, "lookback window in days")
+	threshold := flag.Int("threshold", defaultThreshold, "report tests with strictly more failures than this")
+	dryRun := flag.Bool("dry-run", false, "print Slack payload to stdout instead of posting")
+	flag.Parse()
+
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	token := os.Getenv("GITHUB_TOKEN")
+	slackURL := os.Getenv("SLACK_WEBHOOK_URL")
+
+	if repo == "" {
+		log.Fatal("GITHUB_REPOSITORY is required")
+	}
+	if token == "" {
+		log.Fatal("GITHUB_TOKEN is required")
+	}
+	if !*dryRun && slackURL == "" {
+		log.Fatal("SLACK_WEBHOOK_URL is required (use --dry-run to skip posting)")
+	}
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok {
+		log.Fatalf("GITHUB_REPOSITORY must be owner/name, got %q", repo)
+	}
+
+	//nolint:gocritic // main is the program entry point; context.Background() is the canonical root.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	gh := github.NewClient(nil).WithAuthToken(token)
+
+	since := time.Now().UTC().AddDate(0, 0, -*days)
+	log.Printf("scanning runs across all branches since %s for repo %s", since.Format(time.RFC3339), repo)
+	logRateLimit(ctx, gh, "start")
+
+	runs, err := listFlakeCandidateRuns(ctx, gh, owner, name, since)
+	if err != nil {
+		log.Fatalf("list workflow runs: %v", err)
+	}
+	log.Printf("found %d completed-success runs (flake-candidate scope)", len(runs))
+
+	stats := newAggregator()
+	for _, run := range runs {
+		artifacts, err := listRunArtifacts(ctx, gh, owner, name, run.GetID())
+		if err != nil {
+			log.Printf("WARN: list artifacts for run %d: %v", run.GetID(), err)
+			continue
+		}
+		for _, art := range artifacts {
+			if !isTestArtifact(art.GetName()) {
+				continue
+			}
+			body, err := downloadArtifact(ctx, gh, owner, name, art.GetID())
+			if err != nil {
+				log.Printf("WARN: download artifact %d (%s): %v", art.GetID(), art.GetName(), err)
+				continue
+			}
+			if err := stats.ingestArtifactZip(run, body); err != nil {
+				log.Printf("WARN: parse artifact %d (%s): %v", art.GetID(), art.GetName(), err)
+			}
+		}
+	}
+
+	flaky := stats.filter(*threshold)
+	payload := formatSlackPayload(flaky, *days, *threshold)
+
+	if *dryRun {
+		buf, _ := json.MarshalIndent(payload, "", "  ")
+		fmt.Println(string(buf))
+		return
+	}
+
+	if err := postSlack(ctx, slackURL, payload); err != nil {
+		log.Fatalf("post slack: %v", err)
+	}
+	log.Printf("posted Slack message with %d flaky test(s)", len(flaky))
+	logRateLimit(ctx, gh, "end")
+}
+
+// --- Rate-limit handling ---
+
+// withRetry runs fn, sleeping and retrying on go-github's rate-limit and
+// abuse errors up to maxRetries times. RateLimitError carries the reset
+// timestamp; AbuseRateLimitError carries an explicit Retry-After. We cap
+// each sleep at maxBackoff so a misbehaving response can't stall the whole
+// 30-minute run.
+func withRetry[T any](ctx context.Context, label string, fn func() (T, *github.Response, error)) (T, *github.Response, error) {
+	var zero T
+	for attempt := 0; ; attempt++ {
+		out, resp, err := fn()
+		if err == nil {
+			return out, resp, nil
+		}
+
+		var sleep time.Duration
+		var rle *github.RateLimitError
+		var arle *github.AbuseRateLimitError
+		switch {
+		case errors.As(err, &rle):
+			sleep = time.Until(rle.Rate.Reset.Time)
+		case errors.As(err, &arle):
+			if arle.RetryAfter != nil {
+				sleep = *arle.RetryAfter
+			}
+		default:
+			return zero, resp, err
+		}
+
+		if attempt >= maxRetries {
+			return zero, resp, fmt.Errorf("%s: rate-limited after %d retries: %w", label, maxRetries, err)
+		}
+		if sleep <= 0 {
+			sleep = 30 * time.Second
+		}
+		if sleep > maxBackoff {
+			sleep = maxBackoff
+		}
+		log.Printf("rate-limited on %s (attempt %d/%d); sleeping %s", label, attempt+1, maxRetries, sleep)
+		select {
+		case <-time.After(sleep):
+		case <-ctx.Done():
+			return zero, resp, ctx.Err()
+		}
+	}
+}
+
+func logRateLimit(ctx context.Context, gh *github.Client, label string) {
+	rl, _, err := gh.RateLimit.Get(ctx)
+	if err != nil {
+		log.Printf("rate-limit (%s): unknown: %v", label, err)
+		return
+	}
+	core := rl.GetCore()
+	log.Printf("rate-limit (%s): %d/%d remaining (resets %s)",
+		label, core.Remaining, core.Limit, core.Reset.Format(time.RFC3339))
+}
+
+// --- GitHub API (thin wrappers around go-github) ---
+
+// listFlakeCandidateRuns returns recent successful workflow runs across all
+// branches, scoped to the workflow files listed in testWorkflowFiles. The
+// per-file scoping is the largest single rate-limit saver: it skips lint,
+// docker-build, etc. runs that have no JUnit artifacts. The conclusion=
+// success filter is what makes it safe to include PR branches — if a test
+// failed and the run still concluded success, gotestsum's --rerun-fails
+// recovered, which is the textbook flake signal. Tests that fail every
+// retry make the run conclude failure and are correctly excluded as
+// real-bug noise rather than counted as flakes.
+func listFlakeCandidateRuns(ctx context.Context, gh *github.Client, owner, repo string, since time.Time) ([]*github.WorkflowRun, error) {
+	var all []*github.WorkflowRun
+	for _, file := range testWorkflowFiles {
+		opts := &github.ListWorkflowRunsOptions{
+			Status:      "success",
+			Created:     ">=" + since.Format("2006-01-02"),
+			ListOptions: github.ListOptions{PerPage: 100},
+		}
+		for {
+			label := fmt.Sprintf("ListWorkflowRunsByFileName(%s, page=%d)", file, max(opts.Page, 1))
+			page, resp, err := withRetry(ctx, label, func() (*github.WorkflowRuns, *github.Response, error) {
+				return gh.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, file, opts)
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, r := range page.WorkflowRuns {
+				if r.GetCreatedAt().Time.Before(since) {
+					continue
+				}
+				all = append(all, r)
+			}
+			if len(all) >= maxRunsToInspect {
+				log.Printf("WARN: hit maxRunsToInspect=%d, truncating", maxRunsToInspect)
+				return all, nil
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+	}
+	return all, nil
+}
+
+func listRunArtifacts(ctx context.Context, gh *github.Client, owner, repo string, runID int64) ([]*github.Artifact, error) {
+	opts := &github.ListOptions{PerPage: 100}
+	var all []*github.Artifact
+	for {
+		label := fmt.Sprintf("ListWorkflowRunArtifacts(run=%d, page=%d)", runID, max(opts.Page, 1))
+		page, resp, err := withRetry(ctx, label, func() (*github.ArtifactList, *github.Response, error) {
+			return gh.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, opts)
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Artifacts...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return all, nil
+}
+
+func downloadArtifact(ctx context.Context, gh *github.Client, owner, repo string, artifactID int64) ([]byte, error) {
+	label := fmt.Sprintf("DownloadArtifact(%d)", artifactID)
+	dlURL, _, err := withRetry(ctx, label, func() (*url.URL, *github.Response, error) {
+		return gh.Actions.DownloadArtifact(ctx, owner, repo, artifactID, 3)
+	})
+	if err != nil {
+		return nil, err
+	}
+	// The redirect URL points to GitHub's blob storage; fetching it does NOT
+	// count against the REST rate limit, so no withRetry wrapper here.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := (&http.Client{Timeout: httpTimeoutSec * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("download artifact %d: %s: %s", artifactID, resp.Status, body)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// --- Aggregation ---
+
+// isTestArtifact returns true for artifact names that contain the gotestsum
+// JSONL streams we feed into the flake detector. coverage-* is intentionally
+// not matched: those workflows omit --rerun-fails (a retry would truncate
+// -coverprofile), so their event streams contain no fail-then-pass pairs.
+func isTestArtifact(name string) bool {
+	return strings.Contains(name, testArtifactGlob1)
+}
+
+type testKey struct {
+	pkg  string
+	name string
+}
+
+type testStats struct {
+	// runIDs tracks distinct workflow runs in which this test was observed
+	// failing — a test that fails twice in one run only counts once.
+	runIDs     map[int64]struct{}
+	lastSeen   time.Time
+	lastRunURL string
+}
+
+type aggregator struct {
+	tests map[testKey]*testStats
+}
+
+func newAggregator() *aggregator {
+	return &aggregator{tests: map[testKey]*testStats{}}
+}
+
+func (a *aggregator) recordFailure(run *github.WorkflowRun, key testKey) {
+	s := a.tests[key]
+	if s == nil {
+		s = &testStats{runIDs: map[int64]struct{}{}}
+		a.tests[key] = s
+	}
+	s.runIDs[run.GetID()] = struct{}{}
+	if t := run.GetCreatedAt().Time; t.After(s.lastSeen) {
+		s.lastSeen = t
+		s.lastRunURL = run.GetHTMLURL()
+	}
+}
+
+type flakyEntry struct {
+	Pkg        string
+	Name       string
+	Failures   int
+	LastSeen   time.Time
+	LastRunURL string
+}
+
+func (a *aggregator) filter(threshold int) []flakyEntry {
+	var out []flakyEntry
+	for k, s := range a.tests {
+		if len(s.runIDs) > threshold {
+			out = append(out, flakyEntry{
+				Pkg:        k.pkg,
+				Name:       k.name,
+				Failures:   len(s.runIDs),
+				LastSeen:   s.lastSeen,
+				LastRunURL: s.lastRunURL,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Failures != out[j].Failures {
+			return out[i].Failures > out[j].Failures
+		}
+		if out[i].Pkg != out[j].Pkg {
+			return out[i].Pkg < out[j].Pkg
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func (a *aggregator) ingestArtifactZip(run *github.WorkflowRun, data []byte) error {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, ".jsonl") {
+			continue
+		}
+		// Defensive: skip any path traversal / nested files we don't expect.
+		if strings.Contains(path.Clean(f.Name), "..") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("open %s: %w", f.Name, err)
+		}
+		flakes, err := parseFlakesFromJSONL(rc)
+		rc.Close()
+		if err != nil {
+			log.Printf("WARN: parse %s: %v", f.Name, err)
+			continue
+		}
+		for _, k := range flakes {
+			a.recordFailure(run, k)
+		}
+	}
+	return nil
+}
+
+// --- gotestsum JSONL parsing ---
+
+// testEvent matches the subset of `go test -json` event fields we care about.
+// The full event format also carries Time, Elapsed, and Output, but for
+// flake detection we only need to know which test moved through which
+// terminal state in which order.
+type testEvent struct {
+	Action  string `json:"Action"`
+	Package string `json:"Package"`
+	Test    string `json:"Test"`
+}
+
+// parseFlakesFromJSONL streams a gotestsum --jsonfile output and returns
+// the set of tests that were flaky in this run. A test is flaky iff its
+// event stream contains both a "fail" and a "pass" action — gotestsum's
+// --rerun-fails appends the retry's events, so a recovered flake is
+// recognizable as fail-followed-by-pass on the same (package, test) pair.
+//
+// Package-level events (Test == "") are ignored: they reflect the package's
+// rolled-up status and would double-count tests that are already represented
+// by their own events.
+func parseFlakesFromJSONL(r io.Reader) ([]testKey, error) {
+	type state struct{ sawFail, sawPass bool }
+	seen := map[testKey]*state{}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024) // some events embed long Output strings
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev testEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue // tolerate occasional malformed lines rather than abort
+		}
+		if ev.Test == "" {
+			continue
+		}
+		if ev.Action != "fail" && ev.Action != "pass" {
+			continue
+		}
+		k := testKey{pkg: ev.Package, name: ev.Test}
+		s := seen[k]
+		if s == nil {
+			s = &state{}
+			seen[k] = s
+		}
+		switch ev.Action {
+		case "fail":
+			s.sawFail = true
+		case "pass":
+			s.sawPass = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan jsonl: %w", err)
+	}
+
+	var out []testKey
+	for k, s := range seen {
+		if s.sawFail && s.sawPass {
+			out = append(out, k)
+		}
+	}
+	return out, nil
+}
+
+// --- Slack ---
+
+type slackPayload struct {
+	Text string `json:"text"`
+}
+
+func formatSlackPayload(flaky []flakyEntry, days, threshold int) slackPayload {
+	weekOf := time.Now().UTC().Format("2006-01-02")
+	var b strings.Builder
+	fmt.Fprintf(&b, "*Flaky Test Report — week of %s*\n", weekOf)
+	fmt.Fprintf(&b, "Tests that failed-then-recovered in more than %d successful CI runs (`main` + PRs) over the last %d days:\n\n", threshold, days)
+	if len(flaky) == 0 {
+		b.WriteString("No flaky tests detected this week. :tada:")
+		return slackPayload{Text: b.String()}
+	}
+	for _, f := range flaky {
+		fqn := f.Pkg + "." + f.Name
+		fmt.Fprintf(&b, "• `%s` — *%d* failures (last seen %s, <%s|run>)\n",
+			fqn, f.Failures, f.LastSeen.Format("2006-01-02"), f.LastRunURL)
+	}
+	return slackPayload{Text: b.String()}
+}
+
+func postSlack(ctx context.Context, webhookURL string, p slackPayload) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: httpTimeoutSec * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		out, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("slack POST: %s: %s", resp.Status, out)
+	}
+	return nil
+}

--- a/go/tools/flakyaggregator/main_test.go
+++ b/go/tools/flakyaggregator/main_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRun(id int64, url string, t time.Time) *github.WorkflowRun {
+	return &github.WorkflowRun{
+		ID:        github.Ptr(id),
+		HTMLURL:   github.Ptr(url),
+		CreatedAt: &github.Timestamp{Time: t},
+	}
+}
+
+func TestIsTestArtifact(t *testing.T) {
+	cases := map[string]bool{
+		"short-test-logs":       true,
+		"race-test-logs":        true,
+		"integration-test-logs": true,
+		// coverage workflows omit --rerun-fails so they cannot produce flake
+		// signal; their artifacts are correctly excluded.
+		"coverage-direct":     false,
+		"coverage-subprocess": false,
+		"coverage-merged":     false,
+		"some-other-artifact": false,
+		"":                    false,
+	}
+	for name, want := range cases {
+		assert.Equal(t, want, isTestArtifact(name), "isTestArtifact(%q)", name)
+	}
+}
+
+// flakeFixture is a small gotestsum --jsonfile-style stream where TestFlake
+// fails once and recovers, while TestSolid passes on the first attempt.
+const flakeFixture = `{"Action":"run","Package":"pkg/a","Test":"TestSolid"}
+{"Action":"pass","Package":"pkg/a","Test":"TestSolid","Elapsed":0.01}
+{"Action":"run","Package":"pkg/a","Test":"TestFlake"}
+{"Action":"fail","Package":"pkg/a","Test":"TestFlake","Elapsed":0.02}
+{"Action":"fail","Package":"pkg/a","Elapsed":0.02}
+{"Action":"run","Package":"pkg/a","Test":"TestFlake"}
+{"Action":"pass","Package":"pkg/a","Test":"TestFlake","Elapsed":0.01}
+{"Action":"pass","Package":"pkg/a","Elapsed":0.03}
+`
+
+func TestParseFlakesFromJSONL_FailThenPass(t *testing.T) {
+	got, err := parseFlakesFromJSONL(strings.NewReader(flakeFixture))
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "pkg/a", got[0].pkg)
+	assert.Equal(t, "TestFlake", got[0].name)
+}
+
+func TestParseFlakesFromJSONL_SolidPassOnly(t *testing.T) {
+	stream := `{"Action":"run","Package":"pkg/a","Test":"TestSolid"}
+{"Action":"pass","Package":"pkg/a","Test":"TestSolid"}
+`
+	got, err := parseFlakesFromJSONL(strings.NewReader(stream))
+	require.NoError(t, err)
+	assert.Empty(t, got, "tests that only pass are not flakes")
+}
+
+func TestParseFlakesFromJSONL_FailWithoutRecovery(t *testing.T) {
+	// A test that fails and never passes shouldn't be reported. In
+	// practice the run conclusion would be failure and the API filter
+	// would exclude it, but we want the parser itself to be safe even
+	// if a stream is misclassified.
+	stream := `{"Action":"run","Package":"pkg/a","Test":"TestBroken"}
+{"Action":"fail","Package":"pkg/a","Test":"TestBroken"}
+{"Action":"run","Package":"pkg/a","Test":"TestBroken"}
+{"Action":"fail","Package":"pkg/a","Test":"TestBroken"}
+`
+	got, err := parseFlakesFromJSONL(strings.NewReader(stream))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestParseFlakesFromJSONL_IgnoresPackageLevelEvents(t *testing.T) {
+	// Package-level events have Test=="" and reflect rolled-up status.
+	// Counting them would inflate the flake count.
+	stream := `{"Action":"fail","Package":"pkg/a"}
+{"Action":"pass","Package":"pkg/a"}
+`
+	got, err := parseFlakesFromJSONL(strings.NewReader(stream))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestParseFlakesFromJSONL_ToleratesMalformedLines(t *testing.T) {
+	stream := `not json
+{"Action":"fail","Package":"pkg/a","Test":"TestFlake"}
+{ this isn't valid either
+{"Action":"pass","Package":"pkg/a","Test":"TestFlake"}
+`
+	got, err := parseFlakesFromJSONL(strings.NewReader(stream))
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+}
+
+func TestParseFlakesFromJSONL_Empty(t *testing.T) {
+	got, err := parseFlakesFromJSONL(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestParseFlakesFromJSONL_MultipleFlakesAcrossPackages(t *testing.T) {
+	stream := `{"Action":"fail","Package":"pkg/a","Test":"T1"}
+{"Action":"pass","Package":"pkg/a","Test":"T1"}
+{"Action":"fail","Package":"pkg/b","Test":"T2"}
+{"Action":"pass","Package":"pkg/b","Test":"T2"}
+{"Action":"pass","Package":"pkg/c","Test":"T3"}
+`
+	got, err := parseFlakesFromJSONL(strings.NewReader(stream))
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+}
+
+func TestAggregatorDedupesWithinRun(t *testing.T) {
+	a := newAggregator()
+	run := makeRun(42, "https://example.com/run/42", time.Now())
+	k := testKey{pkg: "pkg/a", name: "TestX"}
+	a.recordFailure(run, k)
+	a.recordFailure(run, k) // same run, should not double-count
+	got := a.filter(0)      // threshold 0 → include any test with >0 distinct runs
+	require.Len(t, got, 1)
+	assert.Equal(t, 1, got[0].Failures, "same run recorded twice should count once")
+}
+
+func TestAggregatorThreshold(t *testing.T) {
+	a := newAggregator()
+	k := testKey{pkg: "p", name: "T"}
+	for i := int64(1); i <= 4; i++ {
+		a.recordFailure(makeRun(i, "", time.Now()), k)
+	}
+
+	got := a.filter(3)
+	require.Len(t, got, 1, "threshold>3 with 4 distinct runs should include test")
+	assert.Equal(t, 4, got[0].Failures)
+
+	assert.Empty(t, a.filter(4), "threshold>4 with 4 distinct runs should exclude test")
+}
+
+func TestAggregatorSortsDescending(t *testing.T) {
+	a := newAggregator()
+	low := testKey{pkg: "p", name: "Low"}
+	high := testKey{pkg: "p", name: "High"}
+	for i := int64(1); i <= 5; i++ {
+		a.recordFailure(makeRun(i, "", time.Now()), high)
+	}
+	for i := int64(100); i <= 102; i++ {
+		a.recordFailure(makeRun(i, "", time.Now()), low)
+	}
+
+	got := a.filter(0)
+	require.Len(t, got, 2)
+	assert.Equal(t, "High", got[0].Name, "highest-failure entry should sort first")
+	assert.Equal(t, 5, got[0].Failures)
+	assert.Equal(t, "Low", got[1].Name)
+	assert.Equal(t, 3, got[1].Failures)
+}
+
+func TestFormatSlackPayload_Empty(t *testing.T) {
+	p := formatSlackPayload(nil, 7, 3)
+	assert.Contains(t, p.Text, "No flaky tests detected")
+}
+
+func TestFormatSlackPayload_NonEmpty(t *testing.T) {
+	entries := []flakyEntry{
+		{Pkg: "pkg/a", Name: "TestA", Failures: 7, LastSeen: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), LastRunURL: "https://example.com/1"},
+		{Pkg: "pkg/b", Name: "TestB", Failures: 4, LastSeen: time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC), LastRunURL: "https://example.com/2"},
+	}
+	p := formatSlackPayload(entries, 7, 3)
+
+	assert.Contains(t, p.Text, "pkg/a.TestA")
+	assert.Contains(t, p.Text, "*7*")
+	assert.Contains(t, p.Text, "pkg/b.TestB")
+	assert.Contains(t, p.Text, "*4*")
+	assert.Less(t, strings.Index(p.Text, "TestA"), strings.Index(p.Text, "TestB"),
+		"highest-failure entry should appear first in the rendered payload")
+}


### PR DESCRIPTION
## Summary

- Wraps the unit / race / integration test workflows in `gotestsum --rerun-fails=3` so a single transient test failure no longer fails a PR. Coverage workflows use a bash retry loop instead — `gotestsum`'s per-package retry would truncate `-coverprofile` and corrupt `GOCOVERDIR`, so the whole suite is retried up to 3 times on failure.
- Adds `go/tools/flakyaggregator`, a weekly scheduled job that fetches gotestsum `--jsonfile` artifacts from the last 7 days of successful CI runs across `main` and PRs, identifies tests that failed-then-passed within a single run, and posts a Slack summary of any test that flaked in more than 3 distinct runs.
- Two-layer design separates _papering over_ flakes (rerun-fails) from _detecting_ them (the aggregator) — green CI doesn't hide flake history, because the original failure remains in the gotestsum JSONL even when the retry recovers.

## Description

### Layer 1: in-run retry (`test-short.yml`, `test-race.yml`, `test-integration.yml`)

`go test` is replaced with `gotestsum --format=testname --rerun-fails=3 --rerun-fails-max-failures=10 --jsonfile=...`. The circuit breaker (`--rerun-fails-max-failures=10`) prevents a genuinely broken commit from burning minutes on doomed retries. Artifacts upload only the JSONL stream now — the JUnit file we briefly emitted turned out to be useless for flake detection because gotestsum dedupes its JUnit output to last-result.

### Layer 1.5: whole-suite retry for coverage (`coverage.yml`)

Coverage runs cannot use `--rerun-fails` (a retry would overwrite the single `-coverprofile` file with only the rerun's package). Instead, a small bash retry loop wraps `go test`. On failure it logs `::warning::` and re-runs the whole suite up to 3 times. Costs more wall-clock on a flake but preserves coverage correctness; coverage isn't merge-blocking, so the duration cost is acceptable. Subprocess coverage also wipes `$GOCOVERDIR` between attempts.

### Layer 2: artifact retention

`*-test-results.jsonl` is uploaded with 14-day retention so the aggregator's 7-day rolling window has headroom for manual investigation.

### Layer 3: weekly aggregator (`flaky-test-report.yml` + `go/tools/flakyaggregator/`)

A weekly scheduled workflow (Mondays 14:00 UTC, also `workflow_dispatch`) runs a small Go program that:

- Lists successful workflow runs across `main` + all PR branches over the last `--days` (default 7), scoped per-workflow-file (`test-short.yml`, `test-race.yml`, `test-integration.yml`) via `Actions.ListWorkflowRunsByFileName`. The per-file scoping skips lint, docker-build, etc. and is the largest single API-rate-limit saver.
- Downloads each run's `*-test-logs` artifact zip (uses `*-test-results.jsonl` only — coverage artifacts are excluded since they can't contribute flake signal).
- Streams the gotestsum JSON event stream and flags any test that observed both a `fail` and a `pass` action — the canonical flake definition.
- Counts distinct **runs** in which each test flaked (so a test failing twice in one run only counts once).
- Filters strictly to tests with `>3` distinct flaking runs (configurable), sorts descending by count, and posts to Slack via `SLACK_WEBHOOK_URL`.

The conclusion=success API filter plus the fail-then-pass parser predicate is the load-bearing definition: a passing CI run with at least one observed failure means a retry recovered it. Tests that fail every retry make the run conclude failure and are correctly excluded as real-bug noise rather than reported as flakes — which is what makes including PR runs (and the larger sample size that comes with them) safe.

### Rate-limit hardening

- Per-workflow-file run listing (above).
- Generic `withRetry[T]` wrapper around every API call, detecting `*github.RateLimitError` and `*github.AbuseRateLimitError` via `errors.As`, sleeping until reset (capped at 5 min) for up to 3 retries.
- Rate-limit budget logged at start and end of the aggregator run.

### Dependencies

`go.mod` gains `github.com/google/go-github/v68` and indirect `github.com/google/go-querystring`. JUnit parsing was briefly handled by `github.com/joshdk/go-junit` and was then removed when we switched to gotestsum JSONL.

## Things to verify before merging

- [x] **Add `SLACK_WEBHOOK_URL` repo secret.** Aggregator fails fast with a clear error if it's missing.
- [x] Optional: trigger the new workflow manually via `workflow_dispatch` with `dry_run=true` once before the first scheduled run lands. This validates the GitHub API plumbing and lets you eyeball the Slack payload format without spamming the channel.
- [x] Confirm `Mondays 14:00 UTC` cron timing works for the team (~7am Pacific / 10am Eastern / 3pm UK). Edit the cron expression if not.
- [x] When a future test workflow with `gotestsum --rerun-fails` is added, append its filename to `testWorkflowFiles` in `go/tools/flakyaggregator/main.go` so the aggregator picks up its artifacts.