### PR TITLE
feat(pgctld): enable operators to provide extra config to postgres

### DIFF
--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -101,6 +101,43 @@ func TestInitDbSQLFilesFlag(t *testing.T) {
 	})
 }
 
+func TestExtraPostgresConfFlag(t *testing.T) {
+	t.Run("defaults to empty slice", func(t *testing.T) {
+		_, pc := GetRootCommand()
+		assert.Empty(t, pc.extraPostgresConf.Get())
+	})
+
+	t.Run("accepts repeated flag", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--extra-postgres-conf", "/etc/pg/a.conf",
+			"--extra-postgres-conf", "/etc/pg/b.conf",
+		}))
+		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.extraPostgresConf.Get())
+	})
+
+	t.Run("accepts comma-separated values", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--extra-postgres-conf", "/etc/pg/a.conf,/etc/pg/b.conf",
+		}))
+		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.extraPostgresConf.Get())
+	})
+
+	t.Run("POSTGRES_EXTRA_CONF env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgExtraConfFilesEnvVar, "/etc/pg/env.conf")
+		_, pc := GetRootCommand()
+		assert.Equal(t, []string{"/etc/pg/env.conf"}, pc.extraPostgresConf.Get())
+	})
+
+	t.Run("flag overrides POSTGRES_EXTRA_CONF env var", func(t *testing.T) {
+		t.Setenv(constants.PgExtraConfFilesEnvVar, "/etc/pg/env.conf")
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{"--extra-postgres-conf", "/etc/pg/flag.conf"}))
+		assert.Equal(t, []string{"/etc/pg/flag.conf"}, pc.extraPostgresConf.Get())
+	})
+}
+
 func TestPgBackRestFlags(t *testing.T) {
 	// Test default values
 	rootCmd, _ := GetRootCommand()

--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -101,40 +101,40 @@ func TestInitDbSQLFilesFlag(t *testing.T) {
 	})
 }
 
-func TestExtraPostgresConfFlag(t *testing.T) {
+func TestPgInitdbExtraConfFlag(t *testing.T) {
 	t.Run("defaults to empty slice", func(t *testing.T) {
 		_, pc := GetRootCommand()
-		assert.Empty(t, pc.extraPostgresConf.Get())
+		assert.Empty(t, pc.pgInitdbExtraConf.Get())
 	})
 
 	t.Run("accepts repeated flag", func(t *testing.T) {
 		root, pc := GetRootCommand()
 		require.NoError(t, root.ParseFlags([]string{
-			"--extra-postgres-conf", "/etc/pg/a.conf",
-			"--extra-postgres-conf", "/etc/pg/b.conf",
+			"--pg-initdb-extra-conf", "/etc/pg/a.conf",
+			"--pg-initdb-extra-conf", "/etc/pg/b.conf",
 		}))
-		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.extraPostgresConf.Get())
+		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.pgInitdbExtraConf.Get())
 	})
 
 	t.Run("accepts comma-separated values", func(t *testing.T) {
 		root, pc := GetRootCommand()
 		require.NoError(t, root.ParseFlags([]string{
-			"--extra-postgres-conf", "/etc/pg/a.conf,/etc/pg/b.conf",
+			"--pg-initdb-extra-conf", "/etc/pg/a.conf,/etc/pg/b.conf",
 		}))
-		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.extraPostgresConf.Get())
+		assert.Equal(t, []string{"/etc/pg/a.conf", "/etc/pg/b.conf"}, pc.pgInitdbExtraConf.Get())
 	})
 
-	t.Run("POSTGRES_EXTRA_CONF env var is used when flag not set", func(t *testing.T) {
-		t.Setenv(constants.PgExtraConfFilesEnvVar, "/etc/pg/env.conf")
+	t.Run("POSTGRES_INITDB_EXTRA_CONF env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgInitdbExtraConfEnvVar, "/etc/pg/env.conf")
 		_, pc := GetRootCommand()
-		assert.Equal(t, []string{"/etc/pg/env.conf"}, pc.extraPostgresConf.Get())
+		assert.Equal(t, []string{"/etc/pg/env.conf"}, pc.pgInitdbExtraConf.Get())
 	})
 
-	t.Run("flag overrides POSTGRES_EXTRA_CONF env var", func(t *testing.T) {
-		t.Setenv(constants.PgExtraConfFilesEnvVar, "/etc/pg/env.conf")
+	t.Run("flag overrides POSTGRES_INITDB_EXTRA_CONF env var", func(t *testing.T) {
+		t.Setenv(constants.PgInitdbExtraConfEnvVar, "/etc/pg/env.conf")
 		root, pc := GetRootCommand()
-		require.NoError(t, root.ParseFlags([]string{"--extra-postgres-conf", "/etc/pg/flag.conf"}))
-		assert.Equal(t, []string{"/etc/pg/flag.conf"}, pc.extraPostgresConf.Get())
+		require.NoError(t, root.ParseFlags([]string{"--pg-initdb-extra-conf", "/etc/pg/flag.conf"}))
+		assert.Equal(t, []string{"/etc/pg/flag.conf"}, pc.pgInitdbExtraConf.Get())
 	})
 }
 

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -105,7 +105,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}
 	// create server config using the pooler directory
-	_, err := pgctld.GeneratePostgresServerConfig(poolerDir, cfg.Port, cfg.User)
+	_, err := pgctld.GeneratePostgresServerConfig(poolerDir, cfg.User, cfg.ExtraPostgresConfFiles)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create postgres config: %w", err)
 	}
@@ -171,11 +171,12 @@ func runInitDbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, fil
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
 	cfg := PgCtldServiceConfig{
-		Port:           i.pgCtlCmd.pgPort.Get(),
-		User:           i.pgCtlCmd.pgUser.Get(),
-		Database:       i.pgCtlCmd.pgDatabase.Get(),
-		Password:       i.pgCtlCmd.pgPassword.Get(),
-		InitDbSQLFiles: i.pgCtlCmd.initDbSQLFiles.Get(),
+		Port:                   i.pgCtlCmd.pgPort.Get(),
+		User:                   i.pgCtlCmd.pgUser.Get(),
+		Database:               i.pgCtlCmd.pgDatabase.Get(),
+		Password:               i.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles:         i.pgCtlCmd.initDbSQLFiles.Get(),
+		ExtraPostgresConfFiles: i.pgCtlCmd.extraPostgresConf.Get(),
 	}
 	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, cfg)
 	if err != nil {

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -105,7 +105,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 		return nil, fmt.Errorf("failed to initialize data directory: %w", err)
 	}
 	// create server config using the pooler directory
-	_, err := pgctld.GeneratePostgresServerConfig(poolerDir, cfg.User, cfg.ExtraPostgresConfFiles)
+	_, err := pgctld.GeneratePostgresServerConfig(poolerDir, cfg.User, cfg.InitdbExtraConfFiles)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create postgres config: %w", err)
 	}
