### PR TITLE
test(multipooler): no data loss when primary crashes with unarchived WAL

### DIFF
--- a/config/pgbackrest/pgbackrest_server_template.conf
+++ b/config/pgbackrest/pgbackrest_server_template.conf
@@ -1,5 +1,6 @@
 [global]
 log-path={{.LogPath}}
+lock-path={{.LockPath}}
 tls-server-cert-file={{.ServerCertFile}}
 tls-server-key-file={{.ServerKeyFile}}
 tls-server-ca-file={{.ServerCAFile}}

--- a/go/common/backup/serverconfig.go
+++ b/go/common/backup/serverconfig.go
@@ -41,9 +41,21 @@ type ServerConfigOpts struct {
 func WriteServerConfig(opts ServerConfigOpts) (string, error) {
 	pgbackrestDir := filepath.Join(opts.PoolerDir, "pgbackrest")
 	logPath := filepath.Join(pgbackrestDir, "log")
+	// lockPath must be per-pooler. Without it, pgbackrest defaults to
+	// /tmp/pgbackrest/, which collides across multiple pgctld instances on the
+	// same host (e.g. parallel endtoend test binaries). The TLS server
+	// acquires this lock when a remote pgbackrest client (--pg2-host=tls)
+	// connects to perform a backup, so a default global path turns concurrent
+	// cross-pooler backups into a flake source.
+	//
+	// Distinct from the *client* lock-path on the same pooler (lock/, see
+	// clientconfig.go). Sharing one path would let same-pooler client and
+	// server processes serialize on pgbackrest's OS lock and race against
+	// our lease-stealing logic; keep them isolated until that race is fixed.
+	lockPath := filepath.Join(pgbackrestDir, "server-lock")
 
 	// Create directories
-	for _, dir := range []string{pgbackrestDir, logPath} {
+	for _, dir := range []string{pgbackrestDir, logPath, lockPath} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return "", fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
@@ -56,6 +68,7 @@ func WriteServerConfig(opts ServerConfigOpts) (string, error) {
 
 	templateData := struct {
 		LogPath        string
+		LockPath       string
 		ServerCertFile string
 		ServerKeyFile  string
 		ServerCAFile   string
@@ -66,6 +79,7 @@ func WriteServerConfig(opts ServerConfigOpts) (string, error) {
 		Pg1User        string
 	}{
 		LogPath:        logPath,
+		LockPath:       lockPath,
 		ServerCertFile: filepath.Join(opts.CertDir, "pgbackrest.crt"),
 		ServerKeyFile:  filepath.Join(opts.CertDir, "pgbackrest.key"),
 		ServerCAFile:   filepath.Join(opts.CertDir, "ca.crt"),

--- a/go/common/backup/serverconfig_test.go
+++ b/go/common/backup/serverconfig_test.go
@@ -47,6 +47,7 @@ func TestWriteServerConfig(t *testing.T) {
 
 	global := cfg.Section("global")
 	assert.Equal(t, filepath.Join(tmpDir, "pgbackrest", "log"), global.Key("log-path").String())
+	assert.Equal(t, filepath.Join(tmpDir, "pgbackrest", "server-lock"), global.Key("lock-path").String())
 	assert.Equal(t, "/certs/pgbackrest.crt", global.Key("tls-server-cert-file").String())
 	assert.Equal(t, "/certs/pgbackrest.key", global.Key("tls-server-key-file").String())
 	assert.Equal(t, "/certs/ca.crt", global.Key("tls-server-ca-file").String())
@@ -66,7 +67,6 @@ func TestWriteServerConfig(t *testing.T) {
 		assert.False(t, strings.HasPrefix(key.Name(), "repo1-"), "server config should not contain repo settings")
 	}
 	assert.False(t, global.HasKey("spool-path"), "server config should not contain spool-path")
-	assert.False(t, global.HasKey("lock-path"), "server config should not contain lock-path")
 }
 
 func TestWriteServerConfig_CreatesLogDir(t *testing.T) {
@@ -85,6 +85,6 @@ func TestWriteServerConfig_CreatesLogDir(t *testing.T) {
 	_, err := WriteServerConfig(opts)
 	require.NoError(t, err)
 
-	logDir := filepath.Join(tmpDir, "pgbackrest", "log")
-	assert.DirExists(t, logDir)
+	assert.DirExists(t, filepath.Join(tmpDir, "pgbackrest", "log"))
+	assert.DirExists(t, filepath.Join(tmpDir, "pgbackrest", "server-lock"))
 }

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -147,7 +147,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 		// 8–12s grace period (configured via WithLeaderFailoverGracePeriod), plus
 		// several seconds for failover execution (BeginTerm + Promote + Demote).
 		t.Logf("Waiting for multiorch to detect primary failure and elect new leader...")
-		newPrimaryName := waitForNewPrimary(t, setup, currentPrimaryName, 30*time.Second)
+		newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, currentPrimaryName, 30*time.Second)
 		require.NotEmpty(t, newPrimaryName, "Expected multiorch to elect new primary automatically")
 		t.Logf("New primary elected: %s", newPrimaryName)
 
@@ -239,7 +239,7 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	// the SIGKILL case. Added to 8–12s grace period and execution time, the worst-case
 	// path needs ~25s — 30s gives adequate headroom.
 	t.Logf("Waiting for multiorch to detect emergency demotion and elect new leader...")
-	newPrimaryName := waitForNewPrimary(t, setup, currentPrimaryName, 30*time.Second)
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, currentPrimaryName, 30*time.Second)
 	require.NotEmpty(t, newPrimaryName, "Expected multiorch to elect new primary after emergency demotion")
 	t.Logf("New primary elected: %s", newPrimaryName)
 
@@ -525,33 +525,6 @@ func verifyStandbyDataConsistency(t *testing.T, name string, inst *shardsetup.Mu
 	err = standbyDB.QueryRow(checksumQuery).Scan(&standbyChecksum)
 	require.NoError(t, err, "Should be able to compute checksum on standby %s", name)
 	assert.Equal(t, expectedChecksum, standbyChecksum, "Standby %s should have identical data to primary", name)
-}
-
-// checkPrimary checks if a specific multipooler is the primary.
-// Returns the multipooler name if it's a primary, empty string otherwise.
-// waitForNewPrimary waits for a new primary (different from oldPrimaryName) to be elected.
-func waitForNewPrimary(t *testing.T, setup *shardsetup.ShardSetup, oldPrimaryName string, timeout time.Duration) string {
-	t.Helper()
-
-	var poolers []*shardsetup.MultipoolerInstance
-	for _, inst := range setup.Multipoolers {
-		poolers = append(poolers, inst)
-	}
-
-	return shardsetup.EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
-		func(statuses []shardsetup.PoolerStatusResult) (string, bool, string) {
-			for _, r := range statuses {
-				if r.Name == oldPrimaryName || r.Err != nil || r.Status == nil {
-					continue
-				}
-				if r.Status.IsInitialized && r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY {
-					return r.Name, true, ""
-				}
-			}
-			return "", false, fmt.Sprintf("no new primary elected yet (old primary: %s)", oldPrimaryName)
-		},
-		"new primary not elected within %v", timeout,
-	)
 }
 
 // waitForNodeToRejoinAsStandby waits for a killed multipooler to be restarted by multiorch

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -94,7 +94,7 @@ func TestDemoteStalePrimary_SIGKILL(t *testing.T) {
 
 	// Step 2: Wait for new primary election
 	t.Log("Waiting for new primary election...")
-	newPrimaryName := waitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
 	require.NotEmpty(t, newPrimaryName, "new primary should be elected")
 	t.Logf("New primary elected: %s", newPrimaryName)
 
@@ -196,7 +196,7 @@ func TestDemoteStalePrimary_GracefulShutdown(t *testing.T) {
 
 	// Step 2: Wait for new primary election
 	t.Log("Waiting for new primary election...")
-	newPrimaryName := waitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
 	require.NotEmpty(t, newPrimaryName, "new primary should be elected")
 	t.Logf("New primary elected: %s", newPrimaryName)
 

--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -1,0 +1,457 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupfaults
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/s3mock"
+)
+
+// TestPrimaryCrashWithUnarchivedWAL_NoDataLoss proves Multigres' synchronous-commit
+// durability contract under a primary postgres crash where committed WAL has not
+// been pushed to the pgBackRest archive yet, AND verifies that the post-failover
+// pgBackRest archive remains usable for provisioning fresh standbys.
+//
+// Scenario:
+//  1. Healthy 3-node cluster with synchronous_commit + synchronous_standby_names
+//     wired by multiorch. Three nodes are required because multiorch's election
+//     refuses to appoint a leader without majority recruitment of the cohort —
+//     a 2-node cluster cannot survive a primary kill.
+//  2. WriterValidator commits rows via multigateway. Under sync_commit, every
+//     successful COMMIT is durable on at least one standby's WAL even if the
+//     primary's archive is behind.
+//  3. The s3mock Gate (MatchWalArchive) deterministically blocks WAL archive PUTs.
+//     gate.Wait confirms we are in the "committed-but-unarchived WAL" state.
+//  4. SetPostgresRestartsEnabled(false) on the primary, then KillPostgres SIGKILLs
+//     postgres. Disabling restarts before the kill prevents the multipooler's
+//     postgres monitor from respawning postgres before multiorch sets rewindPending.
+//  5. Multiorch elects a standby as the new primary.
+//  6. Every successful pre-kill commit must be present on the new primary. If any
+//     are missing, the durability contract has been violated.
+//  7. After re-enabling restarts and forcing recovery, multiorch demotes the stale
+//     primary (pg_rewind + reconfigure as standby). Both replicas — the surviving
+//     original standby and the demoted-and-rejoined old primary — must stream on
+//     the new primary's term and hold the full set of committed ids.
+//  8. A fresh pooler-4 is provisioned via RestoreFromBackup against the baseline
+//     backup taken before the kill. RestoreFromBackup returning success is the
+//     load-bearing assertion that the post-failover archive is still usable for
+//     new-standby provisioning across the timeline change. Multiorch's recovery
+//     loop (FixReplication) wires replication to the new primary; we then assert
+//     pooler-4 streams on the current term and catches up to every committed id.
+func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end test (no postgres binaries available)")
+	}
+
+	// s3mock with a Gate that blocks WAL archive PUTs once armed. The Gate is not
+	// armed during bootstrap or the baseline backup so they archive freely.
+	gate := s3mock.NewGate(s3mock.MatchWalArchive)
+	s3Server, err := s3mock.NewServer(0, s3mock.WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = s3Server.Stop() }()
+
+	require.NoError(t, s3Server.CreateBucket("multigres"))
+
+	// pgBackRest demands AWS credentials; s3mock does not validate them.
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	os.Unsetenv("AWS_SESSION_TOKEN")
+
+	// Three multipoolers so that majority recruitment can be achieved after the
+	// primary is killed (multiorch refuses to appoint a leader if it cannot
+	// recruit a majority of the cohort). A fourth multipooler is provisioned
+	// from the backup repo later in the test to verify archive usability across
+	// the timeline change.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		shardsetup.WithS3Backup("multigres", "us-east-1", s3Server.Endpoint()),
+		shardsetup.WithLeaderFailoverGracePeriod("8s", "4s"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	primary := setup.GetPrimary(t)
+	require.NotNil(t, primary)
+	originalPrimaryName := setup.PrimaryName
+	t.Logf("Initial primary: %s", originalPrimaryName)
+
+	// --- Pre-flight: the cluster must be configured for the durability contract.
+	// Without sync_commit + synchronous_standby_names, this test would prove
+	// nothing — a clean run could simply mean the archive happened to be caught up.
+	primarySocketDir := filepath.Join(primary.Pgctld.PoolerDir, "pg_sockets")
+	primaryDB := connectToPostgresViaSocket(t, primarySocketDir, primary.Pgctld.PgPort)
+	defer primaryDB.Close()
+
+	var syncCommit, syncStandbyNames string
+	require.NoError(t, primaryDB.QueryRow("SHOW synchronous_commit").Scan(&syncCommit))
+	require.NoError(t, primaryDB.QueryRow("SHOW synchronous_standby_names").Scan(&syncStandbyNames))
+	t.Logf("Pre-flight: synchronous_commit=%q synchronous_standby_names=%q", syncCommit, syncStandbyNames)
+	require.NotEqual(t, "off", syncCommit, "cluster is not configured for the durability contract under test")
+	require.NotEqual(t, "local", syncCommit, "cluster is not configured for the durability contract under test")
+	require.NotEmpty(t, syncStandbyNames, "synchronous_standby_names is empty — multiorch did not wire sync replication")
+
+	var syncReplicaCount int
+	require.NoError(t, primaryDB.QueryRow(
+		"SELECT count(*) FROM pg_stat_replication WHERE sync_state IN ('sync','quorum')",
+	).Scan(&syncReplicaCount))
+	require.GreaterOrEqual(t, syncReplicaCount, 1,
+		"no sync standby is currently registered — promoting a standby may lose data")
+	t.Logf("Pre-flight: %d sync standbys registered", syncReplicaCount)
+
+	// --- Baseline full backup so the stanza exists and the archive has real
+	// content. Without this, the "archive lag" condition we force later would
+	// be trivially true (archive empty) instead of meaningful.
+	//
+	// Backup is taken from a standby because backups from the primary are
+	// disallowed by default (would require ForcePrimary). Source choice does
+	// not affect what this test proves.
+	var standbyInst *shardsetup.MultipoolerInstance
+	for name, inst := range setup.Multipoolers {
+		if name != originalPrimaryName {
+			standbyInst = inst
+			break
+		}
+	}
+	require.NotNil(t, standbyInst, "expected a standby instance for the baseline backup")
+
+	backupClient := createBackupClient(t, standbyInst.Multipooler.GrpcPort)
+	baselineCtx, baselineCancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	baselineResp, err := backupClient.Backup(baselineCtx, &multipoolermanagerdata.BackupRequest{
+		Type:  "full",
+		JobId: "baseline-full",
+	})
+	baselineCancel()
+	require.NoError(t, err, "baseline full backup should succeed")
+	t.Logf("Baseline backup id=%s (taken from %s)", baselineResp.GetBackupId(), standbyInst.Multipooler.Name)
+
+	// --- Arm the gate. From now on the next WAL archive PUT will block.
+	gate.Arm()
+	t.Log("Gate armed on MatchWalArchive — next archive_command PUT will block")
+
+	// --- Start the writer. WriterValidator records id only after a successful
+	// COMMIT, which under sync_commit means at least one standby has the WAL.
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	gatewayDB, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer gatewayDB.Close()
+	require.NoError(t, gatewayDB.Ping())
+
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
+		shardsetup.WithWorkerCount(4),
+		shardsetup.WithWriteInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(validatorCleanup)
+
+	t.Logf("Starting WriterValidator (table=%s)", validator.TableName())
+	validator.Start(t)
+
+	// Wait until the writer has produced enough commits that the next WAL
+	// segment will contain real client traffic — not just the switch record.
+	const preSwitchCommits = 20
+	require.Eventually(t, func() bool {
+		s, _ := validator.Stats()
+		return s >= preSwitchCommits
+	}, 15*time.Second, 50*time.Millisecond,
+		"writer should accumulate >= %d successful commits before forcing WAL switch", preSwitchCommits)
+
+	// Force a WAL segment switch on the primary to trigger archive_command.
+	// Without this the writer's modest throughput (~50 commits/sec at small
+	// row sizes) will not fill a 16MB segment within the test budget, so no
+	// archive PUT would ever happen.
+	switchCtx, switchCancel := context.WithTimeout(t.Context(), 10*time.Second)
+	var switchedLSN string
+	require.NoError(t, primaryDB.QueryRowContext(switchCtx, "SELECT pg_switch_wal()::text").Scan(&switchedLSN))
+	switchCancel()
+	t.Logf("Forced pg_switch_wal at LSN %s — archive_command should fire", switchedLSN)
+
+	// --- Wait for the first WAL archive PUT to be intercepted. This is the
+	// proof point that primary has committed WAL not yet uploaded to the repo.
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 90*time.Second)
+	hit, err := gate.Wait(waitCtx)
+	waitCancel()
+	require.NoError(t, err, "timed out waiting for a WAL archive PUT to be intercepted")
+	t.Logf("Gate hit: bucket=%s key=%s", hit.Bucket, hit.Key)
+
+	// Let more commits accumulate against a primary whose archive is now
+	// pinned behind. Each successful commit during this window is durable on a
+	// sync standby per the sync_commit contract — that is the durability claim
+	// this test proves the cluster honors after the kill. We wait for a
+	// meaningful number of *post-archive-block* commits rather than sleeping a
+	// fixed wall-clock amount.
+	gateHitSuccess, _ := validator.Stats()
+	const postBlockCommits = 100
+	targetCommits := gateHitSuccess + postBlockCommits
+	require.Eventually(t, func() bool {
+		s, _ := validator.Stats()
+		return s >= targetCommits
+	}, 30*time.Second, 100*time.Millisecond,
+		"writer should accumulate >= %d more commits after the archive was blocked (target=%d)", postBlockCommits, targetCommits)
+	preKillSuccess, preKillFailed := validator.Stats()
+	t.Logf("At kill: %d successful commits (%d after gate hit), %d failed",
+		preKillSuccess, preKillSuccess-gateHitSuccess, preKillFailed)
+
+	// --- Capture WAL state on each node for the diagnostic log.
+	logWALState(t, setup, originalPrimaryName)
+
+	// --- Disable the primary's postgres monitor so it cannot respawn postgres
+	// between the kill and when multiorch's emergency demote sets rewindPending.
+	// Mirrors dead_primary_recovery_test's pattern.
+	primaryManagerClient, err := shardsetup.NewMultipoolerClient(primary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	_, err = primaryManagerClient.Manager.SetPostgresRestartsEnabled(utils.WithShortDeadline(t),
+		&multipoolermanagerdata.SetPostgresRestartsEnabledRequest{Enabled: false})
+	require.NoError(t, err)
+
+	// --- Kill postgres on the primary (multipooler stays running to report
+	// unhealthy status to multiorch).
+	setup.KillPostgres(t, originalPrimaryName)
+
+	// Release the gate so any goroutines parked inside s3mock unwind cleanly,
+	// and so the new primary's archive_command can flow once promoted.
+	gate.Release()
+
+	// Stop the writer. In-flight inserts to the dead primary will error and be
+	// recorded as failed; that is fine — only successful commits define the
+	// durability invariant.
+	validator.Stop()
+
+	// --- Wait for multiorch to elect a new primary.
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, originalPrimaryName, 30*time.Second)
+	require.NotEmpty(t, newPrimaryName, "no new primary elected within timeout")
+	t.Logf("New primary elected: %s", newPrimaryName)
+
+	// --- Re-enable postgres restarts on the old primary: emergencyDemoteLocked
+	// has already set rewindPending, so the monitor will not restart postgres
+	// before DemoteStalePrimary runs.
+	_, err = primaryManagerClient.Manager.SetPostgresRestartsEnabled(utils.WithShortDeadline(t),
+		&multipoolermanagerdata.SetPostgresRestartsEnabledRequest{Enabled: true})
+	require.NoError(t, err)
+	primaryManagerClient.Close()
+
+	newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
+	require.NotNil(t, newPrimary)
+
+	// --- Verify the durability contract: every committed id must be present
+	// on the new primary. Connect directly to the new primary's postgres so
+	// the assertion does not depend on multigateway's reroute timing.
+	newPrimarySocketDir := filepath.Join(newPrimary.Pgctld.PoolerDir, "pg_sockets")
+	newPrimaryDB := connectToPostgresViaSocket(t, newPrimarySocketDir, newPrimary.Pgctld.PgPort)
+	defer newPrimaryDB.Close()
+
+	committedIDs := validator.SuccessfulWrites()
+	require.NotEmpty(t, committedIDs, "no successful commits to verify against")
+	t.Logf("Verifying %d committed ids against new primary %s", len(committedIDs), newPrimaryName)
+
+	missing := findMissingIDs(t, newPrimaryDB, validator.TableName(), committedIDs)
+	if len(missing) > 0 {
+		showCount := min(len(missing), 20)
+		t.Fatalf("DURABILITY VIOLATION: %d of %d committed ids are missing from new primary %s; first %d missing: %v",
+			len(missing), len(committedIDs), newPrimaryName, showCount, missing[:showCount])
+	}
+	t.Logf("All %d committed ids present on new primary — sync_commit durability contract honored", len(committedIDs))
+
+	// --- Force multiorch to fully resolve recovery: the old primary needs to be
+	// demoted (DemoteStalePrimary: 5s drain + ~15s pg_rewind + ~5s pg restart) and
+	// rejoined as a standby on the new primary's term. RequireRecovery blocks
+	// until all pending problems are resolved.
+	setup.RequireRecovery(t, "multiorch", 60*time.Second)
+
+	// --- Verify both non-primary nodes (the surviving original standby and the
+	// demoted-and-rejoined old primary) are healthy streaming replicas of the
+	// new primary AND have the full set of committed ids. This proves the
+	// failover completed end-to-end before we provision a fresh standby from
+	// the backup repo below.
+	newPrimaryClient, err := shardsetup.NewMultipoolerClient(newPrimary.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	newPrimaryStatus, err := newPrimaryClient.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdata.StatusRequest{})
+	require.NoError(t, err)
+	newPrimaryClient.Close()
+	newPrimaryTerm := newPrimaryStatus.ConsensusStatus.GetTermRevocation().GetRevokedBelowTerm()
+	t.Logf("New primary %s on term %d — verifying rejoined old primary", newPrimaryName, newPrimaryTerm)
+
+	verifyReplicasStreamingOnTerm(t, setup, newPrimaryName, newPrimaryTerm, 60*time.Second)
+	verifyReplicasHaveAllIDs(t, setup, newPrimaryName, validator.TableName(), committedIDs, 30*time.Second)
+
+	// --- Provision a fresh standby (pooler-4) and let it bootstrap itself from
+	// the backup repo. The multipooler's MonitorPostgres detects an empty
+	// PGDATA + an available backup and auto-runs RestoreFromBackup. The
+	// "restore.attempt outcome=success" event is the load-bearing assertion:
+	// if the post-failover archive's WAL chain is broken across the timeline
+	// change, the auto-restore fails and this WaitForEvent times out.
+	const newReplicaName = "pooler-4"
+	t.Logf("Provisioning %s — multipooler will auto-restore from latest backup", newReplicaName)
+	newReplica := setup.CreateMultipoolerInstance(t, newReplicaName,
+		utils.GetFreePort(t), utils.GetFreePort(t), utils.GetFreePort(t))
+	require.NoError(t, newReplica.Pgctld.Start(t.Context(), t))
+	require.NoError(t, newReplica.Multipooler.Start(t.Context(), t))
+
+	shardsetup.WaitForEvent(t, newReplica.Multipooler.LogFile, "restore.attempt", "success", 90*time.Second)
+	t.Logf("%s auto-restored from backup — post-failover archive is usable", newReplicaName)
+
+	shardsetup.WaitForManagerReady(t, newReplica.Multipooler)
+
+	// Drive multiorch's recovery loop synchronously so FixReplication wires
+	// pooler-4's replication to the current primary on the current term.
+	setup.RequireRecovery(t, "multiorch", 60*time.Second)
+
+	// --- Verify the freshly-provisioned pooler-4 streams on the new primary's
+	// term AND has every committed id. The previous block already proved the
+	// other two replicas are healthy; running the same checks now covers
+	// pooler-4's catch-up.
+	verifyReplicasStreamingOnTerm(t, setup, newPrimaryName, newPrimaryTerm, 60*time.Second)
+	verifyReplicasHaveAllIDs(t, setup, newPrimaryName, validator.TableName(), committedIDs, 60*time.Second)
+
+	// --- Sanity: timeline incremented. Cheap evidence that failover actually
+	// happened. pg_control_checkpoint() reflects the last checkpoint's
+	// timeline — stale immediately after promotion until the next checkpoint
+	// runs. The current WAL filename's timeline prefix updates the moment
+	// promotion completes, so use that.
+	var walfile string
+	require.NoError(t, newPrimaryDB.QueryRow("SELECT pg_walfile_name(pg_current_wal_lsn())").Scan(&walfile))
+	require.GreaterOrEqual(t, len(walfile), 8, "unexpected pg_walfile_name format: %q", walfile)
+	tlHex := walfile[:8]
+	var newTimeline int64
+	_, scanErr := fmt.Sscanf(tlHex, "%x", &newTimeline)
+	require.NoError(t, scanErr, "failed to parse timeline from walfile %q", walfile)
+	assert.Greater(t, newTimeline, int64(1), "expected timeline > 1 after failover, got %d (walfile=%s)", newTimeline, walfile)
+	t.Logf("New primary on timeline %d (walfile=%s)", newTimeline, walfile)
+}
+
+// logWALState writes a one-shot snapshot of WAL state across the cluster to
+// the test log. Captured before the kill so a failure narrative can show that
+// standbys were actually receiving WAL via streaming at the moment of crash.
+func logWALState(t *testing.T, setup *shardsetup.ShardSetup, primaryName string) {
+	t.Helper()
+
+	for name, inst := range setup.Multipoolers {
+		socketDir := filepath.Join(inst.Pgctld.PoolerDir, "pg_sockets")
+		db, err := sql.Open("postgres", fmt.Sprintf("host=%s port=%d user=postgres dbname=postgres sslmode=disable", socketDir, inst.Pgctld.PgPort))
+		if err != nil {
+			t.Logf("WAL state %s: connect error: %v", name, err)
+			continue
+		}
+		queryCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		if name == primaryName {
+			var lsn, walfile string
+			row := db.QueryRowContext(queryCtx, "SELECT pg_current_wal_lsn()::text, pg_walfile_name(pg_current_wal_lsn())")
+			if err := row.Scan(&lsn, &walfile); err == nil {
+				t.Logf("WAL state %s (primary): current_lsn=%s walfile=%s", name, lsn, walfile)
+			} else {
+				t.Logf("WAL state %s (primary): query error: %v", name, err)
+			}
+		} else {
+			var receiveLsn, replayLsn string
+			row := db.QueryRowContext(queryCtx, "SELECT COALESCE(pg_last_wal_receive_lsn()::text, ''), COALESCE(pg_last_wal_replay_lsn()::text, '')")
+			if err := row.Scan(&receiveLsn, &replayLsn); err == nil {
+				t.Logf("WAL state %s (standby): receive_lsn=%s replay_lsn=%s", name, receiveLsn, replayLsn)
+			} else {
+				t.Logf("WAL state %s (standby): query error: %v", name, err)
+			}
+		}
+		cancel()
+		_ = db.Close()
+	}
+}
+
+// verifyReplicasStreamingOnTerm waits until every multipooler other than
+// excludePrimaryName reports REPLICA + PostgresReady + streaming wal_receiver +
+// the expected term. Used after each recovery step to confirm the cohort is
+// healthy before the next assertion.
+func verifyReplicasStreamingOnTerm(t *testing.T, setup *shardsetup.ShardSetup, excludePrimaryName string, expectedTerm int64, timeout time.Duration) {
+	t.Helper()
+
+	var replicas []*shardsetup.MultipoolerInstance
+	for name, inst := range setup.Multipoolers {
+		if name == excludePrimaryName {
+			continue
+		}
+		replicas = append(replicas, inst)
+	}
+	require.NotEmpty(t, replicas, "expected at least one non-primary multipooler")
+
+	shardsetup.EventuallyPoolerCondition(t, replicas, timeout, 1*time.Second,
+		func(r shardsetup.PoolerStatusResult) (bool, string) {
+			s := r.Status
+			if s.PoolerType != clustermetadatapb.PoolerType_REPLICA {
+				return false, fmt.Sprintf("not yet REPLICA (is %v)", s.PoolerType)
+			}
+			if !s.PostgresReady {
+				return false, "postgres not running"
+			}
+			if s.ReplicationStatus == nil || s.ReplicationStatus.PrimaryConnInfo == nil {
+				return false, "replication not configured"
+			}
+			if s.ReplicationStatus.WalReceiverStatus != "streaming" {
+				return false, fmt.Sprintf("not streaming (wal_receiver=%s)", s.ReplicationStatus.WalReceiverStatus)
+			}
+			termNum := r.ConsensusStatus.GetTermRevocation().GetRevokedBelowTerm()
+			if termNum != expectedTerm {
+				return false, fmt.Sprintf("wrong term %d, expected %d", termNum, expectedTerm)
+			}
+			return true, ""
+		},
+		"replicas did not converge to streaming on term %d", expectedTerm,
+	)
+}
+
+// verifyReplicasHaveAllIDs queries each non-primary multipooler's postgres
+// directly via Unix socket and asserts every id in want is present. Replication
+// is async, so it polls until the replica catches up or times out.
+func verifyReplicasHaveAllIDs(t *testing.T, setup *shardsetup.ShardSetup, excludePrimaryName, table string, want []int64, timeout time.Duration) {
+	t.Helper()
+
+	for name, replica := range setup.Multipoolers {
+		if name == excludePrimaryName {
+			continue
+		}
+		replicaSocketDir := filepath.Join(replica.Pgctld.PoolerDir, "pg_sockets")
+		replicaDB := connectToPostgresViaSocket(t, replicaSocketDir, replica.Pgctld.PgPort)
+		require.Eventually(t, func() bool {
+			missing := findMissingIDs(t, replicaDB, table, want)
+			if len(missing) > 0 {
+				t.Logf("replica %s still missing %d/%d ids", replica.Name, len(missing), len(want))
+				return false
+			}
+			return true
+		}, timeout, 1*time.Second,
+			"replica %s did not catch up to all %d committed ids", replica.Name, len(want))
+		replicaDB.Close()
+		t.Logf("Replica %s has all %d committed ids", replica.Name, len(want))
+	}
+}

--- a/go/test/endtoend/multipooler/backupfaults/backup_failover_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_failover_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package multipooler
+package backupfaults
 
 import (
 	"context"
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/utils"
@@ -174,29 +173,11 @@ func TestBackup_FailsDuringPrimaryFailover(t *testing.T) {
 	// If GetBackupByJobId returns an error (backup not found), that is also acceptable —
 	// it means pgBackRest never completed the backup and left no record.
 
-	// Assertion 3: cluster is healthy — a new primary is elected and postgres is running
+	// Assertion 3: cluster is healthy — a new primary is elected and postgres is running.
+	// 60s budget rather than 30s: under Code Coverage's subprocess instrumentation,
+	// multiorch's election (grace period + promote + demote) gets CPU-starved on the
+	// shared runner and can slip past 30s. The actual happy path is ~12s.
 	t.Log("Waiting for a new primary to be elected...")
-	require.Eventually(t, func() bool {
-		for name, inst := range setup.Multipoolers {
-			if name == originalPrimaryName {
-				continue
-			}
-			client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
-			if err != nil {
-				continue
-			}
-			resp, err := client.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdata.StatusRequest{})
-			client.Close()
-			if err != nil {
-				continue
-			}
-			if resp.Status.IsInitialized &&
-				resp.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY &&
-				resp.Status.PostgresReady {
-				t.Logf("New primary elected: %s", name)
-				return true
-			}
-		}
-		return false
-	}, 30*time.Second, 500*time.Millisecond, "a new primary should be elected and running after failover")
+	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, originalPrimaryName, 60*time.Second)
+	t.Logf("New primary elected: %s", newPrimaryName)
 }

--- a/go/test/endtoend/multipooler/backupfaults/helpers_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/helpers_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupfaults
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
+)
+
+// connectToPostgresViaSocket opens a SQL connection to PostgreSQL over its
+// Unix socket. The caller is responsible for Close().
+func connectToPostgresViaSocket(t *testing.T, socketDir string, port int) *sql.DB {
+	t.Helper()
+
+	connStr := fmt.Sprintf("host=%s port=%d user=postgres dbname=postgres sslmode=disable", socketDir, port)
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err, "open postgres via socket")
+	require.NoError(t, db.Ping(), "ping postgres via socket")
+	return db
+}
+
+// createBackupClient returns a multipooler manager gRPC client suitable for
+// issuing Backup RPCs. Connection is closed via t.Cleanup.
+func createBackupClient(t *testing.T, grpcPort int) multipoolermanagerpb.MultiPoolerManagerClient {
+	t.Helper()
+
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("localhost:%d", grpcPort),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err, "create gRPC connection")
+	t.Cleanup(func() { conn.Close() })
+
+	return multipoolermanagerpb.NewMultiPoolerManagerClient(conn)
+}
+
+// findMissingIDs returns the subset of want that is not present in
+// SELECT id FROM <table>. Uses a single ANY($1) lookup so the query cost is
+// O(matched rows), not O(want).
+func findMissingIDs(t *testing.T, db *sql.DB, table string, want []int64) []int64 {
+	t.Helper()
+
+	// #nosec G202 -- table is WriterValidator's generated test-only name, not user input.
+	q := "SELECT id FROM " + table + " WHERE id = ANY($1)"
+	queryCtx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(queryCtx, q, pq.Array(want))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	found := make(map[int64]struct{}, len(want))
+	for rows.Next() {
+		var id int64
+		require.NoError(t, rows.Scan(&id))
+		found[id] = struct{}{}
+	}
+	require.NoError(t, rows.Err())
+
+	var missing []int64
+	for _, id := range want {
+		if _, ok := found[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}

--- a/go/test/endtoend/multipooler/backupfaults/main_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backupfaults contains end-to-end fault-tolerance tests that
+// exercise backup, archive, and recovery behavior under failure injection.
+// Lives in its own package so it builds as a separate test binary and runs
+// in parallel with the rest of go/test/endtoend/multipooler/...
+package backupfaults
+
+import (
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(shardsetup.RunTestMain(m)) //nolint:forbidigo // TestMain is allowed to call os.Exit
+}

--- a/go/test/endtoend/shardsetup/pooler_diagnostics.go
+++ b/go/test/endtoend/shardsetup/pooler_diagnostics.go
@@ -157,6 +157,35 @@ func RequirePoolerCondition(
 	}
 }
 
+// WaitForNewPrimary polls all multipoolers in setup until one other than oldPrimaryName
+// reports IsInitialized + PoolerType_PRIMARY + PostgresReady, then returns its name.
+// Fails the test if no new primary is elected within timeout.
+func WaitForNewPrimary(t *testing.T, setup *ShardSetup, oldPrimaryName string, timeout time.Duration) string {
+	t.Helper()
+
+	poolers := make([]*MultipoolerInstance, 0, len(setup.Multipoolers))
+	for _, inst := range setup.Multipoolers {
+		poolers = append(poolers, inst)
+	}
+
+	return EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
+		func(statuses []PoolerStatusResult) (string, bool, string) {
+			for _, r := range statuses {
+				if r.Name == oldPrimaryName || r.Err != nil || r.Status == nil {
+					continue
+				}
+				if r.Status.IsInitialized &&
+					r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY &&
+					r.Status.PostgresReady {
+					return r.Name, true, ""
+				}
+			}
+			return "", false, fmt.Sprintf("no new primary elected yet (old primary: %s)", oldPrimaryName)
+		},
+		"new primary not elected within %v", timeout,
+	)
+}
+
 // FormatPoolerDiagnostics returns a compact diagnostic string for a pooler status,
 // useful for appending to "not yet ready" log messages to aid flake investigation.
 func FormatPoolerDiagnostics(s *multipoolermanagerdatapb.Status, cs *clustermetadatapb.ConsensusStatus) string {

--- a/go/tools/s3mock/gate.go
+++ b/go/tools/s3mock/gate.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3mock
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Matcher reports whether an S3 PUT operation should trigger the gate.
+type Matcher func(bucket, key string) bool
+
+// Hit describes the operation that tripped the gate.
+type Hit struct {
+	Method, Bucket, Key string
+}
+
+// Gate pauses S3 operations matching its Matcher once Arm has been called,
+// records the first match in a Hit, and blocks the request goroutine until
+// Release is called or the request context is cancelled.
+type Gate struct {
+	matcher Matcher
+	armed   atomic.Bool
+
+	mu      sync.Mutex
+	hitCh   chan Hit
+	hitOnce sync.Once
+	relCh   chan struct{}
+}
+
+// NewGate returns a disarmed Gate.
+func NewGate(m Matcher) *Gate {
+	return &Gate{
+		matcher: m,
+		hitCh:   make(chan Hit, 1),
+		relCh:   make(chan struct{}),
+	}
+}
+
+// Arm enables the gate. Before arming, all operations pass through.
+func (g *Gate) Arm() { g.armed.Store(true) }
+
+// Wait blocks until a matching operation arrives, or ctx is done.
+// Returns the Hit on success, or ctx.Err() on cancellation.
+func (g *Gate) Wait(ctx context.Context) (Hit, error) {
+	g.mu.Lock()
+	hitCh := g.hitCh
+	g.mu.Unlock()
+	select {
+	case h := <-hitCh:
+		return h, nil
+	case <-ctx.Done():
+		return Hit{}, ctx.Err()
+	}
+}
+
+// Release unblocks the held operation. Safe to call multiple times; the
+// first call wins, subsequent calls are no-ops.
+func (g *Gate) Release() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	select {
+	case <-g.relCh:
+		// already closed
+	default:
+		close(g.relCh)
+	}
+}
+
+// Rearm disarms, then re-enables the gate for the next match. Resets the
+// release channel and the one-shot hit. Caller is responsible for not
+// racing this with in-flight Wait/Release on the same Gate.
+func (g *Gate) Rearm() {
+	g.mu.Lock()
+	g.relCh = make(chan struct{})
+	g.hitCh = make(chan Hit, 1)
+	g.hitOnce = sync.Once{}
+	g.mu.Unlock()
+	g.armed.Store(true)
+}
+
+// callback returns a PutCallback that consults the gate.
+func (g *Gate) callback() PutCallback {
+	return func(ctx context.Context, bucket, key string) error {
+		if !g.armed.Load() {
+			return nil
+		}
+		if !g.matcher(bucket, key) {
+			return nil
+		}
+		g.mu.Lock()
+		hitCh := g.hitCh
+		relCh := g.relCh
+		hitOnce := &g.hitOnce
+		g.mu.Unlock()
+
+		// Single-shot send so multiple matching PUTs do not stall behind a closed Wait.
+		hitOnce.Do(func() {
+			hitCh <- Hit{Method: "PUT", Bucket: bucket, Key: key}
+		})
+		select {
+		case <-relCh:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// WithGate returns a ServerOption that installs g's callback. If a previous
+// PutCallback was installed via WithPutCallback, it is replaced.
+func WithGate(g *Gate) ServerOption {
+	return func(s *Server) { s.putCallback = g.callback() }
+}
+
+// MatchPut returns a Matcher that fires when the key contains substr.
+func MatchPut(substr string) Matcher {
+	return func(_ string, key string) bool {
+		return strings.Contains(key, substr)
+	}
+}
+
+// MatchPutRegex returns a Matcher that fires when the key matches re.
+func MatchPutRegex(re *regexp.Regexp) Matcher {
+	return func(_, key string) bool { return re.MatchString(key) }
+}
+
+// Phase is a goroutine-safe string label that tests use to drive
+// PhaseMatcher. Use descriptive labels ("bootstrap", "first-backup",
+// "second-backup") so the s3mock log narrates the test as it runs.
+type Phase struct {
+	v atomic.Value
+}
+
+// Set updates the current phase.
+func (p *Phase) Set(s string) { p.v.Store(s) }
+
+// Get returns the current phase, or "" if Set has never been called.
+func (p *Phase) Get() string {
+	if v := p.v.Load(); v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+// PhaseMatcher returns a Matcher that delegates to base only while
+// phase.Get() == want. It is the standard way to use a Gate in tests
+// that need to discriminate between multiple actors hitting the same
+// s3mock — for example, holding the first concurrent backup while
+// letting the second pass through. Switch the phase to a different
+// value to stop matching new requests; goroutines already parked
+// inside gate.callback stay parked until ctx cancellation.
+func PhaseMatcher(phase *Phase, want string, base Matcher) Matcher {
+	return func(bucket, key string) bool {
+		if phase.Get() != want {
+			return false
+		}
+		return base(bucket, key)
+	}
+}
+
+// MatchDataUpload fires on data-file PUTs inside a backup set's pg_data/
+// (loose files like backup_label.zst) or bundle/ (pgBackRest's bundled small
+// files). Excludes manifest writes and WAL archive PUTs.
+//
+// This is the only useful pause point for "kill primary postgres" fault
+// scenarios: pgBackRest's first S3 write during a backup is to a bundle file,
+// and pausing here is early enough that pg_stop_backup has not yet been
+// called. Other pause points were considered (manifest writes at the end of
+// a backup) but they happen after pg_stop_backup returns, so killing postgres
+// at that point is too late to fail the backup.
+var MatchDataUpload Matcher = func(_ string, key string) bool {
+	if !strings.Contains(key, "/backup/") {
+		return false
+	}
+	return strings.Contains(key, "/pg_data/") || strings.Contains(key, "/bundle/")
+}
+
+// MatchWalArchive fires on WAL archive PUTs (pgBackRest archive-push). The
+// pgBackRest layout writes archived WAL segments under
+// <stanza>/archive/<archive-id>/<timeline>-<wal-prefix>/<segment>, so the
+// key contains "/archive/" and not "/backup/".
+//
+// Use to deterministically force a "WAL on the primary's local pg_wal but
+// not yet pushed to the repo" condition for crash/durability tests.
+var MatchWalArchive Matcher = func(_ string, key string) bool {
+	if strings.Contains(key, "/backup/") {
+		return false
+	}
+	return strings.Contains(key, "/archive/")
+}

--- a/go/tools/s3mock/gate_test.go
+++ b/go/tools/s3mock/gate_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s3mock
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestS3Client returns an S3 SDK client configured for srv.
+func newTestS3Client(srv *Server) *s3.Client {
+	cfg := aws.Config{
+		Region: "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider(
+			"test-key", "test-secret", "",
+		),
+		BaseEndpoint: aws.String(srv.Endpoint()),
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true, // #nosec G402 - test code
+				},
+			},
+		},
+	}
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+}
+
+// putObject uploads body to bucket/key on srv.
+func putObject(srv *Server, bucket, key string, body []byte) error {
+	return putObjectWithContext(srv, context.Background(), bucket, key, body)
+}
+
+// putObjectWithContext uploads body to bucket/key on srv using ctx.
+func putObjectWithContext(srv *Server, ctx context.Context, bucket, key string, body []byte) error {
+	client := newTestS3Client(srv)
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(body),
+	})
+	return err
+}
+
+// getObject downloads bucket/key from srv.
+func getObject(srv *Server, bucket, key string) ([]byte, error) {
+	client := newTestS3Client(srv)
+	resp, err := client.GetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestGate_WaitReturnsHitOnFirstMatchingPut(t *testing.T) {
+	gate := NewGate(MatchPut("data/"))
+	srv, err := NewServer(0, WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = srv.Stop() }()
+	require.NoError(t, srv.CreateBucket("b"))
+
+	gate.Arm()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- putObject(srv, "b", "data/file1", []byte("hello"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	hit, err := gate.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "PUT", hit.Method)
+	require.Equal(t, "b", hit.Bucket)
+	require.Equal(t, "data/file1", hit.Key)
+
+	gate.Release()
+	require.NoError(t, <-done)
+}
+
+func TestGate_ReleaseAllowsPutToComplete(t *testing.T) {
+	gate := NewGate(MatchPut("data/"))
+	srv, err := NewServer(0, WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = srv.Stop() }()
+	require.NoError(t, srv.CreateBucket("b"))
+
+	gate.Arm()
+	done := make(chan error, 1)
+	go func() { done <- putObject(srv, "b", "data/file", []byte("x")) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = gate.Wait(ctx)
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		t.Fatalf("PUT completed before Release: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	gate.Release()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("PUT did not complete after Release")
+	}
+
+	body, err := getObject(srv, "b", "data/file")
+	require.NoError(t, err)
+	require.Equal(t, []byte("x"), body)
+}
+
+func TestGate_ContextCancellationUnblocksPut(t *testing.T) {
+	gate := NewGate(MatchPut("data/"))
+	srv, err := NewServer(0, WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = srv.Stop() }()
+	require.NoError(t, srv.CreateBucket("b"))
+
+	gate.Arm()
+
+	putCtx, cancelPut := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- putObjectWithContext(srv, putCtx, "b", "data/x", []byte("x"))
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelWait()
+	_, err = gate.Wait(waitCtx)
+	require.NoError(t, err)
+
+	cancelPut() // simulates pgBackRest process being killed mid-upload
+
+	select {
+	case err := <-done:
+		require.Error(t, err) // SDK reports context cancelled
+	case <-time.After(5 * time.Second):
+		t.Fatal("PUT did not unblock on context cancellation")
+	}
+}
+
+func TestGate_WaitReturnsCtxErrWhenNoMatch(t *testing.T) {
+	gate := NewGate(MatchPut("never/"))
+	srv, err := NewServer(0, WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = srv.Stop() }()
+	require.NoError(t, srv.CreateBucket("b"))
+
+	gate.Arm()
+	// Issue a non-matching PUT — should pass through.
+	require.NoError(t, putObject(srv, "b", "other/x", []byte("y")))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err = gate.Wait(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestMatchDataUpload(t *testing.T) {
+	// Loose files in pg_data/ (backup_label.zst, postgresql.auto.conf.zst, etc.)
+	require.True(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/pg_data/base/16384/1"))
+	require.True(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/pg_data/backup_label.zst"))
+	// Bundled small files — the typical pgBackRest data path.
+	require.True(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/bundle/1"))
+	require.True(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/bundle/42"))
+	// Manifests and archive WAL must not match.
+	require.False(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/backup.manifest.copy"))
+	require.False(t, MatchDataUpload("b", "stanza/backup/20260428-120000F/backup.manifest"))
+	require.False(t, MatchDataUpload("b", "stanza/archive/13-1/000000010000000000000001-abc.gz"))
+}
+
+func TestPhaseMatcher(t *testing.T) {
+	var phase Phase
+	m := PhaseMatcher(&phase, "first", MatchPut("data/"))
+
+	require.False(t, m("b", "data/x"), "unset phase must not match")
+	phase.Set("first")
+	require.True(t, m("b", "data/x"), "phase=first must delegate to base")
+	require.False(t, m("b", "other/x"), "phase=first but base mismatch must not match")
+	phase.Set("second")
+	require.False(t, m("b", "data/x"), "phase=second must not match")
+}
+
+func TestGate_RearmEnablesSecondMatch(t *testing.T) {
+	gate := NewGate(MatchPut("data/"))
+	srv, err := NewServer(0, WithGate(gate))
+	require.NoError(t, err)
+	defer func() { _ = srv.Stop() }()
+	require.NoError(t, srv.CreateBucket("b"))
+
+	gate.Arm()
+	done1 := make(chan error, 1)
+	go func() { done1 <- putObject(srv, "b", "data/1", []byte("a")) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	h1, err := gate.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "data/1", h1.Key)
+	gate.Release()
+	require.NoError(t, <-done1)
+
+	gate.Rearm()
+	done2 := make(chan error, 1)
+	go func() { done2 <- putObject(srv, "b", "data/2", []byte("b")) }()
+	h2, err := gate.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "data/2", h2.Key)
+	gate.Release()
+	require.NoError(t, <-done2)
+}

--- a/go/tools/s3mock/server.go
+++ b/go/tools/s3mock/server.go
@@ -225,6 +225,27 @@ func (s *Server) CreateBucket(name string) error {
 	return s.storage.CreateBucket(name)
 }
 
+// ListKeys returns the object keys in bucket whose names start with prefix.
+// Intended for test assertions; the result is sorted lexicographically.
+func (s *Server) ListKeys(bucket, prefix string) []string {
+	objs := s.storage.ListObjects(bucket, prefix, "")
+	keys := make([]string, 0, len(objs))
+	for _, o := range objs {
+		keys = append(keys, o.Key)
+	}
+	return keys
+}
+
+// GetObjectBytes returns the contents of bucket/key, intended for test
+// assertions. Returns an error if the object does not exist.
+func (s *Server) GetObjectBytes(bucket, key string) ([]byte, error) {
+	obj, err := s.storage.GetObject(bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	return obj.ReadData()
+}
+
 // Stop gracefully stops the server and cleans up storage
 func (s *Server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)


### PR DESCRIPTION
## TestPrimaryCrashWithUnarchivedWAL_NoDataLoss

This was motivated by a real-life issue in a large-scale Postgres deployment, described to me by @sougou.

End-to-end test that proves Multigres' `synchronous_commit` durability contract under a primary postgres crash where committed WAL is held in the primary's local `pg_wal` but not yet pushed to the pgBackRest archive.

Scenario:

1. 3-node cluster with `synchronous_commit` + `synchronous_standby_names` wired by multiorch (3 nodes are required so multiorch can recruit a majority of the cohort after the kill).
2. `WriterValidator` commits rows via multigateway. Under sync_commit, each successful COMMIT is durable on at least one standby's WAL.
3. `s3mock.Gate(MatchWalArchive)` deterministically blocks WAL archive PUTs; `gate.Wait` confirms the "committed-but-unarchived WAL" state.
4. `SetPostgresRestartsEnabled(false)` on the primary, then `KillPostgres` SIGKILLs postgres. Disabling restarts first prevents the postgres monitor from respawning postgres before multiorch sets `rewindPending`.
5. multiorch elects a standby as the new primary; every pre-kill commit must be present on it.
6. `RequireRecovery` drives `DemoteStalePrimary` + pg_rewind. Both replicas — the surviving original standby and the demoted-and-rejoined old primary — must stream on the new primary's term and hold every committed id.
7. A fresh `pooler-4` is provisioned; multipooler's `MonitorPostgres` auto-runs `RestoreFromBackup` because PGDATA is empty and a backup exists. `WaitForEvent("restore.attempt", "success")` is the load-bearing assertion that **the post-failover archive is still usable across the timeline change**. After `FixReplication` wires streaming, pooler-4 must also reach the current term and have every committed id.

Pre-flight assertions fail fast if the cluster isn't configured for the contract under test (sync_commit off, `synchronous_standby_names` empty, or no sync standby registered) — a green run on an async-only cluster would prove nothing.

## Supporting changes

- **New sub-package `go/test/endtoend/multipooler/backupfaults/`**. Its own Go package and test binary, so fault-tolerance tests run in parallel with the rest of `multipooler/...` — shaves ~45s off the multipooler endtoend suite's CI wall-clock. `TestBackup_FailsDuringPrimaryFailover` moves here alongside the new test.
- **`s3mock.Gate`** (`Arm`/`Wait`/`Release`/`Rearm`) with matcher predicates `MatchDataUpload` and `MatchWalArchive`, wired via the existing `PutCallback` hook. Replaces ad-hoc `sync/atomic` + paired channels in tests. Adds `ListKeys`/`GetObjectBytes` helpers on `s3mock.Server`.
- **`shardsetup.WaitForNewPrimary`** promoted from multiorch-test-local to shared, with an added `PostgresReady` check. `TestBackup_FailsDuringPrimaryFailover`'s inline 30s `require.Eventually` is replaced by this helper at 60s — 2× headroom over the ~12s election path under Code Coverage's CPU-starved subprocess instrumentation.
- **pgBackRest TLS server lock-path is now per-pooler** (`<pooler>/pgbackrest/server-lock`). The default `/tmp/pgbackrest/` collides across pgctld instances on the same host, causing concurrent test binaries to flake on `multigres-backup-1.lock`. The server's lock-path is kept distinct from the client's lock-path on the same pooler to avoid serializing TLS-server backups against a concurrent primary-local backup (a separate lease-stealing race not addressed here).

## Verification

- Ran CI 5x. Fixed some flakes discovered along the way.
- Ensured that CI test run time isn't noticeably different from before (new tests are in a new package, which can be run in parallel).