### PR TITLE
fix(parser): preserve SQL/JSON clauses on AST round-trip

### DIFF
--- a/go/common/parser/ast/json_parse_nodes.go
+++ b/go/common/parser/ast/json_parse_nodes.go
@@ -341,7 +341,16 @@ func (n *JsonFormat) String() string {
 func (n *JsonFormat) SqlString() string {
 	switch n.FormatType {
 	case JS_FORMAT_JSON:
-		return "JSON"
+		switch n.Encoding {
+		case JS_ENC_UTF8:
+			return "JSON ENCODING UTF8"
+		case JS_ENC_UTF16:
+			return "JSON ENCODING UTF16"
+		case JS_ENC_UTF32:
+			return "JSON ENCODING UTF32"
+		default:
+			return "JSON"
+		}
 	case JS_FORMAT_JSONB:
 		return "JSONB"
 	default:
@@ -470,6 +479,44 @@ func (n *JsonFuncExpr) String() string {
 func (n *JsonFuncExpr) IsExpr() bool           { return true }
 func (n *JsonFuncExpr) ExpressionType() string { return "JsonFuncExpr" }
 
+// appendJsonReturning writes ` RETURNING <type> [FORMAT JSON [ENCODING X]]`
+// when an output clause is present. The FORMAT clause is carried on
+// Output.Returning.Format and applies to the returning value, distinct from
+// any FORMAT clause on the input expression.
+func appendJsonReturning(b *strings.Builder, output *JsonOutput) {
+	if output == nil || output.TypeName == nil {
+		return
+	}
+	b.WriteString(" RETURNING ")
+	b.WriteString(output.TypeName.SqlString())
+	if output.Returning != nil && output.Returning.Format != nil {
+		if s := output.Returning.Format.SqlString(); s != "" {
+			b.WriteString(" FORMAT ")
+			b.WriteString(s)
+		}
+	}
+}
+
+// appendJsonWrapperAndQuotes writes the [WITH/WITHOUT ARRAY WRAPPER]
+// and [KEEP/OMIT QUOTES] clauses to the builder. Shared by JsonFuncExpr
+// (for JSON_QUERY) and JsonTableColumn (for JTC_REGULAR / JTC_FORMATTED).
+func appendJsonWrapperAndQuotes(b *strings.Builder, wrapper JsonWrapper, quotes JsonQuotes) {
+	switch wrapper {
+	case JSW_NONE:
+		b.WriteString(" WITHOUT ARRAY WRAPPER")
+	case JSW_CONDITIONAL:
+		b.WriteString(" WITH CONDITIONAL ARRAY WRAPPER")
+	case JSW_UNCONDITIONAL:
+		b.WriteString(" WITH UNCONDITIONAL ARRAY WRAPPER")
+	}
+	switch quotes {
+	case JS_QUOTES_KEEP:
+		b.WriteString(" KEEP QUOTES")
+	case JS_QUOTES_OMIT:
+		b.WriteString(" OMIT QUOTES")
+	}
+}
+
 // SqlString returns the SQL representation of JsonFuncExpr
 func (n *JsonFuncExpr) SqlString() string {
 	var result strings.Builder
@@ -494,9 +541,33 @@ func (n *JsonFuncExpr) SqlString() string {
 		result.WriteString(n.Pathspec.SqlString())
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
+	if n.Passing != nil && len(n.Passing.Items) > 0 {
+		result.WriteString(" PASSING ")
+		for i, item := range n.Passing.Items {
+			if i > 0 {
+				result.WriteString(", ")
+			}
+			result.WriteString(item.SqlString())
+		}
+	}
+
+	appendJsonReturning(&result, n.Output)
+
+	// WRAPPER and QUOTES are JSON_QUERY-only.
+	if n.Op == JSON_QUERY_OP {
+		appendJsonWrapperAndQuotes(&result, n.Wrapper, n.Quotes)
+	}
+
+	if n.OnEmpty != nil {
+		result.WriteString(" ")
+		result.WriteString(n.OnEmpty.SqlString())
+		result.WriteString(" ON EMPTY")
+	}
+
+	if n.OnError != nil {
+		result.WriteString(" ")
+		result.WriteString(n.OnError.SqlString())
+		result.WriteString(" ON ERROR")
 	}
 
 	result.WriteString(")")
@@ -508,11 +579,20 @@ func (n *JsonTablePathSpec) String() string {
 }
 
 // SqlString returns the SQL representation of the JsonTablePathSpec.
+// The optional `AS <name>` suffix is required for PG to detect duplicate
+// column/path-name conflicts inside JSON_TABLE.
 func (n *JsonTablePathSpec) SqlString() string {
+	var path string
 	if n.StringExpr != nil {
-		return n.StringExpr.SqlString()
+		path = n.StringExpr.SqlString()
 	}
-	return ""
+	if n.Name != "" {
+		if path == "" {
+			return "AS " + QuoteIdentifier(n.Name)
+		}
+		return path + " AS " + QuoteIdentifier(n.Name)
+	}
+	return path
 }
 
 func (n *JsonTable) String() string {
@@ -609,6 +689,7 @@ func (n *JsonTableColumn) SqlString() string {
 			result.WriteString(" PATH ")
 			result.WriteString(n.Pathspec.SqlString())
 		}
+		appendJsonWrapperAndQuotes(&result, n.Wrapper, n.Quotes)
 
 	case JTC_EXISTS:
 		if n.TypeName != nil {
@@ -637,11 +718,20 @@ func (n *JsonTableColumn) SqlString() string {
 			result.WriteString(" PATH ")
 			result.WriteString(n.Pathspec.SqlString())
 		}
+		appendJsonWrapperAndQuotes(&result, n.Wrapper, n.Quotes)
 
 	case JTC_NESTED:
 		result.WriteString("NESTED PATH ")
 		if n.Pathspec != nil {
 			result.WriteString(n.Pathspec.SqlString())
+		}
+		// The `AS <name>` for a NESTED path is stored on the column's Name
+		// field (the path's own JsonTablePathSpec.Name is left empty by the
+		// grammar for NESTED paths). Emit it here so PG can validate
+		// column/path-name uniqueness.
+		if n.Name != "" {
+			result.WriteString(" AS ")
+			result.WriteString(QuoteIdentifier(n.Name))
 		}
 		if n.Columns != nil && len(n.Columns.Items) > 0 {
 			result.WriteString(" COLUMNS (")
@@ -709,9 +799,10 @@ func (n *JsonParseExpr) SqlString() string {
 		result.WriteString(n.Expr.SqlString())
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
+	appendJsonReturning(&result, n.Output)
+
+	if n.UniqueKeys {
+		result.WriteString(" WITH UNIQUE KEYS")
 	}
 
 	result.WriteString(")")
@@ -734,10 +825,7 @@ func (n *JsonScalarExpr) SqlString() string {
 		result.WriteString(n.Expr.SqlString())
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
-	}
+	appendJsonReturning(&result, n.Output)
 
 	result.WriteString(")")
 	return result.String()
@@ -759,10 +847,7 @@ func (n *JsonSerializeExpr) SqlString() string {
 		result.WriteString(n.Expr.SqlString())
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
-	}
+	appendJsonReturning(&result, n.Output)
 
 	result.WriteString(")")
 	return result.String()
@@ -791,10 +876,16 @@ func (n *JsonObjectConstructor) SqlString() string {
 		}
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
+	// JSON_OBJECT defaults to NULL ON NULL; emit only the non-default.
+	if n.AbsentOnNull {
+		result.WriteString(" ABSENT ON NULL")
 	}
+
+	if n.Unique {
+		result.WriteString(" WITH UNIQUE KEYS")
+	}
+
+	appendJsonReturning(&result, n.Output)
 
 	result.WriteString(")")
 	return result.String()
@@ -825,10 +916,12 @@ func (n *JsonArrayConstructor) SqlString() string {
 		}
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
+	// JSON_ARRAY defaults to ABSENT ON NULL; emit only the non-default.
+	if !n.AbsentOnNull {
+		result.WriteString(" NULL ON NULL")
 	}
+
+	appendJsonReturning(&result, n.Output)
 
 	result.WriteString(")")
 	return result.String()
@@ -855,10 +948,7 @@ func (n *JsonArrayQueryConstructor) SqlString() string {
 		result.WriteString(n.Format.SqlString())
 	}
 
-	if n.Output != nil && n.Output.TypeName != nil {
-		result.WriteString(" RETURNING ")
-		result.WriteString(n.Output.TypeName.SqlString())
-	}
+	appendJsonReturning(&result, n.Output)
 
 	result.WriteString(")")
 	return result.String()
@@ -906,15 +996,18 @@ func (n *JsonObjectAgg) SqlString() string {
 		result.WriteString(n.Arg.SqlString())
 	}
 
+	// JSON_OBJECTAGG defaults to NULL ON NULL; emit only the non-default.
+	if n.AbsentOnNull {
+		result.WriteString(" ABSENT ON NULL")
+	}
+
+	if n.Unique {
+		result.WriteString(" WITH UNIQUE KEYS")
+	}
+
 	// Add RETURNING clause if present
-	if n.Constructor != nil && n.Constructor.Output != nil {
-		if n.Constructor.Output.TypeName != nil {
-			result.WriteString(" RETURNING ")
-			result.WriteString(n.Constructor.Output.TypeName.SqlString())
-		} else if n.Constructor.Output.Returning != nil {
-			result.WriteString(" RETURNING ")
-			result.WriteString(n.Constructor.Output.Returning.SqlString())
-		}
+	if n.Constructor != nil {
+		appendJsonReturning(&result, n.Constructor.Output)
 	}
 
 	result.WriteString(")")
@@ -943,15 +1036,26 @@ func (n *JsonArrayAgg) SqlString() string {
 		result.WriteString(n.Arg.SqlString())
 	}
 
-	// Add RETURNING clause if present
-	if n.Constructor != nil && n.Constructor.Output != nil {
-		if n.Constructor.Output.TypeName != nil {
-			result.WriteString(" RETURNING ")
-			result.WriteString(n.Constructor.Output.TypeName.SqlString())
-		} else if n.Constructor.Output.Returning != nil {
-			result.WriteString(" RETURNING ")
-			result.WriteString(n.Constructor.Output.Returning.SqlString())
+	// ORDER BY (lives on Constructor.AggOrder, between the arg and the
+	// ABSENT/RETURNING clauses per the json_aggregate_func grammar).
+	if n.Constructor != nil && n.Constructor.AggOrder != nil && len(n.Constructor.AggOrder.Items) > 0 {
+		result.WriteString(" ORDER BY ")
+		for i, item := range n.Constructor.AggOrder.Items {
+			if i > 0 {
+				result.WriteString(", ")
+			}
+			result.WriteString(item.SqlString())
 		}
+	}
+
+	// JSON_ARRAYAGG defaults to ABSENT ON NULL; emit only the non-default.
+	if !n.AbsentOnNull {
+		result.WriteString(" NULL ON NULL")
+	}
+
+	// Add RETURNING clause if present
+	if n.Constructor != nil {
+		appendJsonReturning(&result, n.Constructor.Output)
 	}
 
 	result.WriteString(")")

--- a/go/common/parser/postgres.go
+++ b/go/common/parser/postgres.go
@@ -1150,7 +1150,7 @@ const (
 	yyInitialStackSize = 16
 )
 
-//line postgres.y:15598
+//line postgres.y:15623
 
 // Lex implements the lexer interface for goyacc
 func (l *Lexer) Lex(lval *yySymType) int {
@@ -14521,7 +14521,7 @@ var yyPgo = [...]int{
 	257, 4982, 12, 4980, 3614, 455, 4979, 72,
 }
 
-//line postgres.y:15598
+//line postgres.y:15623
 type yySymType struct {
 	union    any
 	ival     int
@@ -30497,13 +30497,24 @@ yydefault:
 				strNode := yyDollar[3].nodeUnion().(*ast.String)
 				jsonTableCol.Pathspec = ast.NewJsonTablePathSpec(strNode, "", 0)
 			}
+			jsonTableCol.Wrapper = ast.JsonWrapper(yyDollar[4].ival)
+			jsonTableCol.Quotes = ast.JsonQuotes(yyDollar[5].ival)
+			if yyDollar[6].nodeUnion() != nil {
+				behaviors := yyDollar[6].nodeUnion().(*ast.NodeList)
+				if linitial(behaviors) != nil {
+					jsonTableCol.OnEmpty = linitial(behaviors).(*ast.JsonBehavior)
+				}
+				if lsecond(behaviors) != nil {
+					jsonTableCol.OnError = lsecond(behaviors).(*ast.JsonBehavior)
+				}
+			}
 			yyLOCAL = jsonTableCol
 		}
 		yyVAL.union = yyLOCAL
 	case 1789:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5795
+//line postgres.y:5806
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_FORMATTED, yyDollar[1].str)
 			jsonTableCol.TypeName = yyDollar[2].typnamUnion()
@@ -30514,13 +30525,24 @@ yydefault:
 			if yyDollar[3].nodeUnion() != nil {
 				jsonTableCol.Format = yyDollar[3].nodeUnion().(*ast.JsonFormat)
 			}
+			jsonTableCol.Wrapper = ast.JsonWrapper(yyDollar[5].ival)
+			jsonTableCol.Quotes = ast.JsonQuotes(yyDollar[6].ival)
+			if yyDollar[7].nodeUnion() != nil {
+				behaviors := yyDollar[7].nodeUnion().(*ast.NodeList)
+				if linitial(behaviors) != nil {
+					jsonTableCol.OnEmpty = linitial(behaviors).(*ast.JsonBehavior)
+				}
+				if lsecond(behaviors) != nil {
+					jsonTableCol.OnError = lsecond(behaviors).(*ast.JsonBehavior)
+				}
+			}
 			yyLOCAL = jsonTableCol
 		}
 		yyVAL.union = yyLOCAL
 	case 1790:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5809
+//line postgres.y:5831
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_EXISTS, yyDollar[1].str)
 			jsonTableCol.TypeName = yyDollar[2].typnamUnion()
@@ -30528,13 +30550,16 @@ yydefault:
 				strNode := yyDollar[4].nodeUnion().(*ast.String)
 				jsonTableCol.Pathspec = ast.NewJsonTablePathSpec(strNode, "", 0)
 			}
+			if yyDollar[5].nodeUnion() != nil {
+				jsonTableCol.OnError = yyDollar[5].nodeUnion().(*ast.JsonBehavior)
+			}
 			yyLOCAL = jsonTableCol
 		}
 		yyVAL.union = yyLOCAL
 	case 1791:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5820
+//line postgres.y:5845
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_NESTED, "")
 			jsonTableCol.Columns = yyDollar[6].listUnion()
@@ -30546,7 +30571,7 @@ yydefault:
 	case 1792:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5829
+//line postgres.y:5854
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_NESTED, yyDollar[5].str)
 			jsonTableCol.Columns = yyDollar[8].listUnion()
@@ -30558,7 +30583,7 @@ yydefault:
 	case 1793:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5840
+//line postgres.y:5865
 		{
 			yyLOCAL = ast.NewString(yyDollar[2].str)
 		}
@@ -30566,7 +30591,7 @@ yydefault:
 	case 1794:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5841
+//line postgres.y:5866
 		{
 			yyLOCAL = nil
 		}
@@ -30574,7 +30599,7 @@ yydefault:
 	case 1795:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:5857
+//line postgres.y:5882
 		{
 			insertStmt := yyDollar[5].nodeUnion().(*ast.InsertStmt)
 			insertStmt.Relation = yyDollar[4].rangevarUnion()
@@ -30587,7 +30612,7 @@ yydefault:
 	case 1796:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:5869
+//line postgres.y:5894
 		{
 			yyLOCAL = yyDollar[1].rangevarUnion()
 		}
@@ -30595,7 +30620,7 @@ yydefault:
 	case 1797:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:5873
+//line postgres.y:5898
 		{
 			rangeVar := yyDollar[1].rangevarUnion()
 			rangeVar.Alias = ast.NewAlias(yyDollar[3].str, nil)
@@ -30605,7 +30630,7 @@ yydefault:
 	case 1798:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5882
+//line postgres.y:5907
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.SelectStmt = yyDollar[1].stmtUnion()
@@ -30615,7 +30640,7 @@ yydefault:
 	case 1799:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5888
+//line postgres.y:5913
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Override = ast.OverridingKind(yyDollar[2].ival)
@@ -30626,7 +30651,7 @@ yydefault:
 	case 1800:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5895
+//line postgres.y:5920
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Cols = yyDollar[2].listUnion()
@@ -30637,7 +30662,7 @@ yydefault:
 	case 1801:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5902
+//line postgres.y:5927
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Cols = yyDollar[2].listUnion()
@@ -30649,7 +30674,7 @@ yydefault:
 	case 1802:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5910
+//line postgres.y:5935
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			// For DEFAULT VALUES, SelectStmt should be nil
@@ -30659,20 +30684,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1803:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:5919
+//line postgres.y:5944
 		{
 			yyVAL.ival = int(ast.OVERRIDING_USER_VALUE)
 		}
 	case 1804:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:5920
+//line postgres.y:5945
 		{
 			yyVAL.ival = int(ast.OVERRIDING_SYSTEM_VALUE)
 		}
 	case 1805:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5925
+//line postgres.y:5950
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].targetUnion())
 		}
@@ -30680,7 +30705,7 @@ yydefault:
 	case 1806:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5929
+//line postgres.y:5954
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].targetUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30689,7 +30714,7 @@ yydefault:
 	case 1807:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ResTarget
-//line postgres.y:5937
+//line postgres.y:5962
 		{
 			yyLOCAL = ast.NewResTargetWithIndirection(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -30697,7 +30722,7 @@ yydefault:
 	case 1808:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:5949
+//line postgres.y:5974
 		{
 			updateStmt := ast.NewUpdateStmt(yyDollar[3].rangevarUnion())
 			updateStmt.WithClause = yyDollar[1].withUnion()
@@ -30711,7 +30736,7 @@ yydefault:
 	case 1809:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5962
+//line postgres.y:5987
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -30719,7 +30744,7 @@ yydefault:
 	case 1810:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5966
+//line postgres.y:5991
 		{
 			// Concatenate the lists - equivalent to PostgreSQL's list_concat
 			for _, item := range yyDollar[3].listUnion().Items {
@@ -30731,7 +30756,7 @@ yydefault:
 	case 1811:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5977
+//line postgres.y:6002
 		{
 			target := yyDollar[1].targetUnion()
 			target.Val = yyDollar[3].nodeUnion()
@@ -30741,7 +30766,7 @@ yydefault:
 	case 1812:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5983
+//line postgres.y:6008
 		{
 			// Multi-column assignment: (col1, col2) = (val1, val2)
 			// Create MultiAssignRef nodes for each target, matching PostgreSQL exactly
@@ -30762,7 +30787,7 @@ yydefault:
 	case 1813:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ResTarget
-//line postgres.y:6003
+//line postgres.y:6028
 		{
 			yyLOCAL = ast.NewResTargetWithIndirection(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -30770,7 +30795,7 @@ yydefault:
 	case 1814:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6009
+//line postgres.y:6034
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].targetUnion())
 		}
@@ -30778,7 +30803,7 @@ yydefault:
 	case 1815:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6010
+//line postgres.y:6035
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].targetUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30787,7 +30812,7 @@ yydefault:
 	case 1816:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6020
+//line postgres.y:6045
 		{
 			deleteStmt := ast.NewDeleteStmt(yyDollar[4].rangevarUnion())
 			deleteStmt.WithClause = yyDollar[1].withUnion()
@@ -30800,7 +30825,7 @@ yydefault:
 	case 1817:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6032
+//line postgres.y:6057
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -30808,7 +30833,7 @@ yydefault:
 	case 1818:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6036
+//line postgres.y:6061
 		{
 			yyLOCAL = nil
 		}
@@ -30816,7 +30841,7 @@ yydefault:
 	case 1819:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6051
+//line postgres.y:6076
 		{
 			mergeStmt := &ast.MergeStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_MergeStmt},
@@ -30833,7 +30858,7 @@ yydefault:
 	case 1820:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6068
+//line postgres.y:6093
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -30841,7 +30866,7 @@ yydefault:
 	case 1821:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6072
+//line postgres.y:6097
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30850,7 +30875,7 @@ yydefault:
 	case 1822:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6083
+//line postgres.y:6108
 		{
 			copyStmt := &ast.CopyStmt{
 				BaseNode:  ast.BaseNode{Tag: ast.T_CopyStmt},
@@ -30876,7 +30901,7 @@ yydefault:
 	case 1823:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6107
+//line postgres.y:6132
 		{
 			copyStmt := &ast.CopyStmt{
 				BaseNode:  ast.BaseNode{Tag: ast.T_CopyStmt},
@@ -30910,50 +30935,50 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1824:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6143
+//line postgres.y:6168
 		{
 			yyVAL.ival = 1
 		}
 	case 1825:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6144
+//line postgres.y:6169
 		{
 			yyVAL.ival = 0
 		}
 	case 1826:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6148
+//line postgres.y:6173
 		{
 			yyVAL.ival = 1
 		}
 	case 1827:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6149
+//line postgres.y:6174
 		{
 			yyVAL.ival = 0
 		}
 	case 1828:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6153
+//line postgres.y:6178
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1829:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6154
+//line postgres.y:6179
 		{
 			yyVAL.str = ""
 		}
 	case 1830:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6155
+//line postgres.y:6180
 		{
 			yyVAL.str = ""
 		}
 	case 1831:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6160
+//line postgres.y:6185
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("binary"))
 		}
@@ -30961,7 +30986,7 @@ yydefault:
 	case 1832:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6163
+//line postgres.y:6188
 		{
 			yyLOCAL = nil
 		}
@@ -30969,7 +30994,7 @@ yydefault:
 	case 1833:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6168
+//line postgres.y:6193
 		{
 			yyLOCAL = ast.NewDefElem("delimiter", ast.NewString(yyDollar[3].str))
 		}
@@ -30977,7 +31002,7 @@ yydefault:
 	case 1834:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6171
+//line postgres.y:6196
 		{
 			yyLOCAL = nil
 		}
@@ -30985,7 +31010,7 @@ yydefault:
 	case 1835:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6175
+//line postgres.y:6200
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -30993,7 +31018,7 @@ yydefault:
 	case 1836:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6176
+//line postgres.y:6201
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31001,7 +31026,7 @@ yydefault:
 	case 1837:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6181
+//line postgres.y:6206
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].nodeUnion())
@@ -31014,7 +31039,7 @@ yydefault:
 	case 1838:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6189
+//line postgres.y:6214
 		{
 			yyLOCAL = nil
 		}
@@ -31022,7 +31047,7 @@ yydefault:
 	case 1839:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6196
+//line postgres.y:6221
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("binary"))
 		}
@@ -31030,7 +31055,7 @@ yydefault:
 	case 1840:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6200
+//line postgres.y:6225
 		{
 			yyLOCAL = ast.NewDefElem("freeze", ast.NewString("true"))
 		}
@@ -31038,7 +31063,7 @@ yydefault:
 	case 1841:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6204
+//line postgres.y:6229
 		{
 			yyLOCAL = ast.NewDefElem("delimiter", ast.NewString(yyDollar[3].str))
 		}
@@ -31046,7 +31071,7 @@ yydefault:
 	case 1842:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6208
+//line postgres.y:6233
 		{
 			yyLOCAL = ast.NewDefElem("null", ast.NewString(yyDollar[3].str))
 		}
@@ -31054,7 +31079,7 @@ yydefault:
 	case 1843:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6212
+//line postgres.y:6237
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("csv"))
 		}
@@ -31062,7 +31087,7 @@ yydefault:
 	case 1844:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6216
+//line postgres.y:6241
 		{
 			yyLOCAL = ast.NewDefElem("header", ast.NewString("true"))
 		}
@@ -31070,7 +31095,7 @@ yydefault:
 	case 1845:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6220
+//line postgres.y:6245
 		{
 			yyLOCAL = ast.NewDefElem("quote", ast.NewString(yyDollar[3].str))
 		}
@@ -31078,7 +31103,7 @@ yydefault:
 	case 1846:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6224
+//line postgres.y:6249
 		{
 			yyLOCAL = ast.NewDefElem("escape", ast.NewString(yyDollar[3].str))
 		}
@@ -31086,7 +31111,7 @@ yydefault:
 	case 1847:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6228
+//line postgres.y:6253
 		{
 			yyLOCAL = ast.NewDefElem("force_quote", yyDollar[3].listUnion())
 		}
@@ -31094,7 +31119,7 @@ yydefault:
 	case 1848:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6232
+//line postgres.y:6257
 		{
 			yyLOCAL = ast.NewDefElem("force_quote", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31102,7 +31127,7 @@ yydefault:
 	case 1849:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6236
+//line postgres.y:6261
 		{
 			yyLOCAL = ast.NewDefElem("force_not_null", yyDollar[4].listUnion())
 		}
@@ -31110,7 +31135,7 @@ yydefault:
 	case 1850:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6240
+//line postgres.y:6265
 		{
 			yyLOCAL = ast.NewDefElem("force_not_null", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31118,7 +31143,7 @@ yydefault:
 	case 1851:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6244
+//line postgres.y:6269
 		{
 			yyLOCAL = ast.NewDefElem("force_null", yyDollar[3].listUnion())
 		}
@@ -31126,7 +31151,7 @@ yydefault:
 	case 1852:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6248
+//line postgres.y:6273
 		{
 			yyLOCAL = ast.NewDefElem("force_null", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31134,7 +31159,7 @@ yydefault:
 	case 1853:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6252
+//line postgres.y:6277
 		{
 			yyLOCAL = ast.NewDefElem("encoding", ast.NewString(yyDollar[2].str))
 		}
@@ -31142,7 +31167,7 @@ yydefault:
 	case 1854:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6260
+//line postgres.y:6285
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31150,7 +31175,7 @@ yydefault:
 	case 1855:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6264
+//line postgres.y:6289
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31159,7 +31184,7 @@ yydefault:
 	case 1856:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6271
+//line postgres.y:6296
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
@@ -31167,7 +31192,7 @@ yydefault:
 	case 1857:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6277
+//line postgres.y:6302
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -31175,7 +31200,7 @@ yydefault:
 	case 1858:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6278
+//line postgres.y:6303
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -31183,7 +31208,7 @@ yydefault:
 	case 1859:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6279
+//line postgres.y:6304
 		{
 			yyLOCAL = ast.NewA_Star(0)
 		}
@@ -31191,7 +31216,7 @@ yydefault:
 	case 1860:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6280
+//line postgres.y:6305
 		{
 			yyLOCAL = ast.NewString("default")
 		}
@@ -31199,7 +31224,7 @@ yydefault:
 	case 1861:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6281
+//line postgres.y:6306
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31207,7 +31232,7 @@ yydefault:
 	case 1862:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6282
+//line postgres.y:6307
 		{
 			yyLOCAL = nil
 		}
@@ -31215,7 +31240,7 @@ yydefault:
 	case 1863:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6287
+//line postgres.y:6312
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31223,7 +31248,7 @@ yydefault:
 	case 1864:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6291
+//line postgres.y:6316
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31232,39 +31257,39 @@ yydefault:
 	case 1865:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6297
+//line postgres.y:6322
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 1866:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6301
+//line postgres.y:6326
 		{
 			yyVAL.str = "true"
 		}
 	case 1867:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6302
+//line postgres.y:6327
 		{
 			yyVAL.str = "false"
 		}
 	case 1868:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6303
+//line postgres.y:6328
 		{
 			yyVAL.str = "on"
 		}
 	case 1869:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6304
+//line postgres.y:6329
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1870:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6308
+//line postgres.y:6333
 		{
 			yyLOCAL = ast.NewFloat(yyDollar[1].str)
 		}
@@ -31272,7 +31297,7 @@ yydefault:
 	case 1871:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6309
+//line postgres.y:6334
 		{
 			yyLOCAL = ast.NewFloat(yyDollar[2].str)
 		}
@@ -31280,7 +31305,7 @@ yydefault:
 	case 1872:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6311
+//line postgres.y:6336
 		{
 			f := ast.NewFloat(yyDollar[2].str)
 			doNegateFloat(f)
@@ -31290,7 +31315,7 @@ yydefault:
 	case 1873:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6316
+//line postgres.y:6341
 		{
 			yyLOCAL = ast.NewInteger(yyDollar[1].ival)
 		}
@@ -31298,7 +31323,7 @@ yydefault:
 	case 1874:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6320
+//line postgres.y:6345
 		{
 			yyLOCAL = ast.NewInteger(yyDollar[1].ival)
 		}
@@ -31306,7 +31331,7 @@ yydefault:
 	case 1875:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6321
+//line postgres.y:6346
 		{
 			yyLOCAL = nil
 		}
@@ -31314,7 +31339,7 @@ yydefault:
 	case 1876:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6325
+//line postgres.y:6350
 		{
 			yyLOCAL = ast.OBJECT_ACCESS_METHOD
 		}
@@ -31322,7 +31347,7 @@ yydefault:
 	case 1877:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6326
+//line postgres.y:6351
 		{
 			yyLOCAL = ast.OBJECT_EVENT_TRIGGER
 		}
@@ -31330,7 +31355,7 @@ yydefault:
 	case 1878:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6327
+//line postgres.y:6352
 		{
 			yyLOCAL = ast.OBJECT_EXTENSION
 		}
@@ -31338,7 +31363,7 @@ yydefault:
 	case 1879:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6328
+//line postgres.y:6353
 		{
 			yyLOCAL = ast.OBJECT_FDW
 		}
@@ -31346,7 +31371,7 @@ yydefault:
 	case 1880:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6329
+//line postgres.y:6354
 		{
 			yyLOCAL = ast.OBJECT_LANGUAGE
 		}
@@ -31354,7 +31379,7 @@ yydefault:
 	case 1881:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6330
+//line postgres.y:6355
 		{
 			yyLOCAL = ast.OBJECT_PUBLICATION
 		}
@@ -31362,7 +31387,7 @@ yydefault:
 	case 1882:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6331
+//line postgres.y:6356
 		{
 			yyLOCAL = ast.OBJECT_SCHEMA
 		}
@@ -31370,7 +31395,7 @@ yydefault:
 	case 1883:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6332
+//line postgres.y:6357
 		{
 			yyLOCAL = ast.OBJECT_FOREIGN_SERVER
 		}
@@ -31378,7 +31403,7 @@ yydefault:
 	case 1884:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6336
+//line postgres.y:6361
 		{
 			yyLOCAL = ast.OBJECT_POLICY
 		}
@@ -31386,7 +31411,7 @@ yydefault:
 	case 1885:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6337
+//line postgres.y:6362
 		{
 			yyLOCAL = ast.OBJECT_RULE
 		}
@@ -31394,7 +31419,7 @@ yydefault:
 	case 1886:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6338
+//line postgres.y:6363
 		{
 			yyLOCAL = ast.OBJECT_TRIGGER
 		}
@@ -31402,7 +31427,7 @@ yydefault:
 	case 1887:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6342
+//line postgres.y:6367
 		{
 			yyLOCAL = yyDollar[1].objTypeUnion()
 		}
@@ -31410,7 +31435,7 @@ yydefault:
 	case 1888:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6343
+//line postgres.y:6368
 		{
 			yyLOCAL = ast.OBJECT_DATABASE
 		}
@@ -31418,7 +31443,7 @@ yydefault:
 	case 1889:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6344
+//line postgres.y:6369
 		{
 			yyLOCAL = ast.OBJECT_ROLE
 		}
@@ -31426,7 +31451,7 @@ yydefault:
 	case 1890:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6345
+//line postgres.y:6370
 		{
 			yyLOCAL = ast.OBJECT_SUBSCRIPTION
 		}
@@ -31434,7 +31459,7 @@ yydefault:
 	case 1891:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6346
+//line postgres.y:6371
 		{
 			yyLOCAL = ast.OBJECT_TABLESPACE
 		}
@@ -31442,7 +31467,7 @@ yydefault:
 	case 1892:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6351
+//line postgres.y:6376
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].typnamUnion())
@@ -31451,7 +31476,7 @@ yydefault:
 	case 1893:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6356
+//line postgres.y:6381
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31460,7 +31485,7 @@ yydefault:
 	case 1894:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:6363
+//line postgres.y:6388
 		{
 			yyLOCAL = true
 		}
@@ -31468,27 +31493,27 @@ yydefault:
 	case 1895:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:6364
+//line postgres.y:6389
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 1896:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6368
+//line postgres.y:6393
 		{
 			yyVAL.ival = 1
 		}
 	case 1897:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6369
+//line postgres.y:6394
 		{
 			yyVAL.ival = 0
 		}
 	case 1900:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6385
+//line postgres.y:6410
 		{
 			yyLOCAL = nil
 		}
@@ -31496,63 +31521,63 @@ yydefault:
 	case 1901:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6387
+//line postgres.y:6412
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 1902:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6395
+//line postgres.y:6420
 		{
 			yyVAL.ival = 1
 		}
 	case 1903:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6396
+//line postgres.y:6421
 		{
 			yyVAL.ival = 0
 		}
 	case 1904:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6400
+//line postgres.y:6425
 		{
 			yyVAL.ival = 1
 		}
 	case 1905:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6401
+//line postgres.y:6426
 		{
 			yyVAL.ival = 0
 		}
 	case 1906:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6405
+//line postgres.y:6430
 		{
 			yyVAL.ival = 1
 		}
 	case 1907:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6406
+//line postgres.y:6431
 		{
 			yyVAL.ival = 0
 		}
 	case 1908:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6410
+//line postgres.y:6435
 		{
 			yyVAL.ival = 1
 		}
 	case 1909:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6411
+//line postgres.y:6436
 		{
 			yyVAL.ival = 0
 		}
 	case 1910:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6420
+//line postgres.y:6445
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31562,7 +31587,7 @@ yydefault:
 	case 1911:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6426
+//line postgres.y:6451
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31572,7 +31597,7 @@ yydefault:
 	case 1912:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6432
+//line postgres.y:6457
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31582,7 +31607,7 @@ yydefault:
 	case 1913:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6438
+//line postgres.y:6463
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MergeMatchKind(yyDollar[1].ival), ast.CMD_NOTHING)
 			mergeWhen.Condition = yyDollar[2].nodeUnion()
@@ -31592,7 +31617,7 @@ yydefault:
 	case 1914:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6444
+//line postgres.y:6469
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MergeMatchKind(yyDollar[1].ival), ast.CMD_NOTHING)
 			mergeWhen.Condition = yyDollar[2].nodeUnion()
@@ -31601,32 +31626,32 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1915:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6452
+//line postgres.y:6477
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_MATCHED)
 		}
 	case 1916:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line postgres.y:6453
+//line postgres.y:6478
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_SOURCE)
 		}
 	case 1917:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6457
+//line postgres.y:6482
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET)
 		}
 	case 1918:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line postgres.y:6458
+//line postgres.y:6483
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET)
 		}
 	case 1919:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6462
+//line postgres.y:6487
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -31634,7 +31659,7 @@ yydefault:
 	case 1920:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6463
+//line postgres.y:6488
 		{
 			yyLOCAL = nil
 		}
@@ -31642,7 +31667,7 @@ yydefault:
 	case 1921:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6468
+//line postgres.y:6493
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_MATCHED, ast.CMD_UPDATE)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31658,7 +31683,7 @@ yydefault:
 	case 1922:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6483
+//line postgres.y:6508
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_MATCHED, ast.CMD_DELETE)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31668,7 +31693,7 @@ yydefault:
 	case 1923:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6492
+//line postgres.y:6517
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31679,7 +31704,7 @@ yydefault:
 	case 1924:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6499
+//line postgres.y:6524
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OverridingKind(yyDollar[3].ival)
@@ -31690,7 +31715,7 @@ yydefault:
 	case 1925:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6506
+//line postgres.y:6531
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31707,7 +31732,7 @@ yydefault:
 	case 1926:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6519
+//line postgres.y:6544
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OverridingKind(yyDollar[6].ival)
@@ -31724,7 +31749,7 @@ yydefault:
 	case 1927:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6532
+//line postgres.y:6557
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31734,7 +31759,7 @@ yydefault:
 	case 1928:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6541
+//line postgres.y:6566
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -31742,7 +31767,7 @@ yydefault:
 	case 1929:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6556
+//line postgres.y:6581
 		{
 			onConflict := ast.NewOnConflictClause(ast.ONCONFLICT_UPDATE)
 			if yyDollar[3].nodeUnion() != nil {
@@ -31756,7 +31781,7 @@ yydefault:
 	case 1930:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6566
+//line postgres.y:6591
 		{
 			onConflict := ast.NewOnConflictClause(ast.ONCONFLICT_NOTHING)
 			if yyDollar[3].nodeUnion() != nil {
@@ -31768,7 +31793,7 @@ yydefault:
 	case 1931:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6574
+//line postgres.y:6599
 		{
 			yyLOCAL = nil
 		}
@@ -31776,7 +31801,7 @@ yydefault:
 	case 1932:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6585
+//line postgres.y:6610
 		{
 			// Create InferClause for column-based conflict detection
 			infer := ast.NewInferClause()
@@ -31789,7 +31814,7 @@ yydefault:
 	case 1933:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6594
+//line postgres.y:6619
 		{
 			// Create InferClause for constraint-based conflict detection
 			infer := ast.NewInferClause()
@@ -31800,7 +31825,7 @@ yydefault:
 	case 1934:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6601
+//line postgres.y:6626
 		{
 			yyLOCAL = nil
 		}
@@ -31808,7 +31833,7 @@ yydefault:
 	case 1935:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6608
+//line postgres.y:6633
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31816,7 +31841,7 @@ yydefault:
 	case 1936:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6612
+//line postgres.y:6637
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31825,7 +31850,7 @@ yydefault:
 	case 1937:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6619
+//line postgres.y:6644
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Name = yyDollar[1].str
@@ -31834,7 +31859,7 @@ yydefault:
 	case 1938:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6624
+//line postgres.y:6649
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Expr = yyDollar[1].nodeUnion()
@@ -31843,7 +31868,7 @@ yydefault:
 	case 1939:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6629
+//line postgres.y:6654
 		{
 			yyLOCAL = yyDollar[4].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Expr = yyDollar[2].nodeUnion()
@@ -31852,7 +31877,7 @@ yydefault:
 	case 1940:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6637
+//line postgres.y:6662
 		{
 			indexElem := &ast.IndexElem{
 				BaseNode: ast.BaseNode{Tag: ast.T_IndexElem},
@@ -31867,7 +31892,7 @@ yydefault:
 	case 1941:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6648
+//line postgres.y:6673
 		{
 			indexElem := &ast.IndexElem{
 				BaseNode: ast.BaseNode{Tag: ast.T_IndexElem},
@@ -31883,7 +31908,7 @@ yydefault:
 	case 1942:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6662
+//line postgres.y:6687
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31891,51 +31916,51 @@ yydefault:
 	case 1943:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6663
+//line postgres.y:6688
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 1944:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6667
+//line postgres.y:6692
 		{
 			yyVAL.ival = int(ast.SORTBY_ASC)
 		}
 	case 1945:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6668
+//line postgres.y:6693
 		{
 			yyVAL.ival = int(ast.SORTBY_DESC)
 		}
 	case 1946:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6669
+//line postgres.y:6694
 		{
 			yyVAL.ival = int(ast.SORTBY_DEFAULT)
 		}
 	case 1947:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6673
+//line postgres.y:6698
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_FIRST)
 		}
 	case 1948:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6674
+//line postgres.y:6699
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_LAST)
 		}
 	case 1949:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6675
+//line postgres.y:6700
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_DEFAULT)
 		}
 	case 1950:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6680
+//line postgres.y:6705
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31943,7 +31968,7 @@ yydefault:
 	case 1951:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6684
+//line postgres.y:6709
 		{
 			yyLOCAL = nil
 		}
@@ -31951,7 +31976,7 @@ yydefault:
 	case 1952:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6705
+//line postgres.y:6730
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -31969,7 +31994,7 @@ yydefault:
 	case 1953:
 		yyDollar = yyS[yypt-16 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6721
+//line postgres.y:6746
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -31988,7 +32013,7 @@ yydefault:
 	case 1954:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6738
+//line postgres.y:6763
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32006,7 +32031,7 @@ yydefault:
 	case 1955:
 		yyDollar = yyS[yypt-15 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6754
+//line postgres.y:6779
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32025,7 +32050,7 @@ yydefault:
 	case 1956:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6771
+//line postgres.y:6796
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32044,7 +32069,7 @@ yydefault:
 	case 1957:
 		yyDollar = yyS[yypt-17 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6788
+//line postgres.y:6813
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32064,7 +32089,7 @@ yydefault:
 	case 1958:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6806
+//line postgres.y:6831
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32072,7 +32097,7 @@ yydefault:
 	case 1959:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6807
+//line postgres.y:6832
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32080,7 +32105,7 @@ yydefault:
 	case 1960:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6808
+//line postgres.y:6833
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32088,7 +32113,7 @@ yydefault:
 	case 1961:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6809
+//line postgres.y:6834
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32096,7 +32121,7 @@ yydefault:
 	case 1962:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6810
+//line postgres.y:6835
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32104,7 +32129,7 @@ yydefault:
 	case 1963:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6811
+//line postgres.y:6836
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32112,7 +32137,7 @@ yydefault:
 	case 1964:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6812
+//line postgres.y:6837
 		{
 			yyLOCAL = ast.RELPERSISTENCE_UNLOGGED
 		}
@@ -32120,7 +32145,7 @@ yydefault:
 	case 1965:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6813
+//line postgres.y:6838
 		{
 			yyLOCAL = ast.RELPERSISTENCE_PERMANENT
 		}
@@ -32128,7 +32153,7 @@ yydefault:
 	case 1966:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6817
+//line postgres.y:6842
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -32136,7 +32161,7 @@ yydefault:
 	case 1967:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6818
+//line postgres.y:6843
 		{
 			yyLOCAL = nil
 		}
@@ -32144,7 +32169,7 @@ yydefault:
 	case 1968:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6823
+//line postgres.y:6848
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -32153,7 +32178,7 @@ yydefault:
 	case 1969:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6828
+//line postgres.y:6853
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32162,7 +32187,7 @@ yydefault:
 	case 1970:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6835
+//line postgres.y:6860
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32170,7 +32195,7 @@ yydefault:
 	case 1971:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6836
+//line postgres.y:6861
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32178,7 +32203,7 @@ yydefault:
 	case 1972:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6837
+//line postgres.y:6862
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32186,141 +32211,141 @@ yydefault:
 	case 1973:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6842
+//line postgres.y:6867
 		{
 			yyLOCAL = ast.NewTableLikeClause(yyDollar[2].rangevarUnion(), ast.TableLikeOption(yyDollar[3].ival))
 		}
 		yyVAL.union = yyLOCAL
 	case 1974:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6849
+//line postgres.y:6874
 		{
 			yyVAL.ival = yyDollar[1].ival | yyDollar[3].ival
 		}
 	case 1975:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6853
+//line postgres.y:6878
 		{
 			yyVAL.ival = yyDollar[1].ival & ^yyDollar[3].ival
 		}
 	case 1976:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6857
+//line postgres.y:6882
 		{
 			yyVAL.ival = 0
 		}
 	case 1977:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6863
+//line postgres.y:6888
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_COMMENTS)
 		}
 	case 1978:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6864
+//line postgres.y:6889
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_COMPRESSION)
 		}
 	case 1979:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6865
+//line postgres.y:6890
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_CONSTRAINTS)
 		}
 	case 1980:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6866
+//line postgres.y:6891
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_DEFAULTS)
 		}
 	case 1981:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6867
+//line postgres.y:6892
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_IDENTITY)
 		}
 	case 1982:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6868
+//line postgres.y:6893
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_GENERATED)
 		}
 	case 1983:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6869
+//line postgres.y:6894
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_INDEXES)
 		}
 	case 1984:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6870
+//line postgres.y:6895
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_STATISTICS)
 		}
 	case 1985:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6871
+//line postgres.y:6896
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_STORAGE)
 		}
 	case 1986:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6872
+//line postgres.y:6897
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_ALL)
 		}
 	case 1987:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6877
+//line postgres.y:6902
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 1988:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6878
+//line postgres.y:6903
 		{
 			yyVAL.str = "default"
 		}
 	case 1989:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6882
+//line postgres.y:6907
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1990:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6883
+//line postgres.y:6908
 		{
 			yyVAL.str = ""
 		}
 	case 1991:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6887
+//line postgres.y:6912
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 1992:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6888
+//line postgres.y:6913
 		{
 			yyVAL.str = "default"
 		}
 	case 1993:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6892
+//line postgres.y:6917
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1994:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6893
+//line postgres.y:6918
 		{
 			yyVAL.str = ""
 		}
 	case 1995:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6898
+//line postgres.y:6923
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -32328,7 +32353,7 @@ yydefault:
 	case 1996:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6899
+//line postgres.y:6924
 		{
 			yyLOCAL = nil
 		}
@@ -32336,7 +32361,7 @@ yydefault:
 	case 1997:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6904
+//line postgres.y:6929
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -32346,7 +32371,7 @@ yydefault:
 	case 1998:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6910
+//line postgres.y:6935
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32355,7 +32380,7 @@ yydefault:
 	case 1999:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6917
+//line postgres.y:6942
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32363,7 +32388,7 @@ yydefault:
 	case 2000:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6918
+//line postgres.y:6943
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32371,7 +32396,7 @@ yydefault:
 	case 2001:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6923
+//line postgres.y:6948
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, nil, 0)
 			colDef.Constraints = yyDollar[2].listUnion()
@@ -32381,7 +32406,7 @@ yydefault:
 	case 2002:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6929
+//line postgres.y:6954
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, nil, 0)
 			colDef.Constraints = yyDollar[4].listUnion()
@@ -32391,7 +32416,7 @@ yydefault:
 	case 2003:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6940
+//line postgres.y:6965
 		{
 			hashSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_HASH)
 			hashSpec.IsDefault = false
@@ -32422,7 +32447,7 @@ yydefault:
 	case 2004:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6969
+//line postgres.y:6994
 		{
 			listSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_LIST)
 			listSpec.IsDefault = false
@@ -32433,7 +32458,7 @@ yydefault:
 	case 2005:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6978
+//line postgres.y:7003
 		{
 			rangeSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_RANGE)
 			rangeSpec.IsDefault = false
@@ -32445,7 +32470,7 @@ yydefault:
 	case 2006:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6988
+//line postgres.y:7013
 		{
 			defaultSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_LIST)
 			defaultSpec.IsDefault = true
@@ -32455,7 +32480,7 @@ yydefault:
 	case 2007:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6997
+//line postgres.y:7022
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewA_Const(ast.NewInteger(yyDollar[2].ival), 0))
 		}
@@ -32463,7 +32488,7 @@ yydefault:
 	case 2008:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7004
+//line postgres.y:7029
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -32471,7 +32496,7 @@ yydefault:
 	case 2009:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7008
+//line postgres.y:7033
 		{
 			nodeList := yyDollar[1].listUnion()
 			nodeList.Append(yyDollar[3].nodeUnion())
@@ -32481,7 +32506,7 @@ yydefault:
 	case 2010:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7016
+//line postgres.y:7041
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -32489,7 +32514,7 @@ yydefault:
 	case 2011:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7017
+//line postgres.y:7042
 		{
 			yyLOCAL = nil
 		}
@@ -32497,7 +32522,7 @@ yydefault:
 	case 2012:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7022
+//line postgres.y:7047
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32505,7 +32530,7 @@ yydefault:
 	case 2013:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7026
+//line postgres.y:7051
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32514,21 +32539,21 @@ yydefault:
 	case 2014:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7034
+//line postgres.y:7059
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2015:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7040
+//line postgres.y:7065
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2016:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7045
+//line postgres.y:7070
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -32536,7 +32561,7 @@ yydefault:
 	case 2017:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7050
+//line postgres.y:7075
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, yyDollar[2].typnamUnion(), 0)
 			colDef.StorageName = yyDollar[3].str
@@ -32552,7 +32577,7 @@ yydefault:
 	case 2018:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7065
+//line postgres.y:7090
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32561,7 +32586,7 @@ yydefault:
 	case 2019:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7070
+//line postgres.y:7095
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -32569,7 +32594,7 @@ yydefault:
 	case 2020:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7077
+//line postgres.y:7102
 		{
 			constraint := yyDollar[3].nodeUnion().(*ast.Constraint)
 			constraint.Conname = yyDollar[2].str
@@ -32579,7 +32604,7 @@ yydefault:
 	case 2021:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7082
+//line postgres.y:7107
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32587,7 +32612,7 @@ yydefault:
 	case 2022:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7083
+//line postgres.y:7108
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32595,7 +32620,7 @@ yydefault:
 	case 2023:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7085
+//line postgres.y:7110
 		{
 			/*
 			 * Note: the CollateClause is momentarily included in
@@ -32609,7 +32634,7 @@ yydefault:
 	case 2024:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7098
+//line postgres.y:7123
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_DEFERRABLE)
 			yyLOCAL = constraint
@@ -32618,7 +32643,7 @@ yydefault:
 	case 2025:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7103
+//line postgres.y:7128
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_NOT_DEFERRABLE)
 			yyLOCAL = constraint
@@ -32627,7 +32652,7 @@ yydefault:
 	case 2026:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7108
+//line postgres.y:7133
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_DEFERRED)
 			yyLOCAL = constraint
@@ -32636,7 +32661,7 @@ yydefault:
 	case 2027:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7113
+//line postgres.y:7138
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_IMMEDIATE)
 			yyLOCAL = constraint
@@ -32645,7 +32670,7 @@ yydefault:
 	case 2028:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7121
+//line postgres.y:7146
 		{
 			yyLOCAL = true
 		}
@@ -32653,7 +32678,7 @@ yydefault:
 	case 2029:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7122
+//line postgres.y:7147
 		{
 			yyLOCAL = false
 		}
@@ -32661,7 +32686,7 @@ yydefault:
 	case 2030:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7123
+//line postgres.y:7148
 		{
 			yyLOCAL = true
 		}
@@ -32669,7 +32694,7 @@ yydefault:
 	case 2031:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7127
+//line postgres.y:7152
 		{
 			yyLOCAL = ast.ATTRIBUTE_IDENTITY_ALWAYS
 		}
@@ -32677,7 +32702,7 @@ yydefault:
 	case 2032:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7128
+//line postgres.y:7153
 		{
 			yyLOCAL = ast.ATTRIBUTE_IDENTITY_BY_DEFAULT
 		}
@@ -32685,7 +32710,7 @@ yydefault:
 	case 2033:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7133
+//line postgres.y:7158
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32693,7 +32718,7 @@ yydefault:
 	case 2034:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7135
+//line postgres.y:7160
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32702,7 +32727,7 @@ yydefault:
 	case 2035:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7140
+//line postgres.y:7165
 		{
 			yyLOCAL = ast.NewDefElem("restart", nil)
 		}
@@ -32710,7 +32735,7 @@ yydefault:
 	case 2036:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7144
+//line postgres.y:7169
 		{
 			yyLOCAL = ast.NewDefElem("restart", yyDollar[3].nodeUnion())
 		}
@@ -32718,7 +32743,7 @@ yydefault:
 	case 2037:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7148
+//line postgres.y:7173
 		{
 			// SeqOptElem already returns a DefElem, so we can use it directly
 			// Check for invalid options as per PostgreSQL
@@ -32732,7 +32757,7 @@ yydefault:
 	case 2038:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7158
+//line postgres.y:7183
 		{
 			yyLOCAL = ast.NewDefElem("generated", ast.NewInteger(int(yyDollar[3].bytUnion())))
 		}
@@ -32740,7 +32765,7 @@ yydefault:
 	case 2039:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7164
+//line postgres.y:7189
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32748,7 +32773,7 @@ yydefault:
 	case 2040:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7165
+//line postgres.y:7190
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32757,7 +32782,7 @@ yydefault:
 	case 2041:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7170
+//line postgres.y:7195
 		{
 			yyLOCAL = ast.NewDefElem("as", yyDollar[2].typnamUnion())
 		}
@@ -32765,7 +32790,7 @@ yydefault:
 	case 2042:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7174
+//line postgres.y:7199
 		{
 			yyLOCAL = ast.NewDefElem("cache", yyDollar[2].nodeUnion())
 		}
@@ -32773,7 +32798,7 @@ yydefault:
 	case 2043:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7178
+//line postgres.y:7203
 		{
 			yyLOCAL = ast.NewDefElem("cycle", ast.NewBoolean(true))
 		}
@@ -32781,7 +32806,7 @@ yydefault:
 	case 2044:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7182
+//line postgres.y:7207
 		{
 			yyLOCAL = ast.NewDefElem("cycle", ast.NewBoolean(false))
 		}
@@ -32789,7 +32814,7 @@ yydefault:
 	case 2045:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7186
+//line postgres.y:7211
 		{
 			yyLOCAL = ast.NewDefElem("increment", yyDollar[3].nodeUnion())
 		}
@@ -32797,7 +32822,7 @@ yydefault:
 	case 2046:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7190
+//line postgres.y:7215
 		{
 			yyLOCAL = ast.NewDefElem("logged", nil)
 		}
@@ -32805,7 +32830,7 @@ yydefault:
 	case 2047:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7194
+//line postgres.y:7219
 		{
 			yyLOCAL = ast.NewDefElem("maxvalue", yyDollar[2].nodeUnion())
 		}
@@ -32813,7 +32838,7 @@ yydefault:
 	case 2048:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7198
+//line postgres.y:7223
 		{
 			yyLOCAL = ast.NewDefElem("minvalue", yyDollar[2].nodeUnion())
 		}
@@ -32821,7 +32846,7 @@ yydefault:
 	case 2049:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7202
+//line postgres.y:7227
 		{
 			yyLOCAL = ast.NewDefElem("maxvalue", nil)
 		}
@@ -32829,7 +32854,7 @@ yydefault:
 	case 2050:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7206
+//line postgres.y:7231
 		{
 			yyLOCAL = ast.NewDefElem("minvalue", nil)
 		}
@@ -32837,7 +32862,7 @@ yydefault:
 	case 2051:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7210
+//line postgres.y:7235
 		{
 			yyLOCAL = ast.NewDefElem("owned_by", yyDollar[3].listUnion())
 		}
@@ -32845,7 +32870,7 @@ yydefault:
 	case 2052:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7214
+//line postgres.y:7239
 		{
 			yyLOCAL = ast.NewDefElem("sequence_name", yyDollar[3].listUnion())
 		}
@@ -32853,7 +32878,7 @@ yydefault:
 	case 2053:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7218
+//line postgres.y:7243
 		{
 			yyLOCAL = ast.NewDefElem("start", yyDollar[3].nodeUnion())
 		}
@@ -32861,7 +32886,7 @@ yydefault:
 	case 2054:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7222
+//line postgres.y:7247
 		{
 			yyLOCAL = ast.NewDefElem("restart", nil)
 		}
@@ -32869,7 +32894,7 @@ yydefault:
 	case 2055:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7226
+//line postgres.y:7251
 		{
 			yyLOCAL = ast.NewDefElem("restart", yyDollar[3].nodeUnion())
 		}
@@ -32877,40 +32902,40 @@ yydefault:
 	case 2056:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7230
+//line postgres.y:7255
 		{
 			yyLOCAL = ast.NewDefElem("unlogged", nil)
 		}
 		yyVAL.union = yyLOCAL
 	case 2057:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7236
+//line postgres.y:7261
 		{
 		}
 	case 2058:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7237
+//line postgres.y:7262
 		{
 		}
 	case 2059:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7241
+//line postgres.y:7266
 		{
 		}
 	case 2060:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7242
+//line postgres.y:7267
 		{
 		}
 	case 2061:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7243
+//line postgres.y:7268
 		{
 		}
 	case 2062:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7248
+//line postgres.y:7273
 		{
 			// RECHECK no longer does anything in opclass definitions,
 			// but we still accept it to ease porting of old database dumps.
@@ -32922,7 +32947,7 @@ yydefault:
 	case 2063:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7255
+//line postgres.y:7280
 		{
 			yyLOCAL = false
 		}
@@ -32930,7 +32955,7 @@ yydefault:
 	case 2064:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7259
+//line postgres.y:7284
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -32938,7 +32963,7 @@ yydefault:
 	case 2065:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7260
+//line postgres.y:7285
 		{
 			yyLOCAL = nil
 		}
@@ -32946,7 +32971,7 @@ yydefault:
 	case 2066:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7265
+//line postgres.y:7290
 		{
 			yyLOCAL = ast.NewConstraint(ast.CONSTR_NOTNULL)
 		}
@@ -32954,7 +32979,7 @@ yydefault:
 	case 2067:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7269
+//line postgres.y:7294
 		{
 			yyLOCAL = ast.NewConstraint(ast.CONSTR_NULL)
 		}
@@ -32962,7 +32987,7 @@ yydefault:
 	case 2068:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7273
+//line postgres.y:7298
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.Keys = nil // Will be filled by the parser
@@ -32975,7 +33000,7 @@ yydefault:
 	case 2069:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7282
+//line postgres.y:7307
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Keys = nil // Will be filled by the parser
@@ -32985,7 +33010,7 @@ yydefault:
 	case 2070:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7288
+//line postgres.y:7313
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_CHECK)
 			constraint.RawExpr = yyDollar[3].nodeUnion()
@@ -32995,7 +33020,7 @@ yydefault:
 	case 2071:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7294
+//line postgres.y:7319
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_DEFAULT)
 			constraint.RawExpr = yyDollar[2].nodeUnion()
@@ -33005,7 +33030,7 @@ yydefault:
 	case 2072:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7300
+//line postgres.y:7325
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
 			constraint.Pktable = yyDollar[2].rangevarUnion()
@@ -33026,7 +33051,7 @@ yydefault:
 	case 2073:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7317
+//line postgres.y:7342
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_IDENTITY)
 			constraint.GeneratedWhen = yyDollar[2].bytUnion()
@@ -33037,7 +33062,7 @@ yydefault:
 	case 2074:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7324
+//line postgres.y:7349
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_GENERATED)
 			constraint.GeneratedWhen = yyDollar[2].bytUnion()
@@ -33048,7 +33073,7 @@ yydefault:
 	case 2075:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7334
+//line postgres.y:7359
 		{
 			constraint := yyDollar[3].nodeUnion().(*ast.Constraint)
 			constraint.Conname = yyDollar[2].str
@@ -33058,7 +33083,7 @@ yydefault:
 	case 2076:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7339
+//line postgres.y:7364
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -33066,7 +33091,7 @@ yydefault:
 	case 2077:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7344
+//line postgres.y:7369
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_CHECK)
 			constraint.RawExpr = yyDollar[3].nodeUnion()
@@ -33077,7 +33102,7 @@ yydefault:
 	case 2078:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7352
+//line postgres.y:7377
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.NullsNotDistinct = !yyDollar[2].bvalUnion()
@@ -33092,7 +33117,7 @@ yydefault:
 	case 2079:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7363
+//line postgres.y:7388
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.Indexname = yyDollar[2].str
@@ -33106,7 +33131,7 @@ yydefault:
 	case 2080:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7374
+//line postgres.y:7399
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Keys = yyDollar[4].listUnion()
@@ -33120,7 +33145,7 @@ yydefault:
 	case 2081:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7384
+//line postgres.y:7409
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Indexname = yyDollar[3].str
@@ -33134,7 +33159,7 @@ yydefault:
 	case 2082:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7395
+//line postgres.y:7420
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
 			constraint.FkAttrs = yyDollar[4].listUnion()
@@ -33157,7 +33182,7 @@ yydefault:
 	case 2083:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7416
+//line postgres.y:7441
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_EXCLUSION)
 			constraint.AccessMethod = yyDollar[2].str
@@ -33173,7 +33198,7 @@ yydefault:
 	case 2084:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7430
+//line postgres.y:7455
 		{
 			yyLOCAL = true
 		}
@@ -33181,7 +33206,7 @@ yydefault:
 	case 2085:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7431
+//line postgres.y:7456
 		{
 			yyLOCAL = false
 		}
@@ -33189,7 +33214,7 @@ yydefault:
 	case 2086:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7437
+//line postgres.y:7462
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -33199,7 +33224,7 @@ yydefault:
 	case 2087:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7443
+//line postgres.y:7468
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33208,7 +33233,7 @@ yydefault:
 	case 2088:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7451
+//line postgres.y:7476
 		{
 			// Create a NodeList with index_elem and operator (matching PostgreSQL's list_make2 approach)
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion(), yyDollar[3].listUnion())
@@ -33217,7 +33242,7 @@ yydefault:
 	case 2089:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7456
+//line postgres.y:7481
 		{
 			// Create a NodeList with index_elem and operator (matching PostgreSQL's list_make2 approach)
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion(), yyDollar[5].listUnion())
@@ -33226,7 +33251,7 @@ yydefault:
 	case 2090:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7464
+//line postgres.y:7489
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33234,7 +33259,7 @@ yydefault:
 	case 2091:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7468
+//line postgres.y:7493
 		{
 			yyLOCAL = nil
 		}
@@ -33242,7 +33267,7 @@ yydefault:
 	case 2092:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7475
+//line postgres.y:7500
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_FULL
 		}
@@ -33250,7 +33275,7 @@ yydefault:
 	case 2093:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7479
+//line postgres.y:7504
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_PARTIAL
 		}
@@ -33258,7 +33283,7 @@ yydefault:
 	case 2094:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7483
+//line postgres.y:7508
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_SIMPLE
 		}
@@ -33266,7 +33291,7 @@ yydefault:
 	case 2095:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7487
+//line postgres.y:7512
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_SIMPLE
 		}
@@ -33274,7 +33299,7 @@ yydefault:
 	case 2096:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7494
+//line postgres.y:7519
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[1].keyactionUnion()
@@ -33288,7 +33313,7 @@ yydefault:
 	case 2097:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7504
+//line postgres.y:7529
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = &ast.KeyAction{
@@ -33302,7 +33327,7 @@ yydefault:
 	case 2098:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7514
+//line postgres.y:7539
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[1].keyactionUnion()
@@ -33313,7 +33338,7 @@ yydefault:
 	case 2099:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7521
+//line postgres.y:7546
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[2].keyactionUnion()
@@ -33324,7 +33349,7 @@ yydefault:
 	case 2100:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7528
+//line postgres.y:7553
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = &ast.KeyAction{
@@ -33341,7 +33366,7 @@ yydefault:
 	case 2101:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7543
+//line postgres.y:7568
 		{
 			// Check for unsupported column lists on UPDATE actions
 			keyAction := yyDollar[3].keyactionUnion()
@@ -33356,7 +33381,7 @@ yydefault:
 	case 2102:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7556
+//line postgres.y:7581
 		{
 			yyLOCAL = yyDollar[3].keyactionUnion()
 		}
@@ -33364,7 +33389,7 @@ yydefault:
 	case 2103:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7563
+//line postgres.y:7588
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_NOACTION
@@ -33375,7 +33400,7 @@ yydefault:
 	case 2104:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7570
+//line postgres.y:7595
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_RESTRICT
@@ -33386,7 +33411,7 @@ yydefault:
 	case 2105:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7577
+//line postgres.y:7602
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_CASCADE
@@ -33397,7 +33422,7 @@ yydefault:
 	case 2106:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7584
+//line postgres.y:7609
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_SETNULL
@@ -33408,7 +33433,7 @@ yydefault:
 	case 2107:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7591
+//line postgres.y:7616
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_SETDEFAULT
@@ -33419,7 +33444,7 @@ yydefault:
 	case 2108:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7600
+//line postgres.y:7625
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33427,7 +33452,7 @@ yydefault:
 	case 2109:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7601
+//line postgres.y:7626
 		{
 			yyLOCAL = nil
 		}
@@ -33435,7 +33460,7 @@ yydefault:
 	case 2110:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7605
+//line postgres.y:7630
 		{
 			yyLOCAL = yyDollar[1].partspecUnion()
 		}
@@ -33443,7 +33468,7 @@ yydefault:
 	case 2111:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7606
+//line postgres.y:7631
 		{
 			yyLOCAL = nil
 		}
@@ -33451,7 +33476,7 @@ yydefault:
 	case 2112:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7611
+//line postgres.y:7636
 		{
 			partitionSpec := ast.NewPartitionSpec(ast.PartitionStrategy(yyDollar[3].str), yyDollar[5].listUnion())
 			yyLOCAL = partitionSpec
@@ -33460,7 +33485,7 @@ yydefault:
 	case 2113:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7619
+//line postgres.y:7644
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33469,7 +33494,7 @@ yydefault:
 	case 2114:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7624
+//line postgres.y:7649
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33478,7 +33503,7 @@ yydefault:
 	case 2115:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7632
+//line postgres.y:7657
 		{
 			partElem := ast.NewPartitionElem(yyDollar[1].str, nil, 0)
 			partElem.Collation = yyDollar[2].listUnion()
@@ -33489,7 +33514,7 @@ yydefault:
 	case 2116:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7639
+//line postgres.y:7664
 		{
 			partElem := ast.NewPartitionElem("", yyDollar[1].nodeUnion(), 0)
 			partElem.Collation = yyDollar[2].listUnion()
@@ -33500,7 +33525,7 @@ yydefault:
 	case 2117:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7646
+//line postgres.y:7671
 		{
 			// Wrap the expression in ParenExpr to preserve parentheses
 			parenExpr := ast.NewParenExpr(yyDollar[2].nodeUnion(), 0)
@@ -33512,20 +33537,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2118:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7657
+//line postgres.y:7682
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2119:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7658
+//line postgres.y:7683
 		{
 			yyVAL.str = ""
 		}
 	case 2120:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7662
+//line postgres.y:7687
 		{
 			yyLOCAL = ast.ONCOMMIT_DROP
 		}
@@ -33533,7 +33558,7 @@ yydefault:
 	case 2121:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7663
+//line postgres.y:7688
 		{
 			yyLOCAL = ast.ONCOMMIT_DELETE_ROWS
 		}
@@ -33541,7 +33566,7 @@ yydefault:
 	case 2122:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7664
+//line postgres.y:7689
 		{
 			yyLOCAL = ast.ONCOMMIT_PRESERVE_ROWS
 		}
@@ -33549,45 +33574,45 @@ yydefault:
 	case 2123:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7665
+//line postgres.y:7690
 		{
 			yyLOCAL = ast.ONCOMMIT_NOOP
 		}
 		yyVAL.union = yyLOCAL
 	case 2124:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7669
+//line postgres.y:7694
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2125:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7670
+//line postgres.y:7695
 		{
 			yyVAL.str = ""
 		}
 	case 2126:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:7674
+//line postgres.y:7699
 		{
 			yyVAL.str = yyDollar[4].str
 		}
 	case 2127:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7675
+//line postgres.y:7700
 		{
 			yyVAL.str = ""
 		}
 	case 2128:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:7679
+//line postgres.y:7704
 		{
 			yyVAL.str = yyDollar[3].str
 		}
 	case 2129:
 		yyDollar = yyS[yypt-16 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7692
+//line postgres.y:7717
 		{
 			indexStmt := ast.NewIndexStmt(yyDollar[5].str, yyDollar[7].rangevarUnion(), yyDollar[10].listUnion())
 			indexStmt.Unique = yyDollar[2].bvalUnion()
@@ -33604,7 +33629,7 @@ yydefault:
 	case 2130:
 		yyDollar = yyS[yypt-19 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7707
+//line postgres.y:7732
 		{
 			indexStmt := ast.NewIndexStmt(yyDollar[8].str, yyDollar[10].rangevarUnion(), yyDollar[13].listUnion())
 			indexStmt.Unique = yyDollar[2].bvalUnion()
@@ -33622,7 +33647,7 @@ yydefault:
 	case 2131:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7723
+//line postgres.y:7748
 		{
 			yyLOCAL = true
 		}
@@ -33630,27 +33655,27 @@ yydefault:
 	case 2132:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7724
+//line postgres.y:7749
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 2133:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7728
+//line postgres.y:7753
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2134:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7729
+//line postgres.y:7754
 		{
 			yyVAL.str = "btree"
 		}
 	case 2135:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7733
+//line postgres.y:7758
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33658,7 +33683,7 @@ yydefault:
 	case 2136:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7734
+//line postgres.y:7759
 		{
 			yyLOCAL = nil
 		}
@@ -33666,7 +33691,7 @@ yydefault:
 	case 2137:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7739
+//line postgres.y:7764
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33675,7 +33700,7 @@ yydefault:
 	case 2138:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7744
+//line postgres.y:7769
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33684,7 +33709,7 @@ yydefault:
 	case 2139:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7752
+//line postgres.y:7777
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -33692,7 +33717,7 @@ yydefault:
 	case 2140:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7753
+//line postgres.y:7778
 		{
 			yyLOCAL = nil
 		}
@@ -33700,7 +33725,7 @@ yydefault:
 	case 2141:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7765
+//line postgres.y:7790
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_TABLE
@@ -33710,7 +33735,7 @@ yydefault:
 	case 2142:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7771
+//line postgres.y:7796
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_TABLE
@@ -33721,7 +33746,7 @@ yydefault:
 	case 2143:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7778
+//line postgres.y:7803
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_INDEX
@@ -33731,7 +33756,7 @@ yydefault:
 	case 2144:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7784
+//line postgres.y:7809
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_INDEX
@@ -33742,7 +33767,7 @@ yydefault:
 	case 2145:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7791
+//line postgres.y:7816
 		{
 			// Index partition attachment - dedicated rule
 			cmdList := ast.NewNodeList()
@@ -33755,7 +33780,7 @@ yydefault:
 	case 2146:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7800
+//line postgres.y:7825
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_SEQUENCE
@@ -33765,7 +33790,7 @@ yydefault:
 	case 2147:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7806
+//line postgres.y:7831
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_SEQUENCE
@@ -33776,7 +33801,7 @@ yydefault:
 	case 2148:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7813
+//line postgres.y:7838
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_VIEW
@@ -33786,7 +33811,7 @@ yydefault:
 	case 2149:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7819
+//line postgres.y:7844
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_VIEW
@@ -33797,7 +33822,7 @@ yydefault:
 	case 2150:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7826
+//line postgres.y:7851
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion())
 			alterStmt.Objtype = ast.OBJECT_MATVIEW
@@ -33807,7 +33832,7 @@ yydefault:
 	case 2151:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7832
+//line postgres.y:7857
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[6].rangevarUnion(), yyDollar[7].listUnion())
 			alterStmt.Objtype = ast.OBJECT_MATVIEW
@@ -33818,7 +33843,7 @@ yydefault:
 	case 2152:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7839
+//line postgres.y:7864
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion())
 			alterStmt.Objtype = ast.OBJECT_FOREIGN_TABLE
@@ -33828,7 +33853,7 @@ yydefault:
 	case 2153:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7845
+//line postgres.y:7870
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[6].rangevarUnion(), yyDollar[7].listUnion())
 			alterStmt.Objtype = ast.OBJECT_FOREIGN_TABLE
@@ -33839,7 +33864,7 @@ yydefault:
 	case 2154:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7852
+//line postgres.y:7877
 		{
 			// Partition commands - dedicated rule for partition-only operations
 			cmdList := ast.NewNodeList()
@@ -33852,7 +33877,7 @@ yydefault:
 	case 2155:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7861
+//line postgres.y:7886
 		{
 			// Partition commands with IF EXISTS
 			cmdList := ast.NewNodeList()
@@ -33866,7 +33891,7 @@ yydefault:
 	case 2156:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7871
+//line postgres.y:7896
 		{
 			// Bulk tablespace move for tables
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_TABLE, yyDollar[9].str)
@@ -33877,7 +33902,7 @@ yydefault:
 	case 2157:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7878
+//line postgres.y:7903
 		{
 			// Bulk tablespace move for tables owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_TABLE, yyDollar[12].str)
@@ -33889,7 +33914,7 @@ yydefault:
 	case 2158:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7886
+//line postgres.y:7911
 		{
 			// Bulk tablespace move for indexes
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_INDEX, yyDollar[9].str)
@@ -33900,7 +33925,7 @@ yydefault:
 	case 2159:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7893
+//line postgres.y:7918
 		{
 			// Bulk tablespace move for indexes owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_INDEX, yyDollar[12].str)
@@ -33912,7 +33937,7 @@ yydefault:
 	case 2160:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7901
+//line postgres.y:7926
 		{
 			// Bulk tablespace move for materialized views
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[7].str, ast.OBJECT_MATVIEW, yyDollar[10].str)
@@ -33923,7 +33948,7 @@ yydefault:
 	case 2161:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7908
+//line postgres.y:7933
 		{
 			// Bulk tablespace move for materialized views owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[7].str, ast.OBJECT_MATVIEW, yyDollar[13].str)
@@ -33935,7 +33960,7 @@ yydefault:
 	case 2162:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7919
+//line postgres.y:7944
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33944,7 +33969,7 @@ yydefault:
 	case 2163:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7924
+//line postgres.y:7949
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33953,7 +33978,7 @@ yydefault:
 	case 2164:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7932
+//line postgres.y:7957
 		{
 			yyLOCAL = true
 		}
@@ -33961,7 +33986,7 @@ yydefault:
 	case 2165:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7933
+//line postgres.y:7958
 		{
 			yyLOCAL = false
 		}
@@ -33969,7 +33994,7 @@ yydefault:
 	case 2166:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7938
+//line postgres.y:7963
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].rolespecUnion())
@@ -33978,7 +34003,7 @@ yydefault:
 	case 2167:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7943
+//line postgres.y:7968
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].rolespecUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33986,7 +34011,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2168:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7951
+//line postgres.y:7976
 		{
 			roleSpec := yyDollar[1].rolespecUnion()
 
@@ -34017,7 +34042,7 @@ yydefault:
 	case 2169:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:7982
+//line postgres.y:8007
 		{
 			// Handle special role names: "public" and "none"
 			var roleSpec *ast.RoleSpec
@@ -34044,7 +34069,7 @@ yydefault:
 	case 2170:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8005
+//line postgres.y:8030
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34055,7 +34080,7 @@ yydefault:
 	case 2171:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8012
+//line postgres.y:8037
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34066,7 +34091,7 @@ yydefault:
 	case 2172:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8019
+//line postgres.y:8044
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34077,7 +34102,7 @@ yydefault:
 	case 2173:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8030
+//line postgres.y:8055
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[2].nodeUnion())
 			cmd.MissingOk = false
@@ -34087,7 +34112,7 @@ yydefault:
 	case 2174:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8037
+//line postgres.y:8062
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[5].nodeUnion())
 			cmd.MissingOk = true
@@ -34097,7 +34122,7 @@ yydefault:
 	case 2175:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8044
+//line postgres.y:8069
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[3].nodeUnion())
 			cmd.MissingOk = false
@@ -34107,7 +34132,7 @@ yydefault:
 	case 2176:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8051
+//line postgres.y:8076
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[6].nodeUnion())
 			cmd.MissingOk = true
@@ -34117,7 +34142,7 @@ yydefault:
 	case 2177:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8058
+//line postgres.y:8083
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ColumnDefault, yyDollar[3].str, yyDollar[4].nodeUnion())
 		}
@@ -34125,7 +34150,7 @@ yydefault:
 	case 2178:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8063
+//line postgres.y:8088
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropNotNull, yyDollar[3].str, nil)
 		}
@@ -34133,7 +34158,7 @@ yydefault:
 	case 2179:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8068
+//line postgres.y:8093
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetNotNull, yyDollar[3].str, nil)
 		}
@@ -34141,7 +34166,7 @@ yydefault:
 	case 2180:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8073
+//line postgres.y:8098
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetExpression, yyDollar[3].str, yyDollar[8].nodeUnion())
 		}
@@ -34149,7 +34174,7 @@ yydefault:
 	case 2181:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8078
+//line postgres.y:8103
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropExpression, yyDollar[3].str, nil)
 		}
@@ -34157,7 +34182,7 @@ yydefault:
 	case 2182:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8083
+//line postgres.y:8108
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropExpression, yyDollar[3].str, nil)
 			cmd.MissingOk = true
@@ -34167,7 +34192,7 @@ yydefault:
 	case 2183:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8090
+//line postgres.y:8115
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetStatistics, yyDollar[3].str, yyDollar[6].nodeUnion())
 		}
@@ -34175,7 +34200,7 @@ yydefault:
 	case 2184:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8095
+//line postgres.y:8120
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_SetStatistics, "", yyDollar[6].nodeUnion())
 			cmd.Num = int16(yyDollar[3].ival)
@@ -34185,7 +34210,7 @@ yydefault:
 	case 2185:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8102
+//line postgres.y:8127
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetOptions, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -34193,7 +34218,7 @@ yydefault:
 	case 2186:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8107
+//line postgres.y:8132
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ResetOptions, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -34201,7 +34226,7 @@ yydefault:
 	case 2187:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8112
+//line postgres.y:8137
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetStorage, yyDollar[3].str, ast.NewString(yyDollar[5].str))
 		}
@@ -34209,7 +34234,7 @@ yydefault:
 	case 2188:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8117
+//line postgres.y:8142
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetCompression, yyDollar[3].str, ast.NewString(yyDollar[5].str))
 		}
@@ -34217,7 +34242,7 @@ yydefault:
 	case 2189:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8122
+//line postgres.y:8147
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddIdentity, yyDollar[3].str, nil)
 			constraint := ast.NewConstraint(ast.CONSTR_IDENTITY)
@@ -34230,7 +34255,7 @@ yydefault:
 	case 2190:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8132
+//line postgres.y:8157
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetIdentity, yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -34238,7 +34263,7 @@ yydefault:
 	case 2191:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8137
+//line postgres.y:8162
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropIdentity, yyDollar[3].str, nil)
 			cmd.MissingOk = false
@@ -34248,7 +34273,7 @@ yydefault:
 	case 2192:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8144
+//line postgres.y:8169
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropIdentity, yyDollar[3].str, nil)
 			cmd.MissingOk = true
@@ -34258,7 +34283,7 @@ yydefault:
 	case 2193:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8151
+//line postgres.y:8176
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[5].str, nil)
 			cmd.Behavior = yyDollar[6].dropBehavUnion()
@@ -34269,7 +34294,7 @@ yydefault:
 	case 2194:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8159
+//line postgres.y:8184
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[3].str, nil)
 			cmd.Behavior = yyDollar[4].dropBehavUnion()
@@ -34280,7 +34305,7 @@ yydefault:
 	case 2195:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8170
+//line postgres.y:8195
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AlterColumnType, yyDollar[3].str, nil)
 			def := ast.NewColumnDef("", yyDollar[6].typnamUnion(), 0)
@@ -34295,7 +34320,7 @@ yydefault:
 	case 2196:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8182
+//line postgres.y:8207
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AlterColumnGenericOptions, yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -34303,7 +34328,7 @@ yydefault:
 	case 2197:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8187
+//line postgres.y:8212
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddConstraint, "", yyDollar[2].nodeUnion())
 		}
@@ -34311,7 +34336,7 @@ yydefault:
 	case 2198:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8192
+//line postgres.y:8217
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AlterConstraint, "", nil)
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
@@ -34325,7 +34350,7 @@ yydefault:
 	case 2199:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8203
+//line postgres.y:8228
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ValidateConstraint, yyDollar[3].str, nil)
 		}
@@ -34333,7 +34358,7 @@ yydefault:
 	case 2200:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8208
+//line postgres.y:8233
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropConstraint, yyDollar[5].str, nil)
 			cmd.Behavior = yyDollar[6].dropBehavUnion()
@@ -34344,7 +34369,7 @@ yydefault:
 	case 2201:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8216
+//line postgres.y:8241
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropConstraint, yyDollar[3].str, nil)
 			cmd.Behavior = yyDollar[4].dropBehavUnion()
@@ -34355,7 +34380,7 @@ yydefault:
 	case 2202:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8224
+//line postgres.y:8249
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropOids, "", nil)
 		}
@@ -34363,7 +34388,7 @@ yydefault:
 	case 2203:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8229
+//line postgres.y:8254
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ClusterOn, yyDollar[3].str, nil)
 		}
@@ -34371,7 +34396,7 @@ yydefault:
 	case 2204:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8234
+//line postgres.y:8259
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropCluster, "", nil)
 		}
@@ -34379,7 +34404,7 @@ yydefault:
 	case 2205:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8239
+//line postgres.y:8264
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetLogged, "", nil)
 		}
@@ -34387,7 +34412,7 @@ yydefault:
 	case 2206:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8244
+//line postgres.y:8269
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetUnLogged, "", nil)
 		}
@@ -34395,7 +34420,7 @@ yydefault:
 	case 2207:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8249
+//line postgres.y:8274
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrig, yyDollar[3].str, nil)
 		}
@@ -34403,7 +34428,7 @@ yydefault:
 	case 2208:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8254
+//line postgres.y:8279
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableAlwaysTrig, yyDollar[4].str, nil)
 		}
@@ -34411,7 +34436,7 @@ yydefault:
 	case 2209:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8259
+//line postgres.y:8284
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableReplicaTrig, yyDollar[4].str, nil)
 		}
@@ -34419,7 +34444,7 @@ yydefault:
 	case 2210:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8264
+//line postgres.y:8289
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrigAll, "", nil)
 		}
@@ -34427,7 +34452,7 @@ yydefault:
 	case 2211:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8269
+//line postgres.y:8294
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrigUser, "", nil)
 		}
@@ -34435,7 +34460,7 @@ yydefault:
 	case 2212:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8274
+//line postgres.y:8299
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrig, yyDollar[3].str, nil)
 		}
@@ -34443,7 +34468,7 @@ yydefault:
 	case 2213:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8279
+//line postgres.y:8304
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrigAll, "", nil)
 		}
@@ -34451,7 +34476,7 @@ yydefault:
 	case 2214:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8284
+//line postgres.y:8309
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrigUser, "", nil)
 		}
@@ -34459,7 +34484,7 @@ yydefault:
 	case 2215:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8289
+//line postgres.y:8314
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableRule, yyDollar[3].str, nil)
 		}
@@ -34467,7 +34492,7 @@ yydefault:
 	case 2216:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8294
+//line postgres.y:8319
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableAlwaysRule, yyDollar[4].str, nil)
 		}
@@ -34475,7 +34500,7 @@ yydefault:
 	case 2217:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8299
+//line postgres.y:8324
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableReplicaRule, yyDollar[4].str, nil)
 		}
@@ -34483,7 +34508,7 @@ yydefault:
 	case 2218:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8304
+//line postgres.y:8329
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableRule, yyDollar[3].str, nil)
 		}
@@ -34491,7 +34516,7 @@ yydefault:
 	case 2219:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8309
+//line postgres.y:8334
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddInherit, "", yyDollar[2].rangevarUnion())
 		}
@@ -34499,7 +34524,7 @@ yydefault:
 	case 2220:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8314
+//line postgres.y:8339
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropInherit, "", yyDollar[3].rangevarUnion())
 		}
@@ -34507,7 +34532,7 @@ yydefault:
 	case 2221:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8319
+//line postgres.y:8344
 		{
 			typeName := makeTypeNameFromNodeList(yyDollar[2].listUnion())
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddOf, "", typeName)
@@ -34516,7 +34541,7 @@ yydefault:
 	case 2222:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8325
+//line postgres.y:8350
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropOf, "", nil)
 		}
@@ -34524,7 +34549,7 @@ yydefault:
 	case 2223:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8330
+//line postgres.y:8355
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_ChangeOwner, "", nil)
 			cmd.Newowner = yyDollar[3].rolespecUnion()
@@ -34534,7 +34559,7 @@ yydefault:
 	case 2224:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8337
+//line postgres.y:8362
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetAccessMethod, yyDollar[4].str, nil)
 		}
@@ -34542,7 +34567,7 @@ yydefault:
 	case 2225:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8342
+//line postgres.y:8367
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetTableSpace, yyDollar[3].str, nil)
 		}
@@ -34550,7 +34575,7 @@ yydefault:
 	case 2226:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8347
+//line postgres.y:8372
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetRelOptions, "", yyDollar[2].listUnion())
 		}
@@ -34558,7 +34583,7 @@ yydefault:
 	case 2227:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8352
+//line postgres.y:8377
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ResetRelOptions, "", yyDollar[2].listUnion())
 		}
@@ -34566,7 +34591,7 @@ yydefault:
 	case 2228:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8357
+//line postgres.y:8382
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ReplicaIdentity, "", yyDollar[3].nodeUnion())
 		}
@@ -34574,7 +34599,7 @@ yydefault:
 	case 2229:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8362
+//line postgres.y:8387
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableRowSecurity, "", nil)
 		}
@@ -34582,7 +34607,7 @@ yydefault:
 	case 2230:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8367
+//line postgres.y:8392
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableRowSecurity, "", nil)
 		}
@@ -34590,7 +34615,7 @@ yydefault:
 	case 2231:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8372
+//line postgres.y:8397
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ForceRowSecurity, "", nil)
 		}
@@ -34598,7 +34623,7 @@ yydefault:
 	case 2232:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8377
+//line postgres.y:8402
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_NoForceRowSecurity, "", nil)
 		}
@@ -34606,7 +34631,7 @@ yydefault:
 	case 2233:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8381
+//line postgres.y:8406
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_GenericOptions, "", yyDollar[1].listUnion())
 		}
@@ -34614,7 +34639,7 @@ yydefault:
 	case 2234:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8389
+//line postgres.y:8414
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AttachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), yyDollar[4].partboundspecUnion(), false, 0)
@@ -34625,7 +34650,7 @@ yydefault:
 	case 2235:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8397
+//line postgres.y:8422
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DetachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, yyDollar[4].bvalUnion(), 0)
@@ -34636,7 +34661,7 @@ yydefault:
 	case 2236:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8404
+//line postgres.y:8429
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DetachPartitionFinalize, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, false, 0)
@@ -34647,7 +34672,7 @@ yydefault:
 	case 2237:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8415
+//line postgres.y:8440
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AttachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, false, 0)
@@ -34658,7 +34683,7 @@ yydefault:
 	case 2238:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8424
+//line postgres.y:8449
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -34666,25 +34691,25 @@ yydefault:
 	case 2239:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8425
+//line postgres.y:8450
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 2240:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:8429
+//line postgres.y:8454
 		{
 		}
 	case 2241:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:8430
+//line postgres.y:8455
 		{
 		}
 	case 2242:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8441
+//line postgres.y:8466
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34701,7 +34726,7 @@ yydefault:
 	case 2243:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8454
+//line postgres.y:8479
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34718,7 +34743,7 @@ yydefault:
 	case 2244:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8467
+//line postgres.y:8492
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34735,7 +34760,7 @@ yydefault:
 	case 2245:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8480
+//line postgres.y:8505
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34752,7 +34777,7 @@ yydefault:
 	case 2246:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8493
+//line postgres.y:8518
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34771,7 +34796,7 @@ yydefault:
 	case 2247:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8508
+//line postgres.y:8533
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34790,7 +34815,7 @@ yydefault:
 	case 2248:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8523
+//line postgres.y:8548
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34807,7 +34832,7 @@ yydefault:
 	case 2249:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8536
+//line postgres.y:8561
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34824,7 +34849,7 @@ yydefault:
 	case 2250:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8549
+//line postgres.y:8574
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34841,7 +34866,7 @@ yydefault:
 	case 2251:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8562
+//line postgres.y:8587
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34858,7 +34883,7 @@ yydefault:
 	case 2252:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8575
+//line postgres.y:8600
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34875,7 +34900,7 @@ yydefault:
 	case 2253:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8588
+//line postgres.y:8613
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34892,7 +34917,7 @@ yydefault:
 	case 2254:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8602
+//line postgres.y:8627
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34909,7 +34934,7 @@ yydefault:
 	case 2255:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8616
+//line postgres.y:8641
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34931,7 +34956,7 @@ yydefault:
 	case 2256:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8634
+//line postgres.y:8659
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34953,7 +34978,7 @@ yydefault:
 	case 2257:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8653
+//line postgres.y:8678
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34975,7 +35000,7 @@ yydefault:
 	case 2258:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8671
+//line postgres.y:8696
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34997,7 +35022,7 @@ yydefault:
 	case 2259:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8690
+//line postgres.y:8715
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35014,7 +35039,7 @@ yydefault:
 	case 2260:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8704
+//line postgres.y:8729
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35031,7 +35056,7 @@ yydefault:
 	case 2261:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8717
+//line postgres.y:8742
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35048,7 +35073,7 @@ yydefault:
 	case 2262:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8737
+//line postgres.y:8762
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35064,7 +35089,7 @@ yydefault:
 	case 2263:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8749
+//line postgres.y:8774
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35080,7 +35105,7 @@ yydefault:
 	case 2264:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8761
+//line postgres.y:8786
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35096,7 +35121,7 @@ yydefault:
 	case 2265:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8773
+//line postgres.y:8798
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35112,7 +35137,7 @@ yydefault:
 	case 2266:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8785
+//line postgres.y:8810
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35128,7 +35153,7 @@ yydefault:
 	case 2267:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8797
+//line postgres.y:8822
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35144,7 +35169,7 @@ yydefault:
 	case 2268:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8812
+//line postgres.y:8837
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35160,7 +35185,7 @@ yydefault:
 	case 2269:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8824
+//line postgres.y:8849
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35176,7 +35201,7 @@ yydefault:
 	case 2270:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8839
+//line postgres.y:8864
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35192,7 +35217,7 @@ yydefault:
 	case 2271:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8851
+//line postgres.y:8876
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35208,7 +35233,7 @@ yydefault:
 	case 2272:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8866
+//line postgres.y:8891
 		{
 			stmt := yyDollar[2].vsetstmtUnion()
 			stmt.IsLocal = false
@@ -35218,7 +35243,7 @@ yydefault:
 	case 2273:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8872
+//line postgres.y:8897
 		{
 			stmt := yyDollar[3].vsetstmtUnion()
 			stmt.IsLocal = true
@@ -35228,7 +35253,7 @@ yydefault:
 	case 2274:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8878
+//line postgres.y:8903
 		{
 			stmt := yyDollar[3].vsetstmtUnion()
 			stmt.IsLocal = false
@@ -35238,7 +35263,7 @@ yydefault:
 	case 2275:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8887
+//line postgres.y:8912
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_MULTI, "TRANSACTION", yyDollar[2].listUnion(), false)
 		}
@@ -35246,7 +35271,7 @@ yydefault:
 	case 2276:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8891
+//line postgres.y:8916
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_MULTI, "SESSION CHARACTERISTICS AS TRANSACTION", yyDollar[5].listUnion(), false)
 		}
@@ -35254,7 +35279,7 @@ yydefault:
 	case 2277:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8894
+//line postgres.y:8919
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -35262,7 +35287,7 @@ yydefault:
 	case 2278:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8898
+//line postgres.y:8923
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -35270,7 +35295,7 @@ yydefault:
 	case 2279:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8900
+//line postgres.y:8925
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "timezone", nil, false)
 		}
@@ -35278,7 +35303,7 @@ yydefault:
 	case 2280:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8904
+//line postgres.y:8929
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "transaction_isolation", nil, false)
 		}
@@ -35286,7 +35311,7 @@ yydefault:
 	case 2281:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8908
+//line postgres.y:8933
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "session_authorization", nil, false)
 		}
@@ -35294,7 +35319,7 @@ yydefault:
 	case 2282:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8915
+//line postgres.y:8940
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, yyDollar[1].str, nil, false)
 		}
@@ -35302,7 +35327,7 @@ yydefault:
 	case 2283:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8919
+//line postgres.y:8944
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET_ALL, "", nil, false)
 		}
@@ -35310,7 +35335,7 @@ yydefault:
 	case 2284:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8925
+//line postgres.y:8950
 		{
 			yyLOCAL = yyDollar[2].vsetstmtUnion()
 		}
@@ -35318,7 +35343,7 @@ yydefault:
 	case 2285:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8926
+//line postgres.y:8951
 		{
 			yyLOCAL = yyDollar[1].stmtUnion().(*ast.VariableSetStmt)
 		}
@@ -35326,7 +35351,7 @@ yydefault:
 	case 2286:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8930
+//line postgres.y:8955
 		{
 			yyLOCAL = ast.Stmt(yyDollar[2].vsetstmtUnion())
 		}
@@ -35334,7 +35359,7 @@ yydefault:
 	case 2287:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8939
+//line postgres.y:8964
 		{
 			yyLOCAL = ast.NewConstraintsSetStmt(yyDollar[3].listUnion(), yyDollar[4].bvalUnion())
 		}
@@ -35342,7 +35367,7 @@ yydefault:
 	case 2288:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:8945
+//line postgres.y:8970
 		{
 			yyLOCAL = nil
 		}
@@ -35350,7 +35375,7 @@ yydefault:
 	case 2289:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:8946
+//line postgres.y:8971
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -35358,7 +35383,7 @@ yydefault:
 	case 2290:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:8950
+//line postgres.y:8975
 		{
 			yyLOCAL = true
 		}
@@ -35366,7 +35391,7 @@ yydefault:
 	case 2291:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:8951
+//line postgres.y:8976
 		{
 			yyLOCAL = false
 		}
@@ -35374,7 +35399,7 @@ yydefault:
 	case 2292:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8963
+//line postgres.y:8988
 		{
 			n := ast.NewSelectStmt()
 			n.DistinctClause = yyDollar[1].listUnion()
@@ -35400,7 +35425,7 @@ yydefault:
 	case 2293:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8988
+//line postgres.y:9013
 		{
 			n := ast.NewPLAssignStmt(yyDollar[1].str, yyDollar[4].stmtUnion().(*ast.SelectStmt))
 			n.Indirection = yyDollar[2].listUnion()
@@ -35409,20 +35434,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2294:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:8996
+//line postgres.y:9021
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2295:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:8997
+//line postgres.y:9022
 		{
 			yyVAL.str = fmt.Sprintf("$%d", yyDollar[1].ival)
 		}
 	case 2298:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9011
+//line postgres.y:9036
 		{
 			yyLOCAL = ast.NewExplainStmt(yyDollar[2].stmtUnion(), nil)
 		}
@@ -35430,7 +35455,7 @@ yydefault:
 	case 2299:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9015
+//line postgres.y:9040
 		{
 			options := ast.NewNodeList(ast.NewDefElem("analyze", nil))
 			if yyDollar[3].ival != 0 {
@@ -35442,7 +35467,7 @@ yydefault:
 	case 2300:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9023
+//line postgres.y:9048
 		{
 			options := ast.NewNodeList(ast.NewDefElem("verbose", nil))
 			yyLOCAL = ast.NewExplainStmt(yyDollar[3].stmtUnion(), options)
@@ -35451,7 +35476,7 @@ yydefault:
 	case 2301:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9028
+//line postgres.y:9053
 		{
 			yyLOCAL = ast.NewExplainStmt(yyDollar[5].stmtUnion(), yyDollar[3].listUnion())
 		}
@@ -35459,7 +35484,7 @@ yydefault:
 	case 2302:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9035
+//line postgres.y:9060
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -35467,7 +35492,7 @@ yydefault:
 	case 2303:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9039
+//line postgres.y:9064
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -35476,33 +35501,33 @@ yydefault:
 	case 2304:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:9047
+//line postgres.y:9072
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2305:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9053
+//line postgres.y:9078
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2306:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9054
+//line postgres.y:9079
 		{
 			yyVAL.str = "analyze"
 		}
 	case 2307:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9055
+//line postgres.y:9080
 		{
 			yyVAL.str = "format"
 		}
 	case 2308:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9059
+//line postgres.y:9084
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -35510,7 +35535,7 @@ yydefault:
 	case 2309:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9060
+//line postgres.y:9085
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -35518,7 +35543,7 @@ yydefault:
 	case 2310:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9061
+//line postgres.y:9086
 		{
 			yyLOCAL = nil
 		}
@@ -35526,7 +35551,7 @@ yydefault:
 	case 2311:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9065
+//line postgres.y:9090
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35534,7 +35559,7 @@ yydefault:
 	case 2312:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9066
+//line postgres.y:9091
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35542,7 +35567,7 @@ yydefault:
 	case 2313:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9067
+//line postgres.y:9092
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35550,7 +35575,7 @@ yydefault:
 	case 2314:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9068
+//line postgres.y:9093
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35558,7 +35583,7 @@ yydefault:
 	case 2315:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9069
+//line postgres.y:9094
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35566,7 +35591,7 @@ yydefault:
 	case 2316:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9070
+//line postgres.y:9095
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35574,7 +35599,7 @@ yydefault:
 	case 2317:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9071
+//line postgres.y:9096
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35582,7 +35607,7 @@ yydefault:
 	case 2318:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9072
+//line postgres.y:9097
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35590,7 +35615,7 @@ yydefault:
 	case 2319:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9073
+//line postgres.y:9098
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35598,7 +35623,7 @@ yydefault:
 	case 2320:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9074
+//line postgres.y:9099
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35606,7 +35631,7 @@ yydefault:
 	case 2321:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9083
+//line postgres.y:9108
 		{
 			var optionsList *ast.NodeList
 			if yyDollar[2].ival != 0 || yyDollar[3].ival != 0 || yyDollar[4].ival != 0 || yyDollar[5].ival != 0 {
@@ -35631,7 +35656,7 @@ yydefault:
 	case 2322:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9104
+//line postgres.y:9129
 		{
 			yyLOCAL = ast.NewVacuumStmt(yyDollar[3].listUnion(), yyDollar[5].listUnion())
 		}
@@ -35639,7 +35664,7 @@ yydefault:
 	case 2323:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9111
+//line postgres.y:9136
 		{
 			var optionsList *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35652,7 +35677,7 @@ yydefault:
 	case 2324:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9120
+//line postgres.y:9145
 		{
 			yyLOCAL = ast.NewAnalyzeStmt(yyDollar[3].listUnion(), yyDollar[5].listUnion())
 		}
@@ -35660,7 +35685,7 @@ yydefault:
 	case 2325:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9126
+//line postgres.y:9151
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -35668,7 +35693,7 @@ yydefault:
 	case 2326:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9127
+//line postgres.y:9152
 		{
 			yyLOCAL = nil
 		}
@@ -35676,7 +35701,7 @@ yydefault:
 	case 2327:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9132
+//line postgres.y:9157
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].vacrelUnion())
 		}
@@ -35684,7 +35709,7 @@ yydefault:
 	case 2328:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9136
+//line postgres.y:9161
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].vacrelUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -35693,27 +35718,27 @@ yydefault:
 	case 2329:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VacuumRelation
-//line postgres.y:9144
+//line postgres.y:9169
 		{
 			yyLOCAL = ast.NewVacuumRelation(yyDollar[1].rangevarUnion(), yyDollar[2].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2330:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9150
+//line postgres.y:9175
 		{
 			yyVAL.str = "analyze"
 		}
 	case 2331:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9151
+//line postgres.y:9176
 		{
 			yyVAL.str = "analyse"
 		}
 	case 2332:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9160
+//line postgres.y:9185
 		{
 			yyLOCAL = ast.NewVariableShowStmt(yyDollar[2].str)
 		}
@@ -35721,7 +35746,7 @@ yydefault:
 	case 2333:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9164
+//line postgres.y:9189
 		{
 			yyLOCAL = ast.NewVariableShowStmt("timezone")
 		}
@@ -35729,7 +35754,7 @@ yydefault:
 	case 2334:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9168
+//line postgres.y:9193
 		{
 			yyLOCAL = ast.NewVariableShowStmt("transaction_isolation")
 		}
@@ -35737,7 +35762,7 @@ yydefault:
 	case 2335:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9172
+//line postgres.y:9197
 		{
 			yyLOCAL = ast.NewVariableShowStmt("session_authorization")
 		}
@@ -35745,7 +35770,7 @@ yydefault:
 	case 2336:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9176
+//line postgres.y:9201
 		{
 			yyLOCAL = ast.NewVariableShowStmt("all")
 		}
@@ -35753,7 +35778,7 @@ yydefault:
 	case 2337:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9187
+//line postgres.y:9212
 		{
 			yyLOCAL = ast.NewAlterSystemStmt(yyDollar[4].vsetstmtUnion())
 		}
@@ -35761,7 +35786,7 @@ yydefault:
 	case 2338:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9191
+//line postgres.y:9216
 		{
 			yyLOCAL = ast.NewAlterSystemStmt(yyDollar[4].vsetstmtUnion())
 		}
@@ -35769,7 +35794,7 @@ yydefault:
 	case 2339:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9202
+//line postgres.y:9227
 		{
 			yyLOCAL = ast.NewClusterStmt(yyDollar[5].rangevarUnion(), yyDollar[6].str, yyDollar[3].listUnion())
 		}
@@ -35777,7 +35802,7 @@ yydefault:
 	case 2340:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9206
+//line postgres.y:9231
 		{
 			yyLOCAL = ast.NewClusterStmt(nil, "", yyDollar[3].listUnion())
 		}
@@ -35785,7 +35810,7 @@ yydefault:
 	case 2341:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9210
+//line postgres.y:9235
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35798,7 +35823,7 @@ yydefault:
 	case 2342:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9219
+//line postgres.y:9244
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35811,7 +35836,7 @@ yydefault:
 	case 2343:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9228
+//line postgres.y:9253
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35823,20 +35848,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2344:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:9239
+//line postgres.y:9264
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2345:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:9240
+//line postgres.y:9265
 		{
 			yyVAL.str = ""
 		}
 	case 2346:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9249
+//line postgres.y:9274
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35853,7 +35878,7 @@ yydefault:
 	case 2347:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9262
+//line postgres.y:9287
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35870,7 +35895,7 @@ yydefault:
 	case 2348:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9275
+//line postgres.y:9300
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35886,32 +35911,32 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2349:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9290
+//line postgres.y:9315
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_INDEX)
 		}
 	case 2350:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9291
+//line postgres.y:9316
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_TABLE)
 		}
 	case 2351:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9295
+//line postgres.y:9320
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_SYSTEM)
 		}
 	case 2352:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9296
+//line postgres.y:9321
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_DATABASE)
 		}
 	case 2353:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9300
+//line postgres.y:9325
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -35919,7 +35944,7 @@ yydefault:
 	case 2354:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9301
+//line postgres.y:9326
 		{
 			yyLOCAL = nil
 		}
@@ -35927,7 +35952,7 @@ yydefault:
 	case 2355:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9310
+//line postgres.y:9335
 		{
 			yyLOCAL = ast.NewCheckPointStmt()
 		}
@@ -35935,7 +35960,7 @@ yydefault:
 	case 2356:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9321
+//line postgres.y:9346
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_ALL)
 		}
@@ -35943,7 +35968,7 @@ yydefault:
 	case 2357:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9325
+//line postgres.y:9350
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_TEMP)
 		}
@@ -35951,7 +35976,7 @@ yydefault:
 	case 2358:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9329
+//line postgres.y:9354
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_TEMP)
 		}
@@ -35959,7 +35984,7 @@ yydefault:
 	case 2359:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9333
+//line postgres.y:9358
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_PLANS)
 		}
@@ -35967,7 +35992,7 @@ yydefault:
 	case 2360:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9337
+//line postgres.y:9362
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_SEQUENCES)
 		}
@@ -35975,7 +36000,7 @@ yydefault:
 	case 2361:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9344
+//line postgres.y:9369
 		{
 			yyLOCAL = ast.OBJECT_TABLE
 		}
@@ -35983,7 +36008,7 @@ yydefault:
 	case 2362:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9345
+//line postgres.y:9370
 		{
 			yyLOCAL = ast.OBJECT_SEQUENCE
 		}
@@ -35991,7 +36016,7 @@ yydefault:
 	case 2363:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9346
+//line postgres.y:9371
 		{
 			yyLOCAL = ast.OBJECT_VIEW
 		}
@@ -35999,7 +36024,7 @@ yydefault:
 	case 2364:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9347
+//line postgres.y:9372
 		{
 			yyLOCAL = ast.OBJECT_MATVIEW
 		}
@@ -36007,7 +36032,7 @@ yydefault:
 	case 2365:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9348
+//line postgres.y:9373
 		{
 			yyLOCAL = ast.OBJECT_INDEX
 		}
@@ -36015,7 +36040,7 @@ yydefault:
 	case 2366:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9349
+//line postgres.y:9374
 		{
 			yyLOCAL = ast.OBJECT_FOREIGN_TABLE
 		}
@@ -36023,7 +36048,7 @@ yydefault:
 	case 2367:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9350
+//line postgres.y:9375
 		{
 			yyLOCAL = ast.OBJECT_COLLATION
 		}
@@ -36031,7 +36056,7 @@ yydefault:
 	case 2368:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9351
+//line postgres.y:9376
 		{
 			yyLOCAL = ast.OBJECT_CONVERSION
 		}
@@ -36039,7 +36064,7 @@ yydefault:
 	case 2369:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9352
+//line postgres.y:9377
 		{
 			yyLOCAL = ast.OBJECT_STATISTIC_EXT
 		}
@@ -36047,7 +36072,7 @@ yydefault:
 	case 2370:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9353
+//line postgres.y:9378
 		{
 			yyLOCAL = ast.OBJECT_TSPARSER
 		}
@@ -36055,7 +36080,7 @@ yydefault:
 	case 2371:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9354
+//line postgres.y:9379
 		{
 			yyLOCAL = ast.OBJECT_TSDICTIONARY
 		}
@@ -36063,7 +36088,7 @@ yydefault:
 	case 2372:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9355
+//line postgres.y:9380
 		{
 			yyLOCAL = ast.OBJECT_TSTEMPLATE
 		}
@@ -36071,7 +36096,7 @@ yydefault:
 	case 2373:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9356
+//line postgres.y:9381
 		{
 			yyLOCAL = ast.OBJECT_TSCONFIGURATION
 		}
@@ -36079,7 +36104,7 @@ yydefault:
 	case 2374:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9369
+//line postgres.y:9394
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -36087,7 +36112,7 @@ yydefault:
 	case 2375:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9370
+//line postgres.y:9395
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -36095,7 +36120,7 @@ yydefault:
 	case 2376:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9375
+//line postgres.y:9400
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].funparamUnion())
 		}
@@ -36103,7 +36128,7 @@ yydefault:
 	case 2377:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9379
+//line postgres.y:9404
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].funparamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -36112,7 +36137,7 @@ yydefault:
 	case 2378:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:9387
+//line postgres.y:9412
 		{
 			objWithArgs := &ast.ObjectWithArgs{
 				BaseNode: ast.BaseNode{Tag: ast.T_ObjectWithArgs},
@@ -36124,7 +36149,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2379:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:9399
+//line postgres.y:9424
 		{
 			yylex.Error("Use NONE to denote the missing argument of a unary operator.")
 			return 1
@@ -36132,7 +36157,7 @@ yydefault:
 	case 2380:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9404
+//line postgres.y:9429
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[2].typnamUnion(), yyDollar[4].typnamUnion())
 		}
@@ -36140,7 +36165,7 @@ yydefault:
 	case 2381:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9406
+//line postgres.y:9431
 		{
 			yyLOCAL = ast.NewNodeList(nil, yyDollar[4].typnamUnion())
 		}
@@ -36148,7 +36173,7 @@ yydefault:
 	case 2382:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9408
+//line postgres.y:9433
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[2].typnamUnion(), nil)
 		}
@@ -36156,7 +36181,7 @@ yydefault:
 	case 2383:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:9412
+//line postgres.y:9437
 		{
 			var objfuncArgs *ast.NodeList
 			if firstElem := linitial(yyDollar[2].listUnion()); firstElem != nil {
@@ -36177,7 +36202,7 @@ yydefault:
 	case 2384:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9431
+//line postgres.y:9456
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -36185,7 +36210,7 @@ yydefault:
 	case 2385:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9433
+//line postgres.y:9458
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -36194,7 +36219,7 @@ yydefault:
 	case 2386:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9437
+//line postgres.y:9462
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36209,7 +36234,7 @@ yydefault:
 	case 2387:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9448
+//line postgres.y:9473
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36224,7 +36249,7 @@ yydefault:
 	case 2388:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9459
+//line postgres.y:9484
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36239,7 +36264,7 @@ yydefault:
 	case 2389:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9470
+//line postgres.y:9495
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36254,7 +36279,7 @@ yydefault:
 	case 2390:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9481
+//line postgres.y:9506
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36269,7 +36294,7 @@ yydefault:
 	case 2391:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9492
+//line postgres.y:9517
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36285,7 +36310,7 @@ yydefault:
 	case 2392:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9504
+//line postgres.y:9529
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36300,7 +36325,7 @@ yydefault:
 	case 2393:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9515
+//line postgres.y:9540
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36315,7 +36340,7 @@ yydefault:
 	case 2394:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9526
+//line postgres.y:9551
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36330,7 +36355,7 @@ yydefault:
 	case 2395:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9537
+//line postgres.y:9562
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36345,7 +36370,7 @@ yydefault:
 	case 2396:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9548
+//line postgres.y:9573
 		{
 			/* lcons equivalent - create NodeList with string name prepended to qualified_name list */
 			list := ast.NewNodeList()
@@ -36366,7 +36391,7 @@ yydefault:
 	case 2397:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9565
+//line postgres.y:9590
 		{
 			/* lcons equivalent - create NodeList with string name prepended to qualified_name list */
 			list := ast.NewNodeList()
@@ -36387,7 +36412,7 @@ yydefault:
 	case 2398:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9582
+//line postgres.y:9607
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36403,7 +36428,7 @@ yydefault:
 	case 2399:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9594
+//line postgres.y:9619
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36419,7 +36444,7 @@ yydefault:
 	case 2400:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9606
+//line postgres.y:9631
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36434,7 +36459,7 @@ yydefault:
 	case 2401:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9617
+//line postgres.y:9642
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36449,7 +36474,7 @@ yydefault:
 	case 2402:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9628
+//line postgres.y:9653
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36464,7 +36489,7 @@ yydefault:
 	case 2403:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9639
+//line postgres.y:9664
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36479,7 +36504,7 @@ yydefault:
 	case 2404:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9650
+//line postgres.y:9675
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36494,7 +36519,7 @@ yydefault:
 	case 2405:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9661
+//line postgres.y:9686
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36509,7 +36534,7 @@ yydefault:
 	case 2406:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9672
+//line postgres.y:9697
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36524,7 +36549,7 @@ yydefault:
 	case 2407:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9683
+//line postgres.y:9708
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36539,7 +36564,7 @@ yydefault:
 	case 2408:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9694
+//line postgres.y:9719
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36554,7 +36579,7 @@ yydefault:
 	case 2409:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9705
+//line postgres.y:9730
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36569,7 +36594,7 @@ yydefault:
 	case 2410:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9716
+//line postgres.y:9741
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36584,7 +36609,7 @@ yydefault:
 	case 2411:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9727
+//line postgres.y:9752
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36599,7 +36624,7 @@ yydefault:
 	case 2412:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9738
+//line postgres.y:9763
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36614,7 +36639,7 @@ yydefault:
 	case 2413:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9749
+//line postgres.y:9774
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36629,7 +36654,7 @@ yydefault:
 	case 2414:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9760
+//line postgres.y:9785
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36644,7 +36669,7 @@ yydefault:
 	case 2415:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9771
+//line postgres.y:9796
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36659,7 +36684,7 @@ yydefault:
 	case 2416:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9782
+//line postgres.y:9807
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36674,7 +36699,7 @@ yydefault:
 	case 2417:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9793
+//line postgres.y:9818
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36689,7 +36714,7 @@ yydefault:
 	case 2418:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9804
+//line postgres.y:9829
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36706,7 +36731,7 @@ yydefault:
 	case 2419:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9817
+//line postgres.y:9842
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36723,7 +36748,7 @@ yydefault:
 	case 2420:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9830
+//line postgres.y:9855
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36740,7 +36765,7 @@ yydefault:
 	case 2421:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9843
+//line postgres.y:9868
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36757,7 +36782,7 @@ yydefault:
 	case 2422:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9856
+//line postgres.y:9881
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36774,7 +36799,7 @@ yydefault:
 	case 2423:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9869
+//line postgres.y:9894
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36791,7 +36816,7 @@ yydefault:
 	case 2424:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9882
+//line postgres.y:9907
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36807,7 +36832,7 @@ yydefault:
 	case 2425:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9894
+//line postgres.y:9919
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36823,7 +36848,7 @@ yydefault:
 	case 2426:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9906
+//line postgres.y:9931
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36840,7 +36865,7 @@ yydefault:
 	case 2427:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9919
+//line postgres.y:9944
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36857,7 +36882,7 @@ yydefault:
 	case 2428:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9932
+//line postgres.y:9957
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36873,7 +36898,7 @@ yydefault:
 	case 2429:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9944
+//line postgres.y:9969
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36889,7 +36914,7 @@ yydefault:
 	case 2430:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9956
+//line postgres.y:9981
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36904,7 +36929,7 @@ yydefault:
 	case 2431:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9967
+//line postgres.y:9992
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36919,7 +36944,7 @@ yydefault:
 	case 2432:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9978
+//line postgres.y:10003
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36934,7 +36959,7 @@ yydefault:
 	case 2433:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9989
+//line postgres.y:10014
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36949,7 +36974,7 @@ yydefault:
 	case 2434:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10000
+//line postgres.y:10025
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36964,7 +36989,7 @@ yydefault:
 	case 2435:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10011
+//line postgres.y:10036
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36979,7 +37004,7 @@ yydefault:
 	case 2436:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10022
+//line postgres.y:10047
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36994,7 +37019,7 @@ yydefault:
 	case 2437:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10033
+//line postgres.y:10058
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37009,7 +37034,7 @@ yydefault:
 	case 2438:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10044
+//line postgres.y:10069
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37024,7 +37049,7 @@ yydefault:
 	case 2439:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10055
+//line postgres.y:10080
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37039,7 +37064,7 @@ yydefault:
 	case 2440:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10066
+//line postgres.y:10091
 		{
 			rv, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -37060,13 +37085,13 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2441:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:10092
+//line postgres.y:10117
 		{
 			yyVAL.ival = 0
 		}
 	case 2442:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10094
+//line postgres.y:10119
 		{
 			// Combine constraint attribute bits
 			newspec := yyDollar[1].ival | yyDollar[2].ival
@@ -37080,44 +37105,44 @@ yydefault:
 		}
 	case 2443:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10108
+//line postgres.y:10133
 		{
 			yyVAL.ival = ast.CAS_NOT_DEFERRABLE
 		}
 	case 2444:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10109
+//line postgres.y:10134
 		{
 			yyVAL.ival = ast.CAS_DEFERRABLE
 		}
 	case 2445:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10110
+//line postgres.y:10135
 		{
 			yyVAL.ival = ast.CAS_INITIALLY_IMMEDIATE
 		}
 	case 2446:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10111
+//line postgres.y:10136
 		{
 			yyVAL.ival = ast.CAS_INITIALLY_DEFERRED
 		}
 	case 2447:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10112
+//line postgres.y:10137
 		{
 			yyVAL.ival = ast.CAS_NOT_VALID
 		}
 	case 2448:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10113
+//line postgres.y:10138
 		{
 			yyVAL.ival = ast.CAS_NO_INHERIT
 		}
 	case 2449:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10117
+//line postgres.y:10142
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37125,7 +37150,7 @@ yydefault:
 	case 2450:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10122
+//line postgres.y:10147
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -37134,7 +37159,7 @@ yydefault:
 	case 2451:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10127
+//line postgres.y:10152
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37143,7 +37168,7 @@ yydefault:
 	case 2452:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10135
+//line postgres.y:10160
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -37151,7 +37176,7 @@ yydefault:
 	case 2453:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10139
+//line postgres.y:10164
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -37159,7 +37184,7 @@ yydefault:
 	case 2454:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10143
+//line postgres.y:10168
 		{
 			yyLOCAL = ast.NewDefElemExtended(yyDollar[1].str, yyDollar[3].str, yyDollar[5].nodeUnion(), ast.DEFELEM_UNSPEC)
 		}
@@ -37167,7 +37192,7 @@ yydefault:
 	case 2455:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10147
+//line postgres.y:10172
 		{
 			yyLOCAL = ast.NewDefElemExtended(yyDollar[1].str, yyDollar[3].str, nil, ast.DEFELEM_UNSPEC)
 		}
@@ -37175,7 +37200,7 @@ yydefault:
 	case 2456:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10161
+//line postgres.y:10186
 		{
 			stmt := &ast.CreateFunctionStmt{
 				IsProcedure: false,
@@ -37192,7 +37217,7 @@ yydefault:
 	case 2457:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10175
+//line postgres.y:10200
 		{
 			// Handle RETURNS TABLE variant - merge table columns into parameters
 			// and create a RECORD return type, matching PostgreSQL's approach
@@ -37211,7 +37236,7 @@ yydefault:
 	case 2458:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10191
+//line postgres.y:10216
 		{
 			// No explicit return type (for procedures disguised as functions)
 			stmt := &ast.CreateFunctionStmt{
@@ -37229,7 +37254,7 @@ yydefault:
 	case 2459:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10206
+//line postgres.y:10231
 		{
 			stmt := &ast.CreateFunctionStmt{
 				IsProcedure: true,
@@ -37246,7 +37271,7 @@ yydefault:
 	case 2460:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10221
+//line postgres.y:10246
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37254,7 +37279,7 @@ yydefault:
 	case 2461:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10222
+//line postgres.y:10247
 		{
 			yyLOCAL = nil
 		}
@@ -37262,7 +37287,7 @@ yydefault:
 	case 2462:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10227
+//line postgres.y:10252
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].funparamUnion())
 		}
@@ -37270,7 +37295,7 @@ yydefault:
 	case 2463:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10231
+//line postgres.y:10256
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].funparamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37279,7 +37304,7 @@ yydefault:
 	case 2464:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10239
+//line postgres.y:10264
 		{
 			yyLOCAL = yyDollar[1].funparamUnion()
 		}
@@ -37287,7 +37312,7 @@ yydefault:
 	case 2465:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10243
+//line postgres.y:10268
 		{
 			yyDollar[1].funparamUnion().DefExpr = yyDollar[3].nodeUnion()
 			yyLOCAL = yyDollar[1].funparamUnion()
@@ -37296,7 +37321,7 @@ yydefault:
 	case 2466:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10248
+//line postgres.y:10273
 		{
 			yyDollar[1].funparamUnion().DefExpr = yyDollar[3].nodeUnion()
 			yyLOCAL = yyDollar[1].funparamUnion()
@@ -37305,7 +37330,7 @@ yydefault:
 	case 2467:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10256
+//line postgres.y:10281
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[1].funparammodeUnion(),
@@ -37318,7 +37343,7 @@ yydefault:
 	case 2468:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10265
+//line postgres.y:10290
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[2].funparammodeUnion(),
@@ -37331,7 +37356,7 @@ yydefault:
 	case 2469:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10274
+//line postgres.y:10299
 		{
 			param := &ast.FunctionParameter{
 				Mode:    ast.FUNC_PARAM_DEFAULT,
@@ -37344,7 +37369,7 @@ yydefault:
 	case 2470:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10283
+//line postgres.y:10308
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[1].funparammodeUnion(),
@@ -37357,7 +37382,7 @@ yydefault:
 	case 2471:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10292
+//line postgres.y:10317
 		{
 			param := &ast.FunctionParameter{
 				Mode:    ast.FUNC_PARAM_DEFAULT,
@@ -37370,7 +37395,7 @@ yydefault:
 	case 2472:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10303
+//line postgres.y:10328
 		{
 			yyLOCAL = ast.FUNC_PARAM_IN
 		}
@@ -37378,7 +37403,7 @@ yydefault:
 	case 2473:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10304
+//line postgres.y:10329
 		{
 			yyLOCAL = ast.FUNC_PARAM_OUT
 		}
@@ -37386,7 +37411,7 @@ yydefault:
 	case 2474:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10305
+//line postgres.y:10330
 		{
 			yyLOCAL = ast.FUNC_PARAM_INOUT
 		}
@@ -37394,7 +37419,7 @@ yydefault:
 	case 2475:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10306
+//line postgres.y:10331
 		{
 			yyLOCAL = ast.FUNC_PARAM_INOUT
 		}
@@ -37402,7 +37427,7 @@ yydefault:
 	case 2476:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10307
+//line postgres.y:10332
 		{
 			yyLOCAL = ast.FUNC_PARAM_VARIADIC
 		}
@@ -37410,7 +37435,7 @@ yydefault:
 	case 2477:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10311
+//line postgres.y:10336
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -37418,7 +37443,7 @@ yydefault:
 	case 2478:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10315
+//line postgres.y:10340
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -37426,7 +37451,7 @@ yydefault:
 	case 2479:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10317
+//line postgres.y:10342
 		{
 			// Handle %TYPE reference
 			list := ast.NewNodeList()
@@ -37445,7 +37470,7 @@ yydefault:
 	case 2480:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10332
+//line postgres.y:10357
 		{
 			// Handle SETOF %TYPE reference
 			list := ast.NewNodeList()
@@ -37465,7 +37490,7 @@ yydefault:
 	case 2481:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10350
+//line postgres.y:10375
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -37473,7 +37498,7 @@ yydefault:
 	case 2482:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10351
+//line postgres.y:10376
 		{
 			yyLOCAL = nil
 		}
@@ -37481,7 +37506,7 @@ yydefault:
 	case 2483:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10356
+//line postgres.y:10381
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].defeltUnion())
@@ -37491,7 +37516,7 @@ yydefault:
 	case 2484:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10362
+//line postgres.y:10387
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37500,7 +37525,7 @@ yydefault:
 	case 2485:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10370
+//line postgres.y:10395
 		{
 			yyLOCAL = ast.NewDefElem("as", yyDollar[2].nodeUnion())
 		}
@@ -37508,7 +37533,7 @@ yydefault:
 	case 2486:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10374
+//line postgres.y:10399
 		{
 			yyLOCAL = ast.NewDefElem("language", ast.NewString(yyDollar[2].str))
 		}
@@ -37516,7 +37541,7 @@ yydefault:
 	case 2487:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10378
+//line postgres.y:10403
 		{
 			yyLOCAL = ast.NewDefElem("transform", yyDollar[2].listUnion())
 		}
@@ -37524,7 +37549,7 @@ yydefault:
 	case 2488:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10382
+//line postgres.y:10407
 		{
 			yyLOCAL = ast.NewDefElem("window", ast.NewBoolean(true))
 		}
@@ -37532,7 +37557,7 @@ yydefault:
 	case 2489:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10386
+//line postgres.y:10411
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -37540,7 +37565,7 @@ yydefault:
 	case 2490:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10393
+//line postgres.y:10418
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewString(yyDollar[1].str))
@@ -37550,7 +37575,7 @@ yydefault:
 	case 2491:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10399
+//line postgres.y:10424
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewString(yyDollar[1].str))
@@ -37561,7 +37586,7 @@ yydefault:
 	case 2492:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10409
+//line postgres.y:10434
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[3].typnamUnion())
@@ -37571,7 +37596,7 @@ yydefault:
 	case 2493:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10415
+//line postgres.y:10440
 		{
 			yyDollar[1].listUnion().Append(yyDollar[5].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37580,7 +37605,7 @@ yydefault:
 	case 2494:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10423
+//line postgres.y:10448
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37588,7 +37613,7 @@ yydefault:
 	case 2495:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10427
+//line postgres.y:10452
 		{
 			/*
 			 * A compound statement is stored as a single-item list
@@ -37604,7 +37629,7 @@ yydefault:
 	case 2496:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10439
+//line postgres.y:10464
 		{
 			yyLOCAL = nil
 		}
@@ -37612,7 +37637,7 @@ yydefault:
 	case 2497:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10446
+//line postgres.y:10471
 		{
 			yyLOCAL = ast.NewReturnStmt(yyDollar[2].nodeUnion())
 		}
@@ -37620,7 +37645,7 @@ yydefault:
 	case 2498:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10453
+//line postgres.y:10478
 		{
 			/* As in stmtmulti, discard empty statements */
 			if yyDollar[2].stmtUnion() != nil {
@@ -37634,7 +37659,7 @@ yydefault:
 	case 2499:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10463
+//line postgres.y:10488
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -37642,7 +37667,7 @@ yydefault:
 	case 2500:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10469
+//line postgres.y:10494
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37650,7 +37675,7 @@ yydefault:
 	case 2501:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10470
+//line postgres.y:10495
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37658,7 +37683,7 @@ yydefault:
 	case 2502:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:10475
+//line postgres.y:10500
 		{
 			yyLOCAL = yyDollar[2].vsetstmtUnion()
 		}
@@ -37666,7 +37691,7 @@ yydefault:
 	case 2503:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:10479
+//line postgres.y:10504
 		{
 			yyLOCAL = yyDollar[1].stmtUnion().(*ast.VariableSetStmt)
 		}
@@ -37674,7 +37699,7 @@ yydefault:
 	case 2504:
 		yyDollar = yyS[yypt-17 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10495
+//line postgres.y:10520
 		{
 			// Extract events and columns from TriggerEvents list [events, columns]
 			eventsList := yyDollar[6].listUnion()
@@ -37707,7 +37732,7 @@ yydefault:
 	case 2505:
 		yyDollar = yyS[yypt-21 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10527
+//line postgres.y:10552
 		{
 			// Extract events and columns from TriggerEvents list [events, columns]
 			eventsList := yyDollar[7].listUnion()
@@ -37739,26 +37764,26 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2506:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10558
+//line postgres.y:10583
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_BEFORE
 		}
 	case 2507:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10559
+//line postgres.y:10584
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_AFTER
 		}
 	case 2508:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10560
+//line postgres.y:10585
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_INSTEAD
 		}
 	case 2509:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10565
+//line postgres.y:10590
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -37766,7 +37791,7 @@ yydefault:
 	case 2510:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10567
+//line postgres.y:10592
 		{
 			// Extract event types and column lists from both sides
 			events1 := yyDollar[1].listUnion().Items[0].(*ast.Integer).IVal
@@ -37807,7 +37832,7 @@ yydefault:
 	case 2511:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10607
+//line postgres.y:10632
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_INSERT)))
@@ -37818,7 +37843,7 @@ yydefault:
 	case 2512:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10614
+//line postgres.y:10639
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_DELETE)))
@@ -37829,7 +37854,7 @@ yydefault:
 	case 2513:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10621
+//line postgres.y:10646
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_UPDATE)))
@@ -37840,7 +37865,7 @@ yydefault:
 	case 2514:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10628
+//line postgres.y:10653
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_UPDATE)))
@@ -37851,7 +37876,7 @@ yydefault:
 	case 2515:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10635
+//line postgres.y:10660
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_TRUNCATE)))
@@ -37862,7 +37887,7 @@ yydefault:
 	case 2516:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10644
+//line postgres.y:10669
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37870,7 +37895,7 @@ yydefault:
 	case 2517:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10645
+//line postgres.y:10670
 		{
 			yyLOCAL = nil
 		}
@@ -37878,7 +37903,7 @@ yydefault:
 	case 2518:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10649
+//line postgres.y:10674
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -37888,7 +37913,7 @@ yydefault:
 	case 2519:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10654
+//line postgres.y:10679
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37897,7 +37922,7 @@ yydefault:
 	case 2520:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10662
+//line postgres.y:10687
 		{
 			trans := &ast.TriggerTransition{
 				Name:    yyDollar[4].str,
@@ -37910,7 +37935,7 @@ yydefault:
 	case 2521:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10673
+//line postgres.y:10698
 		{
 			yyLOCAL = true
 		}
@@ -37918,7 +37943,7 @@ yydefault:
 	case 2522:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10674
+//line postgres.y:10699
 		{
 			yyLOCAL = false
 		}
@@ -37926,7 +37951,7 @@ yydefault:
 	case 2523:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10678
+//line postgres.y:10703
 		{
 			yyLOCAL = true
 		}
@@ -37934,21 +37959,21 @@ yydefault:
 	case 2524:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10679
+//line postgres.y:10704
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 2525:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10683
+//line postgres.y:10708
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2526:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10688
+//line postgres.y:10713
 		{
 			yyLOCAL = yyDollar[3].bvalUnion()
 		}
@@ -37956,7 +37981,7 @@ yydefault:
 	case 2527:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10692
+//line postgres.y:10717
 		{
 			// If ROW/STATEMENT not specified, default to STATEMENT
 			yyLOCAL = false
@@ -37965,7 +37990,7 @@ yydefault:
 	case 2530:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10704
+//line postgres.y:10729
 		{
 			yyLOCAL = true
 		}
@@ -37973,7 +37998,7 @@ yydefault:
 	case 2531:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10705
+//line postgres.y:10730
 		{
 			yyLOCAL = false
 		}
@@ -37981,7 +38006,7 @@ yydefault:
 	case 2532:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10709
+//line postgres.y:10734
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -37989,7 +38014,7 @@ yydefault:
 	case 2533:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10710
+//line postgres.y:10735
 		{
 			yyLOCAL = nil
 		}
@@ -37997,7 +38022,7 @@ yydefault:
 	case 2536:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10719
+//line postgres.y:10744
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -38007,7 +38032,7 @@ yydefault:
 	case 2537:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10724
+//line postgres.y:10749
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -38016,7 +38041,7 @@ yydefault:
 	case 2538:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10728
+//line postgres.y:10753
 		{
 			yyLOCAL = nil
 		}
@@ -38024,7 +38049,7 @@ yydefault:
 	case 2539:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10733
+//line postgres.y:10758
 		{
 			yyLOCAL = ast.NewString(fmt.Sprintf("%d", yyDollar[1].ival))
 		}
@@ -38032,7 +38057,7 @@ yydefault:
 	case 2540:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10736
+//line postgres.y:10761
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38040,7 +38065,7 @@ yydefault:
 	case 2541:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10737
+//line postgres.y:10762
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38048,7 +38073,7 @@ yydefault:
 	case 2542:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10738
+//line postgres.y:10763
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38056,7 +38081,7 @@ yydefault:
 	case 2543:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:10742
+//line postgres.y:10767
 		{
 			yyLOCAL = yyDollar[2].rangevarUnion()
 		}
@@ -38064,7 +38089,7 @@ yydefault:
 	case 2544:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:10743
+//line postgres.y:10768
 		{
 			yyLOCAL = nil
 		}
@@ -38072,7 +38097,7 @@ yydefault:
 	case 2545:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10756
+//line postgres.y:10781
 		{
 			// Apply OptTemp persistence to the view RangeVar
 			view := yyDollar[4].rangevarUnion()
@@ -38091,7 +38116,7 @@ yydefault:
 	case 2546:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10772
+//line postgres.y:10797
 		{
 			// Apply OptTemp persistence to the view RangeVar
 			view := yyDollar[6].rangevarUnion()
@@ -38110,7 +38135,7 @@ yydefault:
 	case 2547:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10788
+//line postgres.y:10813
 		{
 			// RECURSIVE VIEW requires explicit column list
 			view := yyDollar[5].rangevarUnion()
@@ -38129,7 +38154,7 @@ yydefault:
 	case 2548:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10804
+//line postgres.y:10829
 		{
 			// RECURSIVE VIEW requires explicit column list
 			view := yyDollar[7].rangevarUnion()
@@ -38148,7 +38173,7 @@ yydefault:
 	case 2549:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10821
+//line postgres.y:10846
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -38156,39 +38181,39 @@ yydefault:
 	case 2550:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10822
+//line postgres.y:10847
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 2551:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:10826
+//line postgres.y:10851
 		{
 			yyVAL.ival = int(ast.CASCADED_CHECK_OPTION)
 		}
 	case 2552:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:10827
+//line postgres.y:10852
 		{
 			yyVAL.ival = int(ast.CASCADED_CHECK_OPTION)
 		}
 	case 2553:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:10828
+//line postgres.y:10853
 		{
 			yyVAL.ival = int(ast.LOCAL_CHECK_OPTION)
 		}
 	case 2554:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:10829
+//line postgres.y:10854
 		{
 			yyVAL.ival = int(ast.NO_CHECK_OPTION)
 		}
 	case 2555:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10840
+//line postgres.y:10865
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[3].str, false)
 			n.Authrole = yyDollar[5].rolespecUnion()
@@ -38199,7 +38224,7 @@ yydefault:
 	case 2556:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10847
+//line postgres.y:10872
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[3].str, false)
 			n.Authrole = nil
@@ -38210,7 +38235,7 @@ yydefault:
 	case 2557:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10854
+//line postgres.y:10879
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[6].str, true)
 			n.Authrole = yyDollar[8].rolespecUnion()
@@ -38221,7 +38246,7 @@ yydefault:
 	case 2558:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10861
+//line postgres.y:10886
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[6].str, true)
 			n.Authrole = nil
@@ -38232,7 +38257,7 @@ yydefault:
 	case 2559:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10877
+//line postgres.y:10902
 		{
 			n := ast.NewCreatedbStmt(yyDollar[3].str, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38241,7 +38266,7 @@ yydefault:
 	case 2560:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10890
+//line postgres.y:10915
 		{
 			n := ast.NewDropdbStmt(yyDollar[3].str, false, nil)
 			yyLOCAL = n
@@ -38250,7 +38275,7 @@ yydefault:
 	case 2561:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10895
+//line postgres.y:10920
 		{
 			n := ast.NewDropdbStmt(yyDollar[5].str, true, nil)
 			yyLOCAL = n
@@ -38259,7 +38284,7 @@ yydefault:
 	case 2562:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10900
+//line postgres.y:10925
 		{
 			n := ast.NewDropdbStmt(yyDollar[3].str, false, yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -38268,7 +38293,7 @@ yydefault:
 	case 2563:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10905
+//line postgres.y:10930
 		{
 			n := ast.NewDropdbStmt(yyDollar[5].str, true, yyDollar[8].listUnion())
 			yyLOCAL = n
@@ -38277,7 +38302,7 @@ yydefault:
 	case 2564:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10912
+//line postgres.y:10937
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -38285,7 +38310,7 @@ yydefault:
 	case 2565:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10913
+//line postgres.y:10938
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Append(yyDollar[3].defeltUnion())
@@ -38294,7 +38319,7 @@ yydefault:
 	case 2566:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10917
+//line postgres.y:10942
 		{
 			yyLOCAL = ast.NewDefElem("force", nil)
 		}
@@ -38302,7 +38327,7 @@ yydefault:
 	case 2567:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10927
+//line postgres.y:10952
 		{
 			n := ast.NewDropTableSpaceStmt(yyDollar[3].str, false)
 			yyLOCAL = n
@@ -38311,7 +38336,7 @@ yydefault:
 	case 2568:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10932
+//line postgres.y:10957
 		{
 			n := ast.NewDropTableSpaceStmt(yyDollar[5].str, true)
 			yyLOCAL = n
@@ -38320,7 +38345,7 @@ yydefault:
 	case 2569:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10946
+//line postgres.y:10971
 		{
 			n := ast.NewDropOwnedStmt(yyDollar[4].listUnion(), yyDollar[5].dropBehavUnion())
 			yyLOCAL = n
@@ -38329,7 +38354,7 @@ yydefault:
 	case 2570:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10954
+//line postgres.y:10979
 		{
 			n := ast.NewReassignOwnedStmt(yyDollar[4].listUnion(), yyDollar[6].rolespecUnion())
 			yyLOCAL = n
@@ -38338,7 +38363,7 @@ yydefault:
 	case 2571:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10968
+//line postgres.y:10993
 		{
 			n := ast.NewCreateDomainStmt(yyDollar[3].listUnion(), yyDollar[5].typnamUnion())
 			// Use SplitColQualList to separate constraints and collate clause
@@ -38351,7 +38376,7 @@ yydefault:
 	case 2572:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10986
+//line postgres.y:11011
 		{
 			n := ast.NewAlterDomainStmt('T', yyDollar[3].listUnion())
 			n.Def = yyDollar[4].nodeUnion()
@@ -38361,7 +38386,7 @@ yydefault:
 	case 2573:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10992
+//line postgres.y:11017
 		{
 			n := ast.NewAlterDomainStmt('N', yyDollar[3].listUnion())
 			yyLOCAL = n
@@ -38370,7 +38395,7 @@ yydefault:
 	case 2574:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10997
+//line postgres.y:11022
 		{
 			n := ast.NewAlterDomainStmt('O', yyDollar[3].listUnion())
 			yyLOCAL = n
@@ -38379,7 +38404,7 @@ yydefault:
 	case 2575:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11002
+//line postgres.y:11027
 		{
 			n := ast.NewAlterDomainStmt('C', yyDollar[3].listUnion())
 			n.Def = yyDollar[5].nodeUnion()
@@ -38389,7 +38414,7 @@ yydefault:
 	case 2576:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11008
+//line postgres.y:11033
 		{
 			n := ast.NewAlterDomainStmt('X', yyDollar[3].listUnion())
 			n.Name = yyDollar[6].str
@@ -38401,7 +38426,7 @@ yydefault:
 	case 2577:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11016
+//line postgres.y:11041
 		{
 			n := ast.NewAlterDomainStmt('X', yyDollar[3].listUnion())
 			n.Name = yyDollar[8].str
@@ -38413,7 +38438,7 @@ yydefault:
 	case 2578:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11024
+//line postgres.y:11049
 		{
 			n := ast.NewAlterDomainStmt('V', yyDollar[3].listUnion())
 			n.Name = yyDollar[6].str
@@ -38423,7 +38448,7 @@ yydefault:
 	case 2579:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11039
+//line postgres.y:11064
 		{
 			// Store the full aggr_args result [args, position_indicator] for proper deparsing
 			n := ast.NewDefineStmt(ast.OBJECT_AGGREGATE, false, yyDollar[4].listUnion(), yyDollar[5].listUnion(), yyDollar[6].listUnion(), false, yyDollar[2].bvalUnion())
@@ -38433,7 +38458,7 @@ yydefault:
 	case 2580:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11045
+//line postgres.y:11070
 		{
 			// old-style (pre-8.2) syntax for CREATE AGGREGATE
 			n := ast.NewDefineStmt(ast.OBJECT_AGGREGATE, true, yyDollar[4].listUnion(), nil, yyDollar[5].listUnion(), false, yyDollar[2].bvalUnion())
@@ -38443,7 +38468,7 @@ yydefault:
 	case 2581:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11051
+//line postgres.y:11076
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_OPERATOR, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38452,7 +38477,7 @@ yydefault:
 	case 2582:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11056
+//line postgres.y:11081
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TYPE, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38461,7 +38486,7 @@ yydefault:
 	case 2583:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11061
+//line postgres.y:11086
 		{
 			// Shell type (identified by lack of definition)
 			n := ast.NewDefineStmt(ast.OBJECT_TYPE, false, yyDollar[3].listUnion(), nil, nil, false, false)
@@ -38471,7 +38496,7 @@ yydefault:
 	case 2584:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11067
+//line postgres.y:11092
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSPARSER, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38480,7 +38505,7 @@ yydefault:
 	case 2585:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11072
+//line postgres.y:11097
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSDICTIONARY, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38489,7 +38514,7 @@ yydefault:
 	case 2586:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11077
+//line postgres.y:11102
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSTEMPLATE, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38498,7 +38523,7 @@ yydefault:
 	case 2587:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11082
+//line postgres.y:11107
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSCONFIGURATION, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38507,7 +38532,7 @@ yydefault:
 	case 2588:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11087
+//line postgres.y:11112
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38516,7 +38541,7 @@ yydefault:
 	case 2589:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11092
+//line postgres.y:11117
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[6].listUnion(), nil, yyDollar[7].listUnion(), true, false)
 			yyLOCAL = n
@@ -38525,7 +38550,7 @@ yydefault:
 	case 2590:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11097
+//line postgres.y:11122
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[3].listUnion(), nil, ast.NewNodeList(yyDollar[5].listUnion()), false, false)
 			yyLOCAL = n
@@ -38534,7 +38559,7 @@ yydefault:
 	case 2591:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11102
+//line postgres.y:11127
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[6].listUnion(), nil, ast.NewNodeList(yyDollar[8].listUnion()), true, false)
 			yyLOCAL = n
@@ -38543,7 +38568,7 @@ yydefault:
 	case 2592:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11107
+//line postgres.y:11132
 		{
 			typevar, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -38558,7 +38583,7 @@ yydefault:
 	case 2593:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11118
+//line postgres.y:11143
 		{
 			n := ast.NewCreateEnumStmt(yyDollar[3].listUnion(), yyDollar[7].listUnion())
 			yyLOCAL = n
@@ -38567,7 +38592,7 @@ yydefault:
 	case 2594:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11123
+//line postgres.y:11148
 		{
 			n := ast.NewCreateRangeStmt(yyDollar[3].listUnion(), yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -38576,7 +38601,7 @@ yydefault:
 	case 2595:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11137
+//line postgres.y:11162
 		{
 			n := ast.NewCreateSeqStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion(), 0, false, false)
 			yyLOCAL = n
@@ -38585,7 +38610,7 @@ yydefault:
 	case 2596:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11142
+//line postgres.y:11167
 		{
 			n := ast.NewCreateSeqStmt(yyDollar[7].rangevarUnion(), yyDollar[8].listUnion(), 0, false, true)
 			yyLOCAL = n
@@ -38594,7 +38619,7 @@ yydefault:
 	case 2597:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11149
+//line postgres.y:11174
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -38602,7 +38627,7 @@ yydefault:
 	case 2598:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11150
+//line postgres.y:11175
 		{
 			yyLOCAL = nil
 		}
@@ -38610,7 +38635,7 @@ yydefault:
 	case 2599:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11161
+//line postgres.y:11186
 		{
 			yyLOCAL = ast.NewAlterSeqStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion(), false, false)
 		}
@@ -38618,7 +38643,7 @@ yydefault:
 	case 2600:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11165
+//line postgres.y:11190
 		{
 			yyLOCAL = ast.NewAlterSeqStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion(), false, true)
 		}
@@ -38626,7 +38651,7 @@ yydefault:
 	case 2601:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11178
+//line postgres.y:11203
 		{
 			n := ast.NewCreateExtensionStmt(yyDollar[3].str, false, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38635,7 +38660,7 @@ yydefault:
 	case 2602:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11183
+//line postgres.y:11208
 		{
 			n := ast.NewCreateExtensionStmt(yyDollar[6].str, true, yyDollar[8].listUnion())
 			yyLOCAL = n
@@ -38644,7 +38669,7 @@ yydefault:
 	case 2603:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11191
+//line postgres.y:11216
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].defeltUnion())
@@ -38657,7 +38682,7 @@ yydefault:
 	case 2604:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11200
+//line postgres.y:11225
 		{
 			yyLOCAL = nil
 		}
@@ -38665,7 +38690,7 @@ yydefault:
 	case 2605:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11207
+//line postgres.y:11232
 		{
 			yyLOCAL = ast.NewDefElem("schema", ast.NewString(yyDollar[2].str))
 		}
@@ -38673,14 +38698,14 @@ yydefault:
 	case 2606:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11211
+//line postgres.y:11236
 		{
 			yyLOCAL = ast.NewDefElem("version", ast.NewString(yyDollar[2].str))
 		}
 		yyVAL.union = yyLOCAL
 	case 2607:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11215
+//line postgres.y:11240
 		{
 			yylex.Error("CREATE EXTENSION ... FROM is no longer supported")
 			return 1
@@ -38688,7 +38713,7 @@ yydefault:
 	case 2608:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11220
+//line postgres.y:11245
 		{
 			yyLOCAL = ast.NewDefElem("cascade", ast.NewBoolean(true))
 		}
@@ -38696,7 +38721,7 @@ yydefault:
 	case 2609:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11233
+//line postgres.y:11258
 		{
 			n := ast.NewAlterExtensionStmt(yyDollar[3].str, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38705,7 +38730,7 @@ yydefault:
 	case 2610:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11241
+//line postgres.y:11266
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].defeltUnion())
@@ -38718,7 +38743,7 @@ yydefault:
 	case 2611:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11250
+//line postgres.y:11275
 		{
 			yyLOCAL = nil
 		}
@@ -38726,7 +38751,7 @@ yydefault:
 	case 2612:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11257
+//line postgres.y:11282
 		{
 			yyLOCAL = ast.NewDefElem("to", ast.NewString(yyDollar[2].str))
 		}
@@ -38734,7 +38759,7 @@ yydefault:
 	case 2613:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11270
+//line postgres.y:11295
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(yyDollar[5].objTypeUnion()), ast.NewString(yyDollar[6].str))
 		}
@@ -38742,7 +38767,7 @@ yydefault:
 	case 2614:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11274
+//line postgres.y:11299
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(yyDollar[5].objTypeUnion()), yyDollar[6].listUnion())
 		}
@@ -38750,7 +38775,7 @@ yydefault:
 	case 2615:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11278
+//line postgres.y:11303
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_AGGREGATE), yyDollar[6].objwithargsUnion())
 		}
@@ -38758,7 +38783,7 @@ yydefault:
 	case 2616:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11282
+//line postgres.y:11307
 		{
 			// CAST takes two TypeNames as a NodeList
 			list := ast.NewNodeList(yyDollar[7].typnamUnion())
@@ -38769,7 +38794,7 @@ yydefault:
 	case 2617:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11289
+//line postgres.y:11314
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_DOMAIN), yyDollar[6].typnamUnion())
 		}
@@ -38777,7 +38802,7 @@ yydefault:
 	case 2618:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11293
+//line postgres.y:11318
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_FUNCTION), yyDollar[6].objwithargsUnion())
 		}
@@ -38785,7 +38810,7 @@ yydefault:
 	case 2619:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11297
+//line postgres.y:11322
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_OPERATOR), yyDollar[6].objwithargsUnion())
 		}
@@ -38793,7 +38818,7 @@ yydefault:
 	case 2620:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11301
+//line postgres.y:11326
 		{
 			// OPERATOR CLASS takes method name + class name as NodeList
 			list := ast.NewNodeList(ast.NewString(yyDollar[9].str)) // method first
@@ -38806,7 +38831,7 @@ yydefault:
 	case 2621:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11310
+//line postgres.y:11335
 		{
 			// OPERATOR FAMILY takes method name + family name as NodeList
 			list := ast.NewNodeList(ast.NewString(yyDollar[9].str)) // method first
@@ -38819,7 +38844,7 @@ yydefault:
 	case 2622:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11319
+//line postgres.y:11344
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_PROCEDURE), yyDollar[6].objwithargsUnion())
 		}
@@ -38827,7 +38852,7 @@ yydefault:
 	case 2623:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11323
+//line postgres.y:11348
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_ROUTINE), yyDollar[6].objwithargsUnion())
 		}
@@ -38835,7 +38860,7 @@ yydefault:
 	case 2624:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11327
+//line postgres.y:11352
 		{
 			list := ast.NewNodeList(yyDollar[7].typnamUnion(), ast.NewString(yyDollar[9].str))
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_TRANSFORM), list)
@@ -38844,7 +38869,7 @@ yydefault:
 	case 2625:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11332
+//line postgres.y:11357
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_TYPE), yyDollar[6].typnamUnion())
 		}
@@ -38852,7 +38877,7 @@ yydefault:
 	case 2626:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11344
+//line postgres.y:11369
 		{
 			yyLOCAL = ast.NewCreateFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -38860,7 +38885,7 @@ yydefault:
 	case 2627:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11350
+//line postgres.y:11375
 		{
 			yyLOCAL = ast.NewAlterFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -38868,7 +38893,7 @@ yydefault:
 	case 2628:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11354
+//line postgres.y:11379
 		{
 			yyLOCAL = ast.NewAlterFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), nil)
 		}
@@ -38876,7 +38901,7 @@ yydefault:
 	case 2629:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11360
+//line postgres.y:11385
 		{
 			yyLOCAL = ast.NewDefElem("handler", yyDollar[2].listUnion())
 		}
@@ -38884,7 +38909,7 @@ yydefault:
 	case 2630:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11361
+//line postgres.y:11386
 		{
 			yyLOCAL = ast.NewDefElem("handler", nil)
 		}
@@ -38892,7 +38917,7 @@ yydefault:
 	case 2631:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11362
+//line postgres.y:11387
 		{
 			yyLOCAL = ast.NewDefElem("validator", yyDollar[2].listUnion())
 		}
@@ -38900,7 +38925,7 @@ yydefault:
 	case 2632:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11363
+//line postgres.y:11388
 		{
 			yyLOCAL = ast.NewDefElem("validator", nil)
 		}
@@ -38908,7 +38933,7 @@ yydefault:
 	case 2633:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11367
+//line postgres.y:11392
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -38916,7 +38941,7 @@ yydefault:
 	case 2634:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11368
+//line postgres.y:11393
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -38925,7 +38950,7 @@ yydefault:
 	case 2635:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11372
+//line postgres.y:11397
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -38933,7 +38958,7 @@ yydefault:
 	case 2636:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11373
+//line postgres.y:11398
 		{
 			yyLOCAL = nil
 		}
@@ -38941,7 +38966,7 @@ yydefault:
 	case 2637:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11377
+//line postgres.y:11402
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -38949,7 +38974,7 @@ yydefault:
 	case 2638:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11378
+//line postgres.y:11403
 		{
 			result := ast.NewNodeList(ast.NewString(yyDollar[1].str))
 			for _, item := range yyDollar[2].listUnion().Items {
@@ -38961,7 +38986,7 @@ yydefault:
 	case 2639:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11395
+//line postgres.y:11420
 		{
 			yyLOCAL = ast.NewCreateForeignServerStmt(yyDollar[3].str, yyDollar[4].str, yyDollar[5].str, yyDollar[9].str, yyDollar[10].listUnion(), false)
 		}
@@ -38969,7 +38994,7 @@ yydefault:
 	case 2640:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11400
+//line postgres.y:11425
 		{
 			yyLOCAL = ast.NewCreateForeignServerStmt(yyDollar[6].str, yyDollar[7].str, yyDollar[8].str, yyDollar[12].str, yyDollar[13].listUnion(), true)
 		}
@@ -38977,7 +39002,7 @@ yydefault:
 	case 2641:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11406
+//line postgres.y:11431
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, yyDollar[4].str, yyDollar[5].listUnion(), true)
 		}
@@ -38985,7 +39010,7 @@ yydefault:
 	case 2642:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11410
+//line postgres.y:11435
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, yyDollar[4].str, nil, true)
 		}
@@ -38993,51 +39018,51 @@ yydefault:
 	case 2643:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11414
+//line postgres.y:11439
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, "", yyDollar[4].listUnion(), false)
 		}
 		yyVAL.union = yyLOCAL
 	case 2644:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11420
+//line postgres.y:11445
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2645:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:11421
+//line postgres.y:11446
 		{
 			yyVAL.str = ""
 		}
 	case 2646:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11425
+//line postgres.y:11450
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2647:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11426
+//line postgres.y:11451
 		{
 			yyVAL.str = ""
 		}
 	case 2648:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:11430
+//line postgres.y:11455
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2649:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:11431
+//line postgres.y:11456
 		{
 			yyVAL.str = ""
 		}
 	case 2650:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11444
+//line postgres.y:11469
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[4].rangevarUnion(), yyDollar[6].listUnion(), yyDollar[8].listUnion(), yyDollar[10].str, yyDollar[11].listUnion(), nil, false)
 		}
@@ -39045,7 +39070,7 @@ yydefault:
 	case 2651:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11450
+//line postgres.y:11475
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[7].rangevarUnion(), yyDollar[9].listUnion(), yyDollar[11].listUnion(), yyDollar[13].str, yyDollar[14].listUnion(), nil, true)
 		}
@@ -39053,7 +39078,7 @@ yydefault:
 	case 2652:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11456
+//line postgres.y:11481
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[4].rangevarUnion(), yyDollar[8].listUnion(), ast.NewNodeList(yyDollar[7].rangevarUnion()), yyDollar[11].str, yyDollar[12].listUnion(), yyDollar[9].partboundspecUnion(), false)
 		}
@@ -39061,7 +39086,7 @@ yydefault:
 	case 2653:
 		yyDollar = yyS[yypt-15 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11462
+//line postgres.y:11487
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[7].rangevarUnion(), yyDollar[11].listUnion(), ast.NewNodeList(yyDollar[10].rangevarUnion()), yyDollar[14].str, yyDollar[15].listUnion(), yyDollar[12].partboundspecUnion(), true)
 		}
@@ -39069,7 +39094,7 @@ yydefault:
 	case 2654:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11476
+//line postgres.y:11501
 		{
 			stmt := ast.NewImportForeignSchemaStmt(
 				ast.NewString(yyDollar[8].str),           // server name
@@ -39085,7 +39110,7 @@ yydefault:
 	case 2655:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ImportQual
-//line postgres.y:11491
+//line postgres.y:11516
 		{
 			qual := &ImportQual{
 				typ:        yyDollar[1].importqualtypeUnion(),
@@ -39097,7 +39122,7 @@ yydefault:
 	case 2656:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ImportQual
-//line postgres.y:11499
+//line postgres.y:11524
 		{
 			qual := &ImportQual{
 				typ:        ast.FDW_IMPORT_SCHEMA_ALL,
@@ -39109,7 +39134,7 @@ yydefault:
 	case 2657:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ImportForeignSchemaType
-//line postgres.y:11509
+//line postgres.y:11534
 		{
 			yyLOCAL = ast.FDW_IMPORT_SCHEMA_LIMIT_TO
 		}
@@ -39117,7 +39142,7 @@ yydefault:
 	case 2658:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ImportForeignSchemaType
-//line postgres.y:11510
+//line postgres.y:11535
 		{
 			yyLOCAL = ast.FDW_IMPORT_SCHEMA_EXCEPT
 		}
@@ -39125,7 +39150,7 @@ yydefault:
 	case 2659:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11520
+//line postgres.y:11545
 		{
 			yyLOCAL = ast.NewCreateUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, yyDollar[8].listUnion(), false)
 		}
@@ -39133,7 +39158,7 @@ yydefault:
 	case 2660:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11524
+//line postgres.y:11549
 		{
 			yyLOCAL = ast.NewCreateUserMappingStmt(yyDollar[8].rolespecUnion(), yyDollar[10].str, yyDollar[11].listUnion(), true)
 		}
@@ -39141,7 +39166,7 @@ yydefault:
 	case 2661:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11530
+//line postgres.y:11555
 		{
 			yyLOCAL = ast.NewAlterUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, yyDollar[8].listUnion())
 		}
@@ -39149,7 +39174,7 @@ yydefault:
 	case 2662:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11536
+//line postgres.y:11561
 		{
 			yyLOCAL = ast.NewDropUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, false)
 		}
@@ -39157,7 +39182,7 @@ yydefault:
 	case 2663:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11540
+//line postgres.y:11565
 		{
 			yyLOCAL = ast.NewDropUserMappingStmt(yyDollar[7].rolespecUnion(), yyDollar[9].str, true)
 		}
@@ -39165,7 +39190,7 @@ yydefault:
 	case 2664:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:11546
+//line postgres.y:11571
 		{
 			yyLOCAL = yyDollar[1].rolespecUnion()
 		}
@@ -39173,7 +39198,7 @@ yydefault:
 	case 2665:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:11547
+//line postgres.y:11572
 		{
 			yyLOCAL = ast.NewRoleSpec(ast.ROLESPEC_CURRENT_USER, "")
 		}
@@ -39181,7 +39206,7 @@ yydefault:
 	case 2666:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11552
+//line postgres.y:11577
 		{
 			// For aggregates like COUNT(*)
 			// Return a list with [nil, -1] matching PostgreSQL's list_make2(NIL, makeInteger(-1))
@@ -39191,7 +39216,7 @@ yydefault:
 	case 2667:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11558
+//line postgres.y:11583
 		{
 			// Regular aggregate arguments
 			// Return a list with [args, -1] matching PostgreSQL's list_make2($2, makeInteger(-1))
@@ -39201,7 +39226,7 @@ yydefault:
 	case 2668:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11564
+//line postgres.y:11589
 		{
 			// Ordered-set aggregate without direct arguments
 			// Return a list with [args, 0] matching PostgreSQL's list_make2($4, makeInteger(0))
@@ -39211,7 +39236,7 @@ yydefault:
 	case 2669:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11570
+//line postgres.y:11595
 		{
 			// Hypothetical-set aggregate
 			// This is the only case requiring consistency checking in PostgreSQL
@@ -39226,7 +39251,7 @@ yydefault:
 	case 2670:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11584
+//line postgres.y:11609
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -39234,7 +39259,7 @@ yydefault:
 	case 2671:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11588
+//line postgres.y:11613
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39243,7 +39268,7 @@ yydefault:
 	case 2672:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11596
+//line postgres.y:11621
 		{
 			yyLOCAL = yyDollar[1].funparamUnion()
 		}
@@ -39251,7 +39276,7 @@ yydefault:
 	case 2673:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11603
+//line postgres.y:11628
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -39259,7 +39284,7 @@ yydefault:
 	case 2674:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11610
+//line postgres.y:11635
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -39267,7 +39292,7 @@ yydefault:
 	case 2675:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11614
+//line postgres.y:11639
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39276,7 +39301,7 @@ yydefault:
 	case 2676:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11622
+//line postgres.y:11647
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -39284,7 +39309,7 @@ yydefault:
 	case 2677:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11629
+//line postgres.y:11654
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39296,7 +39321,7 @@ yydefault:
 	case 2678:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11637
+//line postgres.y:11662
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39309,7 +39334,7 @@ yydefault:
 	case 2679:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11646
+//line postgres.y:11671
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39322,7 +39347,7 @@ yydefault:
 	case 2680:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11655
+//line postgres.y:11680
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.OldVal = yyDollar[6].str
@@ -39333,7 +39358,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2681:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line postgres.y:11663
+//line postgres.y:11688
 		{
 			// Following PostgreSQL's approach - DROP VALUE is parsed but not implemented
 			// PostgreSQL throws an error saying "dropping an enum value is not implemented"
@@ -39343,7 +39368,7 @@ yydefault:
 	case 2682:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11679
+//line postgres.y:11704
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -39351,7 +39376,7 @@ yydefault:
 	case 2683:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11681
+//line postgres.y:11706
 		{
 			yyLOCAL = nil
 		}
@@ -39359,7 +39384,7 @@ yydefault:
 	case 2684:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11686
+//line postgres.y:11711
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -39367,7 +39392,7 @@ yydefault:
 	case 2685:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11688
+//line postgres.y:11713
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39376,7 +39401,7 @@ yydefault:
 	case 2686:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11693
+//line postgres.y:11718
 		{
 			if constraint, ok := yyDollar[3].nodeUnion().(*ast.Constraint); ok {
 				constraint.Conname = yyDollar[2].str
@@ -39389,7 +39414,7 @@ yydefault:
 	case 2687:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11702
+//line postgres.y:11727
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39397,7 +39422,7 @@ yydefault:
 	case 2688:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11707
+//line postgres.y:11732
 		{
 			n := ast.NewConstraint(ast.CONSTR_CHECK)
 			n.RawExpr = yyDollar[3].nodeUnion()
@@ -39412,7 +39437,7 @@ yydefault:
 	case 2689:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11718
+//line postgres.y:11743
 		{
 			n := ast.NewConstraint(ast.CONSTR_NOTNULL)
 			// In PostgreSQL, domain NOT NULL constraints have keys = list_make1(makeString("value"))
@@ -39427,7 +39452,7 @@ yydefault:
 	case 2690:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11738
+//line postgres.y:11763
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[7].stmtUnion(), yyDollar[5].intoUnion(), ast.OBJECT_MATVIEW, false, false)
 			/* cram additional flags into the IntoClause */
@@ -39439,7 +39464,7 @@ yydefault:
 	case 2691:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11746
+//line postgres.y:11771
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[10].stmtUnion(), yyDollar[8].intoUnion(), ast.OBJECT_MATVIEW, false, true)
 			/* cram additional flags into the IntoClause */
@@ -39451,7 +39476,7 @@ yydefault:
 	case 2692:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11757
+//line postgres.y:11782
 		{
 			n := ast.NewRefreshMatViewStmt(yyDollar[4].bvalUnion(), !yyDollar[6].bvalUnion(), yyDollar[5].rangevarUnion())
 			yyLOCAL = n
@@ -39459,7 +39484,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2693:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line postgres.y:11772
+//line postgres.y:11797
 		{
 			yylex.Error("CREATE ASSERTION is not yet implemented")
 			return 1
@@ -39469,7 +39494,7 @@ yydefault:
 	case 2694:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11788
+//line postgres.y:11813
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[6].stmtUnion(), yyDollar[4].intoUnion(), ast.OBJECT_TABLE, false, false)
 			/* cram additional flags into the IntoClause */
@@ -39483,7 +39508,7 @@ yydefault:
 	case 2695:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11798
+//line postgres.y:11823
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[9].stmtUnion(), yyDollar[7].intoUnion(), ast.OBJECT_TABLE, false, true)
 			/* cram additional flags into the IntoClause */
@@ -39497,7 +39522,7 @@ yydefault:
 	case 2696:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11818
+//line postgres.y:11843
 		{
 			n := &ast.RuleStmt{
 				BaseNode:    ast.BaseNode{Tag: ast.T_RuleStmt},
@@ -39515,7 +39540,7 @@ yydefault:
 	case 2697:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11834
+//line postgres.y:11859
 		{
 			yyLOCAL = nil
 		}
@@ -39523,7 +39548,7 @@ yydefault:
 	case 2698:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11835
+//line postgres.y:11860
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].stmtUnion())
 		}
@@ -39531,7 +39556,7 @@ yydefault:
 	case 2699:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11836
+//line postgres.y:11861
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -39539,7 +39564,7 @@ yydefault:
 	case 2700:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11841
+//line postgres.y:11866
 		{
 			if yyDollar[3].stmtUnion() != nil {
 				if yyDollar[1].listUnion() != nil {
@@ -39554,7 +39579,7 @@ yydefault:
 	case 2701:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11852
+//line postgres.y:11877
 		{
 			if yyDollar[1].stmtUnion() != nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[1].stmtUnion())
@@ -39566,7 +39591,7 @@ yydefault:
 	case 2707:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11870
+//line postgres.y:11895
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -39574,7 +39599,7 @@ yydefault:
 	case 2708:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11871
+//line postgres.y:11896
 		{
 			yyLOCAL = nil
 		}
@@ -39582,7 +39607,7 @@ yydefault:
 	case 2709:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11875
+//line postgres.y:11900
 		{
 			yyLOCAL = true
 		}
@@ -39590,7 +39615,7 @@ yydefault:
 	case 2710:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11876
+//line postgres.y:11901
 		{
 			yyLOCAL = false
 		}
@@ -39598,7 +39623,7 @@ yydefault:
 	case 2711:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11877
+//line postgres.y:11902
 		{
 			yyLOCAL = false
 		}
@@ -39606,7 +39631,7 @@ yydefault:
 	case 2712:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:11880
+//line postgres.y:11905
 		{
 			yyLOCAL = ast.RELPERSISTENCE_UNLOGGED
 		}
@@ -39614,7 +39639,7 @@ yydefault:
 	case 2713:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:11881
+//line postgres.y:11906
 		{
 			yyLOCAL = ast.RELPERSISTENCE_PERMANENT
 		}
@@ -39622,7 +39647,7 @@ yydefault:
 	case 2714:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.IntoClause
-//line postgres.y:11886
+//line postgres.y:11911
 		{
 			yyLOCAL = &ast.IntoClause{
 				Rel:            yyDollar[1].rangevarUnion(),
@@ -39636,7 +39661,7 @@ yydefault:
 	case 2715:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11898
+//line postgres.y:11923
 		{
 			yyLOCAL = true
 		}
@@ -39644,7 +39669,7 @@ yydefault:
 	case 2716:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11899
+//line postgres.y:11924
 		{
 			yyLOCAL = false
 		}
@@ -39652,7 +39677,7 @@ yydefault:
 	case 2717:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11900
+//line postgres.y:11925
 		{
 			yyLOCAL = true
 		}
@@ -39660,7 +39685,7 @@ yydefault:
 	case 2718:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11905
+//line postgres.y:11930
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].stmtUnion())
@@ -39673,7 +39698,7 @@ yydefault:
 	case 2719:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11914
+//line postgres.y:11939
 		{
 			yyLOCAL = nil
 		}
@@ -39681,7 +39706,7 @@ yydefault:
 	case 2726:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11927
+//line postgres.y:11952
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -39689,7 +39714,7 @@ yydefault:
 	case 2727:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11929
+//line postgres.y:11954
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_CURRENT, yyDollar[1].str, nil, false)
 		}
@@ -39697,7 +39722,7 @@ yydefault:
 	case 2728:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11933
+//line postgres.y:11958
 		{
 			args := ast.NewNodeList(yyDollar[3].nodeUnion())
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "timezone", args, false)
@@ -39706,7 +39731,7 @@ yydefault:
 	case 2729:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11938
+//line postgres.y:11963
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "catalog", args, false)
@@ -39715,7 +39740,7 @@ yydefault:
 	case 2730:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11943
+//line postgres.y:11968
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "search_path", args, false)
@@ -39724,7 +39749,7 @@ yydefault:
 	case 2731:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11948
+//line postgres.y:11973
 		{
 			var args *ast.NodeList
 			if yyDollar[2].str != "" {
@@ -39736,7 +39761,7 @@ yydefault:
 	case 2732:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11956
+//line postgres.y:11981
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "role", args, false)
@@ -39745,7 +39770,7 @@ yydefault:
 	case 2733:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11961
+//line postgres.y:11986
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[3].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "session_authorization", args, false)
@@ -39754,7 +39779,7 @@ yydefault:
 	case 2734:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11966
+//line postgres.y:11991
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, "session_authorization", nil, false)
 		}
@@ -39762,7 +39787,7 @@ yydefault:
 	case 2735:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11970
+//line postgres.y:11995
 		{
 			var value string
 			if yyDollar[3].ival == int(ast.XMLOPTION_DOCUMENT) {
@@ -39777,7 +39802,7 @@ yydefault:
 	case 2736:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11981
+//line postgres.y:12006
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[3].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "transaction_snapshot", args, false)
@@ -39786,7 +39811,7 @@ yydefault:
 	case 2737:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11989
+//line postgres.y:12014
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, yyDollar[1].str, yyDollar[3].listUnion(), false)
 		}
@@ -39794,7 +39819,7 @@ yydefault:
 	case 2738:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11993
+//line postgres.y:12018
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, yyDollar[1].str, yyDollar[3].listUnion(), false)
 		}
@@ -39802,7 +39827,7 @@ yydefault:
 	case 2739:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11997
+//line postgres.y:12022
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, yyDollar[1].str, nil, false)
 		}
@@ -39810,27 +39835,27 @@ yydefault:
 	case 2740:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12001
+//line postgres.y:12026
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, yyDollar[1].str, nil, false)
 		}
 		yyVAL.union = yyLOCAL
 	case 2741:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12008
+//line postgres.y:12033
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2742:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:12012
+//line postgres.y:12037
 		{
 			yyVAL.str = yyDollar[1].str + "." + yyDollar[3].str
 		}
 	case 2743:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12019
+//line postgres.y:12044
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -39840,7 +39865,7 @@ yydefault:
 	case 2744:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12025
+//line postgres.y:12050
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39849,7 +39874,7 @@ yydefault:
 	case 2745:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12032
+//line postgres.y:12057
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39857,7 +39882,7 @@ yydefault:
 	case 2746:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12033
+//line postgres.y:12058
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39865,7 +39890,7 @@ yydefault:
 	case 2747:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12037
+//line postgres.y:12062
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39873,7 +39898,7 @@ yydefault:
 	case 2748:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12038
+//line postgres.y:12063
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39881,7 +39906,7 @@ yydefault:
 	case 2749:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12040
+//line postgres.y:12065
 		{
 			t := yyDollar[1].typnamUnion()
 			t.Typmods = yyDollar[3].listUnion()
@@ -39892,7 +39917,7 @@ yydefault:
 	case 2750:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12047
+//line postgres.y:12072
 		{
 			t := yyDollar[1].typnamUnion()
 			// INTERVAL_FULL_RANGE equivalent and precision
@@ -39904,7 +39929,7 @@ yydefault:
 	case 2751:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12054
+//line postgres.y:12079
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39912,7 +39937,7 @@ yydefault:
 	case 2752:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12055
+//line postgres.y:12080
 		{
 			yyLOCAL = ast.NewString("default")
 		}
@@ -39920,81 +39945,81 @@ yydefault:
 	case 2753:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12056
+//line postgres.y:12081
 		{
 			yyLOCAL = ast.NewString("local")
 		}
 		yyVAL.union = yyLOCAL
 	case 2754:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12060
+//line postgres.y:12085
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2755:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12061
+//line postgres.y:12086
 		{
 			yyVAL.str = "default"
 		}
 	case 2756:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12062
+//line postgres.y:12087
 		{
 			yyVAL.str = ""
 		}
 	case 2757:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12066
+//line postgres.y:12091
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2758:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12067
+//line postgres.y:12092
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2759:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12071
+//line postgres.y:12096
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2760:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12072
+//line postgres.y:12097
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2761:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12073
+//line postgres.y:12098
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2762:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12074
+//line postgres.y:12099
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2763:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12078
+//line postgres.y:12103
 		{
 			yyVAL.ival = int(ast.XMLOPTION_DOCUMENT)
 		}
 	case 2764:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12079
+//line postgres.y:12104
 		{
 			yyVAL.ival = int(ast.XMLOPTION_CONTENT)
 		}
 	case 2765:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12084
+//line postgres.y:12109
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -40004,7 +40029,7 @@ yydefault:
 	case 2766:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12090
+//line postgres.y:12115
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40013,7 +40038,7 @@ yydefault:
 	case 2767:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12095
+//line postgres.y:12120
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40022,7 +40047,7 @@ yydefault:
 	case 2768:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12103
+//line postgres.y:12128
 		{
 			yyLOCAL = ast.NewDefElem("transaction_isolation", ast.NewString(yyDollar[3].str))
 		}
@@ -40030,7 +40055,7 @@ yydefault:
 	case 2769:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12107
+//line postgres.y:12132
 		{
 			yyLOCAL = ast.NewDefElem("transaction_read_only", ast.NewBoolean(true))
 		}
@@ -40038,7 +40063,7 @@ yydefault:
 	case 2770:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12111
+//line postgres.y:12136
 		{
 			yyLOCAL = ast.NewDefElem("transaction_read_only", ast.NewBoolean(false))
 		}
@@ -40046,7 +40071,7 @@ yydefault:
 	case 2771:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12115
+//line postgres.y:12140
 		{
 			yyLOCAL = ast.NewDefElem("transaction_deferrable", ast.NewBoolean(true))
 		}
@@ -40054,39 +40079,39 @@ yydefault:
 	case 2772:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12119
+//line postgres.y:12144
 		{
 			yyLOCAL = ast.NewDefElem("transaction_deferrable", ast.NewBoolean(false))
 		}
 		yyVAL.union = yyLOCAL
 	case 2773:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12125
+//line postgres.y:12150
 		{
 			yyVAL.str = "read uncommitted"
 		}
 	case 2774:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12126
+//line postgres.y:12151
 		{
 			yyVAL.str = "read committed"
 		}
 	case 2775:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12127
+//line postgres.y:12152
 		{
 			yyVAL.str = "repeatable read"
 		}
 	case 2776:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12128
+//line postgres.y:12153
 		{
 			yyVAL.str = "serializable"
 		}
 	case 2777:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12132
+//line postgres.y:12157
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -40094,7 +40119,7 @@ yydefault:
 	case 2778:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12133
+//line postgres.y:12158
 		{
 			yyLOCAL = nil
 		}
@@ -40102,7 +40127,7 @@ yydefault:
 	case 2779:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12137
+//line postgres.y:12162
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -40110,7 +40135,7 @@ yydefault:
 	case 2780:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12138
+//line postgres.y:12163
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -40118,7 +40143,7 @@ yydefault:
 	case 2781:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12139
+//line postgres.y:12164
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -40126,7 +40151,7 @@ yydefault:
 	case 2782:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12142
+//line postgres.y:12167
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -40134,7 +40159,7 @@ yydefault:
 	case 2783:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12143
+//line postgres.y:12168
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -40142,7 +40167,7 @@ yydefault:
 	case 2784:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12144
+//line postgres.y:12169
 		{
 			yyLOCAL = ast.NewString("none")
 		}
@@ -40150,7 +40175,7 @@ yydefault:
 	case 2785:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12148
+//line postgres.y:12173
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40158,7 +40183,7 @@ yydefault:
 	case 2786:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12149
+//line postgres.y:12174
 		{
 			yyLOCAL = nil
 		}
@@ -40166,7 +40191,7 @@ yydefault:
 	case 2787:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12153
+//line postgres.y:12178
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -40174,7 +40199,7 @@ yydefault:
 	case 2788:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12154
+//line postgres.y:12179
 		{
 			yyLOCAL = nil
 		}
@@ -40182,7 +40207,7 @@ yydefault:
 	case 2789:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12158
+//line postgres.y:12183
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -40190,7 +40215,7 @@ yydefault:
 	case 2790:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12163
+//line postgres.y:12188
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40199,7 +40224,7 @@ yydefault:
 	case 2791:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12168
+//line postgres.y:12193
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40208,7 +40233,7 @@ yydefault:
 	case 2792:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12176
+//line postgres.y:12201
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -40216,7 +40241,7 @@ yydefault:
 	case 2793:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12180
+//line postgres.y:12205
 		{
 			elem := yyDollar[2].defeltUnion()
 			elem.Defaction = ast.DEFELEM_SET
@@ -40226,7 +40251,7 @@ yydefault:
 	case 2794:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12186
+//line postgres.y:12211
 		{
 			elem := yyDollar[2].defeltUnion()
 			elem.Defaction = ast.DEFELEM_ADD
@@ -40236,27 +40261,27 @@ yydefault:
 	case 2795:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12192
+//line postgres.y:12217
 		{
 			yyLOCAL = ast.NewDefElemExtended("", yyDollar[2].str, nil, ast.DEFELEM_DROP)
 		}
 		yyVAL.union = yyLOCAL
 	case 2796:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12198
+//line postgres.y:12223
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2797:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12199
+//line postgres.y:12224
 		{
 			yyVAL.str = ""
 		}
 	case 2798:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12203
+//line postgres.y:12228
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_NOTHING, "")
 		}
@@ -40264,7 +40289,7 @@ yydefault:
 	case 2799:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12204
+//line postgres.y:12229
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_FULL, "")
 		}
@@ -40272,7 +40297,7 @@ yydefault:
 	case 2800:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12205
+//line postgres.y:12230
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_DEFAULT, "")
 		}
@@ -40280,7 +40305,7 @@ yydefault:
 	case 2801:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12206
+//line postgres.y:12231
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_INDEX, yyDollar[3].str)
 		}
@@ -40288,7 +40313,7 @@ yydefault:
 	case 2802:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12210
+//line postgres.y:12235
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40296,7 +40321,7 @@ yydefault:
 	case 2803:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12215
+//line postgres.y:12240
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40305,7 +40330,7 @@ yydefault:
 	case 2804:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12220
+//line postgres.y:12245
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40314,7 +40339,7 @@ yydefault:
 	case 2805:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12227
+//line postgres.y:12252
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -40322,7 +40347,7 @@ yydefault:
 	case 2806:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12228
+//line postgres.y:12253
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -40330,7 +40355,7 @@ yydefault:
 	case 2807:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12239
+//line postgres.y:12264
 		{
 			yyLOCAL = ast.NewCreateEventTrigStmt(yyDollar[4].str, yyDollar[6].str, yyDollar[9].listUnion(), nil)
 		}
@@ -40338,7 +40363,7 @@ yydefault:
 	case 2808:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12243
+//line postgres.y:12268
 		{
 			yyLOCAL = ast.NewCreateEventTrigStmt(yyDollar[4].str, yyDollar[6].str, yyDollar[11].listUnion(), yyDollar[8].listUnion())
 		}
@@ -40346,39 +40371,39 @@ yydefault:
 	case 2809:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12249
+//line postgres.y:12274
 		{
 			yyLOCAL = ast.NewAlterEventTrigStmt(yyDollar[4].str, ast.TriggerFires(yyDollar[5].ival))
 		}
 		yyVAL.union = yyLOCAL
 	case 2810:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12255
+//line postgres.y:12280
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ON_ORIGIN)
 		}
 	case 2811:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12256
+//line postgres.y:12281
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ON_REPLICA)
 		}
 	case 2812:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12257
+//line postgres.y:12282
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ALWAYS)
 		}
 	case 2813:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12258
+//line postgres.y:12283
 		{
 			yyVAL.ival = int(ast.TRIGGER_DISABLED)
 		}
 	case 2814:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12263
+//line postgres.y:12288
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40387,7 +40412,7 @@ yydefault:
 	case 2815:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12268
+//line postgres.y:12293
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40396,7 +40421,7 @@ yydefault:
 	case 2816:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12276
+//line postgres.y:12301
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[4].listUnion())
 		}
@@ -40404,7 +40429,7 @@ yydefault:
 	case 2817:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12283
+//line postgres.y:12308
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(ast.NewString(yyDollar[1].str))
@@ -40413,7 +40438,7 @@ yydefault:
 	case 2818:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12288
+//line postgres.y:12313
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40422,7 +40447,7 @@ yydefault:
 	case 2819:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12302
+//line postgres.y:12327
 		{
 			yyLOCAL = ast.NewCreateTableSpaceStmt(yyDollar[3].str, yyDollar[4].rolespecUnion(), yyDollar[6].str, yyDollar[7].listUnion())
 		}
@@ -40430,7 +40455,7 @@ yydefault:
 	case 2820:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:12308
+//line postgres.y:12333
 		{
 			yyLOCAL = yyDollar[2].rolespecUnion()
 		}
@@ -40438,7 +40463,7 @@ yydefault:
 	case 2821:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:12309
+//line postgres.y:12334
 		{
 			yyLOCAL = nil
 		}
@@ -40446,7 +40471,7 @@ yydefault:
 	case 2822:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12314
+//line postgres.y:12339
 		{
 			yyLOCAL = ast.NewAlterTableSpaceStmt(yyDollar[3].str, yyDollar[5].listUnion(), false)
 		}
@@ -40454,7 +40479,7 @@ yydefault:
 	case 2823:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12318
+//line postgres.y:12343
 		{
 			yyLOCAL = ast.NewAlterTableSpaceStmt(yyDollar[3].str, yyDollar[5].listUnion(), true)
 		}
@@ -40462,7 +40487,7 @@ yydefault:
 	case 2824:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12333
+//line postgres.y:12358
 		{
 			yyLOCAL = ast.NewCreatePolicyStmt(yyDollar[3].str, yyDollar[5].rangevarUnion(), yyDollar[6].bvalUnion(), yyDollar[7].str, yyDollar[8].listUnion(), yyDollar[9].nodeUnion(), yyDollar[10].nodeUnion())
 		}
@@ -40470,7 +40495,7 @@ yydefault:
 	case 2825:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12341
+//line postgres.y:12366
 		{
 			yyLOCAL = ast.NewAlterPolicyStmt(yyDollar[3].str, yyDollar[5].rangevarUnion(), yyDollar[6].listUnion(), yyDollar[7].nodeUnion(), yyDollar[8].nodeUnion())
 		}
@@ -40478,7 +40503,7 @@ yydefault:
 	case 2826:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12348
+//line postgres.y:12373
 		{
 			// Check for "permissive" or "restrictive" (case-insensitive)
 			if strings.EqualFold(yyDollar[2].str, "permissive") {
@@ -40495,57 +40520,57 @@ yydefault:
 	case 2827:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12360
+//line postgres.y:12385
 		{
 			yyLOCAL = true
 		}
 		yyVAL.union = yyLOCAL
 	case 2828:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12364
+//line postgres.y:12389
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2829:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12365
+//line postgres.y:12390
 		{
 			yyVAL.str = "all"
 		}
 	case 2830:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12369
+//line postgres.y:12394
 		{
 			yyVAL.str = "all"
 		}
 	case 2831:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12370
+//line postgres.y:12395
 		{
 			yyVAL.str = "select"
 		}
 	case 2832:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12371
+//line postgres.y:12396
 		{
 			yyVAL.str = "insert"
 		}
 	case 2833:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12372
+//line postgres.y:12397
 		{
 			yyVAL.str = "update"
 		}
 	case 2834:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12373
+//line postgres.y:12398
 		{
 			yyVAL.str = "delete"
 		}
 	case 2835:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12377
+//line postgres.y:12402
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40553,7 +40578,7 @@ yydefault:
 	case 2836:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12378
+//line postgres.y:12403
 		{
 			// Default to PUBLIC when no TO clause is specified
 			publicRole := ast.NewRoleSpec(ast.ROLESPEC_PUBLIC, "")
@@ -40563,7 +40588,7 @@ yydefault:
 	case 2837:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12386
+//line postgres.y:12411
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40571,7 +40596,7 @@ yydefault:
 	case 2838:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12387
+//line postgres.y:12412
 		{
 			yyLOCAL = nil
 		}
@@ -40579,7 +40604,7 @@ yydefault:
 	case 2839:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12391
+//line postgres.y:12416
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -40587,7 +40612,7 @@ yydefault:
 	case 2840:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12392
+//line postgres.y:12417
 		{
 			yyLOCAL = nil
 		}
@@ -40595,7 +40620,7 @@ yydefault:
 	case 2841:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12396
+//line postgres.y:12421
 		{
 			yyLOCAL = yyDollar[4].nodeUnion()
 		}
@@ -40603,7 +40628,7 @@ yydefault:
 	case 2842:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12397
+//line postgres.y:12422
 		{
 			yyLOCAL = nil
 		}
@@ -40611,27 +40636,27 @@ yydefault:
 	case 2843:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12408
+//line postgres.y:12433
 		{
 			yyLOCAL = ast.NewCreateAmStmt(yyDollar[4].str, ast.AmType(yyDollar[6].ival), yyDollar[8].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2844:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12414
+//line postgres.y:12439
 		{
 			yyVAL.ival = int(ast.AMTYPE_INDEX)
 		}
 	case 2845:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12415
+//line postgres.y:12440
 		{
 			yyVAL.ival = int(ast.AMTYPE_TABLE)
 		}
 	case 2846:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12426
+//line postgres.y:12451
 		{
 			yyLOCAL = ast.NewCreateStatsStmt(yyDollar[3].listUnion(), yyDollar[4].listUnion(), yyDollar[6].listUnion(), yyDollar[8].listUnion(), "", false, false)
 		}
@@ -40639,7 +40664,7 @@ yydefault:
 	case 2847:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12430
+//line postgres.y:12455
 		{
 			yyLOCAL = ast.NewCreateStatsStmt(yyDollar[6].listUnion(), yyDollar[7].listUnion(), yyDollar[9].listUnion(), yyDollar[11].listUnion(), "", false, true)
 		}
@@ -40647,7 +40672,7 @@ yydefault:
 	case 2848:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12437
+//line postgres.y:12462
 		{
 			yyLOCAL = ast.NewAlterStatsStmt(yyDollar[3].listUnion(), yyDollar[6].nodeUnion(), false)
 		}
@@ -40655,7 +40680,7 @@ yydefault:
 	case 2849:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12441
+//line postgres.y:12466
 		{
 			yyLOCAL = ast.NewAlterStatsStmt(yyDollar[5].listUnion(), yyDollar[8].nodeUnion(), true)
 		}
@@ -40663,7 +40688,7 @@ yydefault:
 	case 2850:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12447
+//line postgres.y:12472
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].statelemUnion())
@@ -40672,7 +40697,7 @@ yydefault:
 	case 2851:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12448
+//line postgres.y:12473
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].statelemUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40681,7 +40706,7 @@ yydefault:
 	case 2852:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12452
+//line postgres.y:12477
 		{
 			yyLOCAL = ast.NewStatsElem(yyDollar[1].str)
 		}
@@ -40689,7 +40714,7 @@ yydefault:
 	case 2853:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12453
+//line postgres.y:12478
 		{
 			yyLOCAL = ast.NewStatsElemExpr(yyDollar[1].nodeUnion())
 		}
@@ -40697,7 +40722,7 @@ yydefault:
 	case 2854:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12454
+//line postgres.y:12479
 		{
 			yyLOCAL = ast.NewStatsElemExpr(ast.NewParenExpr(yyDollar[2].nodeUnion(), 0))
 		}
@@ -40705,7 +40730,7 @@ yydefault:
 	case 2855:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12465
+//line postgres.y:12490
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, nil, false, yyDollar[4].listUnion())
 		}
@@ -40713,7 +40738,7 @@ yydefault:
 	case 2856:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12469
+//line postgres.y:12494
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, nil, true, yyDollar[7].listUnion())
 		}
@@ -40721,7 +40746,7 @@ yydefault:
 	case 2857:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12473
+//line postgres.y:12498
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, yyDollar[5].listUnion(), false, yyDollar[6].listUnion())
 		}
@@ -40729,7 +40754,7 @@ yydefault:
 	case 2858:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12480
+//line postgres.y:12505
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, yyDollar[5].listUnion(), nil, ast.AP_SetOptions)
 		}
@@ -40737,7 +40762,7 @@ yydefault:
 	case 2859:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12484
+//line postgres.y:12509
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_AddObjects)
 		}
@@ -40745,7 +40770,7 @@ yydefault:
 	case 2860:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12488
+//line postgres.y:12513
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_SetObjects)
 		}
@@ -40753,7 +40778,7 @@ yydefault:
 	case 2861:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12492
+//line postgres.y:12517
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_DropObjects)
 		}
@@ -40761,7 +40786,7 @@ yydefault:
 	case 2862:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12498
+//line postgres.y:12523
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -40770,7 +40795,7 @@ yydefault:
 	case 2863:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12499
+//line postgres.y:12524
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40779,7 +40804,7 @@ yydefault:
 	case 2864:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12504
+//line postgres.y:12529
 		{
 			pubTable := ast.NewPublicationTable(yyDollar[2].rangevarUnion(), yyDollar[4].nodeUnion(), yyDollar[3].listUnion())
 			yyLOCAL = ast.NewPublicationObjSpecTable(ast.PUBLICATIONOBJ_TABLE, pubTable)
@@ -40788,7 +40813,7 @@ yydefault:
 	case 2865:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12509
+//line postgres.y:12534
 		{
 			yyLOCAL = ast.NewPublicationObjSpecName(ast.PUBLICATIONOBJ_TABLES_IN_SCHEMA, yyDollar[4].str)
 		}
@@ -40796,7 +40821,7 @@ yydefault:
 	case 2866:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12513
+//line postgres.y:12538
 		{
 			yyLOCAL = ast.NewPublicationObjSpec(ast.PUBLICATIONOBJ_TABLES_IN_CUR_SCHEMA)
 		}
@@ -40804,7 +40829,7 @@ yydefault:
 	case 2867:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12517
+//line postgres.y:12542
 		{
 			// If either a row filter or column list is specified, create a PublicationTable object
 			if yyDollar[2].listUnion() != nil || yyDollar[3].nodeUnion() != nil {
@@ -40820,7 +40845,7 @@ yydefault:
 	case 2868:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12529
+//line postgres.y:12554
 		{
 			rangeVar := makeRangeVarFromQualifiedName(yyDollar[1].str, yyDollar[2].listUnion(), -1)
 			pubTable := ast.NewPublicationTable(rangeVar, yyDollar[4].nodeUnion(), yyDollar[3].listUnion())
@@ -40830,7 +40855,7 @@ yydefault:
 	case 2869:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12535
+//line postgres.y:12560
 		{
 			pubTable := ast.NewPublicationTable(yyDollar[1].rangevarUnion(), yyDollar[3].nodeUnion(), yyDollar[2].listUnion())
 			yyLOCAL = ast.NewPublicationObjSpecTable(ast.PUBLICATIONOBJ_CONTINUATION, pubTable)
@@ -40839,7 +40864,7 @@ yydefault:
 	case 2870:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12540
+//line postgres.y:12565
 		{
 			yyLOCAL = ast.NewPublicationObjSpec(ast.PUBLICATIONOBJ_CONTINUATION)
 		}
@@ -40847,7 +40872,7 @@ yydefault:
 	case 2871:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12546
+//line postgres.y:12571
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -40855,7 +40880,7 @@ yydefault:
 	case 2872:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12547
+//line postgres.y:12572
 		{
 			yyLOCAL = nil
 		}
@@ -40863,7 +40888,7 @@ yydefault:
 	case 2873:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12558
+//line postgres.y:12583
 		{
 			yyLOCAL = ast.NewCreateSubscriptionStmt(yyDollar[3].str, yyDollar[5].str, yyDollar[7].listUnion(), yyDollar[8].listUnion())
 		}
@@ -40871,7 +40896,7 @@ yydefault:
 	case 2874:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12565
+//line postgres.y:12590
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_OPTIONS, "", nil, yyDollar[5].listUnion())
 		}
@@ -40879,7 +40904,7 @@ yydefault:
 	case 2875:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12569
+//line postgres.y:12594
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_CONNECTION, yyDollar[5].str, nil, nil)
 		}
@@ -40887,7 +40912,7 @@ yydefault:
 	case 2876:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12573
+//line postgres.y:12598
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_REFRESH, "", nil, yyDollar[6].listUnion())
 		}
@@ -40895,7 +40920,7 @@ yydefault:
 	case 2877:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12577
+//line postgres.y:12602
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_ADD_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40903,7 +40928,7 @@ yydefault:
 	case 2878:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12581
+//line postgres.y:12606
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_DROP_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40911,7 +40936,7 @@ yydefault:
 	case 2879:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12585
+//line postgres.y:12610
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_SET_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40919,7 +40944,7 @@ yydefault:
 	case 2880:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12589
+//line postgres.y:12614
 		{
 			enableOpt := ast.NewNodeList()
 			enableOpt.Append(ast.NewDefElem("enabled", ast.NewBoolean(true)))
@@ -40929,7 +40954,7 @@ yydefault:
 	case 2881:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12595
+//line postgres.y:12620
 		{
 			disableOpt := ast.NewNodeList()
 			disableOpt.Append(ast.NewDefElem("enabled", ast.NewBoolean(false)))
@@ -40939,7 +40964,7 @@ yydefault:
 	case 2882:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12601
+//line postgres.y:12626
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_SKIP, "", nil, yyDollar[5].listUnion())
 		}
@@ -40947,7 +40972,7 @@ yydefault:
 	case 2883:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12614
+//line postgres.y:12639
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), yyDollar[10].objwithargsUnion(), ast.CoercionContext(yyDollar[11].ival), false)
 		}
@@ -40955,7 +40980,7 @@ yydefault:
 	case 2884:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12618
+//line postgres.y:12643
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), nil, ast.CoercionContext(yyDollar[10].ival), false)
 		}
@@ -40963,33 +40988,33 @@ yydefault:
 	case 2885:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12622
+//line postgres.y:12647
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), nil, ast.CoercionContext(yyDollar[10].ival), true)
 		}
 		yyVAL.union = yyLOCAL
 	case 2886:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12628
+//line postgres.y:12653
 		{
 			yyVAL.ival = int(ast.COERCION_IMPLICIT)
 		}
 	case 2887:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12629
+//line postgres.y:12654
 		{
 			yyVAL.ival = int(ast.COERCION_ASSIGNMENT)
 		}
 	case 2888:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12630
+//line postgres.y:12655
 		{
 			yyVAL.ival = int(ast.COERCION_EXPLICIT)
 		}
 	case 2889:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12642
+//line postgres.y:12667
 		{
 			yyLOCAL = ast.NewCreateOpClassStmt(yyDollar[4].listUnion(), yyDollar[11].listUnion(), yyDollar[10].str, yyDollar[8].typnamUnion(), yyDollar[13].listUnion(), yyDollar[5].bvalUnion())
 		}
@@ -40997,7 +41022,7 @@ yydefault:
 	case 2890:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12648
+//line postgres.y:12673
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41005,7 +41030,7 @@ yydefault:
 	case 2891:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12649
+//line postgres.y:12674
 		{
 			yyLOCAL = nil
 		}
@@ -41013,7 +41038,7 @@ yydefault:
 	case 2892:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12653
+//line postgres.y:12678
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41021,7 +41046,7 @@ yydefault:
 	case 2893:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12654
+//line postgres.y:12679
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41030,7 +41055,7 @@ yydefault:
 	case 2894:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12659
+//line postgres.y:12684
 		{
 			// Create ObjectWithArgs for simple operator
 			owa := ast.NewObjectWithArgs(yyDollar[3].listUnion(), nil, false, -1)
@@ -41040,7 +41065,7 @@ yydefault:
 	case 2895:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12665
+//line postgres.y:12690
 		{
 			yyLOCAL = ast.NewOpClassItemOperator(yyDollar[2].ival, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 		}
@@ -41048,7 +41073,7 @@ yydefault:
 	case 2896:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12669
+//line postgres.y:12694
 		{
 			yyLOCAL = ast.NewOpClassItemFunction(yyDollar[2].ival, yyDollar[3].objwithargsUnion(), nil)
 		}
@@ -41056,7 +41081,7 @@ yydefault:
 	case 2897:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12673
+//line postgres.y:12698
 		{
 			yyLOCAL = ast.NewOpClassItemFunction(yyDollar[2].ival, yyDollar[6].objwithargsUnion(), yyDollar[4].listUnion())
 		}
@@ -41064,7 +41089,7 @@ yydefault:
 	case 2898:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12677
+//line postgres.y:12702
 		{
 			yyLOCAL = ast.NewOpClassItemStorage(yyDollar[2].typnamUnion())
 		}
@@ -41072,7 +41097,7 @@ yydefault:
 	case 2899:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12683
+//line postgres.y:12708
 		{
 			yyLOCAL = true
 		}
@@ -41080,7 +41105,7 @@ yydefault:
 	case 2900:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12684
+//line postgres.y:12709
 		{
 			yyLOCAL = false
 		}
@@ -41088,7 +41113,7 @@ yydefault:
 	case 2901:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12688
+//line postgres.y:12713
 		{
 			yyLOCAL = nil
 		}
@@ -41096,7 +41121,7 @@ yydefault:
 	case 2902:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12689
+//line postgres.y:12714
 		{
 			yyLOCAL = yyDollar[4].listUnion()
 		}
@@ -41104,7 +41129,7 @@ yydefault:
 	case 2903:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12690
+//line postgres.y:12715
 		{
 			yyLOCAL = nil
 		}
@@ -41112,7 +41137,7 @@ yydefault:
 	case 2904:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12694
+//line postgres.y:12719
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].typnamUnion())
 		}
@@ -41120,7 +41145,7 @@ yydefault:
 	case 2905:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12695
+//line postgres.y:12720
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41129,7 +41154,7 @@ yydefault:
 	case 2906:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12706
+//line postgres.y:12731
 		{
 			yyLOCAL = ast.NewCreateOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -41137,7 +41162,7 @@ yydefault:
 	case 2907:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12719
+//line postgres.y:12744
 		{
 			yyLOCAL = ast.NewAlterOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str, false, yyDollar[8].listUnion())
 		}
@@ -41145,7 +41170,7 @@ yydefault:
 	case 2908:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12723
+//line postgres.y:12748
 		{
 			yyLOCAL = ast.NewAlterOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str, true, yyDollar[8].listUnion())
 		}
@@ -41153,7 +41178,7 @@ yydefault:
 	case 2909:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12729
+//line postgres.y:12754
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41161,7 +41186,7 @@ yydefault:
 	case 2910:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12730
+//line postgres.y:12755
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41170,7 +41195,7 @@ yydefault:
 	case 2911:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12735
+//line postgres.y:12760
 		{
 			// Create ObjectWithArgs for operator with args
 			owa := ast.NewObjectWithArgs(nil, yyDollar[4].listUnion(), false, -1)
@@ -41180,7 +41205,7 @@ yydefault:
 	case 2912:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12741
+//line postgres.y:12766
 		{
 			// Create ObjectWithArgs for function with args
 			owa := ast.NewObjectWithArgs(nil, yyDollar[4].listUnion(), false, -1)
@@ -41190,7 +41215,7 @@ yydefault:
 	case 2913:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12756
+//line postgres.y:12781
 		{
 			yyLOCAL = ast.NewCreateConversionStmt(yyDollar[4].listUnion(), yyDollar[6].str, yyDollar[8].str, yyDollar[10].listUnion(), yyDollar[2].bvalUnion())
 		}
@@ -41198,7 +41223,7 @@ yydefault:
 	case 2914:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12769
+//line postgres.y:12794
 		{
 			yyLOCAL = ast.NewCreateTransformStmt(yyDollar[2].bvalUnion(), yyDollar[5].typnamUnion(), yyDollar[7].str, linitial(yyDollar[9].listUnion()), lsecond(yyDollar[9].listUnion()))
 		}
@@ -41206,7 +41231,7 @@ yydefault:
 	case 2915:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12776
+//line postgres.y:12801
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[5].objwithargsUnion())  // fromsql
@@ -41216,7 +41241,7 @@ yydefault:
 	case 2916:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12782
+//line postgres.y:12807
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[11].objwithargsUnion()) // fromsql
@@ -41226,7 +41251,7 @@ yydefault:
 	case 2917:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12788
+//line postgres.y:12813
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[5].objwithargsUnion()) // fromsql
@@ -41236,7 +41261,7 @@ yydefault:
 	case 2918:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12794
+//line postgres.y:12819
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(nil)                            // fromsql
@@ -41246,7 +41271,7 @@ yydefault:
 	case 2919:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12809
+//line postgres.y:12834
 		{
 			// Parameterless CREATE LANGUAGE is now treated as CREATE EXTENSION
 			yyLOCAL = ast.NewCreateExtensionStmt(yyDollar[6].str, yyDollar[2].bvalUnion(), nil)
@@ -41255,7 +41280,7 @@ yydefault:
 	case 2920:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12815
+//line postgres.y:12840
 		{
 			yyLOCAL = ast.NewCreatePLangStmt(yyDollar[2].bvalUnion(), yyDollar[6].str, yyDollar[8].listUnion(), yyDollar[9].listUnion(), yyDollar[10].listUnion(), yyDollar[3].bvalUnion())
 		}
@@ -41263,7 +41288,7 @@ yydefault:
 	case 2921:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12821
+//line postgres.y:12846
 		{
 			yyLOCAL = true
 		}
@@ -41271,7 +41296,7 @@ yydefault:
 	case 2922:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12822
+//line postgres.y:12847
 		{
 			yyLOCAL = false
 		}
@@ -41279,7 +41304,7 @@ yydefault:
 	case 2923:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12827
+//line postgres.y:12852
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41287,7 +41312,7 @@ yydefault:
 	case 2924:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12828
+//line postgres.y:12853
 		{
 			yyLOCAL = nil
 		}
@@ -41295,7 +41320,7 @@ yydefault:
 	case 2925:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12832
+//line postgres.y:12857
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -41303,7 +41328,7 @@ yydefault:
 	case 2926:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12833
+//line postgres.y:12858
 		{
 			yyLOCAL = nil
 		}
@@ -41311,7 +41336,7 @@ yydefault:
 	case 2927:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12837
+//line postgres.y:12862
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41319,7 +41344,7 @@ yydefault:
 	case 2928:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12838
+//line postgres.y:12863
 		{
 			yyLOCAL = nil
 		}
@@ -41327,7 +41352,7 @@ yydefault:
 	case 2929:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12841
+//line postgres.y:12866
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_ALL
 		}
@@ -41335,7 +41360,7 @@ yydefault:
 	case 2930:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12842
+//line postgres.y:12867
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_DISTINCT
 		}
@@ -41343,7 +41368,7 @@ yydefault:
 	case 2931:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12843
+//line postgres.y:12868
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_DEFAULT
 		}
@@ -41351,7 +41376,7 @@ yydefault:
 	case 2932:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.GroupClause
-//line postgres.y:12848
+//line postgres.y:12873
 		{
 			yyLOCAL = &ast.GroupClause{
 				Distinct: yyDollar[3].setquantUnion() == ast.SET_QUANTIFIER_DISTINCT,
@@ -41362,7 +41387,7 @@ yydefault:
 	case 2933:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.GroupClause
-//line postgres.y:12855
+//line postgres.y:12880
 		{
 			yyLOCAL = nil
 		}
@@ -41370,7 +41395,7 @@ yydefault:
 	case 2934:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12861
+//line postgres.y:12886
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41378,7 +41403,7 @@ yydefault:
 	case 2935:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12862
+//line postgres.y:12887
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41387,7 +41412,7 @@ yydefault:
 	case 2936:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12866
+//line postgres.y:12891
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41395,7 +41420,7 @@ yydefault:
 	case 2937:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12867
+//line postgres.y:12892
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41403,7 +41428,7 @@ yydefault:
 	case 2938:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12868
+//line postgres.y:12893
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41411,7 +41436,7 @@ yydefault:
 	case 2939:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12869
+//line postgres.y:12894
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41419,7 +41444,7 @@ yydefault:
 	case 2940:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12870
+//line postgres.y:12895
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41427,7 +41452,7 @@ yydefault:
 	case 2941:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12875
+//line postgres.y:12900
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_EMPTY, ast.NewNodeList(), 0)
 		}
@@ -41435,7 +41460,7 @@ yydefault:
 	case 2942:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12882
+//line postgres.y:12907
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_ROLLUP, yyDollar[3].listUnion(), 0)
 		}
@@ -41443,7 +41468,7 @@ yydefault:
 	case 2943:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12889
+//line postgres.y:12914
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_CUBE, yyDollar[3].listUnion(), 0)
 		}
@@ -41451,7 +41476,7 @@ yydefault:
 	case 2944:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12896
+//line postgres.y:12921
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_SETS, yyDollar[4].listUnion(), 0)
 		}
@@ -41459,7 +41484,7 @@ yydefault:
 	case 2945:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12905
+//line postgres.y:12930
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41467,7 +41492,7 @@ yydefault:
 	case 2946:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12906
+//line postgres.y:12931
 		{
 			yyLOCAL = nil
 		}
@@ -41475,7 +41500,7 @@ yydefault:
 	case 2947:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12913
+//line postgres.y:12938
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -41483,7 +41508,7 @@ yydefault:
 	case 2948:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12917
+//line postgres.y:12942
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41491,7 +41516,7 @@ yydefault:
 	case 2949:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12918
+//line postgres.y:12943
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41500,7 +41525,7 @@ yydefault:
 	case 2950:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12923
+//line postgres.y:12948
 		{
 			sortBy := ast.NewSortBy(yyDollar[1].nodeUnion(), ast.SORTBY_USING, ast.SortByNulls(yyDollar[4].ival), 0)
 			// Use qual_all_Op (NodeList) directly for UseOp
@@ -41511,7 +41536,7 @@ yydefault:
 	case 2951:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12930
+//line postgres.y:12955
 		{
 			yyLOCAL = ast.NewSortBy(yyDollar[1].nodeUnion(), ast.SortByDir(yyDollar[2].ival), ast.SortByNulls(yyDollar[3].ival), 0)
 		}
@@ -41519,7 +41544,7 @@ yydefault:
 	case 2952:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12941
+//line postgres.y:12966
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41527,7 +41552,7 @@ yydefault:
 	case 2953:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12943
+//line postgres.y:12968
 		{
 			yyLOCAL = nil
 		}
@@ -41535,7 +41560,7 @@ yydefault:
 	case 2954:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12948
+//line postgres.y:12973
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Items = append(yyLOCAL.Items, yyDollar[1].windefUnion())
@@ -41544,7 +41569,7 @@ yydefault:
 	case 2955:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12953
+//line postgres.y:12978
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Items = append(yyLOCAL.Items, yyDollar[3].windefUnion())
@@ -41553,7 +41578,7 @@ yydefault:
 	case 2956:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12961
+//line postgres.y:12986
 		{
 			n := yyDollar[3].windefUnion()
 			n.Name = yyDollar[1].str
@@ -41563,7 +41588,7 @@ yydefault:
 	case 2957:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12970
+//line postgres.y:12995
 		{
 			yyLOCAL = yyDollar[2].windefUnion()
 		}
@@ -41571,7 +41596,7 @@ yydefault:
 	case 2958:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12972
+//line postgres.y:12997
 		{
 			n := ast.NewWindowDef("", -1)
 			n.Refname = yyDollar[2].str
@@ -41582,7 +41607,7 @@ yydefault:
 	case 2959:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12979
+//line postgres.y:13004
 		{
 			yyLOCAL = nil
 		}
@@ -41590,7 +41615,7 @@ yydefault:
 	case 2960:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12984
+//line postgres.y:13009
 		{
 			n := ast.NewWindowDef("", -1)
 			n.Refname = yyDollar[2].str
@@ -41605,20 +41630,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2961:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12998
+//line postgres.y:13023
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2962:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12999
+//line postgres.y:13024
 		{
 			yyVAL.str = ""
 		}
 	case 2963:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13003
+//line postgres.y:13028
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -41626,7 +41651,7 @@ yydefault:
 	case 2964:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13004
+//line postgres.y:13029
 		{
 			yyLOCAL = nil
 		}
@@ -41634,7 +41659,7 @@ yydefault:
 	case 2965:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13009
+//line postgres.y:13034
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_RANGE
@@ -41645,7 +41670,7 @@ yydefault:
 	case 2966:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13016
+//line postgres.y:13041
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_ROWS
@@ -41656,7 +41681,7 @@ yydefault:
 	case 2967:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13023
+//line postgres.y:13048
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_GROUPS
@@ -41667,7 +41692,7 @@ yydefault:
 	case 2968:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13030
+//line postgres.y:13055
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_DEFAULTS
@@ -41679,7 +41704,7 @@ yydefault:
 	case 2969:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13041
+//line postgres.y:13066
 		{
 			n := yyDollar[1].windefUnion()
 			// reject invalid cases - these would be runtime errors in PostgreSQL
@@ -41697,7 +41722,7 @@ yydefault:
 	case 2970:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13055
+//line postgres.y:13080
 		{
 			n1 := yyDollar[2].windefUnion()
 			n2 := yyDollar[4].windefUnion()
@@ -41733,7 +41758,7 @@ yydefault:
 	case 2971:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13090
+//line postgres.y:13115
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_UNBOUNDED_PRECEDING
@@ -41745,7 +41770,7 @@ yydefault:
 	case 2972:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13098
+//line postgres.y:13123
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_UNBOUNDED_FOLLOWING
@@ -41757,7 +41782,7 @@ yydefault:
 	case 2973:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13106
+//line postgres.y:13131
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_CURRENT_ROW
@@ -41769,7 +41794,7 @@ yydefault:
 	case 2974:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13114
+//line postgres.y:13139
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_OFFSET_PRECEDING
@@ -41781,7 +41806,7 @@ yydefault:
 	case 2975:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13122
+//line postgres.y:13147
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_OFFSET_FOLLOWING
@@ -41792,38 +41817,38 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2976:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13132
+//line postgres.y:13157
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_CURRENT_ROW
 		}
 	case 2977:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:13133
+//line postgres.y:13158
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_GROUP
 		}
 	case 2978:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:13134
+//line postgres.y:13159
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_TIES
 		}
 	case 2979:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13135
+//line postgres.y:13160
 		{
 			yyVAL.ival = 0
 		}
 	case 2980:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13136
+//line postgres.y:13161
 		{
 			yyVAL.ival = 0
 		}
 	case 2981:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13145
+//line postgres.y:13170
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 			yyLOCAL.limitOffset = yyDollar[2].nodeUnion()
@@ -41832,7 +41857,7 @@ yydefault:
 	case 2982:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13150
+//line postgres.y:13175
 		{
 			yyLOCAL = yyDollar[2].selectLimitUnion()
 			yyLOCAL.limitOffset = yyDollar[1].nodeUnion()
@@ -41841,7 +41866,7 @@ yydefault:
 	case 2983:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13155
+//line postgres.y:13180
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 		}
@@ -41849,7 +41874,7 @@ yydefault:
 	case 2984:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13159
+//line postgres.y:13184
 		{
 			n := &selectLimit{}
 			n.limitOffset = yyDollar[1].nodeUnion()
@@ -41861,7 +41886,7 @@ yydefault:
 	case 2985:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13169
+//line postgres.y:13194
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 		}
@@ -41869,7 +41894,7 @@ yydefault:
 	case 2986:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13170
+//line postgres.y:13195
 		{
 			yyLOCAL = nil
 		}
@@ -41877,7 +41902,7 @@ yydefault:
 	case 2987:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13175
+//line postgres.y:13200
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41888,7 +41913,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2988:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:13183
+//line postgres.y:13208
 		{
 			// Disabled because it was too confusing - PostgreSQL error
 			yylex.Error("LIMIT #,# syntax is not supported. Use separate LIMIT and OFFSET clauses.")
@@ -41897,7 +41922,7 @@ yydefault:
 	case 2989:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13190
+//line postgres.y:13215
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41909,7 +41934,7 @@ yydefault:
 	case 2990:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13198
+//line postgres.y:13223
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41921,7 +41946,7 @@ yydefault:
 	case 2991:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13206
+//line postgres.y:13231
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41933,7 +41958,7 @@ yydefault:
 	case 2992:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13214
+//line postgres.y:13239
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41945,7 +41970,7 @@ yydefault:
 	case 2993:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13225
+//line postgres.y:13250
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41953,7 +41978,7 @@ yydefault:
 	case 2994:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13228
+//line postgres.y:13253
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41961,7 +41986,7 @@ yydefault:
 	case 2995:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13232
+//line postgres.y:13257
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41969,7 +41994,7 @@ yydefault:
 	case 2996:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13234
+//line postgres.y:13259
 		{
 			/* LIMIT ALL is represented as a NULL constant */
 			yyLOCAL = ast.NewA_Const(ast.NewNull(), -1)
@@ -41978,7 +42003,7 @@ yydefault:
 	case 2997:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13241
+//line postgres.y:13266
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41986,7 +42011,7 @@ yydefault:
 	case 2998:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13254
+//line postgres.y:13279
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41994,7 +42019,7 @@ yydefault:
 	case 2999:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13256
+//line postgres.y:13281
 		{
 			yyLOCAL = ast.NewA_Expr(ast.AEXPR_OP, &ast.NodeList{Items: []ast.Node{ast.NewString("+")}}, nil, yyDollar[2].nodeUnion(), -1)
 		}
@@ -42002,7 +42027,7 @@ yydefault:
 	case 3000:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13260
+//line postgres.y:13285
 		{
 			// Create a unary minus expression
 			yyLOCAL = ast.NewA_Expr(ast.AEXPR_OP, &ast.NodeList{Items: []ast.Node{ast.NewString("-")}}, nil, yyDollar[2].nodeUnion(), -1)
@@ -42011,7 +42036,7 @@ yydefault:
 	case 3001:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13267
+//line postgres.y:13292
 		{
 			yyLOCAL = ast.NewA_Const(ast.NewInteger(yyDollar[1].ival), -1)
 		}
@@ -42019,39 +42044,39 @@ yydefault:
 	case 3002:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13268
+//line postgres.y:13293
 		{
 			yyLOCAL = ast.NewA_Const(ast.NewFloat(yyDollar[1].str), -1)
 		}
 		yyVAL.union = yyLOCAL
 	case 3003:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13273
+//line postgres.y:13298
 		{
 			yyVAL.ival = 0
 		}
 	case 3004:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13274
+//line postgres.y:13299
 		{
 			yyVAL.ival = 0
 		}
 	case 3005:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13278
+//line postgres.y:13303
 		{
 			yyVAL.ival = 0
 		}
 	case 3006:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13279
+//line postgres.y:13304
 		{
 			yyVAL.ival = 0
 		}
 	case 3007:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13292
+//line postgres.y:13317
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42061,7 +42086,7 @@ yydefault:
 	case 3008:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13298
+//line postgres.y:13323
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_START)
 			stmt.Options = yyDollar[3].listUnion()
@@ -42071,7 +42096,7 @@ yydefault:
 	case 3009:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13304
+//line postgres.y:13329
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42081,7 +42106,7 @@ yydefault:
 	case 3010:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13310
+//line postgres.y:13335
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42091,7 +42116,7 @@ yydefault:
 	case 3011:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13316
+//line postgres.y:13341
 		{
 			stmt := ast.NewSavepointStmt(yyDollar[2].str)
 			yyLOCAL = stmt
@@ -42100,7 +42125,7 @@ yydefault:
 	case 3012:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13321
+//line postgres.y:13346
 		{
 			stmt := ast.NewReleaseStmt(yyDollar[3].str)
 			yyLOCAL = stmt
@@ -42109,7 +42134,7 @@ yydefault:
 	case 3013:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13326
+//line postgres.y:13351
 		{
 			stmt := ast.NewReleaseStmt(yyDollar[2].str)
 			yyLOCAL = stmt
@@ -42118,7 +42143,7 @@ yydefault:
 	case 3014:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13331
+//line postgres.y:13356
 		{
 			stmt := ast.NewRollbackToStmt(yyDollar[5].str)
 			yyLOCAL = stmt
@@ -42127,7 +42152,7 @@ yydefault:
 	case 3015:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13336
+//line postgres.y:13361
 		{
 			stmt := ast.NewRollbackToStmt(yyDollar[4].str)
 			yyLOCAL = stmt
@@ -42136,7 +42161,7 @@ yydefault:
 	case 3016:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13341
+//line postgres.y:13366
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_PREPARE)
 			stmt.Gid = yyDollar[3].str
@@ -42146,7 +42171,7 @@ yydefault:
 	case 3017:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13347
+//line postgres.y:13372
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT_PREPARED)
 			stmt.Gid = yyDollar[3].str
@@ -42156,7 +42181,7 @@ yydefault:
 	case 3018:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13353
+//line postgres.y:13378
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK_PREPARED)
 			stmt.Gid = yyDollar[3].str
@@ -42166,7 +42191,7 @@ yydefault:
 	case 3019:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13362
+//line postgres.y:13387
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42176,7 +42201,7 @@ yydefault:
 	case 3020:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13368
+//line postgres.y:13393
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_BEGIN)
 			stmt.Options = yyDollar[3].listUnion()
@@ -42185,23 +42210,23 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3021:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13375
+//line postgres.y:13400
 		{
 		}
 	case 3022:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13376
+//line postgres.y:13401
 		{
 		}
 	case 3023:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13377
+//line postgres.y:13402
 		{
 		}
 	case 3024:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13381
+//line postgres.y:13406
 		{
 			yyLOCAL = true
 		}
@@ -42209,7 +42234,7 @@ yydefault:
 	case 3025:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13382
+//line postgres.y:13407
 		{
 			yyLOCAL = false
 		}
@@ -42217,7 +42242,7 @@ yydefault:
 	case 3026:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13383
+//line postgres.y:13408
 		{
 			yyLOCAL = false
 		}
@@ -42225,7 +42250,7 @@ yydefault:
 	case 3027:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13396
+//line postgres.y:13421
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_ROLE, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42233,7 +42258,7 @@ yydefault:
 	case 3028:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13403
+//line postgres.y:13428
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_USER, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42241,7 +42266,7 @@ yydefault:
 	case 3029:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13410
+//line postgres.y:13435
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_GROUP, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42249,7 +42274,7 @@ yydefault:
 	case 3030:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13417
+//line postgres.y:13442
 		{
 			as := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), yyDollar[5].listUnion())
 			as.Action = +1
@@ -42259,7 +42284,7 @@ yydefault:
 	case 3031:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13423
+//line postgres.y:13448
 		{
 			as := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), yyDollar[5].listUnion())
 			as.Action = +1
@@ -42269,7 +42294,7 @@ yydefault:
 	case 3032:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13432
+//line postgres.y:13457
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(yyDollar[3].rolespecUnion(), yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42277,7 +42302,7 @@ yydefault:
 	case 3033:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13436
+//line postgres.y:13461
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(nil, yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42285,7 +42310,7 @@ yydefault:
 	case 3034:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13440
+//line postgres.y:13465
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(yyDollar[3].rolespecUnion(), yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42293,27 +42318,27 @@ yydefault:
 	case 3035:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13444
+//line postgres.y:13469
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(nil, yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3036:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13450
+//line postgres.y:13475
 		{
 			yyVAL.str = ""
 		}
 	case 3037:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13451
+//line postgres.y:13476
 		{
 			yyVAL.str = yyDollar[3].str
 		}
 	case 3038:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13456
+//line postgres.y:13481
 		{
 			options := ast.NewNodeList(ast.NewDefElem("rolemembers", yyDollar[6].listUnion()))
 			stmt := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), options)
@@ -42324,7 +42349,7 @@ yydefault:
 	case 3039:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13466
+//line postgres.y:13491
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42332,7 +42357,7 @@ yydefault:
 	case 3040:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13470
+//line postgres.y:13495
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42340,7 +42365,7 @@ yydefault:
 	case 3041:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13474
+//line postgres.y:13499
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42348,7 +42373,7 @@ yydefault:
 	case 3042:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13478
+//line postgres.y:13503
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42356,7 +42381,7 @@ yydefault:
 	case 3043:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13482
+//line postgres.y:13507
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42364,7 +42389,7 @@ yydefault:
 	case 3044:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13486
+//line postgres.y:13511
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42372,7 +42397,7 @@ yydefault:
 	case 3045:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13494
+//line postgres.y:13519
 		{
 			if yyDollar[1].listUnion() == nil {
 				list := ast.NewNodeList()
@@ -42388,7 +42413,7 @@ yydefault:
 	case 3046:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13505
+//line postgres.y:13530
 		{
 			yyLOCAL = nil
 		}
@@ -42396,7 +42421,7 @@ yydefault:
 	case 3047:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13510
+//line postgres.y:13535
 		{
 			if yyDollar[1].listUnion() == nil {
 				list := ast.NewNodeList()
@@ -42412,7 +42437,7 @@ yydefault:
 	case 3048:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13521
+//line postgres.y:13546
 		{
 			yyLOCAL = nil
 		}
@@ -42420,7 +42445,7 @@ yydefault:
 	case 3049:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13525
+//line postgres.y:13550
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -42428,7 +42453,7 @@ yydefault:
 	case 3050:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13527
+//line postgres.y:13552
 		{
 			yyLOCAL = ast.NewDefElem("sysid", ast.NewInteger(yyDollar[2].ival))
 		}
@@ -42436,7 +42461,7 @@ yydefault:
 	case 3051:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13531
+//line postgres.y:13556
 		{
 			yyLOCAL = ast.NewDefElem("adminmembers", yyDollar[2].listUnion())
 		}
@@ -42444,7 +42469,7 @@ yydefault:
 	case 3052:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13535
+//line postgres.y:13560
 		{
 			yyLOCAL = ast.NewDefElem("rolemembers", yyDollar[2].listUnion())
 		}
@@ -42452,7 +42477,7 @@ yydefault:
 	case 3053:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13539
+//line postgres.y:13564
 		{
 			yyLOCAL = ast.NewDefElem("addroleto", yyDollar[3].listUnion())
 		}
@@ -42460,7 +42485,7 @@ yydefault:
 	case 3054:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13543
+//line postgres.y:13568
 		{
 			yyLOCAL = ast.NewDefElem("addroleto", yyDollar[3].listUnion())
 		}
@@ -42468,7 +42493,7 @@ yydefault:
 	case 3055:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13550
+//line postgres.y:13575
 		{
 			yyLOCAL = ast.NewDefElem("password", ast.NewString(yyDollar[2].str))
 		}
@@ -42476,7 +42501,7 @@ yydefault:
 	case 3056:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13554
+//line postgres.y:13579
 		{
 			yyLOCAL = ast.NewDefElem("password", nil)
 		}
@@ -42484,14 +42509,14 @@ yydefault:
 	case 3057:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13558
+//line postgres.y:13583
 		{
 			yyLOCAL = ast.NewDefElem("password", ast.NewString(yyDollar[3].str))
 		}
 		yyVAL.union = yyLOCAL
 	case 3058:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13562
+//line postgres.y:13587
 		{
 			yylex.Error("UNENCRYPTED PASSWORD is no longer supported")
 			return 1
@@ -42499,7 +42524,7 @@ yydefault:
 	case 3059:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13567
+//line postgres.y:13592
 		{
 			yyLOCAL = ast.NewDefElem("inherit", ast.NewBoolean(true))
 		}
@@ -42507,7 +42532,7 @@ yydefault:
 	case 3060:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13571
+//line postgres.y:13596
 		{
 			// Handle identifiers like PostgreSQL does with string comparisons
 			if yyDollar[1].str == "superuser" {
@@ -42546,7 +42571,7 @@ yydefault:
 	case 3061:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13606
+//line postgres.y:13631
 		{
 			yyLOCAL = ast.NewDefElem("connectionlimit", ast.NewInteger(yyDollar[3].ival))
 		}
@@ -42554,7 +42579,7 @@ yydefault:
 	case 3062:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13610
+//line postgres.y:13635
 		{
 			yyLOCAL = ast.NewDefElem("validUntil", ast.NewString(yyDollar[3].str))
 		}
@@ -42562,27 +42587,27 @@ yydefault:
 	case 3063:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13614
+//line postgres.y:13639
 		{
 			yyLOCAL = ast.NewDefElem("rolemembers", yyDollar[2].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3064:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13620
+//line postgres.y:13645
 		{
 			yyVAL.ival = 1
 		}
 	case 3065:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13621
+//line postgres.y:13646
 		{
 			yyVAL.ival = -1
 		}
 	case 3066:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13633
+//line postgres.y:13658
 		{
 			n := ast.NewGrantStmt(yyDollar[4].privtargetUnion().objtype, yyDollar[4].privtargetUnion().objs, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = yyDollar[4].privtargetUnion().targtype
@@ -42594,7 +42619,7 @@ yydefault:
 	case 3067:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13645
+//line postgres.y:13670
 		{
 			n := ast.NewRevokeStmt(yyDollar[4].privtargetUnion().objtype, yyDollar[4].privtargetUnion().objs, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = yyDollar[4].privtargetUnion().targtype
@@ -42606,7 +42631,7 @@ yydefault:
 	case 3068:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13654
+//line postgres.y:13679
 		{
 			n := ast.NewRevokeStmt(yyDollar[7].privtargetUnion().objtype, yyDollar[7].privtargetUnion().objs, yyDollar[5].listUnion(), yyDollar[9].listUnion())
 			n.Targtype = yyDollar[7].privtargetUnion().targtype
@@ -42619,7 +42644,7 @@ yydefault:
 	case 3069:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13666
+//line postgres.y:13691
 		{
 			stmt := ast.NewGrantRoleStmt(yyDollar[2].listUnion(), yyDollar[4].listUnion())
 			stmt.Grantor = yyDollar[5].rolespecUnion()
@@ -42629,7 +42654,7 @@ yydefault:
 	case 3070:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13672
+//line postgres.y:13697
 		{
 			stmt := ast.NewGrantRoleStmtWithOptions(yyDollar[2].listUnion(), yyDollar[4].listUnion(), yyDollar[6].listUnion())
 			stmt.Grantor = yyDollar[7].rolespecUnion()
@@ -42639,7 +42664,7 @@ yydefault:
 	case 3071:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13681
+//line postgres.y:13706
 		{
 			stmt := ast.NewRevokeRoleStmt(yyDollar[2].listUnion(), yyDollar[4].listUnion())
 			stmt.Grantor = yyDollar[5].rolespecUnion()
@@ -42650,7 +42675,7 @@ yydefault:
 	case 3072:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13688
+//line postgres.y:13713
 		{
 			opt := ast.NewDefElem(yyDollar[2].str, ast.NewBoolean(false))
 			stmt := ast.NewRevokeRoleStmt(yyDollar[5].listUnion(), yyDollar[7].listUnion())
@@ -42663,7 +42688,7 @@ yydefault:
 	case 3073:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13707
+//line postgres.y:13732
 		{
 			yyLOCAL = ast.NewAlterDefaultPrivilegesStmt(yyDollar[4].listUnion(), yyDollar[5].nodeUnion().(*ast.GrantStmt))
 		}
@@ -42671,7 +42696,7 @@ yydefault:
 	case 3074:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13713
+//line postgres.y:13738
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -42680,7 +42705,7 @@ yydefault:
 	case 3075:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13714
+//line postgres.y:13739
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -42688,7 +42713,7 @@ yydefault:
 	case 3076:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13719
+//line postgres.y:13744
 		{
 			yyLOCAL = ast.NewDefElem("schemas", yyDollar[3].listUnion())
 		}
@@ -42696,7 +42721,7 @@ yydefault:
 	case 3077:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13723
+//line postgres.y:13748
 		{
 			yyLOCAL = ast.NewDefElem("roles", yyDollar[3].listUnion())
 		}
@@ -42704,7 +42729,7 @@ yydefault:
 	case 3078:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13727
+//line postgres.y:13752
 		{
 			yyLOCAL = ast.NewDefElem("roles", yyDollar[3].listUnion())
 		}
@@ -42712,7 +42737,7 @@ yydefault:
 	case 3079:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13739
+//line postgres.y:13764
 		{
 			n := ast.NewGrantStmt(ast.ObjectType(yyDollar[4].ival), nil, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42723,7 +42748,7 @@ yydefault:
 	case 3080:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13747
+//line postgres.y:13772
 		{
 			n := ast.NewRevokeStmt(ast.ObjectType(yyDollar[4].ival), nil, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42734,7 +42759,7 @@ yydefault:
 	case 3081:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13755
+//line postgres.y:13780
 		{
 			n := ast.NewRevokeStmt(ast.ObjectType(yyDollar[7].ival), nil, yyDollar[5].listUnion(), yyDollar[9].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42745,44 +42770,44 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3082:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13765
+//line postgres.y:13790
 		{
 			yyVAL.ival = int(ast.OBJECT_TABLE)
 		}
 	case 3083:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13766
+//line postgres.y:13791
 		{
 			yyVAL.ival = int(ast.OBJECT_FUNCTION)
 		}
 	case 3084:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13767
+//line postgres.y:13792
 		{
 			yyVAL.ival = int(ast.OBJECT_FUNCTION)
 		}
 	case 3085:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13768
+//line postgres.y:13793
 		{
 			yyVAL.ival = int(ast.OBJECT_SEQUENCE)
 		}
 	case 3086:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13769
+//line postgres.y:13794
 		{
 			yyVAL.ival = int(ast.OBJECT_TYPE)
 		}
 	case 3087:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13770
+//line postgres.y:13795
 		{
 			yyVAL.ival = int(ast.OBJECT_SCHEMA)
 		}
 	case 3088:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13775
+//line postgres.y:13800
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -42790,7 +42815,7 @@ yydefault:
 	case 3089:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13777
+//line postgres.y:13802
 		{
 			yyLOCAL = nil
 		}
@@ -42798,7 +42823,7 @@ yydefault:
 	case 3090:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13779
+//line postgres.y:13804
 		{
 			yyLOCAL = nil
 		}
@@ -42806,7 +42831,7 @@ yydefault:
 	case 3091:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13781
+//line postgres.y:13806
 		{
 			ap := ast.NewAccessPriv("", yyDollar[3].listUnion())
 			yyLOCAL = ast.NewNodeList(ap)
@@ -42815,7 +42840,7 @@ yydefault:
 	case 3092:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13786
+//line postgres.y:13811
 		{
 			ap := ast.NewAccessPriv("", yyDollar[4].listUnion())
 			yyLOCAL = ast.NewNodeList(ap)
@@ -42824,7 +42849,7 @@ yydefault:
 	case 3093:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13792
+//line postgres.y:13817
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].accessprivUnion())
 		}
@@ -42832,7 +42857,7 @@ yydefault:
 	case 3094:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13793
+//line postgres.y:13818
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].accessprivUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -42841,7 +42866,7 @@ yydefault:
 	case 3095:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13797
+//line postgres.y:13822
 		{
 			yyLOCAL = ast.NewAccessPriv("SELECT", yyDollar[2].listUnion())
 		}
@@ -42849,7 +42874,7 @@ yydefault:
 	case 3096:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13801
+//line postgres.y:13826
 		{
 			yyLOCAL = ast.NewAccessPriv("REFERENCES", yyDollar[2].listUnion())
 		}
@@ -42857,7 +42882,7 @@ yydefault:
 	case 3097:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13805
+//line postgres.y:13830
 		{
 			yyLOCAL = ast.NewAccessPriv("CREATE", yyDollar[2].listUnion())
 		}
@@ -42865,7 +42890,7 @@ yydefault:
 	case 3098:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13809
+//line postgres.y:13834
 		{
 			yyLOCAL = ast.NewAccessPriv("ALTER SYSTEM", nil)
 		}
@@ -42873,7 +42898,7 @@ yydefault:
 	case 3099:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13813
+//line postgres.y:13838
 		{
 			yyLOCAL = ast.NewAccessPriv(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -42881,7 +42906,7 @@ yydefault:
 	case 3100:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13823
+//line postgres.y:13848
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42893,7 +42918,7 @@ yydefault:
 	case 3101:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13831
+//line postgres.y:13856
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42905,7 +42930,7 @@ yydefault:
 	case 3102:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13839
+//line postgres.y:13864
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42917,7 +42942,7 @@ yydefault:
 	case 3103:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13847
+//line postgres.y:13872
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42929,7 +42954,7 @@ yydefault:
 	case 3104:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13855
+//line postgres.y:13880
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42941,7 +42966,7 @@ yydefault:
 	case 3105:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13863
+//line postgres.y:13888
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42953,7 +42978,7 @@ yydefault:
 	case 3106:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13871
+//line postgres.y:13896
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42965,7 +42990,7 @@ yydefault:
 	case 3107:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13879
+//line postgres.y:13904
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42977,7 +43002,7 @@ yydefault:
 	case 3108:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13887
+//line postgres.y:13912
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42989,7 +43014,7 @@ yydefault:
 	case 3109:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13895
+//line postgres.y:13920
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43001,7 +43026,7 @@ yydefault:
 	case 3110:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13903
+//line postgres.y:13928
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43013,7 +43038,7 @@ yydefault:
 	case 3111:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13911
+//line postgres.y:13936
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43025,7 +43050,7 @@ yydefault:
 	case 3112:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13919
+//line postgres.y:13944
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43037,7 +43062,7 @@ yydefault:
 	case 3113:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13927
+//line postgres.y:13952
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43049,7 +43074,7 @@ yydefault:
 	case 3114:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13935
+//line postgres.y:13960
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43061,7 +43086,7 @@ yydefault:
 	case 3115:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13943
+//line postgres.y:13968
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43073,7 +43098,7 @@ yydefault:
 	case 3116:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13951
+//line postgres.y:13976
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43085,7 +43110,7 @@ yydefault:
 	case 3117:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13959
+//line postgres.y:13984
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43097,7 +43122,7 @@ yydefault:
 	case 3118:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13967
+//line postgres.y:13992
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43109,7 +43134,7 @@ yydefault:
 	case 3119:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13975
+//line postgres.y:14000
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43121,7 +43146,7 @@ yydefault:
 	case 3120:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13983
+//line postgres.y:14008
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43133,7 +43158,7 @@ yydefault:
 	case 3121:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13994
+//line postgres.y:14019
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].rolespecUnion())
 		}
@@ -43141,7 +43166,7 @@ yydefault:
 	case 3122:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13995
+//line postgres.y:14020
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].rolespecUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43150,7 +43175,7 @@ yydefault:
 	case 3123:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:13999
+//line postgres.y:14024
 		{
 			yyLOCAL = yyDollar[1].rolespecUnion()
 		}
@@ -43158,7 +43183,7 @@ yydefault:
 	case 3124:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14000
+//line postgres.y:14025
 		{
 			yyLOCAL = yyDollar[2].rolespecUnion()
 		}
@@ -43166,7 +43191,7 @@ yydefault:
 	case 3125:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:14005
+//line postgres.y:14030
 		{
 			yyLOCAL = true
 		}
@@ -43174,7 +43199,7 @@ yydefault:
 	case 3126:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:14006
+//line postgres.y:14031
 		{
 			yyLOCAL = false
 		}
@@ -43182,7 +43207,7 @@ yydefault:
 	case 3127:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14010
+//line postgres.y:14035
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43191,7 +43216,7 @@ yydefault:
 	case 3128:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14011
+//line postgres.y:14036
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43199,7 +43224,7 @@ yydefault:
 	case 3129:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14016
+//line postgres.y:14041
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
@@ -43207,7 +43232,7 @@ yydefault:
 	case 3130:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14022
+//line postgres.y:14047
 		{
 			yyLOCAL = ast.NewBoolean(true)
 		}
@@ -43215,7 +43240,7 @@ yydefault:
 	case 3131:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14023
+//line postgres.y:14048
 		{
 			yyLOCAL = ast.NewBoolean(true)
 		}
@@ -43223,7 +43248,7 @@ yydefault:
 	case 3132:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14024
+//line postgres.y:14049
 		{
 			yyLOCAL = ast.NewBoolean(false)
 		}
@@ -43231,7 +43256,7 @@ yydefault:
 	case 3133:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14027
+//line postgres.y:14052
 		{
 			yyLOCAL = yyDollar[3].rolespecUnion()
 		}
@@ -43239,7 +43264,7 @@ yydefault:
 	case 3134:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14028
+//line postgres.y:14053
 		{
 			yyLOCAL = nil
 		}
@@ -43247,7 +43272,7 @@ yydefault:
 	case 3135:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14033
+//line postgres.y:14058
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -43255,7 +43280,7 @@ yydefault:
 	case 3136:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14037
+//line postgres.y:14062
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43263,20 +43288,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3137:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14045
+//line postgres.y:14070
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3138:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14049
+//line postgres.y:14074
 		{
 			yyVAL.str = yyDollar[1].str + "." + yyDollar[3].str
 		}
 	case 3139:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14054
+//line postgres.y:14079
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -43284,7 +43309,7 @@ yydefault:
 	case 3140:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14055
+//line postgres.y:14080
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43293,7 +43318,7 @@ yydefault:
 	case 3141:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14059
+//line postgres.y:14084
 		{
 			n := ast.NewRangeTableSample(nil, yyDollar[2].listUnion(), yyDollar[4].listUnion(), yyDollar[6].nodeUnion(), 0)
 			yyLOCAL = n
@@ -43302,7 +43327,7 @@ yydefault:
 	case 3142:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14067
+//line postgres.y:14092
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -43310,7 +43335,7 @@ yydefault:
 	case 3143:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14071
+//line postgres.y:14096
 		{
 			yyLOCAL = nil
 		}
@@ -43318,7 +43343,7 @@ yydefault:
 	case 3144:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14085
+//line postgres.y:14110
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_FUNCTION, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43327,7 +43352,7 @@ yydefault:
 	case 3145:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14090
+//line postgres.y:14115
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_PROCEDURE, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43336,7 +43361,7 @@ yydefault:
 	case 3146:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14095
+//line postgres.y:14120
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_ROUTINE, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43345,7 +43370,7 @@ yydefault:
 	case 3147:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14103
+//line postgres.y:14128
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43353,7 +43378,7 @@ yydefault:
 	case 3148:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14104
+//line postgres.y:14129
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43362,7 +43387,7 @@ yydefault:
 	case 3149:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14110
+//line postgres.y:14135
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(false))
 		}
@@ -43370,7 +43395,7 @@ yydefault:
 	case 3150:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14114
+//line postgres.y:14139
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(true))
 		}
@@ -43378,7 +43403,7 @@ yydefault:
 	case 3151:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14118
+//line postgres.y:14143
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(true))
 		}
@@ -43386,7 +43411,7 @@ yydefault:
 	case 3152:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14122
+//line postgres.y:14147
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("immutable"))
 		}
@@ -43394,7 +43419,7 @@ yydefault:
 	case 3153:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14126
+//line postgres.y:14151
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("stable"))
 		}
@@ -43402,7 +43427,7 @@ yydefault:
 	case 3154:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14130
+//line postgres.y:14155
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("volatile"))
 		}
@@ -43410,7 +43435,7 @@ yydefault:
 	case 3155:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14134
+//line postgres.y:14159
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(true))
 		}
@@ -43418,7 +43443,7 @@ yydefault:
 	case 3156:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14138
+//line postgres.y:14163
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(false))
 		}
@@ -43426,7 +43451,7 @@ yydefault:
 	case 3157:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14142
+//line postgres.y:14167
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(true))
 		}
@@ -43434,7 +43459,7 @@ yydefault:
 	case 3158:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14146
+//line postgres.y:14171
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(false))
 		}
@@ -43442,7 +43467,7 @@ yydefault:
 	case 3159:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14150
+//line postgres.y:14175
 		{
 			yyLOCAL = ast.NewDefElem("leakproof", ast.NewBoolean(true))
 		}
@@ -43450,7 +43475,7 @@ yydefault:
 	case 3160:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14154
+//line postgres.y:14179
 		{
 			yyLOCAL = ast.NewDefElem("leakproof", ast.NewBoolean(false))
 		}
@@ -43458,7 +43483,7 @@ yydefault:
 	case 3161:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14158
+//line postgres.y:14183
 		{
 			yyLOCAL = ast.NewDefElem("cost", yyDollar[2].nodeUnion())
 		}
@@ -43466,7 +43491,7 @@ yydefault:
 	case 3162:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14162
+//line postgres.y:14187
 		{
 			yyLOCAL = ast.NewDefElem("rows", yyDollar[2].nodeUnion())
 		}
@@ -43474,7 +43499,7 @@ yydefault:
 	case 3163:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14166
+//line postgres.y:14191
 		{
 			yyLOCAL = ast.NewDefElem("support", yyDollar[2].listUnion())
 		}
@@ -43482,7 +43507,7 @@ yydefault:
 	case 3164:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14170
+//line postgres.y:14195
 		{
 			/* we abuse the normal content of a DefElem here */
 			yyLOCAL = ast.NewDefElem("set", yyDollar[1].vsetstmtUnion())
@@ -43491,7 +43516,7 @@ yydefault:
 	case 3165:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14175
+//line postgres.y:14200
 		{
 			yyLOCAL = ast.NewDefElem("parallel", ast.NewString(yyDollar[2].str))
 		}
@@ -43499,7 +43524,7 @@ yydefault:
 	case 3166:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14181
+//line postgres.y:14206
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43507,7 +43532,7 @@ yydefault:
 	case 3167:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14182
+//line postgres.y:14207
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43516,7 +43541,7 @@ yydefault:
 	case 3168:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14187
+//line postgres.y:14212
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -43524,7 +43549,7 @@ yydefault:
 	case 3169:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14191
+//line postgres.y:14216
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -43532,7 +43557,7 @@ yydefault:
 	case 3170:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14195
+//line postgres.y:14220
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -43540,7 +43565,7 @@ yydefault:
 	case 3171:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14201
+//line postgres.y:14226
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -43548,7 +43573,7 @@ yydefault:
 	case 3172:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14202
+//line postgres.y:14227
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -43556,7 +43581,7 @@ yydefault:
 	case 3173:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14203
+//line postgres.y:14228
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -43564,7 +43589,7 @@ yydefault:
 	case 3174:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14204
+//line postgres.y:14229
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -43572,7 +43597,7 @@ yydefault:
 	case 3175:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14205
+//line postgres.y:14230
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -43580,7 +43605,7 @@ yydefault:
 	case 3178:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14216
+//line postgres.y:14241
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = yyDollar[1].listUnion()
@@ -43592,7 +43617,7 @@ yydefault:
 	case 3179:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14229
+//line postgres.y:14254
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43603,7 +43628,7 @@ yydefault:
 	case 3180:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14236
+//line postgres.y:14261
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43614,7 +43639,7 @@ yydefault:
 	case 3181:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14243
+//line postgres.y:14268
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			nameList := ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43630,7 +43655,7 @@ yydefault:
 	case 3182:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14257
+//line postgres.y:14282
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -43638,7 +43663,7 @@ yydefault:
 	case 3183:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14259
+//line postgres.y:14284
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43647,7 +43672,7 @@ yydefault:
 	case 3184:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14263
+//line postgres.y:14288
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -43655,7 +43680,7 @@ yydefault:
 	case 3185:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14265
+//line postgres.y:14290
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43664,7 +43689,7 @@ yydefault:
 	case 3186:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14277
+//line postgres.y:14302
 		{
 			n := ast.NewAlterTypeStmt(yyDollar[3].listUnion(), yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -43673,7 +43698,7 @@ yydefault:
 	case 3187:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14285
+//line postgres.y:14310
 		{
 			relation, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -43688,7 +43713,7 @@ yydefault:
 	case 3188:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14298
+//line postgres.y:14323
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -43696,7 +43721,7 @@ yydefault:
 	case 3189:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14299
+//line postgres.y:14324
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43705,7 +43730,7 @@ yydefault:
 	case 3190:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14305
+//line postgres.y:14330
 		{
 			n := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[3].nodeUnion())
 			n.Behavior = yyDollar[4].dropBehavUnion()
@@ -43715,7 +43740,7 @@ yydefault:
 	case 3191:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14312
+//line postgres.y:14337
 		{
 			n := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[5].str, nil)
 			n.Behavior = yyDollar[6].dropBehavUnion()
@@ -43726,7 +43751,7 @@ yydefault:
 	case 3192:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14320
+//line postgres.y:14345
 		{
 			n := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[3].str, nil)
 			n.Behavior = yyDollar[4].dropBehavUnion()
@@ -43737,7 +43762,7 @@ yydefault:
 	case 3193:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14328
+//line postgres.y:14353
 		{
 			def := ast.NewColumnDef(yyDollar[3].str, yyDollar[6].typnamUnion(), -1)
 			n := ast.NewAlterTableCmd(ast.AT_AlterColumnType, yyDollar[3].str, def)
@@ -43753,94 +43778,94 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3194:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14349
+//line postgres.y:14374
 		{
 			yyVAL.ival = int(ast.CMD_SELECT)
 		}
 	case 3195:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14350
+//line postgres.y:14375
 		{
 			yyVAL.ival = int(ast.CMD_UPDATE)
 		}
 	case 3196:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14351
+//line postgres.y:14376
 		{
 			yyVAL.ival = int(ast.CMD_DELETE)
 		}
 	case 3197:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14352
+//line postgres.y:14377
 		{
 			yyVAL.ival = int(ast.CMD_INSERT)
 		}
 	case 3198:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14362
+//line postgres.y:14387
 		{
 			yyLOCAL = ast.NewDeclareCursorStmt(yyDollar[2].str, yyDollar[3].ival|yyDollar[5].ival|ast.CURSOR_OPT_FAST_PLAN, yyDollar[7].stmtUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3199:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14369
+//line postgres.y:14394
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_BINARY
 		}
 	case 3200:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14373
+//line postgres.y:14398
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_INSENSITIVE
 		}
 	case 3201:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14377
+//line postgres.y:14402
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_ASENSITIVE
 		}
 	case 3202:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14381
+//line postgres.y:14406
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_SCROLL
 		}
 	case 3203:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14385
+//line postgres.y:14410
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_NO_SCROLL
 		}
 	case 3204:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14388
+//line postgres.y:14413
 		{
 			yyVAL.ival = 0
 		}
 	case 3205:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14391
+//line postgres.y:14416
 		{
 			yyVAL.ival = ast.CURSOR_OPT_HOLD
 		}
 	case 3206:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14392
+//line postgres.y:14417
 		{
 			yyVAL.ival = 0
 		}
 	case 3207:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14393
+//line postgres.y:14418
 		{
 			yyVAL.ival = 0
 		}
 	case 3208:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14397
+//line postgres.y:14422
 		{
 			stmt := yyDollar[2].stmtUnion().(*ast.FetchStmt)
 			stmt.IsMove = false
@@ -43850,7 +43875,7 @@ yydefault:
 	case 3209:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14403
+//line postgres.y:14428
 		{
 			stmt := yyDollar[2].stmtUnion().(*ast.FetchStmt)
 			stmt.IsMove = true
@@ -43860,7 +43885,7 @@ yydefault:
 	case 3210:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14411
+//line postgres.y:14436
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[1].str, false)
 		}
@@ -43868,7 +43893,7 @@ yydefault:
 	case 3211:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14415
+//line postgres.y:14440
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[2].str, false)
 		}
@@ -43876,7 +43901,7 @@ yydefault:
 	case 3212:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14419
+//line postgres.y:14444
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[3].str, false)
 		}
@@ -43884,7 +43909,7 @@ yydefault:
 	case 3213:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14423
+//line postgres.y:14448
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, 1, yyDollar[3].str, false)
 		}
@@ -43892,7 +43917,7 @@ yydefault:
 	case 3214:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14427
+//line postgres.y:14452
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, 1, yyDollar[3].str, false)
 		}
@@ -43900,7 +43925,7 @@ yydefault:
 	case 3215:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14431
+//line postgres.y:14456
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, -1, yyDollar[3].str, false)
 		}
@@ -43908,7 +43933,7 @@ yydefault:
 	case 3216:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14435
+//line postgres.y:14460
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43916,7 +43941,7 @@ yydefault:
 	case 3217:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14439
+//line postgres.y:14464
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_RELATIVE, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43924,7 +43949,7 @@ yydefault:
 	case 3218:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14443
+//line postgres.y:14468
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, int64(yyDollar[1].ival), yyDollar[3].str, false)
 		}
@@ -43932,7 +43957,7 @@ yydefault:
 	case 3219:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14447
+//line postgres.y:14472
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, ast.FETCH_ALL, yyDollar[3].str, false)
 		}
@@ -43940,7 +43965,7 @@ yydefault:
 	case 3220:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14451
+//line postgres.y:14476
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[3].str, false)
 		}
@@ -43948,7 +43973,7 @@ yydefault:
 	case 3221:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14455
+//line postgres.y:14480
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43956,7 +43981,7 @@ yydefault:
 	case 3222:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14459
+//line postgres.y:14484
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, ast.FETCH_ALL, yyDollar[4].str, false)
 		}
@@ -43964,7 +43989,7 @@ yydefault:
 	case 3223:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14463
+//line postgres.y:14488
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, 1, yyDollar[3].str, false)
 		}
@@ -43972,7 +43997,7 @@ yydefault:
 	case 3224:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14467
+//line postgres.y:14492
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43980,39 +44005,39 @@ yydefault:
 	case 3225:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14471
+//line postgres.y:14496
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, ast.FETCH_ALL, yyDollar[4].str, false)
 		}
 		yyVAL.union = yyLOCAL
 	case 3226:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14476
+//line postgres.y:14501
 		{
 			yyVAL.ival = 0
 		}
 	case 3227:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14477
+//line postgres.y:14502
 		{
 			yyVAL.ival = 0
 		}
 	case 3228:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14481
+//line postgres.y:14506
 		{
 			yyVAL.ival = 0
 		}
 	case 3229:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14482
+//line postgres.y:14507
 		{
 			yyVAL.ival = 0
 		}
 	case 3230:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14487
+//line postgres.y:14512
 		{
 			name := yyDollar[2].str
 			yyLOCAL = ast.NewClosePortalStmt(name)
@@ -44021,7 +44046,7 @@ yydefault:
 	case 3231:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14492
+//line postgres.y:14517
 		{
 			yyLOCAL = ast.NewClosePortalStmt("")
 		}
@@ -44029,7 +44054,7 @@ yydefault:
 	case 3232:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14504
+//line postgres.y:14529
 		{
 			yyLOCAL = ast.NewPrepareStmt(yyDollar[2].str, yyDollar[3].listUnion(), yyDollar[5].stmtUnion())
 		}
@@ -44037,7 +44062,7 @@ yydefault:
 	case 3233:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14511
+//line postgres.y:14536
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -44045,7 +44070,7 @@ yydefault:
 	case 3234:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14514
+//line postgres.y:14539
 		{
 			yyLOCAL = nil
 		}
@@ -44053,7 +44078,7 @@ yydefault:
 	case 3235:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14518
+//line postgres.y:14543
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44061,7 +44086,7 @@ yydefault:
 	case 3236:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14519
+//line postgres.y:14544
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44069,7 +44094,7 @@ yydefault:
 	case 3237:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14520
+//line postgres.y:14545
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44077,7 +44102,7 @@ yydefault:
 	case 3238:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14521
+//line postgres.y:14546
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44085,7 +44110,7 @@ yydefault:
 	case 3239:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14522
+//line postgres.y:14547
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44093,7 +44118,7 @@ yydefault:
 	case 3240:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14526
+//line postgres.y:14551
 		{
 			yyLOCAL = ast.NewExecuteStmt(yyDollar[2].str, yyDollar[3].listUnion())
 		}
@@ -44101,7 +44126,7 @@ yydefault:
 	case 3241:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14530
+//line postgres.y:14555
 		{
 			executeStmt := ast.NewExecuteStmt(yyDollar[7].str, yyDollar[8].listUnion())
 			ctas := ast.NewCreateTableAsStmt(executeStmt, yyDollar[4].intoUnion(), ast.OBJECT_TABLE, false, false)
@@ -44115,7 +44140,7 @@ yydefault:
 	case 3242:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14540
+//line postgres.y:14565
 		{
 			executeStmt := ast.NewExecuteStmt(yyDollar[10].str, yyDollar[11].listUnion())
 			ctas := ast.NewCreateTableAsStmt(executeStmt, yyDollar[7].intoUnion(), ast.OBJECT_TABLE, false, true)
@@ -44129,7 +44154,7 @@ yydefault:
 	case 3243:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14553
+//line postgres.y:14578
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -44137,7 +44162,7 @@ yydefault:
 	case 3244:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14556
+//line postgres.y:14581
 		{
 			yyLOCAL = nil
 		}
@@ -44145,7 +44170,7 @@ yydefault:
 	case 3245:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.IntoClause
-//line postgres.y:14562
+//line postgres.y:14587
 		{
 			into := ast.NewIntoClause(yyDollar[1].rangevarUnion(), yyDollar[2].listUnion(), yyDollar[3].str, yyDollar[4].listUnion(), yyDollar[5].oncommitUnion(), yyDollar[6].str, nil, false, 0)
 			yyLOCAL = into
@@ -44154,7 +44179,7 @@ yydefault:
 	case 3246:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14570
+//line postgres.y:14595
 		{
 			yyLOCAL = ast.NewDeallocateStmt(yyDollar[2].str)
 		}
@@ -44162,7 +44187,7 @@ yydefault:
 	case 3247:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14574
+//line postgres.y:14599
 		{
 			yyLOCAL = ast.NewDeallocateStmt(yyDollar[3].str)
 		}
@@ -44170,7 +44195,7 @@ yydefault:
 	case 3248:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14578
+//line postgres.y:14603
 		{
 			yyLOCAL = ast.NewDeallocateAllStmt()
 		}
@@ -44178,7 +44203,7 @@ yydefault:
 	case 3249:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14582
+//line postgres.y:14607
 		{
 			yyLOCAL = ast.NewDeallocateAllStmt()
 		}
@@ -44186,7 +44211,7 @@ yydefault:
 	case 3250:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14593
+//line postgres.y:14618
 		{
 			yyLOCAL = ast.NewListenStmt(yyDollar[2].str)
 		}
@@ -44194,7 +44219,7 @@ yydefault:
 	case 3251:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14604
+//line postgres.y:14629
 		{
 			yyLOCAL = ast.NewUnlistenStmt(yyDollar[2].str)
 		}
@@ -44202,7 +44227,7 @@ yydefault:
 	case 3252:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14608
+//line postgres.y:14633
 		{
 			yyLOCAL = ast.NewUnlistenAllStmt()
 		}
@@ -44210,27 +44235,27 @@ yydefault:
 	case 3253:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14619
+//line postgres.y:14644
 		{
 			yyLOCAL = ast.NewNotifyStmt(yyDollar[2].str, yyDollar[3].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 3254:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14629
+//line postgres.y:14654
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 3255:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14630
+//line postgres.y:14655
 		{
 			yyVAL.str = ""
 		}
 	case 3256:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14639
+//line postgres.y:14664
 		{
 			yyLOCAL = ast.NewLoadStmt(yyDollar[2].str)
 		}
@@ -44238,7 +44263,7 @@ yydefault:
 	case 3257:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14650
+//line postgres.y:14675
 		{
 			stmt := ast.NewLockStmt(yyDollar[3].listUnion(), ast.LockMode(yyDollar[4].ival))
 			stmt.Nowait = yyDollar[5].bvalUnion()
@@ -44247,68 +44272,68 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3258:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14662
+//line postgres.y:14687
 		{
 			yyVAL.ival = yyDollar[2].ival
 		}
 	case 3259:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14663
+//line postgres.y:14688
 		{
 			yyVAL.ival = int(ast.AccessExclusiveLock)
 		}
 	case 3260:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14667
+//line postgres.y:14692
 		{
 			yyVAL.ival = int(ast.AccessShareLock)
 		}
 	case 3261:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14668
+//line postgres.y:14693
 		{
 			yyVAL.ival = int(ast.RowShareLock)
 		}
 	case 3262:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14669
+//line postgres.y:14694
 		{
 			yyVAL.ival = int(ast.RowExclusiveLock)
 		}
 	case 3263:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14670
+//line postgres.y:14695
 		{
 			yyVAL.ival = int(ast.ShareUpdateExclusiveLock)
 		}
 	case 3264:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14671
+//line postgres.y:14696
 		{
 			yyVAL.ival = int(ast.ShareLock)
 		}
 	case 3265:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14672
+//line postgres.y:14697
 		{
 			yyVAL.ival = int(ast.ShareRowExclusiveLock)
 		}
 	case 3266:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14673
+//line postgres.y:14698
 		{
 			yyVAL.ival = int(ast.ExclusiveLock)
 		}
 	case 3267:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14674
+//line postgres.y:14699
 		{
 			yyVAL.ival = int(ast.AccessExclusiveLock)
 		}
 	case 3268:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14683
+//line postgres.y:14708
 		{
 			stmt := ast.NewTruncateStmt(yyDollar[3].listUnion())
 			stmt.RestartSeqs = yyDollar[4].bvalUnion()
@@ -44319,7 +44344,7 @@ yydefault:
 	case 3269:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14697
+//line postgres.y:14722
 		{
 			yyLOCAL = ast.NewCommentStmt(yyDollar[3].objTypeUnion(), yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -44327,7 +44352,7 @@ yydefault:
 	case 3270:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14701
+//line postgres.y:14726
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_COLUMN, yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -44335,7 +44360,7 @@ yydefault:
 	case 3271:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14705
+//line postgres.y:14730
 		{
 			yyLOCAL = ast.NewCommentStmt(yyDollar[3].objTypeUnion(), ast.NewString(yyDollar[4].str), yyDollar[6].str)
 		}
@@ -44343,7 +44368,7 @@ yydefault:
 	case 3272:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14709
+//line postgres.y:14734
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_TYPE, yyDollar[4].typnamUnion(), yyDollar[6].str)
 		}
@@ -44351,7 +44376,7 @@ yydefault:
 	case 3273:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14713
+//line postgres.y:14738
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_DOMAIN, yyDollar[4].typnamUnion(), yyDollar[6].str)
 		}
@@ -44359,7 +44384,7 @@ yydefault:
 	case 3274:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14717
+//line postgres.y:14742
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_AGGREGATE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44367,7 +44392,7 @@ yydefault:
 	case 3275:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14721
+//line postgres.y:14746
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_FUNCTION, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44375,7 +44400,7 @@ yydefault:
 	case 3276:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14725
+//line postgres.y:14750
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_OPERATOR, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44383,7 +44408,7 @@ yydefault:
 	case 3277:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14729
+//line postgres.y:14754
 		{
 			// For table constraints, append constraint name to table name list
 			newObj := yyDollar[6].listUnion()
@@ -44394,7 +44419,7 @@ yydefault:
 	case 3278:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14736
+//line postgres.y:14761
 		{
 			// For domain constraints, we need a list of [TypeName, constraint_name]
 			// This matches PostgreSQL's approach where they comment:
@@ -44409,7 +44434,7 @@ yydefault:
 	case 3279:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14747
+//line postgres.y:14772
 		{
 			// For object types that need name ON any_name: append name to any_name list
 			newObj := yyDollar[6].listUnion()
@@ -44420,7 +44445,7 @@ yydefault:
 	case 3280:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14754
+//line postgres.y:14779
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_PROCEDURE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44428,7 +44453,7 @@ yydefault:
 	case 3281:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14758
+//line postgres.y:14783
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_ROUTINE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44436,7 +44461,7 @@ yydefault:
 	case 3282:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14762
+//line postgres.y:14787
 		{
 			// Transform: typename + language name
 			transformObj := ast.NewNodeList()
@@ -44448,7 +44473,7 @@ yydefault:
 	case 3283:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14770
+//line postgres.y:14795
 		{
 			// Operator class: access method + class name
 			opclassObj := ast.NewNodeList()
@@ -44462,7 +44487,7 @@ yydefault:
 	case 3284:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14780
+//line postgres.y:14805
 		{
 			// Operator family: access method + family name
 			opfamilyObj := ast.NewNodeList()
@@ -44476,7 +44501,7 @@ yydefault:
 	case 3285:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14790
+//line postgres.y:14815
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_LARGEOBJECT, yyDollar[5].nodeUnion(), yyDollar[7].str)
 		}
@@ -44484,7 +44509,7 @@ yydefault:
 	case 3286:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14794
+//line postgres.y:14819
 		{
 			// Cast: source type + target type
 			castObj := ast.NewNodeList()
@@ -44495,20 +44520,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3287:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14808
+//line postgres.y:14833
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3288:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14809
+//line postgres.y:14834
 		{
 			yyVAL.str = ""
 		}
 	case 3289:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14818
+//line postgres.y:14843
 		{
 			yyLOCAL = ast.NewSecLabelStmt(yyDollar[5].objTypeUnion(), yyDollar[6].listUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44516,7 +44541,7 @@ yydefault:
 	case 3290:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14822
+//line postgres.y:14847
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_COLUMN, yyDollar[6].listUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44524,7 +44549,7 @@ yydefault:
 	case 3291:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14826
+//line postgres.y:14851
 		{
 			yyLOCAL = ast.NewSecLabelStmt(yyDollar[5].objTypeUnion(), ast.NewString(yyDollar[6].str), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44532,7 +44557,7 @@ yydefault:
 	case 3292:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14830
+//line postgres.y:14855
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_TYPE, yyDollar[6].typnamUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44540,7 +44565,7 @@ yydefault:
 	case 3293:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14834
+//line postgres.y:14859
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_DOMAIN, yyDollar[6].typnamUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44548,7 +44573,7 @@ yydefault:
 	case 3294:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14838
+//line postgres.y:14863
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_AGGREGATE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44556,7 +44581,7 @@ yydefault:
 	case 3295:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14842
+//line postgres.y:14867
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_FUNCTION, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44564,7 +44589,7 @@ yydefault:
 	case 3296:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14846
+//line postgres.y:14871
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_LARGEOBJECT, yyDollar[7].nodeUnion(), yyDollar[3].str, yyDollar[9].str)
 		}
@@ -44572,7 +44597,7 @@ yydefault:
 	case 3297:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14850
+//line postgres.y:14875
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_PROCEDURE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44580,39 +44605,39 @@ yydefault:
 	case 3298:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14854
+//line postgres.y:14879
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_ROUTINE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 3299:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14864
+//line postgres.y:14889
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 3300:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14865
+//line postgres.y:14890
 		{
 			yyVAL.str = ""
 		}
 	case 3301:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14869
+//line postgres.y:14894
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3302:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14870
+//line postgres.y:14895
 		{
 			yyVAL.str = ""
 		}
 	case 3303:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14879
+//line postgres.y:14904
 		{
 			yyLOCAL = ast.NewDoStmt(yyDollar[2].listUnion())
 		}
@@ -44620,7 +44645,7 @@ yydefault:
 	case 3304:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14889
+//line postgres.y:14914
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -44628,7 +44653,7 @@ yydefault:
 	case 3305:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14890
+//line postgres.y:14915
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Append(yyDollar[2].defeltUnion())
@@ -44637,7 +44662,7 @@ yydefault:
 	case 3306:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14895
+//line postgres.y:14920
 		{
 			yyLOCAL = ast.NewDefElem("as", ast.NewString(yyDollar[1].str))
 		}
@@ -44645,7 +44670,7 @@ yydefault:
 	case 3307:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14899
+//line postgres.y:14924
 		{
 			yyLOCAL = ast.NewDefElem("language", ast.NewString(yyDollar[2].str))
 		}
@@ -44653,7 +44678,7 @@ yydefault:
 	case 3308:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14910
+//line postgres.y:14935
 		{
 			yyLOCAL = ast.NewCallStmt(yyDollar[2].nodeUnion().(*ast.FuncCall))
 		}
@@ -44661,7 +44686,7 @@ yydefault:
 	case 3309:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14923
+//line postgres.y:14948
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_AGGREGATE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44672,7 +44697,7 @@ yydefault:
 	case 3310:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14930
+//line postgres.y:14955
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_COLLATION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44683,7 +44708,7 @@ yydefault:
 	case 3311:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14937
+//line postgres.y:14962
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_CONVERSION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44694,7 +44719,7 @@ yydefault:
 	case 3312:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14944
+//line postgres.y:14969
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_DOMAIN, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44705,7 +44730,7 @@ yydefault:
 	case 3313:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14951
+//line postgres.y:14976
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_EXTENSION, yyDollar[6].str)
 			stmt.Object = ast.NewString(yyDollar[3].str)
@@ -44716,7 +44741,7 @@ yydefault:
 	case 3314:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14958
+//line postgres.y:14983
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FUNCTION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44727,7 +44752,7 @@ yydefault:
 	case 3315:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14965
+//line postgres.y:14990
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPERATOR, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44738,7 +44763,7 @@ yydefault:
 	case 3316:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14972
+//line postgres.y:14997
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPCLASS, yyDollar[9].str)
 			// Create list with access method name first, then class name
@@ -44754,7 +44779,7 @@ yydefault:
 	case 3317:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14984
+//line postgres.y:15009
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPFAMILY, yyDollar[9].str)
 			// Create list with access method name first, then family name
@@ -44770,7 +44795,7 @@ yydefault:
 	case 3318:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14996
+//line postgres.y:15021
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_PROCEDURE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44781,7 +44806,7 @@ yydefault:
 	case 3319:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15003
+//line postgres.y:15028
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_ROUTINE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44792,7 +44817,7 @@ yydefault:
 	case 3320:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15010
+//line postgres.y:15035
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TABLE, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44803,7 +44828,7 @@ yydefault:
 	case 3321:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15017
+//line postgres.y:15042
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TABLE, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44814,7 +44839,7 @@ yydefault:
 	case 3322:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15024
+//line postgres.y:15049
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_STATISTIC_EXT, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44825,7 +44850,7 @@ yydefault:
 	case 3323:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15031
+//line postgres.y:15056
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSPARSER, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44836,7 +44861,7 @@ yydefault:
 	case 3324:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15038
+//line postgres.y:15063
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSDICTIONARY, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44847,7 +44872,7 @@ yydefault:
 	case 3325:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15045
+//line postgres.y:15070
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSTEMPLATE, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44858,7 +44883,7 @@ yydefault:
 	case 3326:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15052
+//line postgres.y:15077
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSCONFIGURATION, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44869,7 +44894,7 @@ yydefault:
 	case 3327:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15059
+//line postgres.y:15084
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_SEQUENCE, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44880,7 +44905,7 @@ yydefault:
 	case 3328:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15066
+//line postgres.y:15091
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_SEQUENCE, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44891,7 +44916,7 @@ yydefault:
 	case 3329:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15073
+//line postgres.y:15098
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_VIEW, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44902,7 +44927,7 @@ yydefault:
 	case 3330:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15080
+//line postgres.y:15105
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_VIEW, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44913,7 +44938,7 @@ yydefault:
 	case 3331:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15087
+//line postgres.y:15112
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_MATVIEW, yyDollar[7].str)
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -44924,7 +44949,7 @@ yydefault:
 	case 3332:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15094
+//line postgres.y:15119
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_MATVIEW, yyDollar[9].str)
 			stmt.Relation = yyDollar[6].rangevarUnion()
@@ -44935,7 +44960,7 @@ yydefault:
 	case 3333:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15101
+//line postgres.y:15126
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FOREIGN_TABLE, yyDollar[7].str)
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -44946,7 +44971,7 @@ yydefault:
 	case 3334:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15108
+//line postgres.y:15133
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FOREIGN_TABLE, yyDollar[9].str)
 			stmt.Relation = yyDollar[6].rangevarUnion()
@@ -44957,7 +44982,7 @@ yydefault:
 	case 3335:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15115
+//line postgres.y:15140
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TYPE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44968,7 +44993,7 @@ yydefault:
 	case 3336:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15131
+//line postgres.y:15156
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -44981,7 +45006,7 @@ yydefault:
 	case 3337:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15140
+//line postgres.y:15165
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -44994,7 +45019,7 @@ yydefault:
 	case 3338:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15149
+//line postgres.y:15174
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45007,7 +45032,7 @@ yydefault:
 	case 3339:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15158
+//line postgres.y:15183
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45020,7 +45045,7 @@ yydefault:
 	case 3340:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15167
+//line postgres.y:15192
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45033,7 +45058,7 @@ yydefault:
 	case 3341:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15176
+//line postgres.y:15201
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45046,7 +45071,7 @@ yydefault:
 	case 3342:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15185
+//line postgres.y:15210
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45059,7 +45084,7 @@ yydefault:
 	case 3343:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15194
+//line postgres.y:15219
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45072,7 +45097,7 @@ yydefault:
 	case 3344:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15203
+//line postgres.y:15228
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45085,7 +45110,7 @@ yydefault:
 	case 3345:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15212
+//line postgres.y:15237
 		{
 			list := ast.NewNodeList(ast.NewString(yyDollar[6].str))
 			for _, item := range yyDollar[4].listUnion().Items {
@@ -45102,7 +45127,7 @@ yydefault:
 	case 3346:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15225
+//line postgres.y:15250
 		{
 			list := ast.NewNodeList(ast.NewString(yyDollar[6].str))
 			for _, item := range yyDollar[4].listUnion().Items {
@@ -45119,7 +45144,7 @@ yydefault:
 	case 3347:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15238
+//line postgres.y:15263
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45132,7 +45157,7 @@ yydefault:
 	case 3348:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15247
+//line postgres.y:15272
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45145,7 +45170,7 @@ yydefault:
 	case 3349:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15256
+//line postgres.y:15281
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45158,7 +45183,7 @@ yydefault:
 	case 3350:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15265
+//line postgres.y:15290
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45171,7 +45196,7 @@ yydefault:
 	case 3351:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15274
+//line postgres.y:15299
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45184,7 +45209,7 @@ yydefault:
 	case 3352:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15283
+//line postgres.y:15308
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45197,7 +45222,7 @@ yydefault:
 	case 3353:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15292
+//line postgres.y:15317
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45210,7 +45235,7 @@ yydefault:
 	case 3354:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15301
+//line postgres.y:15326
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45223,7 +45248,7 @@ yydefault:
 	case 3355:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15310
+//line postgres.y:15335
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45236,7 +45261,7 @@ yydefault:
 	case 3356:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15319
+//line postgres.y:15344
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45249,7 +45274,7 @@ yydefault:
 	case 3357:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15328
+//line postgres.y:15353
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45262,7 +45287,7 @@ yydefault:
 	case 3358:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15337
+//line postgres.y:15362
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45275,7 +45300,7 @@ yydefault:
 	case 3359:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15346
+//line postgres.y:15371
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45288,7 +45313,7 @@ yydefault:
 	case 3360:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15364
+//line postgres.y:15389
 		{
 			yyLOCAL = ast.NewAlterOperatorStmt(yyDollar[3].objwithargsUnion(), yyDollar[6].listUnion())
 		}
@@ -45296,7 +45321,7 @@ yydefault:
 	case 3361:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15377
+//line postgres.y:15402
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_FUNCTION, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45306,7 +45331,7 @@ yydefault:
 	case 3362:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15383
+//line postgres.y:15408
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_PROCEDURE, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45316,7 +45341,7 @@ yydefault:
 	case 3363:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15389
+//line postgres.y:15414
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_ROUTINE, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45326,7 +45351,7 @@ yydefault:
 	case 3364:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15395
+//line postgres.y:15420
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_TRIGGER, ast.NewString(yyDollar[10].str), yyDollar[6].bvalUnion())
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -45337,7 +45362,7 @@ yydefault:
 	case 3365:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15402
+//line postgres.y:15427
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_MATVIEW, ast.NewString(yyDollar[9].str), yyDollar[5].bvalUnion())
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -45347,7 +45372,7 @@ yydefault:
 	case 3366:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15408
+//line postgres.y:15433
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_INDEX, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -45357,7 +45382,7 @@ yydefault:
 	case 3367:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15415
+//line postgres.y:15440
 		{
 			yyLOCAL = true
 		}
@@ -45365,7 +45390,7 @@ yydefault:
 	case 3368:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15416
+//line postgres.y:15441
 		{
 			yyLOCAL = false
 		}
@@ -45373,7 +45398,7 @@ yydefault:
 	case 3369:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15427
+//line postgres.y:15452
 		{
 			yyLOCAL = ast.NewAlterCollationStmt(yyDollar[3].listUnion())
 		}
@@ -45381,7 +45406,7 @@ yydefault:
 	case 3370:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15440
+//line postgres.y:15465
 		{
 			yyLOCAL = ast.NewAlterDatabaseStmt(yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -45389,7 +45414,7 @@ yydefault:
 	case 3371:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15444
+//line postgres.y:15469
 		{
 			yyLOCAL = ast.NewAlterDatabaseStmt(yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -45397,7 +45422,7 @@ yydefault:
 	case 3372:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15448
+//line postgres.y:15473
 		{
 			optList := ast.NewNodeList()
 			optList.Append(ast.NewDefElem("tablespace", ast.NewString(yyDollar[6].str)))
@@ -45407,7 +45432,7 @@ yydefault:
 	case 3373:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15454
+//line postgres.y:15479
 		{
 			yyLOCAL = ast.NewAlterDatabaseRefreshCollStmt(yyDollar[3].str)
 		}
@@ -45415,7 +45440,7 @@ yydefault:
 	case 3374:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15460
+//line postgres.y:15485
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -45423,7 +45448,7 @@ yydefault:
 	case 3375:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15461
+//line postgres.y:15486
 		{
 			yyLOCAL = nil
 		}
@@ -45431,7 +45456,7 @@ yydefault:
 	case 3376:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15465
+//line postgres.y:15490
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -45439,7 +45464,7 @@ yydefault:
 	case 3377:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15466
+//line postgres.y:15491
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -45448,7 +45473,7 @@ yydefault:
 	case 3378:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15471
+//line postgres.y:15496
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewInteger(yyDollar[3].ival))
 		}
@@ -45456,7 +45481,7 @@ yydefault:
 	case 3379:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15475
+//line postgres.y:15500
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewString(yyDollar[3].str))
 		}
@@ -45464,67 +45489,67 @@ yydefault:
 	case 3380:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15479
+//line postgres.y:15504
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
 		yyVAL.union = yyLOCAL
 	case 3381:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15485
+//line postgres.y:15510
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3382:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:15486
+//line postgres.y:15511
 		{
 			yyVAL.str = "connection_limit"
 		}
 	case 3383:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15487
+//line postgres.y:15512
 		{
 			yyVAL.str = "encoding"
 		}
 	case 3384:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15488
+//line postgres.y:15513
 		{
 			yyVAL.str = "location"
 		}
 	case 3385:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15489
+//line postgres.y:15514
 		{
 			yyVAL.str = "owner"
 		}
 	case 3386:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15490
+//line postgres.y:15515
 		{
 			yyVAL.str = "tablespace"
 		}
 	case 3387:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15491
+//line postgres.y:15516
 		{
 			yyVAL.str = "template"
 		}
 	case 3388:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15494
+//line postgres.y:15519
 		{
 		}
 	case 3389:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:15495
+//line postgres.y:15520
 		{
 		}
 	case 3390:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15500
+//line postgres.y:15525
 		{
 			yyLOCAL = ast.NewAlterDatabaseSetStmt(yyDollar[3].str, yyDollar[4].vsetstmtUnion())
 		}
@@ -45532,7 +45557,7 @@ yydefault:
 	case 3391:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15513
+//line postgres.y:15538
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_ADD_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45545,7 +45570,7 @@ yydefault:
 	case 3392:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15522
+//line postgres.y:15547
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_ALTER_MAPPING_FOR_TOKEN, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45558,7 +45583,7 @@ yydefault:
 	case 3393:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15531
+//line postgres.y:15556
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_REPLACE_DICT, yyDollar[5].listUnion())
 			stmt.Tokentype = nil
@@ -45574,7 +45599,7 @@ yydefault:
 	case 3394:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15543
+//line postgres.y:15568
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_REPLACE_DICT_FOR_TOKEN, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45590,7 +45615,7 @@ yydefault:
 	case 3395:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15555
+//line postgres.y:15580
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_DROP_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45601,7 +45626,7 @@ yydefault:
 	case 3396:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15562
+//line postgres.y:15587
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_DROP_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[11].listUnion()
@@ -45612,7 +45637,7 @@ yydefault:
 	case 3399:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15583
+//line postgres.y:15608
 		{
 			yyLOCAL = ast.NewAlterTSDictionaryStmt(yyDollar[5].listUnion(), yyDollar[6].listUnion())
 		}
@@ -45620,7 +45645,7 @@ yydefault:
 	case 3400:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15593
+//line postgres.y:15618
 		{
 			yyLOCAL = false
 		}
@@ -45628,7 +45653,7 @@ yydefault:
 	case 3401:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15594
+//line postgres.y:15619
 		{
 			yyLOCAL = true
 		}
@@ -45636,7 +45661,7 @@ yydefault:
 	case 3402:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15595
+//line postgres.y:15620
 		{
 			yyLOCAL = false
 		}

--- a/go/common/parser/postgres.go
+++ b/go/common/parser/postgres.go
@@ -1150,7 +1150,7 @@ const (
 	yyInitialStackSize = 16
 )
 
-//line postgres.y:15623
+//line postgres.y:15630
 
 // Lex implements the lexer interface for goyacc
 func (l *Lexer) Lex(lval *yySymType) int {
@@ -14521,7 +14521,7 @@ var yyPgo = [...]int{
 	257, 4982, 12, 4980, 3614, 455, 4979, 72,
 }
 
-//line postgres.y:15623
+//line postgres.y:15630
 type yySymType struct {
 	union    any
 	ival     int
@@ -30397,7 +30397,13 @@ yydefault:
 		var yyLOCAL ast.Node
 //line postgres.y:5716
 		{
-			// Parse the encoding name and map to JsonEncoding constant
+			// Parse the encoding name and map to JsonEncoding constant.
+			// Match PostgreSQL by rejecting unknown names at parse time
+			// (gram.y json_format_clause raises ereport(ERROR) with
+			// errcode INVALID_PARAMETER_VALUE / "unrecognized JSON
+			// encoding"). The JsonFormat node only carries an enum, so
+			// preserving the raw name through to the backend would mean
+			// reshaping the AST; rejecting here is the simpler match.
 			var encoding ast.JsonEncoding
 			switch yyDollar[4].str {
 			case "utf8":
@@ -30407,6 +30413,7 @@ yydefault:
 			case "utf32":
 				encoding = ast.JS_ENC_UTF32
 			default:
+				yylex.Error(fmt.Sprintf("unrecognized JSON encoding: %s", yyDollar[4].str))
 				encoding = ast.JS_ENC_DEFAULT
 			}
 			yyLOCAL = &ast.JsonFormat{
@@ -30419,7 +30426,7 @@ yydefault:
 	case 1780:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5736
+//line postgres.y:5743
 		{
 			yyLOCAL = &ast.JsonFormat{
 				BaseNode:   ast.BaseNode{Tag: ast.T_JsonFormat},
@@ -30431,7 +30438,7 @@ yydefault:
 	case 1781:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5746
+//line postgres.y:5753
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -30439,7 +30446,7 @@ yydefault:
 	case 1782:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5747
+//line postgres.y:5754
 		{
 			yyLOCAL = nil
 		}
@@ -30447,7 +30454,7 @@ yydefault:
 	case 1783:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5752
+//line postgres.y:5759
 		{
 			yyLOCAL = ast.NewString("path")
 		}
@@ -30455,7 +30462,7 @@ yydefault:
 	case 1784:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5753
+//line postgres.y:5760
 		{
 			yyLOCAL = nil
 		}
@@ -30463,7 +30470,7 @@ yydefault:
 	case 1785:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5759
+//line postgres.y:5766
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -30471,7 +30478,7 @@ yydefault:
 	case 1786:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5763
+//line postgres.y:5770
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30480,7 +30487,7 @@ yydefault:
 	case 1787:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5772
+//line postgres.y:5779
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_FOR_ORDINALITY, yyDollar[1].str)
 			yyLOCAL = jsonTableCol
@@ -30489,7 +30496,7 @@ yydefault:
 	case 1788:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5781
+//line postgres.y:5788
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_REGULAR, yyDollar[1].str)
 			jsonTableCol.TypeName = yyDollar[2].typnamUnion()
@@ -30514,7 +30521,7 @@ yydefault:
 	case 1789:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5806
+//line postgres.y:5813
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_FORMATTED, yyDollar[1].str)
 			jsonTableCol.TypeName = yyDollar[2].typnamUnion()
@@ -30542,7 +30549,7 @@ yydefault:
 	case 1790:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5831
+//line postgres.y:5838
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_EXISTS, yyDollar[1].str)
 			jsonTableCol.TypeName = yyDollar[2].typnamUnion()
@@ -30559,7 +30566,7 @@ yydefault:
 	case 1791:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5845
+//line postgres.y:5852
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_NESTED, "")
 			jsonTableCol.Columns = yyDollar[6].listUnion()
@@ -30571,7 +30578,7 @@ yydefault:
 	case 1792:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5854
+//line postgres.y:5861
 		{
 			jsonTableCol := ast.NewJsonTableColumn(ast.JTC_NESTED, yyDollar[5].str)
 			jsonTableCol.Columns = yyDollar[8].listUnion()
@@ -30583,7 +30590,7 @@ yydefault:
 	case 1793:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5865
+//line postgres.y:5872
 		{
 			yyLOCAL = ast.NewString(yyDollar[2].str)
 		}
@@ -30591,7 +30598,7 @@ yydefault:
 	case 1794:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5866
+//line postgres.y:5873
 		{
 			yyLOCAL = nil
 		}
@@ -30599,7 +30606,7 @@ yydefault:
 	case 1795:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:5882
+//line postgres.y:5889
 		{
 			insertStmt := yyDollar[5].nodeUnion().(*ast.InsertStmt)
 			insertStmt.Relation = yyDollar[4].rangevarUnion()
@@ -30612,7 +30619,7 @@ yydefault:
 	case 1796:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:5894
+//line postgres.y:5901
 		{
 			yyLOCAL = yyDollar[1].rangevarUnion()
 		}
@@ -30620,7 +30627,7 @@ yydefault:
 	case 1797:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:5898
+//line postgres.y:5905
 		{
 			rangeVar := yyDollar[1].rangevarUnion()
 			rangeVar.Alias = ast.NewAlias(yyDollar[3].str, nil)
@@ -30630,7 +30637,7 @@ yydefault:
 	case 1798:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5907
+//line postgres.y:5914
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.SelectStmt = yyDollar[1].stmtUnion()
@@ -30640,7 +30647,7 @@ yydefault:
 	case 1799:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5913
+//line postgres.y:5920
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Override = ast.OverridingKind(yyDollar[2].ival)
@@ -30651,7 +30658,7 @@ yydefault:
 	case 1800:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5920
+//line postgres.y:5927
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Cols = yyDollar[2].listUnion()
@@ -30662,7 +30669,7 @@ yydefault:
 	case 1801:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5927
+//line postgres.y:5934
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			insertStmt.Cols = yyDollar[2].listUnion()
@@ -30674,7 +30681,7 @@ yydefault:
 	case 1802:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:5935
+//line postgres.y:5942
 		{
 			insertStmt := ast.NewInsertStmt(nil)
 			// For DEFAULT VALUES, SelectStmt should be nil
@@ -30684,20 +30691,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1803:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:5944
+//line postgres.y:5951
 		{
 			yyVAL.ival = int(ast.OVERRIDING_USER_VALUE)
 		}
 	case 1804:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:5945
+//line postgres.y:5952
 		{
 			yyVAL.ival = int(ast.OVERRIDING_SYSTEM_VALUE)
 		}
 	case 1805:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5950
+//line postgres.y:5957
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].targetUnion())
 		}
@@ -30705,7 +30712,7 @@ yydefault:
 	case 1806:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5954
+//line postgres.y:5961
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].targetUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30714,7 +30721,7 @@ yydefault:
 	case 1807:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ResTarget
-//line postgres.y:5962
+//line postgres.y:5969
 		{
 			yyLOCAL = ast.NewResTargetWithIndirection(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -30722,7 +30729,7 @@ yydefault:
 	case 1808:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:5974
+//line postgres.y:5981
 		{
 			updateStmt := ast.NewUpdateStmt(yyDollar[3].rangevarUnion())
 			updateStmt.WithClause = yyDollar[1].withUnion()
@@ -30736,7 +30743,7 @@ yydefault:
 	case 1809:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5987
+//line postgres.y:5994
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -30744,7 +30751,7 @@ yydefault:
 	case 1810:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:5991
+//line postgres.y:5998
 		{
 			// Concatenate the lists - equivalent to PostgreSQL's list_concat
 			for _, item := range yyDollar[3].listUnion().Items {
@@ -30756,7 +30763,7 @@ yydefault:
 	case 1811:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6002
+//line postgres.y:6009
 		{
 			target := yyDollar[1].targetUnion()
 			target.Val = yyDollar[3].nodeUnion()
@@ -30766,7 +30773,7 @@ yydefault:
 	case 1812:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6008
+//line postgres.y:6015
 		{
 			// Multi-column assignment: (col1, col2) = (val1, val2)
 			// Create MultiAssignRef nodes for each target, matching PostgreSQL exactly
@@ -30787,7 +30794,7 @@ yydefault:
 	case 1813:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ResTarget
-//line postgres.y:6028
+//line postgres.y:6035
 		{
 			yyLOCAL = ast.NewResTargetWithIndirection(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -30795,7 +30802,7 @@ yydefault:
 	case 1814:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6034
+//line postgres.y:6041
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].targetUnion())
 		}
@@ -30803,7 +30810,7 @@ yydefault:
 	case 1815:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6035
+//line postgres.y:6042
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].targetUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30812,7 +30819,7 @@ yydefault:
 	case 1816:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6045
+//line postgres.y:6052
 		{
 			deleteStmt := ast.NewDeleteStmt(yyDollar[4].rangevarUnion())
 			deleteStmt.WithClause = yyDollar[1].withUnion()
@@ -30825,7 +30832,7 @@ yydefault:
 	case 1817:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6057
+//line postgres.y:6064
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -30833,7 +30840,7 @@ yydefault:
 	case 1818:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6061
+//line postgres.y:6068
 		{
 			yyLOCAL = nil
 		}
@@ -30841,7 +30848,7 @@ yydefault:
 	case 1819:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6076
+//line postgres.y:6083
 		{
 			mergeStmt := &ast.MergeStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_MergeStmt},
@@ -30858,7 +30865,7 @@ yydefault:
 	case 1820:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6093
+//line postgres.y:6100
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -30866,7 +30873,7 @@ yydefault:
 	case 1821:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6097
+//line postgres.y:6104
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -30875,7 +30882,7 @@ yydefault:
 	case 1822:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6108
+//line postgres.y:6115
 		{
 			copyStmt := &ast.CopyStmt{
 				BaseNode:  ast.BaseNode{Tag: ast.T_CopyStmt},
@@ -30901,7 +30908,7 @@ yydefault:
 	case 1823:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6132
+//line postgres.y:6139
 		{
 			copyStmt := &ast.CopyStmt{
 				BaseNode:  ast.BaseNode{Tag: ast.T_CopyStmt},
@@ -30935,50 +30942,50 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1824:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6168
+//line postgres.y:6175
 		{
 			yyVAL.ival = 1
 		}
 	case 1825:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6169
+//line postgres.y:6176
 		{
 			yyVAL.ival = 0
 		}
 	case 1826:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6173
+//line postgres.y:6180
 		{
 			yyVAL.ival = 1
 		}
 	case 1827:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6174
+//line postgres.y:6181
 		{
 			yyVAL.ival = 0
 		}
 	case 1828:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6178
+//line postgres.y:6185
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1829:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6179
+//line postgres.y:6186
 		{
 			yyVAL.str = ""
 		}
 	case 1830:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6180
+//line postgres.y:6187
 		{
 			yyVAL.str = ""
 		}
 	case 1831:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6185
+//line postgres.y:6192
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("binary"))
 		}
@@ -30986,7 +30993,7 @@ yydefault:
 	case 1832:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6188
+//line postgres.y:6195
 		{
 			yyLOCAL = nil
 		}
@@ -30994,7 +31001,7 @@ yydefault:
 	case 1833:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6193
+//line postgres.y:6200
 		{
 			yyLOCAL = ast.NewDefElem("delimiter", ast.NewString(yyDollar[3].str))
 		}
@@ -31002,7 +31009,7 @@ yydefault:
 	case 1834:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6196
+//line postgres.y:6203
 		{
 			yyLOCAL = nil
 		}
@@ -31010,7 +31017,7 @@ yydefault:
 	case 1835:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6200
+//line postgres.y:6207
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -31018,7 +31025,7 @@ yydefault:
 	case 1836:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6201
+//line postgres.y:6208
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31026,7 +31033,7 @@ yydefault:
 	case 1837:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6206
+//line postgres.y:6213
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].nodeUnion())
@@ -31039,7 +31046,7 @@ yydefault:
 	case 1838:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6214
+//line postgres.y:6221
 		{
 			yyLOCAL = nil
 		}
@@ -31047,7 +31054,7 @@ yydefault:
 	case 1839:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6221
+//line postgres.y:6228
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("binary"))
 		}
@@ -31055,7 +31062,7 @@ yydefault:
 	case 1840:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6225
+//line postgres.y:6232
 		{
 			yyLOCAL = ast.NewDefElem("freeze", ast.NewString("true"))
 		}
@@ -31063,7 +31070,7 @@ yydefault:
 	case 1841:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6229
+//line postgres.y:6236
 		{
 			yyLOCAL = ast.NewDefElem("delimiter", ast.NewString(yyDollar[3].str))
 		}
@@ -31071,7 +31078,7 @@ yydefault:
 	case 1842:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6233
+//line postgres.y:6240
 		{
 			yyLOCAL = ast.NewDefElem("null", ast.NewString(yyDollar[3].str))
 		}
@@ -31079,7 +31086,7 @@ yydefault:
 	case 1843:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6237
+//line postgres.y:6244
 		{
 			yyLOCAL = ast.NewDefElem("format", ast.NewString("csv"))
 		}
@@ -31087,7 +31094,7 @@ yydefault:
 	case 1844:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6241
+//line postgres.y:6248
 		{
 			yyLOCAL = ast.NewDefElem("header", ast.NewString("true"))
 		}
@@ -31095,7 +31102,7 @@ yydefault:
 	case 1845:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6245
+//line postgres.y:6252
 		{
 			yyLOCAL = ast.NewDefElem("quote", ast.NewString(yyDollar[3].str))
 		}
@@ -31103,7 +31110,7 @@ yydefault:
 	case 1846:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6249
+//line postgres.y:6256
 		{
 			yyLOCAL = ast.NewDefElem("escape", ast.NewString(yyDollar[3].str))
 		}
@@ -31111,7 +31118,7 @@ yydefault:
 	case 1847:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6253
+//line postgres.y:6260
 		{
 			yyLOCAL = ast.NewDefElem("force_quote", yyDollar[3].listUnion())
 		}
@@ -31119,7 +31126,7 @@ yydefault:
 	case 1848:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6257
+//line postgres.y:6264
 		{
 			yyLOCAL = ast.NewDefElem("force_quote", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31127,7 +31134,7 @@ yydefault:
 	case 1849:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6261
+//line postgres.y:6268
 		{
 			yyLOCAL = ast.NewDefElem("force_not_null", yyDollar[4].listUnion())
 		}
@@ -31135,7 +31142,7 @@ yydefault:
 	case 1850:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6265
+//line postgres.y:6272
 		{
 			yyLOCAL = ast.NewDefElem("force_not_null", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31143,7 +31150,7 @@ yydefault:
 	case 1851:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6269
+//line postgres.y:6276
 		{
 			yyLOCAL = ast.NewDefElem("force_null", yyDollar[3].listUnion())
 		}
@@ -31151,7 +31158,7 @@ yydefault:
 	case 1852:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6273
+//line postgres.y:6280
 		{
 			yyLOCAL = ast.NewDefElem("force_null", &ast.A_Star{BaseNode: ast.BaseNode{Tag: ast.T_A_Star}})
 		}
@@ -31159,7 +31166,7 @@ yydefault:
 	case 1853:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6277
+//line postgres.y:6284
 		{
 			yyLOCAL = ast.NewDefElem("encoding", ast.NewString(yyDollar[2].str))
 		}
@@ -31167,7 +31174,7 @@ yydefault:
 	case 1854:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6285
+//line postgres.y:6292
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31175,7 +31182,7 @@ yydefault:
 	case 1855:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6289
+//line postgres.y:6296
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31184,7 +31191,7 @@ yydefault:
 	case 1856:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6296
+//line postgres.y:6303
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
@@ -31192,7 +31199,7 @@ yydefault:
 	case 1857:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6302
+//line postgres.y:6309
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -31200,7 +31207,7 @@ yydefault:
 	case 1858:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6303
+//line postgres.y:6310
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -31208,7 +31215,7 @@ yydefault:
 	case 1859:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6304
+//line postgres.y:6311
 		{
 			yyLOCAL = ast.NewA_Star(0)
 		}
@@ -31216,7 +31223,7 @@ yydefault:
 	case 1860:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6305
+//line postgres.y:6312
 		{
 			yyLOCAL = ast.NewString("default")
 		}
@@ -31224,7 +31231,7 @@ yydefault:
 	case 1861:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6306
+//line postgres.y:6313
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31232,7 +31239,7 @@ yydefault:
 	case 1862:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6307
+//line postgres.y:6314
 		{
 			yyLOCAL = nil
 		}
@@ -31240,7 +31247,7 @@ yydefault:
 	case 1863:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6312
+//line postgres.y:6319
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31248,7 +31255,7 @@ yydefault:
 	case 1864:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6316
+//line postgres.y:6323
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31257,39 +31264,39 @@ yydefault:
 	case 1865:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6322
+//line postgres.y:6329
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 1866:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6326
+//line postgres.y:6333
 		{
 			yyVAL.str = "true"
 		}
 	case 1867:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6327
+//line postgres.y:6334
 		{
 			yyVAL.str = "false"
 		}
 	case 1868:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6328
+//line postgres.y:6335
 		{
 			yyVAL.str = "on"
 		}
 	case 1869:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6329
+//line postgres.y:6336
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1870:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6333
+//line postgres.y:6340
 		{
 			yyLOCAL = ast.NewFloat(yyDollar[1].str)
 		}
@@ -31297,7 +31304,7 @@ yydefault:
 	case 1871:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6334
+//line postgres.y:6341
 		{
 			yyLOCAL = ast.NewFloat(yyDollar[2].str)
 		}
@@ -31305,7 +31312,7 @@ yydefault:
 	case 1872:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6336
+//line postgres.y:6343
 		{
 			f := ast.NewFloat(yyDollar[2].str)
 			doNegateFloat(f)
@@ -31315,7 +31322,7 @@ yydefault:
 	case 1873:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6341
+//line postgres.y:6348
 		{
 			yyLOCAL = ast.NewInteger(yyDollar[1].ival)
 		}
@@ -31323,7 +31330,7 @@ yydefault:
 	case 1874:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6345
+//line postgres.y:6352
 		{
 			yyLOCAL = ast.NewInteger(yyDollar[1].ival)
 		}
@@ -31331,7 +31338,7 @@ yydefault:
 	case 1875:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6346
+//line postgres.y:6353
 		{
 			yyLOCAL = nil
 		}
@@ -31339,7 +31346,7 @@ yydefault:
 	case 1876:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6350
+//line postgres.y:6357
 		{
 			yyLOCAL = ast.OBJECT_ACCESS_METHOD
 		}
@@ -31347,7 +31354,7 @@ yydefault:
 	case 1877:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6351
+//line postgres.y:6358
 		{
 			yyLOCAL = ast.OBJECT_EVENT_TRIGGER
 		}
@@ -31355,7 +31362,7 @@ yydefault:
 	case 1878:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6352
+//line postgres.y:6359
 		{
 			yyLOCAL = ast.OBJECT_EXTENSION
 		}
@@ -31363,7 +31370,7 @@ yydefault:
 	case 1879:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6353
+//line postgres.y:6360
 		{
 			yyLOCAL = ast.OBJECT_FDW
 		}
@@ -31371,7 +31378,7 @@ yydefault:
 	case 1880:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6354
+//line postgres.y:6361
 		{
 			yyLOCAL = ast.OBJECT_LANGUAGE
 		}
@@ -31379,7 +31386,7 @@ yydefault:
 	case 1881:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6355
+//line postgres.y:6362
 		{
 			yyLOCAL = ast.OBJECT_PUBLICATION
 		}
@@ -31387,7 +31394,7 @@ yydefault:
 	case 1882:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6356
+//line postgres.y:6363
 		{
 			yyLOCAL = ast.OBJECT_SCHEMA
 		}
@@ -31395,7 +31402,7 @@ yydefault:
 	case 1883:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6357
+//line postgres.y:6364
 		{
 			yyLOCAL = ast.OBJECT_FOREIGN_SERVER
 		}
@@ -31403,7 +31410,7 @@ yydefault:
 	case 1884:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6361
+//line postgres.y:6368
 		{
 			yyLOCAL = ast.OBJECT_POLICY
 		}
@@ -31411,7 +31418,7 @@ yydefault:
 	case 1885:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6362
+//line postgres.y:6369
 		{
 			yyLOCAL = ast.OBJECT_RULE
 		}
@@ -31419,7 +31426,7 @@ yydefault:
 	case 1886:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6363
+//line postgres.y:6370
 		{
 			yyLOCAL = ast.OBJECT_TRIGGER
 		}
@@ -31427,7 +31434,7 @@ yydefault:
 	case 1887:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6367
+//line postgres.y:6374
 		{
 			yyLOCAL = yyDollar[1].objTypeUnion()
 		}
@@ -31435,7 +31442,7 @@ yydefault:
 	case 1888:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6368
+//line postgres.y:6375
 		{
 			yyLOCAL = ast.OBJECT_DATABASE
 		}
@@ -31443,7 +31450,7 @@ yydefault:
 	case 1889:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6369
+//line postgres.y:6376
 		{
 			yyLOCAL = ast.OBJECT_ROLE
 		}
@@ -31451,7 +31458,7 @@ yydefault:
 	case 1890:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6370
+//line postgres.y:6377
 		{
 			yyLOCAL = ast.OBJECT_SUBSCRIPTION
 		}
@@ -31459,7 +31466,7 @@ yydefault:
 	case 1891:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:6371
+//line postgres.y:6378
 		{
 			yyLOCAL = ast.OBJECT_TABLESPACE
 		}
@@ -31467,7 +31474,7 @@ yydefault:
 	case 1892:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6376
+//line postgres.y:6383
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].typnamUnion())
@@ -31476,7 +31483,7 @@ yydefault:
 	case 1893:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6381
+//line postgres.y:6388
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31485,7 +31492,7 @@ yydefault:
 	case 1894:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:6388
+//line postgres.y:6395
 		{
 			yyLOCAL = true
 		}
@@ -31493,27 +31500,27 @@ yydefault:
 	case 1895:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:6389
+//line postgres.y:6396
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 1896:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6393
+//line postgres.y:6400
 		{
 			yyVAL.ival = 1
 		}
 	case 1897:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6394
+//line postgres.y:6401
 		{
 			yyVAL.ival = 0
 		}
 	case 1900:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6410
+//line postgres.y:6417
 		{
 			yyLOCAL = nil
 		}
@@ -31521,63 +31528,63 @@ yydefault:
 	case 1901:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6412
+//line postgres.y:6419
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 1902:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6420
+//line postgres.y:6427
 		{
 			yyVAL.ival = 1
 		}
 	case 1903:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6421
+//line postgres.y:6428
 		{
 			yyVAL.ival = 0
 		}
 	case 1904:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6425
+//line postgres.y:6432
 		{
 			yyVAL.ival = 1
 		}
 	case 1905:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6426
+//line postgres.y:6433
 		{
 			yyVAL.ival = 0
 		}
 	case 1906:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6430
+//line postgres.y:6437
 		{
 			yyVAL.ival = 1
 		}
 	case 1907:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6431
+//line postgres.y:6438
 		{
 			yyVAL.ival = 0
 		}
 	case 1908:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6435
+//line postgres.y:6442
 		{
 			yyVAL.ival = 1
 		}
 	case 1909:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6436
+//line postgres.y:6443
 		{
 			yyVAL.ival = 0
 		}
 	case 1910:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6445
+//line postgres.y:6452
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31587,7 +31594,7 @@ yydefault:
 	case 1911:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6451
+//line postgres.y:6458
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31597,7 +31604,7 @@ yydefault:
 	case 1912:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6457
+//line postgres.y:6464
 		{
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).MatchKind = ast.MergeMatchKind(yyDollar[1].ival)
 			yyDollar[4].nodeUnion().(*ast.MergeWhenClause).Condition = yyDollar[2].nodeUnion()
@@ -31607,7 +31614,7 @@ yydefault:
 	case 1913:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6463
+//line postgres.y:6470
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MergeMatchKind(yyDollar[1].ival), ast.CMD_NOTHING)
 			mergeWhen.Condition = yyDollar[2].nodeUnion()
@@ -31617,7 +31624,7 @@ yydefault:
 	case 1914:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6469
+//line postgres.y:6476
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MergeMatchKind(yyDollar[1].ival), ast.CMD_NOTHING)
 			mergeWhen.Condition = yyDollar[2].nodeUnion()
@@ -31626,32 +31633,32 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 1915:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6477
+//line postgres.y:6484
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_MATCHED)
 		}
 	case 1916:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line postgres.y:6478
+//line postgres.y:6485
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_SOURCE)
 		}
 	case 1917:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6482
+//line postgres.y:6489
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET)
 		}
 	case 1918:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line postgres.y:6483
+//line postgres.y:6490
 		{
 			yyVAL.ival = int(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET)
 		}
 	case 1919:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6487
+//line postgres.y:6494
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -31659,7 +31666,7 @@ yydefault:
 	case 1920:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6488
+//line postgres.y:6495
 		{
 			yyLOCAL = nil
 		}
@@ -31667,7 +31674,7 @@ yydefault:
 	case 1921:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6493
+//line postgres.y:6500
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_MATCHED, ast.CMD_UPDATE)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31683,7 +31690,7 @@ yydefault:
 	case 1922:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6508
+//line postgres.y:6515
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_MATCHED, ast.CMD_DELETE)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31693,7 +31700,7 @@ yydefault:
 	case 1923:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6517
+//line postgres.y:6524
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31704,7 +31711,7 @@ yydefault:
 	case 1924:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6524
+//line postgres.y:6531
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OverridingKind(yyDollar[3].ival)
@@ -31715,7 +31722,7 @@ yydefault:
 	case 1925:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6531
+//line postgres.y:6538
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31732,7 +31739,7 @@ yydefault:
 	case 1926:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6544
+//line postgres.y:6551
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OverridingKind(yyDollar[6].ival)
@@ -31749,7 +31756,7 @@ yydefault:
 	case 1927:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6557
+//line postgres.y:6564
 		{
 			mergeWhen := ast.NewMergeWhenClause(ast.MERGE_WHEN_NOT_MATCHED_BY_TARGET, ast.CMD_INSERT)
 			mergeWhen.Override = ast.OVERRIDING_NOT_SET
@@ -31759,7 +31766,7 @@ yydefault:
 	case 1928:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6566
+//line postgres.y:6573
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -31767,7 +31774,7 @@ yydefault:
 	case 1929:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6581
+//line postgres.y:6588
 		{
 			onConflict := ast.NewOnConflictClause(ast.ONCONFLICT_UPDATE)
 			if yyDollar[3].nodeUnion() != nil {
@@ -31781,7 +31788,7 @@ yydefault:
 	case 1930:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6591
+//line postgres.y:6598
 		{
 			onConflict := ast.NewOnConflictClause(ast.ONCONFLICT_NOTHING)
 			if yyDollar[3].nodeUnion() != nil {
@@ -31793,7 +31800,7 @@ yydefault:
 	case 1931:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.OnConflictClause
-//line postgres.y:6599
+//line postgres.y:6606
 		{
 			yyLOCAL = nil
 		}
@@ -31801,7 +31808,7 @@ yydefault:
 	case 1932:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6610
+//line postgres.y:6617
 		{
 			// Create InferClause for column-based conflict detection
 			infer := ast.NewInferClause()
@@ -31814,7 +31821,7 @@ yydefault:
 	case 1933:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6619
+//line postgres.y:6626
 		{
 			// Create InferClause for constraint-based conflict detection
 			infer := ast.NewInferClause()
@@ -31825,7 +31832,7 @@ yydefault:
 	case 1934:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6626
+//line postgres.y:6633
 		{
 			yyLOCAL = nil
 		}
@@ -31833,7 +31840,7 @@ yydefault:
 	case 1935:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6633
+//line postgres.y:6640
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -31841,7 +31848,7 @@ yydefault:
 	case 1936:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6637
+//line postgres.y:6644
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -31850,7 +31857,7 @@ yydefault:
 	case 1937:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6644
+//line postgres.y:6651
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Name = yyDollar[1].str
@@ -31859,7 +31866,7 @@ yydefault:
 	case 1938:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6649
+//line postgres.y:6656
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Expr = yyDollar[1].nodeUnion()
@@ -31868,7 +31875,7 @@ yydefault:
 	case 1939:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6654
+//line postgres.y:6661
 		{
 			yyLOCAL = yyDollar[4].nodeUnion()
 			yyLOCAL.(*ast.IndexElem).Expr = yyDollar[2].nodeUnion()
@@ -31877,7 +31884,7 @@ yydefault:
 	case 1940:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6662
+//line postgres.y:6669
 		{
 			indexElem := &ast.IndexElem{
 				BaseNode: ast.BaseNode{Tag: ast.T_IndexElem},
@@ -31892,7 +31899,7 @@ yydefault:
 	case 1941:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6673
+//line postgres.y:6680
 		{
 			indexElem := &ast.IndexElem{
 				BaseNode: ast.BaseNode{Tag: ast.T_IndexElem},
@@ -31908,7 +31915,7 @@ yydefault:
 	case 1942:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6687
+//line postgres.y:6694
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31916,51 +31923,51 @@ yydefault:
 	case 1943:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6688
+//line postgres.y:6695
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 1944:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6692
+//line postgres.y:6699
 		{
 			yyVAL.ival = int(ast.SORTBY_ASC)
 		}
 	case 1945:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6693
+//line postgres.y:6700
 		{
 			yyVAL.ival = int(ast.SORTBY_DESC)
 		}
 	case 1946:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6694
+//line postgres.y:6701
 		{
 			yyVAL.ival = int(ast.SORTBY_DEFAULT)
 		}
 	case 1947:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6698
+//line postgres.y:6705
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_FIRST)
 		}
 	case 1948:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6699
+//line postgres.y:6706
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_LAST)
 		}
 	case 1949:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6700
+//line postgres.y:6707
 		{
 			yyVAL.ival = int(ast.SORTBY_NULLS_DEFAULT)
 		}
 	case 1950:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6705
+//line postgres.y:6712
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -31968,7 +31975,7 @@ yydefault:
 	case 1951:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6709
+//line postgres.y:6716
 		{
 			yyLOCAL = nil
 		}
@@ -31976,7 +31983,7 @@ yydefault:
 	case 1952:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6730
+//line postgres.y:6737
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -31994,7 +32001,7 @@ yydefault:
 	case 1953:
 		yyDollar = yyS[yypt-16 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6746
+//line postgres.y:6753
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32013,7 +32020,7 @@ yydefault:
 	case 1954:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6763
+//line postgres.y:6770
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32031,7 +32038,7 @@ yydefault:
 	case 1955:
 		yyDollar = yyS[yypt-15 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6779
+//line postgres.y:6786
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32050,7 +32057,7 @@ yydefault:
 	case 1956:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6796
+//line postgres.y:6803
 		{
 			rangeVar := yyDollar[4].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32069,7 +32076,7 @@ yydefault:
 	case 1957:
 		yyDollar = yyS[yypt-17 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:6813
+//line postgres.y:6820
 		{
 			rangeVar := yyDollar[7].rangevarUnion()
 			rangeVar.RelPersistence = yyDollar[2].runeUnion()
@@ -32089,7 +32096,7 @@ yydefault:
 	case 1958:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6831
+//line postgres.y:6838
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32097,7 +32104,7 @@ yydefault:
 	case 1959:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6832
+//line postgres.y:6839
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32105,7 +32112,7 @@ yydefault:
 	case 1960:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6833
+//line postgres.y:6840
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32113,7 +32120,7 @@ yydefault:
 	case 1961:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6834
+//line postgres.y:6841
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32121,7 +32128,7 @@ yydefault:
 	case 1962:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6835
+//line postgres.y:6842
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32129,7 +32136,7 @@ yydefault:
 	case 1963:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6836
+//line postgres.y:6843
 		{
 			yyLOCAL = ast.RELPERSISTENCE_TEMP
 		}
@@ -32137,7 +32144,7 @@ yydefault:
 	case 1964:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6837
+//line postgres.y:6844
 		{
 			yyLOCAL = ast.RELPERSISTENCE_UNLOGGED
 		}
@@ -32145,7 +32152,7 @@ yydefault:
 	case 1965:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:6838
+//line postgres.y:6845
 		{
 			yyLOCAL = ast.RELPERSISTENCE_PERMANENT
 		}
@@ -32153,7 +32160,7 @@ yydefault:
 	case 1966:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6842
+//line postgres.y:6849
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -32161,7 +32168,7 @@ yydefault:
 	case 1967:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6843
+//line postgres.y:6850
 		{
 			yyLOCAL = nil
 		}
@@ -32169,7 +32176,7 @@ yydefault:
 	case 1968:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6848
+//line postgres.y:6855
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -32178,7 +32185,7 @@ yydefault:
 	case 1969:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6853
+//line postgres.y:6860
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32187,7 +32194,7 @@ yydefault:
 	case 1970:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6860
+//line postgres.y:6867
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32195,7 +32202,7 @@ yydefault:
 	case 1971:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6861
+//line postgres.y:6868
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32203,7 +32210,7 @@ yydefault:
 	case 1972:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6862
+//line postgres.y:6869
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32211,141 +32218,141 @@ yydefault:
 	case 1973:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6867
+//line postgres.y:6874
 		{
 			yyLOCAL = ast.NewTableLikeClause(yyDollar[2].rangevarUnion(), ast.TableLikeOption(yyDollar[3].ival))
 		}
 		yyVAL.union = yyLOCAL
 	case 1974:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6874
+//line postgres.y:6881
 		{
 			yyVAL.ival = yyDollar[1].ival | yyDollar[3].ival
 		}
 	case 1975:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:6878
+//line postgres.y:6885
 		{
 			yyVAL.ival = yyDollar[1].ival & ^yyDollar[3].ival
 		}
 	case 1976:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6882
+//line postgres.y:6889
 		{
 			yyVAL.ival = 0
 		}
 	case 1977:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6888
+//line postgres.y:6895
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_COMMENTS)
 		}
 	case 1978:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6889
+//line postgres.y:6896
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_COMPRESSION)
 		}
 	case 1979:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6890
+//line postgres.y:6897
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_CONSTRAINTS)
 		}
 	case 1980:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6891
+//line postgres.y:6898
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_DEFAULTS)
 		}
 	case 1981:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6892
+//line postgres.y:6899
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_IDENTITY)
 		}
 	case 1982:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6893
+//line postgres.y:6900
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_GENERATED)
 		}
 	case 1983:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6894
+//line postgres.y:6901
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_INDEXES)
 		}
 	case 1984:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6895
+//line postgres.y:6902
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_STATISTICS)
 		}
 	case 1985:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6896
+//line postgres.y:6903
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_STORAGE)
 		}
 	case 1986:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6897
+//line postgres.y:6904
 		{
 			yyVAL.ival = int(ast.CREATE_TABLE_LIKE_ALL)
 		}
 	case 1987:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6902
+//line postgres.y:6909
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 1988:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6903
+//line postgres.y:6910
 		{
 			yyVAL.str = "default"
 		}
 	case 1989:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6907
+//line postgres.y:6914
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1990:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6908
+//line postgres.y:6915
 		{
 			yyVAL.str = ""
 		}
 	case 1991:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6912
+//line postgres.y:6919
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 1992:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:6913
+//line postgres.y:6920
 		{
 			yyVAL.str = "default"
 		}
 	case 1993:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:6917
+//line postgres.y:6924
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 1994:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:6918
+//line postgres.y:6925
 		{
 			yyVAL.str = ""
 		}
 	case 1995:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6923
+//line postgres.y:6930
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -32353,7 +32360,7 @@ yydefault:
 	case 1996:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6924
+//line postgres.y:6931
 		{
 			yyLOCAL = nil
 		}
@@ -32361,7 +32368,7 @@ yydefault:
 	case 1997:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6929
+//line postgres.y:6936
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -32371,7 +32378,7 @@ yydefault:
 	case 1998:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:6935
+//line postgres.y:6942
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32380,7 +32387,7 @@ yydefault:
 	case 1999:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6942
+//line postgres.y:6949
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32388,7 +32395,7 @@ yydefault:
 	case 2000:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6943
+//line postgres.y:6950
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32396,7 +32403,7 @@ yydefault:
 	case 2001:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6948
+//line postgres.y:6955
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, nil, 0)
 			colDef.Constraints = yyDollar[2].listUnion()
@@ -32406,7 +32413,7 @@ yydefault:
 	case 2002:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:6954
+//line postgres.y:6961
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, nil, 0)
 			colDef.Constraints = yyDollar[4].listUnion()
@@ -32416,7 +32423,7 @@ yydefault:
 	case 2003:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6965
+//line postgres.y:6972
 		{
 			hashSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_HASH)
 			hashSpec.IsDefault = false
@@ -32447,7 +32454,7 @@ yydefault:
 	case 2004:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:6994
+//line postgres.y:7001
 		{
 			listSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_LIST)
 			listSpec.IsDefault = false
@@ -32458,7 +32465,7 @@ yydefault:
 	case 2005:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:7003
+//line postgres.y:7010
 		{
 			rangeSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_RANGE)
 			rangeSpec.IsDefault = false
@@ -32470,7 +32477,7 @@ yydefault:
 	case 2006:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.PartitionBoundSpec
-//line postgres.y:7013
+//line postgres.y:7020
 		{
 			defaultSpec := ast.NewPartitionBoundSpec(ast.PARTITION_STRATEGY_LIST)
 			defaultSpec.IsDefault = true
@@ -32480,7 +32487,7 @@ yydefault:
 	case 2007:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7022
+//line postgres.y:7029
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewA_Const(ast.NewInteger(yyDollar[2].ival), 0))
 		}
@@ -32488,7 +32495,7 @@ yydefault:
 	case 2008:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7029
+//line postgres.y:7036
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -32496,7 +32503,7 @@ yydefault:
 	case 2009:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7033
+//line postgres.y:7040
 		{
 			nodeList := yyDollar[1].listUnion()
 			nodeList.Append(yyDollar[3].nodeUnion())
@@ -32506,7 +32513,7 @@ yydefault:
 	case 2010:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7041
+//line postgres.y:7048
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -32514,7 +32521,7 @@ yydefault:
 	case 2011:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7042
+//line postgres.y:7049
 		{
 			yyLOCAL = nil
 		}
@@ -32522,7 +32529,7 @@ yydefault:
 	case 2012:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7047
+//line postgres.y:7054
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32530,7 +32537,7 @@ yydefault:
 	case 2013:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7051
+//line postgres.y:7058
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32539,21 +32546,21 @@ yydefault:
 	case 2014:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7059
+//line postgres.y:7066
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2015:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7065
+//line postgres.y:7072
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2016:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7070
+//line postgres.y:7077
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -32561,7 +32568,7 @@ yydefault:
 	case 2017:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7075
+//line postgres.y:7082
 		{
 			colDef := ast.NewColumnDef(yyDollar[1].str, yyDollar[2].typnamUnion(), 0)
 			colDef.StorageName = yyDollar[3].str
@@ -32577,7 +32584,7 @@ yydefault:
 	case 2018:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7090
+//line postgres.y:7097
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32586,7 +32593,7 @@ yydefault:
 	case 2019:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7095
+//line postgres.y:7102
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -32594,7 +32601,7 @@ yydefault:
 	case 2020:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7102
+//line postgres.y:7109
 		{
 			constraint := yyDollar[3].nodeUnion().(*ast.Constraint)
 			constraint.Conname = yyDollar[2].str
@@ -32604,7 +32611,7 @@ yydefault:
 	case 2021:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7107
+//line postgres.y:7114
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32612,7 +32619,7 @@ yydefault:
 	case 2022:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7108
+//line postgres.y:7115
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -32620,7 +32627,7 @@ yydefault:
 	case 2023:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7110
+//line postgres.y:7117
 		{
 			/*
 			 * Note: the CollateClause is momentarily included in
@@ -32634,7 +32641,7 @@ yydefault:
 	case 2024:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7123
+//line postgres.y:7130
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_DEFERRABLE)
 			yyLOCAL = constraint
@@ -32643,7 +32650,7 @@ yydefault:
 	case 2025:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7128
+//line postgres.y:7135
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_NOT_DEFERRABLE)
 			yyLOCAL = constraint
@@ -32652,7 +32659,7 @@ yydefault:
 	case 2026:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7133
+//line postgres.y:7140
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_DEFERRED)
 			yyLOCAL = constraint
@@ -32661,7 +32668,7 @@ yydefault:
 	case 2027:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7138
+//line postgres.y:7145
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_ATTR_IMMEDIATE)
 			yyLOCAL = constraint
@@ -32670,7 +32677,7 @@ yydefault:
 	case 2028:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7146
+//line postgres.y:7153
 		{
 			yyLOCAL = true
 		}
@@ -32678,7 +32685,7 @@ yydefault:
 	case 2029:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7147
+//line postgres.y:7154
 		{
 			yyLOCAL = false
 		}
@@ -32686,7 +32693,7 @@ yydefault:
 	case 2030:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7148
+//line postgres.y:7155
 		{
 			yyLOCAL = true
 		}
@@ -32694,7 +32701,7 @@ yydefault:
 	case 2031:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7152
+//line postgres.y:7159
 		{
 			yyLOCAL = ast.ATTRIBUTE_IDENTITY_ALWAYS
 		}
@@ -32702,7 +32709,7 @@ yydefault:
 	case 2032:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7153
+//line postgres.y:7160
 		{
 			yyLOCAL = ast.ATTRIBUTE_IDENTITY_BY_DEFAULT
 		}
@@ -32710,7 +32717,7 @@ yydefault:
 	case 2033:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7158
+//line postgres.y:7165
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32718,7 +32725,7 @@ yydefault:
 	case 2034:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7160
+//line postgres.y:7167
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32727,7 +32734,7 @@ yydefault:
 	case 2035:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7165
+//line postgres.y:7172
 		{
 			yyLOCAL = ast.NewDefElem("restart", nil)
 		}
@@ -32735,7 +32742,7 @@ yydefault:
 	case 2036:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7169
+//line postgres.y:7176
 		{
 			yyLOCAL = ast.NewDefElem("restart", yyDollar[3].nodeUnion())
 		}
@@ -32743,7 +32750,7 @@ yydefault:
 	case 2037:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7173
+//line postgres.y:7180
 		{
 			// SeqOptElem already returns a DefElem, so we can use it directly
 			// Check for invalid options as per PostgreSQL
@@ -32757,7 +32764,7 @@ yydefault:
 	case 2038:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7183
+//line postgres.y:7190
 		{
 			yyLOCAL = ast.NewDefElem("generated", ast.NewInteger(int(yyDollar[3].bytUnion())))
 		}
@@ -32765,7 +32772,7 @@ yydefault:
 	case 2039:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7189
+//line postgres.y:7196
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -32773,7 +32780,7 @@ yydefault:
 	case 2040:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7190
+//line postgres.y:7197
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -32782,7 +32789,7 @@ yydefault:
 	case 2041:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7195
+//line postgres.y:7202
 		{
 			yyLOCAL = ast.NewDefElem("as", yyDollar[2].typnamUnion())
 		}
@@ -32790,7 +32797,7 @@ yydefault:
 	case 2042:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7199
+//line postgres.y:7206
 		{
 			yyLOCAL = ast.NewDefElem("cache", yyDollar[2].nodeUnion())
 		}
@@ -32798,7 +32805,7 @@ yydefault:
 	case 2043:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7203
+//line postgres.y:7210
 		{
 			yyLOCAL = ast.NewDefElem("cycle", ast.NewBoolean(true))
 		}
@@ -32806,7 +32813,7 @@ yydefault:
 	case 2044:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7207
+//line postgres.y:7214
 		{
 			yyLOCAL = ast.NewDefElem("cycle", ast.NewBoolean(false))
 		}
@@ -32814,7 +32821,7 @@ yydefault:
 	case 2045:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7211
+//line postgres.y:7218
 		{
 			yyLOCAL = ast.NewDefElem("increment", yyDollar[3].nodeUnion())
 		}
@@ -32822,7 +32829,7 @@ yydefault:
 	case 2046:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7215
+//line postgres.y:7222
 		{
 			yyLOCAL = ast.NewDefElem("logged", nil)
 		}
@@ -32830,7 +32837,7 @@ yydefault:
 	case 2047:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7219
+//line postgres.y:7226
 		{
 			yyLOCAL = ast.NewDefElem("maxvalue", yyDollar[2].nodeUnion())
 		}
@@ -32838,7 +32845,7 @@ yydefault:
 	case 2048:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7223
+//line postgres.y:7230
 		{
 			yyLOCAL = ast.NewDefElem("minvalue", yyDollar[2].nodeUnion())
 		}
@@ -32846,7 +32853,7 @@ yydefault:
 	case 2049:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7227
+//line postgres.y:7234
 		{
 			yyLOCAL = ast.NewDefElem("maxvalue", nil)
 		}
@@ -32854,7 +32861,7 @@ yydefault:
 	case 2050:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7231
+//line postgres.y:7238
 		{
 			yyLOCAL = ast.NewDefElem("minvalue", nil)
 		}
@@ -32862,7 +32869,7 @@ yydefault:
 	case 2051:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7235
+//line postgres.y:7242
 		{
 			yyLOCAL = ast.NewDefElem("owned_by", yyDollar[3].listUnion())
 		}
@@ -32870,7 +32877,7 @@ yydefault:
 	case 2052:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7239
+//line postgres.y:7246
 		{
 			yyLOCAL = ast.NewDefElem("sequence_name", yyDollar[3].listUnion())
 		}
@@ -32878,7 +32885,7 @@ yydefault:
 	case 2053:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7243
+//line postgres.y:7250
 		{
 			yyLOCAL = ast.NewDefElem("start", yyDollar[3].nodeUnion())
 		}
@@ -32886,7 +32893,7 @@ yydefault:
 	case 2054:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7247
+//line postgres.y:7254
 		{
 			yyLOCAL = ast.NewDefElem("restart", nil)
 		}
@@ -32894,7 +32901,7 @@ yydefault:
 	case 2055:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7251
+//line postgres.y:7258
 		{
 			yyLOCAL = ast.NewDefElem("restart", yyDollar[3].nodeUnion())
 		}
@@ -32902,40 +32909,40 @@ yydefault:
 	case 2056:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:7255
+//line postgres.y:7262
 		{
 			yyLOCAL = ast.NewDefElem("unlogged", nil)
 		}
 		yyVAL.union = yyLOCAL
 	case 2057:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7261
+//line postgres.y:7268
 		{
 		}
 	case 2058:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7262
+//line postgres.y:7269
 		{
 		}
 	case 2059:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7266
+//line postgres.y:7273
 		{
 		}
 	case 2060:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7267
+//line postgres.y:7274
 		{
 		}
 	case 2061:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7268
+//line postgres.y:7275
 		{
 		}
 	case 2062:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7273
+//line postgres.y:7280
 		{
 			// RECHECK no longer does anything in opclass definitions,
 			// but we still accept it to ease porting of old database dumps.
@@ -32947,7 +32954,7 @@ yydefault:
 	case 2063:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7280
+//line postgres.y:7287
 		{
 			yyLOCAL = false
 		}
@@ -32955,7 +32962,7 @@ yydefault:
 	case 2064:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7284
+//line postgres.y:7291
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -32963,7 +32970,7 @@ yydefault:
 	case 2065:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7285
+//line postgres.y:7292
 		{
 			yyLOCAL = nil
 		}
@@ -32971,7 +32978,7 @@ yydefault:
 	case 2066:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7290
+//line postgres.y:7297
 		{
 			yyLOCAL = ast.NewConstraint(ast.CONSTR_NOTNULL)
 		}
@@ -32979,7 +32986,7 @@ yydefault:
 	case 2067:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7294
+//line postgres.y:7301
 		{
 			yyLOCAL = ast.NewConstraint(ast.CONSTR_NULL)
 		}
@@ -32987,7 +32994,7 @@ yydefault:
 	case 2068:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7298
+//line postgres.y:7305
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.Keys = nil // Will be filled by the parser
@@ -33000,7 +33007,7 @@ yydefault:
 	case 2069:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7307
+//line postgres.y:7314
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Keys = nil // Will be filled by the parser
@@ -33010,7 +33017,7 @@ yydefault:
 	case 2070:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7313
+//line postgres.y:7320
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_CHECK)
 			constraint.RawExpr = yyDollar[3].nodeUnion()
@@ -33020,7 +33027,7 @@ yydefault:
 	case 2071:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7319
+//line postgres.y:7326
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_DEFAULT)
 			constraint.RawExpr = yyDollar[2].nodeUnion()
@@ -33030,7 +33037,7 @@ yydefault:
 	case 2072:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7325
+//line postgres.y:7332
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
 			constraint.Pktable = yyDollar[2].rangevarUnion()
@@ -33051,7 +33058,7 @@ yydefault:
 	case 2073:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7342
+//line postgres.y:7349
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_IDENTITY)
 			constraint.GeneratedWhen = yyDollar[2].bytUnion()
@@ -33062,7 +33069,7 @@ yydefault:
 	case 2074:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7349
+//line postgres.y:7356
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_GENERATED)
 			constraint.GeneratedWhen = yyDollar[2].bytUnion()
@@ -33073,7 +33080,7 @@ yydefault:
 	case 2075:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7359
+//line postgres.y:7366
 		{
 			constraint := yyDollar[3].nodeUnion().(*ast.Constraint)
 			constraint.Conname = yyDollar[2].str
@@ -33083,7 +33090,7 @@ yydefault:
 	case 2076:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7364
+//line postgres.y:7371
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -33091,7 +33098,7 @@ yydefault:
 	case 2077:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7369
+//line postgres.y:7376
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_CHECK)
 			constraint.RawExpr = yyDollar[3].nodeUnion()
@@ -33102,7 +33109,7 @@ yydefault:
 	case 2078:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7377
+//line postgres.y:7384
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.NullsNotDistinct = !yyDollar[2].bvalUnion()
@@ -33117,7 +33124,7 @@ yydefault:
 	case 2079:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7388
+//line postgres.y:7395
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_UNIQUE)
 			constraint.Indexname = yyDollar[2].str
@@ -33131,7 +33138,7 @@ yydefault:
 	case 2080:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7399
+//line postgres.y:7406
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Keys = yyDollar[4].listUnion()
@@ -33145,7 +33152,7 @@ yydefault:
 	case 2081:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7409
+//line postgres.y:7416
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_PRIMARY)
 			constraint.Indexname = yyDollar[3].str
@@ -33159,7 +33166,7 @@ yydefault:
 	case 2082:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7420
+//line postgres.y:7427
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
 			constraint.FkAttrs = yyDollar[4].listUnion()
@@ -33182,7 +33189,7 @@ yydefault:
 	case 2083:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7441
+//line postgres.y:7448
 		{
 			constraint := ast.NewConstraint(ast.CONSTR_EXCLUSION)
 			constraint.AccessMethod = yyDollar[2].str
@@ -33198,7 +33205,7 @@ yydefault:
 	case 2084:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7455
+//line postgres.y:7462
 		{
 			yyLOCAL = true
 		}
@@ -33206,7 +33213,7 @@ yydefault:
 	case 2085:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7456
+//line postgres.y:7463
 		{
 			yyLOCAL = false
 		}
@@ -33214,7 +33221,7 @@ yydefault:
 	case 2086:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7462
+//line postgres.y:7469
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -33224,7 +33231,7 @@ yydefault:
 	case 2087:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7468
+//line postgres.y:7475
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33233,7 +33240,7 @@ yydefault:
 	case 2088:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7476
+//line postgres.y:7483
 		{
 			// Create a NodeList with index_elem and operator (matching PostgreSQL's list_make2 approach)
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion(), yyDollar[3].listUnion())
@@ -33242,7 +33249,7 @@ yydefault:
 	case 2089:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7481
+//line postgres.y:7488
 		{
 			// Create a NodeList with index_elem and operator (matching PostgreSQL's list_make2 approach)
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion(), yyDollar[5].listUnion())
@@ -33251,7 +33258,7 @@ yydefault:
 	case 2090:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7489
+//line postgres.y:7496
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33259,7 +33266,7 @@ yydefault:
 	case 2091:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7493
+//line postgres.y:7500
 		{
 			yyLOCAL = nil
 		}
@@ -33267,7 +33274,7 @@ yydefault:
 	case 2092:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7500
+//line postgres.y:7507
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_FULL
 		}
@@ -33275,7 +33282,7 @@ yydefault:
 	case 2093:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7504
+//line postgres.y:7511
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_PARTIAL
 		}
@@ -33283,7 +33290,7 @@ yydefault:
 	case 2094:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7508
+//line postgres.y:7515
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_SIMPLE
 		}
@@ -33291,7 +33298,7 @@ yydefault:
 	case 2095:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL byte
-//line postgres.y:7512
+//line postgres.y:7519
 		{
 			yyLOCAL = ast.FKCONSTR_MATCH_SIMPLE
 		}
@@ -33299,7 +33306,7 @@ yydefault:
 	case 2096:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7519
+//line postgres.y:7526
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[1].keyactionUnion()
@@ -33313,7 +33320,7 @@ yydefault:
 	case 2097:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7529
+//line postgres.y:7536
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = &ast.KeyAction{
@@ -33327,7 +33334,7 @@ yydefault:
 	case 2098:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7539
+//line postgres.y:7546
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[1].keyactionUnion()
@@ -33338,7 +33345,7 @@ yydefault:
 	case 2099:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7546
+//line postgres.y:7553
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = yyDollar[2].keyactionUnion()
@@ -33349,7 +33356,7 @@ yydefault:
 	case 2100:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.KeyActions
-//line postgres.y:7553
+//line postgres.y:7560
 		{
 			n := &ast.KeyActions{}
 			n.UpdateAction = &ast.KeyAction{
@@ -33366,7 +33373,7 @@ yydefault:
 	case 2101:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7568
+//line postgres.y:7575
 		{
 			// Check for unsupported column lists on UPDATE actions
 			keyAction := yyDollar[3].keyactionUnion()
@@ -33381,7 +33388,7 @@ yydefault:
 	case 2102:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7581
+//line postgres.y:7588
 		{
 			yyLOCAL = yyDollar[3].keyactionUnion()
 		}
@@ -33389,7 +33396,7 @@ yydefault:
 	case 2103:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7588
+//line postgres.y:7595
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_NOACTION
@@ -33400,7 +33407,7 @@ yydefault:
 	case 2104:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7595
+//line postgres.y:7602
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_RESTRICT
@@ -33411,7 +33418,7 @@ yydefault:
 	case 2105:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7602
+//line postgres.y:7609
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_CASCADE
@@ -33422,7 +33429,7 @@ yydefault:
 	case 2106:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7609
+//line postgres.y:7616
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_SETNULL
@@ -33433,7 +33440,7 @@ yydefault:
 	case 2107:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.KeyAction
-//line postgres.y:7616
+//line postgres.y:7623
 		{
 			n := &ast.KeyAction{}
 			n.Action = ast.FKCONSTR_ACTION_SETDEFAULT
@@ -33444,7 +33451,7 @@ yydefault:
 	case 2108:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7625
+//line postgres.y:7632
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33452,7 +33459,7 @@ yydefault:
 	case 2109:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7626
+//line postgres.y:7633
 		{
 			yyLOCAL = nil
 		}
@@ -33460,7 +33467,7 @@ yydefault:
 	case 2110:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7630
+//line postgres.y:7637
 		{
 			yyLOCAL = yyDollar[1].partspecUnion()
 		}
@@ -33468,7 +33475,7 @@ yydefault:
 	case 2111:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7631
+//line postgres.y:7638
 		{
 			yyLOCAL = nil
 		}
@@ -33476,7 +33483,7 @@ yydefault:
 	case 2112:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.PartitionSpec
-//line postgres.y:7636
+//line postgres.y:7643
 		{
 			partitionSpec := ast.NewPartitionSpec(ast.PartitionStrategy(yyDollar[3].str), yyDollar[5].listUnion())
 			yyLOCAL = partitionSpec
@@ -33485,7 +33492,7 @@ yydefault:
 	case 2113:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7644
+//line postgres.y:7651
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33494,7 +33501,7 @@ yydefault:
 	case 2114:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7649
+//line postgres.y:7656
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33503,7 +33510,7 @@ yydefault:
 	case 2115:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7657
+//line postgres.y:7664
 		{
 			partElem := ast.NewPartitionElem(yyDollar[1].str, nil, 0)
 			partElem.Collation = yyDollar[2].listUnion()
@@ -33514,7 +33521,7 @@ yydefault:
 	case 2116:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7664
+//line postgres.y:7671
 		{
 			partElem := ast.NewPartitionElem("", yyDollar[1].nodeUnion(), 0)
 			partElem.Collation = yyDollar[2].listUnion()
@@ -33525,7 +33532,7 @@ yydefault:
 	case 2117:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:7671
+//line postgres.y:7678
 		{
 			// Wrap the expression in ParenExpr to preserve parentheses
 			parenExpr := ast.NewParenExpr(yyDollar[2].nodeUnion(), 0)
@@ -33537,20 +33544,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2118:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7682
+//line postgres.y:7689
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2119:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7683
+//line postgres.y:7690
 		{
 			yyVAL.str = ""
 		}
 	case 2120:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7687
+//line postgres.y:7694
 		{
 			yyLOCAL = ast.ONCOMMIT_DROP
 		}
@@ -33558,7 +33565,7 @@ yydefault:
 	case 2121:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7688
+//line postgres.y:7695
 		{
 			yyLOCAL = ast.ONCOMMIT_DELETE_ROWS
 		}
@@ -33566,7 +33573,7 @@ yydefault:
 	case 2122:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7689
+//line postgres.y:7696
 		{
 			yyLOCAL = ast.ONCOMMIT_PRESERVE_ROWS
 		}
@@ -33574,45 +33581,45 @@ yydefault:
 	case 2123:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.OnCommitAction
-//line postgres.y:7690
+//line postgres.y:7697
 		{
 			yyLOCAL = ast.ONCOMMIT_NOOP
 		}
 		yyVAL.union = yyLOCAL
 	case 2124:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7694
+//line postgres.y:7701
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2125:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7695
+//line postgres.y:7702
 		{
 			yyVAL.str = ""
 		}
 	case 2126:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:7699
+//line postgres.y:7706
 		{
 			yyVAL.str = yyDollar[4].str
 		}
 	case 2127:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7700
+//line postgres.y:7707
 		{
 			yyVAL.str = ""
 		}
 	case 2128:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:7704
+//line postgres.y:7711
 		{
 			yyVAL.str = yyDollar[3].str
 		}
 	case 2129:
 		yyDollar = yyS[yypt-16 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7717
+//line postgres.y:7724
 		{
 			indexStmt := ast.NewIndexStmt(yyDollar[5].str, yyDollar[7].rangevarUnion(), yyDollar[10].listUnion())
 			indexStmt.Unique = yyDollar[2].bvalUnion()
@@ -33629,7 +33636,7 @@ yydefault:
 	case 2130:
 		yyDollar = yyS[yypt-19 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7732
+//line postgres.y:7739
 		{
 			indexStmt := ast.NewIndexStmt(yyDollar[8].str, yyDollar[10].rangevarUnion(), yyDollar[13].listUnion())
 			indexStmt.Unique = yyDollar[2].bvalUnion()
@@ -33647,7 +33654,7 @@ yydefault:
 	case 2131:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7748
+//line postgres.y:7755
 		{
 			yyLOCAL = true
 		}
@@ -33655,27 +33662,27 @@ yydefault:
 	case 2132:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7749
+//line postgres.y:7756
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 2133:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:7753
+//line postgres.y:7760
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2134:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:7754
+//line postgres.y:7761
 		{
 			yyVAL.str = "btree"
 		}
 	case 2135:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7758
+//line postgres.y:7765
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -33683,7 +33690,7 @@ yydefault:
 	case 2136:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7759
+//line postgres.y:7766
 		{
 			yyLOCAL = nil
 		}
@@ -33691,7 +33698,7 @@ yydefault:
 	case 2137:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7764
+//line postgres.y:7771
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33700,7 +33707,7 @@ yydefault:
 	case 2138:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7769
+//line postgres.y:7776
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33709,7 +33716,7 @@ yydefault:
 	case 2139:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7777
+//line postgres.y:7784
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -33717,7 +33724,7 @@ yydefault:
 	case 2140:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7778
+//line postgres.y:7785
 		{
 			yyLOCAL = nil
 		}
@@ -33725,7 +33732,7 @@ yydefault:
 	case 2141:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7790
+//line postgres.y:7797
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_TABLE
@@ -33735,7 +33742,7 @@ yydefault:
 	case 2142:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7796
+//line postgres.y:7803
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_TABLE
@@ -33746,7 +33753,7 @@ yydefault:
 	case 2143:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7803
+//line postgres.y:7810
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_INDEX
@@ -33756,7 +33763,7 @@ yydefault:
 	case 2144:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7809
+//line postgres.y:7816
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_INDEX
@@ -33767,7 +33774,7 @@ yydefault:
 	case 2145:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7816
+//line postgres.y:7823
 		{
 			// Index partition attachment - dedicated rule
 			cmdList := ast.NewNodeList()
@@ -33780,7 +33787,7 @@ yydefault:
 	case 2146:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7825
+//line postgres.y:7832
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_SEQUENCE
@@ -33790,7 +33797,7 @@ yydefault:
 	case 2147:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7831
+//line postgres.y:7838
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_SEQUENCE
@@ -33801,7 +33808,7 @@ yydefault:
 	case 2148:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7838
+//line postgres.y:7845
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion())
 			alterStmt.Objtype = ast.OBJECT_VIEW
@@ -33811,7 +33818,7 @@ yydefault:
 	case 2149:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7844
+//line postgres.y:7851
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion())
 			alterStmt.Objtype = ast.OBJECT_VIEW
@@ -33822,7 +33829,7 @@ yydefault:
 	case 2150:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7851
+//line postgres.y:7858
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion())
 			alterStmt.Objtype = ast.OBJECT_MATVIEW
@@ -33832,7 +33839,7 @@ yydefault:
 	case 2151:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7857
+//line postgres.y:7864
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[6].rangevarUnion(), yyDollar[7].listUnion())
 			alterStmt.Objtype = ast.OBJECT_MATVIEW
@@ -33843,7 +33850,7 @@ yydefault:
 	case 2152:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7864
+//line postgres.y:7871
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion())
 			alterStmt.Objtype = ast.OBJECT_FOREIGN_TABLE
@@ -33853,7 +33860,7 @@ yydefault:
 	case 2153:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7870
+//line postgres.y:7877
 		{
 			alterStmt := ast.NewAlterTableStmt(yyDollar[6].rangevarUnion(), yyDollar[7].listUnion())
 			alterStmt.Objtype = ast.OBJECT_FOREIGN_TABLE
@@ -33864,7 +33871,7 @@ yydefault:
 	case 2154:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7877
+//line postgres.y:7884
 		{
 			// Partition commands - dedicated rule for partition-only operations
 			cmdList := ast.NewNodeList()
@@ -33877,7 +33884,7 @@ yydefault:
 	case 2155:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7886
+//line postgres.y:7893
 		{
 			// Partition commands with IF EXISTS
 			cmdList := ast.NewNodeList()
@@ -33891,7 +33898,7 @@ yydefault:
 	case 2156:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7896
+//line postgres.y:7903
 		{
 			// Bulk tablespace move for tables
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_TABLE, yyDollar[9].str)
@@ -33902,7 +33909,7 @@ yydefault:
 	case 2157:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7903
+//line postgres.y:7910
 		{
 			// Bulk tablespace move for tables owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_TABLE, yyDollar[12].str)
@@ -33914,7 +33921,7 @@ yydefault:
 	case 2158:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7911
+//line postgres.y:7918
 		{
 			// Bulk tablespace move for indexes
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_INDEX, yyDollar[9].str)
@@ -33925,7 +33932,7 @@ yydefault:
 	case 2159:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7918
+//line postgres.y:7925
 		{
 			// Bulk tablespace move for indexes owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[6].str, ast.OBJECT_INDEX, yyDollar[12].str)
@@ -33937,7 +33944,7 @@ yydefault:
 	case 2160:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7926
+//line postgres.y:7933
 		{
 			// Bulk tablespace move for materialized views
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[7].str, ast.OBJECT_MATVIEW, yyDollar[10].str)
@@ -33948,7 +33955,7 @@ yydefault:
 	case 2161:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:7933
+//line postgres.y:7940
 		{
 			// Bulk tablespace move for materialized views owned by specific roles
 			moveStmt := ast.NewAlterTableMoveAllStmt(yyDollar[7].str, ast.OBJECT_MATVIEW, yyDollar[13].str)
@@ -33960,7 +33967,7 @@ yydefault:
 	case 2162:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7944
+//line postgres.y:7951
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -33969,7 +33976,7 @@ yydefault:
 	case 2163:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7949
+//line postgres.y:7956
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -33978,7 +33985,7 @@ yydefault:
 	case 2164:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7957
+//line postgres.y:7964
 		{
 			yyLOCAL = true
 		}
@@ -33986,7 +33993,7 @@ yydefault:
 	case 2165:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:7958
+//line postgres.y:7965
 		{
 			yyLOCAL = false
 		}
@@ -33994,7 +34001,7 @@ yydefault:
 	case 2166:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7963
+//line postgres.y:7970
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].rolespecUnion())
@@ -34003,7 +34010,7 @@ yydefault:
 	case 2167:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:7968
+//line postgres.y:7975
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].rolespecUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -34011,7 +34018,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2168:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:7976
+//line postgres.y:7983
 		{
 			roleSpec := yyDollar[1].rolespecUnion()
 
@@ -34042,7 +34049,7 @@ yydefault:
 	case 2169:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8007
+//line postgres.y:8014
 		{
 			// Handle special role names: "public" and "none"
 			var roleSpec *ast.RoleSpec
@@ -34069,7 +34076,7 @@ yydefault:
 	case 2170:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8030
+//line postgres.y:8037
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34080,7 +34087,7 @@ yydefault:
 	case 2171:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8037
+//line postgres.y:8044
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34091,7 +34098,7 @@ yydefault:
 	case 2172:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:8044
+//line postgres.y:8051
 		{
 			yyLOCAL = &ast.RoleSpec{
 				BaseNode: ast.BaseNode{Tag: ast.T_RoleSpec},
@@ -34102,7 +34109,7 @@ yydefault:
 	case 2173:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8055
+//line postgres.y:8062
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[2].nodeUnion())
 			cmd.MissingOk = false
@@ -34112,7 +34119,7 @@ yydefault:
 	case 2174:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8062
+//line postgres.y:8069
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[5].nodeUnion())
 			cmd.MissingOk = true
@@ -34122,7 +34129,7 @@ yydefault:
 	case 2175:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8069
+//line postgres.y:8076
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[3].nodeUnion())
 			cmd.MissingOk = false
@@ -34132,7 +34139,7 @@ yydefault:
 	case 2176:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8076
+//line postgres.y:8083
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[6].nodeUnion())
 			cmd.MissingOk = true
@@ -34142,7 +34149,7 @@ yydefault:
 	case 2177:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8083
+//line postgres.y:8090
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ColumnDefault, yyDollar[3].str, yyDollar[4].nodeUnion())
 		}
@@ -34150,7 +34157,7 @@ yydefault:
 	case 2178:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8088
+//line postgres.y:8095
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropNotNull, yyDollar[3].str, nil)
 		}
@@ -34158,7 +34165,7 @@ yydefault:
 	case 2179:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8093
+//line postgres.y:8100
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetNotNull, yyDollar[3].str, nil)
 		}
@@ -34166,7 +34173,7 @@ yydefault:
 	case 2180:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8098
+//line postgres.y:8105
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetExpression, yyDollar[3].str, yyDollar[8].nodeUnion())
 		}
@@ -34174,7 +34181,7 @@ yydefault:
 	case 2181:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8103
+//line postgres.y:8110
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropExpression, yyDollar[3].str, nil)
 		}
@@ -34182,7 +34189,7 @@ yydefault:
 	case 2182:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8108
+//line postgres.y:8115
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropExpression, yyDollar[3].str, nil)
 			cmd.MissingOk = true
@@ -34192,7 +34199,7 @@ yydefault:
 	case 2183:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8115
+//line postgres.y:8122
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetStatistics, yyDollar[3].str, yyDollar[6].nodeUnion())
 		}
@@ -34200,7 +34207,7 @@ yydefault:
 	case 2184:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8120
+//line postgres.y:8127
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_SetStatistics, "", yyDollar[6].nodeUnion())
 			cmd.Num = int16(yyDollar[3].ival)
@@ -34210,7 +34217,7 @@ yydefault:
 	case 2185:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8127
+//line postgres.y:8134
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetOptions, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -34218,7 +34225,7 @@ yydefault:
 	case 2186:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8132
+//line postgres.y:8139
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ResetOptions, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -34226,7 +34233,7 @@ yydefault:
 	case 2187:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8137
+//line postgres.y:8144
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetStorage, yyDollar[3].str, ast.NewString(yyDollar[5].str))
 		}
@@ -34234,7 +34241,7 @@ yydefault:
 	case 2188:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8142
+//line postgres.y:8149
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetCompression, yyDollar[3].str, ast.NewString(yyDollar[5].str))
 		}
@@ -34242,7 +34249,7 @@ yydefault:
 	case 2189:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8147
+//line postgres.y:8154
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AddIdentity, yyDollar[3].str, nil)
 			constraint := ast.NewConstraint(ast.CONSTR_IDENTITY)
@@ -34255,7 +34262,7 @@ yydefault:
 	case 2190:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8157
+//line postgres.y:8164
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetIdentity, yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -34263,7 +34270,7 @@ yydefault:
 	case 2191:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8162
+//line postgres.y:8169
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropIdentity, yyDollar[3].str, nil)
 			cmd.MissingOk = false
@@ -34273,7 +34280,7 @@ yydefault:
 	case 2192:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8169
+//line postgres.y:8176
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropIdentity, yyDollar[3].str, nil)
 			cmd.MissingOk = true
@@ -34283,7 +34290,7 @@ yydefault:
 	case 2193:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8176
+//line postgres.y:8183
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[5].str, nil)
 			cmd.Behavior = yyDollar[6].dropBehavUnion()
@@ -34294,7 +34301,7 @@ yydefault:
 	case 2194:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8184
+//line postgres.y:8191
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[3].str, nil)
 			cmd.Behavior = yyDollar[4].dropBehavUnion()
@@ -34305,7 +34312,7 @@ yydefault:
 	case 2195:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8195
+//line postgres.y:8202
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AlterColumnType, yyDollar[3].str, nil)
 			def := ast.NewColumnDef("", yyDollar[6].typnamUnion(), 0)
@@ -34320,7 +34327,7 @@ yydefault:
 	case 2196:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8207
+//line postgres.y:8214
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AlterColumnGenericOptions, yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -34328,7 +34335,7 @@ yydefault:
 	case 2197:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8212
+//line postgres.y:8219
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddConstraint, "", yyDollar[2].nodeUnion())
 		}
@@ -34336,7 +34343,7 @@ yydefault:
 	case 2198:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8217
+//line postgres.y:8224
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AlterConstraint, "", nil)
 			constraint := ast.NewConstraint(ast.CONSTR_FOREIGN)
@@ -34350,7 +34357,7 @@ yydefault:
 	case 2199:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8228
+//line postgres.y:8235
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ValidateConstraint, yyDollar[3].str, nil)
 		}
@@ -34358,7 +34365,7 @@ yydefault:
 	case 2200:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8233
+//line postgres.y:8240
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropConstraint, yyDollar[5].str, nil)
 			cmd.Behavior = yyDollar[6].dropBehavUnion()
@@ -34369,7 +34376,7 @@ yydefault:
 	case 2201:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8241
+//line postgres.y:8248
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DropConstraint, yyDollar[3].str, nil)
 			cmd.Behavior = yyDollar[4].dropBehavUnion()
@@ -34380,7 +34387,7 @@ yydefault:
 	case 2202:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8249
+//line postgres.y:8256
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropOids, "", nil)
 		}
@@ -34388,7 +34395,7 @@ yydefault:
 	case 2203:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8254
+//line postgres.y:8261
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ClusterOn, yyDollar[3].str, nil)
 		}
@@ -34396,7 +34403,7 @@ yydefault:
 	case 2204:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8259
+//line postgres.y:8266
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropCluster, "", nil)
 		}
@@ -34404,7 +34411,7 @@ yydefault:
 	case 2205:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8264
+//line postgres.y:8271
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetLogged, "", nil)
 		}
@@ -34412,7 +34419,7 @@ yydefault:
 	case 2206:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8269
+//line postgres.y:8276
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetUnLogged, "", nil)
 		}
@@ -34420,7 +34427,7 @@ yydefault:
 	case 2207:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8274
+//line postgres.y:8281
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrig, yyDollar[3].str, nil)
 		}
@@ -34428,7 +34435,7 @@ yydefault:
 	case 2208:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8279
+//line postgres.y:8286
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableAlwaysTrig, yyDollar[4].str, nil)
 		}
@@ -34436,7 +34443,7 @@ yydefault:
 	case 2209:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8284
+//line postgres.y:8291
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableReplicaTrig, yyDollar[4].str, nil)
 		}
@@ -34444,7 +34451,7 @@ yydefault:
 	case 2210:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8289
+//line postgres.y:8296
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrigAll, "", nil)
 		}
@@ -34452,7 +34459,7 @@ yydefault:
 	case 2211:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8294
+//line postgres.y:8301
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableTrigUser, "", nil)
 		}
@@ -34460,7 +34467,7 @@ yydefault:
 	case 2212:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8299
+//line postgres.y:8306
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrig, yyDollar[3].str, nil)
 		}
@@ -34468,7 +34475,7 @@ yydefault:
 	case 2213:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8304
+//line postgres.y:8311
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrigAll, "", nil)
 		}
@@ -34476,7 +34483,7 @@ yydefault:
 	case 2214:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8309
+//line postgres.y:8316
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableTrigUser, "", nil)
 		}
@@ -34484,7 +34491,7 @@ yydefault:
 	case 2215:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8314
+//line postgres.y:8321
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableRule, yyDollar[3].str, nil)
 		}
@@ -34492,7 +34499,7 @@ yydefault:
 	case 2216:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8319
+//line postgres.y:8326
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableAlwaysRule, yyDollar[4].str, nil)
 		}
@@ -34500,7 +34507,7 @@ yydefault:
 	case 2217:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8324
+//line postgres.y:8331
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableReplicaRule, yyDollar[4].str, nil)
 		}
@@ -34508,7 +34515,7 @@ yydefault:
 	case 2218:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8329
+//line postgres.y:8336
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableRule, yyDollar[3].str, nil)
 		}
@@ -34516,7 +34523,7 @@ yydefault:
 	case 2219:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8334
+//line postgres.y:8341
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddInherit, "", yyDollar[2].rangevarUnion())
 		}
@@ -34524,7 +34531,7 @@ yydefault:
 	case 2220:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8339
+//line postgres.y:8346
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropInherit, "", yyDollar[3].rangevarUnion())
 		}
@@ -34532,7 +34539,7 @@ yydefault:
 	case 2221:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8344
+//line postgres.y:8351
 		{
 			typeName := makeTypeNameFromNodeList(yyDollar[2].listUnion())
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_AddOf, "", typeName)
@@ -34541,7 +34548,7 @@ yydefault:
 	case 2222:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8350
+//line postgres.y:8357
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DropOf, "", nil)
 		}
@@ -34549,7 +34556,7 @@ yydefault:
 	case 2223:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8355
+//line postgres.y:8362
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_ChangeOwner, "", nil)
 			cmd.Newowner = yyDollar[3].rolespecUnion()
@@ -34559,7 +34566,7 @@ yydefault:
 	case 2224:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8362
+//line postgres.y:8369
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetAccessMethod, yyDollar[4].str, nil)
 		}
@@ -34567,7 +34574,7 @@ yydefault:
 	case 2225:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8367
+//line postgres.y:8374
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetTableSpace, yyDollar[3].str, nil)
 		}
@@ -34575,7 +34582,7 @@ yydefault:
 	case 2226:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8372
+//line postgres.y:8379
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_SetRelOptions, "", yyDollar[2].listUnion())
 		}
@@ -34583,7 +34590,7 @@ yydefault:
 	case 2227:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8377
+//line postgres.y:8384
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ResetRelOptions, "", yyDollar[2].listUnion())
 		}
@@ -34591,7 +34598,7 @@ yydefault:
 	case 2228:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8382
+//line postgres.y:8389
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ReplicaIdentity, "", yyDollar[3].nodeUnion())
 		}
@@ -34599,7 +34606,7 @@ yydefault:
 	case 2229:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8387
+//line postgres.y:8394
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_EnableRowSecurity, "", nil)
 		}
@@ -34607,7 +34614,7 @@ yydefault:
 	case 2230:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8392
+//line postgres.y:8399
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_DisableRowSecurity, "", nil)
 		}
@@ -34615,7 +34622,7 @@ yydefault:
 	case 2231:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8397
+//line postgres.y:8404
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_ForceRowSecurity, "", nil)
 		}
@@ -34623,7 +34630,7 @@ yydefault:
 	case 2232:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8402
+//line postgres.y:8409
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_NoForceRowSecurity, "", nil)
 		}
@@ -34631,7 +34638,7 @@ yydefault:
 	case 2233:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8406
+//line postgres.y:8413
 		{
 			yyLOCAL = ast.NewAlterTableCmd(ast.AT_GenericOptions, "", yyDollar[1].listUnion())
 		}
@@ -34639,7 +34646,7 @@ yydefault:
 	case 2234:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8414
+//line postgres.y:8421
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AttachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), yyDollar[4].partboundspecUnion(), false, 0)
@@ -34650,7 +34657,7 @@ yydefault:
 	case 2235:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8422
+//line postgres.y:8429
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DetachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, yyDollar[4].bvalUnion(), 0)
@@ -34661,7 +34668,7 @@ yydefault:
 	case 2236:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8429
+//line postgres.y:8436
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_DetachPartitionFinalize, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, false, 0)
@@ -34672,7 +34679,7 @@ yydefault:
 	case 2237:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8440
+//line postgres.y:8447
 		{
 			cmd := ast.NewAlterTableCmd(ast.AT_AttachPartition, "", nil)
 			partitionCmd := ast.NewPartitionCmd(yyDollar[3].rangevarUnion(), nil, false, 0)
@@ -34683,7 +34690,7 @@ yydefault:
 	case 2238:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8449
+//line postgres.y:8456
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -34691,25 +34698,25 @@ yydefault:
 	case 2239:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:8450
+//line postgres.y:8457
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 2240:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:8454
+//line postgres.y:8461
 		{
 		}
 	case 2241:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:8455
+//line postgres.y:8462
 		{
 		}
 	case 2242:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8466
+//line postgres.y:8473
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34726,7 +34733,7 @@ yydefault:
 	case 2243:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8479
+//line postgres.y:8486
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34743,7 +34750,7 @@ yydefault:
 	case 2244:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8492
+//line postgres.y:8499
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34760,7 +34767,7 @@ yydefault:
 	case 2245:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8505
+//line postgres.y:8512
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34777,7 +34784,7 @@ yydefault:
 	case 2246:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8518
+//line postgres.y:8525
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34796,7 +34803,7 @@ yydefault:
 	case 2247:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8533
+//line postgres.y:8540
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34815,7 +34822,7 @@ yydefault:
 	case 2248:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8548
+//line postgres.y:8555
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34832,7 +34839,7 @@ yydefault:
 	case 2249:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8561
+//line postgres.y:8568
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34849,7 +34856,7 @@ yydefault:
 	case 2250:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8574
+//line postgres.y:8581
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34866,7 +34873,7 @@ yydefault:
 	case 2251:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8587
+//line postgres.y:8594
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34883,7 +34890,7 @@ yydefault:
 	case 2252:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8600
+//line postgres.y:8607
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34900,7 +34907,7 @@ yydefault:
 	case 2253:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8613
+//line postgres.y:8620
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34917,7 +34924,7 @@ yydefault:
 	case 2254:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8627
+//line postgres.y:8634
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34934,7 +34941,7 @@ yydefault:
 	case 2255:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8641
+//line postgres.y:8648
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34956,7 +34963,7 @@ yydefault:
 	case 2256:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8659
+//line postgres.y:8666
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -34978,7 +34985,7 @@ yydefault:
 	case 2257:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8678
+//line postgres.y:8685
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35000,7 +35007,7 @@ yydefault:
 	case 2258:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8696
+//line postgres.y:8703
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35022,7 +35029,7 @@ yydefault:
 	case 2259:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8715
+//line postgres.y:8722
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35039,7 +35046,7 @@ yydefault:
 	case 2260:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8729
+//line postgres.y:8736
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35056,7 +35063,7 @@ yydefault:
 	case 2261:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8742
+//line postgres.y:8749
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35073,7 +35080,7 @@ yydefault:
 	case 2262:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8762
+//line postgres.y:8769
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35089,7 +35096,7 @@ yydefault:
 	case 2263:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8774
+//line postgres.y:8781
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35105,7 +35112,7 @@ yydefault:
 	case 2264:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8786
+//line postgres.y:8793
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35121,7 +35128,7 @@ yydefault:
 	case 2265:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8798
+//line postgres.y:8805
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35137,7 +35144,7 @@ yydefault:
 	case 2266:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8810
+//line postgres.y:8817
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35153,7 +35160,7 @@ yydefault:
 	case 2267:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8822
+//line postgres.y:8829
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35169,7 +35176,7 @@ yydefault:
 	case 2268:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8837
+//line postgres.y:8844
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35185,7 +35192,7 @@ yydefault:
 	case 2269:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8849
+//line postgres.y:8856
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35201,7 +35208,7 @@ yydefault:
 	case 2270:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8864
+//line postgres.y:8871
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35217,7 +35224,7 @@ yydefault:
 	case 2271:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8876
+//line postgres.y:8883
 		{
 			n := &ast.DropStmt{
 				BaseNode: ast.BaseNode{Tag: ast.T_DropStmt},
@@ -35233,7 +35240,7 @@ yydefault:
 	case 2272:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8891
+//line postgres.y:8898
 		{
 			stmt := yyDollar[2].vsetstmtUnion()
 			stmt.IsLocal = false
@@ -35243,7 +35250,7 @@ yydefault:
 	case 2273:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8897
+//line postgres.y:8904
 		{
 			stmt := yyDollar[3].vsetstmtUnion()
 			stmt.IsLocal = true
@@ -35253,7 +35260,7 @@ yydefault:
 	case 2274:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8903
+//line postgres.y:8910
 		{
 			stmt := yyDollar[3].vsetstmtUnion()
 			stmt.IsLocal = false
@@ -35263,7 +35270,7 @@ yydefault:
 	case 2275:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8912
+//line postgres.y:8919
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_MULTI, "TRANSACTION", yyDollar[2].listUnion(), false)
 		}
@@ -35271,7 +35278,7 @@ yydefault:
 	case 2276:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8916
+//line postgres.y:8923
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_MULTI, "SESSION CHARACTERISTICS AS TRANSACTION", yyDollar[5].listUnion(), false)
 		}
@@ -35279,7 +35286,7 @@ yydefault:
 	case 2277:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8919
+//line postgres.y:8926
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -35287,7 +35294,7 @@ yydefault:
 	case 2278:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8923
+//line postgres.y:8930
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -35295,7 +35302,7 @@ yydefault:
 	case 2279:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8925
+//line postgres.y:8932
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "timezone", nil, false)
 		}
@@ -35303,7 +35310,7 @@ yydefault:
 	case 2280:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8929
+//line postgres.y:8936
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "transaction_isolation", nil, false)
 		}
@@ -35311,7 +35318,7 @@ yydefault:
 	case 2281:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8933
+//line postgres.y:8940
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, "session_authorization", nil, false)
 		}
@@ -35319,7 +35326,7 @@ yydefault:
 	case 2282:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8940
+//line postgres.y:8947
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET, yyDollar[1].str, nil, false)
 		}
@@ -35327,7 +35334,7 @@ yydefault:
 	case 2283:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8944
+//line postgres.y:8951
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_RESET_ALL, "", nil, false)
 		}
@@ -35335,7 +35342,7 @@ yydefault:
 	case 2284:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8950
+//line postgres.y:8957
 		{
 			yyLOCAL = yyDollar[2].vsetstmtUnion()
 		}
@@ -35343,7 +35350,7 @@ yydefault:
 	case 2285:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:8951
+//line postgres.y:8958
 		{
 			yyLOCAL = yyDollar[1].stmtUnion().(*ast.VariableSetStmt)
 		}
@@ -35351,7 +35358,7 @@ yydefault:
 	case 2286:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8955
+//line postgres.y:8962
 		{
 			yyLOCAL = ast.Stmt(yyDollar[2].vsetstmtUnion())
 		}
@@ -35359,7 +35366,7 @@ yydefault:
 	case 2287:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8964
+//line postgres.y:8971
 		{
 			yyLOCAL = ast.NewConstraintsSetStmt(yyDollar[3].listUnion(), yyDollar[4].bvalUnion())
 		}
@@ -35367,7 +35374,7 @@ yydefault:
 	case 2288:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:8970
+//line postgres.y:8977
 		{
 			yyLOCAL = nil
 		}
@@ -35375,7 +35382,7 @@ yydefault:
 	case 2289:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:8971
+//line postgres.y:8978
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -35383,7 +35390,7 @@ yydefault:
 	case 2290:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:8975
+//line postgres.y:8982
 		{
 			yyLOCAL = true
 		}
@@ -35391,7 +35398,7 @@ yydefault:
 	case 2291:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:8976
+//line postgres.y:8983
 		{
 			yyLOCAL = false
 		}
@@ -35399,7 +35406,7 @@ yydefault:
 	case 2292:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:8988
+//line postgres.y:8995
 		{
 			n := ast.NewSelectStmt()
 			n.DistinctClause = yyDollar[1].listUnion()
@@ -35425,7 +35432,7 @@ yydefault:
 	case 2293:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9013
+//line postgres.y:9020
 		{
 			n := ast.NewPLAssignStmt(yyDollar[1].str, yyDollar[4].stmtUnion().(*ast.SelectStmt))
 			n.Indirection = yyDollar[2].listUnion()
@@ -35434,20 +35441,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2294:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9021
+//line postgres.y:9028
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2295:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9022
+//line postgres.y:9029
 		{
 			yyVAL.str = fmt.Sprintf("$%d", yyDollar[1].ival)
 		}
 	case 2298:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9036
+//line postgres.y:9043
 		{
 			yyLOCAL = ast.NewExplainStmt(yyDollar[2].stmtUnion(), nil)
 		}
@@ -35455,7 +35462,7 @@ yydefault:
 	case 2299:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9040
+//line postgres.y:9047
 		{
 			options := ast.NewNodeList(ast.NewDefElem("analyze", nil))
 			if yyDollar[3].ival != 0 {
@@ -35467,7 +35474,7 @@ yydefault:
 	case 2300:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9048
+//line postgres.y:9055
 		{
 			options := ast.NewNodeList(ast.NewDefElem("verbose", nil))
 			yyLOCAL = ast.NewExplainStmt(yyDollar[3].stmtUnion(), options)
@@ -35476,7 +35483,7 @@ yydefault:
 	case 2301:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9053
+//line postgres.y:9060
 		{
 			yyLOCAL = ast.NewExplainStmt(yyDollar[5].stmtUnion(), yyDollar[3].listUnion())
 		}
@@ -35484,7 +35491,7 @@ yydefault:
 	case 2302:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9060
+//line postgres.y:9067
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -35492,7 +35499,7 @@ yydefault:
 	case 2303:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9064
+//line postgres.y:9071
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -35501,33 +35508,33 @@ yydefault:
 	case 2304:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:9072
+//line postgres.y:9079
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2305:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9078
+//line postgres.y:9085
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2306:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9079
+//line postgres.y:9086
 		{
 			yyVAL.str = "analyze"
 		}
 	case 2307:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9080
+//line postgres.y:9087
 		{
 			yyVAL.str = "format"
 		}
 	case 2308:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9084
+//line postgres.y:9091
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -35535,7 +35542,7 @@ yydefault:
 	case 2309:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9085
+//line postgres.y:9092
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -35543,7 +35550,7 @@ yydefault:
 	case 2310:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:9086
+//line postgres.y:9093
 		{
 			yyLOCAL = nil
 		}
@@ -35551,7 +35558,7 @@ yydefault:
 	case 2311:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9090
+//line postgres.y:9097
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35559,7 +35566,7 @@ yydefault:
 	case 2312:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9091
+//line postgres.y:9098
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35567,7 +35574,7 @@ yydefault:
 	case 2313:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9092
+//line postgres.y:9099
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35575,7 +35582,7 @@ yydefault:
 	case 2314:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9093
+//line postgres.y:9100
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35583,7 +35590,7 @@ yydefault:
 	case 2315:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9094
+//line postgres.y:9101
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35591,7 +35598,7 @@ yydefault:
 	case 2316:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9095
+//line postgres.y:9102
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35599,7 +35606,7 @@ yydefault:
 	case 2317:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9096
+//line postgres.y:9103
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35607,7 +35614,7 @@ yydefault:
 	case 2318:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9097
+//line postgres.y:9104
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35615,7 +35622,7 @@ yydefault:
 	case 2319:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9098
+//line postgres.y:9105
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35623,7 +35630,7 @@ yydefault:
 	case 2320:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9099
+//line postgres.y:9106
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -35631,7 +35638,7 @@ yydefault:
 	case 2321:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9108
+//line postgres.y:9115
 		{
 			var optionsList *ast.NodeList
 			if yyDollar[2].ival != 0 || yyDollar[3].ival != 0 || yyDollar[4].ival != 0 || yyDollar[5].ival != 0 {
@@ -35656,7 +35663,7 @@ yydefault:
 	case 2322:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9129
+//line postgres.y:9136
 		{
 			yyLOCAL = ast.NewVacuumStmt(yyDollar[3].listUnion(), yyDollar[5].listUnion())
 		}
@@ -35664,7 +35671,7 @@ yydefault:
 	case 2323:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9136
+//line postgres.y:9143
 		{
 			var optionsList *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35677,7 +35684,7 @@ yydefault:
 	case 2324:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9145
+//line postgres.y:9152
 		{
 			yyLOCAL = ast.NewAnalyzeStmt(yyDollar[3].listUnion(), yyDollar[5].listUnion())
 		}
@@ -35685,7 +35692,7 @@ yydefault:
 	case 2325:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9151
+//line postgres.y:9158
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -35693,7 +35700,7 @@ yydefault:
 	case 2326:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9152
+//line postgres.y:9159
 		{
 			yyLOCAL = nil
 		}
@@ -35701,7 +35708,7 @@ yydefault:
 	case 2327:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9157
+//line postgres.y:9164
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].vacrelUnion())
 		}
@@ -35709,7 +35716,7 @@ yydefault:
 	case 2328:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9161
+//line postgres.y:9168
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].vacrelUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -35718,27 +35725,27 @@ yydefault:
 	case 2329:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VacuumRelation
-//line postgres.y:9169
+//line postgres.y:9176
 		{
 			yyLOCAL = ast.NewVacuumRelation(yyDollar[1].rangevarUnion(), yyDollar[2].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2330:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9175
+//line postgres.y:9182
 		{
 			yyVAL.str = "analyze"
 		}
 	case 2331:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9176
+//line postgres.y:9183
 		{
 			yyVAL.str = "analyse"
 		}
 	case 2332:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9185
+//line postgres.y:9192
 		{
 			yyLOCAL = ast.NewVariableShowStmt(yyDollar[2].str)
 		}
@@ -35746,7 +35753,7 @@ yydefault:
 	case 2333:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9189
+//line postgres.y:9196
 		{
 			yyLOCAL = ast.NewVariableShowStmt("timezone")
 		}
@@ -35754,7 +35761,7 @@ yydefault:
 	case 2334:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9193
+//line postgres.y:9200
 		{
 			yyLOCAL = ast.NewVariableShowStmt("transaction_isolation")
 		}
@@ -35762,7 +35769,7 @@ yydefault:
 	case 2335:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9197
+//line postgres.y:9204
 		{
 			yyLOCAL = ast.NewVariableShowStmt("session_authorization")
 		}
@@ -35770,7 +35777,7 @@ yydefault:
 	case 2336:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9201
+//line postgres.y:9208
 		{
 			yyLOCAL = ast.NewVariableShowStmt("all")
 		}
@@ -35778,7 +35785,7 @@ yydefault:
 	case 2337:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9212
+//line postgres.y:9219
 		{
 			yyLOCAL = ast.NewAlterSystemStmt(yyDollar[4].vsetstmtUnion())
 		}
@@ -35786,7 +35793,7 @@ yydefault:
 	case 2338:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9216
+//line postgres.y:9223
 		{
 			yyLOCAL = ast.NewAlterSystemStmt(yyDollar[4].vsetstmtUnion())
 		}
@@ -35794,7 +35801,7 @@ yydefault:
 	case 2339:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9227
+//line postgres.y:9234
 		{
 			yyLOCAL = ast.NewClusterStmt(yyDollar[5].rangevarUnion(), yyDollar[6].str, yyDollar[3].listUnion())
 		}
@@ -35802,7 +35809,7 @@ yydefault:
 	case 2340:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9231
+//line postgres.y:9238
 		{
 			yyLOCAL = ast.NewClusterStmt(nil, "", yyDollar[3].listUnion())
 		}
@@ -35810,7 +35817,7 @@ yydefault:
 	case 2341:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9235
+//line postgres.y:9242
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35823,7 +35830,7 @@ yydefault:
 	case 2342:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9244
+//line postgres.y:9251
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35836,7 +35843,7 @@ yydefault:
 	case 2343:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9253
+//line postgres.y:9260
 		{
 			var params *ast.NodeList
 			if yyDollar[2].ival != 0 {
@@ -35848,20 +35855,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2344:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:9264
+//line postgres.y:9271
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2345:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:9265
+//line postgres.y:9272
 		{
 			yyVAL.str = ""
 		}
 	case 2346:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9274
+//line postgres.y:9281
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35878,7 +35885,7 @@ yydefault:
 	case 2347:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9287
+//line postgres.y:9294
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35895,7 +35902,7 @@ yydefault:
 	case 2348:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9300
+//line postgres.y:9307
 		{
 			params := yyDollar[2].listUnion()
 			if yyDollar[4].bvalUnion() {
@@ -35911,32 +35918,32 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2349:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9315
+//line postgres.y:9322
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_INDEX)
 		}
 	case 2350:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9316
+//line postgres.y:9323
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_TABLE)
 		}
 	case 2351:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9320
+//line postgres.y:9327
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_SYSTEM)
 		}
 	case 2352:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:9321
+//line postgres.y:9328
 		{
 			yyVAL.ival = int(ast.REINDEX_OBJECT_DATABASE)
 		}
 	case 2353:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9325
+//line postgres.y:9332
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -35944,7 +35951,7 @@ yydefault:
 	case 2354:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9326
+//line postgres.y:9333
 		{
 			yyLOCAL = nil
 		}
@@ -35952,7 +35959,7 @@ yydefault:
 	case 2355:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9335
+//line postgres.y:9342
 		{
 			yyLOCAL = ast.NewCheckPointStmt()
 		}
@@ -35960,7 +35967,7 @@ yydefault:
 	case 2356:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9346
+//line postgres.y:9353
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_ALL)
 		}
@@ -35968,7 +35975,7 @@ yydefault:
 	case 2357:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9350
+//line postgres.y:9357
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_TEMP)
 		}
@@ -35976,7 +35983,7 @@ yydefault:
 	case 2358:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9354
+//line postgres.y:9361
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_TEMP)
 		}
@@ -35984,7 +35991,7 @@ yydefault:
 	case 2359:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9358
+//line postgres.y:9365
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_PLANS)
 		}
@@ -35992,7 +35999,7 @@ yydefault:
 	case 2360:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9362
+//line postgres.y:9369
 		{
 			yyLOCAL = ast.NewDiscardStmt(ast.DISCARD_SEQUENCES)
 		}
@@ -36000,7 +36007,7 @@ yydefault:
 	case 2361:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9369
+//line postgres.y:9376
 		{
 			yyLOCAL = ast.OBJECT_TABLE
 		}
@@ -36008,7 +36015,7 @@ yydefault:
 	case 2362:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9370
+//line postgres.y:9377
 		{
 			yyLOCAL = ast.OBJECT_SEQUENCE
 		}
@@ -36016,7 +36023,7 @@ yydefault:
 	case 2363:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9371
+//line postgres.y:9378
 		{
 			yyLOCAL = ast.OBJECT_VIEW
 		}
@@ -36024,7 +36031,7 @@ yydefault:
 	case 2364:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9372
+//line postgres.y:9379
 		{
 			yyLOCAL = ast.OBJECT_MATVIEW
 		}
@@ -36032,7 +36039,7 @@ yydefault:
 	case 2365:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9373
+//line postgres.y:9380
 		{
 			yyLOCAL = ast.OBJECT_INDEX
 		}
@@ -36040,7 +36047,7 @@ yydefault:
 	case 2366:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9374
+//line postgres.y:9381
 		{
 			yyLOCAL = ast.OBJECT_FOREIGN_TABLE
 		}
@@ -36048,7 +36055,7 @@ yydefault:
 	case 2367:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9375
+//line postgres.y:9382
 		{
 			yyLOCAL = ast.OBJECT_COLLATION
 		}
@@ -36056,7 +36063,7 @@ yydefault:
 	case 2368:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9376
+//line postgres.y:9383
 		{
 			yyLOCAL = ast.OBJECT_CONVERSION
 		}
@@ -36064,7 +36071,7 @@ yydefault:
 	case 2369:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9377
+//line postgres.y:9384
 		{
 			yyLOCAL = ast.OBJECT_STATISTIC_EXT
 		}
@@ -36072,7 +36079,7 @@ yydefault:
 	case 2370:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9378
+//line postgres.y:9385
 		{
 			yyLOCAL = ast.OBJECT_TSPARSER
 		}
@@ -36080,7 +36087,7 @@ yydefault:
 	case 2371:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9379
+//line postgres.y:9386
 		{
 			yyLOCAL = ast.OBJECT_TSDICTIONARY
 		}
@@ -36088,7 +36095,7 @@ yydefault:
 	case 2372:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9380
+//line postgres.y:9387
 		{
 			yyLOCAL = ast.OBJECT_TSTEMPLATE
 		}
@@ -36096,7 +36103,7 @@ yydefault:
 	case 2373:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.ObjectType
-//line postgres.y:9381
+//line postgres.y:9388
 		{
 			yyLOCAL = ast.OBJECT_TSCONFIGURATION
 		}
@@ -36104,7 +36111,7 @@ yydefault:
 	case 2374:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9394
+//line postgres.y:9401
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -36112,7 +36119,7 @@ yydefault:
 	case 2375:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9395
+//line postgres.y:9402
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -36120,7 +36127,7 @@ yydefault:
 	case 2376:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9400
+//line postgres.y:9407
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].funparamUnion())
 		}
@@ -36128,7 +36135,7 @@ yydefault:
 	case 2377:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9404
+//line postgres.y:9411
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].funparamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -36137,7 +36144,7 @@ yydefault:
 	case 2378:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:9412
+//line postgres.y:9419
 		{
 			objWithArgs := &ast.ObjectWithArgs{
 				BaseNode: ast.BaseNode{Tag: ast.T_ObjectWithArgs},
@@ -36149,7 +36156,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2379:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:9424
+//line postgres.y:9431
 		{
 			yylex.Error("Use NONE to denote the missing argument of a unary operator.")
 			return 1
@@ -36157,7 +36164,7 @@ yydefault:
 	case 2380:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9429
+//line postgres.y:9436
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[2].typnamUnion(), yyDollar[4].typnamUnion())
 		}
@@ -36165,7 +36172,7 @@ yydefault:
 	case 2381:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9431
+//line postgres.y:9438
 		{
 			yyLOCAL = ast.NewNodeList(nil, yyDollar[4].typnamUnion())
 		}
@@ -36173,7 +36180,7 @@ yydefault:
 	case 2382:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9433
+//line postgres.y:9440
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[2].typnamUnion(), nil)
 		}
@@ -36181,7 +36188,7 @@ yydefault:
 	case 2383:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:9437
+//line postgres.y:9444
 		{
 			var objfuncArgs *ast.NodeList
 			if firstElem := linitial(yyDollar[2].listUnion()); firstElem != nil {
@@ -36202,7 +36209,7 @@ yydefault:
 	case 2384:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9456
+//line postgres.y:9463
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -36210,7 +36217,7 @@ yydefault:
 	case 2385:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:9458
+//line postgres.y:9465
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -36219,7 +36226,7 @@ yydefault:
 	case 2386:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9462
+//line postgres.y:9469
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36234,7 +36241,7 @@ yydefault:
 	case 2387:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9473
+//line postgres.y:9480
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36249,7 +36256,7 @@ yydefault:
 	case 2388:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9484
+//line postgres.y:9491
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36264,7 +36271,7 @@ yydefault:
 	case 2389:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9495
+//line postgres.y:9502
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36279,7 +36286,7 @@ yydefault:
 	case 2390:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9506
+//line postgres.y:9513
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36294,7 +36301,7 @@ yydefault:
 	case 2391:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9517
+//line postgres.y:9524
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36310,7 +36317,7 @@ yydefault:
 	case 2392:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9529
+//line postgres.y:9536
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36325,7 +36332,7 @@ yydefault:
 	case 2393:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9540
+//line postgres.y:9547
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36340,7 +36347,7 @@ yydefault:
 	case 2394:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9551
+//line postgres.y:9558
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36355,7 +36362,7 @@ yydefault:
 	case 2395:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9562
+//line postgres.y:9569
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36370,7 +36377,7 @@ yydefault:
 	case 2396:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9573
+//line postgres.y:9580
 		{
 			/* lcons equivalent - create NodeList with string name prepended to qualified_name list */
 			list := ast.NewNodeList()
@@ -36391,7 +36398,7 @@ yydefault:
 	case 2397:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9590
+//line postgres.y:9597
 		{
 			/* lcons equivalent - create NodeList with string name prepended to qualified_name list */
 			list := ast.NewNodeList()
@@ -36412,7 +36419,7 @@ yydefault:
 	case 2398:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9607
+//line postgres.y:9614
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36428,7 +36435,7 @@ yydefault:
 	case 2399:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9619
+//line postgres.y:9626
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36444,7 +36451,7 @@ yydefault:
 	case 2400:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9631
+//line postgres.y:9638
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36459,7 +36466,7 @@ yydefault:
 	case 2401:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9642
+//line postgres.y:9649
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36474,7 +36481,7 @@ yydefault:
 	case 2402:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9653
+//line postgres.y:9660
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36489,7 +36496,7 @@ yydefault:
 	case 2403:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9664
+//line postgres.y:9671
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36504,7 +36511,7 @@ yydefault:
 	case 2404:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9675
+//line postgres.y:9682
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36519,7 +36526,7 @@ yydefault:
 	case 2405:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9686
+//line postgres.y:9693
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36534,7 +36541,7 @@ yydefault:
 	case 2406:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9697
+//line postgres.y:9704
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36549,7 +36556,7 @@ yydefault:
 	case 2407:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9708
+//line postgres.y:9715
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36564,7 +36571,7 @@ yydefault:
 	case 2408:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9719
+//line postgres.y:9726
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36579,7 +36586,7 @@ yydefault:
 	case 2409:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9730
+//line postgres.y:9737
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36594,7 +36601,7 @@ yydefault:
 	case 2410:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9741
+//line postgres.y:9748
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36609,7 +36616,7 @@ yydefault:
 	case 2411:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9752
+//line postgres.y:9759
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36624,7 +36631,7 @@ yydefault:
 	case 2412:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9763
+//line postgres.y:9770
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36639,7 +36646,7 @@ yydefault:
 	case 2413:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9774
+//line postgres.y:9781
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36654,7 +36661,7 @@ yydefault:
 	case 2414:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9785
+//line postgres.y:9792
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36669,7 +36676,7 @@ yydefault:
 	case 2415:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9796
+//line postgres.y:9803
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36684,7 +36691,7 @@ yydefault:
 	case 2416:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9807
+//line postgres.y:9814
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36699,7 +36706,7 @@ yydefault:
 	case 2417:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9818
+//line postgres.y:9825
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36714,7 +36721,7 @@ yydefault:
 	case 2418:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9829
+//line postgres.y:9836
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36731,7 +36738,7 @@ yydefault:
 	case 2419:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9842
+//line postgres.y:9849
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36748,7 +36755,7 @@ yydefault:
 	case 2420:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9855
+//line postgres.y:9862
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36765,7 +36772,7 @@ yydefault:
 	case 2421:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9868
+//line postgres.y:9875
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36782,7 +36789,7 @@ yydefault:
 	case 2422:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9881
+//line postgres.y:9888
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36799,7 +36806,7 @@ yydefault:
 	case 2423:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9894
+//line postgres.y:9901
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36816,7 +36823,7 @@ yydefault:
 	case 2424:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9907
+//line postgres.y:9914
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36832,7 +36839,7 @@ yydefault:
 	case 2425:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9919
+//line postgres.y:9926
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36848,7 +36855,7 @@ yydefault:
 	case 2426:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9931
+//line postgres.y:9938
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36865,7 +36872,7 @@ yydefault:
 	case 2427:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9944
+//line postgres.y:9951
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:     ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36882,7 +36889,7 @@ yydefault:
 	case 2428:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9957
+//line postgres.y:9964
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36898,7 +36905,7 @@ yydefault:
 	case 2429:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9969
+//line postgres.y:9976
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36914,7 +36921,7 @@ yydefault:
 	case 2430:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9981
+//line postgres.y:9988
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36929,7 +36936,7 @@ yydefault:
 	case 2431:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:9992
+//line postgres.y:9999
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36944,7 +36951,7 @@ yydefault:
 	case 2432:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10003
+//line postgres.y:10010
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36959,7 +36966,7 @@ yydefault:
 	case 2433:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10014
+//line postgres.y:10021
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36974,7 +36981,7 @@ yydefault:
 	case 2434:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10025
+//line postgres.y:10032
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -36989,7 +36996,7 @@ yydefault:
 	case 2435:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10036
+//line postgres.y:10043
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37004,7 +37011,7 @@ yydefault:
 	case 2436:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10047
+//line postgres.y:10054
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37019,7 +37026,7 @@ yydefault:
 	case 2437:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10058
+//line postgres.y:10065
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37034,7 +37041,7 @@ yydefault:
 	case 2438:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10069
+//line postgres.y:10076
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37049,7 +37056,7 @@ yydefault:
 	case 2439:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10080
+//line postgres.y:10087
 		{
 			renameStmt := &ast.RenameStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_RenameStmt},
@@ -37064,7 +37071,7 @@ yydefault:
 	case 2440:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10091
+//line postgres.y:10098
 		{
 			rv, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -37085,13 +37092,13 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2441:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:10117
+//line postgres.y:10124
 		{
 			yyVAL.ival = 0
 		}
 	case 2442:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10119
+//line postgres.y:10126
 		{
 			// Combine constraint attribute bits
 			newspec := yyDollar[1].ival | yyDollar[2].ival
@@ -37105,44 +37112,44 @@ yydefault:
 		}
 	case 2443:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10133
+//line postgres.y:10140
 		{
 			yyVAL.ival = ast.CAS_NOT_DEFERRABLE
 		}
 	case 2444:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10134
+//line postgres.y:10141
 		{
 			yyVAL.ival = ast.CAS_DEFERRABLE
 		}
 	case 2445:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10135
+//line postgres.y:10142
 		{
 			yyVAL.ival = ast.CAS_INITIALLY_IMMEDIATE
 		}
 	case 2446:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10136
+//line postgres.y:10143
 		{
 			yyVAL.ival = ast.CAS_INITIALLY_DEFERRED
 		}
 	case 2447:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10137
+//line postgres.y:10144
 		{
 			yyVAL.ival = ast.CAS_NOT_VALID
 		}
 	case 2448:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10138
+//line postgres.y:10145
 		{
 			yyVAL.ival = ast.CAS_NO_INHERIT
 		}
 	case 2449:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10142
+//line postgres.y:10149
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37150,7 +37157,7 @@ yydefault:
 	case 2450:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10147
+//line postgres.y:10154
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -37159,7 +37166,7 @@ yydefault:
 	case 2451:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10152
+//line postgres.y:10159
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37168,7 +37175,7 @@ yydefault:
 	case 2452:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10160
+//line postgres.y:10167
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -37176,7 +37183,7 @@ yydefault:
 	case 2453:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10164
+//line postgres.y:10171
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -37184,7 +37191,7 @@ yydefault:
 	case 2454:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10168
+//line postgres.y:10175
 		{
 			yyLOCAL = ast.NewDefElemExtended(yyDollar[1].str, yyDollar[3].str, yyDollar[5].nodeUnion(), ast.DEFELEM_UNSPEC)
 		}
@@ -37192,7 +37199,7 @@ yydefault:
 	case 2455:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10172
+//line postgres.y:10179
 		{
 			yyLOCAL = ast.NewDefElemExtended(yyDollar[1].str, yyDollar[3].str, nil, ast.DEFELEM_UNSPEC)
 		}
@@ -37200,7 +37207,7 @@ yydefault:
 	case 2456:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10186
+//line postgres.y:10193
 		{
 			stmt := &ast.CreateFunctionStmt{
 				IsProcedure: false,
@@ -37217,7 +37224,7 @@ yydefault:
 	case 2457:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10200
+//line postgres.y:10207
 		{
 			// Handle RETURNS TABLE variant - merge table columns into parameters
 			// and create a RECORD return type, matching PostgreSQL's approach
@@ -37236,7 +37243,7 @@ yydefault:
 	case 2458:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10216
+//line postgres.y:10223
 		{
 			// No explicit return type (for procedures disguised as functions)
 			stmt := &ast.CreateFunctionStmt{
@@ -37254,7 +37261,7 @@ yydefault:
 	case 2459:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10231
+//line postgres.y:10238
 		{
 			stmt := &ast.CreateFunctionStmt{
 				IsProcedure: true,
@@ -37271,7 +37278,7 @@ yydefault:
 	case 2460:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10246
+//line postgres.y:10253
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37279,7 +37286,7 @@ yydefault:
 	case 2461:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10247
+//line postgres.y:10254
 		{
 			yyLOCAL = nil
 		}
@@ -37287,7 +37294,7 @@ yydefault:
 	case 2462:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10252
+//line postgres.y:10259
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].funparamUnion())
 		}
@@ -37295,7 +37302,7 @@ yydefault:
 	case 2463:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10256
+//line postgres.y:10263
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].funparamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37304,7 +37311,7 @@ yydefault:
 	case 2464:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10264
+//line postgres.y:10271
 		{
 			yyLOCAL = yyDollar[1].funparamUnion()
 		}
@@ -37312,7 +37319,7 @@ yydefault:
 	case 2465:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10268
+//line postgres.y:10275
 		{
 			yyDollar[1].funparamUnion().DefExpr = yyDollar[3].nodeUnion()
 			yyLOCAL = yyDollar[1].funparamUnion()
@@ -37321,7 +37328,7 @@ yydefault:
 	case 2466:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10273
+//line postgres.y:10280
 		{
 			yyDollar[1].funparamUnion().DefExpr = yyDollar[3].nodeUnion()
 			yyLOCAL = yyDollar[1].funparamUnion()
@@ -37330,7 +37337,7 @@ yydefault:
 	case 2467:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10281
+//line postgres.y:10288
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[1].funparammodeUnion(),
@@ -37343,7 +37350,7 @@ yydefault:
 	case 2468:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10290
+//line postgres.y:10297
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[2].funparammodeUnion(),
@@ -37356,7 +37363,7 @@ yydefault:
 	case 2469:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10299
+//line postgres.y:10306
 		{
 			param := &ast.FunctionParameter{
 				Mode:    ast.FUNC_PARAM_DEFAULT,
@@ -37369,7 +37376,7 @@ yydefault:
 	case 2470:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10308
+//line postgres.y:10315
 		{
 			param := &ast.FunctionParameter{
 				Mode:    yyDollar[1].funparammodeUnion(),
@@ -37382,7 +37389,7 @@ yydefault:
 	case 2471:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.FunctionParameter
-//line postgres.y:10317
+//line postgres.y:10324
 		{
 			param := &ast.FunctionParameter{
 				Mode:    ast.FUNC_PARAM_DEFAULT,
@@ -37395,7 +37402,7 @@ yydefault:
 	case 2472:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10328
+//line postgres.y:10335
 		{
 			yyLOCAL = ast.FUNC_PARAM_IN
 		}
@@ -37403,7 +37410,7 @@ yydefault:
 	case 2473:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10329
+//line postgres.y:10336
 		{
 			yyLOCAL = ast.FUNC_PARAM_OUT
 		}
@@ -37411,7 +37418,7 @@ yydefault:
 	case 2474:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10330
+//line postgres.y:10337
 		{
 			yyLOCAL = ast.FUNC_PARAM_INOUT
 		}
@@ -37419,7 +37426,7 @@ yydefault:
 	case 2475:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10331
+//line postgres.y:10338
 		{
 			yyLOCAL = ast.FUNC_PARAM_INOUT
 		}
@@ -37427,7 +37434,7 @@ yydefault:
 	case 2476:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.FunctionParameterMode
-//line postgres.y:10332
+//line postgres.y:10339
 		{
 			yyLOCAL = ast.FUNC_PARAM_VARIADIC
 		}
@@ -37435,7 +37442,7 @@ yydefault:
 	case 2477:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10336
+//line postgres.y:10343
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -37443,7 +37450,7 @@ yydefault:
 	case 2478:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10340
+//line postgres.y:10347
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -37451,7 +37458,7 @@ yydefault:
 	case 2479:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10342
+//line postgres.y:10349
 		{
 			// Handle %TYPE reference
 			list := ast.NewNodeList()
@@ -37470,7 +37477,7 @@ yydefault:
 	case 2480:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.TypeName
-//line postgres.y:10357
+//line postgres.y:10364
 		{
 			// Handle SETOF %TYPE reference
 			list := ast.NewNodeList()
@@ -37490,7 +37497,7 @@ yydefault:
 	case 2481:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10375
+//line postgres.y:10382
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -37498,7 +37505,7 @@ yydefault:
 	case 2482:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10376
+//line postgres.y:10383
 		{
 			yyLOCAL = nil
 		}
@@ -37506,7 +37513,7 @@ yydefault:
 	case 2483:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10381
+//line postgres.y:10388
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].defeltUnion())
@@ -37516,7 +37523,7 @@ yydefault:
 	case 2484:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10387
+//line postgres.y:10394
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37525,7 +37532,7 @@ yydefault:
 	case 2485:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10395
+//line postgres.y:10402
 		{
 			yyLOCAL = ast.NewDefElem("as", yyDollar[2].nodeUnion())
 		}
@@ -37533,7 +37540,7 @@ yydefault:
 	case 2486:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10399
+//line postgres.y:10406
 		{
 			yyLOCAL = ast.NewDefElem("language", ast.NewString(yyDollar[2].str))
 		}
@@ -37541,7 +37548,7 @@ yydefault:
 	case 2487:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10403
+//line postgres.y:10410
 		{
 			yyLOCAL = ast.NewDefElem("transform", yyDollar[2].listUnion())
 		}
@@ -37549,7 +37556,7 @@ yydefault:
 	case 2488:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10407
+//line postgres.y:10414
 		{
 			yyLOCAL = ast.NewDefElem("window", ast.NewBoolean(true))
 		}
@@ -37557,7 +37564,7 @@ yydefault:
 	case 2489:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10411
+//line postgres.y:10418
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -37565,7 +37572,7 @@ yydefault:
 	case 2490:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10418
+//line postgres.y:10425
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewString(yyDollar[1].str))
@@ -37575,7 +37582,7 @@ yydefault:
 	case 2491:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10424
+//line postgres.y:10431
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewString(yyDollar[1].str))
@@ -37586,7 +37593,7 @@ yydefault:
 	case 2492:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10434
+//line postgres.y:10441
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[3].typnamUnion())
@@ -37596,7 +37603,7 @@ yydefault:
 	case 2493:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10440
+//line postgres.y:10447
 		{
 			yyDollar[1].listUnion().Append(yyDollar[5].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37605,7 +37612,7 @@ yydefault:
 	case 2494:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10448
+//line postgres.y:10455
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37613,7 +37620,7 @@ yydefault:
 	case 2495:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10452
+//line postgres.y:10459
 		{
 			/*
 			 * A compound statement is stored as a single-item list
@@ -37629,7 +37636,7 @@ yydefault:
 	case 2496:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10464
+//line postgres.y:10471
 		{
 			yyLOCAL = nil
 		}
@@ -37637,7 +37644,7 @@ yydefault:
 	case 2497:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10471
+//line postgres.y:10478
 		{
 			yyLOCAL = ast.NewReturnStmt(yyDollar[2].nodeUnion())
 		}
@@ -37645,7 +37652,7 @@ yydefault:
 	case 2498:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10478
+//line postgres.y:10485
 		{
 			/* As in stmtmulti, discard empty statements */
 			if yyDollar[2].stmtUnion() != nil {
@@ -37659,7 +37666,7 @@ yydefault:
 	case 2499:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10488
+//line postgres.y:10495
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -37667,7 +37674,7 @@ yydefault:
 	case 2500:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10494
+//line postgres.y:10501
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37675,7 +37682,7 @@ yydefault:
 	case 2501:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10495
+//line postgres.y:10502
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -37683,7 +37690,7 @@ yydefault:
 	case 2502:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:10500
+//line postgres.y:10507
 		{
 			yyLOCAL = yyDollar[2].vsetstmtUnion()
 		}
@@ -37691,7 +37698,7 @@ yydefault:
 	case 2503:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:10504
+//line postgres.y:10511
 		{
 			yyLOCAL = yyDollar[1].stmtUnion().(*ast.VariableSetStmt)
 		}
@@ -37699,7 +37706,7 @@ yydefault:
 	case 2504:
 		yyDollar = yyS[yypt-17 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10520
+//line postgres.y:10527
 		{
 			// Extract events and columns from TriggerEvents list [events, columns]
 			eventsList := yyDollar[6].listUnion()
@@ -37732,7 +37739,7 @@ yydefault:
 	case 2505:
 		yyDollar = yyS[yypt-21 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10552
+//line postgres.y:10559
 		{
 			// Extract events and columns from TriggerEvents list [events, columns]
 			eventsList := yyDollar[7].listUnion()
@@ -37764,26 +37771,26 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2506:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10583
+//line postgres.y:10590
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_BEFORE
 		}
 	case 2507:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10584
+//line postgres.y:10591
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_AFTER
 		}
 	case 2508:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:10585
+//line postgres.y:10592
 		{
 			yyVAL.ival = ast.TRIGGER_TIMING_INSTEAD
 		}
 	case 2509:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10590
+//line postgres.y:10597
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -37791,7 +37798,7 @@ yydefault:
 	case 2510:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10592
+//line postgres.y:10599
 		{
 			// Extract event types and column lists from both sides
 			events1 := yyDollar[1].listUnion().Items[0].(*ast.Integer).IVal
@@ -37832,7 +37839,7 @@ yydefault:
 	case 2511:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10632
+//line postgres.y:10639
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_INSERT)))
@@ -37843,7 +37850,7 @@ yydefault:
 	case 2512:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10639
+//line postgres.y:10646
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_DELETE)))
@@ -37854,7 +37861,7 @@ yydefault:
 	case 2513:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10646
+//line postgres.y:10653
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_UPDATE)))
@@ -37865,7 +37872,7 @@ yydefault:
 	case 2514:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10653
+//line postgres.y:10660
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_UPDATE)))
@@ -37876,7 +37883,7 @@ yydefault:
 	case 2515:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10660
+//line postgres.y:10667
 		{
 			list := ast.NewNodeList()
 			list.Append(ast.NewInteger(int(ast.TRIGGER_TYPE_TRUNCATE)))
@@ -37887,7 +37894,7 @@ yydefault:
 	case 2516:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10669
+//line postgres.y:10676
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -37895,7 +37902,7 @@ yydefault:
 	case 2517:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10670
+//line postgres.y:10677
 		{
 			yyLOCAL = nil
 		}
@@ -37903,7 +37910,7 @@ yydefault:
 	case 2518:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10674
+//line postgres.y:10681
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -37913,7 +37920,7 @@ yydefault:
 	case 2519:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10679
+//line postgres.y:10686
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -37922,7 +37929,7 @@ yydefault:
 	case 2520:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10687
+//line postgres.y:10694
 		{
 			trans := &ast.TriggerTransition{
 				Name:    yyDollar[4].str,
@@ -37935,7 +37942,7 @@ yydefault:
 	case 2521:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10698
+//line postgres.y:10705
 		{
 			yyLOCAL = true
 		}
@@ -37943,7 +37950,7 @@ yydefault:
 	case 2522:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10699
+//line postgres.y:10706
 		{
 			yyLOCAL = false
 		}
@@ -37951,7 +37958,7 @@ yydefault:
 	case 2523:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10703
+//line postgres.y:10710
 		{
 			yyLOCAL = true
 		}
@@ -37959,21 +37966,21 @@ yydefault:
 	case 2524:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10704
+//line postgres.y:10711
 		{
 			yyLOCAL = false
 		}
 		yyVAL.union = yyLOCAL
 	case 2525:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:10708
+//line postgres.y:10715
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2526:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10713
+//line postgres.y:10720
 		{
 			yyLOCAL = yyDollar[3].bvalUnion()
 		}
@@ -37981,7 +37988,7 @@ yydefault:
 	case 2527:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10717
+//line postgres.y:10724
 		{
 			// If ROW/STATEMENT not specified, default to STATEMENT
 			yyLOCAL = false
@@ -37990,7 +37997,7 @@ yydefault:
 	case 2530:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10729
+//line postgres.y:10736
 		{
 			yyLOCAL = true
 		}
@@ -37998,7 +38005,7 @@ yydefault:
 	case 2531:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:10730
+//line postgres.y:10737
 		{
 			yyLOCAL = false
 		}
@@ -38006,7 +38013,7 @@ yydefault:
 	case 2532:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10734
+//line postgres.y:10741
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -38014,7 +38021,7 @@ yydefault:
 	case 2533:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10735
+//line postgres.y:10742
 		{
 			yyLOCAL = nil
 		}
@@ -38022,7 +38029,7 @@ yydefault:
 	case 2536:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10744
+//line postgres.y:10751
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -38032,7 +38039,7 @@ yydefault:
 	case 2537:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10749
+//line postgres.y:10756
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -38041,7 +38048,7 @@ yydefault:
 	case 2538:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10753
+//line postgres.y:10760
 		{
 			yyLOCAL = nil
 		}
@@ -38049,7 +38056,7 @@ yydefault:
 	case 2539:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10758
+//line postgres.y:10765
 		{
 			yyLOCAL = ast.NewString(fmt.Sprintf("%d", yyDollar[1].ival))
 		}
@@ -38057,7 +38064,7 @@ yydefault:
 	case 2540:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10761
+//line postgres.y:10768
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38065,7 +38072,7 @@ yydefault:
 	case 2541:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10762
+//line postgres.y:10769
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38073,7 +38080,7 @@ yydefault:
 	case 2542:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:10763
+//line postgres.y:10770
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -38081,7 +38088,7 @@ yydefault:
 	case 2543:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:10767
+//line postgres.y:10774
 		{
 			yyLOCAL = yyDollar[2].rangevarUnion()
 		}
@@ -38089,7 +38096,7 @@ yydefault:
 	case 2544:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RangeVar
-//line postgres.y:10768
+//line postgres.y:10775
 		{
 			yyLOCAL = nil
 		}
@@ -38097,7 +38104,7 @@ yydefault:
 	case 2545:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10781
+//line postgres.y:10788
 		{
 			// Apply OptTemp persistence to the view RangeVar
 			view := yyDollar[4].rangevarUnion()
@@ -38116,7 +38123,7 @@ yydefault:
 	case 2546:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10797
+//line postgres.y:10804
 		{
 			// Apply OptTemp persistence to the view RangeVar
 			view := yyDollar[6].rangevarUnion()
@@ -38135,7 +38142,7 @@ yydefault:
 	case 2547:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10813
+//line postgres.y:10820
 		{
 			// RECURSIVE VIEW requires explicit column list
 			view := yyDollar[5].rangevarUnion()
@@ -38154,7 +38161,7 @@ yydefault:
 	case 2548:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10829
+//line postgres.y:10836
 		{
 			// RECURSIVE VIEW requires explicit column list
 			view := yyDollar[7].rangevarUnion()
@@ -38173,7 +38180,7 @@ yydefault:
 	case 2549:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10846
+//line postgres.y:10853
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -38181,39 +38188,39 @@ yydefault:
 	case 2550:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10847
+//line postgres.y:10854
 		{
 			yyLOCAL = nil
 		}
 		yyVAL.union = yyLOCAL
 	case 2551:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:10851
+//line postgres.y:10858
 		{
 			yyVAL.ival = int(ast.CASCADED_CHECK_OPTION)
 		}
 	case 2552:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:10852
+//line postgres.y:10859
 		{
 			yyVAL.ival = int(ast.CASCADED_CHECK_OPTION)
 		}
 	case 2553:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:10853
+//line postgres.y:10860
 		{
 			yyVAL.ival = int(ast.LOCAL_CHECK_OPTION)
 		}
 	case 2554:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:10854
+//line postgres.y:10861
 		{
 			yyVAL.ival = int(ast.NO_CHECK_OPTION)
 		}
 	case 2555:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10865
+//line postgres.y:10872
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[3].str, false)
 			n.Authrole = yyDollar[5].rolespecUnion()
@@ -38224,7 +38231,7 @@ yydefault:
 	case 2556:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10872
+//line postgres.y:10879
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[3].str, false)
 			n.Authrole = nil
@@ -38235,7 +38242,7 @@ yydefault:
 	case 2557:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10879
+//line postgres.y:10886
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[6].str, true)
 			n.Authrole = yyDollar[8].rolespecUnion()
@@ -38246,7 +38253,7 @@ yydefault:
 	case 2558:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10886
+//line postgres.y:10893
 		{
 			n := ast.NewCreateSchemaStmt(yyDollar[6].str, true)
 			n.Authrole = nil
@@ -38257,7 +38264,7 @@ yydefault:
 	case 2559:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10902
+//line postgres.y:10909
 		{
 			n := ast.NewCreatedbStmt(yyDollar[3].str, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38266,7 +38273,7 @@ yydefault:
 	case 2560:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10915
+//line postgres.y:10922
 		{
 			n := ast.NewDropdbStmt(yyDollar[3].str, false, nil)
 			yyLOCAL = n
@@ -38275,7 +38282,7 @@ yydefault:
 	case 2561:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10920
+//line postgres.y:10927
 		{
 			n := ast.NewDropdbStmt(yyDollar[5].str, true, nil)
 			yyLOCAL = n
@@ -38284,7 +38291,7 @@ yydefault:
 	case 2562:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10925
+//line postgres.y:10932
 		{
 			n := ast.NewDropdbStmt(yyDollar[3].str, false, yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -38293,7 +38300,7 @@ yydefault:
 	case 2563:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10930
+//line postgres.y:10937
 		{
 			n := ast.NewDropdbStmt(yyDollar[5].str, true, yyDollar[8].listUnion())
 			yyLOCAL = n
@@ -38302,7 +38309,7 @@ yydefault:
 	case 2564:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10937
+//line postgres.y:10944
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -38310,7 +38317,7 @@ yydefault:
 	case 2565:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:10938
+//line postgres.y:10945
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Append(yyDollar[3].defeltUnion())
@@ -38319,7 +38326,7 @@ yydefault:
 	case 2566:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:10942
+//line postgres.y:10949
 		{
 			yyLOCAL = ast.NewDefElem("force", nil)
 		}
@@ -38327,7 +38334,7 @@ yydefault:
 	case 2567:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10952
+//line postgres.y:10959
 		{
 			n := ast.NewDropTableSpaceStmt(yyDollar[3].str, false)
 			yyLOCAL = n
@@ -38336,7 +38343,7 @@ yydefault:
 	case 2568:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10957
+//line postgres.y:10964
 		{
 			n := ast.NewDropTableSpaceStmt(yyDollar[5].str, true)
 			yyLOCAL = n
@@ -38345,7 +38352,7 @@ yydefault:
 	case 2569:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10971
+//line postgres.y:10978
 		{
 			n := ast.NewDropOwnedStmt(yyDollar[4].listUnion(), yyDollar[5].dropBehavUnion())
 			yyLOCAL = n
@@ -38354,7 +38361,7 @@ yydefault:
 	case 2570:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10979
+//line postgres.y:10986
 		{
 			n := ast.NewReassignOwnedStmt(yyDollar[4].listUnion(), yyDollar[6].rolespecUnion())
 			yyLOCAL = n
@@ -38363,7 +38370,7 @@ yydefault:
 	case 2571:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:10993
+//line postgres.y:11000
 		{
 			n := ast.NewCreateDomainStmt(yyDollar[3].listUnion(), yyDollar[5].typnamUnion())
 			// Use SplitColQualList to separate constraints and collate clause
@@ -38376,7 +38383,7 @@ yydefault:
 	case 2572:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11011
+//line postgres.y:11018
 		{
 			n := ast.NewAlterDomainStmt('T', yyDollar[3].listUnion())
 			n.Def = yyDollar[4].nodeUnion()
@@ -38386,7 +38393,7 @@ yydefault:
 	case 2573:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11017
+//line postgres.y:11024
 		{
 			n := ast.NewAlterDomainStmt('N', yyDollar[3].listUnion())
 			yyLOCAL = n
@@ -38395,7 +38402,7 @@ yydefault:
 	case 2574:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11022
+//line postgres.y:11029
 		{
 			n := ast.NewAlterDomainStmt('O', yyDollar[3].listUnion())
 			yyLOCAL = n
@@ -38404,7 +38411,7 @@ yydefault:
 	case 2575:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11027
+//line postgres.y:11034
 		{
 			n := ast.NewAlterDomainStmt('C', yyDollar[3].listUnion())
 			n.Def = yyDollar[5].nodeUnion()
@@ -38414,7 +38421,7 @@ yydefault:
 	case 2576:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11033
+//line postgres.y:11040
 		{
 			n := ast.NewAlterDomainStmt('X', yyDollar[3].listUnion())
 			n.Name = yyDollar[6].str
@@ -38426,7 +38433,7 @@ yydefault:
 	case 2577:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11041
+//line postgres.y:11048
 		{
 			n := ast.NewAlterDomainStmt('X', yyDollar[3].listUnion())
 			n.Name = yyDollar[8].str
@@ -38438,7 +38445,7 @@ yydefault:
 	case 2578:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11049
+//line postgres.y:11056
 		{
 			n := ast.NewAlterDomainStmt('V', yyDollar[3].listUnion())
 			n.Name = yyDollar[6].str
@@ -38448,7 +38455,7 @@ yydefault:
 	case 2579:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11064
+//line postgres.y:11071
 		{
 			// Store the full aggr_args result [args, position_indicator] for proper deparsing
 			n := ast.NewDefineStmt(ast.OBJECT_AGGREGATE, false, yyDollar[4].listUnion(), yyDollar[5].listUnion(), yyDollar[6].listUnion(), false, yyDollar[2].bvalUnion())
@@ -38458,7 +38465,7 @@ yydefault:
 	case 2580:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11070
+//line postgres.y:11077
 		{
 			// old-style (pre-8.2) syntax for CREATE AGGREGATE
 			n := ast.NewDefineStmt(ast.OBJECT_AGGREGATE, true, yyDollar[4].listUnion(), nil, yyDollar[5].listUnion(), false, yyDollar[2].bvalUnion())
@@ -38468,7 +38475,7 @@ yydefault:
 	case 2581:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11076
+//line postgres.y:11083
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_OPERATOR, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38477,7 +38484,7 @@ yydefault:
 	case 2582:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11081
+//line postgres.y:11088
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TYPE, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38486,7 +38493,7 @@ yydefault:
 	case 2583:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11086
+//line postgres.y:11093
 		{
 			// Shell type (identified by lack of definition)
 			n := ast.NewDefineStmt(ast.OBJECT_TYPE, false, yyDollar[3].listUnion(), nil, nil, false, false)
@@ -38496,7 +38503,7 @@ yydefault:
 	case 2584:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11092
+//line postgres.y:11099
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSPARSER, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38505,7 +38512,7 @@ yydefault:
 	case 2585:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11097
+//line postgres.y:11104
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSDICTIONARY, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38514,7 +38521,7 @@ yydefault:
 	case 2586:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11102
+//line postgres.y:11109
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSTEMPLATE, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38523,7 +38530,7 @@ yydefault:
 	case 2587:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11107
+//line postgres.y:11114
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_TSCONFIGURATION, false, yyDollar[5].listUnion(), nil, yyDollar[6].listUnion(), false, false)
 			yyLOCAL = n
@@ -38532,7 +38539,7 @@ yydefault:
 	case 2588:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11112
+//line postgres.y:11119
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[3].listUnion(), nil, yyDollar[4].listUnion(), false, false)
 			yyLOCAL = n
@@ -38541,7 +38548,7 @@ yydefault:
 	case 2589:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11117
+//line postgres.y:11124
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[6].listUnion(), nil, yyDollar[7].listUnion(), true, false)
 			yyLOCAL = n
@@ -38550,7 +38557,7 @@ yydefault:
 	case 2590:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11122
+//line postgres.y:11129
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[3].listUnion(), nil, ast.NewNodeList(yyDollar[5].listUnion()), false, false)
 			yyLOCAL = n
@@ -38559,7 +38566,7 @@ yydefault:
 	case 2591:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11127
+//line postgres.y:11134
 		{
 			n := ast.NewDefineStmt(ast.OBJECT_COLLATION, false, yyDollar[6].listUnion(), nil, ast.NewNodeList(yyDollar[8].listUnion()), true, false)
 			yyLOCAL = n
@@ -38568,7 +38575,7 @@ yydefault:
 	case 2592:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11132
+//line postgres.y:11139
 		{
 			typevar, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -38583,7 +38590,7 @@ yydefault:
 	case 2593:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11143
+//line postgres.y:11150
 		{
 			n := ast.NewCreateEnumStmt(yyDollar[3].listUnion(), yyDollar[7].listUnion())
 			yyLOCAL = n
@@ -38592,7 +38599,7 @@ yydefault:
 	case 2594:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11148
+//line postgres.y:11155
 		{
 			n := ast.NewCreateRangeStmt(yyDollar[3].listUnion(), yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -38601,7 +38608,7 @@ yydefault:
 	case 2595:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11162
+//line postgres.y:11169
 		{
 			n := ast.NewCreateSeqStmt(yyDollar[4].rangevarUnion(), yyDollar[5].listUnion(), 0, false, false)
 			yyLOCAL = n
@@ -38610,7 +38617,7 @@ yydefault:
 	case 2596:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11167
+//line postgres.y:11174
 		{
 			n := ast.NewCreateSeqStmt(yyDollar[7].rangevarUnion(), yyDollar[8].listUnion(), 0, false, true)
 			yyLOCAL = n
@@ -38619,7 +38626,7 @@ yydefault:
 	case 2597:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11174
+//line postgres.y:11181
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -38627,7 +38634,7 @@ yydefault:
 	case 2598:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11175
+//line postgres.y:11182
 		{
 			yyLOCAL = nil
 		}
@@ -38635,7 +38642,7 @@ yydefault:
 	case 2599:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11186
+//line postgres.y:11193
 		{
 			yyLOCAL = ast.NewAlterSeqStmt(yyDollar[3].rangevarUnion(), yyDollar[4].listUnion(), false, false)
 		}
@@ -38643,7 +38650,7 @@ yydefault:
 	case 2600:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11190
+//line postgres.y:11197
 		{
 			yyLOCAL = ast.NewAlterSeqStmt(yyDollar[5].rangevarUnion(), yyDollar[6].listUnion(), false, true)
 		}
@@ -38651,7 +38658,7 @@ yydefault:
 	case 2601:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11203
+//line postgres.y:11210
 		{
 			n := ast.NewCreateExtensionStmt(yyDollar[3].str, false, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38660,7 +38667,7 @@ yydefault:
 	case 2602:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11208
+//line postgres.y:11215
 		{
 			n := ast.NewCreateExtensionStmt(yyDollar[6].str, true, yyDollar[8].listUnion())
 			yyLOCAL = n
@@ -38669,7 +38676,7 @@ yydefault:
 	case 2603:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11216
+//line postgres.y:11223
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].defeltUnion())
@@ -38682,7 +38689,7 @@ yydefault:
 	case 2604:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11225
+//line postgres.y:11232
 		{
 			yyLOCAL = nil
 		}
@@ -38690,7 +38697,7 @@ yydefault:
 	case 2605:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11232
+//line postgres.y:11239
 		{
 			yyLOCAL = ast.NewDefElem("schema", ast.NewString(yyDollar[2].str))
 		}
@@ -38698,14 +38705,14 @@ yydefault:
 	case 2606:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11236
+//line postgres.y:11243
 		{
 			yyLOCAL = ast.NewDefElem("version", ast.NewString(yyDollar[2].str))
 		}
 		yyVAL.union = yyLOCAL
 	case 2607:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11240
+//line postgres.y:11247
 		{
 			yylex.Error("CREATE EXTENSION ... FROM is no longer supported")
 			return 1
@@ -38713,7 +38720,7 @@ yydefault:
 	case 2608:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11245
+//line postgres.y:11252
 		{
 			yyLOCAL = ast.NewDefElem("cascade", ast.NewBoolean(true))
 		}
@@ -38721,7 +38728,7 @@ yydefault:
 	case 2609:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11258
+//line postgres.y:11265
 		{
 			n := ast.NewAlterExtensionStmt(yyDollar[3].str, yyDollar[5].listUnion())
 			yyLOCAL = n
@@ -38730,7 +38737,7 @@ yydefault:
 	case 2610:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11266
+//line postgres.y:11273
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].defeltUnion())
@@ -38743,7 +38750,7 @@ yydefault:
 	case 2611:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11275
+//line postgres.y:11282
 		{
 			yyLOCAL = nil
 		}
@@ -38751,7 +38758,7 @@ yydefault:
 	case 2612:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11282
+//line postgres.y:11289
 		{
 			yyLOCAL = ast.NewDefElem("to", ast.NewString(yyDollar[2].str))
 		}
@@ -38759,7 +38766,7 @@ yydefault:
 	case 2613:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11295
+//line postgres.y:11302
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(yyDollar[5].objTypeUnion()), ast.NewString(yyDollar[6].str))
 		}
@@ -38767,7 +38774,7 @@ yydefault:
 	case 2614:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11299
+//line postgres.y:11306
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(yyDollar[5].objTypeUnion()), yyDollar[6].listUnion())
 		}
@@ -38775,7 +38782,7 @@ yydefault:
 	case 2615:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11303
+//line postgres.y:11310
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_AGGREGATE), yyDollar[6].objwithargsUnion())
 		}
@@ -38783,7 +38790,7 @@ yydefault:
 	case 2616:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11307
+//line postgres.y:11314
 		{
 			// CAST takes two TypeNames as a NodeList
 			list := ast.NewNodeList(yyDollar[7].typnamUnion())
@@ -38794,7 +38801,7 @@ yydefault:
 	case 2617:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11314
+//line postgres.y:11321
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_DOMAIN), yyDollar[6].typnamUnion())
 		}
@@ -38802,7 +38809,7 @@ yydefault:
 	case 2618:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11318
+//line postgres.y:11325
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_FUNCTION), yyDollar[6].objwithargsUnion())
 		}
@@ -38810,7 +38817,7 @@ yydefault:
 	case 2619:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11322
+//line postgres.y:11329
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_OPERATOR), yyDollar[6].objwithargsUnion())
 		}
@@ -38818,7 +38825,7 @@ yydefault:
 	case 2620:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11326
+//line postgres.y:11333
 		{
 			// OPERATOR CLASS takes method name + class name as NodeList
 			list := ast.NewNodeList(ast.NewString(yyDollar[9].str)) // method first
@@ -38831,7 +38838,7 @@ yydefault:
 	case 2621:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11335
+//line postgres.y:11342
 		{
 			// OPERATOR FAMILY takes method name + family name as NodeList
 			list := ast.NewNodeList(ast.NewString(yyDollar[9].str)) // method first
@@ -38844,7 +38851,7 @@ yydefault:
 	case 2622:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11344
+//line postgres.y:11351
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_PROCEDURE), yyDollar[6].objwithargsUnion())
 		}
@@ -38852,7 +38859,7 @@ yydefault:
 	case 2623:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11348
+//line postgres.y:11355
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_ROUTINE), yyDollar[6].objwithargsUnion())
 		}
@@ -38860,7 +38867,7 @@ yydefault:
 	case 2624:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11352
+//line postgres.y:11359
 		{
 			list := ast.NewNodeList(yyDollar[7].typnamUnion(), ast.NewString(yyDollar[9].str))
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_TRANSFORM), list)
@@ -38869,7 +38876,7 @@ yydefault:
 	case 2625:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11357
+//line postgres.y:11364
 		{
 			yyLOCAL = ast.NewAlterExtensionContentsStmt(yyDollar[3].str, yyDollar[4].ival != 0, int(ast.OBJECT_TYPE), yyDollar[6].typnamUnion())
 		}
@@ -38877,7 +38884,7 @@ yydefault:
 	case 2626:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11369
+//line postgres.y:11376
 		{
 			yyLOCAL = ast.NewCreateFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -38885,7 +38892,7 @@ yydefault:
 	case 2627:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11375
+//line postgres.y:11382
 		{
 			yyLOCAL = ast.NewAlterFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -38893,7 +38900,7 @@ yydefault:
 	case 2628:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11379
+//line postgres.y:11386
 		{
 			yyLOCAL = ast.NewAlterFdwStmt(yyDollar[5].str, yyDollar[6].listUnion(), nil)
 		}
@@ -38901,7 +38908,7 @@ yydefault:
 	case 2629:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11385
+//line postgres.y:11392
 		{
 			yyLOCAL = ast.NewDefElem("handler", yyDollar[2].listUnion())
 		}
@@ -38909,7 +38916,7 @@ yydefault:
 	case 2630:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11386
+//line postgres.y:11393
 		{
 			yyLOCAL = ast.NewDefElem("handler", nil)
 		}
@@ -38917,7 +38924,7 @@ yydefault:
 	case 2631:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11387
+//line postgres.y:11394
 		{
 			yyLOCAL = ast.NewDefElem("validator", yyDollar[2].listUnion())
 		}
@@ -38925,7 +38932,7 @@ yydefault:
 	case 2632:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11388
+//line postgres.y:11395
 		{
 			yyLOCAL = ast.NewDefElem("validator", nil)
 		}
@@ -38933,7 +38940,7 @@ yydefault:
 	case 2633:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11392
+//line postgres.y:11399
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -38941,7 +38948,7 @@ yydefault:
 	case 2634:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11393
+//line postgres.y:11400
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -38950,7 +38957,7 @@ yydefault:
 	case 2635:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11397
+//line postgres.y:11404
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -38958,7 +38965,7 @@ yydefault:
 	case 2636:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11398
+//line postgres.y:11405
 		{
 			yyLOCAL = nil
 		}
@@ -38966,7 +38973,7 @@ yydefault:
 	case 2637:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11402
+//line postgres.y:11409
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -38974,7 +38981,7 @@ yydefault:
 	case 2638:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11403
+//line postgres.y:11410
 		{
 			result := ast.NewNodeList(ast.NewString(yyDollar[1].str))
 			for _, item := range yyDollar[2].listUnion().Items {
@@ -38986,7 +38993,7 @@ yydefault:
 	case 2639:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11420
+//line postgres.y:11427
 		{
 			yyLOCAL = ast.NewCreateForeignServerStmt(yyDollar[3].str, yyDollar[4].str, yyDollar[5].str, yyDollar[9].str, yyDollar[10].listUnion(), false)
 		}
@@ -38994,7 +39001,7 @@ yydefault:
 	case 2640:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11425
+//line postgres.y:11432
 		{
 			yyLOCAL = ast.NewCreateForeignServerStmt(yyDollar[6].str, yyDollar[7].str, yyDollar[8].str, yyDollar[12].str, yyDollar[13].listUnion(), true)
 		}
@@ -39002,7 +39009,7 @@ yydefault:
 	case 2641:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11431
+//line postgres.y:11438
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, yyDollar[4].str, yyDollar[5].listUnion(), true)
 		}
@@ -39010,7 +39017,7 @@ yydefault:
 	case 2642:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11435
+//line postgres.y:11442
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, yyDollar[4].str, nil, true)
 		}
@@ -39018,51 +39025,51 @@ yydefault:
 	case 2643:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11439
+//line postgres.y:11446
 		{
 			yyLOCAL = ast.NewAlterForeignServerStmt(yyDollar[3].str, "", yyDollar[4].listUnion(), false)
 		}
 		yyVAL.union = yyLOCAL
 	case 2644:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11445
+//line postgres.y:11452
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2645:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:11446
+//line postgres.y:11453
 		{
 			yyVAL.str = ""
 		}
 	case 2646:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11450
+//line postgres.y:11457
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2647:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:11451
+//line postgres.y:11458
 		{
 			yyVAL.str = ""
 		}
 	case 2648:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:11455
+//line postgres.y:11462
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2649:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:11456
+//line postgres.y:11463
 		{
 			yyVAL.str = ""
 		}
 	case 2650:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11469
+//line postgres.y:11476
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[4].rangevarUnion(), yyDollar[6].listUnion(), yyDollar[8].listUnion(), yyDollar[10].str, yyDollar[11].listUnion(), nil, false)
 		}
@@ -39070,7 +39077,7 @@ yydefault:
 	case 2651:
 		yyDollar = yyS[yypt-14 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11475
+//line postgres.y:11482
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[7].rangevarUnion(), yyDollar[9].listUnion(), yyDollar[11].listUnion(), yyDollar[13].str, yyDollar[14].listUnion(), nil, true)
 		}
@@ -39078,7 +39085,7 @@ yydefault:
 	case 2652:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11481
+//line postgres.y:11488
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[4].rangevarUnion(), yyDollar[8].listUnion(), ast.NewNodeList(yyDollar[7].rangevarUnion()), yyDollar[11].str, yyDollar[12].listUnion(), yyDollar[9].partboundspecUnion(), false)
 		}
@@ -39086,7 +39093,7 @@ yydefault:
 	case 2653:
 		yyDollar = yyS[yypt-15 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11487
+//line postgres.y:11494
 		{
 			yyLOCAL = ast.NewCreateForeignTableStmt(yyDollar[7].rangevarUnion(), yyDollar[11].listUnion(), ast.NewNodeList(yyDollar[10].rangevarUnion()), yyDollar[14].str, yyDollar[15].listUnion(), yyDollar[12].partboundspecUnion(), true)
 		}
@@ -39094,7 +39101,7 @@ yydefault:
 	case 2654:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11501
+//line postgres.y:11508
 		{
 			stmt := ast.NewImportForeignSchemaStmt(
 				ast.NewString(yyDollar[8].str),           // server name
@@ -39110,7 +39117,7 @@ yydefault:
 	case 2655:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ImportQual
-//line postgres.y:11516
+//line postgres.y:11523
 		{
 			qual := &ImportQual{
 				typ:        yyDollar[1].importqualtypeUnion(),
@@ -39122,7 +39129,7 @@ yydefault:
 	case 2656:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ImportQual
-//line postgres.y:11524
+//line postgres.y:11531
 		{
 			qual := &ImportQual{
 				typ:        ast.FDW_IMPORT_SCHEMA_ALL,
@@ -39134,7 +39141,7 @@ yydefault:
 	case 2657:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.ImportForeignSchemaType
-//line postgres.y:11534
+//line postgres.y:11541
 		{
 			yyLOCAL = ast.FDW_IMPORT_SCHEMA_LIMIT_TO
 		}
@@ -39142,7 +39149,7 @@ yydefault:
 	case 2658:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.ImportForeignSchemaType
-//line postgres.y:11535
+//line postgres.y:11542
 		{
 			yyLOCAL = ast.FDW_IMPORT_SCHEMA_EXCEPT
 		}
@@ -39150,7 +39157,7 @@ yydefault:
 	case 2659:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11545
+//line postgres.y:11552
 		{
 			yyLOCAL = ast.NewCreateUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, yyDollar[8].listUnion(), false)
 		}
@@ -39158,7 +39165,7 @@ yydefault:
 	case 2660:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11549
+//line postgres.y:11556
 		{
 			yyLOCAL = ast.NewCreateUserMappingStmt(yyDollar[8].rolespecUnion(), yyDollar[10].str, yyDollar[11].listUnion(), true)
 		}
@@ -39166,7 +39173,7 @@ yydefault:
 	case 2661:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11555
+//line postgres.y:11562
 		{
 			yyLOCAL = ast.NewAlterUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, yyDollar[8].listUnion())
 		}
@@ -39174,7 +39181,7 @@ yydefault:
 	case 2662:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11561
+//line postgres.y:11568
 		{
 			yyLOCAL = ast.NewDropUserMappingStmt(yyDollar[5].rolespecUnion(), yyDollar[7].str, false)
 		}
@@ -39182,7 +39189,7 @@ yydefault:
 	case 2663:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11565
+//line postgres.y:11572
 		{
 			yyLOCAL = ast.NewDropUserMappingStmt(yyDollar[7].rolespecUnion(), yyDollar[9].str, true)
 		}
@@ -39190,7 +39197,7 @@ yydefault:
 	case 2664:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:11571
+//line postgres.y:11578
 		{
 			yyLOCAL = yyDollar[1].rolespecUnion()
 		}
@@ -39198,7 +39205,7 @@ yydefault:
 	case 2665:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:11572
+//line postgres.y:11579
 		{
 			yyLOCAL = ast.NewRoleSpec(ast.ROLESPEC_CURRENT_USER, "")
 		}
@@ -39206,7 +39213,7 @@ yydefault:
 	case 2666:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11577
+//line postgres.y:11584
 		{
 			// For aggregates like COUNT(*)
 			// Return a list with [nil, -1] matching PostgreSQL's list_make2(NIL, makeInteger(-1))
@@ -39216,7 +39223,7 @@ yydefault:
 	case 2667:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11583
+//line postgres.y:11590
 		{
 			// Regular aggregate arguments
 			// Return a list with [args, -1] matching PostgreSQL's list_make2($2, makeInteger(-1))
@@ -39226,7 +39233,7 @@ yydefault:
 	case 2668:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11589
+//line postgres.y:11596
 		{
 			// Ordered-set aggregate without direct arguments
 			// Return a list with [args, 0] matching PostgreSQL's list_make2($4, makeInteger(0))
@@ -39236,7 +39243,7 @@ yydefault:
 	case 2669:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11595
+//line postgres.y:11602
 		{
 			// Hypothetical-set aggregate
 			// This is the only case requiring consistency checking in PostgreSQL
@@ -39251,7 +39258,7 @@ yydefault:
 	case 2670:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11609
+//line postgres.y:11616
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -39259,7 +39266,7 @@ yydefault:
 	case 2671:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11613
+//line postgres.y:11620
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39268,7 +39275,7 @@ yydefault:
 	case 2672:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11621
+//line postgres.y:11628
 		{
 			yyLOCAL = yyDollar[1].funparamUnion()
 		}
@@ -39276,7 +39283,7 @@ yydefault:
 	case 2673:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11628
+//line postgres.y:11635
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -39284,7 +39291,7 @@ yydefault:
 	case 2674:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11635
+//line postgres.y:11642
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -39292,7 +39299,7 @@ yydefault:
 	case 2675:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11639
+//line postgres.y:11646
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39301,7 +39308,7 @@ yydefault:
 	case 2676:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:11647
+//line postgres.y:11654
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -39309,7 +39316,7 @@ yydefault:
 	case 2677:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11654
+//line postgres.y:11661
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39321,7 +39328,7 @@ yydefault:
 	case 2678:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11662
+//line postgres.y:11669
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39334,7 +39341,7 @@ yydefault:
 	case 2679:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11671
+//line postgres.y:11678
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.NewVal = yyDollar[7].str
@@ -39347,7 +39354,7 @@ yydefault:
 	case 2680:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11680
+//line postgres.y:11687
 		{
 			n := ast.NewAlterEnumStmt(yyDollar[3].listUnion())
 			n.OldVal = yyDollar[6].str
@@ -39358,7 +39365,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2681:
 		yyDollar = yyS[yypt-6 : yypt+1]
-//line postgres.y:11688
+//line postgres.y:11695
 		{
 			// Following PostgreSQL's approach - DROP VALUE is parsed but not implemented
 			// PostgreSQL throws an error saying "dropping an enum value is not implemented"
@@ -39368,7 +39375,7 @@ yydefault:
 	case 2682:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11704
+//line postgres.y:11711
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -39376,7 +39383,7 @@ yydefault:
 	case 2683:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11706
+//line postgres.y:11713
 		{
 			yyLOCAL = nil
 		}
@@ -39384,7 +39391,7 @@ yydefault:
 	case 2684:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11711
+//line postgres.y:11718
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -39392,7 +39399,7 @@ yydefault:
 	case 2685:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11713
+//line postgres.y:11720
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39401,7 +39408,7 @@ yydefault:
 	case 2686:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11718
+//line postgres.y:11725
 		{
 			if constraint, ok := yyDollar[3].nodeUnion().(*ast.Constraint); ok {
 				constraint.Conname = yyDollar[2].str
@@ -39414,7 +39421,7 @@ yydefault:
 	case 2687:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11727
+//line postgres.y:11734
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39422,7 +39429,7 @@ yydefault:
 	case 2688:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11732
+//line postgres.y:11739
 		{
 			n := ast.NewConstraint(ast.CONSTR_CHECK)
 			n.RawExpr = yyDollar[3].nodeUnion()
@@ -39437,7 +39444,7 @@ yydefault:
 	case 2689:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:11743
+//line postgres.y:11750
 		{
 			n := ast.NewConstraint(ast.CONSTR_NOTNULL)
 			// In PostgreSQL, domain NOT NULL constraints have keys = list_make1(makeString("value"))
@@ -39452,7 +39459,7 @@ yydefault:
 	case 2690:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11763
+//line postgres.y:11770
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[7].stmtUnion(), yyDollar[5].intoUnion(), ast.OBJECT_MATVIEW, false, false)
 			/* cram additional flags into the IntoClause */
@@ -39464,7 +39471,7 @@ yydefault:
 	case 2691:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11771
+//line postgres.y:11778
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[10].stmtUnion(), yyDollar[8].intoUnion(), ast.OBJECT_MATVIEW, false, true)
 			/* cram additional flags into the IntoClause */
@@ -39476,7 +39483,7 @@ yydefault:
 	case 2692:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11782
+//line postgres.y:11789
 		{
 			n := ast.NewRefreshMatViewStmt(yyDollar[4].bvalUnion(), !yyDollar[6].bvalUnion(), yyDollar[5].rangevarUnion())
 			yyLOCAL = n
@@ -39484,7 +39491,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2693:
 		yyDollar = yyS[yypt-8 : yypt+1]
-//line postgres.y:11797
+//line postgres.y:11804
 		{
 			yylex.Error("CREATE ASSERTION is not yet implemented")
 			return 1
@@ -39494,7 +39501,7 @@ yydefault:
 	case 2694:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11813
+//line postgres.y:11820
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[6].stmtUnion(), yyDollar[4].intoUnion(), ast.OBJECT_TABLE, false, false)
 			/* cram additional flags into the IntoClause */
@@ -39508,7 +39515,7 @@ yydefault:
 	case 2695:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11823
+//line postgres.y:11830
 		{
 			ctas := ast.NewCreateTableAsStmt(yyDollar[9].stmtUnion(), yyDollar[7].intoUnion(), ast.OBJECT_TABLE, false, true)
 			/* cram additional flags into the IntoClause */
@@ -39522,7 +39529,7 @@ yydefault:
 	case 2696:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11843
+//line postgres.y:11850
 		{
 			n := &ast.RuleStmt{
 				BaseNode:    ast.BaseNode{Tag: ast.T_RuleStmt},
@@ -39540,7 +39547,7 @@ yydefault:
 	case 2697:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11859
+//line postgres.y:11866
 		{
 			yyLOCAL = nil
 		}
@@ -39548,7 +39555,7 @@ yydefault:
 	case 2698:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11860
+//line postgres.y:11867
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].stmtUnion())
 		}
@@ -39556,7 +39563,7 @@ yydefault:
 	case 2699:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11861
+//line postgres.y:11868
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -39564,7 +39571,7 @@ yydefault:
 	case 2700:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11866
+//line postgres.y:11873
 		{
 			if yyDollar[3].stmtUnion() != nil {
 				if yyDollar[1].listUnion() != nil {
@@ -39579,7 +39586,7 @@ yydefault:
 	case 2701:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11877
+//line postgres.y:11884
 		{
 			if yyDollar[1].stmtUnion() != nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[1].stmtUnion())
@@ -39591,7 +39598,7 @@ yydefault:
 	case 2707:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11895
+//line postgres.y:11902
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -39599,7 +39606,7 @@ yydefault:
 	case 2708:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:11896
+//line postgres.y:11903
 		{
 			yyLOCAL = nil
 		}
@@ -39607,7 +39614,7 @@ yydefault:
 	case 2709:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11900
+//line postgres.y:11907
 		{
 			yyLOCAL = true
 		}
@@ -39615,7 +39622,7 @@ yydefault:
 	case 2710:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11901
+//line postgres.y:11908
 		{
 			yyLOCAL = false
 		}
@@ -39623,7 +39630,7 @@ yydefault:
 	case 2711:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11902
+//line postgres.y:11909
 		{
 			yyLOCAL = false
 		}
@@ -39631,7 +39638,7 @@ yydefault:
 	case 2712:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:11905
+//line postgres.y:11912
 		{
 			yyLOCAL = ast.RELPERSISTENCE_UNLOGGED
 		}
@@ -39639,7 +39646,7 @@ yydefault:
 	case 2713:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL rune
-//line postgres.y:11906
+//line postgres.y:11913
 		{
 			yyLOCAL = ast.RELPERSISTENCE_PERMANENT
 		}
@@ -39647,7 +39654,7 @@ yydefault:
 	case 2714:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.IntoClause
-//line postgres.y:11911
+//line postgres.y:11918
 		{
 			yyLOCAL = &ast.IntoClause{
 				Rel:            yyDollar[1].rangevarUnion(),
@@ -39661,7 +39668,7 @@ yydefault:
 	case 2715:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11923
+//line postgres.y:11930
 		{
 			yyLOCAL = true
 		}
@@ -39669,7 +39676,7 @@ yydefault:
 	case 2716:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11924
+//line postgres.y:11931
 		{
 			yyLOCAL = false
 		}
@@ -39677,7 +39684,7 @@ yydefault:
 	case 2717:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:11925
+//line postgres.y:11932
 		{
 			yyLOCAL = true
 		}
@@ -39685,7 +39692,7 @@ yydefault:
 	case 2718:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11930
+//line postgres.y:11937
 		{
 			if yyDollar[1].listUnion() == nil {
 				yyLOCAL = ast.NewNodeList(yyDollar[2].stmtUnion())
@@ -39698,7 +39705,7 @@ yydefault:
 	case 2719:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:11939
+//line postgres.y:11946
 		{
 			yyLOCAL = nil
 		}
@@ -39706,7 +39713,7 @@ yydefault:
 	case 2726:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11952
+//line postgres.y:11959
 		{
 			yyLOCAL = yyDollar[1].vsetstmtUnion()
 		}
@@ -39714,7 +39721,7 @@ yydefault:
 	case 2727:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11954
+//line postgres.y:11961
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_CURRENT, yyDollar[1].str, nil, false)
 		}
@@ -39722,7 +39729,7 @@ yydefault:
 	case 2728:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11958
+//line postgres.y:11965
 		{
 			args := ast.NewNodeList(yyDollar[3].nodeUnion())
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "timezone", args, false)
@@ -39731,7 +39738,7 @@ yydefault:
 	case 2729:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11963
+//line postgres.y:11970
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "catalog", args, false)
@@ -39740,7 +39747,7 @@ yydefault:
 	case 2730:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11968
+//line postgres.y:11975
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "search_path", args, false)
@@ -39749,7 +39756,7 @@ yydefault:
 	case 2731:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11973
+//line postgres.y:11980
 		{
 			var args *ast.NodeList
 			if yyDollar[2].str != "" {
@@ -39761,7 +39768,7 @@ yydefault:
 	case 2732:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11981
+//line postgres.y:11988
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[2].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "role", args, false)
@@ -39770,7 +39777,7 @@ yydefault:
 	case 2733:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11986
+//line postgres.y:11993
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[3].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "session_authorization", args, false)
@@ -39779,7 +39786,7 @@ yydefault:
 	case 2734:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11991
+//line postgres.y:11998
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, "session_authorization", nil, false)
 		}
@@ -39787,7 +39794,7 @@ yydefault:
 	case 2735:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:11995
+//line postgres.y:12002
 		{
 			var value string
 			if yyDollar[3].ival == int(ast.XMLOPTION_DOCUMENT) {
@@ -39802,7 +39809,7 @@ yydefault:
 	case 2736:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12006
+//line postgres.y:12013
 		{
 			args := ast.NewNodeList(ast.NewString(yyDollar[3].str))
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, "transaction_snapshot", args, false)
@@ -39811,7 +39818,7 @@ yydefault:
 	case 2737:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12014
+//line postgres.y:12021
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, yyDollar[1].str, yyDollar[3].listUnion(), false)
 		}
@@ -39819,7 +39826,7 @@ yydefault:
 	case 2738:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12018
+//line postgres.y:12025
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_VALUE, yyDollar[1].str, yyDollar[3].listUnion(), false)
 		}
@@ -39827,7 +39834,7 @@ yydefault:
 	case 2739:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12022
+//line postgres.y:12029
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, yyDollar[1].str, nil, false)
 		}
@@ -39835,27 +39842,27 @@ yydefault:
 	case 2740:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.VariableSetStmt
-//line postgres.y:12026
+//line postgres.y:12033
 		{
 			yyLOCAL = ast.NewVariableSetStmt(ast.VAR_SET_DEFAULT, yyDollar[1].str, nil, false)
 		}
 		yyVAL.union = yyLOCAL
 	case 2741:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12033
+//line postgres.y:12040
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2742:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:12037
+//line postgres.y:12044
 		{
 			yyVAL.str = yyDollar[1].str + "." + yyDollar[3].str
 		}
 	case 2743:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12044
+//line postgres.y:12051
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -39865,7 +39872,7 @@ yydefault:
 	case 2744:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12050
+//line postgres.y:12057
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -39874,7 +39881,7 @@ yydefault:
 	case 2745:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12057
+//line postgres.y:12064
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39882,7 +39889,7 @@ yydefault:
 	case 2746:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12058
+//line postgres.y:12065
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39890,7 +39897,7 @@ yydefault:
 	case 2747:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12062
+//line postgres.y:12069
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39898,7 +39905,7 @@ yydefault:
 	case 2748:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12063
+//line postgres.y:12070
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -39906,7 +39913,7 @@ yydefault:
 	case 2749:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12065
+//line postgres.y:12072
 		{
 			t := yyDollar[1].typnamUnion()
 			t.Typmods = yyDollar[3].listUnion()
@@ -39917,7 +39924,7 @@ yydefault:
 	case 2750:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12072
+//line postgres.y:12079
 		{
 			t := yyDollar[1].typnamUnion()
 			// INTERVAL_FULL_RANGE equivalent and precision
@@ -39929,7 +39936,7 @@ yydefault:
 	case 2751:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12079
+//line postgres.y:12086
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -39937,7 +39944,7 @@ yydefault:
 	case 2752:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12080
+//line postgres.y:12087
 		{
 			yyLOCAL = ast.NewString("default")
 		}
@@ -39945,81 +39952,81 @@ yydefault:
 	case 2753:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12081
+//line postgres.y:12088
 		{
 			yyLOCAL = ast.NewString("local")
 		}
 		yyVAL.union = yyLOCAL
 	case 2754:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12085
+//line postgres.y:12092
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2755:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12086
+//line postgres.y:12093
 		{
 			yyVAL.str = "default"
 		}
 	case 2756:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12087
+//line postgres.y:12094
 		{
 			yyVAL.str = ""
 		}
 	case 2757:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12091
+//line postgres.y:12098
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2758:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12092
+//line postgres.y:12099
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2759:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12096
+//line postgres.y:12103
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2760:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12097
+//line postgres.y:12104
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2761:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12098
+//line postgres.y:12105
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2762:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12099
+//line postgres.y:12106
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2763:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12103
+//line postgres.y:12110
 		{
 			yyVAL.ival = int(ast.XMLOPTION_DOCUMENT)
 		}
 	case 2764:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12104
+//line postgres.y:12111
 		{
 			yyVAL.ival = int(ast.XMLOPTION_CONTENT)
 		}
 	case 2765:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12109
+//line postgres.y:12116
 		{
 			list := ast.NewNodeList()
 			list.Append(yyDollar[1].nodeUnion())
@@ -40029,7 +40036,7 @@ yydefault:
 	case 2766:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12115
+//line postgres.y:12122
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40038,7 +40045,7 @@ yydefault:
 	case 2767:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12120
+//line postgres.y:12127
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40047,7 +40054,7 @@ yydefault:
 	case 2768:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12128
+//line postgres.y:12135
 		{
 			yyLOCAL = ast.NewDefElem("transaction_isolation", ast.NewString(yyDollar[3].str))
 		}
@@ -40055,7 +40062,7 @@ yydefault:
 	case 2769:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12132
+//line postgres.y:12139
 		{
 			yyLOCAL = ast.NewDefElem("transaction_read_only", ast.NewBoolean(true))
 		}
@@ -40063,7 +40070,7 @@ yydefault:
 	case 2770:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12136
+//line postgres.y:12143
 		{
 			yyLOCAL = ast.NewDefElem("transaction_read_only", ast.NewBoolean(false))
 		}
@@ -40071,7 +40078,7 @@ yydefault:
 	case 2771:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12140
+//line postgres.y:12147
 		{
 			yyLOCAL = ast.NewDefElem("transaction_deferrable", ast.NewBoolean(true))
 		}
@@ -40079,39 +40086,39 @@ yydefault:
 	case 2772:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12144
+//line postgres.y:12151
 		{
 			yyLOCAL = ast.NewDefElem("transaction_deferrable", ast.NewBoolean(false))
 		}
 		yyVAL.union = yyLOCAL
 	case 2773:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12150
+//line postgres.y:12157
 		{
 			yyVAL.str = "read uncommitted"
 		}
 	case 2774:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12151
+//line postgres.y:12158
 		{
 			yyVAL.str = "read committed"
 		}
 	case 2775:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12152
+//line postgres.y:12159
 		{
 			yyVAL.str = "repeatable read"
 		}
 	case 2776:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12153
+//line postgres.y:12160
 		{
 			yyVAL.str = "serializable"
 		}
 	case 2777:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12157
+//line postgres.y:12164
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -40119,7 +40126,7 @@ yydefault:
 	case 2778:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12158
+//line postgres.y:12165
 		{
 			yyLOCAL = nil
 		}
@@ -40127,7 +40134,7 @@ yydefault:
 	case 2779:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12162
+//line postgres.y:12169
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -40135,7 +40142,7 @@ yydefault:
 	case 2780:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12163
+//line postgres.y:12170
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -40143,7 +40150,7 @@ yydefault:
 	case 2781:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12164
+//line postgres.y:12171
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -40151,7 +40158,7 @@ yydefault:
 	case 2782:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12167
+//line postgres.y:12174
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -40159,7 +40166,7 @@ yydefault:
 	case 2783:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12168
+//line postgres.y:12175
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -40167,7 +40174,7 @@ yydefault:
 	case 2784:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12169
+//line postgres.y:12176
 		{
 			yyLOCAL = ast.NewString("none")
 		}
@@ -40175,7 +40182,7 @@ yydefault:
 	case 2785:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12173
+//line postgres.y:12180
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40183,7 +40190,7 @@ yydefault:
 	case 2786:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12174
+//line postgres.y:12181
 		{
 			yyLOCAL = nil
 		}
@@ -40191,7 +40198,7 @@ yydefault:
 	case 2787:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12178
+//line postgres.y:12185
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -40199,7 +40206,7 @@ yydefault:
 	case 2788:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12179
+//line postgres.y:12186
 		{
 			yyLOCAL = nil
 		}
@@ -40207,7 +40214,7 @@ yydefault:
 	case 2789:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12183
+//line postgres.y:12190
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -40215,7 +40222,7 @@ yydefault:
 	case 2790:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12188
+//line postgres.y:12195
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40224,7 +40231,7 @@ yydefault:
 	case 2791:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12193
+//line postgres.y:12200
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40233,7 +40240,7 @@ yydefault:
 	case 2792:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12201
+//line postgres.y:12208
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -40241,7 +40248,7 @@ yydefault:
 	case 2793:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12205
+//line postgres.y:12212
 		{
 			elem := yyDollar[2].defeltUnion()
 			elem.Defaction = ast.DEFELEM_SET
@@ -40251,7 +40258,7 @@ yydefault:
 	case 2794:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12211
+//line postgres.y:12218
 		{
 			elem := yyDollar[2].defeltUnion()
 			elem.Defaction = ast.DEFELEM_ADD
@@ -40261,27 +40268,27 @@ yydefault:
 	case 2795:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12217
+//line postgres.y:12224
 		{
 			yyLOCAL = ast.NewDefElemExtended("", yyDollar[2].str, nil, ast.DEFELEM_DROP)
 		}
 		yyVAL.union = yyLOCAL
 	case 2796:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12223
+//line postgres.y:12230
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2797:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12224
+//line postgres.y:12231
 		{
 			yyVAL.str = ""
 		}
 	case 2798:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12228
+//line postgres.y:12235
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_NOTHING, "")
 		}
@@ -40289,7 +40296,7 @@ yydefault:
 	case 2799:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12229
+//line postgres.y:12236
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_FULL, "")
 		}
@@ -40297,7 +40304,7 @@ yydefault:
 	case 2800:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12230
+//line postgres.y:12237
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_DEFAULT, "")
 		}
@@ -40305,7 +40312,7 @@ yydefault:
 	case 2801:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12231
+//line postgres.y:12238
 		{
 			yyLOCAL = ast.NewReplicaIdentityStmt(ast.REPLICA_IDENTITY_INDEX, yyDollar[3].str)
 		}
@@ -40313,7 +40320,7 @@ yydefault:
 	case 2802:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12235
+//line postgres.y:12242
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40321,7 +40328,7 @@ yydefault:
 	case 2803:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12240
+//line postgres.y:12247
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40330,7 +40337,7 @@ yydefault:
 	case 2804:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12245
+//line postgres.y:12252
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40339,7 +40346,7 @@ yydefault:
 	case 2805:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12252
+//line postgres.y:12259
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -40347,7 +40354,7 @@ yydefault:
 	case 2806:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12253
+//line postgres.y:12260
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -40355,7 +40362,7 @@ yydefault:
 	case 2807:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12264
+//line postgres.y:12271
 		{
 			yyLOCAL = ast.NewCreateEventTrigStmt(yyDollar[4].str, yyDollar[6].str, yyDollar[9].listUnion(), nil)
 		}
@@ -40363,7 +40370,7 @@ yydefault:
 	case 2808:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12268
+//line postgres.y:12275
 		{
 			yyLOCAL = ast.NewCreateEventTrigStmt(yyDollar[4].str, yyDollar[6].str, yyDollar[11].listUnion(), yyDollar[8].listUnion())
 		}
@@ -40371,39 +40378,39 @@ yydefault:
 	case 2809:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12274
+//line postgres.y:12281
 		{
 			yyLOCAL = ast.NewAlterEventTrigStmt(yyDollar[4].str, ast.TriggerFires(yyDollar[5].ival))
 		}
 		yyVAL.union = yyLOCAL
 	case 2810:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12280
+//line postgres.y:12287
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ON_ORIGIN)
 		}
 	case 2811:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12281
+//line postgres.y:12288
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ON_REPLICA)
 		}
 	case 2812:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12282
+//line postgres.y:12289
 		{
 			yyVAL.ival = int(ast.TRIGGER_FIRES_ALWAYS)
 		}
 	case 2813:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12283
+//line postgres.y:12290
 		{
 			yyVAL.ival = int(ast.TRIGGER_DISABLED)
 		}
 	case 2814:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12288
+//line postgres.y:12295
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].defeltUnion())
@@ -40412,7 +40419,7 @@ yydefault:
 	case 2815:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12293
+//line postgres.y:12300
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40421,7 +40428,7 @@ yydefault:
 	case 2816:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:12301
+//line postgres.y:12308
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[4].listUnion())
 		}
@@ -40429,7 +40436,7 @@ yydefault:
 	case 2817:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12308
+//line postgres.y:12315
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(ast.NewString(yyDollar[1].str))
@@ -40438,7 +40445,7 @@ yydefault:
 	case 2818:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12313
+//line postgres.y:12320
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40447,7 +40454,7 @@ yydefault:
 	case 2819:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12327
+//line postgres.y:12334
 		{
 			yyLOCAL = ast.NewCreateTableSpaceStmt(yyDollar[3].str, yyDollar[4].rolespecUnion(), yyDollar[6].str, yyDollar[7].listUnion())
 		}
@@ -40455,7 +40462,7 @@ yydefault:
 	case 2820:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:12333
+//line postgres.y:12340
 		{
 			yyLOCAL = yyDollar[2].rolespecUnion()
 		}
@@ -40463,7 +40470,7 @@ yydefault:
 	case 2821:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:12334
+//line postgres.y:12341
 		{
 			yyLOCAL = nil
 		}
@@ -40471,7 +40478,7 @@ yydefault:
 	case 2822:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12339
+//line postgres.y:12346
 		{
 			yyLOCAL = ast.NewAlterTableSpaceStmt(yyDollar[3].str, yyDollar[5].listUnion(), false)
 		}
@@ -40479,7 +40486,7 @@ yydefault:
 	case 2823:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12343
+//line postgres.y:12350
 		{
 			yyLOCAL = ast.NewAlterTableSpaceStmt(yyDollar[3].str, yyDollar[5].listUnion(), true)
 		}
@@ -40487,7 +40494,7 @@ yydefault:
 	case 2824:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12358
+//line postgres.y:12365
 		{
 			yyLOCAL = ast.NewCreatePolicyStmt(yyDollar[3].str, yyDollar[5].rangevarUnion(), yyDollar[6].bvalUnion(), yyDollar[7].str, yyDollar[8].listUnion(), yyDollar[9].nodeUnion(), yyDollar[10].nodeUnion())
 		}
@@ -40495,7 +40502,7 @@ yydefault:
 	case 2825:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12366
+//line postgres.y:12373
 		{
 			yyLOCAL = ast.NewAlterPolicyStmt(yyDollar[3].str, yyDollar[5].rangevarUnion(), yyDollar[6].listUnion(), yyDollar[7].nodeUnion(), yyDollar[8].nodeUnion())
 		}
@@ -40503,7 +40510,7 @@ yydefault:
 	case 2826:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12373
+//line postgres.y:12380
 		{
 			// Check for "permissive" or "restrictive" (case-insensitive)
 			if strings.EqualFold(yyDollar[2].str, "permissive") {
@@ -40520,57 +40527,57 @@ yydefault:
 	case 2827:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12385
+//line postgres.y:12392
 		{
 			yyLOCAL = true
 		}
 		yyVAL.union = yyLOCAL
 	case 2828:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12389
+//line postgres.y:12396
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 2829:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12390
+//line postgres.y:12397
 		{
 			yyVAL.str = "all"
 		}
 	case 2830:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12394
+//line postgres.y:12401
 		{
 			yyVAL.str = "all"
 		}
 	case 2831:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12395
+//line postgres.y:12402
 		{
 			yyVAL.str = "select"
 		}
 	case 2832:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12396
+//line postgres.y:12403
 		{
 			yyVAL.str = "insert"
 		}
 	case 2833:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12397
+//line postgres.y:12404
 		{
 			yyVAL.str = "update"
 		}
 	case 2834:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12398
+//line postgres.y:12405
 		{
 			yyVAL.str = "delete"
 		}
 	case 2835:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12402
+//line postgres.y:12409
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40578,7 +40585,7 @@ yydefault:
 	case 2836:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12403
+//line postgres.y:12410
 		{
 			// Default to PUBLIC when no TO clause is specified
 			publicRole := ast.NewRoleSpec(ast.ROLESPEC_PUBLIC, "")
@@ -40588,7 +40595,7 @@ yydefault:
 	case 2837:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12411
+//line postgres.y:12418
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -40596,7 +40603,7 @@ yydefault:
 	case 2838:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12412
+//line postgres.y:12419
 		{
 			yyLOCAL = nil
 		}
@@ -40604,7 +40611,7 @@ yydefault:
 	case 2839:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12416
+//line postgres.y:12423
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -40612,7 +40619,7 @@ yydefault:
 	case 2840:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12417
+//line postgres.y:12424
 		{
 			yyLOCAL = nil
 		}
@@ -40620,7 +40627,7 @@ yydefault:
 	case 2841:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12421
+//line postgres.y:12428
 		{
 			yyLOCAL = yyDollar[4].nodeUnion()
 		}
@@ -40628,7 +40635,7 @@ yydefault:
 	case 2842:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12422
+//line postgres.y:12429
 		{
 			yyLOCAL = nil
 		}
@@ -40636,27 +40643,27 @@ yydefault:
 	case 2843:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12433
+//line postgres.y:12440
 		{
 			yyLOCAL = ast.NewCreateAmStmt(yyDollar[4].str, ast.AmType(yyDollar[6].ival), yyDollar[8].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 2844:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12439
+//line postgres.y:12446
 		{
 			yyVAL.ival = int(ast.AMTYPE_INDEX)
 		}
 	case 2845:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:12440
+//line postgres.y:12447
 		{
 			yyVAL.ival = int(ast.AMTYPE_TABLE)
 		}
 	case 2846:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12451
+//line postgres.y:12458
 		{
 			yyLOCAL = ast.NewCreateStatsStmt(yyDollar[3].listUnion(), yyDollar[4].listUnion(), yyDollar[6].listUnion(), yyDollar[8].listUnion(), "", false, false)
 		}
@@ -40664,7 +40671,7 @@ yydefault:
 	case 2847:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12455
+//line postgres.y:12462
 		{
 			yyLOCAL = ast.NewCreateStatsStmt(yyDollar[6].listUnion(), yyDollar[7].listUnion(), yyDollar[9].listUnion(), yyDollar[11].listUnion(), "", false, true)
 		}
@@ -40672,7 +40679,7 @@ yydefault:
 	case 2848:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12462
+//line postgres.y:12469
 		{
 			yyLOCAL = ast.NewAlterStatsStmt(yyDollar[3].listUnion(), yyDollar[6].nodeUnion(), false)
 		}
@@ -40680,7 +40687,7 @@ yydefault:
 	case 2849:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12466
+//line postgres.y:12473
 		{
 			yyLOCAL = ast.NewAlterStatsStmt(yyDollar[5].listUnion(), yyDollar[8].nodeUnion(), true)
 		}
@@ -40688,7 +40695,7 @@ yydefault:
 	case 2850:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12472
+//line postgres.y:12479
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].statelemUnion())
@@ -40697,7 +40704,7 @@ yydefault:
 	case 2851:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12473
+//line postgres.y:12480
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].statelemUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40706,7 +40713,7 @@ yydefault:
 	case 2852:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12477
+//line postgres.y:12484
 		{
 			yyLOCAL = ast.NewStatsElem(yyDollar[1].str)
 		}
@@ -40714,7 +40721,7 @@ yydefault:
 	case 2853:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12478
+//line postgres.y:12485
 		{
 			yyLOCAL = ast.NewStatsElemExpr(yyDollar[1].nodeUnion())
 		}
@@ -40722,7 +40729,7 @@ yydefault:
 	case 2854:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.StatsElem
-//line postgres.y:12479
+//line postgres.y:12486
 		{
 			yyLOCAL = ast.NewStatsElemExpr(ast.NewParenExpr(yyDollar[2].nodeUnion(), 0))
 		}
@@ -40730,7 +40737,7 @@ yydefault:
 	case 2855:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12490
+//line postgres.y:12497
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, nil, false, yyDollar[4].listUnion())
 		}
@@ -40738,7 +40745,7 @@ yydefault:
 	case 2856:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12494
+//line postgres.y:12501
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, nil, true, yyDollar[7].listUnion())
 		}
@@ -40746,7 +40753,7 @@ yydefault:
 	case 2857:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12498
+//line postgres.y:12505
 		{
 			yyLOCAL = ast.NewCreatePublicationStmt(yyDollar[3].str, yyDollar[5].listUnion(), false, yyDollar[6].listUnion())
 		}
@@ -40754,7 +40761,7 @@ yydefault:
 	case 2858:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12505
+//line postgres.y:12512
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, yyDollar[5].listUnion(), nil, ast.AP_SetOptions)
 		}
@@ -40762,7 +40769,7 @@ yydefault:
 	case 2859:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12509
+//line postgres.y:12516
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_AddObjects)
 		}
@@ -40770,7 +40777,7 @@ yydefault:
 	case 2860:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12513
+//line postgres.y:12520
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_SetObjects)
 		}
@@ -40778,7 +40785,7 @@ yydefault:
 	case 2861:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12517
+//line postgres.y:12524
 		{
 			yyLOCAL = ast.NewAlterPublicationStmt(yyDollar[3].str, nil, yyDollar[5].listUnion(), ast.AP_DropObjects)
 		}
@@ -40786,7 +40793,7 @@ yydefault:
 	case 2862:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12523
+//line postgres.y:12530
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[1].nodeUnion())
@@ -40795,7 +40802,7 @@ yydefault:
 	case 2863:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12524
+//line postgres.y:12531
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -40804,7 +40811,7 @@ yydefault:
 	case 2864:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12529
+//line postgres.y:12536
 		{
 			pubTable := ast.NewPublicationTable(yyDollar[2].rangevarUnion(), yyDollar[4].nodeUnion(), yyDollar[3].listUnion())
 			yyLOCAL = ast.NewPublicationObjSpecTable(ast.PUBLICATIONOBJ_TABLE, pubTable)
@@ -40813,7 +40820,7 @@ yydefault:
 	case 2865:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12534
+//line postgres.y:12541
 		{
 			yyLOCAL = ast.NewPublicationObjSpecName(ast.PUBLICATIONOBJ_TABLES_IN_SCHEMA, yyDollar[4].str)
 		}
@@ -40821,7 +40828,7 @@ yydefault:
 	case 2866:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12538
+//line postgres.y:12545
 		{
 			yyLOCAL = ast.NewPublicationObjSpec(ast.PUBLICATIONOBJ_TABLES_IN_CUR_SCHEMA)
 		}
@@ -40829,7 +40836,7 @@ yydefault:
 	case 2867:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12542
+//line postgres.y:12549
 		{
 			// If either a row filter or column list is specified, create a PublicationTable object
 			if yyDollar[2].listUnion() != nil || yyDollar[3].nodeUnion() != nil {
@@ -40845,7 +40852,7 @@ yydefault:
 	case 2868:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12554
+//line postgres.y:12561
 		{
 			rangeVar := makeRangeVarFromQualifiedName(yyDollar[1].str, yyDollar[2].listUnion(), -1)
 			pubTable := ast.NewPublicationTable(rangeVar, yyDollar[4].nodeUnion(), yyDollar[3].listUnion())
@@ -40855,7 +40862,7 @@ yydefault:
 	case 2869:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12560
+//line postgres.y:12567
 		{
 			pubTable := ast.NewPublicationTable(yyDollar[1].rangevarUnion(), yyDollar[3].nodeUnion(), yyDollar[2].listUnion())
 			yyLOCAL = ast.NewPublicationObjSpecTable(ast.PUBLICATIONOBJ_CONTINUATION, pubTable)
@@ -40864,7 +40871,7 @@ yydefault:
 	case 2870:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12565
+//line postgres.y:12572
 		{
 			yyLOCAL = ast.NewPublicationObjSpec(ast.PUBLICATIONOBJ_CONTINUATION)
 		}
@@ -40872,7 +40879,7 @@ yydefault:
 	case 2871:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12571
+//line postgres.y:12578
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -40880,7 +40887,7 @@ yydefault:
 	case 2872:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12572
+//line postgres.y:12579
 		{
 			yyLOCAL = nil
 		}
@@ -40888,7 +40895,7 @@ yydefault:
 	case 2873:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12583
+//line postgres.y:12590
 		{
 			yyLOCAL = ast.NewCreateSubscriptionStmt(yyDollar[3].str, yyDollar[5].str, yyDollar[7].listUnion(), yyDollar[8].listUnion())
 		}
@@ -40896,7 +40903,7 @@ yydefault:
 	case 2874:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12590
+//line postgres.y:12597
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_OPTIONS, "", nil, yyDollar[5].listUnion())
 		}
@@ -40904,7 +40911,7 @@ yydefault:
 	case 2875:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12594
+//line postgres.y:12601
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_CONNECTION, yyDollar[5].str, nil, nil)
 		}
@@ -40912,7 +40919,7 @@ yydefault:
 	case 2876:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12598
+//line postgres.y:12605
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_REFRESH, "", nil, yyDollar[6].listUnion())
 		}
@@ -40920,7 +40927,7 @@ yydefault:
 	case 2877:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12602
+//line postgres.y:12609
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_ADD_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40928,7 +40935,7 @@ yydefault:
 	case 2878:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12606
+//line postgres.y:12613
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_DROP_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40936,7 +40943,7 @@ yydefault:
 	case 2879:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12610
+//line postgres.y:12617
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_SET_PUBLICATION, "", yyDollar[6].listUnion(), yyDollar[7].listUnion())
 		}
@@ -40944,7 +40951,7 @@ yydefault:
 	case 2880:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12614
+//line postgres.y:12621
 		{
 			enableOpt := ast.NewNodeList()
 			enableOpt.Append(ast.NewDefElem("enabled", ast.NewBoolean(true)))
@@ -40954,7 +40961,7 @@ yydefault:
 	case 2881:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12620
+//line postgres.y:12627
 		{
 			disableOpt := ast.NewNodeList()
 			disableOpt.Append(ast.NewDefElem("enabled", ast.NewBoolean(false)))
@@ -40964,7 +40971,7 @@ yydefault:
 	case 2882:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12626
+//line postgres.y:12633
 		{
 			yyLOCAL = ast.NewAlterSubscriptionStmt(yyDollar[3].str, ast.ALTER_SUBSCRIPTION_SKIP, "", nil, yyDollar[5].listUnion())
 		}
@@ -40972,7 +40979,7 @@ yydefault:
 	case 2883:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12639
+//line postgres.y:12646
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), yyDollar[10].objwithargsUnion(), ast.CoercionContext(yyDollar[11].ival), false)
 		}
@@ -40980,7 +40987,7 @@ yydefault:
 	case 2884:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12643
+//line postgres.y:12650
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), nil, ast.CoercionContext(yyDollar[10].ival), false)
 		}
@@ -40988,33 +40995,33 @@ yydefault:
 	case 2885:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12647
+//line postgres.y:12654
 		{
 			yyLOCAL = ast.NewCreateCastStmt(yyDollar[4].typnamUnion(), yyDollar[6].typnamUnion(), nil, ast.CoercionContext(yyDollar[10].ival), true)
 		}
 		yyVAL.union = yyLOCAL
 	case 2886:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12653
+//line postgres.y:12660
 		{
 			yyVAL.ival = int(ast.COERCION_IMPLICIT)
 		}
 	case 2887:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:12654
+//line postgres.y:12661
 		{
 			yyVAL.ival = int(ast.COERCION_ASSIGNMENT)
 		}
 	case 2888:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:12655
+//line postgres.y:12662
 		{
 			yyVAL.ival = int(ast.COERCION_EXPLICIT)
 		}
 	case 2889:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12667
+//line postgres.y:12674
 		{
 			yyLOCAL = ast.NewCreateOpClassStmt(yyDollar[4].listUnion(), yyDollar[11].listUnion(), yyDollar[10].str, yyDollar[8].typnamUnion(), yyDollar[13].listUnion(), yyDollar[5].bvalUnion())
 		}
@@ -41022,7 +41029,7 @@ yydefault:
 	case 2890:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12673
+//line postgres.y:12680
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41030,7 +41037,7 @@ yydefault:
 	case 2891:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12674
+//line postgres.y:12681
 		{
 			yyLOCAL = nil
 		}
@@ -41038,7 +41045,7 @@ yydefault:
 	case 2892:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12678
+//line postgres.y:12685
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41046,7 +41053,7 @@ yydefault:
 	case 2893:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12679
+//line postgres.y:12686
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41055,7 +41062,7 @@ yydefault:
 	case 2894:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12684
+//line postgres.y:12691
 		{
 			// Create ObjectWithArgs for simple operator
 			owa := ast.NewObjectWithArgs(yyDollar[3].listUnion(), nil, false, -1)
@@ -41065,7 +41072,7 @@ yydefault:
 	case 2895:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12690
+//line postgres.y:12697
 		{
 			yyLOCAL = ast.NewOpClassItemOperator(yyDollar[2].ival, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 		}
@@ -41073,7 +41080,7 @@ yydefault:
 	case 2896:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12694
+//line postgres.y:12701
 		{
 			yyLOCAL = ast.NewOpClassItemFunction(yyDollar[2].ival, yyDollar[3].objwithargsUnion(), nil)
 		}
@@ -41081,7 +41088,7 @@ yydefault:
 	case 2897:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12698
+//line postgres.y:12705
 		{
 			yyLOCAL = ast.NewOpClassItemFunction(yyDollar[2].ival, yyDollar[6].objwithargsUnion(), yyDollar[4].listUnion())
 		}
@@ -41089,7 +41096,7 @@ yydefault:
 	case 2898:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12702
+//line postgres.y:12709
 		{
 			yyLOCAL = ast.NewOpClassItemStorage(yyDollar[2].typnamUnion())
 		}
@@ -41097,7 +41104,7 @@ yydefault:
 	case 2899:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12708
+//line postgres.y:12715
 		{
 			yyLOCAL = true
 		}
@@ -41105,7 +41112,7 @@ yydefault:
 	case 2900:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12709
+//line postgres.y:12716
 		{
 			yyLOCAL = false
 		}
@@ -41113,7 +41120,7 @@ yydefault:
 	case 2901:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12713
+//line postgres.y:12720
 		{
 			yyLOCAL = nil
 		}
@@ -41121,7 +41128,7 @@ yydefault:
 	case 2902:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12714
+//line postgres.y:12721
 		{
 			yyLOCAL = yyDollar[4].listUnion()
 		}
@@ -41129,7 +41136,7 @@ yydefault:
 	case 2903:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12715
+//line postgres.y:12722
 		{
 			yyLOCAL = nil
 		}
@@ -41137,7 +41144,7 @@ yydefault:
 	case 2904:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12719
+//line postgres.y:12726
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].typnamUnion())
 		}
@@ -41145,7 +41152,7 @@ yydefault:
 	case 2905:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12720
+//line postgres.y:12727
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].typnamUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41154,7 +41161,7 @@ yydefault:
 	case 2906:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12731
+//line postgres.y:12738
 		{
 			yyLOCAL = ast.NewCreateOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -41162,7 +41169,7 @@ yydefault:
 	case 2907:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12744
+//line postgres.y:12751
 		{
 			yyLOCAL = ast.NewAlterOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str, false, yyDollar[8].listUnion())
 		}
@@ -41170,7 +41177,7 @@ yydefault:
 	case 2908:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12748
+//line postgres.y:12755
 		{
 			yyLOCAL = ast.NewAlterOpFamilyStmt(yyDollar[4].listUnion(), yyDollar[6].str, true, yyDollar[8].listUnion())
 		}
@@ -41178,7 +41185,7 @@ yydefault:
 	case 2909:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12754
+//line postgres.y:12761
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41186,7 +41193,7 @@ yydefault:
 	case 2910:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12755
+//line postgres.y:12762
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41195,7 +41202,7 @@ yydefault:
 	case 2911:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12760
+//line postgres.y:12767
 		{
 			// Create ObjectWithArgs for operator with args
 			owa := ast.NewObjectWithArgs(nil, yyDollar[4].listUnion(), false, -1)
@@ -41205,7 +41212,7 @@ yydefault:
 	case 2912:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12766
+//line postgres.y:12773
 		{
 			// Create ObjectWithArgs for function with args
 			owa := ast.NewObjectWithArgs(nil, yyDollar[4].listUnion(), false, -1)
@@ -41215,7 +41222,7 @@ yydefault:
 	case 2913:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12781
+//line postgres.y:12788
 		{
 			yyLOCAL = ast.NewCreateConversionStmt(yyDollar[4].listUnion(), yyDollar[6].str, yyDollar[8].str, yyDollar[10].listUnion(), yyDollar[2].bvalUnion())
 		}
@@ -41223,7 +41230,7 @@ yydefault:
 	case 2914:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12794
+//line postgres.y:12801
 		{
 			yyLOCAL = ast.NewCreateTransformStmt(yyDollar[2].bvalUnion(), yyDollar[5].typnamUnion(), yyDollar[7].str, linitial(yyDollar[9].listUnion()), lsecond(yyDollar[9].listUnion()))
 		}
@@ -41231,7 +41238,7 @@ yydefault:
 	case 2915:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12801
+//line postgres.y:12808
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[5].objwithargsUnion())  // fromsql
@@ -41241,7 +41248,7 @@ yydefault:
 	case 2916:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12807
+//line postgres.y:12814
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[11].objwithargsUnion()) // fromsql
@@ -41251,7 +41258,7 @@ yydefault:
 	case 2917:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12813
+//line postgres.y:12820
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(yyDollar[5].objwithargsUnion()) // fromsql
@@ -41261,7 +41268,7 @@ yydefault:
 	case 2918:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12819
+//line postgres.y:12826
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Append(nil)                            // fromsql
@@ -41271,7 +41278,7 @@ yydefault:
 	case 2919:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12834
+//line postgres.y:12841
 		{
 			// Parameterless CREATE LANGUAGE is now treated as CREATE EXTENSION
 			yyLOCAL = ast.NewCreateExtensionStmt(yyDollar[6].str, yyDollar[2].bvalUnion(), nil)
@@ -41280,7 +41287,7 @@ yydefault:
 	case 2920:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:12840
+//line postgres.y:12847
 		{
 			yyLOCAL = ast.NewCreatePLangStmt(yyDollar[2].bvalUnion(), yyDollar[6].str, yyDollar[8].listUnion(), yyDollar[9].listUnion(), yyDollar[10].listUnion(), yyDollar[3].bvalUnion())
 		}
@@ -41288,7 +41295,7 @@ yydefault:
 	case 2921:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12846
+//line postgres.y:12853
 		{
 			yyLOCAL = true
 		}
@@ -41296,7 +41303,7 @@ yydefault:
 	case 2922:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:12847
+//line postgres.y:12854
 		{
 			yyLOCAL = false
 		}
@@ -41304,7 +41311,7 @@ yydefault:
 	case 2923:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12852
+//line postgres.y:12859
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41312,7 +41319,7 @@ yydefault:
 	case 2924:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12853
+//line postgres.y:12860
 		{
 			yyLOCAL = nil
 		}
@@ -41320,7 +41327,7 @@ yydefault:
 	case 2925:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12857
+//line postgres.y:12864
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -41328,7 +41335,7 @@ yydefault:
 	case 2926:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12858
+//line postgres.y:12865
 		{
 			yyLOCAL = nil
 		}
@@ -41336,7 +41343,7 @@ yydefault:
 	case 2927:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12862
+//line postgres.y:12869
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41344,7 +41351,7 @@ yydefault:
 	case 2928:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12863
+//line postgres.y:12870
 		{
 			yyLOCAL = nil
 		}
@@ -41352,7 +41359,7 @@ yydefault:
 	case 2929:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12866
+//line postgres.y:12873
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_ALL
 		}
@@ -41360,7 +41367,7 @@ yydefault:
 	case 2930:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12867
+//line postgres.y:12874
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_DISTINCT
 		}
@@ -41368,7 +41375,7 @@ yydefault:
 	case 2931:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.SetQuantifier
-//line postgres.y:12868
+//line postgres.y:12875
 		{
 			yyLOCAL = ast.SET_QUANTIFIER_DEFAULT
 		}
@@ -41376,7 +41383,7 @@ yydefault:
 	case 2932:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.GroupClause
-//line postgres.y:12873
+//line postgres.y:12880
 		{
 			yyLOCAL = &ast.GroupClause{
 				Distinct: yyDollar[3].setquantUnion() == ast.SET_QUANTIFIER_DISTINCT,
@@ -41387,7 +41394,7 @@ yydefault:
 	case 2933:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.GroupClause
-//line postgres.y:12880
+//line postgres.y:12887
 		{
 			yyLOCAL = nil
 		}
@@ -41395,7 +41402,7 @@ yydefault:
 	case 2934:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12886
+//line postgres.y:12893
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41403,7 +41410,7 @@ yydefault:
 	case 2935:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12887
+//line postgres.y:12894
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41412,7 +41419,7 @@ yydefault:
 	case 2936:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12891
+//line postgres.y:12898
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41420,7 +41427,7 @@ yydefault:
 	case 2937:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12892
+//line postgres.y:12899
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41428,7 +41435,7 @@ yydefault:
 	case 2938:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12893
+//line postgres.y:12900
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41436,7 +41443,7 @@ yydefault:
 	case 2939:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12894
+//line postgres.y:12901
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41444,7 +41451,7 @@ yydefault:
 	case 2940:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12895
+//line postgres.y:12902
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41452,7 +41459,7 @@ yydefault:
 	case 2941:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12900
+//line postgres.y:12907
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_EMPTY, ast.NewNodeList(), 0)
 		}
@@ -41460,7 +41467,7 @@ yydefault:
 	case 2942:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12907
+//line postgres.y:12914
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_ROLLUP, yyDollar[3].listUnion(), 0)
 		}
@@ -41468,7 +41475,7 @@ yydefault:
 	case 2943:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12914
+//line postgres.y:12921
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_CUBE, yyDollar[3].listUnion(), 0)
 		}
@@ -41476,7 +41483,7 @@ yydefault:
 	case 2944:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12921
+//line postgres.y:12928
 		{
 			yyLOCAL = ast.NewGroupingSet(ast.GROUPING_SET_SETS, yyDollar[4].listUnion(), 0)
 		}
@@ -41484,7 +41491,7 @@ yydefault:
 	case 2945:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12930
+//line postgres.y:12937
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41492,7 +41499,7 @@ yydefault:
 	case 2946:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12931
+//line postgres.y:12938
 		{
 			yyLOCAL = nil
 		}
@@ -41500,7 +41507,7 @@ yydefault:
 	case 2947:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12938
+//line postgres.y:12945
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -41508,7 +41515,7 @@ yydefault:
 	case 2948:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12942
+//line postgres.y:12949
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -41516,7 +41523,7 @@ yydefault:
 	case 2949:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12943
+//line postgres.y:12950
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -41525,7 +41532,7 @@ yydefault:
 	case 2950:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12948
+//line postgres.y:12955
 		{
 			sortBy := ast.NewSortBy(yyDollar[1].nodeUnion(), ast.SORTBY_USING, ast.SortByNulls(yyDollar[4].ival), 0)
 			// Use qual_all_Op (NodeList) directly for UseOp
@@ -41536,7 +41543,7 @@ yydefault:
 	case 2951:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:12955
+//line postgres.y:12962
 		{
 			yyLOCAL = ast.NewSortBy(yyDollar[1].nodeUnion(), ast.SortByDir(yyDollar[2].ival), ast.SortByNulls(yyDollar[3].ival), 0)
 		}
@@ -41544,7 +41551,7 @@ yydefault:
 	case 2952:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12966
+//line postgres.y:12973
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -41552,7 +41559,7 @@ yydefault:
 	case 2953:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12968
+//line postgres.y:12975
 		{
 			yyLOCAL = nil
 		}
@@ -41560,7 +41567,7 @@ yydefault:
 	case 2954:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12973
+//line postgres.y:12980
 		{
 			yyLOCAL = ast.NewNodeList()
 			yyLOCAL.Items = append(yyLOCAL.Items, yyDollar[1].windefUnion())
@@ -41569,7 +41576,7 @@ yydefault:
 	case 2955:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:12978
+//line postgres.y:12985
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Items = append(yyLOCAL.Items, yyDollar[3].windefUnion())
@@ -41578,7 +41585,7 @@ yydefault:
 	case 2956:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12986
+//line postgres.y:12993
 		{
 			n := yyDollar[3].windefUnion()
 			n.Name = yyDollar[1].str
@@ -41588,7 +41595,7 @@ yydefault:
 	case 2957:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12995
+//line postgres.y:13002
 		{
 			yyLOCAL = yyDollar[2].windefUnion()
 		}
@@ -41596,7 +41603,7 @@ yydefault:
 	case 2958:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:12997
+//line postgres.y:13004
 		{
 			n := ast.NewWindowDef("", -1)
 			n.Refname = yyDollar[2].str
@@ -41607,7 +41614,7 @@ yydefault:
 	case 2959:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13004
+//line postgres.y:13011
 		{
 			yyLOCAL = nil
 		}
@@ -41615,7 +41622,7 @@ yydefault:
 	case 2960:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13009
+//line postgres.y:13016
 		{
 			n := ast.NewWindowDef("", -1)
 			n.Refname = yyDollar[2].str
@@ -41630,20 +41637,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2961:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13023
+//line postgres.y:13030
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 2962:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13024
+//line postgres.y:13031
 		{
 			yyVAL.str = ""
 		}
 	case 2963:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13028
+//line postgres.y:13035
 		{
 			yyLOCAL = yyDollar[3].listUnion()
 		}
@@ -41651,7 +41658,7 @@ yydefault:
 	case 2964:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13029
+//line postgres.y:13036
 		{
 			yyLOCAL = nil
 		}
@@ -41659,7 +41666,7 @@ yydefault:
 	case 2965:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13034
+//line postgres.y:13041
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_RANGE
@@ -41670,7 +41677,7 @@ yydefault:
 	case 2966:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13041
+//line postgres.y:13048
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_ROWS
@@ -41681,7 +41688,7 @@ yydefault:
 	case 2967:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13048
+//line postgres.y:13055
 		{
 			n := yyDollar[2].windefUnion()
 			n.FrameOptions |= ast.FRAMEOPTION_NONDEFAULT | ast.FRAMEOPTION_GROUPS
@@ -41692,7 +41699,7 @@ yydefault:
 	case 2968:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13055
+//line postgres.y:13062
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_DEFAULTS
@@ -41704,7 +41711,7 @@ yydefault:
 	case 2969:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13066
+//line postgres.y:13073
 		{
 			n := yyDollar[1].windefUnion()
 			// reject invalid cases - these would be runtime errors in PostgreSQL
@@ -41722,7 +41729,7 @@ yydefault:
 	case 2970:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13080
+//line postgres.y:13087
 		{
 			n1 := yyDollar[2].windefUnion()
 			n2 := yyDollar[4].windefUnion()
@@ -41758,7 +41765,7 @@ yydefault:
 	case 2971:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13115
+//line postgres.y:13122
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_UNBOUNDED_PRECEDING
@@ -41770,7 +41777,7 @@ yydefault:
 	case 2972:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13123
+//line postgres.y:13130
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_UNBOUNDED_FOLLOWING
@@ -41782,7 +41789,7 @@ yydefault:
 	case 2973:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13131
+//line postgres.y:13138
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_CURRENT_ROW
@@ -41794,7 +41801,7 @@ yydefault:
 	case 2974:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13139
+//line postgres.y:13146
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_OFFSET_PRECEDING
@@ -41806,7 +41813,7 @@ yydefault:
 	case 2975:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.WindowDef
-//line postgres.y:13147
+//line postgres.y:13154
 		{
 			n := ast.NewWindowDef("", -1)
 			n.FrameOptions = ast.FRAMEOPTION_START_OFFSET_FOLLOWING
@@ -41817,38 +41824,38 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2976:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13157
+//line postgres.y:13164
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_CURRENT_ROW
 		}
 	case 2977:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:13158
+//line postgres.y:13165
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_GROUP
 		}
 	case 2978:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:13159
+//line postgres.y:13166
 		{
 			yyVAL.ival = ast.FRAMEOPTION_EXCLUDE_TIES
 		}
 	case 2979:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13160
+//line postgres.y:13167
 		{
 			yyVAL.ival = 0
 		}
 	case 2980:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13161
+//line postgres.y:13168
 		{
 			yyVAL.ival = 0
 		}
 	case 2981:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13170
+//line postgres.y:13177
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 			yyLOCAL.limitOffset = yyDollar[2].nodeUnion()
@@ -41857,7 +41864,7 @@ yydefault:
 	case 2982:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13175
+//line postgres.y:13182
 		{
 			yyLOCAL = yyDollar[2].selectLimitUnion()
 			yyLOCAL.limitOffset = yyDollar[1].nodeUnion()
@@ -41866,7 +41873,7 @@ yydefault:
 	case 2983:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13180
+//line postgres.y:13187
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 		}
@@ -41874,7 +41881,7 @@ yydefault:
 	case 2984:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13184
+//line postgres.y:13191
 		{
 			n := &selectLimit{}
 			n.limitOffset = yyDollar[1].nodeUnion()
@@ -41886,7 +41893,7 @@ yydefault:
 	case 2985:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13194
+//line postgres.y:13201
 		{
 			yyLOCAL = yyDollar[1].selectLimitUnion()
 		}
@@ -41894,7 +41901,7 @@ yydefault:
 	case 2986:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13195
+//line postgres.y:13202
 		{
 			yyLOCAL = nil
 		}
@@ -41902,7 +41909,7 @@ yydefault:
 	case 2987:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13200
+//line postgres.y:13207
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41913,7 +41920,7 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 2988:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line postgres.y:13208
+//line postgres.y:13215
 		{
 			// Disabled because it was too confusing - PostgreSQL error
 			yylex.Error("LIMIT #,# syntax is not supported. Use separate LIMIT and OFFSET clauses.")
@@ -41922,7 +41929,7 @@ yydefault:
 	case 2989:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13215
+//line postgres.y:13222
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41934,7 +41941,7 @@ yydefault:
 	case 2990:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13223
+//line postgres.y:13230
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41946,7 +41953,7 @@ yydefault:
 	case 2991:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13231
+//line postgres.y:13238
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41958,7 +41965,7 @@ yydefault:
 	case 2992:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *selectLimit
-//line postgres.y:13239
+//line postgres.y:13246
 		{
 			n := &selectLimit{}
 			n.limitOffset = nil
@@ -41970,7 +41977,7 @@ yydefault:
 	case 2993:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13250
+//line postgres.y:13257
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41978,7 +41985,7 @@ yydefault:
 	case 2994:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13253
+//line postgres.y:13260
 		{
 			yyLOCAL = yyDollar[2].nodeUnion()
 		}
@@ -41986,7 +41993,7 @@ yydefault:
 	case 2995:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13257
+//line postgres.y:13264
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -41994,7 +42001,7 @@ yydefault:
 	case 2996:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13259
+//line postgres.y:13266
 		{
 			/* LIMIT ALL is represented as a NULL constant */
 			yyLOCAL = ast.NewA_Const(ast.NewNull(), -1)
@@ -42003,7 +42010,7 @@ yydefault:
 	case 2997:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13266
+//line postgres.y:13273
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -42011,7 +42018,7 @@ yydefault:
 	case 2998:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13279
+//line postgres.y:13286
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -42019,7 +42026,7 @@ yydefault:
 	case 2999:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13281
+//line postgres.y:13288
 		{
 			yyLOCAL = ast.NewA_Expr(ast.AEXPR_OP, &ast.NodeList{Items: []ast.Node{ast.NewString("+")}}, nil, yyDollar[2].nodeUnion(), -1)
 		}
@@ -42027,7 +42034,7 @@ yydefault:
 	case 3000:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13285
+//line postgres.y:13292
 		{
 			// Create a unary minus expression
 			yyLOCAL = ast.NewA_Expr(ast.AEXPR_OP, &ast.NodeList{Items: []ast.Node{ast.NewString("-")}}, nil, yyDollar[2].nodeUnion(), -1)
@@ -42036,7 +42043,7 @@ yydefault:
 	case 3001:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13292
+//line postgres.y:13299
 		{
 			yyLOCAL = ast.NewA_Const(ast.NewInteger(yyDollar[1].ival), -1)
 		}
@@ -42044,39 +42051,39 @@ yydefault:
 	case 3002:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13293
+//line postgres.y:13300
 		{
 			yyLOCAL = ast.NewA_Const(ast.NewFloat(yyDollar[1].str), -1)
 		}
 		yyVAL.union = yyLOCAL
 	case 3003:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13298
+//line postgres.y:13305
 		{
 			yyVAL.ival = 0
 		}
 	case 3004:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13299
+//line postgres.y:13306
 		{
 			yyVAL.ival = 0
 		}
 	case 3005:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13303
+//line postgres.y:13310
 		{
 			yyVAL.ival = 0
 		}
 	case 3006:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13304
+//line postgres.y:13311
 		{
 			yyVAL.ival = 0
 		}
 	case 3007:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13317
+//line postgres.y:13324
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42086,7 +42093,7 @@ yydefault:
 	case 3008:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13323
+//line postgres.y:13330
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_START)
 			stmt.Options = yyDollar[3].listUnion()
@@ -42096,7 +42103,7 @@ yydefault:
 	case 3009:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13329
+//line postgres.y:13336
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42106,7 +42113,7 @@ yydefault:
 	case 3010:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13335
+//line postgres.y:13342
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42116,7 +42123,7 @@ yydefault:
 	case 3011:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13341
+//line postgres.y:13348
 		{
 			stmt := ast.NewSavepointStmt(yyDollar[2].str)
 			yyLOCAL = stmt
@@ -42125,7 +42132,7 @@ yydefault:
 	case 3012:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13346
+//line postgres.y:13353
 		{
 			stmt := ast.NewReleaseStmt(yyDollar[3].str)
 			yyLOCAL = stmt
@@ -42134,7 +42141,7 @@ yydefault:
 	case 3013:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13351
+//line postgres.y:13358
 		{
 			stmt := ast.NewReleaseStmt(yyDollar[2].str)
 			yyLOCAL = stmt
@@ -42143,7 +42150,7 @@ yydefault:
 	case 3014:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13356
+//line postgres.y:13363
 		{
 			stmt := ast.NewRollbackToStmt(yyDollar[5].str)
 			yyLOCAL = stmt
@@ -42152,7 +42159,7 @@ yydefault:
 	case 3015:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13361
+//line postgres.y:13368
 		{
 			stmt := ast.NewRollbackToStmt(yyDollar[4].str)
 			yyLOCAL = stmt
@@ -42161,7 +42168,7 @@ yydefault:
 	case 3016:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13366
+//line postgres.y:13373
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_PREPARE)
 			stmt.Gid = yyDollar[3].str
@@ -42171,7 +42178,7 @@ yydefault:
 	case 3017:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13372
+//line postgres.y:13379
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT_PREPARED)
 			stmt.Gid = yyDollar[3].str
@@ -42181,7 +42188,7 @@ yydefault:
 	case 3018:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13378
+//line postgres.y:13385
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_ROLLBACK_PREPARED)
 			stmt.Gid = yyDollar[3].str
@@ -42191,7 +42198,7 @@ yydefault:
 	case 3019:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13387
+//line postgres.y:13394
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_COMMIT)
 			stmt.Chain = yyDollar[3].bvalUnion()
@@ -42201,7 +42208,7 @@ yydefault:
 	case 3020:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13393
+//line postgres.y:13400
 		{
 			stmt := ast.NewTransactionStmt(ast.TRANS_STMT_BEGIN)
 			stmt.Options = yyDollar[3].listUnion()
@@ -42210,23 +42217,23 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3021:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13400
+//line postgres.y:13407
 		{
 		}
 	case 3022:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13401
+//line postgres.y:13408
 		{
 		}
 	case 3023:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13402
+//line postgres.y:13409
 		{
 		}
 	case 3024:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13406
+//line postgres.y:13413
 		{
 			yyLOCAL = true
 		}
@@ -42234,7 +42241,7 @@ yydefault:
 	case 3025:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13407
+//line postgres.y:13414
 		{
 			yyLOCAL = false
 		}
@@ -42242,7 +42249,7 @@ yydefault:
 	case 3026:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:13408
+//line postgres.y:13415
 		{
 			yyLOCAL = false
 		}
@@ -42250,7 +42257,7 @@ yydefault:
 	case 3027:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13421
+//line postgres.y:13428
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_ROLE, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42258,7 +42265,7 @@ yydefault:
 	case 3028:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13428
+//line postgres.y:13435
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_USER, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42266,7 +42273,7 @@ yydefault:
 	case 3029:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13435
+//line postgres.y:13442
 		{
 			yyLOCAL = ast.NewCreateRoleStmt(ast.ROLESTMT_GROUP, yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -42274,7 +42281,7 @@ yydefault:
 	case 3030:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13442
+//line postgres.y:13449
 		{
 			as := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), yyDollar[5].listUnion())
 			as.Action = +1
@@ -42284,7 +42291,7 @@ yydefault:
 	case 3031:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13448
+//line postgres.y:13455
 		{
 			as := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), yyDollar[5].listUnion())
 			as.Action = +1
@@ -42294,7 +42301,7 @@ yydefault:
 	case 3032:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13457
+//line postgres.y:13464
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(yyDollar[3].rolespecUnion(), yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42302,7 +42309,7 @@ yydefault:
 	case 3033:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13461
+//line postgres.y:13468
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(nil, yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42310,7 +42317,7 @@ yydefault:
 	case 3034:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13465
+//line postgres.y:13472
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(yyDollar[3].rolespecUnion(), yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
@@ -42318,27 +42325,27 @@ yydefault:
 	case 3035:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13469
+//line postgres.y:13476
 		{
 			yyLOCAL = ast.NewAlterRoleSetStmt(nil, yyDollar[4].str, yyDollar[5].vsetstmtUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3036:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:13475
+//line postgres.y:13482
 		{
 			yyVAL.str = ""
 		}
 	case 3037:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13476
+//line postgres.y:13483
 		{
 			yyVAL.str = yyDollar[3].str
 		}
 	case 3038:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13481
+//line postgres.y:13488
 		{
 			options := ast.NewNodeList(ast.NewDefElem("rolemembers", yyDollar[6].listUnion()))
 			stmt := ast.NewAlterRoleStmt(yyDollar[3].rolespecUnion(), options)
@@ -42349,7 +42356,7 @@ yydefault:
 	case 3039:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13491
+//line postgres.y:13498
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42357,7 +42364,7 @@ yydefault:
 	case 3040:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13495
+//line postgres.y:13502
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42365,7 +42372,7 @@ yydefault:
 	case 3041:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13499
+//line postgres.y:13506
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42373,7 +42380,7 @@ yydefault:
 	case 3042:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13503
+//line postgres.y:13510
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42381,7 +42388,7 @@ yydefault:
 	case 3043:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13507
+//line postgres.y:13514
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[3].listUnion(), false)
 		}
@@ -42389,7 +42396,7 @@ yydefault:
 	case 3044:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13511
+//line postgres.y:13518
 		{
 			yyLOCAL = ast.NewDropRoleStmt(yyDollar[5].listUnion(), true)
 		}
@@ -42397,7 +42404,7 @@ yydefault:
 	case 3045:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13519
+//line postgres.y:13526
 		{
 			if yyDollar[1].listUnion() == nil {
 				list := ast.NewNodeList()
@@ -42413,7 +42420,7 @@ yydefault:
 	case 3046:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13530
+//line postgres.y:13537
 		{
 			yyLOCAL = nil
 		}
@@ -42421,7 +42428,7 @@ yydefault:
 	case 3047:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13535
+//line postgres.y:13542
 		{
 			if yyDollar[1].listUnion() == nil {
 				list := ast.NewNodeList()
@@ -42437,7 +42444,7 @@ yydefault:
 	case 3048:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13546
+//line postgres.y:13553
 		{
 			yyLOCAL = nil
 		}
@@ -42445,7 +42452,7 @@ yydefault:
 	case 3049:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13550
+//line postgres.y:13557
 		{
 			yyLOCAL = yyDollar[1].defeltUnion()
 		}
@@ -42453,7 +42460,7 @@ yydefault:
 	case 3050:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13552
+//line postgres.y:13559
 		{
 			yyLOCAL = ast.NewDefElem("sysid", ast.NewInteger(yyDollar[2].ival))
 		}
@@ -42461,7 +42468,7 @@ yydefault:
 	case 3051:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13556
+//line postgres.y:13563
 		{
 			yyLOCAL = ast.NewDefElem("adminmembers", yyDollar[2].listUnion())
 		}
@@ -42469,7 +42476,7 @@ yydefault:
 	case 3052:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13560
+//line postgres.y:13567
 		{
 			yyLOCAL = ast.NewDefElem("rolemembers", yyDollar[2].listUnion())
 		}
@@ -42477,7 +42484,7 @@ yydefault:
 	case 3053:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13564
+//line postgres.y:13571
 		{
 			yyLOCAL = ast.NewDefElem("addroleto", yyDollar[3].listUnion())
 		}
@@ -42485,7 +42492,7 @@ yydefault:
 	case 3054:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13568
+//line postgres.y:13575
 		{
 			yyLOCAL = ast.NewDefElem("addroleto", yyDollar[3].listUnion())
 		}
@@ -42493,7 +42500,7 @@ yydefault:
 	case 3055:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13575
+//line postgres.y:13582
 		{
 			yyLOCAL = ast.NewDefElem("password", ast.NewString(yyDollar[2].str))
 		}
@@ -42501,7 +42508,7 @@ yydefault:
 	case 3056:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13579
+//line postgres.y:13586
 		{
 			yyLOCAL = ast.NewDefElem("password", nil)
 		}
@@ -42509,14 +42516,14 @@ yydefault:
 	case 3057:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13583
+//line postgres.y:13590
 		{
 			yyLOCAL = ast.NewDefElem("password", ast.NewString(yyDollar[3].str))
 		}
 		yyVAL.union = yyLOCAL
 	case 3058:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:13587
+//line postgres.y:13594
 		{
 			yylex.Error("UNENCRYPTED PASSWORD is no longer supported")
 			return 1
@@ -42524,7 +42531,7 @@ yydefault:
 	case 3059:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13592
+//line postgres.y:13599
 		{
 			yyLOCAL = ast.NewDefElem("inherit", ast.NewBoolean(true))
 		}
@@ -42532,7 +42539,7 @@ yydefault:
 	case 3060:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13596
+//line postgres.y:13603
 		{
 			// Handle identifiers like PostgreSQL does with string comparisons
 			if yyDollar[1].str == "superuser" {
@@ -42571,7 +42578,7 @@ yydefault:
 	case 3061:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13631
+//line postgres.y:13638
 		{
 			yyLOCAL = ast.NewDefElem("connectionlimit", ast.NewInteger(yyDollar[3].ival))
 		}
@@ -42579,7 +42586,7 @@ yydefault:
 	case 3062:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13635
+//line postgres.y:13642
 		{
 			yyLOCAL = ast.NewDefElem("validUntil", ast.NewString(yyDollar[3].str))
 		}
@@ -42587,27 +42594,27 @@ yydefault:
 	case 3063:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13639
+//line postgres.y:13646
 		{
 			yyLOCAL = ast.NewDefElem("rolemembers", yyDollar[2].listUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3064:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13645
+//line postgres.y:13652
 		{
 			yyVAL.ival = 1
 		}
 	case 3065:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13646
+//line postgres.y:13653
 		{
 			yyVAL.ival = -1
 		}
 	case 3066:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13658
+//line postgres.y:13665
 		{
 			n := ast.NewGrantStmt(yyDollar[4].privtargetUnion().objtype, yyDollar[4].privtargetUnion().objs, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = yyDollar[4].privtargetUnion().targtype
@@ -42619,7 +42626,7 @@ yydefault:
 	case 3067:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13670
+//line postgres.y:13677
 		{
 			n := ast.NewRevokeStmt(yyDollar[4].privtargetUnion().objtype, yyDollar[4].privtargetUnion().objs, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = yyDollar[4].privtargetUnion().targtype
@@ -42631,7 +42638,7 @@ yydefault:
 	case 3068:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13679
+//line postgres.y:13686
 		{
 			n := ast.NewRevokeStmt(yyDollar[7].privtargetUnion().objtype, yyDollar[7].privtargetUnion().objs, yyDollar[5].listUnion(), yyDollar[9].listUnion())
 			n.Targtype = yyDollar[7].privtargetUnion().targtype
@@ -42644,7 +42651,7 @@ yydefault:
 	case 3069:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13691
+//line postgres.y:13698
 		{
 			stmt := ast.NewGrantRoleStmt(yyDollar[2].listUnion(), yyDollar[4].listUnion())
 			stmt.Grantor = yyDollar[5].rolespecUnion()
@@ -42654,7 +42661,7 @@ yydefault:
 	case 3070:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13697
+//line postgres.y:13704
 		{
 			stmt := ast.NewGrantRoleStmtWithOptions(yyDollar[2].listUnion(), yyDollar[4].listUnion(), yyDollar[6].listUnion())
 			stmt.Grantor = yyDollar[7].rolespecUnion()
@@ -42664,7 +42671,7 @@ yydefault:
 	case 3071:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13706
+//line postgres.y:13713
 		{
 			stmt := ast.NewRevokeRoleStmt(yyDollar[2].listUnion(), yyDollar[4].listUnion())
 			stmt.Grantor = yyDollar[5].rolespecUnion()
@@ -42675,7 +42682,7 @@ yydefault:
 	case 3072:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13713
+//line postgres.y:13720
 		{
 			opt := ast.NewDefElem(yyDollar[2].str, ast.NewBoolean(false))
 			stmt := ast.NewRevokeRoleStmt(yyDollar[5].listUnion(), yyDollar[7].listUnion())
@@ -42688,7 +42695,7 @@ yydefault:
 	case 3073:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:13732
+//line postgres.y:13739
 		{
 			yyLOCAL = ast.NewAlterDefaultPrivilegesStmt(yyDollar[4].listUnion(), yyDollar[5].nodeUnion().(*ast.GrantStmt))
 		}
@@ -42696,7 +42703,7 @@ yydefault:
 	case 3074:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13738
+//line postgres.y:13745
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -42705,7 +42712,7 @@ yydefault:
 	case 3075:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13739
+//line postgres.y:13746
 		{
 			yyLOCAL = ast.NewNodeList()
 		}
@@ -42713,7 +42720,7 @@ yydefault:
 	case 3076:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13744
+//line postgres.y:13751
 		{
 			yyLOCAL = ast.NewDefElem("schemas", yyDollar[3].listUnion())
 		}
@@ -42721,7 +42728,7 @@ yydefault:
 	case 3077:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13748
+//line postgres.y:13755
 		{
 			yyLOCAL = ast.NewDefElem("roles", yyDollar[3].listUnion())
 		}
@@ -42729,7 +42736,7 @@ yydefault:
 	case 3078:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:13752
+//line postgres.y:13759
 		{
 			yyLOCAL = ast.NewDefElem("roles", yyDollar[3].listUnion())
 		}
@@ -42737,7 +42744,7 @@ yydefault:
 	case 3079:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13764
+//line postgres.y:13771
 		{
 			n := ast.NewGrantStmt(ast.ObjectType(yyDollar[4].ival), nil, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42748,7 +42755,7 @@ yydefault:
 	case 3080:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13772
+//line postgres.y:13779
 		{
 			n := ast.NewRevokeStmt(ast.ObjectType(yyDollar[4].ival), nil, yyDollar[2].listUnion(), yyDollar[6].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42759,7 +42766,7 @@ yydefault:
 	case 3081:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:13780
+//line postgres.y:13787
 		{
 			n := ast.NewRevokeStmt(ast.ObjectType(yyDollar[7].ival), nil, yyDollar[5].listUnion(), yyDollar[9].listUnion())
 			n.Targtype = ast.ACL_TARGET_DEFAULTS
@@ -42770,44 +42777,44 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3082:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13790
+//line postgres.y:13797
 		{
 			yyVAL.ival = int(ast.OBJECT_TABLE)
 		}
 	case 3083:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13791
+//line postgres.y:13798
 		{
 			yyVAL.ival = int(ast.OBJECT_FUNCTION)
 		}
 	case 3084:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13792
+//line postgres.y:13799
 		{
 			yyVAL.ival = int(ast.OBJECT_FUNCTION)
 		}
 	case 3085:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13793
+//line postgres.y:13800
 		{
 			yyVAL.ival = int(ast.OBJECT_SEQUENCE)
 		}
 	case 3086:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13794
+//line postgres.y:13801
 		{
 			yyVAL.ival = int(ast.OBJECT_TYPE)
 		}
 	case 3087:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:13795
+//line postgres.y:13802
 		{
 			yyVAL.ival = int(ast.OBJECT_SCHEMA)
 		}
 	case 3088:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13800
+//line postgres.y:13807
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -42815,7 +42822,7 @@ yydefault:
 	case 3089:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13802
+//line postgres.y:13809
 		{
 			yyLOCAL = nil
 		}
@@ -42823,7 +42830,7 @@ yydefault:
 	case 3090:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13804
+//line postgres.y:13811
 		{
 			yyLOCAL = nil
 		}
@@ -42831,7 +42838,7 @@ yydefault:
 	case 3091:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13806
+//line postgres.y:13813
 		{
 			ap := ast.NewAccessPriv("", yyDollar[3].listUnion())
 			yyLOCAL = ast.NewNodeList(ap)
@@ -42840,7 +42847,7 @@ yydefault:
 	case 3092:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13811
+//line postgres.y:13818
 		{
 			ap := ast.NewAccessPriv("", yyDollar[4].listUnion())
 			yyLOCAL = ast.NewNodeList(ap)
@@ -42849,7 +42856,7 @@ yydefault:
 	case 3093:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13817
+//line postgres.y:13824
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].accessprivUnion())
 		}
@@ -42857,7 +42864,7 @@ yydefault:
 	case 3094:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:13818
+//line postgres.y:13825
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].accessprivUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -42866,7 +42873,7 @@ yydefault:
 	case 3095:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13822
+//line postgres.y:13829
 		{
 			yyLOCAL = ast.NewAccessPriv("SELECT", yyDollar[2].listUnion())
 		}
@@ -42874,7 +42881,7 @@ yydefault:
 	case 3096:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13826
+//line postgres.y:13833
 		{
 			yyLOCAL = ast.NewAccessPriv("REFERENCES", yyDollar[2].listUnion())
 		}
@@ -42882,7 +42889,7 @@ yydefault:
 	case 3097:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13830
+//line postgres.y:13837
 		{
 			yyLOCAL = ast.NewAccessPriv("CREATE", yyDollar[2].listUnion())
 		}
@@ -42890,7 +42897,7 @@ yydefault:
 	case 3098:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13834
+//line postgres.y:13841
 		{
 			yyLOCAL = ast.NewAccessPriv("ALTER SYSTEM", nil)
 		}
@@ -42898,7 +42905,7 @@ yydefault:
 	case 3099:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.AccessPriv
-//line postgres.y:13838
+//line postgres.y:13845
 		{
 			yyLOCAL = ast.NewAccessPriv(yyDollar[1].str, yyDollar[2].listUnion())
 		}
@@ -42906,7 +42913,7 @@ yydefault:
 	case 3100:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13848
+//line postgres.y:13855
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42918,7 +42925,7 @@ yydefault:
 	case 3101:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13856
+//line postgres.y:13863
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42930,7 +42937,7 @@ yydefault:
 	case 3102:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13864
+//line postgres.y:13871
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42942,7 +42949,7 @@ yydefault:
 	case 3103:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13872
+//line postgres.y:13879
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42954,7 +42961,7 @@ yydefault:
 	case 3104:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13880
+//line postgres.y:13887
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42966,7 +42973,7 @@ yydefault:
 	case 3105:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13888
+//line postgres.y:13895
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42978,7 +42985,7 @@ yydefault:
 	case 3106:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13896
+//line postgres.y:13903
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -42990,7 +42997,7 @@ yydefault:
 	case 3107:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13904
+//line postgres.y:13911
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43002,7 +43009,7 @@ yydefault:
 	case 3108:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13912
+//line postgres.y:13919
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43014,7 +43021,7 @@ yydefault:
 	case 3109:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13920
+//line postgres.y:13927
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43026,7 +43033,7 @@ yydefault:
 	case 3110:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13928
+//line postgres.y:13935
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43038,7 +43045,7 @@ yydefault:
 	case 3111:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13936
+//line postgres.y:13943
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43050,7 +43057,7 @@ yydefault:
 	case 3112:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13944
+//line postgres.y:13951
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43062,7 +43069,7 @@ yydefault:
 	case 3113:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13952
+//line postgres.y:13959
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43074,7 +43081,7 @@ yydefault:
 	case 3114:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13960
+//line postgres.y:13967
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43086,7 +43093,7 @@ yydefault:
 	case 3115:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13968
+//line postgres.y:13975
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_OBJECT,
@@ -43098,7 +43105,7 @@ yydefault:
 	case 3116:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13976
+//line postgres.y:13983
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43110,7 +43117,7 @@ yydefault:
 	case 3117:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13984
+//line postgres.y:13991
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43122,7 +43129,7 @@ yydefault:
 	case 3118:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:13992
+//line postgres.y:13999
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43134,7 +43141,7 @@ yydefault:
 	case 3119:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:14000
+//line postgres.y:14007
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43146,7 +43153,7 @@ yydefault:
 	case 3120:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *PrivTarget
-//line postgres.y:14008
+//line postgres.y:14015
 		{
 			yyLOCAL = &PrivTarget{
 				targtype: ast.ACL_TARGET_ALL_IN_SCHEMA,
@@ -43158,7 +43165,7 @@ yydefault:
 	case 3121:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14019
+//line postgres.y:14026
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].rolespecUnion())
 		}
@@ -43166,7 +43173,7 @@ yydefault:
 	case 3122:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14020
+//line postgres.y:14027
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].rolespecUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43175,7 +43182,7 @@ yydefault:
 	case 3123:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14024
+//line postgres.y:14031
 		{
 			yyLOCAL = yyDollar[1].rolespecUnion()
 		}
@@ -43183,7 +43190,7 @@ yydefault:
 	case 3124:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14025
+//line postgres.y:14032
 		{
 			yyLOCAL = yyDollar[2].rolespecUnion()
 		}
@@ -43191,7 +43198,7 @@ yydefault:
 	case 3125:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:14030
+//line postgres.y:14037
 		{
 			yyLOCAL = true
 		}
@@ -43199,7 +43206,7 @@ yydefault:
 	case 3126:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:14031
+//line postgres.y:14038
 		{
 			yyLOCAL = false
 		}
@@ -43207,7 +43214,7 @@ yydefault:
 	case 3127:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14035
+//line postgres.y:14042
 		{
 			yyDollar[1].listUnion().Items = append(yyDollar[1].listUnion().Items, yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43216,7 +43223,7 @@ yydefault:
 	case 3128:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14036
+//line postgres.y:14043
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43224,7 +43231,7 @@ yydefault:
 	case 3129:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14041
+//line postgres.y:14048
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[2].nodeUnion())
 		}
@@ -43232,7 +43239,7 @@ yydefault:
 	case 3130:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14047
+//line postgres.y:14054
 		{
 			yyLOCAL = ast.NewBoolean(true)
 		}
@@ -43240,7 +43247,7 @@ yydefault:
 	case 3131:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14048
+//line postgres.y:14055
 		{
 			yyLOCAL = ast.NewBoolean(true)
 		}
@@ -43248,7 +43255,7 @@ yydefault:
 	case 3132:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14049
+//line postgres.y:14056
 		{
 			yyLOCAL = ast.NewBoolean(false)
 		}
@@ -43256,7 +43263,7 @@ yydefault:
 	case 3133:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14052
+//line postgres.y:14059
 		{
 			yyLOCAL = yyDollar[3].rolespecUnion()
 		}
@@ -43264,7 +43271,7 @@ yydefault:
 	case 3134:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.RoleSpec
-//line postgres.y:14053
+//line postgres.y:14060
 		{
 			yyLOCAL = nil
 		}
@@ -43272,7 +43279,7 @@ yydefault:
 	case 3135:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14058
+//line postgres.y:14065
 		{
 			yyLOCAL = ast.NewNodeList(ast.NewString(yyDollar[1].str))
 		}
@@ -43280,7 +43287,7 @@ yydefault:
 	case 3136:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14062
+//line postgres.y:14069
 		{
 			yyDollar[1].listUnion().Append(ast.NewString(yyDollar[3].str))
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43288,20 +43295,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3137:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14070
+//line postgres.y:14077
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3138:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14074
+//line postgres.y:14081
 		{
 			yyVAL.str = yyDollar[1].str + "." + yyDollar[3].str
 		}
 	case 3139:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14079
+//line postgres.y:14086
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -43309,7 +43316,7 @@ yydefault:
 	case 3140:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14080
+//line postgres.y:14087
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43318,7 +43325,7 @@ yydefault:
 	case 3141:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14084
+//line postgres.y:14091
 		{
 			n := ast.NewRangeTableSample(nil, yyDollar[2].listUnion(), yyDollar[4].listUnion(), yyDollar[6].nodeUnion(), 0)
 			yyLOCAL = n
@@ -43327,7 +43334,7 @@ yydefault:
 	case 3142:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14092
+//line postgres.y:14099
 		{
 			yyLOCAL = yyDollar[3].nodeUnion()
 		}
@@ -43335,7 +43342,7 @@ yydefault:
 	case 3143:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14096
+//line postgres.y:14103
 		{
 			yyLOCAL = nil
 		}
@@ -43343,7 +43350,7 @@ yydefault:
 	case 3144:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14110
+//line postgres.y:14117
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_FUNCTION, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43352,7 +43359,7 @@ yydefault:
 	case 3145:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14115
+//line postgres.y:14122
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_PROCEDURE, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43361,7 +43368,7 @@ yydefault:
 	case 3146:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14120
+//line postgres.y:14127
 		{
 			n := ast.NewAlterFunctionStmt(ast.OBJECT_ROUTINE, yyDollar[3].objwithargsUnion(), yyDollar[4].listUnion())
 			yyLOCAL = n
@@ -43370,7 +43377,7 @@ yydefault:
 	case 3147:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14128
+//line postgres.y:14135
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43378,7 +43385,7 @@ yydefault:
 	case 3148:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14129
+//line postgres.y:14136
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43387,7 +43394,7 @@ yydefault:
 	case 3149:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14135
+//line postgres.y:14142
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(false))
 		}
@@ -43395,7 +43402,7 @@ yydefault:
 	case 3150:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14139
+//line postgres.y:14146
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(true))
 		}
@@ -43403,7 +43410,7 @@ yydefault:
 	case 3151:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14143
+//line postgres.y:14150
 		{
 			yyLOCAL = ast.NewDefElem("strict", ast.NewBoolean(true))
 		}
@@ -43411,7 +43418,7 @@ yydefault:
 	case 3152:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14147
+//line postgres.y:14154
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("immutable"))
 		}
@@ -43419,7 +43426,7 @@ yydefault:
 	case 3153:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14151
+//line postgres.y:14158
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("stable"))
 		}
@@ -43427,7 +43434,7 @@ yydefault:
 	case 3154:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14155
+//line postgres.y:14162
 		{
 			yyLOCAL = ast.NewDefElem("volatility", ast.NewString("volatile"))
 		}
@@ -43435,7 +43442,7 @@ yydefault:
 	case 3155:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14159
+//line postgres.y:14166
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(true))
 		}
@@ -43443,7 +43450,7 @@ yydefault:
 	case 3156:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14163
+//line postgres.y:14170
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(false))
 		}
@@ -43451,7 +43458,7 @@ yydefault:
 	case 3157:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14167
+//line postgres.y:14174
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(true))
 		}
@@ -43459,7 +43466,7 @@ yydefault:
 	case 3158:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14171
+//line postgres.y:14178
 		{
 			yyLOCAL = ast.NewDefElem("security", ast.NewBoolean(false))
 		}
@@ -43467,7 +43474,7 @@ yydefault:
 	case 3159:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14175
+//line postgres.y:14182
 		{
 			yyLOCAL = ast.NewDefElem("leakproof", ast.NewBoolean(true))
 		}
@@ -43475,7 +43482,7 @@ yydefault:
 	case 3160:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14179
+//line postgres.y:14186
 		{
 			yyLOCAL = ast.NewDefElem("leakproof", ast.NewBoolean(false))
 		}
@@ -43483,7 +43490,7 @@ yydefault:
 	case 3161:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14183
+//line postgres.y:14190
 		{
 			yyLOCAL = ast.NewDefElem("cost", yyDollar[2].nodeUnion())
 		}
@@ -43491,7 +43498,7 @@ yydefault:
 	case 3162:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14187
+//line postgres.y:14194
 		{
 			yyLOCAL = ast.NewDefElem("rows", yyDollar[2].nodeUnion())
 		}
@@ -43499,7 +43506,7 @@ yydefault:
 	case 3163:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14191
+//line postgres.y:14198
 		{
 			yyLOCAL = ast.NewDefElem("support", yyDollar[2].listUnion())
 		}
@@ -43507,7 +43514,7 @@ yydefault:
 	case 3164:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14195
+//line postgres.y:14202
 		{
 			/* we abuse the normal content of a DefElem here */
 			yyLOCAL = ast.NewDefElem("set", yyDollar[1].vsetstmtUnion())
@@ -43516,7 +43523,7 @@ yydefault:
 	case 3165:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14200
+//line postgres.y:14207
 		{
 			yyLOCAL = ast.NewDefElem("parallel", ast.NewString(yyDollar[2].str))
 		}
@@ -43524,7 +43531,7 @@ yydefault:
 	case 3166:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14206
+//line postgres.y:14213
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -43532,7 +43539,7 @@ yydefault:
 	case 3167:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14207
+//line postgres.y:14214
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43541,7 +43548,7 @@ yydefault:
 	case 3168:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14212
+//line postgres.y:14219
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -43549,7 +43556,7 @@ yydefault:
 	case 3169:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14216
+//line postgres.y:14223
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, yyDollar[3].nodeUnion())
 		}
@@ -43557,7 +43564,7 @@ yydefault:
 	case 3170:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14220
+//line postgres.y:14227
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
@@ -43565,7 +43572,7 @@ yydefault:
 	case 3171:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14226
+//line postgres.y:14233
 		{
 			yyLOCAL = yyDollar[1].typnamUnion()
 		}
@@ -43573,7 +43580,7 @@ yydefault:
 	case 3172:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14227
+//line postgres.y:14234
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -43581,7 +43588,7 @@ yydefault:
 	case 3173:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14228
+//line postgres.y:14235
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -43589,7 +43596,7 @@ yydefault:
 	case 3174:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14229
+//line postgres.y:14236
 		{
 			yyLOCAL = yyDollar[1].nodeUnion()
 		}
@@ -43597,7 +43604,7 @@ yydefault:
 	case 3175:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14230
+//line postgres.y:14237
 		{
 			yyLOCAL = ast.NewString(yyDollar[1].str)
 		}
@@ -43605,7 +43612,7 @@ yydefault:
 	case 3178:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14241
+//line postgres.y:14248
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = yyDollar[1].listUnion()
@@ -43617,7 +43624,7 @@ yydefault:
 	case 3179:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14254
+//line postgres.y:14261
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43628,7 +43635,7 @@ yydefault:
 	case 3180:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14261
+//line postgres.y:14268
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			n.Objname = ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43639,7 +43646,7 @@ yydefault:
 	case 3181:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.ObjectWithArgs
-//line postgres.y:14268
+//line postgres.y:14275
 		{
 			n := ast.NewEmptyObjectWithArgs()
 			nameList := ast.NewNodeList(ast.NewString(yyDollar[1].str))
@@ -43655,7 +43662,7 @@ yydefault:
 	case 3182:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14282
+//line postgres.y:14289
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -43663,7 +43670,7 @@ yydefault:
 	case 3183:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14284
+//line postgres.y:14291
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43672,7 +43679,7 @@ yydefault:
 	case 3184:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14288
+//line postgres.y:14295
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].objwithargsUnion())
 		}
@@ -43680,7 +43687,7 @@ yydefault:
 	case 3185:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14290
+//line postgres.y:14297
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].objwithargsUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43689,7 +43696,7 @@ yydefault:
 	case 3186:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14302
+//line postgres.y:14309
 		{
 			n := ast.NewAlterTypeStmt(yyDollar[3].listUnion(), yyDollar[6].listUnion())
 			yyLOCAL = n
@@ -43698,7 +43705,7 @@ yydefault:
 	case 3187:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14310
+//line postgres.y:14317
 		{
 			relation, err := makeRangeVarFromAnyName(yyDollar[3].listUnion(), 0)
 			if err != nil {
@@ -43713,7 +43720,7 @@ yydefault:
 	case 3188:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14323
+//line postgres.y:14330
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].nodeUnion())
 		}
@@ -43721,7 +43728,7 @@ yydefault:
 	case 3189:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14324
+//line postgres.y:14331
 		{
 			yyDollar[1].listUnion().Append(yyDollar[3].nodeUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -43730,7 +43737,7 @@ yydefault:
 	case 3190:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14330
+//line postgres.y:14337
 		{
 			n := ast.NewAlterTableCmd(ast.AT_AddColumn, "", yyDollar[3].nodeUnion())
 			n.Behavior = yyDollar[4].dropBehavUnion()
@@ -43740,7 +43747,7 @@ yydefault:
 	case 3191:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14337
+//line postgres.y:14344
 		{
 			n := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[5].str, nil)
 			n.Behavior = yyDollar[6].dropBehavUnion()
@@ -43751,7 +43758,7 @@ yydefault:
 	case 3192:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14345
+//line postgres.y:14352
 		{
 			n := ast.NewAlterTableCmd(ast.AT_DropColumn, yyDollar[3].str, nil)
 			n.Behavior = yyDollar[4].dropBehavUnion()
@@ -43762,7 +43769,7 @@ yydefault:
 	case 3193:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Node
-//line postgres.y:14353
+//line postgres.y:14360
 		{
 			def := ast.NewColumnDef(yyDollar[3].str, yyDollar[6].typnamUnion(), -1)
 			n := ast.NewAlterTableCmd(ast.AT_AlterColumnType, yyDollar[3].str, def)
@@ -43778,94 +43785,94 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3194:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14374
+//line postgres.y:14381
 		{
 			yyVAL.ival = int(ast.CMD_SELECT)
 		}
 	case 3195:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14375
+//line postgres.y:14382
 		{
 			yyVAL.ival = int(ast.CMD_UPDATE)
 		}
 	case 3196:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14376
+//line postgres.y:14383
 		{
 			yyVAL.ival = int(ast.CMD_DELETE)
 		}
 	case 3197:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14377
+//line postgres.y:14384
 		{
 			yyVAL.ival = int(ast.CMD_INSERT)
 		}
 	case 3198:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14387
+//line postgres.y:14394
 		{
 			yyLOCAL = ast.NewDeclareCursorStmt(yyDollar[2].str, yyDollar[3].ival|yyDollar[5].ival|ast.CURSOR_OPT_FAST_PLAN, yyDollar[7].stmtUnion())
 		}
 		yyVAL.union = yyLOCAL
 	case 3199:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14394
+//line postgres.y:14401
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_BINARY
 		}
 	case 3200:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14398
+//line postgres.y:14405
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_INSENSITIVE
 		}
 	case 3201:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14402
+//line postgres.y:14409
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_ASENSITIVE
 		}
 	case 3202:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14406
+//line postgres.y:14413
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_SCROLL
 		}
 	case 3203:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14410
+//line postgres.y:14417
 		{
 			yyVAL.ival = yyDollar[1].ival | ast.CURSOR_OPT_NO_SCROLL
 		}
 	case 3204:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14413
+//line postgres.y:14420
 		{
 			yyVAL.ival = 0
 		}
 	case 3205:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14416
+//line postgres.y:14423
 		{
 			yyVAL.ival = ast.CURSOR_OPT_HOLD
 		}
 	case 3206:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14417
+//line postgres.y:14424
 		{
 			yyVAL.ival = 0
 		}
 	case 3207:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14418
+//line postgres.y:14425
 		{
 			yyVAL.ival = 0
 		}
 	case 3208:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14422
+//line postgres.y:14429
 		{
 			stmt := yyDollar[2].stmtUnion().(*ast.FetchStmt)
 			stmt.IsMove = false
@@ -43875,7 +43882,7 @@ yydefault:
 	case 3209:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14428
+//line postgres.y:14435
 		{
 			stmt := yyDollar[2].stmtUnion().(*ast.FetchStmt)
 			stmt.IsMove = true
@@ -43885,7 +43892,7 @@ yydefault:
 	case 3210:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14436
+//line postgres.y:14443
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[1].str, false)
 		}
@@ -43893,7 +43900,7 @@ yydefault:
 	case 3211:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14440
+//line postgres.y:14447
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[2].str, false)
 		}
@@ -43901,7 +43908,7 @@ yydefault:
 	case 3212:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14444
+//line postgres.y:14451
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[3].str, false)
 		}
@@ -43909,7 +43916,7 @@ yydefault:
 	case 3213:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14448
+//line postgres.y:14455
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, 1, yyDollar[3].str, false)
 		}
@@ -43917,7 +43924,7 @@ yydefault:
 	case 3214:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14452
+//line postgres.y:14459
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, 1, yyDollar[3].str, false)
 		}
@@ -43925,7 +43932,7 @@ yydefault:
 	case 3215:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14456
+//line postgres.y:14463
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, -1, yyDollar[3].str, false)
 		}
@@ -43933,7 +43940,7 @@ yydefault:
 	case 3216:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14460
+//line postgres.y:14467
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_ABSOLUTE, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43941,7 +43948,7 @@ yydefault:
 	case 3217:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14464
+//line postgres.y:14471
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_RELATIVE, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43949,7 +43956,7 @@ yydefault:
 	case 3218:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14468
+//line postgres.y:14475
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, int64(yyDollar[1].ival), yyDollar[3].str, false)
 		}
@@ -43957,7 +43964,7 @@ yydefault:
 	case 3219:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14472
+//line postgres.y:14479
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, ast.FETCH_ALL, yyDollar[3].str, false)
 		}
@@ -43965,7 +43972,7 @@ yydefault:
 	case 3220:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14476
+//line postgres.y:14483
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, 1, yyDollar[3].str, false)
 		}
@@ -43973,7 +43980,7 @@ yydefault:
 	case 3221:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14480
+//line postgres.y:14487
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -43981,7 +43988,7 @@ yydefault:
 	case 3222:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14484
+//line postgres.y:14491
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_FORWARD, ast.FETCH_ALL, yyDollar[4].str, false)
 		}
@@ -43989,7 +43996,7 @@ yydefault:
 	case 3223:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14488
+//line postgres.y:14495
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, 1, yyDollar[3].str, false)
 		}
@@ -43997,7 +44004,7 @@ yydefault:
 	case 3224:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14492
+//line postgres.y:14499
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, int64(yyDollar[2].ival), yyDollar[4].str, false)
 		}
@@ -44005,39 +44012,39 @@ yydefault:
 	case 3225:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14496
+//line postgres.y:14503
 		{
 			yyLOCAL = ast.NewFetchStmt(ast.FETCH_BACKWARD, ast.FETCH_ALL, yyDollar[4].str, false)
 		}
 		yyVAL.union = yyLOCAL
 	case 3226:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14501
+//line postgres.y:14508
 		{
 			yyVAL.ival = 0
 		}
 	case 3227:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14502
+//line postgres.y:14509
 		{
 			yyVAL.ival = 0
 		}
 	case 3228:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14506
+//line postgres.y:14513
 		{
 			yyVAL.ival = 0
 		}
 	case 3229:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14507
+//line postgres.y:14514
 		{
 			yyVAL.ival = 0
 		}
 	case 3230:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14512
+//line postgres.y:14519
 		{
 			name := yyDollar[2].str
 			yyLOCAL = ast.NewClosePortalStmt(name)
@@ -44046,7 +44053,7 @@ yydefault:
 	case 3231:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14517
+//line postgres.y:14524
 		{
 			yyLOCAL = ast.NewClosePortalStmt("")
 		}
@@ -44054,7 +44061,7 @@ yydefault:
 	case 3232:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14529
+//line postgres.y:14536
 		{
 			yyLOCAL = ast.NewPrepareStmt(yyDollar[2].str, yyDollar[3].listUnion(), yyDollar[5].stmtUnion())
 		}
@@ -44062,7 +44069,7 @@ yydefault:
 	case 3233:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14536
+//line postgres.y:14543
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -44070,7 +44077,7 @@ yydefault:
 	case 3234:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14539
+//line postgres.y:14546
 		{
 			yyLOCAL = nil
 		}
@@ -44078,7 +44085,7 @@ yydefault:
 	case 3235:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14543
+//line postgres.y:14550
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44086,7 +44093,7 @@ yydefault:
 	case 3236:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14544
+//line postgres.y:14551
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44094,7 +44101,7 @@ yydefault:
 	case 3237:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14545
+//line postgres.y:14552
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44102,7 +44109,7 @@ yydefault:
 	case 3238:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14546
+//line postgres.y:14553
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44110,7 +44117,7 @@ yydefault:
 	case 3239:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14547
+//line postgres.y:14554
 		{
 			yyLOCAL = yyDollar[1].stmtUnion()
 		}
@@ -44118,7 +44125,7 @@ yydefault:
 	case 3240:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14551
+//line postgres.y:14558
 		{
 			yyLOCAL = ast.NewExecuteStmt(yyDollar[2].str, yyDollar[3].listUnion())
 		}
@@ -44126,7 +44133,7 @@ yydefault:
 	case 3241:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14555
+//line postgres.y:14562
 		{
 			executeStmt := ast.NewExecuteStmt(yyDollar[7].str, yyDollar[8].listUnion())
 			ctas := ast.NewCreateTableAsStmt(executeStmt, yyDollar[4].intoUnion(), ast.OBJECT_TABLE, false, false)
@@ -44140,7 +44147,7 @@ yydefault:
 	case 3242:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14565
+//line postgres.y:14572
 		{
 			executeStmt := ast.NewExecuteStmt(yyDollar[10].str, yyDollar[11].listUnion())
 			ctas := ast.NewCreateTableAsStmt(executeStmt, yyDollar[7].intoUnion(), ast.OBJECT_TABLE, false, true)
@@ -44154,7 +44161,7 @@ yydefault:
 	case 3243:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14578
+//line postgres.y:14585
 		{
 			yyLOCAL = yyDollar[2].listUnion()
 		}
@@ -44162,7 +44169,7 @@ yydefault:
 	case 3244:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14581
+//line postgres.y:14588
 		{
 			yyLOCAL = nil
 		}
@@ -44170,7 +44177,7 @@ yydefault:
 	case 3245:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL *ast.IntoClause
-//line postgres.y:14587
+//line postgres.y:14594
 		{
 			into := ast.NewIntoClause(yyDollar[1].rangevarUnion(), yyDollar[2].listUnion(), yyDollar[3].str, yyDollar[4].listUnion(), yyDollar[5].oncommitUnion(), yyDollar[6].str, nil, false, 0)
 			yyLOCAL = into
@@ -44179,7 +44186,7 @@ yydefault:
 	case 3246:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14595
+//line postgres.y:14602
 		{
 			yyLOCAL = ast.NewDeallocateStmt(yyDollar[2].str)
 		}
@@ -44187,7 +44194,7 @@ yydefault:
 	case 3247:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14599
+//line postgres.y:14606
 		{
 			yyLOCAL = ast.NewDeallocateStmt(yyDollar[3].str)
 		}
@@ -44195,7 +44202,7 @@ yydefault:
 	case 3248:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14603
+//line postgres.y:14610
 		{
 			yyLOCAL = ast.NewDeallocateAllStmt()
 		}
@@ -44203,7 +44210,7 @@ yydefault:
 	case 3249:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14607
+//line postgres.y:14614
 		{
 			yyLOCAL = ast.NewDeallocateAllStmt()
 		}
@@ -44211,7 +44218,7 @@ yydefault:
 	case 3250:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14618
+//line postgres.y:14625
 		{
 			yyLOCAL = ast.NewListenStmt(yyDollar[2].str)
 		}
@@ -44219,7 +44226,7 @@ yydefault:
 	case 3251:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14629
+//line postgres.y:14636
 		{
 			yyLOCAL = ast.NewUnlistenStmt(yyDollar[2].str)
 		}
@@ -44227,7 +44234,7 @@ yydefault:
 	case 3252:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14633
+//line postgres.y:14640
 		{
 			yyLOCAL = ast.NewUnlistenAllStmt()
 		}
@@ -44235,27 +44242,27 @@ yydefault:
 	case 3253:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14644
+//line postgres.y:14651
 		{
 			yyLOCAL = ast.NewNotifyStmt(yyDollar[2].str, yyDollar[3].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 3254:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14654
+//line postgres.y:14661
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 3255:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14655
+//line postgres.y:14662
 		{
 			yyVAL.str = ""
 		}
 	case 3256:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14664
+//line postgres.y:14671
 		{
 			yyLOCAL = ast.NewLoadStmt(yyDollar[2].str)
 		}
@@ -44263,7 +44270,7 @@ yydefault:
 	case 3257:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14675
+//line postgres.y:14682
 		{
 			stmt := ast.NewLockStmt(yyDollar[3].listUnion(), ast.LockMode(yyDollar[4].ival))
 			stmt.Nowait = yyDollar[5].bvalUnion()
@@ -44272,68 +44279,68 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3258:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14687
+//line postgres.y:14694
 		{
 			yyVAL.ival = yyDollar[2].ival
 		}
 	case 3259:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14688
+//line postgres.y:14695
 		{
 			yyVAL.ival = int(ast.AccessExclusiveLock)
 		}
 	case 3260:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14692
+//line postgres.y:14699
 		{
 			yyVAL.ival = int(ast.AccessShareLock)
 		}
 	case 3261:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14693
+//line postgres.y:14700
 		{
 			yyVAL.ival = int(ast.RowShareLock)
 		}
 	case 3262:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14694
+//line postgres.y:14701
 		{
 			yyVAL.ival = int(ast.RowExclusiveLock)
 		}
 	case 3263:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14695
+//line postgres.y:14702
 		{
 			yyVAL.ival = int(ast.ShareUpdateExclusiveLock)
 		}
 	case 3264:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14696
+//line postgres.y:14703
 		{
 			yyVAL.ival = int(ast.ShareLock)
 		}
 	case 3265:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line postgres.y:14697
+//line postgres.y:14704
 		{
 			yyVAL.ival = int(ast.ShareRowExclusiveLock)
 		}
 	case 3266:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14698
+//line postgres.y:14705
 		{
 			yyVAL.ival = int(ast.ExclusiveLock)
 		}
 	case 3267:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14699
+//line postgres.y:14706
 		{
 			yyVAL.ival = int(ast.AccessExclusiveLock)
 		}
 	case 3268:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14708
+//line postgres.y:14715
 		{
 			stmt := ast.NewTruncateStmt(yyDollar[3].listUnion())
 			stmt.RestartSeqs = yyDollar[4].bvalUnion()
@@ -44344,7 +44351,7 @@ yydefault:
 	case 3269:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14722
+//line postgres.y:14729
 		{
 			yyLOCAL = ast.NewCommentStmt(yyDollar[3].objTypeUnion(), yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -44352,7 +44359,7 @@ yydefault:
 	case 3270:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14726
+//line postgres.y:14733
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_COLUMN, yyDollar[4].listUnion(), yyDollar[6].str)
 		}
@@ -44360,7 +44367,7 @@ yydefault:
 	case 3271:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14730
+//line postgres.y:14737
 		{
 			yyLOCAL = ast.NewCommentStmt(yyDollar[3].objTypeUnion(), ast.NewString(yyDollar[4].str), yyDollar[6].str)
 		}
@@ -44368,7 +44375,7 @@ yydefault:
 	case 3272:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14734
+//line postgres.y:14741
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_TYPE, yyDollar[4].typnamUnion(), yyDollar[6].str)
 		}
@@ -44376,7 +44383,7 @@ yydefault:
 	case 3273:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14738
+//line postgres.y:14745
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_DOMAIN, yyDollar[4].typnamUnion(), yyDollar[6].str)
 		}
@@ -44384,7 +44391,7 @@ yydefault:
 	case 3274:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14742
+//line postgres.y:14749
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_AGGREGATE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44392,7 +44399,7 @@ yydefault:
 	case 3275:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14746
+//line postgres.y:14753
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_FUNCTION, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44400,7 +44407,7 @@ yydefault:
 	case 3276:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14750
+//line postgres.y:14757
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_OPERATOR, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44408,7 +44415,7 @@ yydefault:
 	case 3277:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14754
+//line postgres.y:14761
 		{
 			// For table constraints, append constraint name to table name list
 			newObj := yyDollar[6].listUnion()
@@ -44419,7 +44426,7 @@ yydefault:
 	case 3278:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14761
+//line postgres.y:14768
 		{
 			// For domain constraints, we need a list of [TypeName, constraint_name]
 			// This matches PostgreSQL's approach where they comment:
@@ -44434,7 +44441,7 @@ yydefault:
 	case 3279:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14772
+//line postgres.y:14779
 		{
 			// For object types that need name ON any_name: append name to any_name list
 			newObj := yyDollar[6].listUnion()
@@ -44445,7 +44452,7 @@ yydefault:
 	case 3280:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14779
+//line postgres.y:14786
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_PROCEDURE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44453,7 +44460,7 @@ yydefault:
 	case 3281:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14783
+//line postgres.y:14790
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_ROUTINE, yyDollar[4].objwithargsUnion(), yyDollar[6].str)
 		}
@@ -44461,7 +44468,7 @@ yydefault:
 	case 3282:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14787
+//line postgres.y:14794
 		{
 			// Transform: typename + language name
 			transformObj := ast.NewNodeList()
@@ -44473,7 +44480,7 @@ yydefault:
 	case 3283:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14795
+//line postgres.y:14802
 		{
 			// Operator class: access method + class name
 			opclassObj := ast.NewNodeList()
@@ -44487,7 +44494,7 @@ yydefault:
 	case 3284:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14805
+//line postgres.y:14812
 		{
 			// Operator family: access method + family name
 			opfamilyObj := ast.NewNodeList()
@@ -44501,7 +44508,7 @@ yydefault:
 	case 3285:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14815
+//line postgres.y:14822
 		{
 			yyLOCAL = ast.NewCommentStmt(ast.OBJECT_LARGEOBJECT, yyDollar[5].nodeUnion(), yyDollar[7].str)
 		}
@@ -44509,7 +44516,7 @@ yydefault:
 	case 3286:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14819
+//line postgres.y:14826
 		{
 			// Cast: source type + target type
 			castObj := ast.NewNodeList()
@@ -44520,20 +44527,20 @@ yydefault:
 		yyVAL.union = yyLOCAL
 	case 3287:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14833
+//line postgres.y:14840
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3288:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14834
+//line postgres.y:14841
 		{
 			yyVAL.str = ""
 		}
 	case 3289:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14843
+//line postgres.y:14850
 		{
 			yyLOCAL = ast.NewSecLabelStmt(yyDollar[5].objTypeUnion(), yyDollar[6].listUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44541,7 +44548,7 @@ yydefault:
 	case 3290:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14847
+//line postgres.y:14854
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_COLUMN, yyDollar[6].listUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44549,7 +44556,7 @@ yydefault:
 	case 3291:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14851
+//line postgres.y:14858
 		{
 			yyLOCAL = ast.NewSecLabelStmt(yyDollar[5].objTypeUnion(), ast.NewString(yyDollar[6].str), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44557,7 +44564,7 @@ yydefault:
 	case 3292:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14855
+//line postgres.y:14862
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_TYPE, yyDollar[6].typnamUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44565,7 +44572,7 @@ yydefault:
 	case 3293:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14859
+//line postgres.y:14866
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_DOMAIN, yyDollar[6].typnamUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44573,7 +44580,7 @@ yydefault:
 	case 3294:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14863
+//line postgres.y:14870
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_AGGREGATE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44581,7 +44588,7 @@ yydefault:
 	case 3295:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14867
+//line postgres.y:14874
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_FUNCTION, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44589,7 +44596,7 @@ yydefault:
 	case 3296:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14871
+//line postgres.y:14878
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_LARGEOBJECT, yyDollar[7].nodeUnion(), yyDollar[3].str, yyDollar[9].str)
 		}
@@ -44597,7 +44604,7 @@ yydefault:
 	case 3297:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14875
+//line postgres.y:14882
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_PROCEDURE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
@@ -44605,39 +44612,39 @@ yydefault:
 	case 3298:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14879
+//line postgres.y:14886
 		{
 			yyLOCAL = ast.NewSecLabelStmt(ast.OBJECT_ROUTINE, yyDollar[6].objwithargsUnion(), yyDollar[3].str, yyDollar[8].str)
 		}
 		yyVAL.union = yyLOCAL
 	case 3299:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:14889
+//line postgres.y:14896
 		{
 			yyVAL.str = yyDollar[2].str
 		}
 	case 3300:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:14890
+//line postgres.y:14897
 		{
 			yyVAL.str = ""
 		}
 	case 3301:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14894
+//line postgres.y:14901
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3302:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:14895
+//line postgres.y:14902
 		{
 			yyVAL.str = ""
 		}
 	case 3303:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14904
+//line postgres.y:14911
 		{
 			yyLOCAL = ast.NewDoStmt(yyDollar[2].listUnion())
 		}
@@ -44645,7 +44652,7 @@ yydefault:
 	case 3304:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14914
+//line postgres.y:14921
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -44653,7 +44660,7 @@ yydefault:
 	case 3305:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:14915
+//line postgres.y:14922
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 			yyLOCAL.Append(yyDollar[2].defeltUnion())
@@ -44662,7 +44669,7 @@ yydefault:
 	case 3306:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14920
+//line postgres.y:14927
 		{
 			yyLOCAL = ast.NewDefElem("as", ast.NewString(yyDollar[1].str))
 		}
@@ -44670,7 +44677,7 @@ yydefault:
 	case 3307:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:14924
+//line postgres.y:14931
 		{
 			yyLOCAL = ast.NewDefElem("language", ast.NewString(yyDollar[2].str))
 		}
@@ -44678,7 +44685,7 @@ yydefault:
 	case 3308:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14935
+//line postgres.y:14942
 		{
 			yyLOCAL = ast.NewCallStmt(yyDollar[2].nodeUnion().(*ast.FuncCall))
 		}
@@ -44686,7 +44693,7 @@ yydefault:
 	case 3309:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14948
+//line postgres.y:14955
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_AGGREGATE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44697,7 +44704,7 @@ yydefault:
 	case 3310:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14955
+//line postgres.y:14962
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_COLLATION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44708,7 +44715,7 @@ yydefault:
 	case 3311:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14962
+//line postgres.y:14969
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_CONVERSION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44719,7 +44726,7 @@ yydefault:
 	case 3312:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14969
+//line postgres.y:14976
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_DOMAIN, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44730,7 +44737,7 @@ yydefault:
 	case 3313:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14976
+//line postgres.y:14983
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_EXTENSION, yyDollar[6].str)
 			stmt.Object = ast.NewString(yyDollar[3].str)
@@ -44741,7 +44748,7 @@ yydefault:
 	case 3314:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14983
+//line postgres.y:14990
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FUNCTION, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44752,7 +44759,7 @@ yydefault:
 	case 3315:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14990
+//line postgres.y:14997
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPERATOR, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44763,7 +44770,7 @@ yydefault:
 	case 3316:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:14997
+//line postgres.y:15004
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPCLASS, yyDollar[9].str)
 			// Create list with access method name first, then class name
@@ -44779,7 +44786,7 @@ yydefault:
 	case 3317:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15009
+//line postgres.y:15016
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_OPFAMILY, yyDollar[9].str)
 			// Create list with access method name first, then family name
@@ -44795,7 +44802,7 @@ yydefault:
 	case 3318:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15021
+//line postgres.y:15028
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_PROCEDURE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44806,7 +44813,7 @@ yydefault:
 	case 3319:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15028
+//line postgres.y:15035
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_ROUTINE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -44817,7 +44824,7 @@ yydefault:
 	case 3320:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15035
+//line postgres.y:15042
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TABLE, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44828,7 +44835,7 @@ yydefault:
 	case 3321:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15042
+//line postgres.y:15049
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TABLE, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44839,7 +44846,7 @@ yydefault:
 	case 3322:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15049
+//line postgres.y:15056
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_STATISTIC_EXT, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44850,7 +44857,7 @@ yydefault:
 	case 3323:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15056
+//line postgres.y:15063
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSPARSER, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44861,7 +44868,7 @@ yydefault:
 	case 3324:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15063
+//line postgres.y:15070
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSDICTIONARY, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44872,7 +44879,7 @@ yydefault:
 	case 3325:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15070
+//line postgres.y:15077
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSTEMPLATE, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44883,7 +44890,7 @@ yydefault:
 	case 3326:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15077
+//line postgres.y:15084
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TSCONFIGURATION, yyDollar[8].str)
 			stmt.Object = yyDollar[5].listUnion()
@@ -44894,7 +44901,7 @@ yydefault:
 	case 3327:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15084
+//line postgres.y:15091
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_SEQUENCE, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44905,7 +44912,7 @@ yydefault:
 	case 3328:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15091
+//line postgres.y:15098
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_SEQUENCE, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44916,7 +44923,7 @@ yydefault:
 	case 3329:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15098
+//line postgres.y:15105
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_VIEW, yyDollar[6].str)
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -44927,7 +44934,7 @@ yydefault:
 	case 3330:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15105
+//line postgres.y:15112
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_VIEW, yyDollar[8].str)
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -44938,7 +44945,7 @@ yydefault:
 	case 3331:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15112
+//line postgres.y:15119
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_MATVIEW, yyDollar[7].str)
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -44949,7 +44956,7 @@ yydefault:
 	case 3332:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15119
+//line postgres.y:15126
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_MATVIEW, yyDollar[9].str)
 			stmt.Relation = yyDollar[6].rangevarUnion()
@@ -44960,7 +44967,7 @@ yydefault:
 	case 3333:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15126
+//line postgres.y:15133
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FOREIGN_TABLE, yyDollar[7].str)
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -44971,7 +44978,7 @@ yydefault:
 	case 3334:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15133
+//line postgres.y:15140
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_FOREIGN_TABLE, yyDollar[9].str)
 			stmt.Relation = yyDollar[6].rangevarUnion()
@@ -44982,7 +44989,7 @@ yydefault:
 	case 3335:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15140
+//line postgres.y:15147
 		{
 			stmt := ast.NewAlterObjectSchemaStmt(ast.OBJECT_TYPE, yyDollar[6].str)
 			stmt.Object = yyDollar[3].listUnion()
@@ -44993,7 +45000,7 @@ yydefault:
 	case 3336:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15156
+//line postgres.y:15163
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45006,7 +45013,7 @@ yydefault:
 	case 3337:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15165
+//line postgres.y:15172
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45019,7 +45026,7 @@ yydefault:
 	case 3338:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15174
+//line postgres.y:15181
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45032,7 +45039,7 @@ yydefault:
 	case 3339:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15183
+//line postgres.y:15190
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45045,7 +45052,7 @@ yydefault:
 	case 3340:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15192
+//line postgres.y:15199
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45058,7 +45065,7 @@ yydefault:
 	case 3341:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15201
+//line postgres.y:15208
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45071,7 +45078,7 @@ yydefault:
 	case 3342:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15210
+//line postgres.y:15217
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45084,7 +45091,7 @@ yydefault:
 	case 3343:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15219
+//line postgres.y:15226
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45097,7 +45104,7 @@ yydefault:
 	case 3344:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15228
+//line postgres.y:15235
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45110,7 +45117,7 @@ yydefault:
 	case 3345:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15237
+//line postgres.y:15244
 		{
 			list := ast.NewNodeList(ast.NewString(yyDollar[6].str))
 			for _, item := range yyDollar[4].listUnion().Items {
@@ -45127,7 +45134,7 @@ yydefault:
 	case 3346:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15250
+//line postgres.y:15257
 		{
 			list := ast.NewNodeList(ast.NewString(yyDollar[6].str))
 			for _, item := range yyDollar[4].listUnion().Items {
@@ -45144,7 +45151,7 @@ yydefault:
 	case 3347:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15263
+//line postgres.y:15270
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45157,7 +45164,7 @@ yydefault:
 	case 3348:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15272
+//line postgres.y:15279
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45170,7 +45177,7 @@ yydefault:
 	case 3349:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15281
+//line postgres.y:15288
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45183,7 +45190,7 @@ yydefault:
 	case 3350:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15290
+//line postgres.y:15297
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45196,7 +45203,7 @@ yydefault:
 	case 3351:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15299
+//line postgres.y:15306
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45209,7 +45216,7 @@ yydefault:
 	case 3352:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15308
+//line postgres.y:15315
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45222,7 +45229,7 @@ yydefault:
 	case 3353:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15317
+//line postgres.y:15324
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45235,7 +45242,7 @@ yydefault:
 	case 3354:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15326
+//line postgres.y:15333
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45248,7 +45255,7 @@ yydefault:
 	case 3355:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15335
+//line postgres.y:15342
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45261,7 +45268,7 @@ yydefault:
 	case 3356:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15344
+//line postgres.y:15351
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45274,7 +45281,7 @@ yydefault:
 	case 3357:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15353
+//line postgres.y:15360
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45287,7 +45294,7 @@ yydefault:
 	case 3358:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15362
+//line postgres.y:15369
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45300,7 +45307,7 @@ yydefault:
 	case 3359:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15371
+//line postgres.y:15378
 		{
 			yyLOCAL = &ast.AlterOwnerStmt{
 				BaseNode:   ast.BaseNode{Tag: ast.T_AlterOwnerStmt},
@@ -45313,7 +45320,7 @@ yydefault:
 	case 3360:
 		yyDollar = yyS[yypt-7 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15389
+//line postgres.y:15396
 		{
 			yyLOCAL = ast.NewAlterOperatorStmt(yyDollar[3].objwithargsUnion(), yyDollar[6].listUnion())
 		}
@@ -45321,7 +45328,7 @@ yydefault:
 	case 3361:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15402
+//line postgres.y:15409
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_FUNCTION, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45331,7 +45338,7 @@ yydefault:
 	case 3362:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15408
+//line postgres.y:15415
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_PROCEDURE, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45341,7 +45348,7 @@ yydefault:
 	case 3363:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15414
+//line postgres.y:15421
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_ROUTINE, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Object = yyDollar[3].objwithargsUnion()
@@ -45351,7 +45358,7 @@ yydefault:
 	case 3364:
 		yyDollar = yyS[yypt-10 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15420
+//line postgres.y:15427
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_TRIGGER, ast.NewString(yyDollar[10].str), yyDollar[6].bvalUnion())
 			stmt.Relation = yyDollar[5].rangevarUnion()
@@ -45362,7 +45369,7 @@ yydefault:
 	case 3365:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15427
+//line postgres.y:15434
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_MATVIEW, ast.NewString(yyDollar[9].str), yyDollar[5].bvalUnion())
 			stmt.Relation = yyDollar[4].rangevarUnion()
@@ -45372,7 +45379,7 @@ yydefault:
 	case 3366:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15433
+//line postgres.y:15440
 		{
 			stmt := ast.NewAlterObjectDependsStmt(ast.OBJECT_INDEX, ast.NewString(yyDollar[8].str), yyDollar[4].bvalUnion())
 			stmt.Relation = yyDollar[3].rangevarUnion()
@@ -45382,7 +45389,7 @@ yydefault:
 	case 3367:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15440
+//line postgres.y:15447
 		{
 			yyLOCAL = true
 		}
@@ -45390,7 +45397,7 @@ yydefault:
 	case 3368:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15441
+//line postgres.y:15448
 		{
 			yyLOCAL = false
 		}
@@ -45398,7 +45405,7 @@ yydefault:
 	case 3369:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15452
+//line postgres.y:15459
 		{
 			yyLOCAL = ast.NewAlterCollationStmt(yyDollar[3].listUnion())
 		}
@@ -45406,7 +45413,7 @@ yydefault:
 	case 3370:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15465
+//line postgres.y:15472
 		{
 			yyLOCAL = ast.NewAlterDatabaseStmt(yyDollar[3].str, yyDollar[5].listUnion())
 		}
@@ -45414,7 +45421,7 @@ yydefault:
 	case 3371:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15469
+//line postgres.y:15476
 		{
 			yyLOCAL = ast.NewAlterDatabaseStmt(yyDollar[3].str, yyDollar[4].listUnion())
 		}
@@ -45422,7 +45429,7 @@ yydefault:
 	case 3372:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15473
+//line postgres.y:15480
 		{
 			optList := ast.NewNodeList()
 			optList.Append(ast.NewDefElem("tablespace", ast.NewString(yyDollar[6].str)))
@@ -45432,7 +45439,7 @@ yydefault:
 	case 3373:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15479
+//line postgres.y:15486
 		{
 			yyLOCAL = ast.NewAlterDatabaseRefreshCollStmt(yyDollar[3].str)
 		}
@@ -45440,7 +45447,7 @@ yydefault:
 	case 3374:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15485
+//line postgres.y:15492
 		{
 			yyLOCAL = yyDollar[1].listUnion()
 		}
@@ -45448,7 +45455,7 @@ yydefault:
 	case 3375:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15486
+//line postgres.y:15493
 		{
 			yyLOCAL = nil
 		}
@@ -45456,7 +45463,7 @@ yydefault:
 	case 3376:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15490
+//line postgres.y:15497
 		{
 			yyLOCAL = ast.NewNodeList(yyDollar[1].defeltUnion())
 		}
@@ -45464,7 +45471,7 @@ yydefault:
 	case 3377:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL *ast.NodeList
-//line postgres.y:15491
+//line postgres.y:15498
 		{
 			yyDollar[1].listUnion().Append(yyDollar[2].defeltUnion())
 			yyLOCAL = yyDollar[1].listUnion()
@@ -45473,7 +45480,7 @@ yydefault:
 	case 3378:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15496
+//line postgres.y:15503
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewInteger(yyDollar[3].ival))
 		}
@@ -45481,7 +45488,7 @@ yydefault:
 	case 3379:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15500
+//line postgres.y:15507
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, ast.NewString(yyDollar[3].str))
 		}
@@ -45489,67 +45496,67 @@ yydefault:
 	case 3380:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		var yyLOCAL *ast.DefElem
-//line postgres.y:15504
+//line postgres.y:15511
 		{
 			yyLOCAL = ast.NewDefElem(yyDollar[1].str, nil)
 		}
 		yyVAL.union = yyLOCAL
 	case 3381:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15510
+//line postgres.y:15517
 		{
 			yyVAL.str = yyDollar[1].str
 		}
 	case 3382:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line postgres.y:15511
+//line postgres.y:15518
 		{
 			yyVAL.str = "connection_limit"
 		}
 	case 3383:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15512
+//line postgres.y:15519
 		{
 			yyVAL.str = "encoding"
 		}
 	case 3384:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15513
+//line postgres.y:15520
 		{
 			yyVAL.str = "location"
 		}
 	case 3385:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15514
+//line postgres.y:15521
 		{
 			yyVAL.str = "owner"
 		}
 	case 3386:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15515
+//line postgres.y:15522
 		{
 			yyVAL.str = "tablespace"
 		}
 	case 3387:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15516
+//line postgres.y:15523
 		{
 			yyVAL.str = "template"
 		}
 	case 3388:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line postgres.y:15519
+//line postgres.y:15526
 		{
 		}
 	case 3389:
 		yyDollar = yyS[yypt-0 : yypt+1]
-//line postgres.y:15520
+//line postgres.y:15527
 		{
 		}
 	case 3390:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15525
+//line postgres.y:15532
 		{
 			yyLOCAL = ast.NewAlterDatabaseSetStmt(yyDollar[3].str, yyDollar[4].vsetstmtUnion())
 		}
@@ -45557,7 +45564,7 @@ yydefault:
 	case 3391:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15538
+//line postgres.y:15545
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_ADD_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45570,7 +45577,7 @@ yydefault:
 	case 3392:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15547
+//line postgres.y:15554
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_ALTER_MAPPING_FOR_TOKEN, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45583,7 +45590,7 @@ yydefault:
 	case 3393:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15556
+//line postgres.y:15563
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_REPLACE_DICT, yyDollar[5].listUnion())
 			stmt.Tokentype = nil
@@ -45599,7 +45606,7 @@ yydefault:
 	case 3394:
 		yyDollar = yyS[yypt-13 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15568
+//line postgres.y:15575
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_REPLACE_DICT_FOR_TOKEN, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45615,7 +45622,7 @@ yydefault:
 	case 3395:
 		yyDollar = yyS[yypt-9 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15580
+//line postgres.y:15587
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_DROP_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[9].listUnion()
@@ -45626,7 +45633,7 @@ yydefault:
 	case 3396:
 		yyDollar = yyS[yypt-11 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15587
+//line postgres.y:15594
 		{
 			stmt := ast.NewAlterTSConfigurationStmt(ast.ALTER_TSCONFIG_DROP_MAPPING, yyDollar[5].listUnion())
 			stmt.Tokentype = yyDollar[11].listUnion()
@@ -45637,7 +45644,7 @@ yydefault:
 	case 3399:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		var yyLOCAL ast.Stmt
-//line postgres.y:15608
+//line postgres.y:15615
 		{
 			yyLOCAL = ast.NewAlterTSDictionaryStmt(yyDollar[5].listUnion(), yyDollar[6].listUnion())
 		}
@@ -45645,7 +45652,7 @@ yydefault:
 	case 3400:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15618
+//line postgres.y:15625
 		{
 			yyLOCAL = false
 		}
@@ -45653,7 +45660,7 @@ yydefault:
 	case 3401:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15619
+//line postgres.y:15626
 		{
 			yyLOCAL = true
 		}
@@ -45661,7 +45668,7 @@ yydefault:
 	case 3402:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		var yyLOCAL bool
-//line postgres.y:15620
+//line postgres.y:15627
 		{
 			yyLOCAL = false
 		}

--- a/go/common/parser/postgres.y
+++ b/go/common/parser/postgres.y
@@ -5785,6 +5785,17 @@ json_table_column_definition:
 					strNode := $3.(*ast.String)
 					jsonTableCol.Pathspec = ast.NewJsonTablePathSpec(strNode, "", 0)
 				}
+				jsonTableCol.Wrapper = ast.JsonWrapper($4)
+				jsonTableCol.Quotes = ast.JsonQuotes($5)
+				if $6 != nil {
+					behaviors := $6.(*ast.NodeList)
+					if linitial(behaviors) != nil {
+						jsonTableCol.OnEmpty = linitial(behaviors).(*ast.JsonBehavior)
+					}
+					if lsecond(behaviors) != nil {
+						jsonTableCol.OnError = lsecond(behaviors).(*ast.JsonBehavior)
+					}
+				}
 				$$ = jsonTableCol
 			}
 		|	ColId Typename json_format_clause
@@ -5802,6 +5813,17 @@ json_table_column_definition:
 				if $3 != nil {
 					jsonTableCol.Format = $3.(*ast.JsonFormat)
 				}
+				jsonTableCol.Wrapper = ast.JsonWrapper($5)
+				jsonTableCol.Quotes = ast.JsonQuotes($6)
+				if $7 != nil {
+					behaviors := $7.(*ast.NodeList)
+					if linitial(behaviors) != nil {
+						jsonTableCol.OnEmpty = linitial(behaviors).(*ast.JsonBehavior)
+					}
+					if lsecond(behaviors) != nil {
+						jsonTableCol.OnError = lsecond(behaviors).(*ast.JsonBehavior)
+					}
+				}
 				$$ = jsonTableCol
 			}
 		|	ColId Typename EXISTS json_table_column_path_clause_opt
@@ -5812,6 +5834,9 @@ json_table_column_definition:
 				if $4 != nil {
 					strNode := $4.(*ast.String)
 					jsonTableCol.Pathspec = ast.NewJsonTablePathSpec(strNode, "", 0)
+				}
+				if $5 != nil {
+					jsonTableCol.OnError = $5.(*ast.JsonBehavior)
 				}
 				$$ = jsonTableCol
 			}

--- a/go/common/parser/postgres.y
+++ b/go/common/parser/postgres.y
@@ -5714,7 +5714,13 @@ json_quotes_clause_opt:
 json_format_clause:
 			FORMAT_LA JSON ENCODING name
 			{
-				// Parse the encoding name and map to JsonEncoding constant
+				// Parse the encoding name and map to JsonEncoding constant.
+				// Match PostgreSQL by rejecting unknown names at parse time
+				// (gram.y json_format_clause raises ereport(ERROR) with
+				// errcode INVALID_PARAMETER_VALUE / "unrecognized JSON
+				// encoding"). The JsonFormat node only carries an enum, so
+				// preserving the raw name through to the backend would mean
+				// reshaping the AST; rejecting here is the simpler match.
 				var encoding ast.JsonEncoding
 				switch $4 {
 				case "utf8":
@@ -5724,6 +5730,7 @@ json_format_clause:
 				case "utf32":
 					encoding = ast.JS_ENC_UTF32
 				default:
+					yylex.Error(fmt.Sprintf("unrecognized JSON encoding: %s", $4))
 					encoding = ast.JS_ENC_DEFAULT
 				}
 				$$ = &ast.JsonFormat{

--- a/go/common/parser/testdata/postgres/sqljson.json
+++ b/go/common/parser/testdata/postgres/sqljson.json
@@ -262,7 +262,7 @@
   {
     "comment": "sqljson - Statement 57",
     "query": "SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING)",
-    "expected": "SELECT JSON_OBJECT( RETURNING TEXT FORMAT JSON)"
+    "error": "parse error at position 71: unrecognized JSON encoding: invalid_encoding"
   },
   {
     "comment": "sqljson - Statement 58",
@@ -563,7 +563,7 @@
   {
     "comment": "sqljson - Statement 118",
     "query": "SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING)",
-    "expected": "SELECT JSON_ARRAY( RETURNING TEXT FORMAT JSON)"
+    "error": "parse error at position 70: unrecognized JSON encoding: invalid_encoding"
   },
   {
     "comment": "sqljson - Statement 119",

--- a/go/common/parser/testdata/postgres/sqljson.json
+++ b/go/common/parser/testdata/postgres/sqljson.json
@@ -18,13 +18,12 @@
   },
   {
     "comment": "sqljson - Statement 5",
-    "query": "SELECT JSON('{ \"a\" : 1 } ' FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON('{ \"a\" : 1 } ' FORMAT JSON)"
+    "query": "SELECT JSON('{ \"a\" : 1 } ' FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 6",
     "query": "SELECT JSON('{ \"a\" : 1 } '::bytea FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON(CAST('{ \"a\" : 1 } ' AS BYTEA) FORMAT JSON)"
+    "expected": "SELECT JSON(CAST('{ \"a\" : 1 } ' AS BYTEA) FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 7",
@@ -43,7 +42,7 @@
   {
     "comment": "sqljson - Statement 10",
     "query": "SELECT JSON('   1   '::json WITH UNIQUE KEYS)",
-    "expected": "SELECT JSON(CAST('   1   ' AS JSON))"
+    "expected": "SELECT JSON(CAST('   1   ' AS JSON) WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 11",
@@ -55,8 +54,7 @@
   },
   {
     "comment": "sqljson - Statement 13",
-    "query": "SELECT JSON('{\"a\": 1, \"a\": 2}' WITH UNIQUE KEYS)",
-    "expected": "SELECT JSON('{\"a\": 1, \"a\": 2}')"
+    "query": "SELECT JSON('{\"a\": 1, \"a\": 2}' WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 14",
@@ -81,12 +79,12 @@
   {
     "comment": "sqljson - Statement 18",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON('123'::bytea FORMAT JSON ENCODING UTF8)",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON(CAST('123' AS BYTEA) FORMAT JSON)"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON(CAST('123' AS BYTEA) FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 19",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON('123' WITH UNIQUE KEYS)",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON('123')"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON('123' WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 20",
@@ -234,7 +232,7 @@
   {
     "comment": "sqljson - Statement 51",
     "query": "SELECT JSON_OBJECT(RETURNING json FORMAT JSON)",
-    "expected": "SELECT JSON_OBJECT( RETURNING JSON)"
+    "expected": "SELECT JSON_OBJECT( RETURNING JSON FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 52",
@@ -244,7 +242,7 @@
   {
     "comment": "sqljson - Statement 53",
     "query": "SELECT JSON_OBJECT(RETURNING jsonb FORMAT JSON)",
-    "expected": "SELECT JSON_OBJECT( RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT( RETURNING JSONB FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 54",
@@ -254,17 +252,17 @@
   {
     "comment": "sqljson - Statement 55",
     "query": "SELECT JSON_OBJECT(RETURNING text FORMAT JSON)",
-    "expected": "SELECT JSON_OBJECT( RETURNING TEXT)"
+    "expected": "SELECT JSON_OBJECT( RETURNING TEXT FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 56",
     "query": "SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_OBJECT( RETURNING TEXT)"
+    "expected": "SELECT JSON_OBJECT( RETURNING TEXT FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 57",
     "query": "SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING)",
-    "expected": "SELECT JSON_OBJECT( RETURNING TEXT)"
+    "expected": "SELECT JSON_OBJECT( RETURNING TEXT FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 58",
@@ -274,22 +272,22 @@
   {
     "comment": "sqljson - Statement 59",
     "query": "SELECT JSON_OBJECT(RETURNING bytea FORMAT JSON)",
-    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA)"
+    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 60",
     "query": "SELECT JSON_OBJECT(RETURNING bytea FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA)"
+    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 61",
     "query": "SELECT JSON_OBJECT(RETURNING bytea FORMAT JSON ENCODING UTF16)",
-    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA)"
+    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA FORMAT JSON ENCODING UTF16)"
   },
   {
     "comment": "sqljson - Statement 62",
     "query": "SELECT JSON_OBJECT(RETURNING bytea FORMAT JSON ENCODING UTF32)",
-    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA)"
+    "expected": "SELECT JSON_OBJECT( RETURNING BYTEA FORMAT JSON ENCODING UTF32)"
   },
   {
     "comment": "sqljson - Statement 63",
@@ -299,7 +297,7 @@
   {
     "comment": "sqljson - Statement 64",
     "query": "SELECT JSON_OBJECT('foo': NULL::int FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS INT) FORMAT JSON)"
+    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS INT) FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 65",
@@ -309,7 +307,7 @@
   {
     "comment": "sqljson - Statement 66",
     "query": "SELECT JSON_OBJECT('foo': NULL::json FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS JSON) FORMAT JSON)"
+    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS JSON) FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 67",
@@ -319,7 +317,7 @@
   {
     "comment": "sqljson - Statement 68",
     "query": "SELECT JSON_OBJECT('foo': NULL::jsonb FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS JSONB) FORMAT JSON)"
+    "expected": "SELECT JSON_OBJECT('foo' : CAST(NULL AS JSONB) FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 69",
@@ -434,62 +432,62 @@
   {
     "comment": "sqljson - Statement 91",
     "query": "SELECT JSON_OBJECT('a': '1', 'b': NULL, 'c': 2 ABSENT ON NULL)",
-    "expected": "SELECT JSON_OBJECT('a' : '1', 'b' : NULL, 'c' : 2)"
+    "expected": "SELECT JSON_OBJECT('a' : '1', 'b' : NULL, 'c' : 2 ABSENT ON NULL)"
   },
   {
     "comment": "sqljson - Statement 92",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '3': 1, repeat('x', 1000): 1, 2: repeat('a', 100) WITH UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '3' : 1, repeat('x', 1000) : 1, 2 : repeat('a', 100))"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '3' : 1, repeat('x', 1000) : 1, 2 : repeat('a', 100) WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 93",
     "query": "SELECT JSON_OBJECT(1: 1, '1': NULL WITH UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 94",
     "query": "SELECT JSON_OBJECT(1: 1, '1': NULL ABSENT ON NULL WITH UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL ABSENT ON NULL WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 95",
     "query": "SELECT JSON_OBJECT(1: 1, '1': NULL NULL ON NULL WITH UNIQUE RETURNING jsonb)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL WITH UNIQUE KEYS RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 96",
     "query": "SELECT JSON_OBJECT(1: 1, '1': NULL ABSENT ON NULL WITH UNIQUE RETURNING jsonb)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '1' : NULL ABSENT ON NULL WITH UNIQUE KEYS RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 97",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '1': 1 NULL ON NULL WITH UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 98",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '1': 1 ABSENT ON NULL WITH UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 ABSENT ON NULL WITH UNIQUE KEYS)"
   },
   {
     "comment": "sqljson - Statement 99",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '1': 1 ABSENT ON NULL WITHOUT UNIQUE)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 ABSENT ON NULL)"
   },
   {
     "comment": "sqljson - Statement 100",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '1': 1 ABSENT ON NULL WITH UNIQUE RETURNING jsonb)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 ABSENT ON NULL WITH UNIQUE KEYS RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 101",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '1': 1 ABSENT ON NULL WITHOUT UNIQUE RETURNING jsonb)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '1' : 1 ABSENT ON NULL RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 102",
     "query": "SELECT JSON_OBJECT(1: 1, '2': NULL, '3': 1, 4: NULL, '5': 'a' ABSENT ON NULL WITH UNIQUE RETURNING jsonb)",
-    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '3' : 1, 4 : NULL, '5' : 'a' RETURNING JSONB)"
+    "expected": "SELECT JSON_OBJECT(1 : 1, '2' : NULL, '3' : 1, 4 : NULL, '5' : 'a' ABSENT ON NULL WITH UNIQUE KEYS RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 103",
@@ -535,7 +533,7 @@
   {
     "comment": "sqljson - Statement 112",
     "query": "SELECT JSON_ARRAY(RETURNING json FORMAT JSON)",
-    "expected": "SELECT JSON_ARRAY( RETURNING JSON)"
+    "expected": "SELECT JSON_ARRAY( RETURNING JSON FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 113",
@@ -545,7 +543,7 @@
   {
     "comment": "sqljson - Statement 114",
     "query": "SELECT JSON_ARRAY(RETURNING jsonb FORMAT JSON)",
-    "expected": "SELECT JSON_ARRAY( RETURNING JSONB)"
+    "expected": "SELECT JSON_ARRAY( RETURNING JSONB FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 115",
@@ -555,17 +553,17 @@
   {
     "comment": "sqljson - Statement 116",
     "query": "SELECT JSON_ARRAY(RETURNING text FORMAT JSON)",
-    "expected": "SELECT JSON_ARRAY( RETURNING TEXT)"
+    "expected": "SELECT JSON_ARRAY( RETURNING TEXT FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 117",
     "query": "SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_ARRAY( RETURNING TEXT)"
+    "expected": "SELECT JSON_ARRAY( RETURNING TEXT FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 118",
     "query": "SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING)",
-    "expected": "SELECT JSON_ARRAY( RETURNING TEXT)"
+    "expected": "SELECT JSON_ARRAY( RETURNING TEXT FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 119",
@@ -575,22 +573,22 @@
   {
     "comment": "sqljson - Statement 120",
     "query": "SELECT JSON_ARRAY(RETURNING bytea FORMAT JSON)",
-    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA)"
+    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA FORMAT JSON)"
   },
   {
     "comment": "sqljson - Statement 121",
     "query": "SELECT JSON_ARRAY(RETURNING bytea FORMAT JSON ENCODING UTF8)",
-    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA)"
+    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA FORMAT JSON ENCODING UTF8)"
   },
   {
     "comment": "sqljson - Statement 122",
     "query": "SELECT JSON_ARRAY(RETURNING bytea FORMAT JSON ENCODING UTF16)",
-    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA)"
+    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA FORMAT JSON ENCODING UTF16)"
   },
   {
     "comment": "sqljson - Statement 123",
     "query": "SELECT JSON_ARRAY(RETURNING bytea FORMAT JSON ENCODING UTF32)",
-    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA)"
+    "expected": "SELECT JSON_ARRAY( RETURNING BYTEA FORMAT JSON ENCODING UTF32)"
   },
   {
     "comment": "sqljson - Statement 124",
@@ -600,7 +598,7 @@
   {
     "comment": "sqljson - Statement 125",
     "query": "SELECT JSON_ARRAY('a',  NULL, 'b' NULL   ON NULL)",
-    "expected": "SELECT JSON_ARRAY('a', NULL, 'b')"
+    "expected": "SELECT JSON_ARRAY('a', NULL, 'b' NULL ON NULL)"
   },
   {
     "comment": "sqljson - Statement 126",
@@ -615,7 +613,7 @@
   {
     "comment": "sqljson - Statement 128",
     "query": "SELECT JSON_ARRAY('a',  NULL, 'b' NULL   ON NULL RETURNING jsonb)",
-    "expected": "SELECT JSON_ARRAY('a', NULL, 'b' RETURNING JSONB)"
+    "expected": "SELECT JSON_ARRAY('a', NULL, 'b' NULL ON NULL RETURNING JSONB)"
   },
   {
     "comment": "sqljson - Statement 129",
@@ -695,7 +693,7 @@
   {
     "comment": "sqljson - Statement 144",
     "query": "SELECT JSON_ARRAYAGG(i ORDER BY i DESC) FROM generate_series(1, 5) i",
-    "expected": "SELECT JSON_ARRAYAGG(i) FROM generate_series(1, 5) AS i"
+    "expected": "SELECT JSON_ARRAYAGG(i ORDER BY i DESC) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 145",
@@ -715,7 +713,7 @@
   {
     "comment": "sqljson - Statement 148",
     "query": "SELECT\tJSON_ARRAYAGG(NULL NULL ON NULL), JSON_ARRAYAGG(NULL NULL ON NULL RETURNING jsonb) FROM generate_series(1, 5)",
-    "expected": "SELECT JSON_ARRAYAGG(NULL), JSON_ARRAYAGG(NULL RETURNING JSONB) FROM generate_series(1, 5)"
+    "expected": "SELECT JSON_ARRAYAGG(NULL NULL ON NULL), JSON_ARRAYAGG(NULL NULL ON NULL RETURNING JSONB) FROM generate_series(1, 5)"
   },
   {
     "comment": "sqljson - Statement 149",
@@ -740,42 +738,42 @@
   {
     "comment": "sqljson - Statement 153",
     "query": "SELECT JSON_OBJECTAGG(k: v), JSON_OBJECTAGG(k: v NULL ON NULL), JSON_OBJECTAGG(k: v ABSENT ON NULL), JSON_OBJECTAGG(k: v RETURNING jsonb), JSON_OBJECTAGG(k: v NULL ON NULL RETURNING jsonb), JSON_OBJECTAGG(k: v ABSENT ON NULL RETURNING jsonb) FROM (VALUES (1, 1), (1, NULL), (2, NULL), (3, 3)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v), JSON_OBJECTAGG(k : v), JSON_OBJECTAGG(k : v), JSON_OBJECTAGG(k : v RETURNING JSONB), JSON_OBJECTAGG(k : v RETURNING JSONB), JSON_OBJECTAGG(k : v RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, NULL), (3, 3)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v), JSON_OBJECTAGG(k : v), JSON_OBJECTAGG(k : v ABSENT ON NULL), JSON_OBJECTAGG(k : v RETURNING JSONB), JSON_OBJECTAGG(k : v RETURNING JSONB), JSON_OBJECTAGG(k : v ABSENT ON NULL RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, NULL), (3, 3)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 154",
     "query": "SELECT JSON_OBJECTAGG(k: v WITH UNIQUE KEYS) FROM (VALUES (1, 1), (1, NULL), (2, 2)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v WITH UNIQUE KEYS) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 155",
     "query": "SELECT JSON_OBJECTAGG(k: v ABSENT ON NULL WITH UNIQUE KEYS) FROM (VALUES (1, 1), (1, NULL), (2, 2)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 156",
     "query": "SELECT JSON_OBJECTAGG(k: v ABSENT ON NULL WITH UNIQUE KEYS) FROM (VALUES (1, 1), (0, NULL), (3, NULL), (2, 2), (4, NULL)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v) FROM (VALUES (1, 1), (0, NULL), (3, NULL), (2, 2), (4, NULL)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS) FROM (VALUES (1, 1), (0, NULL), (3, NULL), (2, 2), (4, NULL)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 157",
     "query": "SELECT JSON_OBJECTAGG(k: v WITH UNIQUE KEYS RETURNING jsonb) FROM (VALUES (1, 1), (1, NULL), (2, 2)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v WITH UNIQUE KEYS RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 158",
     "query": "SELECT JSON_OBJECTAGG(k: v ABSENT ON NULL WITH UNIQUE KEYS RETURNING jsonb) FROM (VALUES (1, 1), (1, NULL), (2, 2)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS RETURNING JSONB) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 159",
     "query": "SELECT JSON_OBJECTAGG(k: v ABSENT ON NULL WITH UNIQUE KEYS RETURNING jsonb) FROM (VALUES (1, 1), (0, NULL),(4, null), (5, null),(6, null),(2, 2)) foo(k, v)",
-    "expected": "SELECT JSON_OBJECTAGG(k : v RETURNING JSONB) FROM (VALUES (1, 1), (0, NULL), (4, NULL), (5, NULL), (6, NULL), (2, 2)) AS foo(k, v)"
+    "expected": "SELECT JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS RETURNING JSONB) FROM (VALUES (1, 1), (0, NULL), (4, NULL), (5, NULL), (6, NULL), (2, 2)) AS foo(k, v)"
   },
   {
     "comment": "sqljson - Statement 160",
     "query": "SELECT JSON_OBJECTAGG(mod(i,100): (i)::text FORMAT JSON WITH UNIQUE) FROM generate_series(0, 199) i",
-    "expected": "SELECT JSON_OBJECTAGG(mod(i, 100) : CAST((i) AS TEXT) FORMAT JSON) FROM generate_series(0, 199) AS i"
+    "expected": "SELECT JSON_OBJECTAGG(mod(i, 100) : CAST((i) AS TEXT) FORMAT JSON WITH UNIQUE KEYS) FROM generate_series(0, 199) AS i"
   },
   {
     "comment": "sqljson - Statement 161",
@@ -790,27 +788,27 @@
   {
     "comment": "sqljson - Statement 163",
     "query": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1,1), (2,2)) a(k,v)",
-    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v) OVER (ORDER BY k) FROM (VALUES (1, 1), (2, 2)) AS a(k, v)"
+    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1, 1), (2, 2)) AS a(k, v)"
   },
   {
     "comment": "sqljson - Statement 164",
     "query": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1,1), (1,2), (2,2)) a(k,v)",
-    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, 2), (2, 2)) AS a(k, v)"
+    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, 2), (2, 2)) AS a(k, v)"
   },
   {
     "comment": "sqljson - Statement 165",
     "query": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1,1), (1,null), (2,2)) a(k,v)",
-    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
+    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL WITH UNIQUE KEYS) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
   },
   {
     "comment": "sqljson - Statement 166",
     "query": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL) OVER (ORDER BY k) FROM (VALUES (1,1), (1,null), (2,2)) a(k,v)",
-    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
+    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL) OVER (ORDER BY k) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
   },
   {
     "comment": "sqljson - Statement 167",
     "query": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL) OVER (ORDER BY k RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES (1,1), (1,null), (2,2)) a(k,v)",
-    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v) OVER (ORDER BY k RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
+    "expected": "SELECT to_json(a) AS a, JSON_OBJECTAGG(k : v ABSENT ON NULL) OVER (ORDER BY k RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES (1, 1), (1, NULL), (2, 2)) AS a(k, v)"
   },
   {
     "comment": "sqljson - Statement 168",
@@ -825,32 +823,32 @@
   {
     "comment": "sqljson - Statement 170",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON_OBJECTAGG(i: ('111' || i)::bytea FORMAT JSON WITH UNIQUE RETURNING text) FILTER (WHERE i \u003e 3) FROM generate_series(1,5) i",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON WITH UNIQUE KEYS RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 171",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON_OBJECTAGG(i: ('111' || i)::bytea FORMAT JSON WITH UNIQUE RETURNING text) OVER (PARTITION BY i % 2) FROM generate_series(1,5) i",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) OVER (PARTITION BY i % 2) FROM generate_series(1, 5) AS i"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON WITH UNIQUE KEYS RETURNING TEXT) OVER (PARTITION BY i % 2) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 172",
     "query": "CREATE VIEW json_objectagg_view AS SELECT JSON_OBJECTAGG(i: ('111' || i)::bytea FORMAT JSON WITH UNIQUE RETURNING text) FILTER (WHERE i \u003e 3) FROM generate_series(1,5) i",
-    "expected": "CREATE VIEW json_objectagg_view AS SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
+    "expected": "CREATE VIEW json_objectagg_view AS SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON WITH UNIQUE KEYS RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 173",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON_ARRAYAGG(('111' || i)::bytea FORMAT JSON NULL ON NULL RETURNING text) FILTER (WHERE i \u003e 3) FROM generate_series(1,5) i",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON NULL ON NULL RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 174",
     "query": "EXPLAIN (VERBOSE, COSTS OFF) SELECT JSON_ARRAYAGG(('111' || i)::bytea FORMAT JSON NULL ON NULL RETURNING text) OVER (PARTITION BY i % 2) FROM generate_series(1,5) i",
-    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) OVER (PARTITION BY i % 2) FROM generate_series(1, 5) AS i"
+    "expected": "EXPLAIN (VERBOSE true, COSTS false) SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON NULL ON NULL RETURNING TEXT) OVER (PARTITION BY i % 2) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 175",
     "query": "CREATE VIEW json_arrayagg_view AS SELECT JSON_ARRAYAGG(('111' || i)::bytea FORMAT JSON NULL ON NULL RETURNING text) FILTER (WHERE i \u003e 3) FROM generate_series(1,5) i",
-    "expected": "CREATE VIEW json_arrayagg_view AS SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
+    "expected": "CREATE VIEW json_arrayagg_view AS SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON NULL ON NULL RETURNING TEXT) FILTER (WHERE i \u003e 3) FROM generate_series(1, 5) AS i"
   },
   {
     "comment": "sqljson - Statement 176",
@@ -962,12 +960,12 @@
   {
     "comment": "sqljson - Statement 198",
     "query": "SELECT JSON_ARRAYAGG(('111' || i)::bytea FORMAT JSON NULL ON NULL RETURNING varchar(2)) FROM generate_series(1,1) i",
-    "expected": "SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING VARCHAR(2)) FROM generate_series(1, 1) AS i"
+    "expected": "SELECT JSON_ARRAYAGG(CAST(('111' || i) AS BYTEA) FORMAT JSON NULL ON NULL RETURNING VARCHAR(2)) FROM generate_series(1, 1) AS i"
   },
   {
     "comment": "sqljson - Statement 199",
     "query": "SELECT JSON_OBJECTAGG(i: ('111' || i)::bytea FORMAT JSON WITH UNIQUE RETURNING varchar(2)) FROM generate_series(1, 1) i",
-    "expected": "SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON RETURNING VARCHAR(2)) FROM generate_series(1, 1) AS i"
+    "expected": "SELECT JSON_OBJECTAGG(i : CAST(('111' || i) AS BYTEA) FORMAT JSON WITH UNIQUE KEYS RETURNING VARCHAR(2)) FROM generate_series(1, 1) AS i"
   },
   {
     "comment": "sqljson - Statement 200",

--- a/go/common/parser/testdata/postgres/sqljson_jsontable.json
+++ b/go/common/parser/testdata/postgres/sqljson_jsontable.json
@@ -27,7 +27,7 @@
   {
     "comment": "sqljson_jsontable - Statement 6",
     "query": "SELECT * FROM JSON_TABLE(jsonb'\"1.23\"', '$.a' as js2 COLUMNS (js2 int path '$'))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"1.23\"' AS JSONB), '$.a' COLUMNS (js2 INT PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"1.23\"' AS JSONB), '$.a' AS js2 COLUMNS (js2 INT PATH '$'))"
   },
   {
     "comment": "sqljson_jsontable - Statement 7",
@@ -52,7 +52,7 @@
   {
     "comment": "sqljson_jsontable - Statement 11",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"rec\": \"(1,2)\"}', '$' COLUMNS (id FOR ORDINALITY, comp comp path '$.rec' omit quotes)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"rec\": \"(1,2)\"}' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, comp comp PATH '$.rec')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"rec\": \"(1,2)\"}' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, comp comp PATH '$.rec' OMIT QUOTES)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 12",
@@ -92,42 +92,42 @@
   {
     "comment": "sqljson_jsontable - Statement 19",
     "query": "SELECT * FROM json_table_test vals LEFT OUTER JOIN JSON_TABLE( vals.js::jsonb, 'lax $[*]' COLUMNS ( id FOR ORDINALITY, jst text    FORMAT JSON  PATH '$', jsc char(4) FORMAT JSON  PATH '$', jsv varchar(4) FORMAT JSON  PATH '$', jsb jsonb FORMAT JSON PATH '$', jsbq jsonb FORMAT JSON PATH '$' OMIT QUOTES ) ) jt ON true",
-    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, jst TEXT FORMAT JSON PATH '$', jsc CHAR(4) FORMAT JSON PATH '$', jsv VARCHAR(4) FORMAT JSON PATH '$', jsb JSONB FORMAT JSON PATH '$', jsbq JSONB FORMAT JSON PATH '$')) AS jt ON TRUE"
+    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, jst TEXT FORMAT JSON PATH '$', jsc CHAR(4) FORMAT JSON PATH '$', jsv VARCHAR(4) FORMAT JSON PATH '$', jsb JSONB FORMAT JSON PATH '$', jsbq JSONB FORMAT JSON PATH '$' OMIT QUOTES)) AS jt ON TRUE"
   },
   {
     "comment": "sqljson_jsontable - Statement 20",
     "query": "SELECT * FROM json_table_test vals LEFT OUTER JOIN JSON_TABLE( vals.js::jsonb, 'lax $[*]' COLUMNS ( id FOR ORDINALITY, exists1 bool EXISTS PATH '$.aaa', exists2 int EXISTS PATH '$.aaa', exists3 int EXISTS PATH 'strict $.aaa' UNKNOWN ON ERROR, exists4 text EXISTS PATH 'strict $.aaa' FALSE ON ERROR ) ) jt ON true",
-    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, exists1 BOOLEAN EXISTS PATH '$.aaa', exists2 INT EXISTS PATH '$.aaa', exists3 INT EXISTS PATH 'strict $.aaa', exists4 TEXT EXISTS PATH 'strict $.aaa')) AS jt ON TRUE"
+    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, exists1 BOOLEAN EXISTS PATH '$.aaa', exists2 INT EXISTS PATH '$.aaa', exists3 INT EXISTS PATH 'strict $.aaa' UNKNOWN ON ERROR, exists4 TEXT EXISTS PATH 'strict $.aaa' FALSE ON ERROR)) AS jt ON TRUE"
   },
   {
     "comment": "sqljson_jsontable - Statement 21",
     "query": "SELECT * FROM json_table_test vals LEFT OUTER JOIN JSON_TABLE( vals.js::jsonb, 'lax $[*]' COLUMNS ( id FOR ORDINALITY, aaa int, aaa1 int PATH '$.aaa', js2 json PATH '$', jsb2w jsonb PATH '$' WITH WRAPPER, jsb2q jsonb PATH '$' OMIT QUOTES, ia int[] PATH '$', ta text[] PATH '$', jba jsonb[] PATH '$' ) ) jt ON true",
-    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, aaa INT, aaa1 INT PATH '$.aaa', js2 JSON PATH '$', jsb2w JSONB PATH '$', jsb2q JSONB PATH '$', ia INT[] PATH '$', ta TEXT[] PATH '$', jba JSONB[] PATH '$')) AS jt ON TRUE"
+    "expected": "SELECT * FROM json_table_test AS vals LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), 'lax $[*]' COLUMNS (id FOR ORDINALITY, aaa INT, aaa1 INT PATH '$.aaa', js2 JSON PATH '$', jsb2w JSONB PATH '$' WITH UNCONDITIONAL ARRAY WRAPPER, jsb2q JSONB PATH '$' OMIT QUOTES, ia INT[] PATH '$', ta TEXT[] PATH '$', jba JSONB[] PATH '$')) AS jt ON TRUE"
   },
   {
     "comment": "sqljson_jsontable - Statement 22",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"d1\": \"H\"}', '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT '\"foo1\"'::jsonb::text ON EMPTY))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT CAST(CAST('\"foo1\"' AS JSONB) AS TEXT) ON EMPTY))"
   },
   {
     "comment": "sqljson_jsontable - Statement 23",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"d1\": \"H\"}', '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT 'foo'::jsonb_test_domain ON EMPTY))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT CAST('foo' AS jsonb_test_domain) ON EMPTY))"
   },
   {
     "comment": "sqljson_jsontable - Statement 24",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"d1\": \"H\"}', '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT 'foo1'::jsonb_test_domain ON EMPTY))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"H\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.a2' DEFAULT CAST('foo1' AS jsonb_test_domain) ON EMPTY))"
   },
   {
     "comment": "sqljson_jsontable - Statement 25",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"d1\": \"foo\"}', '$' COLUMNS (js1 jsonb_test_domain PATH '$.d1' DEFAULT 'foo2'::jsonb_test_domain ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.d1'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$' COLUMNS (js1 jsonb_test_domain PATH '$.d1' DEFAULT CAST('foo2' AS jsonb_test_domain) ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 26",
     "query": "SELECT * FROM JSON_TABLE(jsonb '{\"d1\": \"foo\"}', '$' COLUMNS (js1 oid[] PATH '$.d2' DEFAULT '{1}'::int[]::oid[] ON EMPTY))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$' COLUMNS (js1 oid[] PATH '$.d2'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$' COLUMNS (js1 oid[] PATH '$.d2' DEFAULT CAST(CAST('{1}' AS INT[]) AS oid[]) ON EMPTY))"
   },
   {
     "comment": "sqljson_jsontable - Statement 27",
@@ -142,17 +142,17 @@
   {
     "comment": "sqljson_jsontable - Statement 29",
     "query": "CREATE VIEW jsonb_table_view4 AS SELECT * FROM JSON_TABLE( jsonb 'null', 'lax $[*]' PASSING 1 + 2 AS a, json '\"foo\"' AS \"b c\" COLUMNS ( jsb jsonb   FORMAT JSON PATH '$', jsbq jsonb FORMAT JSON PATH '$' OMIT QUOTES, aaa int, aaa1 int PATH '$.aaa'))",
-    "expected": "CREATE VIEW jsonb_table_view4 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (jsb JSONB FORMAT JSON PATH '$', jsbq JSONB FORMAT JSON PATH '$', aaa INT, aaa1 INT PATH '$.aaa'))"
+    "expected": "CREATE VIEW jsonb_table_view4 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (jsb JSONB FORMAT JSON PATH '$', jsbq JSONB FORMAT JSON PATH '$' OMIT QUOTES, aaa INT, aaa1 INT PATH '$.aaa'))"
   },
   {
     "comment": "sqljson_jsontable - Statement 30",
     "query": "CREATE VIEW jsonb_table_view5 AS SELECT * FROM JSON_TABLE( jsonb 'null', 'lax $[*]' PASSING 1 + 2 AS a, json '\"foo\"' AS \"b c\" COLUMNS ( exists1 bool EXISTS PATH '$.aaa', exists2 int EXISTS PATH '$.aaa' TRUE ON ERROR, exists3 text EXISTS PATH 'strict $.aaa' UNKNOWN ON ERROR))",
-    "expected": "CREATE VIEW jsonb_table_view5 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (exists1 BOOLEAN EXISTS PATH '$.aaa', exists2 INT EXISTS PATH '$.aaa', exists3 TEXT EXISTS PATH 'strict $.aaa'))"
+    "expected": "CREATE VIEW jsonb_table_view5 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (exists1 BOOLEAN EXISTS PATH '$.aaa', exists2 INT EXISTS PATH '$.aaa' TRUE ON ERROR, exists3 TEXT EXISTS PATH 'strict $.aaa' UNKNOWN ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 31",
     "query": "CREATE VIEW jsonb_table_view6 AS SELECT * FROM JSON_TABLE( jsonb 'null', 'lax $[*]' PASSING 1 + 2 AS a, json '\"foo\"' AS \"b c\" COLUMNS ( js2 json PATH '$', jsb2w jsonb PATH '$' WITH WRAPPER, jsb2q jsonb PATH '$' OMIT QUOTES, ia int[] PATH '$', ta text[] PATH '$', jba jsonb[] PATH '$'))",
-    "expected": "CREATE VIEW jsonb_table_view6 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (js2 JSON PATH '$', jsb2w JSONB PATH '$', jsb2q JSONB PATH '$', ia INT[] PATH '$', ta TEXT[] PATH '$', jba JSONB[] PATH '$'))"
+    "expected": "CREATE VIEW jsonb_table_view6 AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (js2 JSON PATH '$', jsb2w JSONB PATH '$' WITH UNCONDITIONAL ARRAY WRAPPER, jsb2q JSONB PATH '$' OMIT QUOTES, ia INT[] PATH '$', ta TEXT[] PATH '$', jba JSONB[] PATH '$'))"
   },
   {
     "comment": "sqljson_jsontable - Statement 32",
@@ -211,12 +211,12 @@
   {
     "comment": "sqljson_jsontable - Statement 44",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY, a int PATH '$.a' ERROR ON EMPTY)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY, a INT PATH '$.a')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY, a INT PATH '$.a' ERROR ON EMPTY)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 45",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, a int PATH '$' ERROR ON EMPTY)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, a INT PATH '$')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (id FOR ORDINALITY, a INT PATH '$' ERROR ON EMPTY)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 46",
@@ -226,47 +226,47 @@
   {
     "comment": "sqljson_jsontable - Statement 47",
     "query": "SELECT * FROM (VALUES ('1'), ('\"err\"')) vals(js) LEFT OUTER JOIN JSON_TABLE(vals.js::jsonb, '$' COLUMNS (a int PATH '$' ERROR ON ERROR)) jt ON true",
-    "expected": "SELECT * FROM (VALUES ('1'), ('\"err\"')) AS vals(js) LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), '$' COLUMNS (a INT PATH '$')) AS jt ON TRUE"
+    "expected": "SELECT * FROM (VALUES ('1'), ('\"err\"')) AS vals(js) LEFT OUTER JOIN JSON_TABLE(CAST(vals.js AS JSONB), '$' COLUMNS (a INT PATH '$' ERROR ON ERROR)) AS jt ON TRUE"
   },
   {
     "comment": "sqljson_jsontable - Statement 48",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int PATH '$.a' ERROR ON EMPTY)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH '$.a')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH '$.a' ERROR ON EMPTY)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 49",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int PATH 'strict $.a' ERROR ON ERROR) ERROR ON ERROR) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH 'strict $.a') ERROR ON ERROR) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH 'strict $.a' ERROR ON ERROR) ERROR ON ERROR) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 50",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int PATH 'lax $.a' ERROR ON EMPTY) ERROR ON ERROR) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH 'lax $.a') ERROR ON ERROR) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT PATH 'lax $.a' ERROR ON EMPTY) ERROR ON ERROR) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 51",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a int PATH '$'   DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH '$')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH '$' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 52",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a int PATH 'strict $.a' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH 'strict $.a')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH 'strict $.a' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 53",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a int PATH 'lax $.a' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH 'lax $.a')) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT PATH 'lax $.a' DEFAULT 1 ON EMPTY DEFAULT 2 ON ERROR)) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 54",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a int4 EXISTS PATH '$.a' ERROR ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT EXISTS PATH '$.a'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT EXISTS PATH '$.a' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 55",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a int4 EXISTS PATH '$' ERROR ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT EXISTS PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a INT EXISTS PATH '$' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 56",
@@ -291,12 +291,12 @@
   {
     "comment": "sqljson_jsontable - Statement 60",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a char(3) EXISTS PATH '$.a' ERROR ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a CHAR(3) EXISTS PATH '$.a'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a CHAR(3) EXISTS PATH '$.a' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 61",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"a\"', '$' COLUMNS (a char(5) EXISTS PATH '$.a' ERROR ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a CHAR(5) EXISTS PATH '$.a'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"a\"' AS JSONB), '$' COLUMNS (a CHAR(5) EXISTS PATH '$.a' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 62",
@@ -331,17 +331,17 @@
   {
     "comment": "sqljson_jsontable - Statement 68",
     "query": "SELECT a, a::bool FROM JSON_TABLE(jsonb '{\"a\":1}', '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' ERROR ON ERROR))",
-    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b'))"
+    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 69",
     "query": "SELECT a, a::bool FROM JSON_TABLE(jsonb '{\"a\":1}', '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' FALSE ON ERROR))",
-    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b'))"
+    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' FALSE ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 70",
     "query": "SELECT a, a::bool FROM JSON_TABLE(jsonb '{\"a\":1}', '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' TRUE ON ERROR))",
-    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b'))"
+    "expected": "SELECT a, CAST(a AS BOOLEAN) FROM JSON_TABLE(CAST('{\"a\":1}' AS JSONB), '$' COLUMNS (a dint4_0 EXISTS PATH '$.b' TRUE ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 71",
@@ -350,47 +350,47 @@
   {
     "comment": "sqljson_jsontable - Statement 72",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text PATH '$' KEEP QUOTES ON SCALAR STRING))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$' KEEP QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 73",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text PATH '$' OMIT QUOTES ON SCALAR STRING))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$' OMIT QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 74",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text FORMAT JSON PATH '$' KEEP QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$' KEEP QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 75",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text FORMAT JSON PATH '$' OMIT QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$' OMIT QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 76",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text FORMAT JSON PATH '$' WITHOUT WRAPPER KEEP QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$' WITHOUT ARRAY WRAPPER KEEP QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 77",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text PATH '$' WITHOUT WRAPPER OMIT QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$' WITHOUT ARRAY WRAPPER OMIT QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 78",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text FORMAT JSON PATH '$' WITH WRAPPER))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$' WITH UNCONDITIONAL ARRAY WRAPPER))"
   },
   {
     "comment": "sqljson_jsontable - Statement 79",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text PATH '$' WITH WRAPPER OMIT QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT PATH '$' WITH UNCONDITIONAL ARRAY WRAPPER OMIT QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 80",
     "query": "SELECT * FROM JSON_TABLE(jsonb '\"world\"', '$' COLUMNS (item text FORMAT JSON PATH '$' WITH WRAPPER KEEP QUOTES))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$'))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('\"world\"' AS JSONB), '$' COLUMNS (item TEXT FORMAT JSON PATH '$' WITH UNCONDITIONAL ARRAY WRAPPER KEEP QUOTES))"
   },
   {
     "comment": "sqljson_jsontable - Statement 81",
@@ -410,27 +410,27 @@
   {
     "comment": "sqljson_jsontable - Statement 84",
     "query": "SELECT * FROM JSON_TABLE('{\"a\": [{\"b\": \"1\"}, {\"b\": \"2\"}]}', '$' COLUMNS (b json path '$.a[*].b' ERROR ON ERROR))",
-    "expected": "SELECT * FROM JSON_TABLE('{\"a\": [{\"b\": \"1\"}, {\"b\": \"2\"}]}', '$' COLUMNS (b JSON PATH '$.a[*].b'))"
+    "expected": "SELECT * FROM JSON_TABLE('{\"a\": [{\"b\": \"1\"}, {\"b\": \"2\"}]}', '$' COLUMNS (b JSON PATH '$.a[*].b' ERROR ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 85",
     "query": "SELECT * FROM JSON_TABLE( jsonb '[]', '$' AS a COLUMNS ( b int, NESTED PATH '$' AS a COLUMNS ( c int ) ) ) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (b INT, NESTED PATH '$' COLUMNS (c INT))) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' AS a COLUMNS (b INT, NESTED PATH '$' AS a COLUMNS (c INT))) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 86",
     "query": "SELECT * FROM JSON_TABLE( jsonb '[]', '$' AS a COLUMNS ( b int, NESTED PATH '$' AS n_a COLUMNS ( c int ) ) ) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (b INT, NESTED PATH '$' COLUMNS (c INT))) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' AS a COLUMNS (b INT, NESTED PATH '$' AS n_a COLUMNS (c INT))) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 87",
     "query": "SELECT * FROM JSON_TABLE( jsonb '[]', '$' COLUMNS ( b int, NESTED PATH '$' AS b COLUMNS ( c int ) ) ) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (b INT, NESTED PATH '$' COLUMNS (c INT))) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (b INT, NESTED PATH '$' AS b COLUMNS (c INT))) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 88",
     "query": "SELECT * FROM JSON_TABLE( jsonb '[]', '$' COLUMNS ( NESTED PATH '$' AS a COLUMNS ( b int ), NESTED PATH '$' COLUMNS ( NESTED PATH '$' AS a COLUMNS ( c int ) ) ) ) jt",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (NESTED PATH '$' COLUMNS (b INT), NESTED PATH '$' COLUMNS (NESTED PATH '$' COLUMNS (c INT)))) AS jt"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('[]' AS JSONB), '$' COLUMNS (NESTED PATH '$' AS a COLUMNS (b INT), NESTED PATH '$' COLUMNS (NESTED PATH '$' AS a COLUMNS (c INT)))) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 89",
@@ -445,7 +445,7 @@
   {
     "comment": "sqljson_jsontable - Statement 91",
     "query": "select jt.* from jsonb_table_test jtt, json_table ( jtt.js,'strict $[*]' as p columns ( n for ordinality, a int path 'lax $.a' default -1 on empty, nested path 'strict $.b[*]' as pb columns (b_id for ordinality, b int path '$' ), nested path 'strict $.c[*]' as pc columns (c_id for ordinality, c int path '$' ) ) ) jt",
-    "expected": "SELECT jt.* FROM jsonb_table_test AS jtt, JSON_TABLE(jtt.js, 'strict $[*]' COLUMNS (n FOR ORDINALITY, a INT PATH 'lax $.a', NESTED PATH 'strict $.b[*]' COLUMNS (b_id FOR ORDINALITY, b INT PATH '$'), NESTED PATH 'strict $.c[*]' COLUMNS (c_id FOR ORDINALITY, c INT PATH '$'))) AS jt"
+    "expected": "SELECT jt.* FROM jsonb_table_test AS jtt, JSON_TABLE(jtt.js, 'strict $[*]' AS p COLUMNS (n FOR ORDINALITY, a INT PATH 'lax $.a' DEFAULT -1 ON EMPTY, NESTED PATH 'strict $.b[*]' AS pb COLUMNS (b_id FOR ORDINALITY, b INT PATH '$'), NESTED PATH 'strict $.c[*]' AS pc COLUMNS (c_id FOR ORDINALITY, c INT PATH '$'))) AS jt"
   },
   {
     "comment": "sqljson_jsontable - Statement 92",
@@ -455,7 +455,7 @@
   {
     "comment": "sqljson_jsontable - Statement 93",
     "query": "CREATE VIEW jsonb_table_view_nested AS SELECT * FROM JSON_TABLE( jsonb 'null', 'lax $[*]' PASSING 1 + 2 AS a, json '\"foo\"' AS \"b c\" COLUMNS ( id FOR ORDINALITY, NESTED PATH '$[1]' AS p1 COLUMNS ( a1 int, NESTED PATH '$[*]' AS \"p1 1\" COLUMNS ( a11 text ), b1 text ), NESTED PATH '$[2]' AS p2 COLUMNS ( NESTED PATH '$[*]' AS \"p2:1\" COLUMNS ( a21 text ), NESTED PATH '$[*]' AS p22 COLUMNS ( a22 text ) ) ) )",
-    "expected": "CREATE VIEW jsonb_table_view_nested AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (id FOR ORDINALITY, NESTED PATH '$[1]' COLUMNS (a1 INT, NESTED PATH '$[*]' COLUMNS (a11 TEXT), b1 TEXT), NESTED PATH '$[2]' COLUMNS (NESTED PATH '$[*]' COLUMNS (a21 TEXT), NESTED PATH '$[*]' COLUMNS (a22 TEXT))))"
+    "expected": "CREATE VIEW jsonb_table_view_nested AS SELECT * FROM JSON_TABLE(CAST('null' AS JSONB), 'lax $[*]' PASSING 1 + 2 AS a, CAST('\"foo\"' AS JSON) AS \"b c\" COLUMNS (id FOR ORDINALITY, NESTED PATH '$[1]' AS p1 COLUMNS (a1 INT, NESTED PATH '$[*]' AS \"p1 1\" COLUMNS (a11 TEXT), b1 TEXT), NESTED PATH '$[2]' AS p2 COLUMNS (NESTED PATH '$[*]' AS \"p2:1\" COLUMNS (a21 TEXT), NESTED PATH '$[*]' AS p22 COLUMNS (a22 TEXT))))"
   },
   {
     "comment": "sqljson_jsontable - Statement 94",
@@ -469,32 +469,32 @@
   {
     "comment": "sqljson_jsontable - Statement 96",
     "query": "SELECT sub.* FROM s, JSON_TABLE(js, '$' PASSING 32 AS x, 13 AS y COLUMNS ( xx int path '$.c', NESTED PATH '$.a.za[1]' columns (NESTED PATH '$.z21[*]' COLUMNS (z21 int path '$?(@ \u003e= $\"x\")' ERROR ON ERROR)) )) sub",
-    "expected": "SELECT sub.* FROM s, JSON_TABLE(js, '$' PASSING 32 AS x, 13 AS y COLUMNS (xx INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (z21 INT PATH '$?(@ \u003e= $\"x\")')))) AS sub"
+    "expected": "SELECT sub.* FROM s, JSON_TABLE(js, '$' PASSING 32 AS x, 13 AS y COLUMNS (xx INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (z21 INT PATH '$?(@ \u003e= $\"x\")' ERROR ON ERROR)))) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 97",
     "query": "SELECT sub.* FROM s, (VALUES (23)) x(x), generate_series(13, 13) y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS ( NESTED PATH '$.a.za[2]' COLUMNS ( NESTED PATH '$.z22[*]' as z22 COLUMNS (c int PATH '$')), NESTED PATH '$.a.za[1]' columns (d int[] PATH '$.z21'), NESTED PATH '$.a.za[0]' columns (NESTED PATH '$.z1[*]' as z1 COLUMNS (a int PATH  '$')), xx1 int PATH '$.c', NESTED PATH '$.a.za[1]'  columns (NESTED PATH '$.z21[*]' as z21 COLUMNS (b int PATH '$')), xx int PATH '$.c' )) sub",
-    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' PASSING x AS x, y AS y COLUMNS (NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' COLUMNS (c INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d INT[] PATH '$.z21'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*]' COLUMNS (a INT PATH '$')), xx1 INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (b INT PATH '$')), xx INT PATH '$.c')) AS sub"
+    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS (NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' AS z22 COLUMNS (c INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d INT[] PATH '$.z21'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*]' AS z1 COLUMNS (a INT PATH '$')), xx1 INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' AS z21 COLUMNS (b INT PATH '$')), xx INT PATH '$.c')) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 98",
     "query": "SELECT sub.* FROM s, (VALUES (23)) x(x), generate_series(13, 13) y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS ( xx1 int PATH '$.c', NESTED PATH '$.a.za[0].z1[*]' COLUMNS (NESTED PATH '$ ?(@ \u003e= ($\"x\" -2))' COLUMNS (a int PATH '$')), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' COLUMNS (b int PATH '$')) )) sub",
-    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[0].z1[*]' COLUMNS (NESTED PATH '$ ?(@ \u003e= ($\"x\" -2))' COLUMNS (a INT PATH '$')), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' COLUMNS (b INT PATH '$')))) AS sub"
+    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[0].z1[*]' COLUMNS (NESTED PATH '$ ?(@ \u003e= ($\"x\" -2))' COLUMNS (a INT PATH '$')), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' COLUMNS (b INT PATH '$')))) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 99",
     "query": "SELECT sub.* FROM s, (VALUES (23)) x(x), generate_series(13, 13) y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS ( xx1 int PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (b int PATH '$')), NESTED PATH '$.a.za[1] ? (@.z21[*] \u003e= ($\"x\"-1))' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" + 3))' as z22 COLUMNS (a int PATH '$ ? (@ \u003e= ($\"y\" + 12))')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' as z21 COLUMNS (c int PATH '$ ? (@ \u003e ($\"x\" +111))')) )) sub",
-    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (b INT PATH '$')), NESTED PATH '$.a.za[1] ? (@.z21[*] \u003e= ($\"x\"-1))' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" + 3))' COLUMNS (a INT PATH '$ ? (@ \u003e= ($\"y\" + 12))')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' COLUMNS (c INT PATH '$ ? (@ \u003e ($\"x\" +111))')))) AS sub"
+    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*]' COLUMNS (b INT PATH '$')), NESTED PATH '$.a.za[1] ? (@.z21[*] \u003e= ($\"x\"-1))' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" + 3))' AS z22 COLUMNS (a INT PATH '$ ? (@ \u003e= ($\"y\" + 12))')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' AS z21 COLUMNS (c INT PATH '$ ? (@ \u003e ($\"x\" +111))')))) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 100",
     "query": "SELECT sub.* FROM s, (values(23)) x(x), generate_series(13, 13) y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS ( xx1 int PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' as z22 COLUMNS (c int PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d json PATH '$ ? (@.z21[*] == ($\"x\" -1))'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' as z1 COLUMNS (a int PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' as z21 COLUMNS (b int PATH '$ ? (@ \u003e ($\"x\" +111))' DEFAULT 0 ON EMPTY)) )) sub",
-    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' COLUMNS (c INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d JSON PATH '$ ? (@.z21[*] == ($\"x\" -1))'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' COLUMNS (a INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' COLUMNS (b INT PATH '$ ? (@ \u003e ($\"x\" +111))')))) AS sub"
+    "expected": "SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' AS z22 COLUMNS (c INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d JSON PATH '$ ? (@.z21[*] == ($\"x\" -1))'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' AS z1 COLUMNS (a INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' AS z21 COLUMNS (b INT PATH '$ ? (@ \u003e ($\"x\" +111))' DEFAULT 0 ON EMPTY)))) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 101",
     "query": "CREATE OR REPLACE VIEW jsonb_table_view7 AS SELECT sub.* FROM s, (values(23)) x(x), generate_series(13, 13) y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS ( xx1 int PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' as z22 COLUMNS (c int PATH '$' WITHOUT WRAPPER OMIT QUOTES)), NESTED PATH '$.a.za[1]' COLUMNS (d json PATH '$ ? (@.z21[*] == ($\"x\" -1))' WITH WRAPPER), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' as z1 COLUMNS (a int PATH '$' KEEP QUOTES)), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' as z21 COLUMNS (b int PATH '$ ? (@ \u003e ($\"x\" +111))' DEFAULT 0 ON EMPTY)) )) sub",
-    "expected": "CREATE OR REPLACE VIEW jsonb_table_view7 AS SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' COLUMNS (c INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (d JSON PATH '$ ? (@.z21[*] == ($\"x\" -1))'), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' COLUMNS (a INT PATH '$')), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' COLUMNS (b INT PATH '$ ? (@ \u003e ($\"x\" +111))')))) AS sub"
+    "expected": "CREATE OR REPLACE VIEW jsonb_table_view7 AS SELECT sub.* FROM s, (VALUES (23)) AS x(x), generate_series(13, 13) AS y, JSON_TABLE(js, '$' AS c1 PASSING x AS x, y AS y COLUMNS (xx1 INT PATH '$.c', NESTED PATH '$.a.za[2]' COLUMNS (NESTED PATH '$.z22[*]' AS z22 COLUMNS (c INT PATH '$' WITHOUT ARRAY WRAPPER OMIT QUOTES)), NESTED PATH '$.a.za[1]' COLUMNS (d JSON PATH '$ ? (@.z21[*] == ($\"x\" -1))' WITH UNCONDITIONAL ARRAY WRAPPER), NESTED PATH '$.a.za[0]' COLUMNS (NESTED PATH '$.z1[*] ? (@ \u003e= ($\"x\" -2))' AS z1 COLUMNS (a INT PATH '$' KEEP QUOTES)), NESTED PATH '$.a.za[1]' COLUMNS (NESTED PATH '$.z21[*] ? (@ \u003e= ($\"y\" +121))' AS z21 COLUMNS (b INT PATH '$ ? (@ \u003e ($\"x\" +111))' DEFAULT 0 ON EMPTY)))) AS sub"
   },
   {
     "comment": "sqljson_jsontable - Statement 102",
@@ -513,17 +513,17 @@
   {
     "comment": "sqljson_jsontable - Statement 105",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on empty))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT TRUE ON EMPTY))"
   },
   {
     "comment": "sqljson_jsontable - Statement 106",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int omit quotes true on error))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT OMIT QUOTES TRUE ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 107",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on error))",
-    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT EXISTS))"
+    "expected": "SELECT * FROM JSON_TABLE(CAST('1' AS JSONB), '$' COLUMNS (a INT EXISTS EMPTY OBJECT ON ERROR))"
   },
   {
     "comment": "sqljson_jsontable - Statement 108",

--- a/go/common/parser/testdata/postgres/sqljson_queryfuncs.json
+++ b/go/common/parser/testdata/postgres/sqljson_queryfuncs.json
@@ -37,7 +37,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 8",
     "query": "SELECT JSON_EXISTS(jsonb '1', 'strict $.a' ERROR ON ERROR)",
-    "expected": "SELECT JSON_EXISTS(CAST('1' AS JSONB), 'strict $.a')"
+    "expected": "SELECT JSON_EXISTS(CAST('1' AS JSONB), 'strict $.a' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 9",
@@ -87,22 +87,22 @@
   {
     "comment": "sqljson_queryfuncs - Statement 18",
     "query": "SELECT JSON_EXISTS(jsonb '{\"a\": 1, \"b\": 2}', '$.* ? (@ \u003e $x)' PASSING 1 AS x)",
-    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)')"
+    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)' PASSING 1 AS x)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 19",
     "query": "SELECT JSON_EXISTS(jsonb '{\"a\": 1, \"b\": 2}', '$.* ? (@ \u003e $x)' PASSING '1' AS x)",
-    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)')"
+    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)' PASSING '1' AS x)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 20",
     "query": "SELECT JSON_EXISTS(jsonb '{\"a\": 1, \"b\": 2}', '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)' PASSING 0 AS x, 2 AS y)",
-    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)')"
+    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)' PASSING 0 AS x, 2 AS y)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 21",
     "query": "SELECT JSON_EXISTS(jsonb '{\"a\": 1, \"b\": 2}', '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)' PASSING 0 AS x, 1 AS y)",
-    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)')"
+    "expected": "SELECT JSON_EXISTS(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x \u0026\u0026 @ \u003c $y)' PASSING 0 AS x, 1 AS y)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 22",
@@ -112,7 +112,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 23",
     "query": "SELECT JSON_EXISTS(jsonb '1', '$.a \u003e 2' ERROR ON ERROR)",
-    "expected": "SELECT JSON_EXISTS(CAST('1' AS JSONB), '$.a \u003e 2')"
+    "expected": "SELECT JSON_EXISTS(CAST('1' AS JSONB), '$.a \u003e 2' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 24",
@@ -157,7 +157,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 32",
     "query": "/* jsonb bytea ??? */ SELECT JSON_VALUE(jsonb '123', '$' RETURNING bytea ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING BYTEA)"
+    "expected": "SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING BYTEA ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 33",
@@ -177,7 +177,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 36",
     "query": "SELECT JSON_VALUE(jsonb '\"1.23\"', '$' RETURNING int ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"1.23\"' AS JSONB), '$' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('\"1.23\"' AS JSONB), '$' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 37",
@@ -197,7 +197,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 40",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING char(2) ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(2))"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(2) ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 41",
@@ -207,7 +207,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 42",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING char(3) ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3))"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3) ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 43",
@@ -222,12 +222,12 @@
   {
     "comment": "sqljson_queryfuncs - Statement 45",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING json ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSON)"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSON ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 46",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING jsonb ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSONB)"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSONB ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 47",
@@ -247,12 +247,12 @@
   {
     "comment": "sqljson_queryfuncs - Statement 50",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING int ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 51",
     "query": "SELECT JSON_VALUE(jsonb '\"aaa\"', '$' RETURNING int DEFAULT 111 ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('\"aaa\"' AS JSONB), '$' RETURNING INT DEFAULT 111 ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 52",
@@ -277,22 +277,22 @@
   {
     "comment": "sqljson_queryfuncs - Statement 56",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$' RETURNING sqljsonb_int_not_null ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$' RETURNING sqljsonb_int_not_null)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$' RETURNING sqljsonb_int_not_null ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 57",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$' RETURNING sqljsonb_int_not_null DEFAULT 2 ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$' RETURNING sqljsonb_int_not_null)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$' RETURNING sqljsonb_int_not_null DEFAULT 2 ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 58",
     "query": "SELECT JSON_VALUE(jsonb '1',  '$.a' RETURNING sqljsonb_int_not_null DEFAULT 2 ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), '$.a' RETURNING sqljsonb_int_not_null)"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), '$.a' RETURNING sqljsonb_int_not_null DEFAULT 2 ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 59",
     "query": "SELECT JSON_VALUE(jsonb '1',  '$.a' RETURNING sqljsonb_int_not_null DEFAULT NULL ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), '$.a' RETURNING sqljsonb_int_not_null)"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), '$.a' RETURNING sqljsonb_int_not_null DEFAULT NULL ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 60",
@@ -311,7 +311,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 63",
     "query": "SELECT JSON_VALUE('\"purple\"'::jsonb, 'lax $[*]' RETURNING rgb ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('\"purple\"' AS JSONB), 'lax $[*]' RETURNING rgb)"
+    "expected": "SELECT JSON_VALUE(CAST('\"purple\"' AS JSONB), 'lax $[*]' RETURNING rgb ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 64",
@@ -321,7 +321,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 65",
     "query": "SELECT JSON_VALUE(jsonb '[]', '$' ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[]' AS JSONB), '$')"
+    "expected": "SELECT JSON_VALUE(CAST('[]' AS JSONB), '$' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 66",
@@ -331,7 +331,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 67",
     "query": "SELECT JSON_VALUE(jsonb '{}', '$' ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('{}' AS JSONB), '$')"
+    "expected": "SELECT JSON_VALUE(CAST('{}' AS JSONB), '$' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 68",
@@ -341,82 +341,82 @@
   {
     "comment": "sqljson_queryfuncs - Statement 69",
     "query": "SELECT JSON_VALUE(jsonb '1', 'strict $.a' ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.a' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 70",
     "query": "SELECT JSON_VALUE(jsonb '1', 'strict $.a' DEFAULT 'error' ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.a' DEFAULT 'error' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 71",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 72",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' ERROR ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' ERROR ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 73",
     "query": "SELECT JSON_VALUE(jsonb '1', 'strict $.*' DEFAULT 2 ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.*')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'strict $.*' DEFAULT 2 ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 74",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' DEFAULT 2 ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' DEFAULT 2 ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 75",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' DEFAULT '2' ON EMPTY)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' DEFAULT '2' ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 76",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' NULL ON EMPTY DEFAULT '2' ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' NULL ON EMPTY DEFAULT '2' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 77",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' DEFAULT '2' ON EMPTY DEFAULT '3' ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' DEFAULT '2' ON EMPTY DEFAULT '3' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 78",
     "query": "SELECT JSON_VALUE(jsonb '1', 'lax $.a' ERROR ON EMPTY DEFAULT '3' ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a')"
+    "expected": "SELECT JSON_VALUE(CAST('1' AS JSONB), 'lax $.a' ERROR ON EMPTY DEFAULT '3' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 79",
     "query": "SELECT JSON_VALUE(jsonb '[1,2]', '$[*]' ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[1,2]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_VALUE(CAST('[1,2]' AS JSONB), '$[*]' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 80",
     "query": "SELECT JSON_VALUE(jsonb '[1,2]', '$[*]' DEFAULT '0' ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[1,2]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_VALUE(CAST('[1,2]' AS JSONB), '$[*]' DEFAULT '0' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 81",
     "query": "SELECT JSON_VALUE(jsonb '[\" \"]', '$[*]' RETURNING int ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[\" \"]' AS JSONB), '$[*]' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('[\" \"]' AS JSONB), '$[*]' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 82",
     "query": "SELECT JSON_VALUE(jsonb '[\" \"]', '$[*]' RETURNING int DEFAULT 2 + 3 ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[\" \"]' AS JSONB), '$[*]' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('[\" \"]' AS JSONB), '$[*]' RETURNING INT DEFAULT 2 + 3 ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 83",
     "query": "SELECT JSON_VALUE(jsonb '[\"1\"]', '$[*]' RETURNING int DEFAULT 2 + 3 ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('[\"1\"]' AS JSONB), '$[*]' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('[\"1\"]' AS JSONB), '$[*]' RETURNING INT DEFAULT 2 + 3 ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 84",
     "query": "SELECT JSON_VALUE(jsonb '[\"1\"]', '$[*]' RETURNING int FORMAT JSON)",
-    "expected": "SELECT JSON_VALUE(CAST('[\"1\"]' AS JSONB), '$[*]' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE(CAST('[\"1\"]' AS JSONB), '$[*]' RETURNING INT FORMAT JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 85",
@@ -426,87 +426,87 @@
   {
     "comment": "sqljson_queryfuncs - Statement 86",
     "query": "SELECT x, JSON_VALUE( jsonb '{\"a\": 1, \"b\": 2}', '$.* ? (@ \u003e $x)' PASSING x AS x RETURNING int DEFAULT -1 ON EMPTY DEFAULT -2 ON ERROR ) y FROM generate_series(0, 2) x",
-    "expected": "SELECT x, JSON_VALUE(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)' RETURNING INT) AS y FROM generate_series(0, 2) AS x"
+    "expected": "SELECT x, JSON_VALUE(CAST('{\"a\": 1, \"b\": 2}' AS JSONB), '$.* ? (@ \u003e $x)' PASSING x AS x RETURNING INT DEFAULT -1 ON EMPTY DEFAULT -2 ON ERROR) AS y FROM generate_series(0, 2) AS x"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 87",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$a' PASSING point ' (1, 2 )' AS a)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a')"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a' PASSING CAST(' (1, 2 )' AS point) AS a)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 88",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$a' PASSING point ' (1, 2 )' AS a RETURNING point)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a' RETURNING point)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a' PASSING CAST(' (1, 2 )' AS point) AS a RETURNING point)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 89",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$a' PASSING point ' (1, 2 )' AS a RETURNING point ERROR ON ERROR)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a' RETURNING point)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$a' PASSING CAST(' (1, 2 )' AS point) AS a RETURNING point ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 90",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts')"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 91",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING timestamptz)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING TIMESTAMPTZ)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING TIMESTAMPTZ)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 92",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING timestamp)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING TIMESTAMP)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING TIMESTAMP)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 93",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING date '2018-02-21 12:34:56 +10' AS ts RETURNING date)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING DATE)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS DATE) AS ts RETURNING DATE)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 94",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING time '2018-02-21 12:34:56 +10' AS ts RETURNING time)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING TIME)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIME) AS ts RETURNING TIME)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 95",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timetz '2018-02-21 12:34:56 +10' AS ts RETURNING timetz)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING TIMETZ)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMETZ) AS ts RETURNING TIMETZ)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 96",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamp '2018-02-21 12:34:56 +10' AS ts RETURNING timestamp)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING TIMESTAMP)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMP) AS ts RETURNING TIMESTAMP)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 97",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING json)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING JSON)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 98",
     "query": "SELECT JSON_VALUE(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING jsonb)",
-    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' RETURNING JSONB)"
+    "expected": "SELECT JSON_VALUE(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING JSONB)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 99",
     "query": "select json_value('{\"a\": 1.234}', '$.a' returning int error on error)",
-    "expected": "SELECT JSON_VALUE('{\"a\": 1.234}', '$.a' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE('{\"a\": 1.234}', '$.a' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 100",
     "query": "select json_value('{\"a\": \"1.234\"}', '$.a' returning int error on error)",
-    "expected": "SELECT JSON_VALUE('{\"a\": \"1.234\"}', '$.a' RETURNING INT)"
+    "expected": "SELECT JSON_VALUE('{\"a\": \"1.234\"}', '$.a' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 101",
     "query": "SELECT JSON_QUERY(js, '$') AS \"unspec\", JSON_QUERY(js, '$' WITHOUT WRAPPER) AS \"without\", JSON_QUERY(js, '$' WITH CONDITIONAL WRAPPER) AS \"with cond\", JSON_QUERY(js, '$' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with uncond\", JSON_QUERY(js, '$' WITH ARRAY WRAPPER) AS \"with\" FROM (VALUES (jsonb 'null'), ('12.3'), ('true'), ('\"aaa\"'), ('[1, null, \"2\"]'), ('{\"a\": 1, \"b\": [2]}') ) foo(js)",
-    "expected": "SELECT JSON_QUERY(js, '$') AS unspec, JSON_QUERY(js, '$') AS without, JSON_QUERY(js, '$') AS \"with cond\", JSON_QUERY(js, '$') AS \"with uncond\", JSON_QUERY(js, '$') AS \"with\" FROM (VALUES (CAST('null' AS JSONB)), ('12.3'), ('true'), ('\"aaa\"'), ('[1, null, \"2\"]'), ('{\"a\": 1, \"b\": [2]}')) AS foo(js)"
+    "expected": "SELECT JSON_QUERY(js, '$') AS unspec, JSON_QUERY(js, '$' WITHOUT ARRAY WRAPPER) AS without, JSON_QUERY(js, '$' WITH CONDITIONAL ARRAY WRAPPER) AS \"with cond\", JSON_QUERY(js, '$' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with uncond\", JSON_QUERY(js, '$' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with\" FROM (VALUES (CAST('null' AS JSONB)), ('12.3'), ('true'), ('\"aaa\"'), ('[1, null, \"2\"]'), ('{\"a\": 1, \"b\": [2]}')) AS foo(js)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 102",
     "query": "SELECT JSON_QUERY(js, 'strict $[*]') AS \"unspec\", JSON_QUERY(js, 'strict $[*]' WITHOUT WRAPPER) AS \"without\", JSON_QUERY(js, 'strict $[*]' WITH CONDITIONAL WRAPPER) AS \"with cond\", JSON_QUERY(js, 'strict $[*]' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with uncond\", JSON_QUERY(js, 'strict $[*]' WITH ARRAY WRAPPER) AS \"with\" FROM (VALUES (jsonb '1'), ('[]'), ('[null]'), ('[12.3]'), ('[true]'), ('[\"aaa\"]'), ('[[1, 2, 3]]'), ('[{\"a\": 1, \"b\": [2]}]'), ('[1, \"2\", null, [3]]') ) foo(js)",
-    "expected": "SELECT JSON_QUERY(js, 'strict $[*]') AS unspec, JSON_QUERY(js, 'strict $[*]') AS without, JSON_QUERY(js, 'strict $[*]') AS \"with cond\", JSON_QUERY(js, 'strict $[*]') AS \"with uncond\", JSON_QUERY(js, 'strict $[*]') AS \"with\" FROM (VALUES (CAST('1' AS JSONB)), ('[]'), ('[null]'), ('[12.3]'), ('[true]'), ('[\"aaa\"]'), ('[[1, 2, 3]]'), ('[{\"a\": 1, \"b\": [2]}]'), ('[1, \"2\", null, [3]]')) AS foo(js)"
+    "expected": "SELECT JSON_QUERY(js, 'strict $[*]') AS unspec, JSON_QUERY(js, 'strict $[*]' WITHOUT ARRAY WRAPPER) AS without, JSON_QUERY(js, 'strict $[*]' WITH CONDITIONAL ARRAY WRAPPER) AS \"with cond\", JSON_QUERY(js, 'strict $[*]' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with uncond\", JSON_QUERY(js, 'strict $[*]' WITH UNCONDITIONAL ARRAY WRAPPER) AS \"with\" FROM (VALUES (CAST('1' AS JSONB)), ('[]'), ('[null]'), ('[12.3]'), ('[true]'), ('[\"aaa\"]'), ('[[1, 2, 3]]'), ('[{\"a\": 1, \"b\": [2]}]'), ('[1, \"2\", null, [3]]')) AS foo(js)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 103",
@@ -516,42 +516,42 @@
   {
     "comment": "sqljson_queryfuncs - Statement 104",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING text KEEP QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 105",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING text KEEP QUOTES ON SCALAR STRING)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 106",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING text OMIT QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 107",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING text OMIT QUOTES ON SCALAR STRING)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING TEXT OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 108",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$')"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 109",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING json OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSON)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING JSON OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 110",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING bytea FORMAT JSON OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING BYTEA)"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING BYTEA FORMAT JSON OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 111",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING char(3) ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3))"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3) ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 112",
@@ -561,82 +561,82 @@
   {
     "comment": "sqljson_queryfuncs - Statement 113",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$' RETURNING char(3) OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3))"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$' RETURNING CHAR(3) OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 114",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$.a' RETURNING char(2) OMIT QUOTES DEFAULT 'bb' ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$.a' RETURNING CHAR(2))"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$.a' RETURNING CHAR(2) OMIT QUOTES DEFAULT 'bb' ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 115",
     "query": "SELECT JSON_QUERY(jsonb '\"aaa\"', '$.a' RETURNING char(2) OMIT QUOTES DEFAULT '\"bb\"'::jsonb ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$.a' RETURNING CHAR(2))"
+    "expected": "SELECT JSON_QUERY(CAST('\"aaa\"' AS JSONB), '$.a' RETURNING CHAR(2) OMIT QUOTES DEFAULT CAST('\"bb\"' AS JSONB) ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 116",
     "query": "SELECT JSON_QUERY(jsonb '[1]', '$' WITH WRAPPER OMIT QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[1]' AS JSONB), '$')"
+    "expected": "SELECT JSON_QUERY(CAST('[1]' AS JSONB), '$' WITH UNCONDITIONAL ARRAY WRAPPER OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 117",
     "query": "SELECT JSON_QUERY(jsonb '[1]', '$' WITH CONDITIONAL WRAPPER OMIT QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[1]' AS JSONB), '$')"
+    "expected": "SELECT JSON_QUERY(CAST('[1]' AS JSONB), '$' WITH CONDITIONAL ARRAY WRAPPER OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 118",
     "query": "SELECT JSON_QUERY(jsonb '[\"1\"]', '$[*]' WITH CONDITIONAL WRAPPER KEEP QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]' WITH CONDITIONAL ARRAY WRAPPER KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 119",
     "query": "SELECT JSON_QUERY(jsonb '[\"1\"]', '$[*]' WITH UNCONDITIONAL WRAPPER KEEP QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]' WITH UNCONDITIONAL ARRAY WRAPPER KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 120",
     "query": "SELECT JSON_QUERY(jsonb '[\"1\"]', '$[*]' WITH WRAPPER KEEP QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]' WITH UNCONDITIONAL ARRAY WRAPPER KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 121",
     "query": "SELECT JSON_QUERY(jsonb '[\"1\"]', '$[*]' WITHOUT WRAPPER OMIT QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]' WITHOUT ARRAY WRAPPER OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 122",
     "query": "SELECT JSON_QUERY(jsonb '[\"1\"]', '$[*]' WITHOUT WRAPPER KEEP QUOTES)",
-    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[\"1\"]' AS JSONB), '$[*]' WITHOUT ARRAY WRAPPER KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 123",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"{1,2,3}\"}', '$.rec' returning int[] omit quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[] OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 124",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"{1,2,3}\"}', '$.rec' returning int[] keep quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[] KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 125",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"{1,2,3}\"}', '$.rec' returning int[] keep quotes error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"{1,2,3}\"}' AS JSONB), '$.rec' RETURNING INT[] KEEP QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 126",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"[1,2]\"}', '$.rec' returning int4range omit quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 127",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"[1,2]\"}', '$.rec' returning int4range keep quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 128",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"[1,2]\"}', '$.rec' \treturning int4range keep quotes error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"[1,2]\"}' AS JSONB), '$.rec' RETURNING int4range KEEP QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 129",
@@ -651,12 +651,12 @@
   {
     "comment": "sqljson_queryfuncs - Statement 131",
     "query": "SELECT JSON_QUERY(jsonb '\"1\"', '$' RETURNING qf_char_domain OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"1\"' AS JSONB), '$' RETURNING qf_char_domain)"
+    "expected": "SELECT JSON_QUERY(CAST('\"1\"' AS JSONB), '$' RETURNING qf_char_domain OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 132",
     "query": "SELECT JSON_QUERY(jsonb '\"1\"', '$' RETURNING qf_jsonb_domain OMIT QUOTES ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"1\"' AS JSONB), '$' RETURNING qf_jsonb_domain)"
+    "expected": "SELECT JSON_QUERY(CAST('\"1\"' AS JSONB), '$' RETURNING qf_jsonb_domain OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 133",
@@ -670,67 +670,67 @@
   {
     "comment": "sqljson_queryfuncs - Statement 135",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' NULL ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' NULL ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 136",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' EMPTY ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' EMPTY ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 137",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' EMPTY ARRAY ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' EMPTY ARRAY ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 138",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' EMPTY OBJECT ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' EMPTY OBJECT ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 139",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 140",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' DEFAULT '\"empty\"' ON EMPTY)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' DEFAULT '\"empty\"' ON EMPTY)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 141",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON EMPTY NULL ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON EMPTY NULL ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 142",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON EMPTY EMPTY ARRAY ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON EMPTY EMPTY ARRAY ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 143",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON EMPTY EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON EMPTY EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 144",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 145",
     "query": "SELECT JSON_QUERY(jsonb '[]', '$[*]' ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[]' AS JSONB), '$[*]' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 146",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 147",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' DEFAULT '\"empty\"' ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]')"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' DEFAULT '\"empty\"' ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 148",
@@ -740,7 +740,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 149",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$' RETURNING json FORMAT JSON)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING JSON)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING JSON FORMAT JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 150",
@@ -750,7 +750,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 151",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$' RETURNING jsonb FORMAT JSON)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING JSONB)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING JSONB FORMAT JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 152",
@@ -765,7 +765,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 154",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$' RETURNING text FORMAT JSON)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING TEXT)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING TEXT FORMAT JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 155",
@@ -775,92 +775,92 @@
   {
     "comment": "sqljson_queryfuncs - Statement 156",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$' RETURNING bytea FORMAT JSON)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING BYTEA)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$' RETURNING BYTEA FORMAT JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 157",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' RETURNING bytea EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING BYTEA)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING BYTEA EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 158",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' RETURNING bytea FORMAT JSON EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING BYTEA)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING BYTEA FORMAT JSON EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 159",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' RETURNING json EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING JSON)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING JSON EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 160",
     "query": "SELECT JSON_QUERY(jsonb '[1,2]', '$[*]' RETURNING jsonb EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING JSONB)"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' RETURNING JSONB EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 161",
     "query": "SELECT JSON_QUERY(jsonb '[3,4]', '$[*]' RETURNING bigint[] EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[3,4]' AS JSONB), '$[*]' RETURNING BIGINT[])"
+    "expected": "SELECT JSON_QUERY(CAST('[3,4]' AS JSONB), '$[*]' RETURNING BIGINT[] EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 162",
     "query": "SELECT JSON_QUERY(jsonb '\"[3,4]\"', '$[*]' RETURNING bigint[] EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('\"[3,4]\"' AS JSONB), '$[*]' RETURNING BIGINT[])"
+    "expected": "SELECT JSON_QUERY(CAST('\"[3,4]\"' AS JSONB), '$[*]' RETURNING BIGINT[] EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 163",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING int2 error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING SMALLINT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING SMALLINT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 164",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING int4 error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING INT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING INT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 165",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING int8 error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING BIGINT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING BIGINT ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 166",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING bool error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING BOOLEAN)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING BOOLEAN ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 167",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING numeric error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING NUMERIC)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING NUMERIC ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 168",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING real error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING REAL)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING REAL ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 169",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING float8 error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING FLOAT8)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING FLOAT8 ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 170",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING int2 omit quotes error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING SMALLINT)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING SMALLINT OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 171",
     "query": "SELECT JSON_QUERY(jsonb '\"123.1\"', '$' RETURNING float8 omit quotes error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING FLOAT8)"
+    "expected": "SELECT JSON_QUERY(CAST('\"123.1\"' AS JSONB), '$' RETURNING FLOAT8 OMIT QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 172",
     "query": "SELECT JSON_QUERY(jsonb '[3,4]', '$[*]' RETURNING anyarray EMPTY OBJECT ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[3,4]' AS JSONB), '$[*]' RETURNING anyarray)"
+    "expected": "SELECT JSON_QUERY(CAST('[3,4]' AS JSONB), '$[*]' RETURNING anyarray EMPTY OBJECT ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 173",
     "query": "SELECT x, y, JSON_QUERY( jsonb '[1,2,3,4,5,null]', '$[*] ? (@ \u003e= $x \u0026\u0026 @ \u003c= $y)' PASSING x AS x, y AS y WITH CONDITIONAL WRAPPER EMPTY ARRAY ON EMPTY ) list FROM generate_series(0, 4) x, generate_series(0, 4) y",
-    "expected": "SELECT x, y, JSON_QUERY(CAST('[1,2,3,4,5,null]' AS JSONB), '$[*] ? (@ \u003e= $x \u0026\u0026 @ \u003c= $y)') AS list FROM generate_series(0, 4) AS x, generate_series(0, 4) AS y"
+    "expected": "SELECT x, y, JSON_QUERY(CAST('[1,2,3,4,5,null]' AS JSONB), '$[*] ? (@ \u003e= $x \u0026\u0026 @ \u003c= $y)' PASSING x AS x, y AS y WITH CONDITIONAL ARRAY WRAPPER EMPTY ARRAY ON EMPTY) AS list FROM generate_series(0, 4) AS x, generate_series(0, 4) AS y"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 174",
@@ -870,17 +870,17 @@
   {
     "comment": "sqljson_queryfuncs - Statement 175",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"(abc,42,01.02.2003)\"}', '$.rec' returning comp_abc omit quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc OMIT QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 176",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"(abc,42,01.02.2003)\"}', '$.rec' returning comp_abc keep quotes)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc KEEP QUOTES)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 177",
     "query": "SELECT JSON_QUERY(jsonb'{\"rec\": \"(abc,42,01.02.2003)\"}', '$.rec' returning comp_abc keep quotes error on error)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"rec\": \"(abc,42,01.02.2003)\"}' AS JSONB), '$.rec' RETURNING comp_abc KEEP QUOTES ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 178",
@@ -903,7 +903,7 @@
   {
     "comment": "sqljson_queryfuncs - Statement 182",
     "query": "SELECT JSON_QUERY(jsonb '[{\"a\": \"a\", \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]', '$[0]' RETURNING sqljsonb_rec ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[{\"a\": \"a\", \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]' AS JSONB), '$[0]' RETURNING sqljsonb_rec)"
+    "expected": "SELECT JSON_QUERY(CAST('[{\"a\": \"a\", \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]' AS JSONB), '$[0]' RETURNING sqljsonb_rec ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 183",
@@ -928,22 +928,22 @@
   {
     "comment": "sqljson_queryfuncs - Statement 187",
     "query": "SELECT JSON_QUERY(jsonb '[{\"a\": 1, \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]', '$[0]' RETURNING jsonpath ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[{\"a\": 1, \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]' AS JSONB), '$[0]' RETURNING jsonpath)"
+    "expected": "SELECT JSON_QUERY(CAST('[{\"a\": 1, \"b\": \"foo\", \"t\": \"aaa\", \"js\": [1, \"2\", {}], \"jb\": {\"x\": [1, \"2\", {}]}},  {\"a\": 2}]' AS JSONB), '$[0]' RETURNING jsonpath ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 188",
     "query": "SELECT JSON_QUERY(jsonb '[1,2,null,\"3\"]', '$[*]' RETURNING int[] WITH WRAPPER)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"3\"]' AS JSONB), '$[*]' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"3\"]' AS JSONB), '$[*]' RETURNING INT[] WITH UNCONDITIONAL ARRAY WRAPPER)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 189",
     "query": "SELECT JSON_QUERY(jsonb '[1,2,null,\"a\"]', '$[*]' RETURNING int[] WITH WRAPPER ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"a\"]' AS JSONB), '$[*]' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"a\"]' AS JSONB), '$[*]' RETURNING INT[] WITH UNCONDITIONAL ARRAY WRAPPER ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 190",
     "query": "SELECT JSON_QUERY(jsonb '[1,2,null,\"a\"]', '$[*]' RETURNING int[] WITH WRAPPER)",
-    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"a\"]' AS JSONB), '$[*]' RETURNING INT[])"
+    "expected": "SELECT JSON_QUERY(CAST('[1,2,null,\"a\"]' AS JSONB), '$[*]' RETURNING INT[] WITH UNCONDITIONAL ARRAY WRAPPER)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 191",
@@ -963,27 +963,27 @@
   {
     "comment": "sqljson_queryfuncs - Statement 194",
     "query": "SELECT JSON_QUERY(jsonb '{\"a\": 1}', '$.b' RETURNING sqljsonb_int_not_null ERROR ON EMPTY ERROR ON ERROR)",
-    "expected": "SELECT JSON_QUERY(CAST('{\"a\": 1}' AS JSONB), '$.b' RETURNING sqljsonb_int_not_null)"
+    "expected": "SELECT JSON_QUERY(CAST('{\"a\": 1}' AS JSONB), '$.b' RETURNING sqljsonb_int_not_null ERROR ON EMPTY ERROR ON ERROR)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 195",
     "query": "SELECT JSON_QUERY(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts)",
-    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts')"
+    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 196",
     "query": "SELECT JSON_QUERY(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING json)",
-    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts' RETURNING JSON)"
+    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING JSON)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 197",
     "query": "SELECT JSON_QUERY(jsonb 'null', '$ts' PASSING timestamptz '2018-02-21 12:34:56 +10' AS ts RETURNING jsonb)",
-    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts' RETURNING JSONB)"
+    "expected": "SELECT JSON_QUERY(CAST('null' AS JSONB), '$ts' PASSING CAST('2018-02-21 12:34:56 +10' AS TIMESTAMPTZ) AS ts RETURNING JSONB)"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 198",
     "query": "CREATE TABLE test_jsonb_constraints ( js text, i int, x jsonb DEFAULT JSON_QUERY(jsonb '[1,2]', '$[*]' WITH WRAPPER) CONSTRAINT test_jsonb_constraint1 CHECK (js IS JSON) CONSTRAINT test_jsonb_constraint2 CHECK (JSON_EXISTS(js::jsonb, '$.a' PASSING i + 5 AS int, i::text AS \"TXT\", array[1,2,3] as arr)) CONSTRAINT test_jsonb_constraint3 CHECK (JSON_VALUE(js::jsonb, '$.a' RETURNING int DEFAULT '12' ON EMPTY ERROR ON ERROR) \u003e i) CONSTRAINT test_jsonb_constraint4 CHECK (JSON_QUERY(js::jsonb, '$.a' WITH CONDITIONAL WRAPPER EMPTY OBJECT ON ERROR) = jsonb '[10]') CONSTRAINT test_jsonb_constraint5 CHECK (JSON_QUERY(js::jsonb, '$.a' RETURNING char(5) OMIT QUOTES EMPTY ARRAY ON EMPTY) \u003e  'a' COLLATE \"C\") )",
-    "expected": "CREATE TABLE test_jsonb_constraints (js TEXT, i INT, x JSONB DEFAULT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]') CONSTRAINT test_jsonb_constraint1 CHECK (js IS JSON) CONSTRAINT test_jsonb_constraint2 CHECK (JSON_EXISTS(CAST(js AS JSONB), '$.a')) CONSTRAINT test_jsonb_constraint3 CHECK (JSON_VALUE(CAST(js AS JSONB), '$.a' RETURNING INT) \u003e i) CONSTRAINT test_jsonb_constraint4 CHECK (JSON_QUERY(CAST(js AS JSONB), '$.a') = CAST('[10]' AS JSONB)) CONSTRAINT test_jsonb_constraint5 CHECK (JSON_QUERY(CAST(js AS JSONB), '$.a' RETURNING CHAR(5)) \u003e 'a' COLLATE \"C\"))"
+    "expected": "CREATE TABLE test_jsonb_constraints (js TEXT, i INT, x JSONB DEFAULT JSON_QUERY(CAST('[1,2]' AS JSONB), '$[*]' WITH UNCONDITIONAL ARRAY WRAPPER) CONSTRAINT test_jsonb_constraint1 CHECK (js IS JSON) CONSTRAINT test_jsonb_constraint2 CHECK (JSON_EXISTS(CAST(js AS JSONB), '$.a' PASSING i + 5 AS int, CAST(i AS TEXT) AS \"TXT\", ARRAY[1,2,3] AS arr)) CONSTRAINT test_jsonb_constraint3 CHECK (JSON_VALUE(CAST(js AS JSONB), '$.a' RETURNING INT DEFAULT '12' ON EMPTY ERROR ON ERROR) \u003e i) CONSTRAINT test_jsonb_constraint4 CHECK (JSON_QUERY(CAST(js AS JSONB), '$.a' WITH CONDITIONAL ARRAY WRAPPER EMPTY OBJECT ON ERROR) = CAST('[10]' AS JSONB)) CONSTRAINT test_jsonb_constraint5 CHECK (JSON_QUERY(CAST(js AS JSONB), '$.a' RETURNING CHAR(5) OMIT QUOTES EMPTY ARRAY ON EMPTY) \u003e 'a' COLLATE \"C\"))"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 199",
@@ -1121,12 +1121,12 @@
   {
     "comment": "sqljson_queryfuncs - Statement 227",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.date() \u003c $x' PASSING '12:34'::timetz AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.date() \u003c $x')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.date() \u003c $x' PASSING CAST('12:34' AS TIMETZ) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 228",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.date() \u003c $x' PASSING '1234'::int AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.date() \u003c $x')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.date() \u003c $x' PASSING CAST('1234' AS INT) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 229",
@@ -1171,56 +1171,56 @@
   {
     "comment": "sqljson_queryfuncs - Statement 237",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $x' PASSING '12:34'::timetz AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $x')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $x' PASSING CAST('12:34' AS TIMETZ) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 238",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $y' PASSING '12:34'::timetz AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $y')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"HH:MI TZH\") \u003c $y' PASSING CAST('12:34' AS TIMETZ) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 239",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime() \u003c $x' PASSING '12:34'::timetz AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() \u003c $x')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() \u003c $x' PASSING CAST('12:34' AS TIMETZ) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 240",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime() \u003c $x' PASSING '1234'::int AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() \u003c $x')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() \u003c $x' PASSING CAST('1234' AS INT) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 241",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime() ? (@ == $x)' PASSING '12:34'::time AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() ? (@ == $x)')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime() ? (@ == $x)' PASSING CAST('12:34' AS TIME) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 242",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$.datetime(\"YY-MM-DD\") ? (@ == $x)' PASSING '2020-07-14'::date AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"YY-MM-DD\") ? (@ == $x)')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$.datetime(\"YY-MM-DD\") ? (@ == $x)' PASSING CAST('2020-07-14' AS DATE) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 243",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$[1, $.a ? (@.datetime() == $x)]' PASSING '12:34'::time AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, $.a ? (@.datetime() == $x)]')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, $.a ? (@.datetime() == $x)]' PASSING CAST('12:34' AS TIME) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 244",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$[1, 0 to $.a ? (@.datetime() == $x)]' PASSING '12:34'::time AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, 0 to $.a ? (@.datetime() == $x)]')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, 0 to $.a ? (@.datetime() == $x)]' PASSING CAST('12:34' AS TIME) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 245",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_QUERY(js, '$[1, $.a ? (@.datetime(\"HH:MI\") == $x)]' PASSING '12:34'::time AS x))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, $.a ? (@.datetime(\"HH:MI\") == $x)]')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_QUERY(js, '$[1, $.a ? (@.datetime(\"HH:MI\") == $x)]' PASSING CAST('12:34' AS TIME) AS x)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 246",
     "query": "CREATE INDEX ON test_jsonb_mutability (JSON_VALUE(js, '$' DEFAULT random()::int ON ERROR))",
-    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_VALUE(js, '$')) )"
+    "expected": "CREATE INDEX ON test_jsonb_mutability USING btree ( (JSON_VALUE(js, '$' DEFAULT CAST(random() AS INT) ON ERROR)) )"
   },
   {
     "comment": "sqljson_queryfuncs - Statement 247",
     "query": "CREATE OR REPLACE FUNCTION ret_setint() RETURNS SETOF integer AS $$ BEGIN RETURN QUERY EXECUTE 'select 1 union all select 1'; END; $$ LANGUAGE plpgsql IMMUTABLE; SELECT JSON_QUERY(js, '$'  RETURNING int DEFAULT ret_setint() ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$'  RETURNING int DEFAULT b + 1 ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$'  RETURNING int DEFAULT sum(1) over() ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$'  RETURNING int DEFAULT (SELECT 1) ON ERROR) FROM test_jsonb_mutability; DROP TABLE test_jsonb_mutability; DROP FUNCTION ret_setint;  CREATE DOMAIN queryfuncs_test_domain AS text CHECK (value \u003c\u003e 'foo'); SELECT JSON_VALUE(jsonb '{\"d1\": \"H\"}', '$.a2' RETURNING queryfuncs_test_domain DEFAULT 'foo'::queryfuncs_test_domain ON EMPTY); SELECT JSON_VALUE(jsonb '{\"d1\": \"H\"}', '$.a2' RETURNING queryfuncs_test_domain DEFAULT 'foo1'::queryfuncs_test_domain ON EMPTY); SELECT JSON_VALUE(jsonb '{\"d1\": \"H\"}', '$.a2' RETURNING queryfuncs_test_domain DEFAULT '\"foo1\"'::jsonb::text ON EMPTY); SELECT JSON_VALUE(jsonb '{\"d1\": \"foo\"}', '$.a2' RETURNING queryfuncs_test_domain DEFAULT 'foo1'::queryfuncs_test_domain ON EMPTY);      SELECT JSON_QUERY('\"a\"', '$.a'  RETURNING int DEFAULT (SELECT '\"1\"')::jsonb ON ERROR);  SELECT JSON_QUERY('\"a\"', '$.a' RETURNING queryfuncs_test_domain DEFAULT (select '\"1\"')::queryfuncs_test_domain ON ERROR);  SELECT JSON_QUERY('\"a\"', '$.a'  RETURNING int DEFAULT (SELECT 1)::oid::int ON ERROR);  SELECT JSON_QUERY('\"a\"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::oid[]::int[] ON ERROR);  SELECT JSON_QUERY('\"a\"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::text COLLATE \"C\" ON ERROR);  CREATE TABLE someparent (a int); CREATE TABLE somechild () INHERITS (someparent); SELECT JSON_QUERY('\"a\"', '$.a'  RETURNING someparent DEFAULT (SELECT '(1)')::somechild::someparent ON ERROR);  DROP DOMAIN queryfuncs_test_domain; DROP TABLE someparent, somechild;   SELECT JSON_EXISTS(jsonb '{\"a\": 123}', '$' || '.' || 'a'); SELECT JSON_VALUE(jsonb '{\"a\": 123}', '$' || '.' || 'a'); SELECT JSON_VALUE(jsonb '{\"a\": 123}', '$' || '.' || 'b' DEFAULT 'foo' ON EMPTY); SELECT JSON_QUERY(jsonb '{\"a\": 123}', '$' || '.' || 'a'); SELECT JSON_QUERY(jsonb '{\"a\": 123}', '$' || '.' || 'a' WITH WRAPPER);  SELECT JSON_QUERY(jsonb '{\"a\": 123}', 'error' || ' ' || 'error');   SELECT JSON_EXISTS(json '{\"a\": 123}', '$' || '.' || 'a'); SELECT JSON_QUERY(NULL FORMAT JSON, '$');   CREATE TEMP TABLE jsonpaths (path) AS SELECT '$'; SELECT json_value('\"aaa\"', path RETURNING json) FROM jsonpaths;   SELECT JSON_QUERY(jsonb 'null', '$xyz' PASSING 1 AS xy); SELECT JSON_QUERY(jsonb 'null', '$xy' PASSING 1 AS xyz); SELECT JSON_QUERY(jsonb 'null', '$xyz' PASSING 1 AS xyz); SELECT JSON_QUERY(jsonb 'null', '$Xyz' PASSING 1 AS Xyz); SELECT JSON_QUERY(jsonb 'null', '$Xyz' PASSING 1 AS \"Xyz\"); SELECT JSON_QUERY(jsonb 'null', '$\"Xyz\"' PASSING 1 AS \"Xyz\");   SELECT JSON_EXISTS(jsonb '1', '$' DEFAULT 1 ON ERROR); SELECT JSON_VALUE(jsonb '1', '$' EMPTY ON ERROR); SELECT JSON_QUERY(jsonb '1', '$' TRUE ON ERROR);    CREATE DOMAIN queryfuncs_char2 AS char(2); CREATE DOMAIN queryfuncs_char2_chk AS char(2) CHECK (VALUE NOT IN ('12')); SELECT JSON_QUERY(jsonb '123', '$' RETURNING queryfuncs_char2 ERROR ON ERROR); SELECT JSON_QUERY(jsonb '123', '$' RETURNING queryfuncs_char2 DEFAULT '1' ON ERROR); SELECT JSON_QUERY(jsonb '123', '$' RETURNING queryfuncs_char2_chk ERROR ON ERROR); SELECT JSON_QUERY(jsonb '123', '$' RETURNING queryfuncs_char2_chk DEFAULT '1' ON ERROR); SELECT JSON_VALUE(jsonb '123', '$' RETURNING queryfuncs_char2 ERROR ON ERROR); SELECT JSON_VALUE(jsonb '123', '$' RETURNING queryfuncs_char2 DEFAULT 1 ON ERROR); SELECT JSON_VALUE(jsonb '123', '$' RETURNING queryfuncs_char2_chk ERROR ON ERROR); SELECT JSON_VALUE(jsonb '123', '$' RETURNING queryfuncs_char2_chk DEFAULT 1 ON ERROR); DROP DOMAIN queryfuncs_char2, queryfuncs_char2_chk;     CREATE DOMAIN queryfuncs_d_varbit3 AS varbit(3) CHECK (VALUE \u003c\u003e '01'); SELECT JSON_VALUE(jsonb '1234', '$' RETURNING queryfuncs_d_varbit3  DEFAULT '111111' ON ERROR); SELECT JSON_VALUE(jsonb '1234', '$' RETURNING queryfuncs_d_varbit3  DEFAULT '010' ON ERROR); SELECT JSON_VALUE(jsonb '1234', '$' RETURNING queryfuncs_d_varbit3  DEFAULT '01' ON ERROR); SELECT JSON_VALUE(jsonb '\"111\"', '$'  RETURNING bit(2) ERROR ON ERROR); SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR); SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1::bit(3) ON ERROR); SELECT JSON_VALUE(jsonb '\"111\"', '$.a'  RETURNING bit(3) DEFAULT '1111' ON EMPTY); DROP DOMAIN queryfuncs_d_varbit3",
-    "expected": "CREATE OR REPLACE FUNCTION ret_setint () RETURNS SETOF INT AS $$ BEGIN RETURN QUERY EXECUTE 'select 1 union all select 1'; END; $$ LANGUAGE plpgsql IMMUTABLE; SELECT JSON_QUERY(js, '$' RETURNING INT) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT) FROM test_jsonb_mutability; DROP TABLE test_jsonb_mutability; DROP FUNCTION ret_setint; CREATE DOMAIN queryfuncs_test_domain AS TEXT CHECK (value \u003c\u003e 'foo'); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain); SELECT JSON_VALUE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING queryfuncs_test_domain); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT[]); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT[]); CREATE TABLE someparent (a INT); CREATE TABLE somechild () INHERITS (someparent); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING someparent); DROP DOMAIN queryfuncs_test_domain; DROP TABLE someparent, somechild; SELECT JSON_EXISTS(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_VALUE(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_VALUE(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'b'); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), 'error' || ' ' || 'error'); SELECT JSON_EXISTS(CAST('{\"a\": 123}' AS JSON), '$' || '.' || 'a'); SELECT JSON_QUERY(NULL FORMAT JSON, '$'); CREATE TEMP TABLE jsonpaths (path) AS SELECT '$'; SELECT JSON_VALUE('\"aaa\"', path RETURNING JSON) FROM jsonpaths; SELECT JSON_QUERY(CAST('null' AS JSONB), '$xyz'); SELECT JSON_QUERY(CAST('null' AS JSONB), '$xy'); SELECT JSON_QUERY(CAST('null' AS JSONB), '$xyz'); SELECT JSON_QUERY(CAST('null' AS JSONB), '$Xyz'); SELECT JSON_QUERY(CAST('null' AS JSONB), '$Xyz'); SELECT JSON_QUERY(CAST('null' AS JSONB), '$\"Xyz\"'); SELECT JSON_EXISTS(CAST('1' AS JSONB), '$'); SELECT JSON_VALUE(CAST('1' AS JSONB), '$'); SELECT JSON_QUERY(CAST('1' AS JSONB), '$'); CREATE DOMAIN queryfuncs_char2 AS CHAR(2); CREATE DOMAIN queryfuncs_char2_chk AS CHAR(2) CHECK (value NOT IN ('12')); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk); DROP DOMAIN queryfuncs_char2, queryfuncs_char2_chk; CREATE DOMAIN queryfuncs_d_varbit3 AS varbit(3) CHECK (value \u003c\u003e '01'); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3); SELECT JSON_VALUE(CAST('\"111\"' AS JSONB), '$' RETURNING bit(2)); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING bit(3)); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING bit(3)); SELECT JSON_VALUE(CAST('\"111\"' AS JSONB), '$.a' RETURNING bit(3)); DROP DOMAIN queryfuncs_d_varbit3"
+    "expected": "CREATE OR REPLACE FUNCTION ret_setint () RETURNS SETOF INT AS $$ BEGIN RETURN QUERY EXECUTE 'select 1 union all select 1'; END; $$ LANGUAGE plpgsql IMMUTABLE; SELECT JSON_QUERY(js, '$' RETURNING INT DEFAULT ret_setint() ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT DEFAULT b + 1 ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT DEFAULT SUM(1) OVER () ON ERROR) FROM test_jsonb_mutability; SELECT JSON_QUERY(js, '$' RETURNING INT DEFAULT (SELECT 1) ON ERROR) FROM test_jsonb_mutability; DROP TABLE test_jsonb_mutability; DROP FUNCTION ret_setint; CREATE DOMAIN queryfuncs_test_domain AS TEXT CHECK (value \u003c\u003e 'foo'); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain DEFAULT CAST('foo' AS queryfuncs_test_domain) ON EMPTY); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain DEFAULT CAST('foo1' AS queryfuncs_test_domain) ON EMPTY); SELECT JSON_VALUE(CAST('{\"d1\": \"H\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain DEFAULT CAST(CAST('\"foo1\"' AS JSONB) AS TEXT) ON EMPTY); SELECT JSON_VALUE(CAST('{\"d1\": \"foo\"}' AS JSONB), '$.a2' RETURNING queryfuncs_test_domain DEFAULT CAST('foo1' AS queryfuncs_test_domain) ON EMPTY); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT DEFAULT CAST((SELECT '\"1\"') AS JSONB) ON ERROR); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING queryfuncs_test_domain DEFAULT CAST((SELECT '\"1\"') AS queryfuncs_test_domain) ON ERROR); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT DEFAULT CAST(CAST((SELECT 1) AS oid) AS INT) ON ERROR); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT[] DEFAULT CAST(CAST((SELECT '{1}') AS oid[]) AS INT[]) ON ERROR); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING INT[] DEFAULT CAST((SELECT '{1}') AS TEXT) COLLATE \"C\" ON ERROR); CREATE TABLE someparent (a INT); CREATE TABLE somechild () INHERITS (someparent); SELECT JSON_QUERY('\"a\"', '$.a' RETURNING someparent DEFAULT CAST(CAST((SELECT '(1)') AS somechild) AS someparent) ON ERROR); DROP DOMAIN queryfuncs_test_domain; DROP TABLE someparent, somechild; SELECT JSON_EXISTS(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_VALUE(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_VALUE(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'b' DEFAULT 'foo' ON EMPTY); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a'); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), '$' || '.' || 'a' WITH UNCONDITIONAL ARRAY WRAPPER); SELECT JSON_QUERY(CAST('{\"a\": 123}' AS JSONB), 'error' || ' ' || 'error'); SELECT JSON_EXISTS(CAST('{\"a\": 123}' AS JSON), '$' || '.' || 'a'); SELECT JSON_QUERY(NULL FORMAT JSON, '$'); CREATE TEMP TABLE jsonpaths (path) AS SELECT '$'; SELECT JSON_VALUE('\"aaa\"', path RETURNING JSON) FROM jsonpaths; SELECT JSON_QUERY(CAST('null' AS JSONB), '$xyz' PASSING 1 AS xy); SELECT JSON_QUERY(CAST('null' AS JSONB), '$xy' PASSING 1 AS xyz); SELECT JSON_QUERY(CAST('null' AS JSONB), '$xyz' PASSING 1 AS xyz); SELECT JSON_QUERY(CAST('null' AS JSONB), '$Xyz' PASSING 1 AS xyz); SELECT JSON_QUERY(CAST('null' AS JSONB), '$Xyz' PASSING 1 AS \"Xyz\"); SELECT JSON_QUERY(CAST('null' AS JSONB), '$\"Xyz\"' PASSING 1 AS \"Xyz\"); SELECT JSON_EXISTS(CAST('1' AS JSONB), '$' DEFAULT 1 ON ERROR); SELECT JSON_VALUE(CAST('1' AS JSONB), '$' EMPTY ON ERROR); SELECT JSON_QUERY(CAST('1' AS JSONB), '$' TRUE ON ERROR); CREATE DOMAIN queryfuncs_char2 AS CHAR(2); CREATE DOMAIN queryfuncs_char2_chk AS CHAR(2) CHECK (value NOT IN ('12')); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2 ERROR ON ERROR); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2 DEFAULT '1' ON ERROR); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk ERROR ON ERROR); SELECT JSON_QUERY(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk DEFAULT '1' ON ERROR); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2 ERROR ON ERROR); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2 DEFAULT 1 ON ERROR); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk ERROR ON ERROR); SELECT JSON_VALUE(CAST('123' AS JSONB), '$' RETURNING queryfuncs_char2_chk DEFAULT 1 ON ERROR); DROP DOMAIN queryfuncs_char2, queryfuncs_char2_chk; CREATE DOMAIN queryfuncs_d_varbit3 AS varbit(3) CHECK (value \u003c\u003e '01'); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3 DEFAULT '111111' ON ERROR); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3 DEFAULT '010' ON ERROR); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING queryfuncs_d_varbit3 DEFAULT '01' ON ERROR); SELECT JSON_VALUE(CAST('\"111\"' AS JSONB), '$' RETURNING bit(2) ERROR ON ERROR); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING bit(3) DEFAULT 1 ON ERROR); SELECT JSON_VALUE(CAST('1234' AS JSONB), '$' RETURNING bit(3) DEFAULT CAST(1 AS bit(3)) ON ERROR); SELECT JSON_VALUE(CAST('\"111\"' AS JSONB), '$.a' RETURNING bit(3) DEFAULT '1111' ON EMPTY); DROP DOMAIN queryfuncs_d_varbit3"
   }
 ]

--- a/go/test/endtoend/pgregresstest/patch_verify.go
+++ b/go/test/endtoend/pgregresstest/patch_verify.go
@@ -92,7 +92,8 @@ type VerifyInput struct {
 // VerifyTest runs the patch-based verification pipeline for one test.
 //
 // Pipeline:
-//  1. Read expected and actual.
+//  1. Read expected and actual; whitespace-normalize both so all subsequent
+//     operations work in a canonical, platform-independent form.
 //  2. If a patch file exists at PatchDir/<Name>.patch, apply it to expected.
 //     - verify mode: patch failure => fail with reason "patch did not apply".
 //     - generate mode: patch failure just means we'll regenerate from scratch.
@@ -108,14 +109,19 @@ type VerifyInput struct {
 func VerifyTest(ctx context.Context, in VerifyInput, mode PatchMode) (*VerifyOutcome, error) {
 	out := &VerifyOutcome{Name: in.Name}
 
-	expected, err := os.ReadFile(in.ExpectedPath)
+	rawExpected, err := os.ReadFile(in.ExpectedPath)
 	if err != nil {
 		return nil, fmt.Errorf("read expected %q: %w", in.ExpectedPath, err)
 	}
-	actual, err := os.ReadFile(in.ActualPath)
+	rawActual, err := os.ReadFile(in.ActualPath)
 	if err != nil {
 		return nil, fmt.Errorf("read actual %q: %w", in.ActualPath, err)
 	}
+	// Normalize once on entry so applyPatch, generateDiff, and patch
+	// regeneration all operate on the same canonical bytes. See
+	// normalizeWhitespace for the rationale.
+	expected := normalizeWhitespace(rawExpected)
+	actual := normalizeWhitespace(rawActual)
 
 	patchPath := filepath.Join(in.PatchDir, in.Name+".patch")
 	patchExists := fileExists(patchPath)
@@ -244,15 +250,70 @@ func applyPatch(ctx context.Context, original []byte, patchPath string) ([]byte,
 	return os.ReadFile(dstPath)
 }
 
-// generateDiff runs `diff -U3 -b --label a --label b` and returns the unified
-// diff bytes. Returns an empty slice when files are identical (modulo
-// whitespace).
+// normalizeWhitespace canonicalises whitespace inside `input` so byte-level
+// comparison is stable across platforms. Each line gets:
+//   - all runs of `[ \t]+` collapsed to a single space;
+//   - leading and trailing whitespace stripped.
 //
-// The `-b` flag ignores changes in the amount of whitespace — lines that
-// differ only in spacing (e.g. the `^` caret position under a `LINE N:`
-// error block) are treated as matching. This lets us accept psql-format
-// nits that don't represent real regressions without maintaining a patch
-// per test file for every column-alignment tweak.
+// Newlines are preserved as separators. Trailing newlines on the file are
+// preserved.
+//
+// Why this exists: `diff -b` is supposed to ignore changes in the amount of
+// whitespace, but the BSD diff (macOS) and GNU diff (Linux/CI) implementations
+// disagree on edge cases — most importantly, leading-whitespace-only changes
+// like the `^` caret position under a psql `LINE N:` error block. BSD diff -b
+// treats `"   ^"` and `"    ^"` as identical; GNU diff -b reports them as
+// different. Generating patches on macOS and verifying them on Linux therefore
+// produces phantom residual diffs.
+//
+// Doing the normalization in Go before invoking `diff` removes the dependency
+// on the diff binary's `-b` semantics. After normalization, plain `diff -U3`
+// gives identical output on every platform.
+func normalizeWhitespace(input []byte) []byte {
+	if len(input) == 0 {
+		return input
+	}
+	// Track whether the input ended with a newline so we can preserve that
+	// (or lack thereof) on output.
+	hasTrailingNewline := input[len(input)-1] == '\n'
+
+	lines := bytes.Split(input, []byte("\n"))
+	if hasTrailingNewline {
+		// bytes.Split leaves a trailing empty element when the input ends
+		// with the separator; drop it so we don't synthesize an extra blank
+		// line, then re-add the newline at the very end.
+		lines = lines[:len(lines)-1]
+	}
+
+	for i, line := range lines {
+		var b []byte
+		prevWS := false
+		for _, c := range line {
+			if c == ' ' || c == '\t' {
+				if !prevWS {
+					b = append(b, ' ')
+					prevWS = true
+				}
+			} else {
+				b = append(b, c)
+				prevWS = false
+			}
+		}
+		// Strip leading and trailing single-space runs (already collapsed).
+		b = bytes.TrimSpace(b)
+		lines[i] = b
+	}
+
+	out := bytes.Join(lines, []byte("\n"))
+	if hasTrailingNewline {
+		out = append(out, '\n')
+	}
+	return out
+}
+
+// generateDiff runs `diff -U3 --label a --label b` against the bytes and
+// returns the unified diff. Inputs are expected to already be canonicalized
+// by normalizeWhitespace — see that function for why we don't pass `-b`.
 //
 // The `--label` flags replace the `---`/`+++` header lines with stable
 // literals so patch files don't embed absolute temp-directory paths or
@@ -276,7 +337,7 @@ func generateDiff(ctx context.Context, a, b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	cmd := executil.Command(ctx, "diff", "-U3", "-b",
+	cmd := executil.Command(ctx, "diff", "-U3",
 		"--label", "a",
 		"--label", "b",
 		aPath, bPath)

--- a/go/test/endtoend/pgregresstest/patch_verify.go
+++ b/go/test/endtoend/pgregresstest/patch_verify.go
@@ -250,25 +250,14 @@ func applyPatch(ctx context.Context, original []byte, patchPath string) ([]byte,
 	return os.ReadFile(dstPath)
 }
 
-// normalizeWhitespace canonicalises whitespace inside `input` so byte-level
-// comparison is stable across platforms. Each line gets:
-//   - all runs of `[ \t]+` collapsed to a single space;
-//   - leading and trailing whitespace stripped.
-//
-// Newlines are preserved as separators. Trailing newlines on the file are
+// normalizeWhitespace canonicalises whitespace so byte-level comparison is
+// stable across platforms. Each line has runs of `[ \t]+` collapsed to a
+// single space and leading/trailing whitespace stripped. Newlines are
 // preserved.
 //
-// Why this exists: in practice, patches generated against psql output on
-// macOS (BSD diff) drift when verified on Linux (GNU diff). PR #952 surfaced
-// this when locally-generated patches for `sqljson_queryfuncs` and
-// `sqljson_jsontable` passed locally but produced residual hunks in CI —
-// most visibly caret-position lines under `LINE N:` error blocks where the
-// only difference between the two sides was the amount of leading whitespace.
-// Both diff implementations document `-b` as ignoring whitespace amount, so
-// the exact behavioral divergence is undocumented and possibly version- or
-// edge-case specific; rather than trace it down, we sidestep it by doing
-// the whitespace canonicalisation here in Go and invoking plain `diff -U3`
-// against bytes that have no whitespace ambiguity left to resolve.
+// Why: BSD diff (macOS) and GNU diff (Linux) drift on `-b` for some
+// whitespace-only changes. Normalising here lets us drop `-b` and invoke
+// plain `diff -U3` against bytes with no whitespace ambiguity left.
 func normalizeWhitespace(input []byte) []byte {
 	if len(input) == 0 {
 		return input

--- a/go/test/endtoend/pgregresstest/patch_verify.go
+++ b/go/test/endtoend/pgregresstest/patch_verify.go
@@ -258,17 +258,17 @@ func applyPatch(ctx context.Context, original []byte, patchPath string) ([]byte,
 // Newlines are preserved as separators. Trailing newlines on the file are
 // preserved.
 //
-// Why this exists: `diff -b` is supposed to ignore changes in the amount of
-// whitespace, but the BSD diff (macOS) and GNU diff (Linux/CI) implementations
-// disagree on edge cases — most importantly, leading-whitespace-only changes
-// like the `^` caret position under a psql `LINE N:` error block. BSD diff -b
-// treats `"   ^"` and `"    ^"` as identical; GNU diff -b reports them as
-// different. Generating patches on macOS and verifying them on Linux therefore
-// produces phantom residual diffs.
-//
-// Doing the normalization in Go before invoking `diff` removes the dependency
-// on the diff binary's `-b` semantics. After normalization, plain `diff -U3`
-// gives identical output on every platform.
+// Why this exists: in practice, patches generated against psql output on
+// macOS (BSD diff) drift when verified on Linux (GNU diff). PR #952 surfaced
+// this when locally-generated patches for `sqljson_queryfuncs` and
+// `sqljson_jsontable` passed locally but produced residual hunks in CI —
+// most visibly caret-position lines under `LINE N:` error blocks where the
+// only difference between the two sides was the amount of leading whitespace.
+// Both diff implementations document `-b` as ignoring whitespace amount, so
+// the exact behavioral divergence is undocumented and possibly version- or
+// edge-case specific; rather than trace it down, we sidestep it by doing
+// the whitespace canonicalisation here in Go and invoking plain `diff -U3`
+// against bytes that have no whitespace ambiguity left to resolve.
 func normalizeWhitespace(input []byte) []byte {
 	if len(input) == 0 {
 		return input

--- a/go/test/endtoend/pgregresstest/patch_verify_test.go
+++ b/go/test/endtoend/pgregresstest/patch_verify_test.go
@@ -127,9 +127,11 @@ func TestVerify_DiffAbsorbedByPatch_Passes(t *testing.T) {
 	exp := "line1\nERROR:  invalid input syntax for type boolean: \"XXX\"\nLINE 2:    VALUES (bool 'XXX');\n                        ^\nline5\n"
 	act := "line1\nERROR:  parse error at position 64: invalid boolean\nline5\n"
 
-	// Generate the patch by running diff between exp and act. In real usage
-	// this is what `make pgregress-update-patches` produces.
-	patch, err := generateDiff(t.Context(), []byte(exp), []byte(act))
+	// Generate the patch by running diff between normalized exp and normalized
+	// act. In real usage this is what VerifyTest does internally on every
+	// run; tests that bypass VerifyTest must normalize first so the patch
+	// applies to the normalized expected that VerifyTest will hand back.
+	patch, err := generateDiff(t.Context(), normalizeWhitespace([]byte(exp)), normalizeWhitespace([]byte(act)))
 	if err != nil || len(patch) == 0 {
 		t.Fatalf("could not generate test patch: %v (len=%d)", err, len(patch))
 	}
@@ -234,6 +236,56 @@ func TestGenerate_RemovesRedundantPatch(t *testing.T) {
 	patchFile := filepath.Join(in.PatchDir, in.Name+".patch")
 	if _, err := os.Stat(patchFile); !os.IsNotExist(err) {
 		t.Errorf("expected stale patch to be removed; stat err=%v", err)
+	}
+}
+
+func TestNormalizeWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single line, no whitespace", "abc", "abc"},
+		{"trailing newline preserved", "abc\n", "abc\n"},
+		{"trailing whitespace trimmed", "abc   \n", "abc\n"},
+		{"leading whitespace trimmed", "   abc\n", "abc\n"},
+		{"runs collapsed within line", "a    b\tc\n", "a b c\n"},
+		{
+			"caret shift becomes equal — BSD/GNU divergence case",
+			"   ^\n", "    ^\n",
+		}, // both inputs normalize to identical output below
+		// Separate cases for the divergence to make the equivalence explicit.
+		{"caret with 3 leading spaces", "   ^\n", "^\n"},
+		{"caret with 4 leading spaces", "    ^\n", "^\n"},
+		{
+			"multiline mixed",
+			"   line1   \n  a  b  \n   ^\n",
+			"line1\na b\n^\n",
+		},
+		{
+			"no trailing newline",
+			"   ^",
+			"^",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(normalizeWhitespace([]byte(tc.in)))
+			if tc.name == "caret shift becomes equal — BSD/GNU divergence case" {
+				// Special case: assert that two different inputs both
+				// collapse to the same canonical form.
+				a := string(normalizeWhitespace([]byte("   ^\n")))
+				b := string(normalizeWhitespace([]byte("    ^\n")))
+				if a != b {
+					t.Errorf("caret-shift inputs should normalize equal; a=%q b=%q", a, b)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("normalizeWhitespace(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_generic.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_generic.patch
@@ -4,40 +4,38 @@
  -- Foreign Data Wrapper and Foreign Server
  --
  CREATE FOREIGN DATA WRAPPER alt_fdw1;
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  CREATE FOREIGN DATA WRAPPER alt_fdw2;
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  CREATE SERVER alt_fserv1 FOREIGN DATA WRAPPER alt_fdw1;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  CREATE SERVER alt_fserv2 FOREIGN DATA WRAPPER alt_fdw2;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
- ALTER FOREIGN DATA WRAPPER alt_fdw1 RENAME TO alt_fdw2;  -- failed (name conflict)
--ERROR:  foreign-data wrapper "alt_fdw2" already exists
-+ERROR:  foreign-data wrapper "alt_fdw1" does not exist
- ALTER FOREIGN DATA WRAPPER alt_fdw1 RENAME TO alt_fdw3;  -- OK
-+ERROR:  foreign-data wrapper "alt_fdw1" does not exist
- ALTER SERVER alt_fserv1 RENAME TO alt_fserv2;   -- failed (name conflict)
--ERROR:  server "alt_fserv2" already exists
-+ERROR:  server "alt_fserv1" does not exist
- ALTER SERVER alt_fserv1 RENAME TO alt_fserv3;   -- OK
-+ERROR:  server "alt_fserv1" does not exist
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ ALTER FOREIGN DATA WRAPPER alt_fdw1 RENAME TO alt_fdw2; -- failed (name conflict)
+-ERROR: foreign-data wrapper "alt_fdw2" already exists
++ERROR: foreign-data wrapper "alt_fdw1" does not exist
+ ALTER FOREIGN DATA WRAPPER alt_fdw1 RENAME TO alt_fdw3; -- OK
++ERROR: foreign-data wrapper "alt_fdw1" does not exist
+ ALTER SERVER alt_fserv1 RENAME TO alt_fserv2; -- failed (name conflict)
+-ERROR: server "alt_fserv2" already exists
++ERROR: server "alt_fserv1" does not exist
+ ALTER SERVER alt_fserv1 RENAME TO alt_fserv3; -- OK
++ERROR: server "alt_fserv1" does not exist
  SELECT fdwname FROM pg_foreign_data_wrapper WHERE fdwname like 'alt_fdw%';
-- fdwname  
+ fdwname
 -----------
-- alt_fdw2
-- alt_fdw3
+-alt_fdw2
+-alt_fdw3
 -(2 rows)
-+ fdwname 
 +---------
 +(0 rows)
  
  SELECT srvname FROM pg_foreign_server WHERE srvname like 'alt_fserv%';
--  srvname   
+ srvname
 -------------
-- alt_fserv2
-- alt_fserv3
+-alt_fserv2
+-alt_fserv3
 -(2 rows)
-+ srvname 
 +---------
 +(0 rows)
  
@@ -45,41 +43,40 @@
  -- Procedural Language
  --
  CREATE LANGUAGE alt_lang1 HANDLER plpgsql_call_handler;
-+ERROR:  CREATE LANGUAGE is not supported: installing procedural languages is not permitted through the connection pooler
++ERROR: CREATE LANGUAGE is not supported: installing procedural languages is not permitted through the connection pooler
  CREATE LANGUAGE alt_lang2 HANDLER plpgsql_call_handler;
-+ERROR:  CREATE LANGUAGE is not supported: installing procedural languages is not permitted through the connection pooler
- ALTER LANGUAGE alt_lang1 OWNER TO regress_alter_generic_user1;  -- OK
-+ERROR:  language "alt_lang1" does not exist
- ALTER LANGUAGE alt_lang2 OWNER TO regress_alter_generic_user2;  -- OK
-+ERROR:  language "alt_lang2" does not exist
++ERROR: CREATE LANGUAGE is not supported: installing procedural languages is not permitted through the connection pooler
+ ALTER LANGUAGE alt_lang1 OWNER TO regress_alter_generic_user1; -- OK
++ERROR: language "alt_lang1" does not exist
+ ALTER LANGUAGE alt_lang2 OWNER TO regress_alter_generic_user2; -- OK
++ERROR: language "alt_lang2" does not exist
  SET SESSION AUTHORIZATION regress_alter_generic_user1;
- ALTER LANGUAGE alt_lang1 RENAME TO alt_lang2;   -- failed (name conflict)
--ERROR:  language "alt_lang2" already exists
-+ERROR:  language "alt_lang1" does not exist
- ALTER LANGUAGE alt_lang2 RENAME TO alt_lang3;   -- failed (not owner)
--ERROR:  must be owner of language alt_lang2
-+ERROR:  language "alt_lang2" does not exist
- ALTER LANGUAGE alt_lang1 RENAME TO alt_lang3;   -- OK
-+ERROR:  language "alt_lang1" does not exist
- ALTER LANGUAGE alt_lang2 OWNER TO regress_alter_generic_user3;  -- failed (not owner)
--ERROR:  must be owner of language alt_lang2
-+ERROR:  language "alt_lang2" does not exist
- ALTER LANGUAGE alt_lang3 OWNER TO regress_alter_generic_user2;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user2"
-+ERROR:  language "alt_lang3" does not exist
- ALTER LANGUAGE alt_lang3 OWNER TO regress_alter_generic_user3;  -- OK
-+ERROR:  language "alt_lang3" does not exist
+ ALTER LANGUAGE alt_lang1 RENAME TO alt_lang2; -- failed (name conflict)
+-ERROR: language "alt_lang2" already exists
++ERROR: language "alt_lang1" does not exist
+ ALTER LANGUAGE alt_lang2 RENAME TO alt_lang3; -- failed (not owner)
+-ERROR: must be owner of language alt_lang2
++ERROR: language "alt_lang2" does not exist
+ ALTER LANGUAGE alt_lang1 RENAME TO alt_lang3; -- OK
++ERROR: language "alt_lang1" does not exist
+ ALTER LANGUAGE alt_lang2 OWNER TO regress_alter_generic_user3; -- failed (not owner)
+-ERROR: must be owner of language alt_lang2
++ERROR: language "alt_lang2" does not exist
+ ALTER LANGUAGE alt_lang3 OWNER TO regress_alter_generic_user2; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user2"
++ERROR: language "alt_lang3" does not exist
+ ALTER LANGUAGE alt_lang3 OWNER TO regress_alter_generic_user3; -- OK
++ERROR: language "alt_lang3" does not exist
  RESET SESSION AUTHORIZATION;
  SELECT lanname, a.rolname
-   FROM pg_language l, pg_authid a
-   WHERE l.lanowner = a.oid AND l.lanname like 'alt_lang%'
-   ORDER BY lanname;
--  lanname  |           rolname           
+ FROM pg_language l, pg_authid a
+ WHERE l.lanowner = a.oid AND l.lanname like 'alt_lang%'
+ ORDER BY lanname;
+ lanname | rolname
 ------------+-----------------------------
-- alt_lang2 | regress_alter_generic_user2
-- alt_lang3 | regress_alter_generic_user3
+-alt_lang2 | regress_alter_generic_user2
+-alt_lang3 | regress_alter_generic_user3
 -(2 rows)
-+ lanname | rolname 
 +---------+---------
 +(0 rows)
  
@@ -89,46 +86,47 @@
  ROLLBACK;
  -- Should fail. Only two arguments required for ALTER OPERATOR FAMILY ... DROP OPERATOR
  CREATE OPERATOR FAMILY alt_opf7 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf7 USING btree ADD OPERATOR 1 < (int4, int2);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8);
--ERROR:  one or two argument types must be specified
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8);
+-ERROR: one or two argument types must be specified
++ERROR: role "regress_alter_generic_user6" does not exist
++ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8);
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf7 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should work. During ALTER OPERATOR FAMILY ... DROP OPERATOR
  -- when left type is the same as right type, a DROP with only one argument type should work
  CREATE OPERATOR FAMILY alt_opf8 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf8 USING btree ADD OPERATOR 1 < (int4, int4);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf8 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should work. Textbook case of ALTER OPERATOR FAMILY ... ADD OPERATOR with FOR ORDER BY
  CREATE OPERATOR FAMILY alt_opf9 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf9 USING gist ADD OPERATOR 1 < (int4, int4) FOR ORDER BY float_ops;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf9 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. Ensure correct ordering methods in ALTER OPERATOR FAMILY ... ADD OPERATOR .. FOR ORDER BY
  CREATE OPERATOR FAMILY alt_opf10 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf10 USING btree ADD OPERATOR 1 < (int4, int4) FOR ORDER BY float_ops;
--ERROR:  access method "btree" does not support ordering operators
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: access method "btree" does not support ordering operators
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf10 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should work. Textbook case of ALTER OPERATOR FAMILY ... ADD OPERATOR with FOR ORDER BY
  CREATE OPERATOR FAMILY alt_opf11 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf11 USING gist ADD OPERATOR 1 < (int4, int4) FOR ORDER BY float_ops;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf11 USING gist DROP OPERATOR 1 (int4, int4);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf11 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. btree comparison functions should return INTEGER in ALTER OPERATOR FAMILY ... ADD FUNCTION
  BEGIN TRANSACTION;
  CREATE OPERATOR FAMILY alt_opf12 USING btree;
@@ -136,359 +134,359 @@
  -- Should fail. In gist throw an error when giving different data types for function argument
  -- without defining left / right type in ALTER OPERATOR FAMILY ... ADD FUNCTION
  CREATE OPERATOR FAMILY alt_opf16 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf16 USING gist ADD FUNCTION 1 btint42cmp(int4, int2);
--ERROR:  associated data types must be specified for index support function
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: associated data types must be specified for index support function
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf16 USING gist;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. duplicate operator number / function number in ALTER OPERATOR FAMILY ... ADD FUNCTION
  CREATE OPERATOR FAMILY alt_opf17 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4), OPERATOR 1 < (int4, int4); -- operator # appears twice in same statement
--ERROR:  operator number 1 for (integer,integer) appears more than once
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: operator number 1 for (integer,integer) appears more than once
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested first-time
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD OPERATOR 1 < (int4, int4); -- operator 1 requested again in separate statement
--ERROR:  operator 1(integer,integer) already exists in operator family "alt_opf17"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: operator 1(integer,integer) already exists in operator family "alt_opf17"
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
-   OPERATOR 1 < (int4, int2) ,
-   OPERATOR 2 <= (int4, int2) ,
+ OPERATOR 1 < (int4, int2) ,
+ OPERATOR 2 <= (int4, int2) ,
 @@ -472,7 +497,7 @@
-   OPERATOR 5 > (int4, int2) ,
-   FUNCTION 1 btint42cmp(int4, int2) ,
-   FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears twice in same statement
--ERROR:  function number 1 for (integer,smallint) appears more than once
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ OPERATOR 5 > (int4, int2) ,
+ FUNCTION 1 btint42cmp(int4, int2) ,
+ FUNCTION 1 btint42cmp(int4, int2); -- procedure 1 appears twice in same statement
+-ERROR: function number 1 for (integer,smallint) appears more than once
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
-   OPERATOR 1 < (int4, int2) ,
-   OPERATOR 2 <= (int4, int2) ,
+ OPERATOR 1 < (int4, int2) ,
+ OPERATOR 2 <= (int4, int2) ,
 @@ -480,6 +505,7 @@
-   OPERATOR 4 >= (int4, int2) ,
-   OPERATOR 5 > (int4, int2) ,
-   FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 appears first time
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ OPERATOR 4 >= (int4, int2) ,
+ OPERATOR 5 > (int4, int2) ,
+ FUNCTION 1 btint42cmp(int4, int2); -- procedure 1 appears first time
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf17 USING btree ADD
-   OPERATOR 1 < (int4, int2) ,
-   OPERATOR 2 <= (int4, int2) ,
+ OPERATOR 1 < (int4, int2) ,
+ OPERATOR 2 <= (int4, int2) ,
 @@ -487,13 +513,15 @@
-   OPERATOR 4 >= (int4, int2) ,
-   OPERATOR 5 > (int4, int2) ,
-   FUNCTION 1 btint42cmp(int4, int2);    -- procedure 1 requested again in separate statement
--ERROR:  operator 1(integer,smallint) already exists in operator family "alt_opf17"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ OPERATOR 4 >= (int4, int2) ,
+ OPERATOR 5 > (int4, int2) ,
+ FUNCTION 1 btint42cmp(int4, int2); -- procedure 1 requested again in separate statement
+-ERROR: operator 1(integer,smallint) already exists in operator family "alt_opf17"
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf17 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. Ensure that DROP requests for missing OPERATOR / FUNCTIONS
  -- return appropriate message in ALTER OPERATOR FAMILY ... DROP OPERATOR / FUNCTION
  CREATE OPERATOR FAMILY alt_opf18 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf18 USING btree DROP OPERATOR 1 (int4, int4);
--ERROR:  operator 1(integer,integer) does not exist in operator family "alt_opf18"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: operator 1(integer,integer) does not exist in operator family "alt_opf18"
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf18 USING btree ADD
-   OPERATOR 1 < (int4, int2) ,
-   OPERATOR 2 <= (int4, int2) ,
+ OPERATOR 1 < (int4, int2) ,
+ OPERATOR 2 <= (int4, int2) ,
 @@ -501,255 +529,231 @@
-   OPERATOR 4 >= (int4, int2) ,
-   OPERATOR 5 > (int4, int2) ,
-   FUNCTION 1 btint42cmp(int4, int2);
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ OPERATOR 4 >= (int4, int2) ,
+ OPERATOR 5 > (int4, int2) ,
+ FUNCTION 1 btint42cmp(int4, int2);
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. Not allowed to have cross-type equalimage function.
  ALTER OPERATOR FAMILY alt_opf18 USING btree
-   ADD FUNCTION 4 (int4, int2) btequalimage(oid);
--ERROR:  btree equal image functions must not be cross-type
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ ADD FUNCTION 4 (int4, int2) btequalimage(oid);
+-ERROR: btree equal image functions must not be cross-type
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf18 USING btree DROP FUNCTION 2 (int4, int4);
--ERROR:  function 2(integer,integer) does not exist in operator family "alt_opf18"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: function 2(integer,integer) does not exist in operator family "alt_opf18"
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf18 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  -- Should fail. Invalid opclass options function (#5) specifications.
  CREATE OPERATOR FAMILY alt_opf19 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf19 USING btree ADD FUNCTION 5 test_opclass_options_func(internal, text[], bool);
--ERROR:  function test_opclass_options_func(internal, text[], boolean) does not exist
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: function test_opclass_options_func(internal, text[], boolean) does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf19 USING btree ADD FUNCTION 5 (int4) btint42cmp(int4, int2);
--ERROR:  invalid operator class options parsing function
--HINT:  Valid signature of operator class options parsing function is (internal) RETURNS void.
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: invalid operator class options parsing function
+-HINT: Valid signature of operator class options parsing function is (internal) RETURNS void.
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf19 USING btree ADD FUNCTION 5 (int4, int2) btint42cmp(int4, int2);
--ERROR:  left and right associated data types for operator class options parsing functions must match
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: left and right associated data types for operator class options parsing functions must match
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf19 USING btree ADD FUNCTION 5 (int4) test_opclass_options_func(internal); -- Ok
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER OPERATOR FAMILY alt_opf19 USING btree DROP FUNCTION 5 (int4, int4);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP OPERATOR FAMILY alt_opf19 USING btree;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  --
  -- Statistics
  --
  SET SESSION AUTHORIZATION regress_alter_generic_user1;
  CREATE TABLE alt_regress_1 (a INTEGER, b INTEGER);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE STATISTICS alt_stat1 ON a, b FROM alt_regress_1;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE STATISTICS alt_stat2 ON a, b FROM alt_regress_1;
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat1 RENAME TO alt_stat2;   -- failed (name conflict)
--ERROR:  statistics object "alt_stat2" already exists in schema "alt_nsp1"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat1 RENAME TO alt_stat3;   -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat2 OWNER TO regress_alter_generic_user2;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat2 OWNER TO regress_alter_generic_user3;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat2 SET SCHEMA alt_nsp2;    -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat1 RENAME TO alt_stat2; -- failed (name conflict)
+-ERROR: statistics object "alt_stat2" already exists in schema "alt_nsp1"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat1 RENAME TO alt_stat3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat2 OWNER TO regress_alter_generic_user2; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user2"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat2 OWNER TO regress_alter_generic_user3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat2 SET SCHEMA alt_nsp2; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  SET SESSION AUTHORIZATION regress_alter_generic_user2;
  CREATE TABLE alt_regress_2 (a INTEGER, b INTEGER);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE STATISTICS alt_stat1 ON a, b FROM alt_regress_2;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE STATISTICS alt_stat2 ON a, b FROM alt_regress_2;
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat3 RENAME TO alt_stat4;    -- failed (not owner)
--ERROR:  must be owner of statistics object alt_stat3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat1 RENAME TO alt_stat4;    -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat3 RENAME TO alt_stat4; -- failed (not owner)
+-ERROR: must be owner of statistics object alt_stat3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat1 RENAME TO alt_stat4; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER STATISTICS alt_stat3 OWNER TO regress_alter_generic_user2; -- failed (not owner)
--ERROR:  must be owner of statistics object alt_stat3
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: must be owner of statistics object alt_stat3
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER STATISTICS alt_stat2 OWNER TO regress_alter_generic_user3; -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user3"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat3 SET SCHEMA alt_nsp2;		-- failed (not owner)
--ERROR:  must be owner of statistics object alt_stat3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER STATISTICS alt_stat2 SET SCHEMA alt_nsp2;		-- failed (name conflict)
--ERROR:  statistics object "alt_stat2" already exists in schema "alt_nsp2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: must be able to SET ROLE "regress_alter_generic_user3"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat3 SET SCHEMA alt_nsp2; -- failed (not owner)
+-ERROR: must be owner of statistics object alt_stat3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER STATISTICS alt_stat2 SET SCHEMA alt_nsp2; -- failed (name conflict)
+-ERROR: statistics object "alt_stat2" already exists in schema "alt_nsp2"
++ERROR: role "regress_alter_generic_user6" does not exist
  RESET SESSION AUTHORIZATION;
  SELECT nspname, stxname, rolname
-   FROM pg_statistic_ext s, pg_namespace n, pg_authid a
-  WHERE s.stxnamespace = n.oid AND s.stxowner = a.oid
-    AND n.nspname in ('alt_nsp1', 'alt_nsp2')
-  ORDER BY nspname, stxname;
-- nspname  |  stxname  |           rolname           
+ FROM pg_statistic_ext s, pg_namespace n, pg_authid a
+ WHERE s.stxnamespace = n.oid AND s.stxowner = a.oid
+ AND n.nspname in ('alt_nsp1', 'alt_nsp2')
+ ORDER BY nspname, stxname;
+-nspname | stxname | rolname
 -----------+-----------+-----------------------------
-- alt_nsp1 | alt_stat2 | regress_alter_generic_user2
-- alt_nsp1 | alt_stat3 | regress_alter_generic_user1
-- alt_nsp1 | alt_stat4 | regress_alter_generic_user2
-- alt_nsp2 | alt_stat2 | regress_alter_generic_user3
+-alt_nsp1 | alt_stat2 | regress_alter_generic_user2
+-alt_nsp1 | alt_stat3 | regress_alter_generic_user1
+-alt_nsp1 | alt_stat4 | regress_alter_generic_user2
+-alt_nsp2 | alt_stat2 | regress_alter_generic_user3
 -(4 rows)
 -
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  --
  -- Text Search Dictionary
  --
  SET SESSION AUTHORIZATION regress_alter_generic_user1;
  CREATE TEXT SEARCH DICTIONARY alt_ts_dict1 (template=simple);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH DICTIONARY alt_ts_dict2 (template=simple);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict2;  -- failed (name conflict)
--ERROR:  text search dictionary "alt_ts_dict2" already exists in schema "alt_nsp1"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict3;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user2;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user3;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 SET SCHEMA alt_nsp2;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict2; -- failed (name conflict)
+-ERROR: text search dictionary "alt_ts_dict2" already exists in schema "alt_nsp1"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user2; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user2"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 SET SCHEMA alt_nsp2; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  SET SESSION AUTHORIZATION regress_alter_generic_user2;
  CREATE TEXT SEARCH DICTIONARY alt_ts_dict1 (template=simple);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH DICTIONARY alt_ts_dict2 (template=simple);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 RENAME TO alt_ts_dict4;  -- failed (not owner)
--ERROR:  must be owner of text search dictionary alt_ts_dict3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict4;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 OWNER TO regress_alter_generic_user2;  -- failed (not owner)
--ERROR:  must be owner of text search dictionary alt_ts_dict3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user3;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user3"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 SET SCHEMA alt_nsp2;  -- failed (not owner)
--ERROR:  must be owner of text search dictionary alt_ts_dict3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 SET SCHEMA alt_nsp2;  -- failed (name conflict)
--ERROR:  text search dictionary "alt_ts_dict2" already exists in schema "alt_nsp2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 RENAME TO alt_ts_dict4; -- failed (not owner)
+-ERROR: must be owner of text search dictionary alt_ts_dict3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict1 RENAME TO alt_ts_dict4; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 OWNER TO regress_alter_generic_user2; -- failed (not owner)
+-ERROR: must be owner of text search dictionary alt_ts_dict3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 OWNER TO regress_alter_generic_user3; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user3"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict3 SET SCHEMA alt_nsp2; -- failed (not owner)
+-ERROR: must be owner of text search dictionary alt_ts_dict3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH DICTIONARY alt_ts_dict2 SET SCHEMA alt_nsp2; -- failed (name conflict)
+-ERROR: text search dictionary "alt_ts_dict2" already exists in schema "alt_nsp2"
++ERROR: role "regress_alter_generic_user6" does not exist
  RESET SESSION AUTHORIZATION;
  SELECT nspname, dictname, rolname
-   FROM pg_ts_dict t, pg_namespace n, pg_authid a
-   WHERE t.dictnamespace = n.oid AND t.dictowner = a.oid
-     AND n.nspname in ('alt_nsp1', 'alt_nsp2')
-   ORDER BY nspname, dictname;
-- nspname  |   dictname   |           rolname           
+ FROM pg_ts_dict t, pg_namespace n, pg_authid a
+ WHERE t.dictnamespace = n.oid AND t.dictowner = a.oid
+ AND n.nspname in ('alt_nsp1', 'alt_nsp2')
+ ORDER BY nspname, dictname;
+-nspname | dictname | rolname
 -----------+--------------+-----------------------------
-- alt_nsp1 | alt_ts_dict2 | regress_alter_generic_user2
-- alt_nsp1 | alt_ts_dict3 | regress_alter_generic_user1
-- alt_nsp1 | alt_ts_dict4 | regress_alter_generic_user2
-- alt_nsp2 | alt_ts_dict2 | regress_alter_generic_user3
+-alt_nsp1 | alt_ts_dict2 | regress_alter_generic_user2
+-alt_nsp1 | alt_ts_dict3 | regress_alter_generic_user1
+-alt_nsp1 | alt_ts_dict4 | regress_alter_generic_user2
+-alt_nsp2 | alt_ts_dict2 | regress_alter_generic_user3
 -(4 rows)
 -
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  --
  -- Text Search Configuration
  --
  SET SESSION AUTHORIZATION regress_alter_generic_user1;
  CREATE TEXT SEARCH CONFIGURATION alt_ts_conf1 (copy=english);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH CONFIGURATION alt_ts_conf2 (copy=english);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf2;  -- failed (name conflict)
--ERROR:  text search configuration "alt_ts_conf2" already exists in schema "alt_nsp1"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf3;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user2;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user3;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 SET SCHEMA alt_nsp2;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf2; -- failed (name conflict)
+-ERROR: text search configuration "alt_ts_conf2" already exists in schema "alt_nsp1"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user2; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user2"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user3; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 SET SCHEMA alt_nsp2; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  SET SESSION AUTHORIZATION regress_alter_generic_user2;
  CREATE TEXT SEARCH CONFIGURATION alt_ts_conf1 (copy=english);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH CONFIGURATION alt_ts_conf2 (copy=english);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 RENAME TO alt_ts_conf4;  -- failed (not owner)
--ERROR:  must be owner of text search configuration alt_ts_conf3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf4;  -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 OWNER TO regress_alter_generic_user2;  -- failed (not owner)
--ERROR:  must be owner of text search configuration alt_ts_conf3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user3;  -- failed (no role membership)
--ERROR:  must be able to SET ROLE "regress_alter_generic_user3"
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 SET SCHEMA alt_nsp2;  -- failed (not owner)
--ERROR:  must be owner of text search configuration alt_ts_conf3
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 SET SCHEMA alt_nsp2;  -- failed (name conflict)
--ERROR:  text search configuration "alt_ts_conf2" already exists in schema "alt_nsp2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 RENAME TO alt_ts_conf4; -- failed (not owner)
+-ERROR: must be owner of text search configuration alt_ts_conf3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf1 RENAME TO alt_ts_conf4; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 OWNER TO regress_alter_generic_user2; -- failed (not owner)
+-ERROR: must be owner of text search configuration alt_ts_conf3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 OWNER TO regress_alter_generic_user3; -- failed (no role membership)
+-ERROR: must be able to SET ROLE "regress_alter_generic_user3"
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf3 SET SCHEMA alt_nsp2; -- failed (not owner)
+-ERROR: must be owner of text search configuration alt_ts_conf3
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH CONFIGURATION alt_ts_conf2 SET SCHEMA alt_nsp2; -- failed (name conflict)
+-ERROR: text search configuration "alt_ts_conf2" already exists in schema "alt_nsp2"
++ERROR: role "regress_alter_generic_user6" does not exist
  RESET SESSION AUTHORIZATION;
  SELECT nspname, cfgname, rolname
-   FROM pg_ts_config t, pg_namespace n, pg_authid a
-   WHERE t.cfgnamespace = n.oid AND t.cfgowner = a.oid
-     AND n.nspname in ('alt_nsp1', 'alt_nsp2')
-   ORDER BY nspname, cfgname;
-- nspname  |   cfgname    |           rolname           
+ FROM pg_ts_config t, pg_namespace n, pg_authid a
+ WHERE t.cfgnamespace = n.oid AND t.cfgowner = a.oid
+ AND n.nspname in ('alt_nsp1', 'alt_nsp2')
+ ORDER BY nspname, cfgname;
+-nspname | cfgname | rolname
 -----------+--------------+-----------------------------
-- alt_nsp1 | alt_ts_conf2 | regress_alter_generic_user2
-- alt_nsp1 | alt_ts_conf3 | regress_alter_generic_user1
-- alt_nsp1 | alt_ts_conf4 | regress_alter_generic_user2
-- alt_nsp2 | alt_ts_conf2 | regress_alter_generic_user3
+-alt_nsp1 | alt_ts_conf2 | regress_alter_generic_user2
+-alt_nsp1 | alt_ts_conf3 | regress_alter_generic_user1
+-alt_nsp1 | alt_ts_conf4 | regress_alter_generic_user2
+-alt_nsp2 | alt_ts_conf2 | regress_alter_generic_user3
 -(4 rows)
 -
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  --
  -- Text Search Template
  --
  CREATE TEXT SEARCH TEMPLATE alt_ts_temp1 (lexize=dsimple_lexize);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH TEMPLATE alt_ts_temp2 (lexize=dsimple_lexize);
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER TEXT SEARCH TEMPLATE alt_ts_temp1 RENAME TO alt_ts_temp2; -- failed (name conflict)
--ERROR:  text search template "alt_ts_temp2" already exists in schema "alt_nsp1"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: text search template "alt_ts_temp2" already exists in schema "alt_nsp1"
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER TEXT SEARCH TEMPLATE alt_ts_temp1 RENAME TO alt_ts_temp3; -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH TEMPLATE alt_ts_temp2 SET SCHEMA alt_nsp2;    -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH TEMPLATE alt_ts_temp2 SET SCHEMA alt_nsp2; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH TEMPLATE alt_ts_temp2 (lexize=dsimple_lexize);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH TEMPLATE alt_ts_temp2 SET SCHEMA alt_nsp2;    -- failed (name conflict)
--ERROR:  text search template "alt_ts_temp2" already exists in schema "alt_nsp2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH TEMPLATE alt_ts_temp2 SET SCHEMA alt_nsp2; -- failed (name conflict)
+-ERROR: text search template "alt_ts_temp2" already exists in schema "alt_nsp2"
++ERROR: role "regress_alter_generic_user6" does not exist
  -- invalid: non-lowercase quoted identifiers
  CREATE TEXT SEARCH TEMPLATE tstemp_case ("Init" = init_function);
--ERROR:  text search template parameter "Init" not recognized
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: text search template parameter "Init" not recognized
++ERROR: role "regress_alter_generic_user6" does not exist
  SELECT nspname, tmplname
-   FROM pg_ts_template t, pg_namespace n
-   WHERE t.tmplnamespace = n.oid AND nspname like 'alt_nsp%'
-   ORDER BY nspname, tmplname;
-- nspname  |   tmplname   
+ FROM pg_ts_template t, pg_namespace n
+ WHERE t.tmplnamespace = n.oid AND nspname like 'alt_nsp%'
+ ORDER BY nspname, tmplname;
+-nspname | tmplname
 -----------+--------------
-- alt_nsp1 | alt_ts_temp2
-- alt_nsp1 | alt_ts_temp3
-- alt_nsp2 | alt_ts_temp2
+-alt_nsp1 | alt_ts_temp2
+-alt_nsp1 | alt_ts_temp3
+-alt_nsp2 | alt_ts_temp2
 -(3 rows)
 -
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  --
  -- Text Search Parser
  --
  CREATE TEXT SEARCH PARSER alt_ts_prs1
-     (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH PARSER alt_ts_prs2
-     (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER TEXT SEARCH PARSER alt_ts_prs1 RENAME TO alt_ts_prs2; -- failed (name conflict)
--ERROR:  text search parser "alt_ts_prs2" already exists in schema "alt_nsp1"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: text search parser "alt_ts_prs2" already exists in schema "alt_nsp1"
++ERROR: role "regress_alter_generic_user6" does not exist
  ALTER TEXT SEARCH PARSER alt_ts_prs1 RENAME TO alt_ts_prs3; -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH PARSER alt_ts_prs2 SET SCHEMA alt_nsp2;   -- OK
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH PARSER alt_ts_prs2 SET SCHEMA alt_nsp2; -- OK
++ERROR: role "regress_alter_generic_user6" does not exist
  CREATE TEXT SEARCH PARSER alt_ts_prs2
-     (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
-+ERROR:  role "regress_alter_generic_user6" does not exist
- ALTER TEXT SEARCH PARSER alt_ts_prs2 SET SCHEMA alt_nsp2;   -- failed (name conflict)
--ERROR:  text search parser "alt_ts_prs2" already exists in schema "alt_nsp2"
-+ERROR:  role "regress_alter_generic_user6" does not exist
+ (start = prsd_start, gettoken = prsd_nexttoken, end = prsd_end, lextypes = prsd_lextype);
++ERROR: role "regress_alter_generic_user6" does not exist
+ ALTER TEXT SEARCH PARSER alt_ts_prs2 SET SCHEMA alt_nsp2; -- failed (name conflict)
+-ERROR: text search parser "alt_ts_prs2" already exists in schema "alt_nsp2"
++ERROR: role "regress_alter_generic_user6" does not exist
  -- invalid: non-lowercase quoted identifiers
  CREATE TEXT SEARCH PARSER tspars_case ("Start" = start_function);
--ERROR:  text search parser parameter "Start" not recognized
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-ERROR: text search parser parameter "Start" not recognized
++ERROR: role "regress_alter_generic_user6" does not exist
  SELECT nspname, prsname
-   FROM pg_ts_parser t, pg_namespace n
-   WHERE t.prsnamespace = n.oid AND nspname like 'alt_nsp%'
-   ORDER BY nspname, prsname;
-- nspname  |   prsname   
+ FROM pg_ts_parser t, pg_namespace n
+ WHERE t.prsnamespace = n.oid AND nspname like 'alt_nsp%'
+ ORDER BY nspname, prsname;
+-nspname | prsname
 -----------+-------------
-- alt_nsp1 | alt_ts_prs2
-- alt_nsp1 | alt_ts_prs3
-- alt_nsp2 | alt_ts_prs2
+-alt_nsp1 | alt_ts_prs2
+-alt_nsp1 | alt_ts_prs3
+-alt_nsp2 | alt_ts_prs2
 -(3 rows)
 -
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  ---
  --- Cleanup resources
  ---
  DROP FOREIGN DATA WRAPPER alt_fdw2 CASCADE;
--NOTICE:  drop cascades to server alt_fserv2
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-NOTICE: drop cascades to server alt_fserv2
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP FOREIGN DATA WRAPPER alt_fdw3 CASCADE;
--NOTICE:  drop cascades to server alt_fserv3
-+ERROR:  role "regress_alter_generic_user6" does not exist
+-NOTICE: drop cascades to server alt_fserv3
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP LANGUAGE alt_lang2 CASCADE;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP LANGUAGE alt_lang3 CASCADE;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP SCHEMA alt_nsp1 CASCADE;
--NOTICE:  drop cascades to 28 other objects
--DETAIL:  drop cascades to function alt_func3(integer)
+-NOTICE: drop cascades to 28 other objects
+-DETAIL: drop cascades to function alt_func3(integer)
 -drop cascades to function alt_agg3(integer)
 -drop cascades to function alt_func4(integer)
 -drop cascades to function alt_func2(integer)
@@ -516,10 +514,10 @@
 -drop cascades to text search template alt_ts_temp2
 -drop cascades to text search parser alt_ts_prs3
 -drop cascades to text search parser alt_ts_prs2
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP SCHEMA alt_nsp2 CASCADE;
--NOTICE:  drop cascades to 9 other objects
--DETAIL:  drop cascades to function alt_nsp2.alt_func2(integer)
+-NOTICE: drop cascades to 9 other objects
+-DETAIL: drop cascades to function alt_nsp2.alt_func2(integer)
 -drop cascades to function alt_nsp2.alt_agg2(integer)
 -drop cascades to conversion alt_nsp2.alt_conv2
 -drop cascades to operator alt_nsp2.@-@(integer,integer)
@@ -528,10 +526,10 @@
 -drop cascades to text search configuration alt_nsp2.alt_ts_conf2
 -drop cascades to text search template alt_nsp2.alt_ts_temp2
 -drop cascades to text search parser alt_nsp2.alt_ts_prs2
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP USER regress_alter_generic_user1;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP USER regress_alter_generic_user2;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist
  DROP USER regress_alter_generic_user3;
-+ERROR:  role "regress_alter_generic_user6" does not exist
++ERROR: role "regress_alter_generic_user6" does not exist

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
@@ -4,41 +4,41 @@
  alter table atacc1 SET WITHOUT OIDS;
  -- try adding an oid column, should fail (not supported)
  alter table atacc1 SET WITH OIDS;
--ERROR:  syntax error at or near "WITH"
+-ERROR: syntax error at or near "WITH"
 -LINE 1: alter table atacc1 SET WITH OIDS;
--                               ^
-+ERROR:  parse error at position 27: syntax error
+-^
++ERROR: parse error at position 27: syntax error
  -- try dropping the xmin column, should fail
  alter table atacc1 drop xmin;
- ERROR:  cannot drop system column "xmin"
+ ERROR: cannot drop system column "xmin"
 @@ -1631,14 +1629,13 @@
  insert into attest values (1,2,3);
  alter table attest drop a;
  copy attest to stdout;
--2	3
-+ERROR:  COPY TO STDOUT not yet supported
+-2 3
++ERROR: COPY TO STDOUT not yet supported
  copy attest(a) to stdout;
--ERROR:  column "a" of relation "attest" does not exist
-+ERROR:  COPY TO STDOUT not yet supported
+-ERROR: column "a" of relation "attest" does not exist
++ERROR: COPY TO STDOUT not yet supported
  copy attest("........pg.dropped.1........") to stdout;
--ERROR:  column "........pg.dropped.1........" of relation "attest" does not exist
-+ERROR:  COPY TO STDOUT not yet supported
+-ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
++ERROR: COPY TO STDOUT not yet supported
  copy attest from stdin;
--ERROR:  extra data after last expected column
--CONTEXT:  COPY attest, line 1: "10	11	12"
-+ERROR:  failed to finalize COPY: COPY finalization failed: COPY operation failed: ERROR: extra data after last expected column
+-ERROR: extra data after last expected column
+-CONTEXT: COPY attest, line 1: "10 11 12"
++ERROR: failed to finalize COPY: COPY finalization failed: COPY operation failed: ERROR: extra data after last expected column
  select * from attest;
-  b | c 
+ b | c
  ---+---
 @@ -1654,9 +1651,9 @@
  (2 rows)
  
  copy attest(a) from stdin;
--ERROR:  column "a" of relation "attest" does not exist
-+ERROR:  failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "a" of relation "attest" does not exist
+-ERROR: column "a" of relation "attest" does not exist
++ERROR: failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "a" of relation "attest" does not exist
  copy attest("........pg.dropped.1........") from stdin;
--ERROR:  column "........pg.dropped.1........" of relation "attest" does not exist
-+ERROR:  failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
+-ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
++ERROR: failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
  copy attest(b,c) from stdin;
  select * from attest;
-  b  | c  
+ b | c

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/collate.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/collate.patch
@@ -4,10 +4,10 @@
  
  -- casting
  SELECT CAST('42' AS text COLLATE "C");
--ERROR:  syntax error at or near "COLLATE"
+-ERROR: syntax error at or near "COLLATE"
 -LINE 1: SELECT CAST('42' AS text COLLATE "C");
--                                 ^
-+ERROR:  parse error at position 33: syntax error
+-^
++ERROR: parse error at position 33: syntax error
  SELECT a, CAST(b AS varchar) FROM collate_test1 ORDER BY 2;
-  a |  b  
+ a | b
  ---+-----

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/constraints.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/constraints.patch
@@ -2,40 +2,40 @@
 +++ b
 @@ -48,16 +48,12 @@
  -- syntax errors
- --  test for extraneous comma
+ -- test for extraneous comma
  CREATE TABLE error_tbl (i int DEFAULT (100, ));
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: CREATE TABLE error_tbl (i int DEFAULT (100, ));
--                                                    ^
-+ERROR:  parse error at position 45: syntax error
- --  this will fail because gram.y uses b_expr not a_expr for defaults,
- --  to avoid a shift/reduce conflict that arises from NOT NULL being
- --  part of the column definition syntax:
+-^
++ERROR: parse error at position 45: syntax error
+ -- this will fail because gram.y uses b_expr not a_expr for defaults,
+ -- to avoid a shift/reduce conflict that arises from NOT NULL being
+ -- part of the column definition syntax:
  CREATE TABLE error_tbl (b1 bool DEFAULT 1 IN (1, 2));
--ERROR:  syntax error at or near "IN"
+-ERROR: syntax error at or near "IN"
 -LINE 1: CREATE TABLE error_tbl (b1 bool DEFAULT 1 IN (1, 2));
--                                                  ^
-+ERROR:  parse error at position 44: syntax error
- --  this should work, however:
+-^
++ERROR: parse error at position 44: syntax error
+ -- this should work, however:
  CREATE TABLE error_tbl (b1 bool DEFAULT (1 IN (1, 2)));
  DROP TABLE error_tbl;
 @@ -560,8 +556,7 @@
  BEGIN;
  INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
  COMMIT; -- should fail
--ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
--DETAIL:  Key (i)=(3) already exists.
-+ERROR:  conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
+-ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
+-DETAIL: Key (i)=(3) already exists.
++ERROR: conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
  -- make constraint check immediate
  BEGIN;
  SET CONSTRAINTS ALL IMMEDIATE;
 @@ -600,8 +595,7 @@
  SET CONSTRAINTS parted_uniq_tbl_i_key DEFERRED;
- INSERT INTO parted_uniq_tbl VALUES (1);	-- OK now, fail at commit
+ INSERT INTO parted_uniq_tbl VALUES (1); -- OK now, fail at commit
  COMMIT;
--ERROR:  duplicate key value violates unique constraint "parted_uniq_tbl_1_i_key"
--DETAIL:  Key (i)=(1) already exists.
-+ERROR:  conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "parted_uniq_tbl_1_i_key"
+-ERROR: duplicate key value violates unique constraint "parted_uniq_tbl_1_i_key"
+-DETAIL: Key (i)=(1) already exists.
++ERROR: conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "parted_uniq_tbl_1_i_key"
  DROP TABLE parted_uniq_tbl;
  -- test naming a constraint in a partition when a conflict exists
  CREATE TABLE parted_fk_naming (
@@ -43,26 +43,26 @@
  INSERT INTO unique_tbl VALUES (3, 'Three'); -- should succeed for now
  UPDATE unique_tbl SET t = 'THREE' WHERE i = 3 AND t = 'Three';
  COMMIT; -- should fail
--ERROR:  duplicate key value violates unique constraint "unique_tbl_i_key"
--DETAIL:  Key (i)=(3) already exists.
-+ERROR:  conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
+-ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
+-DETAIL: Key (i)=(3) already exists.
++ERROR: conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: duplicate key value violates unique constraint "unique_tbl_i_key"
  SELECT * FROM unique_tbl;
-  i |   t   
+ i | t
  ---+-------
 @@ -769,14 +762,12 @@
  BEGIN;
  INSERT INTO deferred_excl VALUES(2); -- no fail here
  COMMIT; -- should fail here
--ERROR:  conflicting key value violates exclusion constraint "deferred_excl_con"
--DETAIL:  Key (f1)=(2) conflicts with existing key (f1)=(2).
-+ERROR:  conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
+-ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
+-DETAIL: Key (f1)=(2) conflicts with existing key (f1)=(2).
++ERROR: conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
  BEGIN;
  INSERT INTO deferred_excl VALUES(3);
  INSERT INTO deferred_excl VALUES(3); -- no fail here
  COMMIT; -- should fail here
--ERROR:  conflicting key value violates exclusion constraint "deferred_excl_con"
--DETAIL:  Key (f1)=(3) conflicts with existing key (f1)=(3).
-+ERROR:  conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
+-ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
+-DETAIL: Key (f1)=(3) conflicts with existing key (f1)=(3).
++ERROR: conclude transaction failed for table_group:"default" shard:"0-inf" pooler_type:PRIMARY: conclude transaction failed: rpc error: code = Unknown desc = failed to commit transaction: ERROR: conflicting key value violates exclusion constraint "deferred_excl_con"
  -- bug #13148: deferred constraint versus HOT update
  BEGIN;
  INSERT INTO deferred_excl VALUES(2, 1); -- no fail here

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_function_c.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_function_c.patch
@@ -4,7 +4,7 @@
  -- is checked in many other test scripts.)
  --
  LOAD :'regresslib';
-+ERROR:  LOAD is not supported: loading shared libraries is not permitted through the connection pooler
++ERROR: LOAD is not supported: loading shared libraries is not permitted through the connection pooler
  -- Things that shouldn't work:
  CREATE FUNCTION test1 (int) RETURNS int LANGUAGE C
-     AS 'nosuchfile';
+ AS 'nosuchfile';

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_index.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_index.patch
@@ -2,12 +2,12 @@
 +++ b
 @@ -11,9 +11,7 @@
  CREATE INDEX IF NOT EXISTS onek_unique1 ON onek USING btree(unique1 int4_ops);
- NOTICE:  relation "onek_unique1" already exists, skipping
+ NOTICE: relation "onek_unique1" already exists, skipping
  CREATE INDEX IF NOT EXISTS ON onek USING btree(unique1 int4_ops);
--ERROR:  syntax error at or near "ON"
+-ERROR: syntax error at or near "ON"
 -LINE 1: CREATE INDEX IF NOT EXISTS ON onek USING btree(unique1 int4_...
--                                   ^
-+ERROR:  parse error at position 29: syntax error
+-^
++ERROR: parse error at position 29: syntax error
  CREATE INDEX onek_unique2 ON onek USING btree(unique2 int4_ops);
  CREATE INDEX onek_hundred ON onek USING btree(hundred int4_ops);
  CREATE INDEX onek_stringu1 ON onek USING btree(stringu1 name_ops);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_table.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_table.patch
@@ -4,21 +4,21 @@
  
  -- check that tables with oids cannot be created anymore
  CREATE TABLE withoid() WITH OIDS;
--ERROR:  syntax error at or near "OIDS"
+-ERROR: syntax error at or near "OIDS"
 -LINE 1: CREATE TABLE withoid() WITH OIDS;
--                                    ^
-+ERROR:  parse error at position 32: syntax error
+-^
++ERROR: parse error at position 32: syntax error
  CREATE TABLE withoid() WITH (oids);
- ERROR:  tables declared WITH OIDS are not supported
+ ERROR: tables declared WITH OIDS are not supported
  CREATE TABLE withoid() WITH (oids = true);
 @@ -445,9 +443,7 @@
-                                                              ^
+ ^
  -- syntax does not allow empty list of values for list partitions
  CREATE TABLE fail_part PARTITION OF list_parted FOR VALUES IN ();
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: ...E TABLE fail_part PARTITION OF list_parted FOR VALUES IN ();
--                                                                     ^
-+ERROR:  parse error at position 64: syntax error
+-^
++ERROR: parse error at position 64: syntax error
  -- trying to specify range for list partitioned table
  CREATE TABLE fail_part PARTITION OF list_parted FOR VALUES FROM (1) TO (2);
- ERROR:  invalid bound specification for a list partition
+ ERROR: invalid bound specification for a list partition

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/database.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/database.patch
@@ -2,31 +2,31 @@
 +++ b
 @@ -1,9 +1,14 @@
  CREATE DATABASE regression_tbd
- 	ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
-+ERROR:  CREATE DATABASE is not supported through the connection pooler
+ ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
++ERROR: CREATE DATABASE is not supported through the connection pooler
  ALTER DATABASE regression_tbd RENAME TO regression_utf8;
-+ERROR:  database "regression_tbd" does not exist
++ERROR: database "regression_tbd" does not exist
  ALTER DATABASE regression_utf8 SET TABLESPACE regress_tblspace;
-+ERROR:  database "regression_utf8" does not exist
++ERROR: database "regression_utf8" does not exist
  ALTER DATABASE regression_utf8 RESET TABLESPACE;
-+ERROR:  database "regression_utf8" does not exist
++ERROR: database "regression_utf8" does not exist
  ALTER DATABASE regression_utf8 CONNECTION_LIMIT 123;
-+ERROR:  database "regression_utf8" does not exist
- -- Test PgDatabaseToastTable.  Doing this with GRANT would be slow.
++ERROR: database "regression_utf8" does not exist
+ -- Test PgDatabaseToastTable. Doing this with GRANT would be slow.
  BEGIN;
  UPDATE pg_database
 @@ -11,11 +16,14 @@
  WHERE datname = 'regression_utf8';
  -- load catcache entry, if nothing else does
  ALTER DATABASE regression_utf8 RESET TABLESPACE;
-+ERROR:  database "regression_utf8" does not exist
++ERROR: database "regression_utf8" does not exist
  ROLLBACK;
  CREATE ROLE regress_datdba_before;
  CREATE ROLE regress_datdba_after;
  ALTER DATABASE regression_utf8 OWNER TO regress_datdba_before;
-+ERROR:  database "regression_utf8" does not exist
++ERROR: database "regression_utf8" does not exist
  REASSIGN OWNED BY regress_datdba_before TO regress_datdba_after;
  DROP DATABASE regression_utf8;
-+ERROR:  DROP DATABASE is not supported through the connection pooler
++ERROR: DROP DATABASE is not supported through the connection pooler
  DROP ROLE regress_datdba_before;
  DROP ROLE regress_datdba_after;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/drop_if_exists.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/drop_if_exists.patch
@@ -4,15 +4,15 @@
  -- This test checks both the functionality of 'if exists' and the syntax
  -- of the drop database command.
  drop database test_database_exists (force);
--ERROR:  database "test_database_exists" does not exist
-+ERROR:  DROP DATABASE is not supported through the connection pooler
+-ERROR: database "test_database_exists" does not exist
++ERROR: DROP DATABASE is not supported through the connection pooler
  drop database test_database_exists with (force);
--ERROR:  database "test_database_exists" does not exist
+-ERROR: database "test_database_exists" does not exist
 -drop database if exists test_database_exists (force);
--NOTICE:  database "test_database_exists" does not exist, skipping
-+ERROR:  DROP DATABASE is not supported through the connection pooler
+-NOTICE: database "test_database_exists" does not exist, skipping
++ERROR: DROP DATABASE is not supported through the connection pooler
 +drop database if exists test_database_exists (force);
-+ERROR:  DROP DATABASE is not supported through the connection pooler
++ERROR: DROP DATABASE is not supported through the connection pooler
  drop database if exists test_database_exists with (force);
--NOTICE:  database "test_database_exists" does not exist, skipping
-+ERROR:  DROP DATABASE is not supported through the connection pooler
+-NOTICE: database "test_database_exists" does not exist, skipping
++ERROR: DROP DATABASE is not supported through the connection pooler

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/errors.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/errors.patch
@@ -1,57 +1,57 @@
 --- a
 +++ b
 @@ -32,9 +32,7 @@
-                ^
+ ^
  -- empty distinct list isn't OK
  select distinct from pg_database;
--ERROR:  syntax error at or near "from"
+-ERROR: syntax error at or near "from"
 -LINE 1: select distinct from pg_database;
--                        ^
-+ERROR:  parse error at position 20: syntax error
+-^
++ERROR: parse error at position 20: syntax error
  -- bad attribute name on lhs of operator
  select * from pg_database where nonesuch = pg_database.datname;
- ERROR:  column "nonesuch" does not exist
+ ERROR: column "nonesuch" does not exist
 @@ -59,9 +57,7 @@
  -- DELETE
  -- missing relation name (this had better not wildcard!)
  delete from;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: delete from;
--                   ^
-+ERROR:  parse error at position 12: syntax error
+-^
++ERROR: parse error at position 12: syntax error
  -- no such relation
  delete from nonesuch;
- ERROR:  relation "nonesuch" does not exist
+ ERROR: relation "nonesuch" does not exist
 @@ -71,9 +67,7 @@
  -- DROP
  -- missing relation name (this had better not wildcard!)
  drop table;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop table;
--                  ^
-+ERROR:  parse error at position 11: syntax error
+-^
++ERROR: parse error at position 11: syntax error
  -- no such relation
  drop table nonesuch;
- ERROR:  table "nonesuch" does not exist
+ ERROR: table "nonesuch" does not exist
 @@ -82,9 +76,7 @@
  -- relation renaming
  -- missing relation name
  alter table rename;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: alter table rename;
--                          ^
-+ERROR:  parse error at position 19: syntax error
+-^
++ERROR: parse error at position 19: syntax error
  -- no such relation
  alter table nonesuch rename to newnonesuch;
- ERROR:  relation "nonesuch" does not exist
+ ERROR: relation "nonesuch" does not exist
 @@ -114,10 +106,8 @@
  -- TRANSACTION STUFF
  -- not in a xact
  abort;
--WARNING:  there is no transaction in progress
+-WARNING: there is no transaction in progress
  -- not in a xact
  end;
--WARNING:  there is no transaction in progress
+-WARNING: there is no transaction in progress
  --
  -- CREATE AGGREGATE
  -- sfunc/finalfunc type disagreement
@@ -59,181 +59,181 @@
  -- DROP INDEX
  -- missing index name
  drop index;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop index;
--                  ^
-+ERROR:  parse error at position 11: syntax error
+-^
++ERROR: parse error at position 11: syntax error
  -- bad index name
  drop index 314159;
--ERROR:  syntax error at or near "314159"
+-ERROR: syntax error at or near "314159"
 -LINE 1: drop index 314159;
--                   ^
-+ERROR:  parse error at position 17: syntax error
+-^
++ERROR: parse error at position 17: syntax error
  -- no such index
  drop index nonesuch;
- ERROR:  index "nonesuch" does not exist
+ ERROR: index "nonesuch" does not exist
 @@ -151,19 +137,13 @@
  -- DROP AGGREGATE
  -- missing aggregate name
  drop aggregate;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop aggregate;
--                      ^
-+ERROR:  parse error at position 15: syntax error
+-^
++ERROR: parse error at position 15: syntax error
  -- missing aggregate type
  drop aggregate newcnt1;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop aggregate newcnt1;
--                              ^
-+ERROR:  parse error at position 23: syntax error
+-^
++ERROR: parse error at position 23: syntax error
  -- bad aggregate name
  drop aggregate 314159 (int);
--ERROR:  syntax error at or near "314159"
+-ERROR: syntax error at or near "314159"
 -LINE 1: drop aggregate 314159 (int);
--                       ^
-+ERROR:  parse error at position 21: syntax error
+-^
++ERROR: parse error at position 21: syntax error
  -- bad aggregate type
  drop aggregate newcnt (nonesuch);
- ERROR:  type "nonesuch" does not exist
+ ERROR: type "nonesuch" does not exist
 @@ -177,14 +157,10 @@
  -- DROP FUNCTION
  -- missing function name
  drop function ();
--ERROR:  syntax error at or near "("
+-ERROR: syntax error at or near "("
 -LINE 1: drop function ();
--                      ^
-+ERROR:  parse error at position 15: syntax error
+-^
++ERROR: parse error at position 15: syntax error
  -- bad function name
  drop function 314159();
--ERROR:  syntax error at or near "314159"
+-ERROR: syntax error at or near "314159"
 -LINE 1: drop function 314159();
--                      ^
-+ERROR:  parse error at position 20: syntax error
+-^
++ERROR: parse error at position 20: syntax error
  -- no such function
  drop function nonesuch();
- ERROR:  function nonesuch() does not exist
+ ERROR: function nonesuch() does not exist
 @@ -192,14 +168,10 @@
  -- DROP TYPE
  -- missing type name
  drop type;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop type;
--                 ^
-+ERROR:  parse error at position 10: syntax error
+-^
++ERROR: parse error at position 10: syntax error
  -- bad type name
  drop type 314159;
--ERROR:  syntax error at or near "314159"
+-ERROR: syntax error at or near "314159"
 -LINE 1: drop type 314159;
--                  ^
-+ERROR:  parse error at position 16: syntax error
+-^
++ERROR: parse error at position 16: syntax error
  -- no such type
  drop type nonesuch;
- ERROR:  type "nonesuch" does not exist
+ ERROR: type "nonesuch" does not exist
 @@ -207,54 +179,34 @@
  -- DROP OPERATOR
  -- missing everything
  drop operator;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop operator;
--                     ^
-+ERROR:  parse error at position 14: syntax error
+-^
++ERROR: parse error at position 14: syntax error
  -- bad operator name
  drop operator equals;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop operator equals;
--                            ^
-+ERROR:  parse error at position 21: syntax error
+-^
++ERROR: parse error at position 21: syntax error
  -- missing type list
  drop operator ===;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop operator ===;
--                         ^
-+ERROR:  parse error at position 18: syntax error
+-^
++ERROR: parse error at position 18: syntax error
  -- missing parentheses
  drop operator int4, int4;
--ERROR:  syntax error at or near ","
+-ERROR: syntax error at or near ","
 -LINE 1: drop operator int4, int4;
--                          ^
-+ERROR:  parse error at position 19: syntax error
+-^
++ERROR: parse error at position 19: syntax error
  -- missing operator name
  drop operator (int4, int4);
--ERROR:  syntax error at or near "("
+-ERROR: syntax error at or near "("
 -LINE 1: drop operator (int4, int4);
--                      ^
-+ERROR:  parse error at position 15: syntax error
+-^
++ERROR: parse error at position 15: syntax error
  -- missing type list contents
  drop operator === ();
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: drop operator === ();
--                           ^
-+ERROR:  parse error at position 20: syntax error
+-^
++ERROR: parse error at position 20: syntax error
  -- no such operator
  drop operator === (int4);
--ERROR:  missing argument
+-ERROR: missing argument
 -LINE 1: drop operator === (int4);
--                               ^
--HINT:  Use NONE to denote the missing argument of a unary operator.
-+ERROR:  parse error at position 24: Use NONE to denote the missing argument of a unary operator.
+-^
+-HINT: Use NONE to denote the missing argument of a unary operator.
++ERROR: parse error at position 24: Use NONE to denote the missing argument of a unary operator.
  -- no such operator by that name
  drop operator === (int4, int4);
- ERROR:  operator does not exist: integer === integer
+ ERROR: operator does not exist: integer === integer
  -- no such type1
  drop operator = (nonesuch);
--ERROR:  missing argument
+-ERROR: missing argument
 -LINE 1: drop operator = (nonesuch);
--                                 ^
--HINT:  Use NONE to denote the missing argument of a unary operator.
-+ERROR:  parse error at position 26: Use NONE to denote the missing argument of a unary operator.
+-^
+-HINT: Use NONE to denote the missing argument of a unary operator.
++ERROR: parse error at position 26: Use NONE to denote the missing argument of a unary operator.
  -- no such type1
  drop operator = ( , int4);
--ERROR:  syntax error at or near ","
+-ERROR: syntax error at or near ","
 -LINE 1: drop operator = ( , int4);
--                          ^
-+ERROR:  parse error at position 19: syntax error
+-^
++ERROR: parse error at position 19: syntax error
  -- no such type1
  drop operator = (nonesuch, int4);
- ERROR:  type "nonesuch" does not exist
+ ERROR: type "nonesuch" does not exist
 @@ -263,37 +215,25 @@
- ERROR:  type "nonesuch" does not exist
+ ERROR: type "nonesuch" does not exist
  -- no such type2
  drop operator = (int4, );
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: drop operator = (int4, );
--                               ^
-+ERROR:  parse error at position 24: syntax error
+-^
++ERROR: parse error at position 24: syntax error
  --
  -- DROP RULE
  -- missing rule name
  drop rule;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: drop rule;
--                 ^
-+ERROR:  parse error at position 10: syntax error
+-^
++ERROR: parse error at position 10: syntax error
  -- bad rule name
  drop rule 314159;
--ERROR:  syntax error at or near "314159"
+-ERROR: syntax error at or near "314159"
 -LINE 1: drop rule 314159;
--                  ^
-+ERROR:  parse error at position 16: syntax error
+-^
++ERROR: parse error at position 16: syntax error
  -- no such rule
  drop rule nonesuch on noplace;
- ERROR:  relation "noplace" does not exist
+ ERROR: relation "noplace" does not exist
  -- these postquel variants are no longer supported
  drop tuple rule nonesuch;
--ERROR:  syntax error at or near "tuple"
+-ERROR: syntax error at or near "tuple"
 -LINE 1: drop tuple rule nonesuch;
--             ^
-+ERROR:  parse error at position 10: syntax error
+-^
++ERROR: parse error at position 10: syntax error
  drop instance rule nonesuch on noplace;
--ERROR:  syntax error at or near "instance"
+-ERROR: syntax error at or near "instance"
 -LINE 1: drop instance rule nonesuch on noplace;
--             ^
-+ERROR:  parse error at position 13: syntax error
+-^
++ERROR: parse error at position 13: syntax error
  drop rewrite rule nonesuch;
--ERROR:  syntax error at or near "rewrite"
+-ERROR: syntax error at or near "rewrite"
 -LINE 1: drop rewrite rule nonesuch;
--             ^
-+ERROR:  parse error at position 12: syntax error
+-^
++ERROR: parse error at position 12: syntax error
  --
  -- Check that division-by-zero is properly caught.
  --
@@ -241,73 +241,73 @@
  -- Test psql's reporting of syntax error location
  --
  xxx;
--ERROR:  syntax error at or near "xxx"
+-ERROR: syntax error at or near "xxx"
 -LINE 1: xxx;
--        ^
-+ERROR:  parse error at position 3: syntax error
+-^
++ERROR: parse error at position 3: syntax error
  CREATE foo;
--ERROR:  syntax error at or near "foo"
+-ERROR: syntax error at or near "foo"
 -LINE 1: CREATE foo;
--               ^
-+ERROR:  parse error at position 10: syntax error
+-^
++ERROR: parse error at position 10: syntax error
  CREATE TABLE ;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: CREATE TABLE ;
--                     ^
-+ERROR:  parse error at position 14: syntax error
+-^
++ERROR: parse error at position 14: syntax error
  CREATE TABLE
  \g
--ERROR:  syntax error at end of input
+-ERROR: syntax error at end of input
 -LINE 1: CREATE TABLE
--                    ^
-+ERROR:  parse error at position 12: syntax error
+-^
++ERROR: parse error at position 12: syntax error
  INSERT INTO foo VALUES(123) foo;
--ERROR:  syntax error at or near "foo"
+-ERROR: syntax error at or near "foo"
 -LINE 1: INSERT INTO foo VALUES(123) foo;
--                                    ^
-+ERROR:  parse error at position 31: syntax error
+-^
++ERROR: parse error at position 31: syntax error
  INSERT INTO 123
  VALUES(123);
--ERROR:  syntax error at or near "123"
+-ERROR: syntax error at or near "123"
 -LINE 1: INSERT INTO 123
--                    ^
-+ERROR:  parse error at position 15: syntax error
+-^
++ERROR: parse error at position 15: syntax error
  INSERT INTO foo
  VALUES(123) 123
  ;
--ERROR:  syntax error at or near "123"
+-ERROR: syntax error at or near "123"
 -LINE 2: VALUES(123) 123
--                    ^
-+ERROR:  parse error at position 31: syntax error
+-^
++ERROR: parse error at position 31: syntax error
  -- with a tab
  CREATE TABLE foo
-   (id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY,
- 	id3 INTEGER NOT NUL,
-    id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL);
--ERROR:  syntax error at or near "NUL"
--LINE 3:  id3 INTEGER NOT NUL,
--                         ^
-+ERROR:  parse error at position 96: syntax error
+ (id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY,
+ id3 INTEGER NOT NUL,
+ id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL);
+-ERROR: syntax error at or near "NUL"
+-LINE 3: id3 INTEGER NOT NUL,
+-^
++ERROR: parse error at position 96: syntax error
  -- long line to be truncated on the left
  CREATE TABLE foo(id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL,
  id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL);
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 1: ...OT NULL, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL,
--                                                                   ^
-+ERROR:  parse error at position 92: syntax error
+-^
++ERROR: parse error at position 92: syntax error
  -- long line to be truncated on the right
  CREATE TABLE foo(
  id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL, id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY);
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 2: id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQ...
--                        ^
-+ERROR:  parse error at position 37: syntax error
+-^
++ERROR: parse error at position 37: syntax error
  -- long line to be truncated both ways
  CREATE TABLE foo(id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL);
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 1: ...L, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 I...
--                                                             ^
-+ERROR:  parse error at position 92: syntax error
+-^
++ERROR: parse error at position 92: syntax error
  -- long line to be truncated on the left, many lines
  CREATE
  TEMPORARY
@@ -315,10 +315,10 @@
  NOT
  NULL)
  ;
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 4: ...OT NULL, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL,
--                                                                   ^
-+ERROR:  parse error at position 102: syntax error
+-^
++ERROR: parse error at position 102: syntax error
  -- long line to be truncated on the right, many lines
  CREATE
  TEMPORARY
@@ -326,10 +326,10 @@
  foo(
  id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL, id INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY)
  ;
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 5: id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQ...
--                        ^
-+ERROR:  parse error at position 47: syntax error
+-^
++ERROR: parse error at position 47: syntax error
  -- long line to be truncated both ways, many lines
  CREATE
  TEMPORARY
@@ -337,10 +337,10 @@
  UNIQUE NOT NULL, idx INT4 UNIQUE NOT NULL, idy INT4 UNIQUE NOT NULL, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 INT4 UNIQUE NOT NULL, id5 TEXT UNIQUE NOT NULL,
  idz INT4 UNIQUE NOT NULL,
  idv INT4 UNIQUE NOT NULL);
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 7: ...L, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 I...
--                                                             ^
-+ERROR:  parse error at position 155: syntax error
+-^
++ERROR: parse error at position 155: syntax error
  -- more than 10 lines...
  CREATE
  TEMPORARY
@@ -348,7 +348,7 @@
  UNIQUE
  NOT
  NULL);
--ERROR:  syntax error at or near "NUL"
+-ERROR: syntax error at or near "NUL"
 -LINE 16: ...L, id2 TEXT NOT NULL PRIMARY KEY, id3 INTEGER NOT NUL, id4 I...
--                                                              ^
-+ERROR:  parse error at position 182: syntax error
+-^
++ERROR: parse error at position 182: syntax error

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/event_trigger.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/event_trigger.patch
@@ -3,33 +3,33 @@
 @@ -75,9 +75,7 @@
  -- should fail, can't have arguments
  create event trigger regress_event_trigger2 on ddl_command_start
-    execute procedure test_event_trigger('argument not allowed');
--ERROR:  syntax error at or near "'argument not allowed'"
--LINE 2:    execute procedure test_event_trigger('argument not allowe...
--                                                ^
-+ERROR:  parse error at position 127: syntax error
+ execute procedure test_event_trigger('argument not allowed');
+-ERROR: syntax error at or near "'argument not allowed'"
+-LINE 2: execute procedure test_event_trigger('argument not allowe...
+-^
++ERROR: parse error at position 127: syntax error
  -- OK
  create event trigger regress_event_trigger2 on ddl_command_start
-    when tag in ('create table', 'CREATE FUNCTION')
+ when tag in ('create table', 'CREATE FUNCTION')
 @@ -165,11 +163,11 @@
  drop table event_trigger_fire1;
- NOTICE:  test_event_trigger: ddl_command_end DROP TABLE
+ NOTICE: test_event_trigger: ddl_command_end DROP TABLE
  create foreign data wrapper useless;
--NOTICE:  test_event_trigger: ddl_command_end CREATE FOREIGN DATA WRAPPER
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+-NOTICE: test_event_trigger: ddl_command_end CREATE FOREIGN DATA WRAPPER
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  create server useless_server foreign data wrapper useless;
--NOTICE:  test_event_trigger: ddl_command_end CREATE SERVER
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+-NOTICE: test_event_trigger: ddl_command_end CREATE SERVER
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  create user mapping for regress_evt_user server useless_server;
--NOTICE:  test_event_trigger: ddl_command_end CREATE USER MAPPING
-+ERROR:  server "useless_server" does not exist
+-NOTICE: test_event_trigger: ddl_command_end CREATE USER MAPPING
++ERROR: server "useless_server" does not exist
  alter default privileges for role regress_evt_user
-  revoke delete on tables from regress_evt_user;
- NOTICE:  test_event_trigger: ddl_command_end ALTER DEFAULT PRIVILEGES
+ revoke delete on tables from regress_evt_user;
+ NOTICE: test_event_trigger: ddl_command_end ALTER DEFAULT PRIVILEGES
 @@ -192,7 +190,6 @@
  drop role regress_evt_user;
- ERROR:  role "regress_evt_user" cannot be dropped because some objects depend on it
- DETAIL:  owner of event trigger regress_event_trigger3
+ ERROR: role "regress_evt_user" cannot be dropped because some objects depend on it
+ DETAIL: owner of event trigger regress_event_trigger3
 -owner of user mapping for regress_evt_user on server useless_server
  owner of default privileges on new relations belonging to role regress_evt_user
  -- cleanup before next test
@@ -38,8 +38,8 @@
  -- matview rewrite when changing access method
  CREATE MATERIALIZED VIEW heapmv USING heap AS SELECT 1 AS a;
  ALTER MATERIALIZED VIEW heapmv SET ACCESS METHOD heap2;
--NOTICE:  Table 'heapmv' is being rewritten (reason = 8)
-+ERROR:  access method "heap2" does not exist
+-NOTICE: Table 'heapmv' is being rewritten (reason = 8)
++ERROR: access method "heap2" does not exist
  DROP MATERIALIZED VIEW heapmv;
  -- shouldn't trigger a table_rewrite event
  alter table rewriteme alter column foo type numeric(12,4);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/fast_default.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/fast_default.patch
@@ -4,34 +4,34 @@
  -- verify that a default set on a non-plain table doesn't set a missing
  -- value on the attribute
  CREATE FOREIGN DATA WRAPPER dummy;
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  CREATE SERVER s0 FOREIGN DATA WRAPPER dummy;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  CREATE FOREIGN TABLE ft1 (c1 integer NOT NULL) SERVER s0;
-+ERROR:  server "s0" does not exist
++ERROR: server "s0" does not exist
  ALTER FOREIGN TABLE ft1 ADD COLUMN c8 integer DEFAULT 0;
-+ERROR:  relation "ft1" does not exist
++ERROR: relation "ft1" does not exist
  ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE char(10);
-+ERROR:  relation "ft1" does not exist
++ERROR: relation "ft1" does not exist
  SELECT count(*)
-   FROM pg_attribute
-   WHERE attrelid = 'ft1'::regclass AND
-     (attmissingval IS NOT NULL OR atthasmissing);
-- count 
+ FROM pg_attribute
+ WHERE attrelid = 'ft1'::regclass AND
+ (attmissingval IS NOT NULL OR atthasmissing);
+-count
 --------
--     0
+-0
 -(1 row)
 -
-+ERROR:  relation "ft1" does not exist
-+LINE 3:   WHERE attrelid = 'ft1'::regclass AND
-+                            ^
++ERROR: relation "ft1" does not exist
++LINE 3: WHERE attrelid = 'ft1'::regclass AND
++^
  -- cleanup
  DROP FOREIGN TABLE ft1;
-+ERROR:  foreign table "ft1" does not exist
++ERROR: foreign table "ft1" does not exist
  DROP SERVER s0;
-+ERROR:  server "s0" does not exist
++ERROR: server "s0" does not exist
  DROP FOREIGN DATA WRAPPER dummy;
-+ERROR:  foreign-data wrapper "dummy" does not exist
++ERROR: foreign-data wrapper "dummy" does not exist
  DROP TABLE vtype;
  DROP TABLE vtype2;
  DROP TABLE follower;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/functional_deps.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/functional_deps.patch
@@ -2,7 +2,7 @@
 +++ b
 @@ -230,3 +230,5 @@
  ALTER TABLE articles DROP CONSTRAINT articles_pkey RESTRICT;
- EXECUTE foo;  -- fail
- ERROR:  column "articles.keywords" must appear in the GROUP BY clause or be used in an aggregate function
+ EXECUTE foo; -- fail
+ ERROR: column "articles.keywords" must appear in the GROUP BY clause or be used in an aggregate function
 +LINE 1: EXECUTE foo;
-+                   ^
++^

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/merge.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/merge.patch
@@ -3,118 +3,111 @@
 @@ -60,81 +60,63 @@
  ON t.tid = s.sid
  WHEN MATCHED THEN
- 	UPDATE SET balance = 0;
--ERROR:  syntax error at or near "RANDOMWORD"
+ UPDATE SET balance = 0;
+-ERROR: syntax error at or near "RANDOMWORD"
 -LINE 1: MERGE INTO target t RANDOMWORD
--                            ^
-+ERROR:  parse error at position 30: syntax error
+-^
++ERROR: parse error at position 30: syntax error
  -- MATCHED/INSERT error
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN MATCHED THEN
- 	INSERT DEFAULT VALUES;
--ERROR:  syntax error at or near "INSERT"
--LINE 5:  INSERT DEFAULT VALUES;
--         ^
-+ERROR:  parse error at position 80: syntax error
+ INSERT DEFAULT VALUES;
+-ERROR: syntax error at or near "INSERT"
+-LINE 5: INSERT DEFAULT VALUES;
+-^
++ERROR: parse error at position 80: syntax error
  -- NOT MATCHED BY SOURCE/INSERT error
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED BY SOURCE THEN
- 	INSERT DEFAULT VALUES;
--ERROR:  syntax error at or near "INSERT"
--LINE 5:  INSERT DEFAULT VALUES;
--         ^
-+ERROR:  parse error at position 94: syntax error
+ INSERT DEFAULT VALUES;
+-ERROR: syntax error at or near "INSERT"
+-LINE 5: INSERT DEFAULT VALUES;
+-^
++ERROR: parse error at position 94: syntax error
  -- incorrectly specifying INTO target
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED THEN
- 	INSERT INTO target DEFAULT VALUES;
--ERROR:  syntax error at or near "INTO"
--LINE 5:  INSERT INTO target DEFAULT VALUES;
--                ^
-+ERROR:  parse error at position 89: syntax error
+ INSERT INTO target DEFAULT VALUES;
+-ERROR: syntax error at or near "INTO"
+-LINE 5: INSERT INTO target DEFAULT VALUES;
+-^
++ERROR: parse error at position 89: syntax error
  -- Multiple VALUES clause
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED THEN
- 	INSERT VALUES (1,1), (2,2);
--ERROR:  syntax error at or near ","
--LINE 5:  INSERT VALUES (1,1), (2,2);
--                            ^
-+ERROR:  parse error at position 98: syntax error
+ INSERT VALUES (1,1), (2,2);
+-ERROR: syntax error at or near ","
+-LINE 5: INSERT VALUES (1,1), (2,2);
+-^
++ERROR: parse error at position 98: syntax error
  -- SELECT query for INSERT
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED THEN
- 	INSERT SELECT (1, 1);
--ERROR:  syntax error at or near "SELECT"
--LINE 5:  INSERT SELECT (1, 1);
--                ^
-+ERROR:  parse error at position 91: syntax error
+ INSERT SELECT (1, 1);
+-ERROR: syntax error at or near "SELECT"
+-LINE 5: INSERT SELECT (1, 1);
+-^
++ERROR: parse error at position 91: syntax error
  -- NOT MATCHED/UPDATE
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED THEN
- 	UPDATE SET balance = 0;
--ERROR:  syntax error at or near "UPDATE"
--LINE 5:  UPDATE SET balance = 0;
--         ^
-+ERROR:  parse error at position 84: syntax error
+ UPDATE SET balance = 0;
+-ERROR: syntax error at or near "UPDATE"
+-LINE 5: UPDATE SET balance = 0;
+-^
++ERROR: parse error at position 84: syntax error
  -- NOT MATCHED BY TARGET/UPDATE
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN NOT MATCHED BY TARGET THEN
- 	UPDATE SET balance = 0;
--ERROR:  syntax error at or near "UPDATE"
--LINE 5:  UPDATE SET balance = 0;
--         ^
-+ERROR:  parse error at position 94: syntax error
+ UPDATE SET balance = 0;
+-ERROR: syntax error at or near "UPDATE"
+-LINE 5: UPDATE SET balance = 0;
+-^
++ERROR: parse error at position 94: syntax error
  -- UPDATE tablename
  MERGE INTO target t
  USING source AS s
  ON t.tid = s.sid
  WHEN MATCHED THEN
- 	UPDATE target SET balance = 0;
--ERROR:  syntax error at or near "target"
--LINE 5:  UPDATE target SET balance = 0;
--                ^
-+ERROR:  parse error at position 87: syntax error
+ UPDATE target SET balance = 0;
+-ERROR: syntax error at or near "target"
+-LINE 5: UPDATE target SET balance = 0;
+-^
++ERROR: parse error at position 87: syntax error
  -- source and target names the same
  MERGE INTO target
  USING target
-@@ -149,13 +131,13 @@
- ) SELECT * FROM foo;
- ERROR:  WITH query "foo" does not have a RETURNING clause
- LINE 4: ) SELECT * FROM foo;
--                        ^
-+                  ^
- -- used in COPY without RETURNING
- COPY (
-   MERGE INTO target USING source ON (true)
-   WHEN MATCHED THEN DELETE
+@@ -155,7 +137,7 @@
+ MERGE INTO target USING source ON (true)
+ WHEN MATCHED THEN DELETE
  ) TO stdout;
--ERROR:  COPY query must have a RETURNING clause
-+ERROR:  COPY TO STDOUT not yet supported
+-ERROR: COPY query must have a RETURNING clause
++ERROR: COPY TO STDOUT not yet supported
  -- unsupported relation types
  -- materialized view
  CREATE MATERIALIZED VIEW mv AS SELECT * FROM target;
 @@ -1520,9 +1502,7 @@
-         DELETE
-     RETURNING merge_action(), t.*
+ DELETE
+ RETURNING merge_action(), t.*
  ) TO stdout;
--DELETE	1	100
--UPDATE	2	220
--INSERT	4	40
-+ERROR:  COPY TO STDOUT not yet supported
+-DELETE 1 100
+-UPDATE 2 220
+-INSERT 4 40
++ERROR: COPY TO STDOUT not yet supported
  ROLLBACK;
  -- SQL function with MERGE ... RETURNING
  BEGIN;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/object_address.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/object_address.patch
@@ -4,9 +4,9 @@
  CREATE SCHEMA addr_nsp;
  SET search_path TO 'addr_nsp';
  CREATE FOREIGN DATA WRAPPER addr_fdw;
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  CREATE SERVER addr_fserv FOREIGN DATA WRAPPER addr_fdw;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  CREATE TEXT SEARCH DICTIONARY addr_ts_dict (template=simple);
  CREATE TEXT SEARCH CONFIGURATION addr_ts_conf (copy=english);
  CREATE TEXT SEARCH TEMPLATE addr_ts_temp (lexize=dsimple_lexize);
@@ -14,7 +14,7 @@
  CREATE TYPE addr_nsp.gencomptype AS (a int);
  CREATE TYPE addr_nsp.genenum AS ENUM ('one', 'two');
  CREATE FOREIGN TABLE addr_nsp.genftable (a int) SERVER addr_fserv;
-+ERROR:  server "addr_fserv" does not exist
++ERROR: server "addr_fserv" does not exist
  CREATE AGGREGATE addr_nsp.genaggr(int4) (sfunc = int4pl, stype = int4);
  CREATE DOMAIN addr_nsp.gendomain AS int4 CONSTRAINT domconstr CHECK (value > 0);
  CREATE FUNCTION addr_nsp.trig() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN END; $$;
@@ -22,9 +22,9 @@
  CREATE POLICY genpol ON addr_nsp.gentable;
  CREATE PROCEDURE addr_nsp.proc(int4) LANGUAGE SQL AS $$ $$;
  CREATE SERVER "integer" FOREIGN DATA WRAPPER addr_fdw;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  CREATE USER MAPPING FOR regress_addr_user SERVER "integer";
-+ERROR:  server "integer" does not exist
++ERROR: server "integer" does not exist
  ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user IN SCHEMA public GRANT ALL ON TABLES TO regress_addr_user;
  ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM regress_addr_user;
  -- this transform would be quite unsafe to leave lying around,
@@ -32,15 +32,15 @@
  CREATE PUBLICATION addr_pub_schema FOR TABLES IN SCHEMA addr_nsp;
  RESET client_min_messages;
  CREATE SUBSCRIPTION regress_addr_sub CONNECTION '' PUBLICATION bar WITH (connect = false, slot_name = NONE);
--WARNING:  subscription was created, but is not connected
--HINT:  To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
-+ERROR:  CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
+-WARNING: subscription was created, but is not connected
+-HINT: To initiate replication, you must manually create the replication slot, enable the subscription, and refresh the subscription.
++ERROR: CREATE SUBSCRIPTION is not supported: creating replication subscriptions is not permitted through the connection pooler
  CREATE STATISTICS addr_nsp.gentable_stat ON a, b FROM addr_nsp.gentable;
  -- test some error cases
  SELECT pg_get_object_address('stone', '{}', '{}');
 @@ -455,68 +459,16 @@
-      pg_identify_object_as_address(classid, objid, objsubid) AS ioa (typ, nms, args),
-      pg_get_object_address(typ, nms, ioa.args) AS addr2
+ pg_identify_object_as_address(classid, objid, objsubid) AS ioa (typ, nms, args),
+ pg_get_object_address(typ, nms, ioa.args) AS addr2
  ORDER BY addr1.classid, addr1.objid, addr1.objsubid;
 -default acl|NULL|NULL|for role regress_addr_user in schema public on tables|t
 -default acl|NULL|NULL|for role regress_addr_user on tables|t
@@ -92,21 +92,21 @@
 -publication|NULL|addr_pub|addr_pub|t
 -publication relation|NULL|NULL|addr_nsp.gentable in publication addr_pub|t
 -publication namespace|NULL|NULL|addr_nsp in publication addr_pub_schema|t
-+ERROR:  relation "addr_nsp.genftable" does not exist
++ERROR: relation "addr_nsp.genftable" does not exist
  ---
  --- Cleanup resources
  ---
  DROP FOREIGN DATA WRAPPER addr_fdw CASCADE;
--NOTICE:  drop cascades to 4 other objects
--DETAIL:  drop cascades to server addr_fserv
+-NOTICE: drop cascades to 4 other objects
+-DETAIL: drop cascades to server addr_fserv
 -drop cascades to foreign table genftable
 -drop cascades to server integer
 -drop cascades to user mapping for regress_addr_user on server integer
-+ERROR:  foreign-data wrapper "addr_fdw" does not exist
++ERROR: foreign-data wrapper "addr_fdw" does not exist
  DROP PUBLICATION addr_pub;
  DROP PUBLICATION addr_pub_schema;
  DROP SUBSCRIPTION regress_addr_sub;
-+ERROR:  subscription "regress_addr_sub" does not exist
++ERROR: subscription "regress_addr_sub" does not exist
  DROP SCHEMA addr_nsp CASCADE;
- NOTICE:  drop cascades to 14 other objects
- DETAIL:  drop cascades to text search dictionary addr_ts_dict
+ NOTICE: drop cascades to 14 other objects
+ DETAIL: drop cascades to text search dictionary addr_ts_dict

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/select_having.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/select_having.patch
@@ -1,22 +1,22 @@
 --- a
 +++ b
 @@ -26,8 +26,8 @@
- 	GROUP BY b, c HAVING b = 3 ORDER BY b, c;
-  b |    c     
+ GROUP BY b, c HAVING b = 3 ORDER BY b, c;
+ b | c
  ---+----------
-- 3 | BBBB    
-  3 | bbbb    
-+ 3 | BBBB    
+-3 | BBBB
+ 3 | bbbb
++3 | BBBB
  (2 rows)
  
  SELECT lower(c), count(c) FROM test_having
 @@ -45,8 +45,8 @@
- 	ORDER BY c;
-     c     | max 
+ ORDER BY c;
+ c | max
  ----------+-----
-- XXXX     |   0
-  bbbb     |   5
-+ XXXX     |   0
+-XXXX | 0
+ bbbb | 5
++XXXX | 0
  (2 rows)
  
  -- test degenerate cases involving HAVING without GROUP BY

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson.patch
@@ -1,0 +1,52 @@
+--- a
++++ b
+@@ -1,8 +1,6 @@
+ -- JSON()
+ SELECT JSON();
+-ERROR:  syntax error at or near ")"
+-LINE 1: SELECT JSON();
+-                    ^
++ERROR:  parse error at position 13: syntax error
+ SELECT JSON(NULL);
+  json 
+ ------
+@@ -128,9 +126,7 @@
+ 
+ -- JSON_SCALAR()
+ SELECT JSON_SCALAR();
+-ERROR:  syntax error at or near ")"
+-LINE 1: SELECT JSON_SCALAR();
+-                           ^
++ERROR:  parse error at position 20: syntax error
+ SELECT JSON_SCALAR(NULL);
+  json_scalar 
+ -------------
+@@ -219,9 +215,7 @@
+ 
+ -- JSON_SERIALIZE()
+ SELECT JSON_SERIALIZE();
+-ERROR:  syntax error at or near ")"
+-LINE 1: SELECT JSON_SERIALIZE();
+-                              ^
++ERROR:  parse error at position 23: syntax error
+ SELECT JSON_SERIALIZE(NULL);
+  json_serialize 
+ ----------------
+@@ -336,7 +330,7 @@
+ LINE 1: SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING UTF8)...
+                                           ^
+ SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING);
+-ERROR:  unrecognized JSON encoding: invalid_encoding
++ERROR:  parse error at position 71: unrecognized JSON encoding: invalid_encoding
+ SELECT JSON_OBJECT(RETURNING bytea);
+  json_object 
+ -------------
+@@ -631,7 +625,7 @@
+ LINE 1: SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING UTF8);
+                                          ^
+ SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING);
+-ERROR:  unrecognized JSON encoding: invalid_encoding
++ERROR:  parse error at position 70: unrecognized JSON encoding: invalid_encoding
+ SELECT JSON_ARRAY(RETURNING bytea);
+  json_array 
+ ------------

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson.patch
@@ -3,50 +3,50 @@
 @@ -1,8 +1,6 @@
  -- JSON()
  SELECT JSON();
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: SELECT JSON();
--                    ^
-+ERROR:  parse error at position 13: syntax error
+-^
++ERROR: parse error at position 13: syntax error
  SELECT JSON(NULL);
-  json 
+ json
  ------
 @@ -128,9 +126,7 @@
  
  -- JSON_SCALAR()
  SELECT JSON_SCALAR();
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: SELECT JSON_SCALAR();
--                           ^
-+ERROR:  parse error at position 20: syntax error
+-^
++ERROR: parse error at position 20: syntax error
  SELECT JSON_SCALAR(NULL);
-  json_scalar 
+ json_scalar
  -------------
 @@ -219,9 +215,7 @@
  
  -- JSON_SERIALIZE()
  SELECT JSON_SERIALIZE();
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: SELECT JSON_SERIALIZE();
--                              ^
-+ERROR:  parse error at position 23: syntax error
+-^
++ERROR: parse error at position 23: syntax error
  SELECT JSON_SERIALIZE(NULL);
-  json_serialize 
+ json_serialize
  ----------------
 @@ -336,7 +330,7 @@
  LINE 1: SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING UTF8)...
-                                           ^
+ ^
  SELECT JSON_OBJECT(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING);
--ERROR:  unrecognized JSON encoding: invalid_encoding
-+ERROR:  parse error at position 71: unrecognized JSON encoding: invalid_encoding
+-ERROR: unrecognized JSON encoding: invalid_encoding
++ERROR: parse error at position 71: unrecognized JSON encoding: invalid_encoding
  SELECT JSON_OBJECT(RETURNING bytea);
-  json_object 
+ json_object
  -------------
 @@ -631,7 +625,7 @@
  LINE 1: SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING UTF8);
-                                          ^
+ ^
  SELECT JSON_ARRAY(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING);
--ERROR:  unrecognized JSON encoding: invalid_encoding
-+ERROR:  parse error at position 70: unrecognized JSON encoding: invalid_encoding
+-ERROR: unrecognized JSON encoding: invalid_encoding
++ERROR: parse error at position 70: unrecognized JSON encoding: invalid_encoding
  SELECT JSON_ARRAY(RETURNING bytea);
-  json_array 
+ json_array
  ------------

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
@@ -1,0 +1,98 @@
+--- a
++++ b
+@@ -1,9 +1,7 @@
+ -- JSON_TABLE
+ -- Should fail (JSON_TABLE can be used only in FROM clause)
+ SELECT JSON_TABLE('[]', '$');
+-ERROR:  syntax error at or near "("
+-LINE 1: SELECT JSON_TABLE('[]', '$');
+-                         ^
++ERROR:  parse error at position 18: syntax error
+ -- Only allow EMPTY and ERROR for ON ERROR
+ SELECT * FROM JSON_TABLE('[]', 'strict $.a' COLUMNS (js2 int PATH '$') DEFAULT 1 ON ERROR);
+ ERROR:  invalid ON ERROR behavior
+@@ -25,19 +23,17 @@
+ -- Column and path names must be distinct
+ SELECT * FROM JSON_TABLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int path '$'));
+ ERROR:  duplicate JSON_TABLE column or path name: js2
+-LINE 1: ...M JSON_TABLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int pa...
++LINE 1: ...BLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int path '$'));
+                                                              ^
+ -- Should fail (no columns)
+ SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ());
+-ERROR:  syntax error at or near ")"
+-LINE 1: SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ());
+-                                                    ^
++ERROR:  parse error at position 46: syntax error
+ SELECT * FROM JSON_TABLE (NULL::jsonb, '$' COLUMNS (v1 timestamp)) AS f (v1, v2);
+ ERROR:  JSON_TABLE function has 1 columns available but 2 columns specified
+ --duplicated column name
+ SELECT * FROM JSON_TABLE(jsonb'"1.23"', '$.a' COLUMNS (js2 int path '$', js2 int path '$'));
+ ERROR:  duplicate JSON_TABLE column or path name: js2
+-LINE 1: ...E(jsonb'"1.23"', '$.a' COLUMNS (js2 int path '$', js2 int pa...
++LINE 1: ...1.23"', '$.a' COLUMNS (js2 int path '$', js2 int path '$'));
+                                                               ^
+ --return composite data type.
+ create type comp as (a int, b int);
+@@ -490,7 +486,7 @@
+ -- JSON_TABLE: only one FOR ORDINALITY columns allowed
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY, a int PATH '$.a' ERROR ON EMPTY)) jt;
+ ERROR:  only one FOR ORDINALITY column is allowed
+-LINE 1: ..._TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR OR...
++LINE 1: ...onb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY,...
+                                                              ^
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, a int PATH '$' ERROR ON EMPTY)) jt;
+  id | a 
+@@ -664,7 +660,7 @@
+ -- Error: OMIT QUOTES should not be specified when WITH WRAPPER is present
+ SELECT * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text PATH '$' WITH WRAPPER OMIT QUOTES));
+ ERROR:  SQL/JSON QUOTES behavior must not be specified when WITH WRAPPER is used
+-LINE 1: ...T * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text ...
++LINE 1: ...JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text PATH '$' ...
+                                                              ^
+ -- But KEEP QUOTES (the default) is fine
+ SELECT * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text FORMAT JSON PATH '$' WITH WRAPPER KEEP QUOTES));
+@@ -705,7 +701,7 @@
+ -- Should fail (not supported)
+ SELECT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || 'a' COLUMNS (foo int));
+ ERROR:  only string constants are supported in JSON_TABLE path specification
+-LINE 1: SELECT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || '...
++LINE 1: ...CT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || 'a' C...
+                                                              ^
+ -- JsonPathQuery() error message mentioning column name
+ SELECT * FROM JSON_TABLE('{"a": [{"b": "1"}, {"b": "2"}]}', '$' COLUMNS (b json path '$.a[*].b' ERROR ON ERROR));
+@@ -1107,29 +1103,27 @@
+ DROP TABLE s;
+ -- Prevent ON EMPTY specification on EXISTS columns
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on empty));
+-ERROR:  syntax error at or near "empty"
+-LINE 1: ...sonb '1', '$' COLUMNS (a int exists empty object on empty));
+-                                                               ^
++ERROR:  parse error at position 84: syntax error
+ -- Test ON ERROR / EMPTY value validity for the function and column types;
+ -- all fail
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ERROR);
+ ERROR:  invalid ON ERROR behavior
+-LINE 1: ... * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ER...
++LINE 1: ...OM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ERROR);
+                                                              ^
+ DETAIL:  Only EMPTY [ ARRAY ] or ERROR is allowed in the top-level ON ERROR clause.
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on empty));
+ ERROR:  invalid ON EMPTY behavior for column "a"
+-LINE 1: ...T * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on em...
++LINE 1: ...OM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on empty));
+                                                              ^
+ DETAIL:  Only ERROR, NULL, or DEFAULT expression is allowed in ON EMPTY for scalar columns.
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int omit quotes true on error));
+ ERROR:  invalid ON ERROR behavior for column "a"
+-LINE 1: ...N_TABLE(jsonb '1', '$' COLUMNS (a int omit quotes true on er...
++LINE 1: ...E(jsonb '1', '$' COLUMNS (a int omit quotes true on error));
+                                                              ^
+ DETAIL:  Only ERROR, NULL, EMPTY ARRAY, EMPTY OBJECT, or DEFAULT expression is allowed in ON ERROR for formatted columns.
+ SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on error));
+ ERROR:  invalid ON ERROR behavior for column "a"
+-LINE 1: ...M JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty obje...
++LINE 1: ...BLE(jsonb '1', '$' COLUMNS (a int exists empty object on err...
+                                                              ^
+ DETAIL:  Only ERROR, TRUE, FALSE, or UNKNOWN is allowed in ON ERROR for EXISTS columns.
+ -- Test JSON_TABLE() column deparsing -- don't emit default ON ERROR / EMPTY

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
@@ -4,95 +4,95 @@
  -- JSON_TABLE
  -- Should fail (JSON_TABLE can be used only in FROM clause)
  SELECT JSON_TABLE('[]', '$');
--ERROR:  syntax error at or near "("
+-ERROR: syntax error at or near "("
 -LINE 1: SELECT JSON_TABLE('[]', '$');
--                         ^
-+ERROR:  parse error at position 18: syntax error
+-^
++ERROR: parse error at position 18: syntax error
  -- Only allow EMPTY and ERROR for ON ERROR
  SELECT * FROM JSON_TABLE('[]', 'strict $.a' COLUMNS (js2 int PATH '$') DEFAULT 1 ON ERROR);
- ERROR:  invalid ON ERROR behavior
+ ERROR: invalid ON ERROR behavior
 @@ -25,19 +23,17 @@
  -- Column and path names must be distinct
  SELECT * FROM JSON_TABLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int path '$'));
- ERROR:  duplicate JSON_TABLE column or path name: js2
+ ERROR: duplicate JSON_TABLE column or path name: js2
 -LINE 1: ...M JSON_TABLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int pa...
 +LINE 1: ...BLE(jsonb'"1.23"', '$.a' as js2 COLUMNS (js2 int path '$'));
-                                                              ^
+ ^
  -- Should fail (no columns)
  SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ());
--ERROR:  syntax error at or near ")"
+-ERROR: syntax error at or near ")"
 -LINE 1: SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ());
--                                                    ^
-+ERROR:  parse error at position 46: syntax error
+-^
++ERROR: parse error at position 46: syntax error
  SELECT * FROM JSON_TABLE (NULL::jsonb, '$' COLUMNS (v1 timestamp)) AS f (v1, v2);
- ERROR:  JSON_TABLE function has 1 columns available but 2 columns specified
+ ERROR: JSON_TABLE function has 1 columns available but 2 columns specified
  --duplicated column name
  SELECT * FROM JSON_TABLE(jsonb'"1.23"', '$.a' COLUMNS (js2 int path '$', js2 int path '$'));
- ERROR:  duplicate JSON_TABLE column or path name: js2
+ ERROR: duplicate JSON_TABLE column or path name: js2
 -LINE 1: ...E(jsonb'"1.23"', '$.a' COLUMNS (js2 int path '$', js2 int pa...
 +LINE 1: ...1.23"', '$.a' COLUMNS (js2 int path '$', js2 int path '$'));
-                                                               ^
+ ^
  --return composite data type.
  create type comp as (a int, b int);
 @@ -490,7 +486,7 @@
  -- JSON_TABLE: only one FOR ORDINALITY columns allowed
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY, a int PATH '$.a' ERROR ON EMPTY)) jt;
- ERROR:  only one FOR ORDINALITY column is allowed
+ ERROR: only one FOR ORDINALITY column is allowed
 -LINE 1: ..._TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR OR...
 +LINE 1: ...onb '1', '$' COLUMNS (id FOR ORDINALITY, id2 FOR ORDINALITY,...
-                                                              ^
+ ^
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (id FOR ORDINALITY, a int PATH '$' ERROR ON EMPTY)) jt;
-  id | a 
+ id | a
 @@ -664,7 +660,7 @@
  -- Error: OMIT QUOTES should not be specified when WITH WRAPPER is present
  SELECT * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text PATH '$' WITH WRAPPER OMIT QUOTES));
- ERROR:  SQL/JSON QUOTES behavior must not be specified when WITH WRAPPER is used
+ ERROR: SQL/JSON QUOTES behavior must not be specified when WITH WRAPPER is used
 -LINE 1: ...T * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text ...
 +LINE 1: ...JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text PATH '$' ...
-                                                              ^
+ ^
  -- But KEEP QUOTES (the default) is fine
  SELECT * FROM JSON_TABLE(jsonb '"world"', '$' COLUMNS (item text FORMAT JSON PATH '$' WITH WRAPPER KEEP QUOTES));
 @@ -705,7 +701,7 @@
  -- Should fail (not supported)
  SELECT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || 'a' COLUMNS (foo int));
- ERROR:  only string constants are supported in JSON_TABLE path specification
+ ERROR: only string constants are supported in JSON_TABLE path specification
 -LINE 1: SELECT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || '...
 +LINE 1: ...CT * FROM JSON_TABLE(jsonb '{"a": 123}', '$' || '.' || 'a' C...
-                                                              ^
+ ^
  -- JsonPathQuery() error message mentioning column name
  SELECT * FROM JSON_TABLE('{"a": [{"b": "1"}, {"b": "2"}]}', '$' COLUMNS (b json path '$.a[*].b' ERROR ON ERROR));
 @@ -1107,29 +1103,27 @@
  DROP TABLE s;
  -- Prevent ON EMPTY specification on EXISTS columns
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on empty));
--ERROR:  syntax error at or near "empty"
+-ERROR: syntax error at or near "empty"
 -LINE 1: ...sonb '1', '$' COLUMNS (a int exists empty object on empty));
--                                                               ^
-+ERROR:  parse error at position 84: syntax error
+-^
++ERROR: parse error at position 84: syntax error
  -- Test ON ERROR / EMPTY value validity for the function and column types;
  -- all fail
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ERROR);
- ERROR:  invalid ON ERROR behavior
+ ERROR: invalid ON ERROR behavior
 -LINE 1: ... * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ER...
 +LINE 1: ...OM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ERROR);
-                                                              ^
- DETAIL:  Only EMPTY [ ARRAY ] or ERROR is allowed in the top-level ON ERROR clause.
+ ^
+ DETAIL: Only EMPTY [ ARRAY ] or ERROR is allowed in the top-level ON ERROR clause.
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on empty));
- ERROR:  invalid ON EMPTY behavior for column "a"
+ ERROR: invalid ON EMPTY behavior for column "a"
 -LINE 1: ...T * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on em...
 +LINE 1: ...OM JSON_TABLE(jsonb '1', '$' COLUMNS (a int true on empty));
-                                                              ^
- DETAIL:  Only ERROR, NULL, or DEFAULT expression is allowed in ON EMPTY for scalar columns.
+ ^
+ DETAIL: Only ERROR, NULL, or DEFAULT expression is allowed in ON EMPTY for scalar columns.
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int omit quotes true on error));
- ERROR:  invalid ON ERROR behavior for column "a"
+ ERROR: invalid ON ERROR behavior for column "a"
 -LINE 1: ...N_TABLE(jsonb '1', '$' COLUMNS (a int omit quotes true on er...
 +LINE 1: ...E(jsonb '1', '$' COLUMNS (a int omit quotes true on error));
-                                                              ^
- DETAIL:  Only ERROR, NULL, EMPTY ARRAY, EMPTY OBJECT, or DEFAULT expression is allowed in ON ERROR for formatted columns.
+ ^
+ DETAIL: Only ERROR, NULL, EMPTY ARRAY, EMPTY OBJECT, or DEFAULT expression is allowed in ON ERROR for formatted columns.
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on error));
- ERROR:  invalid ON ERROR behavior for column "a"
+ ERROR: invalid ON ERROR behavior for column "a"
 -LINE 1: ...M JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty obje...
 +LINE 1: ...BLE(jsonb '1', '$' COLUMNS (a int exists empty object on err...
-                                                              ^
- DETAIL:  Only ERROR, TRUE, FALSE, or UNKNOWN is allowed in ON ERROR for EXISTS columns.
+ ^
+ DETAIL: Only ERROR, TRUE, FALSE, or UNKNOWN is allowed in ON ERROR for EXISTS columns.
  -- Test JSON_TABLE() column deparsing -- don't emit default ON ERROR / EMPTY

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_queryfuncs.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_queryfuncs.patch
@@ -3,56 +3,56 @@
 @@ -431,7 +431,7 @@
  
  SELECT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSON); -- RETURNING FORMAT not allowed
- ERROR:  cannot specify FORMAT JSON in RETURNING clause of JSON_VALUE()
+ ERROR: cannot specify FORMAT JSON in RETURNING clause of JSON_VALUE()
 -LINE 1: ...CT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSO...
 +LINE 1: ...JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSON);
-                                                                    ^
+ ^
  -- RETUGNING pseudo-types not allowed
  SELECT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING record);
 @@ -1269,7 +1269,7 @@
  -- CoerceViaIO
- SELECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '"1"')::jsonb ON ERROR);
- ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
--LINE 1: ...CT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '"...
-+LINE 1: ...ECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '...
-                                                              ^
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT '"1"')::jsonb ON ERROR);
+ ERROR: can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ...CT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT '"...
++LINE 1: ...ECT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT '...
+ ^
  -- CoerceToDomain
  SELECT JSON_QUERY('"a"', '$.a' RETURNING queryfuncs_test_domain DEFAULT (select '"1"')::queryfuncs_test_domain ON ERROR);
 @@ -1279,24 +1279,24 @@
  -- RelabelType
- SELECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1)::oid::int ON ERROR);
- ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
--LINE 1: ...CT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1)...
-+LINE 1: ...ECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1...
-                                                              ^
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT 1)::oid::int ON ERROR);
+ ERROR: can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ...CT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT 1)...
++LINE 1: ...ECT JSON_QUERY('"a"', '$.a' RETURNING int DEFAULT (SELECT 1...
+ ^
  -- ArrayCoerceExpr
- SELECT JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::oid[]::int[] ON ERROR);
- ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
--LINE 1: ... JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{...
-+LINE 1: ...T JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '...
-                                                              ^
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '{1}')::oid[]::int[] ON ERROR);
+ ERROR: can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ... JSON_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '{...
++LINE 1: ...T JSON_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '...
+ ^
  -- CollateExpr
- SELECT JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::text COLLATE "C" ON ERROR);
- ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
--LINE 1: ... JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{...
-+LINE 1: ...N_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')...
-                                                              ^
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '{1}')::text COLLATE "C" ON ERROR);
+ ERROR: can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ... JSON_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '{...
++LINE 1: ...N_QUERY('"a"', '$.a' RETURNING int[] DEFAULT (SELECT '{1}')...
+ ^
  -- ConvertRowtypeExpr
  CREATE TABLE someparent (a int);
  CREATE TABLE somechild () INHERITS (someparent);
- SELECT JSON_QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '(1)')::somechild::someparent ON ERROR);
- ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
--LINE 1: ..._QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '(...
-+LINE 1: ...N_QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '...
-                                                              ^
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING someparent DEFAULT (SELECT '(1)')::somechild::someparent ON ERROR);
+ ERROR: can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ..._QUERY('"a"', '$.a' RETURNING someparent DEFAULT (SELECT '(...
++LINE 1: ...N_QUERY('"a"', '$.a' RETURNING someparent DEFAULT (SELECT '...
+ ^
  DROP DOMAIN queryfuncs_test_domain;
  DROP TABLE someparent, somechild;
 @@ -1452,7 +1452,7 @@
- ERROR:  bit string length 3 does not match type bit(2)
- SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR);
- ERROR:  cannot cast behavior expression of type integer to bit
--LINE 1: ...VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR...
-+LINE 1: ...LUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR);
-                                                                    ^
- HINT:  You will need to explicitly cast the expression to type bit.
- SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1::bit(3) ON ERROR);
+ ERROR: bit string length 3 does not match type bit(2)
+ SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3) DEFAULT 1 ON ERROR);
+ ERROR: cannot cast behavior expression of type integer to bit
+-LINE 1: ...VALUE(jsonb '1234', '$' RETURNING bit(3) DEFAULT 1 ON ERROR...
++LINE 1: ...LUE(jsonb '1234', '$' RETURNING bit(3) DEFAULT 1 ON ERROR);
+ ^
+ HINT: You will need to explicitly cast the expression to type bit.
+ SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3) DEFAULT 1::bit(3) ON ERROR);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_queryfuncs.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_queryfuncs.patch
@@ -1,0 +1,58 @@
+--- a
++++ b
+@@ -431,7 +431,7 @@
+ 
+ SELECT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSON); -- RETURNING FORMAT not allowed
+ ERROR:  cannot specify FORMAT JSON in RETURNING clause of JSON_VALUE()
+-LINE 1: ...CT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSO...
++LINE 1: ...JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING int FORMAT JSON);
+                                                                    ^
+ -- RETUGNING pseudo-types not allowed
+ SELECT JSON_VALUE(jsonb '["1"]', '$[*]' RETURNING record);
+@@ -1269,7 +1269,7 @@
+ -- CoerceViaIO
+ SELECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '"1"')::jsonb ON ERROR);
+ ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ...CT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '"...
++LINE 1: ...ECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT '...
+                                                              ^
+ -- CoerceToDomain
+ SELECT JSON_QUERY('"a"', '$.a' RETURNING queryfuncs_test_domain DEFAULT (select '"1"')::queryfuncs_test_domain ON ERROR);
+@@ -1279,24 +1279,24 @@
+ -- RelabelType
+ SELECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1)::oid::int ON ERROR);
+ ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ...CT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1)...
++LINE 1: ...ECT JSON_QUERY('"a"', '$.a'  RETURNING int DEFAULT (SELECT 1...
+                                                              ^
+ -- ArrayCoerceExpr
+ SELECT JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::oid[]::int[] ON ERROR);
+ ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ... JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{...
++LINE 1: ...T JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '...
+                                                              ^
+ -- CollateExpr
+ SELECT JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')::text COLLATE "C" ON ERROR);
+ ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ... JSON_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{...
++LINE 1: ...N_QUERY('"a"', '$.a'  RETURNING int[] DEFAULT (SELECT '{1}')...
+                                                              ^
+ -- ConvertRowtypeExpr
+ CREATE TABLE someparent (a int);
+ CREATE TABLE somechild () INHERITS (someparent);
+ SELECT JSON_QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '(1)')::somechild::someparent ON ERROR);
+ ERROR:  can only specify a constant, non-aggregate function, or operator expression for DEFAULT
+-LINE 1: ..._QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '(...
++LINE 1: ...N_QUERY('"a"', '$.a'  RETURNING someparent DEFAULT (SELECT '...
+                                                              ^
+ DROP DOMAIN queryfuncs_test_domain;
+ DROP TABLE someparent, somechild;
+@@ -1452,7 +1452,7 @@
+ ERROR:  bit string length 3 does not match type bit(2)
+ SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR);
+ ERROR:  cannot cast behavior expression of type integer to bit
+-LINE 1: ...VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR...
++LINE 1: ...LUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1 ON ERROR);
+                                                                    ^
+ HINT:  You will need to explicitly cast the expression to type bit.
+ SELECT JSON_VALUE(jsonb '1234', '$' RETURNING bit(3)  DEFAULT 1::bit(3) ON ERROR);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/stats_ext.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/stats_ext.patch
@@ -4,36 +4,36 @@
  -- Verify failures
  CREATE TABLE ext_stats_test (x text, y int, z int);
  CREATE STATISTICS tst;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: CREATE STATISTICS tst;
--                             ^
-+ERROR:  parse error at position 22: syntax error
+-^
++ERROR: parse error at position 22: syntax error
  CREATE STATISTICS tst ON a, b;
--ERROR:  syntax error at or near ";"
+-ERROR: syntax error at or near ";"
 -LINE 1: CREATE STATISTICS tst ON a, b;
--                                     ^
-+ERROR:  parse error at position 30: syntax error
+-^
++ERROR: parse error at position 30: syntax error
  CREATE STATISTICS tst FROM sometab;
--ERROR:  syntax error at or near "FROM"
+-ERROR: syntax error at or near "FROM"
 -LINE 1: CREATE STATISTICS tst FROM sometab;
--                              ^
-+ERROR:  parse error at position 26: syntax error
+-^
++ERROR: parse error at position 26: syntax error
  CREATE STATISTICS tst ON a, b FROM nonexistent;
- ERROR:  relation "nonexistent" does not exist
+ ERROR: relation "nonexistent" does not exist
  CREATE STATISTICS tst ON a, b FROM ext_stats_test;
 @@ -58,13 +52,9 @@
  CREATE STATISTICS tst ON (y) FROM ext_stats_test; -- single column reference
- ERROR:  extended statistics require at least 2 columns
+ ERROR: extended statistics require at least 2 columns
  CREATE STATISTICS tst ON y + z FROM ext_stats_test; -- missing parentheses
--ERROR:  syntax error at or near "+"
+-ERROR: syntax error at or near "+"
 -LINE 1: CREATE STATISTICS tst ON y + z FROM ext_stats_test;
--                                   ^
-+ERROR:  parse error at position 28: syntax error
+-^
++ERROR: parse error at position 28: syntax error
  CREATE STATISTICS tst ON (x, y) FROM ext_stats_test; -- tuple expression
--ERROR:  syntax error at or near ","
+-ERROR: syntax error at or near ","
 -LINE 1: CREATE STATISTICS tst ON (x, y) FROM ext_stats_test;
--                                   ^
-+ERROR:  parse error at position 28: syntax error
+-^
++ERROR: parse error at position 28: syntax error
  DROP TABLE ext_stats_test;
  -- Ensure stats are dropped sanely, and test IF NOT EXISTS while at it
  CREATE TABLE ab1 (a INTEGER, b INTEGER, c INTEGER);
@@ -41,29 +41,29 @@
  CREATE MATERIALIZED VIEW tststats.mv AS SELECT * FROM tststats.t;
  CREATE TYPE tststats.ty AS (a int, b int, c text);
  CREATE FOREIGN DATA WRAPPER extstats_dummy_fdw;
-+ERROR:  CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
  CREATE SERVER extstats_dummy_srv FOREIGN DATA WRAPPER extstats_dummy_fdw;
-+ERROR:  CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
  CREATE FOREIGN TABLE tststats.f (a int, b int, c text) SERVER extstats_dummy_srv;
-+ERROR:  server "extstats_dummy_srv" does not exist
++ERROR: server "extstats_dummy_srv" does not exist
  CREATE TABLE tststats.pt (a int, b int, c text) PARTITION BY RANGE (a, b);
  CREATE TABLE tststats.pt1 PARTITION OF tststats.pt FOR VALUES FROM (-10, -10) TO (10, 10);
  CREATE STATISTICS tststats.s1 ON a, b FROM tststats.t;
 @@ -323,6 +316,7 @@
- ERROR:  cannot define statistics for relation "ty"
- DETAIL:  This operation is not supported for composite types.
+ ERROR: cannot define statistics for relation "ty"
+ DETAIL: This operation is not supported for composite types.
  CREATE STATISTICS tststats.s7 ON a, b FROM tststats.f;
-+ERROR:  relation "tststats.f" does not exist
++ERROR: relation "tststats.f" does not exist
  CREATE STATISTICS tststats.s8 ON a, b FROM tststats.pt;
  CREATE STATISTICS tststats.s9 ON a, b FROM tststats.pt1;
  DO $$
 @@ -336,16 +330,15 @@
  $$;
- NOTICE:  stats on toast table not created
+ NOTICE: stats on toast table not created
  DROP SCHEMA tststats CASCADE;
--NOTICE:  drop cascades to 7 other objects
-+NOTICE:  drop cascades to 6 other objects
- DETAIL:  drop cascades to table tststats.t
+-NOTICE: drop cascades to 7 other objects
++NOTICE: drop cascades to 6 other objects
+ DETAIL: drop cascades to table tststats.t
  drop cascades to sequence tststats.s
  drop cascades to view tststats.v
  drop cascades to materialized view tststats.mv
@@ -71,8 +71,8 @@
 -drop cascades to foreign table tststats.f
  drop cascades to table tststats.pt
  DROP FOREIGN DATA WRAPPER extstats_dummy_fdw CASCADE;
--NOTICE:  drop cascades to server extstats_dummy_srv
-+ERROR:  foreign-data wrapper "extstats_dummy_fdw" does not exist
+-NOTICE: drop cascades to server extstats_dummy_srv
++ERROR: foreign-data wrapper "extstats_dummy_fdw" does not exist
  -- n-distinct tests
  CREATE TABLE ndistinct (
-     filler1 TEXT,
+ filler1 TEXT,

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/tablesample.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/tablesample.patch
@@ -2,12 +2,12 @@
 +++ b
 @@ -310,9 +310,7 @@
  LINE 2: SELECT * FROM query_select TABLESAMPLE BERNOULLI (5.5) REPEA...
-                       ^
+ ^
  SELECT q.* FROM (SELECT * FROM test_tablesample) as q TABLESAMPLE BERNOULLI (5);
--ERROR:  syntax error at or near "TABLESAMPLE"
+-ERROR: syntax error at or near "TABLESAMPLE"
 -LINE 1: ...CT q.* FROM (SELECT * FROM test_tablesample) as q TABLESAMPL...
--                                                             ^
-+ERROR:  parse error at position 65: syntax error
+-^
++ERROR: parse error at position 65: syntax error
  -- check partitioned tables support tablesample
  create table parted_sample (a int) partition by list (a);
  create table parted_sample_1 partition of parted_sample for values in (1);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/unicode.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/unicode.patch
@@ -3,19 +3,19 @@
 @@ -69,7 +69,9 @@
  (1 row)
  
- SELECT "normalize"('abc', 'def');  -- run-time error
--ERROR:  invalid normalization form: def
-+ERROR:  syntax error at or near "def"
+ SELECT "normalize"('abc', 'def'); -- run-time error
+-ERROR: invalid normalization form: def
++ERROR: syntax error at or near "def"
 +LINE 1: SELECT "normalize"('abc', 'def');
-+                                ^
++^
  SELECT U&'\00E4\24D1c' IS NORMALIZED AS test_default;
-  test_default 
+ test_default
  --------------
 @@ -104,4 +106,6 @@
  (5 rows)
  
- SELECT is_normalized('abc', 'def');  -- run-time error
--ERROR:  invalid normalization form: def
-+ERROR:  syntax error at or near "def"
+ SELECT is_normalized('abc', 'def'); -- run-time error
+-ERROR: invalid normalization form: def
++ERROR: syntax error at or near "def"
 +LINE 1: SELECT is_normalized('abc', 'def');
-+                        ^
++^

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/vacuum.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/vacuum.patch
@@ -2,12 +2,12 @@
 +++ b
 @@ -307,9 +307,7 @@
  ANALYZE (VERBOSE) does_not_exist;
- ERROR:  relation "does_not_exist" does not exist
+ ERROR: relation "does_not_exist" does not exist
  ANALYZE (nonexistent-arg) does_not_exist;
--ERROR:  syntax error at or near "arg"
+-ERROR: syntax error at or near "arg"
 -LINE 1: ANALYZE (nonexistent-arg) does_not_exist;
--                             ^
-+ERROR:  parse error at position 24: syntax error
+-^
++ERROR: parse error at position 24: syntax error
  ANALYZE (nonexistentarg) does_not_exit;
- ERROR:  unrecognized ANALYZE option "nonexistentarg"
+ ERROR: unrecognized ANALYZE option "nonexistentarg"
  LINE 1: ANALYZE (nonexistentarg) does_not_exit;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/window.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/window.patch
@@ -1,51 +1,42 @@
 --- a
 +++ b
-@@ -2301,7 +2301,7 @@
-              1 preceding and 1.1::float8 following);  -- currently unsupported
- ERROR:  RANGE with offset PRECEDING/FOLLOWING is not supported for column type numeric and offset type double precision
- LINE 4:              1 preceding and 1.1::float8 following);
--                                     ^
-+                        ^
- HINT:  Cast the offset value to an appropriate type.
- select id, f_numeric, first_value(id) over w, last_value(id) over w
- from numerics
 @@ -2953,7 +2953,7 @@
  select sum(salary) over (order by depname range between '1 year'::interval preceding and '2 years'::interval following
- 	exclude ties), salary, enroll_date from empsalary;
- ERROR:  RANGE with offset PRECEDING/FOLLOWING is not supported for column type text
+ exclude ties), salary, enroll_date from empsalary;
+ ERROR: RANGE with offset PRECEDING/FOLLOWING is not supported for column type text
 -LINE 1: ... sum(salary) over (order by depname range between '1 year'::...
 +LINE 1: ...salary) over (order by depname range between '1 year'::inter...
-                                                              ^
+ ^
  select max(enroll_date) over (order by enroll_date range between 1 preceding and 2 following
- 	exclude ties), salary, enroll_date from empsalary;
+ exclude ties), salary, enroll_date from empsalary;
 @@ -2970,7 +2970,7 @@
  select max(enroll_date) over (order by salary range between '1 year'::interval preceding and '2 years'::interval following
- 	exclude ties), salary, enroll_date from empsalary;
- ERROR:  RANGE with offset PRECEDING/FOLLOWING is not supported for column type integer and offset type interval
+ exclude ties), salary, enroll_date from empsalary;
+ ERROR: RANGE with offset PRECEDING/FOLLOWING is not supported for column type integer and offset type interval
 -LINE 1: ...(enroll_date) over (order by salary range between '1 year'::...
 +LINE 1: ...ll_date) over (order by salary range between '1 year'::inter...
-                                                              ^
- HINT:  Cast the offset value to an appropriate type.
+ ^
+ HINT: Cast the offset value to an appropriate type.
  select max(enroll_date) over (order by enroll_date range between '1 year'::interval preceding and '-2 years'::interval following
 @@ -3645,9 +3645,7 @@
  LINE 1: SELECT rank() OVER (ORDER BY 1), count(*) FROM empsalary GRO...
-                ^
+ ^
  SELECT * FROM rank() OVER (ORDER BY random());
--ERROR:  syntax error at or near "ORDER"
+-ERROR: syntax error at or near "ORDER"
 -LINE 1: SELECT * FROM rank() OVER (ORDER BY random());
--                                   ^
-+ERROR:  parse error at position 32: syntax error
+-^
++ERROR: parse error at position 32: syntax error
  DELETE FROM empsalary WHERE (rank() OVER (ORDER BY random())) > 10;
- ERROR:  window functions are not allowed in WHERE
+ ERROR: window functions are not allowed in WHERE
  LINE 1: DELETE FROM empsalary WHERE (rank() OVER (ORDER BY random())...
 @@ -3661,9 +3659,7 @@
  LINE 1: ...w FROM tenk1 WINDOW w AS (ORDER BY unique1), w AS (ORDER BY ...
-                                                              ^
+ ^
  SELECT rank() OVER (PARTITION BY four, ORDER BY ten) FROM tenk1;
--ERROR:  syntax error at or near "ORDER"
+-ERROR: syntax error at or near "ORDER"
 -LINE 1: SELECT rank() OVER (PARTITION BY four, ORDER BY ten) FROM te...
--                                               ^
-+ERROR:  parse error at position 44: syntax error
+-^
++ERROR: parse error at position 44: syntax error
  SELECT count() OVER () FROM tenk1;
- ERROR:  count(*) must be used to call a parameterless aggregate function
+ ERROR: count(*) must be used to call a parameterless aggregate function
  LINE 1: SELECT count() OVER () FROM tenk1;


### PR DESCRIPTION
## Summary

- Extends the SqlString() deparsers on the SQL/JSON-2024 AST nodes to emit clauses that were previously dropped (ENCODING, ABSENT/NULL ON NULL, WITH UNIQUE [KEYS], PASSING, ON EMPTY/ERROR with DEFAULT expr, WRAPPER, KEEP/OMIT QUOTES, JSON_TABLE path AS name, RETURNING FORMAT JSON ENCODING X).
- Fixes the json_table_column_definition grammar to actually populate Wrapper / Quotes / OnEmpty / OnError on JsonTableColumn (REGULAR, FORMATTED, EXISTS) — these were captured by the rule and discarded.
- Rejects unknown encoding names in json_format_clause at parse time (instead of silently mapping them to JS_ENC_DEFAULT) so JSON_OBJECT(... FORMAT JSON ENCODING INVALID_ENCODING) errors as PG does.
- Records the remaining out-of-scope residual diffs as patches under `testdata/pg17/patches/` so the patch-based verification reports ✅ for the three sqljson tests.

Refs MUL-405.

## Problem

The gateway pipeline parses → normalizes → re-stringifies every query before forwarding to PostgreSQL (executor.go:151-168, route.go:98-101). Several SQL/JSON-2024 AST nodes silently dropped clauses on that round-trip, and the JSON_TABLE column grammar discarded Wrapper / Quotes / OnEmpty / OnError at parse time. Net effect: PG 17.6 received a stripped query, and the three pgregress sqljson tests either succeeded where PG should error, or returned the wrong shape.

Concrete symptoms in the diff:

- `JSON('1' WITH UNIQUE KEYS)` → backend saw `JSON('1')` → succeeded where PG should error.
- `JSON_OBJECT('a':'1','b':NULL,'c':2 ABSENT ON NULL)` → returned `{"a":"1","b":null,"c":2}` instead of dropping `b`.
- `JSON_EXISTS(... PASSING 1 AS x)` → PASSING dropped → backend errored `could not find jsonpath variable "x"`.
- `JSON_VALUE(... ERROR ON ERROR)` / `DEFAULT 'x' ON ERROR` → behavior dropped → silent NULL where PG expects ERROR or `'x'`.
- `JSON_TABLE(... COLUMNS(... jsonb FORMAT JSON PATH '$' WITH WRAPPER))` and `OMIT QUOTES` → wrapper/quotes specs dropped, so `jsb2w` returned raw scalars instead of `[1]` and `jsb2q` kept quoted strings.
- `JSON_TABLE(jsonb'…', '$.a' as js2 COLUMNS (js2 …))` → table path's `AS js2` dropped, so PG couldn't detect the column/path-name conflict.
- `JSON_OBJECT(RETURNING text FORMAT JSON ENCODING INVALID_ENCODING)` → unknown encoding mapped to default, query silently succeeded with `{}` instead of erroring.

## Solution

**`fix(parser): preserve SQL/JSON clauses on AST deparse round-trip`** (893ff33b)

- `JsonFormat`: emit `ENCODING UTF8/UTF16/UTF32`.
- `JsonParseExpr`: emit `WITH UNIQUE KEYS`.
- `JsonObjectConstructor` / `JsonArrayConstructor` / `JsonObjectAgg` / `JsonArrayAgg`: emit `ABSENT ON NULL` and `WITH UNIQUE KEYS` based on the parsed defaults (JSON_OBJECT defaults to NULL ON NULL; JSON_ARRAY defaults to ABSENT ON NULL).
- `JsonFuncExpr` (`JSON_EXISTS` / `JSON_VALUE` / `JSON_QUERY`): emit `PASSING` args, `ON EMPTY` / `ON ERROR` (incl. `DEFAULT <expr>` payload), and `WITH/WITHOUT [CONDITIONAL/UNCONDITIONAL] ARRAY WRAPPER` plus `KEEP/OMIT QUOTES` for `JSON_QUERY`.
- `JsonTableColumn`: emit `WITH WRAPPER` / `OMIT QUOTES` for `JTC_REGULAR` and `JTC_FORMATTED`.
- `JsonTablePathSpec` / `JsonTableColumn` (`JTC_NESTED`): emit `AS <name>` for the table-level path alias and nested-column path alias — required for PG's duplicate column/path-name validation.
- All RETURNING clauses go through a shared `appendJsonReturning` helper that emits `RETURNING <type> [FORMAT JSON [ENCODING X]]`.
- Grammar fix in `json_table_column_definition`: actually populate `Wrapper`, `Quotes`, `OnEmpty`, `OnError` on `JsonTableColumn` for `JTC_REGULAR` / `JTC_FORMATTED`, and `OnError` on `JTC_EXISTS`.
- Round-trip parser test fixtures regenerated for `sqljson`, `sqljson_jsontable`, `sqljson_queryfuncs`.

**`fix(parser): reject unknown JSON encoding name at parse time`** (3c84c3bd)

- `json_format_clause` now calls `yylex.Error("unrecognized JSON encoding: <name>")` when the name isn't `utf8` / `utf16` / `utf32`. The `JsonFormat` node only carries an enum, so preserving the raw name through to the backend would mean reshaping the AST; rejecting at the gateway parser is the simpler match.

**`test(pgregresstest): record residual sqljson patches`** (ce805103)

- Captures the remaining out-of-scope diffs (parser error wrapper + caret column shifts) as patch files so `testdata/pg17/patches/sqljson*.patch` absorbs them in patch-based verification.


## Test plan

- [x] `go test -short ./go/common/parser/... ./go/services/multigateway/...` — all pass.
- [x] `RUN_PGREGRESS=1 PGREGRESS_TESTS="sqljson sqljson_queryfuncs sqljson_jsontable"` against a local cluster — diff dropped from ~2286 to ~360 lines; every previously-dropped clause is now correctly round-tripped to PG 17.6; with the recorded patches in place, all three tests now report ✅ in patch-based verification.
- [x] Round-trip parser tests (`TestParseTestSuite/TestPostgresTestsParsing`) cover each of the three updated fixture files.