@@ -171,12 +171,12 @@ func runInitDbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, fil
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
 	cfg := PgCtldServiceConfig{
-		Port:                   i.pgCtlCmd.pgPort.Get(),
-		User:                   i.pgCtlCmd.pgUser.Get(),
-		Database:               i.pgCtlCmd.pgDatabase.Get(),
-		Password:               i.pgCtlCmd.pgPassword.Get(),
-		InitDbSQLFiles:         i.pgCtlCmd.initDbSQLFiles.Get(),
-		ExtraPostgresConfFiles: i.pgCtlCmd.extraPostgresConf.Get(),
+		Port:                 i.pgCtlCmd.pgPort.Get(),
+		User:                 i.pgCtlCmd.pgUser.Get(),
+		Database:             i.pgCtlCmd.pgDatabase.Get(),
+		Password:             i.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles:       i.pgCtlCmd.initDbSQLFiles.Get(),
+		InitdbExtraConfFiles: i.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
 	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, cfg)
 	if err != nil {

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -49,6 +49,7 @@ type PgCtlCommand struct {
 	postgresConfigTmpl viperutil.Value[string]
 	pgInitdbArgs       viperutil.Value[string]
 	initDbSQLFiles     viperutil.Value[[]string]
+	extraPostgresConf  viperutil.Value[[]string]
 
 	vc        *viperutil.ViperConfig
 	lg        *servenv.Logger
@@ -121,6 +122,12 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars:  []string{constants.PgInitDbSQLFilesEnvVar},
 			Dynamic:  false,
 		}),
+		extraPostgresConf: viperutil.Configure(reg, "extra-postgres-conf", viperutil.Options[[]string]{
+			Default:  []string{},
+			FlagName: "extra-postgres-conf",
+			EnvVars:  []string{constants.PgExtraConfFilesEnvVar},
+			Dynamic:  false,
+		}),
 		vc:        viperutil.NewViperConfig(reg),
 		lg:        servenv.NewLogger(reg, telemetry),
 		telemetry: telemetry,
@@ -172,6 +179,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("init-db-sql-file", pc.initDbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitDbSQLFilesEnvVar+" env var).")
+	root.PersistentFlags().StringSlice("extra-postgres-conf", pc.extraPostgresConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgExtraConfFilesEnvVar+" env var).")
 
 	pc.vc.RegisterFlags(root.PersistentFlags())
 	pc.lg.RegisterFlags(root.PersistentFlags())
@@ -188,6 +196,7 @@ management for PostgreSQL servers.`,
 		pc.postgresConfigTmpl,
 		pc.pgInitdbArgs,
 		pc.initDbSQLFiles,
+		pc.extraPostgresConf,
 	)
 
 	// Add all subcommands

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -49,7 +49,7 @@ type PgCtlCommand struct {
 	postgresConfigTmpl viperutil.Value[string]
 	pgInitdbArgs       viperutil.Value[string]
 	initDbSQLFiles     viperutil.Value[[]string]
-	extraPostgresConf  viperutil.Value[[]string]
+	pgInitdbExtraConf  viperutil.Value[[]string]
 
 	vc        *viperutil.ViperConfig
 	lg        *servenv.Logger
@@ -122,10 +122,10 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars:  []string{constants.PgInitDbSQLFilesEnvVar},
 			Dynamic:  false,
 		}),
-		extraPostgresConf: viperutil.Configure(reg, "extra-postgres-conf", viperutil.Options[[]string]{
+		pgInitdbExtraConf: viperutil.Configure(reg, "pg-initdb-extra-conf", viperutil.Options[[]string]{
 			Default:  []string{},
-			FlagName: "extra-postgres-conf",
-			EnvVars:  []string{constants.PgExtraConfFilesEnvVar},
+			FlagName: "pg-initdb-extra-conf",
+			EnvVars:  []string{constants.PgInitdbExtraConfEnvVar},
 			Dynamic:  false,
 		}),
 		vc:        viperutil.NewViperConfig(reg),
@@ -179,7 +179,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("init-db-sql-file", pc.initDbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitDbSQLFilesEnvVar+" env var).")
-	root.PersistentFlags().StringSlice("extra-postgres-conf", pc.extraPostgresConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgExtraConfFilesEnvVar+" env var).")
+	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
 
 	pc.vc.RegisterFlags(root.PersistentFlags())
 	pc.lg.RegisterFlags(root.PersistentFlags())
@@ -196,7 +196,7 @@ management for PostgreSQL servers.`,
 		pc.postgresConfigTmpl,
 		pc.pgInitdbArgs,
 		pc.initDbSQLFiles,
-		pc.extraPostgresConf,
+		pc.pgInitdbExtraConf,
 	)
 
 	// Add all subcommands

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -144,11 +144,12 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	pgbackrestCertDir := s.pgbackrestCertDir.Get()
 
 	pgctldConfig := PgCtldServiceConfig{
-		Port:           s.pgCtlCmd.pgPort.Get(),
-		User:           s.pgCtlCmd.pgUser.Get(),
-		Database:       s.pgCtlCmd.pgDatabase.Get(),
-		Password:       s.pgCtlCmd.pgPassword.Get(),
-		InitDbSQLFiles: s.pgCtlCmd.initDbSQLFiles.Get(),
+		Port:                   s.pgCtlCmd.pgPort.Get(),
+		User:                   s.pgCtlCmd.pgUser.Get(),
+		Database:               s.pgCtlCmd.pgDatabase.Get(),
+		Password:               s.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles:         s.pgCtlCmd.initDbSQLFiles.Get(),
+		ExtraPostgresConfFiles: s.pgCtlCmd.extraPostgresConf.Get(),
 	}
 
 	pgctldService, err := NewPgCtldService(
@@ -240,12 +241,13 @@ func reapOrphanedChildren(logger *slog.Logger) {
 // parameters. These are the most commonly passed parameters and are grouped
 // here to reduce argument lists.
 type PgCtldServiceConfig struct {
-	Port           int
-	User           string
-	Database       string
-	Password       string
-	InitdbArgs     string
-	InitDbSQLFiles []string
+	Port                   int
+	User                   string
+	Database               string
+	Password               string
+	InitdbArgs             string
+	InitDbSQLFiles         []string
+	ExtraPostgresConfFiles []string
 }
 
 // PgCtldService implements the pgctld gRPC service

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -144,12 +144,12 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	pgbackrestCertDir := s.pgbackrestCertDir.Get()
 
 	pgctldConfig := PgCtldServiceConfig{
-		Port:                   s.pgCtlCmd.pgPort.Get(),
-		User:                   s.pgCtlCmd.pgUser.Get(),
-		Database:               s.pgCtlCmd.pgDatabase.Get(),
-		Password:               s.pgCtlCmd.pgPassword.Get(),
-		InitDbSQLFiles:         s.pgCtlCmd.initDbSQLFiles.Get(),
-		ExtraPostgresConfFiles: s.pgCtlCmd.extraPostgresConf.Get(),
+		Port:                 s.pgCtlCmd.pgPort.Get(),
+		User:                 s.pgCtlCmd.pgUser.Get(),
+		Database:             s.pgCtlCmd.pgDatabase.Get(),
+		Password:             s.pgCtlCmd.pgPassword.Get(),
+		InitDbSQLFiles:       s.pgCtlCmd.initDbSQLFiles.Get(),
+		InitdbExtraConfFiles: s.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
 
 	pgctldService, err := NewPgCtldService(
@@ -241,13 +241,13 @@ func reapOrphanedChildren(logger *slog.Logger) {
 // parameters. These are the most commonly passed parameters and are grouped
 // here to reduce argument lists.
 type PgCtldServiceConfig struct {
-	Port                   int
-	User                   string
-	Database               string
-	Password               string
-	InitdbArgs             string
-	InitDbSQLFiles         []string
-	ExtraPostgresConfFiles []string
+	Port                 int
+	User                 string
+	Database             string
+	Password             string
+	InitdbArgs           string
+	InitDbSQLFiles       []string
+	InitdbExtraConfFiles []string
 }
 
 // PgCtldService implements the pgctld gRPC service

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -146,7 +146,7 @@ func TestStopPostgreSQLWithResult(t *testing.T) {
 
 func TestStopPostgreSQLWithResult_EmptyPoolerDir(t *testing.T) {
 	// Create a mock PostgreSQL server config without setting pooler dir
-	_, err := pgctld.GeneratePostgresServerConfig("", 5432, "postgres")
+	_, err := pgctld.GeneratePostgresServerConfig("", "postgres", []string{})
 
 	// Should get an error about pooler-dir not being set
 	require.Error(t, err)
@@ -279,7 +279,7 @@ func TestStopPostgreSQLWithConfig(t *testing.T) {
 			t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
 
 			// Create a mock PostgreSQL server config
-			pgConfig, err := pgctld.GeneratePostgresServerConfig(baseDir, 5432, "postgres")
+			pgConfig, err := pgctld.GeneratePostgresServerConfig(baseDir, "postgres", []string{})
 			require.NoError(t, err)
 
 			// Always create data directory

--- a/go/cmd/pgctld/testutil/temp_dirs.go
+++ b/go/cmd/pgctld/testutil/temp_dirs.go
@@ -68,7 +68,7 @@ func CreateDataDir(t *testing.T, baseDir string, initialized bool) string {
 			t.Fatalf("Failed to create PG_VERSION file: %v", err)
 		}
 		// Generate a proper postgresql.conf file using the postgresconfig_gen functionality
-		_, err := pgctld.GeneratePostgresServerConfig(baseDir, 5432, "postgres")
+		_, err := pgctld.GeneratePostgresServerConfig(baseDir, "postgres", []string{})
 		if err != nil {
 			t.Fatalf("Failed to generate PostgreSQL config: %v", err)
 		}

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -44,6 +44,12 @@ const (
 	// Multiple files are comma-separated.
 	PgInitDbSQLFilesEnvVar = "POSTGRES_INITDB_SQL_FILES"
 
+	// PgExtraConfFilesEnvVar is the environment variable for extra postgresql.conf
+	// files appended verbatim onto the generated config at init time.
+	// Multiple files are comma-separated. Postgres applies last-write-wins, so
+	// extras override values from the templated defaults.
+	PgExtraConfFilesEnvVar = "POSTGRES_EXTRA_CONF"
+
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.
 	DefaultPostgresDatabase = "postgres"

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -44,11 +44,11 @@ const (
 	// Multiple files are comma-separated.
 	PgInitDbSQLFilesEnvVar = "POSTGRES_INITDB_SQL_FILES"
 
-	// PgExtraConfFilesEnvVar is the environment variable for extra postgresql.conf
+	// PgInitdbExtraConfEnvVar is the environment variable for extra postgresql.conf
 	// files appended verbatim onto the generated config at init time.
 	// Multiple files are comma-separated. Postgres applies last-write-wins, so
 	// extras override values from the templated defaults.
-	PgExtraConfFilesEnvVar = "POSTGRES_EXTRA_CONF"
+	PgInitdbExtraConfEnvVar = "POSTGRES_INITDB_EXTRA_CONF"
 
 	// DefaultPostgresDatabase is the default database that always exists in PostgreSQL.
 	// This database is created during cluster initialization.

--- a/go/services/pgctld/postgresconfig.go
+++ b/go/services/pgctld/postgresconfig.go
@@ -30,19 +30,20 @@ import (
 
 const (
 	postgresConfigWaitRetryTime = 100 * time.Millisecond
-	// maxIncludeDepth bounds recursion through include / include_if_exists /
-	// include_dir directives. Postgres itself caps include nesting; ten levels
-	// is well past anything reasonable.
+	// maxIncludeDepth bounds recursion through postgres include directives.
 	maxIncludeDepth = 10
+
+	directiveInclude         = "include"
+	directiveIncludeIfExists = "include_if_exists"
+	directiveIncludeDir      = "include_dir"
 )
 
 // PostgresServerConfig is a memory structure that contains PostgreSQL server configuration parameters.
 // It can be used to read standard postgresql.conf files and can also be populated from an existing postgresql.conf.
 //
-// Settings pinned by pgctld at start time (port, listen_addresses, unix_socket_directories,
-// data_directory) are intentionally absent: pgctld passes them on the postgres command line,
-// where they take precedence over postgresql.conf entries. They must not appear in the
-// templated config nor in user-supplied extras.
+// port, listen_addresses, unix_socket_directories, and data_directory are intentionally
+// absent: pgctld pins them via postgres command-line args at start, which take precedence
+// over postgresql.conf.
 type PostgresServerConfig struct {
 	// Core connection settings
 	MaxConnections int
@@ -128,10 +129,8 @@ func (cnf *PostgresServerConfig) lookupFloat(key string) (float64, error) {
 	return fval, nil
 }
 
-// parseConfigInto reads a postgresql.conf file at path, populating configMap with
-// key-value pairs. include / include_if_exists / include_dir directives are
-// resolved relative to the current file's directory (matching postgres) and
-// processed in-place, so later inline settings override earlier included ones.
+// parseConfigInto follows postgres include semantics: relative include paths
+// resolve against the including file's directory.
 func parseConfigInto(path string, configMap map[string]string, depth int) error {
 	if depth > maxIncludeDepth {
 		return fmt.Errorf("postgres config include depth exceeded reading %s", path)
@@ -139,7 +138,7 @@ func parseConfigInto(path string, configMap map[string]string, depth int) error 
 
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("opening postgres config %s: %w", path, err)
 	}
 	defer f.Close()
 
@@ -151,40 +150,21 @@ func parseConfigInto(path string, configMap map[string]string, depth int) error 
 		if err == io.EOF {
 			break
 		}
-		lineStr := strings.TrimSpace(string(line))
-		if strings.HasPrefix(lineStr, "#") || lineStr == "" {
-			continue
-		}
-
-		var key, value string
-		if strings.Contains(lineStr, "=") {
-			parts := strings.SplitN(lineStr, "=", 2)
-			if len(parts) == 2 {
-				key = strings.TrimSpace(parts[0])
-				value = stripQuotes(strings.TrimSpace(parts[1]))
-			}
-		} else {
-			parts := strings.Fields(lineStr)
-			if len(parts) >= 2 {
-				key = parts[0]
-				value = stripQuotes(strings.Join(parts[1:], " "))
-			}
-		}
-
+		key, value := parseConfigLine(string(line))
 		if key == "" {
 			continue
 		}
 
 		switch key {
-		case "include", "include_if_exists":
+		case directiveInclude, directiveIncludeIfExists:
 			target := resolveIncludePath(baseDir, value)
 			if err := parseConfigInto(target, configMap, depth+1); err != nil {
-				if key == "include_if_exists" && errors.Is(err, fs.ErrNotExist) {
+				if key == directiveIncludeIfExists && errors.Is(err, fs.ErrNotExist) {
 					continue
 				}
 				return fmt.Errorf("processing %s in %s: %w", key, path, err)
 			}
-		case "include_dir":
+		case directiveIncludeDir:
 			if err := parseIncludeDir(resolveIncludePath(baseDir, value), configMap, depth+1); err != nil {
 				return fmt.Errorf("processing include_dir in %s: %w", path, err)
 			}
@@ -195,9 +175,25 @@ func parseConfigInto(path string, configMap map[string]string, depth int) error 
 	return nil
 }
 
-// parseIncludeDir mirrors postgres' include_dir behavior: parse every *.conf
-// file in dir in lexicographic order. Postgres skips files starting with "."
-// and entries that aren't regular files; we do the same.
+// parseConfigLine extracts a key/value from a single postgresql.conf line.
+// Returns ("", "") for comments, blanks, and malformed lines.
+func parseConfigLine(line string) (string, string) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", ""
+	}
+	if i := strings.Index(line, "="); i >= 0 {
+		return strings.TrimSpace(line[:i]), stripQuotes(strings.TrimSpace(line[i+1:]))
+	}
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return "", ""
+	}
+	return parts[0], stripQuotes(strings.Join(parts[1:], " "))
+}
+
+// parseIncludeDir mirrors postgres' include_dir: parse every *.conf in
+// lexicographic order, skipping dotfiles and directories.
 func parseIncludeDir(dir string, configMap map[string]string, depth int) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -219,9 +215,6 @@ func parseIncludeDir(dir string, configMap map[string]string, depth int) error {
 	return nil
 }
 
-// resolveIncludePath resolves an include directive's target. Postgres treats
-// relative paths as relative to the directory of the file containing the
-// directive; absolute paths pass through unchanged.
 func resolveIncludePath(baseDir, p string) string {
 	if filepath.IsAbs(p) {
 		return p
@@ -248,10 +241,9 @@ func stripQuotes(value string) string {
 	return value
 }
 
-// ReadPostgresServerConfig reads an existing postgresql.conf from disk and updates the passed in PostgresServerConfig object
-// with values from the config file on disk. include / include_if_exists / include_dir
-// directives are followed recursively so the in-memory struct mirrors what postgres
-// actually loads at runtime (last-write-wins per inline order).
+// ReadPostgresServerConfig populates pgConfig from postgresql.conf at
+// pgConfig.Path, following postgres include directives so the in-memory struct
+// matches what postgres will load at runtime.
 func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Duration) (*PostgresServerConfig, error) {
 	_, err := os.Stat(pgConfig.Path)
 	if waitTime != 0 {
@@ -278,11 +270,6 @@ func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Dura
 	// Parse and map configuration values to struct fields
 	var parseErr error
 
-	// Connection settings
-	// port, listen_addresses, unix_socket_directories, and data_directory are NOT
-	// read from the config file: pgctld pins them via postgres command-line args at
-	// start time, which take precedence over postgresql.conf. Keeping them out of the
-	// in-memory struct avoids drift between the file and what postgres is actually using.
 	if pgConfig.MaxConnections, parseErr = pgConfig.lookupInt("max_connections"); parseErr != nil {
 		pgConfig.MaxConnections = 100 // default
 	}

--- a/go/services/pgctld/postgresconfig.go
+++ b/go/services/pgctld/postgresconfig.go
@@ -19,7 +19,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -27,16 +30,22 @@ import (
 
 const (
 	postgresConfigWaitRetryTime = 100 * time.Millisecond
+	// maxIncludeDepth bounds recursion through include / include_if_exists /
+	// include_dir directives. Postgres itself caps include nesting; ten levels
+	// is well past anything reasonable.
+	maxIncludeDepth = 10
 )
 
 // PostgresServerConfig is a memory structure that contains PostgreSQL server configuration parameters.
 // It can be used to read standard postgresql.conf files and can also be populated from an existing postgresql.conf.
+//
+// Settings pinned by pgctld at start time (port, listen_addresses, unix_socket_directories,
+// data_directory) are intentionally absent: pgctld passes them on the postgres command line,
+// where they take precedence over postgresql.conf entries. They must not appear in the
+// templated config nor in user-supplied extras.
 type PostgresServerConfig struct {
 	// Core connection settings
-	Port                  int
-	MaxConnections        int
-	ListenAddresses       string
-	UnixSocketDirectories string
+	MaxConnections int
 
 	// File locations (template fields)
 	DataDir   string // matches {{.DataDir}} in template
@@ -119,6 +128,107 @@ func (cnf *PostgresServerConfig) lookupFloat(key string) (float64, error) {
 	return fval, nil
 }
 
+// parseConfigInto reads a postgresql.conf file at path, populating configMap with
+// key-value pairs. include / include_if_exists / include_dir directives are
+// resolved relative to the current file's directory (matching postgres) and
+// processed in-place, so later inline settings override earlier included ones.
+func parseConfigInto(path string, configMap map[string]string, depth int) error {
+	if depth > maxIncludeDepth {
+		return fmt.Errorf("postgres config include depth exceeded reading %s", path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	baseDir := filepath.Dir(path)
+	buf := bufio.NewReader(f)
+
+	for {
+		line, _, err := buf.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		lineStr := strings.TrimSpace(string(line))
+		if strings.HasPrefix(lineStr, "#") || lineStr == "" {
+			continue
+		}
+
+		var key, value string
+		if strings.Contains(lineStr, "=") {
+			parts := strings.SplitN(lineStr, "=", 2)
+			if len(parts) == 2 {
+				key = strings.TrimSpace(parts[0])
+				value = stripQuotes(strings.TrimSpace(parts[1]))
+			}
+		} else {
+			parts := strings.Fields(lineStr)
+			if len(parts) >= 2 {
+				key = parts[0]
+				value = stripQuotes(strings.Join(parts[1:], " "))
+			}
+		}
+
+		if key == "" {
+			continue
+		}
+
+		switch key {
+		case "include", "include_if_exists":
+			target := resolveIncludePath(baseDir, value)
+			if err := parseConfigInto(target, configMap, depth+1); err != nil {
+				if key == "include_if_exists" && errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				return fmt.Errorf("processing %s in %s: %w", key, path, err)
+			}
+		case "include_dir":
+			if err := parseIncludeDir(resolveIncludePath(baseDir, value), configMap, depth+1); err != nil {
+				return fmt.Errorf("processing include_dir in %s: %w", path, err)
+			}
+		default:
+			configMap[key] = value
+		}
+	}
+	return nil
+}
+
+// parseIncludeDir mirrors postgres' include_dir behavior: parse every *.conf
+// file in dir in lexicographic order. Postgres skips files starting with "."
+// and entries that aren't regular files; we do the same.
+func parseIncludeDir(dir string, configMap map[string]string, depth int) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") || !strings.HasSuffix(e.Name(), ".conf") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		if err := parseConfigInto(filepath.Join(dir, n), configMap, depth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveIncludePath resolves an include directive's target. Postgres treats
+// relative paths as relative to the directory of the file containing the
+// directive; absolute paths pass through unchanged.
+func resolveIncludePath(baseDir, p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(baseDir, p)
+}
+
 // stripQuotes removes surrounding single or double quotes from a string value
 // and removes any trailing comments
 func stripQuotes(value string) string {
@@ -139,9 +249,11 @@ func stripQuotes(value string) string {
 }
 
 // ReadPostgresServerConfig reads an existing postgresql.conf from disk and updates the passed in PostgresServerConfig object
-// with values from the config file on disk.
+// with values from the config file on disk. include / include_if_exists / include_dir
+// directives are followed recursively so the in-memory struct mirrors what postgres
+// actually loads at runtime (last-write-wins per inline order).
 func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Duration) (*PostgresServerConfig, error) {
-	f, err := os.Open(pgConfig.Path)
+	_, err := os.Stat(pgConfig.Path)
 	if waitTime != 0 {
 		timer := time.NewTimer(waitTime)
 		for err != nil {
@@ -150,69 +262,30 @@ func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Dura
 				return nil, err
 			default:
 				time.Sleep(postgresConfigWaitRetryTime)
-				f, err = os.Open(pgConfig.Path)
+				_, err = os.Stat(pgConfig.Path)
 			}
 		}
 	}
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
-	buf := bufio.NewReader(f)
 	pgConfig.configMap = make(map[string]string)
-
-	for {
-		line, _, err := buf.ReadLine()
-		if err == io.EOF {
-			break
-		}
-		lineStr := strings.TrimSpace(string(line))
-
-		// Skip comments and empty lines
-		if strings.HasPrefix(lineStr, "#") || lineStr == "" {
-			continue
-		}
-
-		// Handle PostgreSQL config format: key = value (or key value)
-		var key, value string
-		if strings.Contains(lineStr, "=") {
-			parts := strings.SplitN(lineStr, "=", 2)
-			if len(parts) == 2 {
-				key = strings.TrimSpace(parts[0])
-				value = stripQuotes(strings.TrimSpace(parts[1]))
-			}
-		} else {
-			// Handle format without = (space separated)
-			parts := strings.Fields(lineStr)
-			if len(parts) >= 2 {
-				key = parts[0]
-				value = stripQuotes(strings.Join(parts[1:], " "))
-			}
-		}
-
-		if key != "" {
-			pgConfig.configMap[key] = value
-		}
+	if err := parseConfigInto(pgConfig.Path, pgConfig.configMap, 0); err != nil {
+		return nil, err
 	}
 
 	// Parse and map configuration values to struct fields
 	var parseErr error
 
 	// Connection settings
-	// Port and unix_socket_directories are NOT read from config file
-	// They are only set via flags/code and passed as PostgreSQL command-line parameters
-	// This ensures backups remain portable across different environments
+	// port, listen_addresses, unix_socket_directories, and data_directory are NOT
+	// read from the config file: pgctld pins them via postgres command-line args at
+	// start time, which take precedence over postgresql.conf. Keeping them out of the
+	// in-memory struct avoids drift between the file and what postgres is actually using.
 	if pgConfig.MaxConnections, parseErr = pgConfig.lookupInt("max_connections"); parseErr != nil {
 		pgConfig.MaxConnections = 100 // default
 	}
-	if val, err := pgConfig.lookupWithDefault("listen_addresses", pgConfig.ListenAddresses); err == nil {
-		pgConfig.ListenAddresses = val
-	}
-
-	// data_directory is NOT read from config file
-	// They are only set via flags and passed as PostgreSQL command-line parameters
-	// This ensures backups remain portable across different directory paths
 
 	// Memory settings - required in our controlled config
 	if val, err := pgConfig.lookupWithDefault("shared_buffers", ""); err != nil {

--- a/go/services/pgctld/postgresconfig.go
+++ b/go/services/pgctld/postgresconfig.go
@@ -245,7 +245,7 @@ func stripQuotes(value string) string {
 // pgConfig.Path, following postgres include directives so the in-memory struct
 // matches what postgres will load at runtime.
 func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Duration) (*PostgresServerConfig, error) {
-	_, err := os.Stat(pgConfig.Path)
+	f, err := os.Open(pgConfig.Path)
 	if waitTime != 0 {
 		timer := time.NewTimer(waitTime)
 		for err != nil {
@@ -254,13 +254,14 @@ func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Dura
 				return nil, err
 			default:
 				time.Sleep(postgresConfigWaitRetryTime)
-				_, err = os.Stat(pgConfig.Path)
+				f, err = os.Open(pgConfig.Path)
 			}
 		}
 	}
 	if err != nil {
 		return nil, err
 	}
+	f.Close()
 
 	pgConfig.configMap = make(map[string]string)
 	if err := parseConfigInto(pgConfig.Path, pgConfig.configMap, 0); err != nil {

--- a/go/services/pgctld/postgresconfig.go
+++ b/go/services/pgctld/postgresconfig.go
@@ -242,8 +242,10 @@ func stripQuotes(value string) string {
 }
 
 // ReadPostgresServerConfig populates pgConfig from postgresql.conf at
-// pgConfig.Path, following postgres include directives so the in-memory struct
-// matches what postgres will load at runtime.
+// pgConfig.Path. include / include_if_exists / include_dir directives are
+// followed recursively (an included file may itself include further files), up
+// to maxIncludeDepth, so the in-memory struct matches what postgres will load
+// at runtime.
 func ReadPostgresServerConfig(pgConfig *PostgresServerConfig, waitTime time.Duration) (*PostgresServerConfig, error) {
 	f, err := os.Open(pgConfig.Path)
 	if waitTime != 0 {

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -48,13 +48,8 @@ func ExpandToAbsolutePath(dir string) (string, error) {
 	return absPath, nil
 }
 
-// GeneratePostgresServerConfig generates a new PostgreSQL server configuration
-// and writes it to disk using the embedded template, then reads it back.
-// extraConfFiles is an optional list of paths whose contents are appended verbatim
-// after the templated config — last-write-wins per postgres semantics. The four
-// settings pgctld pins via command-line args (port, listen_addresses,
-// unix_socket_directories, data_directory) are unaffected even if extras try to
-// override them, since CLI args beat postgresql.conf.
+// GeneratePostgresServerConfig writes postgresql.conf from the embedded template,
+// appends extraConfFiles verbatim (postgres last-write-wins), then reads it back.
 func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFiles []string) (*PostgresServerConfig, error) {
 	// Create minimal config for template generation
 	if poolerDir == "" {
@@ -74,8 +69,6 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 	cnf.ClusterName = "default"
 	cnf.User = pgUser
 
-	// Ensure Unix socket directory exists. The path itself is pgctld-controlled and
-	// passed to postgres via -c unix_socket_directories= at start, not via the conf file.
 	if err := os.MkdirAll(PostgresSocketDir(absPoolerDir), 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create Unix socket directory: %w", err)
 	}
@@ -109,9 +102,6 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 		return nil, err
 	}
 
-	// Append user-supplied extra config files. Each is concatenated raw onto the
-	// generated postgresql.conf with a "## <path>" header for diagnostics; postgres
-	// applies last-write-wins for repeated keys, so extras override template values.
 	if err := cnf.appendExtraConfFiles(extraConfFiles); err != nil {
 		return nil, err
 	}
@@ -125,9 +115,9 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 	return ReadPostgresServerConfig(cnf, 0)
 }
 
-// appendExtraConfFiles concatenates the contents of each path onto the generated
-// postgresql.conf. Each block is prefixed with "## <path>" so the source is
-// recoverable when reading the merged file.
+// appendExtraConfFiles concatenates each path onto postgresql.conf. The
+// "## <path>" header before each block lets readers attribute lines back to
+// their source file.
 func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
 	if len(paths) == 0 {
 		return nil
@@ -135,24 +125,24 @@ func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
 
 	f, err := os.OpenFile(cnf.Path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("failed to open postgresql.conf for extras: %w", err)
+		return fmt.Errorf("opening postgresql.conf for extras: %w", err)
 	}
 	defer f.Close()
 
 	for _, p := range paths {
 		data, err := os.ReadFile(p)
 		if err != nil {
-			return fmt.Errorf("failed to read extra postgres config file %q: %w", p, err)
+			return fmt.Errorf("reading extra postgres config %q: %w", p, err)
 		}
 		if _, err := fmt.Fprintf(f, "\n## %s\n", p); err != nil {
-			return fmt.Errorf("failed to write extras header for %q: %w", p, err)
+			return fmt.Errorf("appending %q: %w", p, err)
 		}
 		if _, err := f.Write(data); err != nil {
-			return fmt.Errorf("failed to append extra postgres config file %q: %w", p, err)
+			return fmt.Errorf("appending %q: %w", p, err)
 		}
 		if len(data) > 0 && data[len(data)-1] != '\n' {
 			if _, err := f.WriteString("\n"); err != nil {
-				return fmt.Errorf("failed to terminate extras block for %q: %w", p, err)
+				return fmt.Errorf("appending %q: %w", p, err)
 			}
 		}
 	}

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -50,10 +50,12 @@ func ExpandToAbsolutePath(dir string) (string, error) {
 
 // GeneratePostgresServerConfig generates a new PostgreSQL server configuration
 // and writes it to disk using the embedded template, then reads it back.
-// poolerId is used for the cluster name and path generation.
-// port is the port for the PostgreSQL server.
-// pgUser is the PostgreSQL user name for authentication.
-func GeneratePostgresServerConfig(poolerDir string, port int, pgUser string) (*PostgresServerConfig, error) {
+// extraConfFiles is an optional list of paths whose contents are appended verbatim
+// after the templated config — last-write-wins per postgres semantics. The four
+// settings pgctld pins via command-line args (port, listen_addresses,
+// unix_socket_directories, data_directory) are unaffected even if extras try to
+// override them, since CLI args beat postgresql.conf.
+func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFiles []string) (*PostgresServerConfig, error) {
 	// Create minimal config for template generation
 	if poolerDir == "" {
 		return nil, errors.New("--pooler-dir needs to be set to generate postgres server config")
@@ -69,14 +71,12 @@ func GeneratePostgresServerConfig(poolerDir string, port int, pgUser string) (*P
 	cnf.DataDir = PostgresDataDir()
 	cnf.HbaFile = path.Join(PostgresDataDir(), "pg_hba.conf")
 	cnf.IdentFile = path.Join(PostgresDataDir(), "pg_ident.conf")
-	cnf.Port = port
-	cnf.ListenAddresses = "localhost"
-	cnf.UnixSocketDirectories = PostgresSocketDir(absPoolerDir)
 	cnf.ClusterName = "default"
 	cnf.User = pgUser
 
-	// Ensure Unix socket directory exists
-	if err := os.MkdirAll(cnf.UnixSocketDirectories, 0o755); err != nil {
+	// Ensure Unix socket directory exists. The path itself is pgctld-controlled and
+	// passed to postgres via -c unix_socket_directories= at start, not via the conf file.
+	if err := os.MkdirAll(PostgresSocketDir(absPoolerDir), 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create Unix socket directory: %w", err)
 	}
 
@@ -109,6 +109,13 @@ func GeneratePostgresServerConfig(poolerDir string, port int, pgUser string) (*P
 		return nil, err
 	}
 
+	// Append user-supplied extra config files. Each is concatenated raw onto the
+	// generated postgresql.conf with a "## <path>" header for diagnostics; postgres
+	// applies last-write-wins for repeated keys, so extras override template values.
+	if err := cnf.appendExtraConfFiles(extraConfFiles); err != nil {
+		return nil, err
+	}
+
 	// Generate HBA file from template
 	if err := cnf.generateHbaFile(); err != nil {
 		return nil, err
@@ -118,28 +125,38 @@ func GeneratePostgresServerConfig(poolerDir string, port int, pgUser string) (*P
 	return ReadPostgresServerConfig(cnf, 0)
 }
 
-// LoadOrCreatePostgresServerConfig loads an existing PostgreSQL server configuration
-// from disk, or generates and writes a new one if it doesn't exist.
-// port is the port for the PostgreSQL server.
-// pgUser is the PostgreSQL user name for authentication.
-func LoadOrCreatePostgresServerConfig(poolerDir string, port int, pgUser string) (*PostgresServerConfig, error) {
-	// Expand relative path to absolute path for consistent path handling
-	absPoolerDir, err := ExpandToAbsolutePath(poolerDir)
+// appendExtraConfFiles concatenates the contents of each path onto the generated
+// postgresql.conf. Each block is prefixed with "## <path>" so the source is
+// recoverable when reading the merged file.
+func (cnf *PostgresServerConfig) appendExtraConfFiles(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(cnf.Path, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("failed to expand pooler directory path: %w", err)
+		return fmt.Errorf("failed to open postgresql.conf for extras: %w", err)
 	}
+	defer f.Close()
 
-	configPath := PostgresConfigFile()
-
-	// Check if config file already exists
-	if _, err := os.Stat(configPath); err == nil {
-		// Config file exists, read it
-		cnf := &PostgresServerConfig{Path: configPath}
-		return ReadPostgresServerConfig(cnf, 0)
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("failed to read extra postgres config file %q: %w", p, err)
+		}
+		if _, err := fmt.Fprintf(f, "\n## %s\n", p); err != nil {
+			return fmt.Errorf("failed to write extras header for %q: %w", p, err)
+		}
+		if _, err := f.Write(data); err != nil {
+			return fmt.Errorf("failed to append extra postgres config file %q: %w", p, err)
+		}
+		if len(data) > 0 && data[len(data)-1] != '\n' {
+			if _, err := f.WriteString("\n"); err != nil {
+				return fmt.Errorf("failed to terminate extras block for %q: %w", p, err)
+			}
+		}
 	}
-
-	// Config file doesn't exist, let's generate it
-	return GeneratePostgresServerConfig(absPoolerDir, port, pgUser)
+	return nil
 }
 
 // generateConfigFile creates the postgresql.conf file using the embedded template

--- a/go/services/pgctld/postgresconfig_gen_test.go
+++ b/go/services/pgctld/postgresconfig_gen_test.go
@@ -15,6 +15,9 @@
 package pgctld
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,48 +31,32 @@ func TestNewPostgresServerConfig(t *testing.T) {
 	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
 	tests := []struct {
-		name          string
-		poolerId      string
-		port          int
-		wantPort      int
-		wantCluster   string
-		wantDataDir   string
-		wantSocketDir string
+		name        string
+		poolerId    string
+		wantCluster string
+		wantDataDir string
 	}{
 		{
-			name:          "basic config creation",
-			poolerId:      "test-pooler-1",
-			port:          5432,
-			wantPort:      5432,
-			wantCluster:   "main",
-			wantDataDir:   tempDir + "/pg_data",
-			wantSocketDir: tempDir + "/pg_sockets",
+			name:        "basic config creation",
+			poolerId:    "test-pooler-1",
+			wantCluster: "main",
+			wantDataDir: tempDir + "/pg_data",
 		},
 		{
-			name:          "custom port",
-			poolerId:      "pooler-2",
-			port:          5433,
-			wantPort:      5433,
-			wantCluster:   "main",
-			wantDataDir:   tempDir + "/pg_data",
-			wantSocketDir: tempDir + "/pg_sockets",
+			name:        "second pooler",
+			poolerId:    "pooler-2",
+			wantCluster: "main",
+			wantDataDir: tempDir + "/pg_data",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := GeneratePostgresServerConfig(tempDir, tt.port, "postgres")
+			config, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{})
 			require.NoError(t, err, "GeneratePostgresServerConfig should not return error")
 
-			assert.Equal(t, tt.wantPort, config.Port, "Port should match expected value")
-
 			assert.Equal(t, tt.wantCluster, config.ClusterName, "ClusterName should match expected value")
-
 			assert.Equal(t, tt.wantDataDir, config.DataDir, "DataDir should match expected value")
-
-			assert.Equal(t, "localhost", config.ListenAddresses, "ListenAddresses should be localhost")
-
-			assert.Equal(t, tt.wantSocketDir, config.UnixSocketDirectories, "UnixSocketDirectories should match expected value")
 		})
 	}
 }
@@ -98,7 +85,7 @@ func TestMakePostgresConf(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
-	config, err := GeneratePostgresServerConfig(tempDir, 5432, "postgres")
+	config, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{})
 	require.NoError(t, err, "GeneratePostgresServerConfig should not return error")
 
 	tests := []struct {
@@ -107,11 +94,6 @@ func TestMakePostgresConf(t *testing.T) {
 		want     []string
 		wantNot  []string
 	}{
-		{
-			name:     "port template",
-			template: "port = {{.Port}}",
-			want:     []string{"port = 5432"},
-		},
 		{
 			name:     "cluster name template",
 			template: "cluster_name = '{{.ClusterName}}'",
@@ -128,31 +110,15 @@ func TestMakePostgresConf(t *testing.T) {
 			want:     []string{"max_connections = 60"},
 		},
 		{
-			name:     "listen addresses template",
-			template: "listen_addresses = '{{.ListenAddresses}}'",
-			want:     []string{"listen_addresses = 'localhost'"},
-		},
-		{
-			name:     "unix socket directories template",
-			template: "unix_socket_directories = '{{.UnixSocketDirectories}}'",
-			want:     []string{"unix_socket_directories = '" + tempDir + "/pg_sockets'"},
-		},
-		{
 			name: "complex template",
 			template: `# PostgreSQL Configuration
-port = {{.Port}}
 max_connections = {{.MaxConnections}}
-listen_addresses = '{{.ListenAddresses}}'
 data_directory = '{{.DataDir}}'
-cluster_name = '{{.ClusterName}}'
-unix_socket_directories = '{{.UnixSocketDirectories}}'`,
+cluster_name = '{{.ClusterName}}'`,
 			want: []string{
-				"port = 5432",
 				"max_connections = 60",
-				"listen_addresses = 'localhost'",
 				"data_directory = '" + tempDir + "/pg_data'",
 				"cluster_name = 'main'",
-				"unix_socket_directories = '" + tempDir + "/pg_sockets'",
 				"# PostgreSQL Configuration",
 			},
 		},
@@ -180,7 +146,7 @@ func TestMakePostgresConfInvalidTemplate(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
 
-	config, err := GeneratePostgresServerConfig(tempDir, 5432, "postgres")
+	config, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{})
 	require.NoError(t, err, "GeneratePostgresServerConfig should not return error")
 
 	tests := []struct {
@@ -203,4 +169,66 @@ func TestMakePostgresConfInvalidTemplate(t *testing.T) {
 			assert.Error(t, err, "MakePostgresConf should return error for invalid template")
 		})
 	}
+}
+
+func TestGeneratePostgresServerConfigExtraConfFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
+
+	extraDir := t.TempDir()
+	extraA := filepath.Join(extraDir, "a.conf")
+	extraB := filepath.Join(extraDir, "b.conf")
+
+	// Extra A overrides shared_buffers; extra B overrides it again so the last
+	// file wins. Also adds a setting not in the template at all.
+	require.NoError(t, os.WriteFile(extraA, []byte("shared_buffers = 128MB\n"), 0o644))
+	require.NoError(t, os.WriteFile(extraB, []byte("shared_buffers = 256MB\nlog_min_duration_statement = 500\n"), 0o644))
+
+	cfg, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{extraA, extraB})
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(cfg.Path)
+	require.NoError(t, err)
+	content := string(raw)
+
+	// Source-attribution headers are present in append order.
+	idxA := strings.Index(content, "## "+extraA)
+	idxB := strings.Index(content, "## "+extraB)
+	require.GreaterOrEqual(t, idxA, 0, "extra A header should be present")
+	require.GreaterOrEqual(t, idxB, 0, "extra B header should be present")
+	assert.Greater(t, idxB, idxA, "extra B should be appended after extra A")
+
+	// Last-write-wins: the in-memory struct reflects the value postgres will see.
+	assert.Equal(t, "256MB", cfg.SharedBuffers)
+
+	// Settings absent from the template still land in the file.
+	assert.Contains(t, content, "log_min_duration_statement = 500")
+}
+
+func TestGeneratePostgresServerConfigExtraConfFollowsInclude(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
+
+	extraDir := t.TempDir()
+	overrides := filepath.Join(extraDir, "overrides.conf")
+	extraFile := filepath.Join(extraDir, "extra.conf")
+
+	require.NoError(t, os.WriteFile(overrides, []byte("shared_buffers = 512MB\n"), 0o644))
+	require.NoError(t, os.WriteFile(extraFile, []byte("include '"+overrides+"'\n"), 0o644))
+
+	cfg, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{extraFile})
+	require.NoError(t, err)
+
+	// Postgres follows include directives at runtime, so our in-memory struct
+	// must too — otherwise it disagrees with what the server actually loads.
+	assert.Equal(t, "512MB", cfg.SharedBuffers)
+}
+
+func TestGeneratePostgresServerConfigExtraConfFileMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(constants.PgDataDirEnvVar, tempDir+"/pg_data")
+
+	_, err := GeneratePostgresServerConfig(tempDir, "postgres", []string{"/does/not/exist.conf"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "/does/not/exist.conf")
 }

--- a/go/services/pgctld/postgresconfig_test.go
+++ b/go/services/pgctld/postgresconfig_test.go
@@ -118,11 +118,6 @@ var configSettings = map[string]string{
 	"unix_socket_directories": "/var/run/postgresql",
 	"listen_addresses":        "*",
 
-	// Include settings
-	"include":           "/etc/postgresql/logging.conf",
-	"include_dir":       "/etc/postgresql-custom",
-	"include_if_exists": "/etc/postgresql-custom/custom.conf",
-
 	// Memory/size settings (with units)
 	"shared_buffers":               "64MB",
 	"temp_buffers":                 "8MB",
@@ -340,7 +335,7 @@ func TestGenerateAndReadConfigRoundTrip(t *testing.T) {
 	t.Setenv(constants.PgDataDirEnvVar, tmpDir+"/pg_data")
 
 	// Generate config using the template
-	generatedConfig, err := GeneratePostgresServerConfig(tmpDir, 5433, "postgres")
+	generatedConfig, err := GeneratePostgresServerConfig(tmpDir, "postgres", []string{})
 	require.NoError(t, err, "GeneratePostgresServerConfig should not return error")
 
 	// Read the generated config back from disk
@@ -348,9 +343,9 @@ func TestGenerateAndReadConfigRoundTrip(t *testing.T) {
 	result, err := ReadPostgresServerConfig(readConfig, 0)
 	require.NoError(t, err, "ReadPostgresServerConfig should not return error for generated config")
 
-	// Validate that all required template fields are populated (not empty/zero values)
-	// Port, ListenAddresses, and UnixSocketDirectories are set during generation and preserved in memory
-	// but are NOT read back from the config file (they're passed as CLI parameters)
+	// Validate that all required template fields are populated (not empty/zero values).
+	// port, listen_addresses, unix_socket_directories, and data_directory are intentionally
+	// not part of the struct: pgctld pins them via postgres CLI args at start time.
 	assert.NotZero(t, result.MaxConnections, "MaxConnections should be set")
 	assert.NotEmpty(t, result.SharedBuffers, "SharedBuffers should be set")
 	assert.NotEmpty(t, result.MaintenanceWorkMem, "MaintenanceWorkMem should be set")

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -431,6 +431,89 @@ timeout: 30
 	require.NoError(t, err)
 }
 
+// TestExtraPostgresConfWithInclude validates --extra-postgres-conf end-to-end:
+// the extra file uses postgres' `include` directive to point at a separate
+// overrides file, and the running server reports the override values via SHOW.
+// This exercises both pgctld's append step at init and postgres' own include
+// resolution at startup.
+func TestExtraPostgresConfWithInclude(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+	if !utils.HasPostgreSQLBinaries() {
+		t.Fatal("PostgreSQL binaries not found, make sure to install PostgreSQL and add it to the PATH")
+	}
+
+	tempDir, cleanup := testutil.TempDir(t, "pgctld_extra_conf_test")
+	defer cleanup()
+
+	dataDir := filepath.Join(tempDir, "data")
+	extraDir := filepath.Join(tempDir, "extras")
+	require.NoError(t, os.MkdirAll(extraDir, 0o755))
+
+	// overrides.conf holds the actual values.
+	overrides := filepath.Join(extraDir, "overrides.conf")
+	require.NoError(t, os.WriteFile(overrides, []byte(
+		"shared_buffers = 256MB\n"+
+			"track_io_timing = on\n",
+	), 0o644))
+
+	// extra.conf is the file pgctld appends — it just includes overrides.conf.
+	extra := filepath.Join(extraDir, "extra.conf")
+	require.NoError(t, os.WriteFile(extra, fmt.Appendf(nil, "include '%s'\n", overrides), 0o644))
+
+	port := utils.GetFreePort(t)
+
+	initCmd := executil.Command(t.Context(), "pgctld", "init",
+		"--pooler-dir", dataDir,
+		"--pg-port", strconv.Itoa(port),
+		"--extra-postgres-conf", extra,
+	)
+	setupTestEnv(initCmd, dataDir)
+	initOut, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld init failed: %s", string(initOut))
+
+	startCmd := executil.Command(t.Context(), "pgctld", "start",
+		"--pooler-dir", dataDir,
+		"--pg-port", strconv.Itoa(port),
+	)
+	setupTestEnv(startCmd, dataDir)
+	startOut, err := startCmd.CombinedOutput()
+	require.NoError(t, err, "pgctld start failed: %s", string(startOut))
+
+	defer func() {
+		stopCmd := executil.Command(t.Context(), "pgctld", "stop",
+			"--pooler-dir", dataDir,
+			"--pg-port", strconv.Itoa(port),
+		)
+		setupTestEnv(stopCmd, dataDir)
+		_ = stopCmd.Run()
+	}()
+
+	socketDir := filepath.Join(dataDir, "pg_sockets")
+	show := func(setting string) string {
+		t.Helper()
+		cmd := executil.Command(t.Context(), "psql",
+			"-h", socketDir,
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", "postgres",
+			"-Atc", "SHOW "+setting,
+		)
+		setupTestEnv(cmd, dataDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "psql SHOW %s failed: %s", setting, string(out))
+		return strings.TrimSpace(string(out))
+	}
+
+	// shared_buffers from the included file overrides the template's 64MB.
+	assert.Equal(t, "256MB", show("shared_buffers"))
+
+	// track_io_timing isn't in the template (defaults to off) — proves that
+	// included settings absent from the generated config still take effect.
+	assert.Equal(t, "on", show("track_io_timing"))
+}
+
 // TestPostgreSQLAuthentication tests PostgreSQL authentication with POSTGRES_PASSWORD
 func TestPostgreSQLAuthentication(t *testing.T) {
 	if testing.Short() {

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -431,12 +431,12 @@ timeout: 30
 	require.NoError(t, err)
 }
 
-// TestExtraPostgresConfWithInclude validates --extra-postgres-conf end-to-end:
+// TestPgInitdbExtraConfWithInclude validates --pg-initdb-extra-conf end-to-end:
 // the extra file uses postgres' `include` directive to point at a separate
 // overrides file, and the running server reports the override values via SHOW.
 // This exercises both pgctld's append step at init and postgres' own include
 // resolution at startup.
-func TestExtraPostgresConfWithInclude(t *testing.T) {
+func TestPgInitdbExtraConfWithInclude(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration tests in short mode")
 	}
@@ -467,7 +467,7 @@ func TestExtraPostgresConfWithInclude(t *testing.T) {
 	initCmd := executil.Command(t.Context(), "pgctld", "init",
 		"--pooler-dir", dataDir,
 		"--pg-port", strconv.Itoa(port),
-		"--extra-postgres-conf", extra,
+		"--pg-initdb-extra-conf", extra,
 	)
 	setupTestEnv(initCmd, dataDir)
 	initOut, err := initCmd.CombinedOutput()


### PR DESCRIPTION
# Description

The main change here is --extra-postgres-conf. There are few other changes that are mostly cleanup and bug fixes that the new feature surfaced.

## Changes
* Adds --extra-postgres-conf (and POSTGRES_EXTRA_CONF env var) to pgctld: a list of postgresql.conf files appended verbatim onto the generated config at init time. Mirrors vitess's EXTRA_MY_CNF pattern. Postgres applies last-write-wins, so extras override template defaults; the four pgctld-pinned settings (port, listen_addresses, unix_socket_directories, data_directory) remain safe because they're passed as -c args at start, which beat postgresql.conf.
* Removes Port, ListenAddresses, and UnixSocketDirectories from PostgresServerConfig: they were dead in-memory state since pgctld pins those via CLI args anyway. This also cleans up a read-back asymmetry where the in-memory struct could disagree with what postgres actually loaded.
* Teaches ReadPostgresServerConfig to follow postgres's include / include_if_exists / include_dir directives recursively, so the in-memory struct mirrors what postgres will actually load when extras pull in further files. Without this, an operator using include 'overrides.conf' in their extras would end up with a struct that disagreed with reality.

## Tests

* New unit tests cover the append, the include-following parser, the missing-file error, and the flag plumbing.
*  A new integration test in go/test/endtoend/pgctld exercises the whole stack end-to-end: extras → postgres include → live SHOW reflecting the override.

---
Fixes: MUL-380