### PR TITLE
refactor(proto): replace flat MultiPooler shard fields with nested ShardKey message

### DIFF
--- a/go/common/topoclient/memorytopo/test_helpers.go
+++ b/go/common/topoclient/memorytopo/test_helpers.go
@@ -46,7 +46,11 @@ func CreateTestPooler(ctx context.Context, ts topoclient.Store, cellName, pooler
 		},
 		Hostname: fmt.Sprintf("pooler-%s.%s", poolerName, cellName),
 		PortMap:  map[string]int32{"grpc": 8081, "postgres": 5433},
-		Database: database,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: "default",
+			Shard:      "0",
+		},
 	}
 	return ts.CreateMultiPooler(ctx, pooler)
 }

--- a/go/common/topoclient/multipooler.go
+++ b/go/common/topoclient/multipooler.go
@@ -35,9 +35,11 @@ func NewMultiPooler(name string, cell, host, tableGroup string) *clustermetadata
 			Cell:      cell,
 			Name:      name,
 		},
-		Hostname:   host,
-		TableGroup: tableGroup,
-		PortMap:    make(map[string]int32),
+		Hostname: host,
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: tableGroup,
+		},
+		PortMap: make(map[string]int32),
 	}
 }
 
@@ -198,16 +200,17 @@ func (ts *store) GetMultiPoolersByCell(ctx context.Context, cellName string, opt
 			return nil, err
 		}
 		if opt != nil && opt.DatabaseShard != nil && opt.DatabaseShard.Database != "" {
+			sk := multipooler.GetShardKey()
 			// Database must match
-			if opt.DatabaseShard.Database != multipooler.Database {
+			if opt.DatabaseShard.Database != sk.GetDatabase() {
 				continue
 			}
 			// If TableGroup is specified, it must match
-			if opt.DatabaseShard.TableGroup != "" && opt.DatabaseShard.TableGroup != multipooler.TableGroup {
+			if opt.DatabaseShard.TableGroup != "" && opt.DatabaseShard.TableGroup != sk.GetTableGroup() {
 				continue
 			}
 			// If Shard is specified, it must match
-			if opt.DatabaseShard.Shard != "" && opt.DatabaseShard.Shard != multipooler.Shard {
+			if opt.DatabaseShard.Shard != "" && opt.DatabaseShard.Shard != sk.GetShard() {
 				continue
 			}
 		}

--- a/go/common/topoclient/multipooler_test.go
+++ b/go/common/topoclient/multipooler_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 
@@ -61,8 +62,11 @@ func getMultiPooler(database string, shard string, cell string, uid uint32) *clu
 			Cell:      cell,
 			Name:      strconv.FormatUint(uint64(uid), 10),
 		},
-		Database: database,
-		Shard:    shard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: "default",
+			Shard:      shard,
+		},
 		Hostname: "host1",
 		PortMap: map[string]int32{
 			"grpc": int32(uid),
@@ -75,9 +79,7 @@ func getMultiPooler(database string, shard string, cell string, uid uint32) *clu
 func checkMultiPoolersEqual(t *testing.T, expected, actual *clustermetadatapb.MultiPooler) {
 	t.Helper()
 	require.Equal(t, expected.Id.String(), actual.Id.String())
-	require.Equal(t, expected.Database, actual.Database)
-	require.Equal(t, expected.Shard, actual.Shard)
-	require.Equal(t, expected.Hostname, actual.Hostname)
+	require.True(t, proto.Equal(expected.ShardKey, actual.ShardKey), "ShardKey mismatch: expected %v, got %v", expected.ShardKey, actual.ShardKey)
 	require.Equal(t, expected.Type, actual.Type)
 	require.Equal(t, expected.ServingStatus, actual.ServingStatus)
 	require.Equal(t, expected.PortMap, actual.PortMap)
@@ -132,8 +134,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(1),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -157,8 +162,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(1),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -172,8 +180,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(2),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -187,8 +198,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(3),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -202,8 +216,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(4),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -223,11 +240,13 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Cell:      cell,
 						Name:      "hotel",
 					},
-					Hostname:      "host1",
-					PortMap:       map[string]int32{"grpc": int32(1)},
-					Database:      database,
-					TableGroup:    "tg1",
-					Shard:         shard,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": int32(1)},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "tg1",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -237,11 +256,13 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Cell:      cell,
 						Name:      "india",
 					},
-					Hostname:      "host1",
-					PortMap:       map[string]int32{"grpc": int32(2)},
-					Database:      database,
-					TableGroup:    "tg1",
-					Shard:         shard,
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": int32(2)},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "tg1",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -272,8 +293,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(1),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -287,8 +311,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(2),
 					},
-					Database:      database,
-					Shard:         shard,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard,
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -302,8 +329,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(3),
 					},
-					Database:      database,
-					Shard:         shard + "2",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard + "2",
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -317,8 +347,11 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					PortMap: map[string]int32{
 						"grpc": int32(4),
 					},
-					Database:      database,
-					Shard:         shard + "2",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "default",
+						Shard:      shard + "2",
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -345,11 +378,13 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Cell:      cell,
 						Name:      "laperla",
 					},
-					Hostname:      "host1",
-					PortMap:       map[string]int32{"grpc": int32(1)},
-					Database:      database,
-					TableGroup:    "tg1",
-					Shard:         "shard1",
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": int32(1)},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "tg1",
+						Shard:      "shard1",
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -359,11 +394,13 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Cell:      cell,
 						Name:      "berghain",
 					},
-					Hostname:      "host1",
-					PortMap:       map[string]int32{"grpc": int32(2)},
-					Database:      database,
-					TableGroup:    "tg1",
-					Shard:         "shard2",
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": int32(2)},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "tg1",
+						Shard:      "shard2",
+					},
 					Type:          clustermetadatapb.PoolerType_REPLICA,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -390,11 +427,13 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 						Cell:      cell,
 						Name:      "papa",
 					},
-					Hostname:      "host1",
-					PortMap:       map[string]int32{"grpc": int32(1)},
-					Database:      database,
-					TableGroup:    "tg1",
-					Shard:         "shard1",
+					Hostname: "host1",
+					PortMap:  map[string]int32{"grpc": int32(1)},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   database,
+						TableGroup: "tg1",
+						Shard:      "shard1",
+					},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
 					ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 				},
@@ -470,9 +509,7 @@ func TestServerGetMultiPoolersByCell(t *testing.T) {
 					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": int32(i + 1)},
-					Database:      expectedMP.Database,
-					TableGroup:    expectedMP.TableGroup,
-					Shard:         expectedMP.Shard,
+					ShardKey:      expectedMP.GetShardKey(),
 					Type:          expectedMP.Type,
 					ServingStatus: expectedMP.ServingStatus,
 				}
@@ -564,8 +601,11 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 						Cell:      cell,
 						Name:      "november",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080, "http": 8081},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -598,8 +638,11 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 						Cell:      cell,
 						Name:      "oscar",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -622,8 +665,11 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 						Cell:      cell,
 						Name:      "papa",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -660,8 +706,11 @@ func TestMultiPoolerCRUDOperations(t *testing.T) {
 						Cell:      cell,
 						Name:      "quebec",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -718,8 +767,11 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 							Cell:      cell1,
 							Name:      "bravo",
 						},
-						Database:      "db1",
-						Shard:         "shard1",
+						ShardKey: &clustermetadatapb.ShardKey{
+							Database:   "db1",
+							TableGroup: "default",
+							Shard:      "shard1",
+						},
 						Hostname:      "host1",
 						PortMap:       map[string]int32{"grpc": 8080},
 						Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -731,8 +783,11 @@ func TestGetMultiPoolerIDsByCell(t *testing.T) {
 							Cell:      cell1,
 							Name:      "charlie",
 						},
-						Database:      "db2",
-						Shard:         "shard2",
+						ShardKey: &clustermetadatapb.ShardKey{
+							Database:   "db2",
+							TableGroup: "default",
+							Shard:      "shard2",
+						},
 						Hostname:      "host3",
 						PortMap:       map[string]int32{"grpc": 8083},
 						Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -813,9 +868,12 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 					Name:      "tango",
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
-					Id:            id,
-					Database:      "testdb",
-					Shard:         "testshard",
+					Id: id,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -847,9 +905,12 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 					Name:      "uniform",
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
-					Id:            id,
-					Database:      "testdb",
-					Shard:         "testshard",
+					Id: id,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -878,9 +939,12 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 					Name:      "victor",
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
-					Id:            id,
-					Database:      "testdb",
-					Shard:         "testshard",
+					Id: id,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -907,9 +971,12 @@ func TestUpdateMultiPoolerFields(t *testing.T) {
 					Name:      "whiskey",
 				}
 				multipooler := &clustermetadatapb.MultiPooler{
-					Id:            id,
-					Database:      "testdb",
-					Shard:         "testshard",
+					Id: id,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -965,8 +1032,11 @@ func TestInitMultiPooler(t *testing.T) {
 						Cell:      cell,
 						Name:      "zulu",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -990,8 +1060,11 @@ func TestInitMultiPooler(t *testing.T) {
 						Cell:      cell,
 						Name:      "xray",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1005,8 +1078,11 @@ func TestInitMultiPooler(t *testing.T) {
 						Cell:      cell,
 						Name:      "xray",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "newhost",
 					PortMap:       map[string]int32{"grpc": 8081},
 					Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -1030,8 +1106,11 @@ func TestInitMultiPooler(t *testing.T) {
 						Cell:      cell,
 						Name:      "whiskey",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1045,8 +1124,11 @@ func TestInitMultiPooler(t *testing.T) {
 						Cell:      cell,
 						Name:      "whiskey",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "newhost",
 					PortMap:       map[string]int32{"grpc": 8081},
 					Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -1090,10 +1172,12 @@ func TestNewMultiPooler(t *testing.T) {
 					Cell: "zone1",
 					Name: "100",
 				},
-				Hostname:   "host.example.com",
-				TableGroup: constants.DefaultTableGroup,
-				PortMap:    map[string]int32{},
-				Database:   "", // Default empty database
+				Hostname: "host.example.com",
+				ShardKey: &clustermetadatapb.ShardKey{
+					TableGroup: constants.DefaultTableGroup,
+					Database:   "", // Default empty database
+				},
+				PortMap: map[string]int32{},
 			},
 		},
 	}
@@ -1104,7 +1188,7 @@ func TestNewMultiPooler(t *testing.T) {
 			require.Equal(t, tt.expected.Id.Cell, result.Id.Cell)
 			require.Equal(t, tt.expected.Id.Name, result.Id.Name)
 			require.Equal(t, tt.expected.Hostname, result.Hostname)
-			require.Equal(t, tt.expected.TableGroup, result.TableGroup)
+			require.Equal(t, tt.expected.ShardKey.TableGroup, result.ShardKey.TableGroup)
 			require.NotNil(t, result.PortMap)
 		})
 	}
@@ -1141,8 +1225,11 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 						Cell:      cell,
 						Name:      "db-test1",
 					},
-					Database:      "testdb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1153,7 +1240,7 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 
 				retrieved, err := ts.GetMultiPooler(ctx, multipooler.Id)
 				require.NoError(t, err)
-				require.Equal(t, "testdb", retrieved.Database)
+				require.Equal(t, "testdb", retrieved.ShardKey.Database)
 			},
 		},
 		{
@@ -1165,8 +1252,11 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 						Cell:      cell,
 						Name:      "db-test2",
 					},
-					Database:      "originaldb",
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "originaldb",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1187,7 +1277,7 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 
 				updated, err := ts.GetMultiPooler(ctx, multipooler.Id)
 				require.NoError(t, err)
-				require.Equal(t, "originaldb", updated.Database) // Database preserved
+				require.Equal(t, "originaldb", updated.ShardKey.Database) // Database preserved
 				require.Equal(t, "host2.example.com", updated.Hostname)
 				require.NotEqual(t, oldVersion, updated.Version())
 			},
@@ -1201,8 +1291,11 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 						Cell:      cell,
 						Name:      "db-test3",
 					},
-					Database:      "", // Empty database
-					Shard:         "testshard",
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "",
+						TableGroup: "default",
+						Shard:      "testshard",
+					},
 					Hostname:      "host1.example.com",
 					PortMap:       map[string]int32{"grpc": 8080},
 					Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1213,7 +1306,7 @@ func TestMultiPoolerDatabaseField(t *testing.T) {
 
 				retrieved, err := ts.GetMultiPooler(ctx, multipooler.Id)
 				require.NoError(t, err)
-				require.Equal(t, "", retrieved.Database)
+				require.Equal(t, "", retrieved.ShardKey.Database)
 			},
 		},
 	}
@@ -1298,36 +1391,48 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		// Setup: Create 4 multipoolers in zone1 (2 databases × 2 shards)
 		multipoolers := []*clustermetadatapb.MultiPooler{
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "1"},
-				Database:      "db1",
-				Shard:         "-8",
+				Id: &clustermetadatapb.ID{Cell: "zone1", Name: "1"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "default",
+					Shard:      "-8",
+				},
 				Hostname:      "host1",
 				PortMap:       map[string]int32{"grpc": 8080},
 				Type:          clustermetadatapb.PoolerType_PRIMARY,
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "2"},
-				Database:      "db1",
-				Shard:         "8-",
+				Id: &clustermetadatapb.ID{Cell: "zone1", Name: "2"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "default",
+					Shard:      "8-",
+				},
 				Hostname:      "host2",
 				PortMap:       map[string]int32{"grpc": 8081},
 				Type:          clustermetadatapb.PoolerType_REPLICA,
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "3"},
-				Database:      "db2",
-				Shard:         "-8",
+				Id: &clustermetadatapb.ID{Cell: "zone1", Name: "3"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db2",
+					TableGroup: "default",
+					Shard:      "-8",
+				},
 				Hostname:      "host3",
 				PortMap:       map[string]int32{"grpc": 8082},
 				Type:          clustermetadatapb.PoolerType_PRIMARY,
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
 			},
 			{
-				Id:            &clustermetadatapb.ID{Cell: "zone1", Name: "4"},
-				Database:      "db2",
-				Shard:         "8-",
+				Id: &clustermetadatapb.ID{Cell: "zone1", Name: "4"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db2",
+					TableGroup: "default",
+					Shard:      "8-",
+				},
 				Hostname:      "host4",
 				PortMap:       map[string]int32{"grpc": 8083},
 				Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -1373,8 +1478,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 					Cell:      "zone1",
 					Name:      "1",
 				},
-				Database:      "db1",
-				Shard:         "-8",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "default",
+					Shard:      "-8",
+				},
 				Hostname:      "host1",
 				PortMap:       map[string]int32{"grpc": 8080},
 				Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1386,8 +1494,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 					Cell:      "zone1",
 					Name:      "2",
 				},
-				Database:      "db1",
-				Shard:         "8-",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "default",
+					Shard:      "8-",
+				},
 				Hostname:      "host2",
 				PortMap:       map[string]int32{"grpc": 8081},
 				Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -1414,7 +1525,7 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 
 		// Verify only db1 multipoolers are returned
 		for _, info := range multipoolerInfos {
-			require.Equal(t, "db1", info.Database)
+			require.Equal(t, "db1", info.GetShardKey().GetDatabase())
 		}
 
 		// Verify cell boundary: multipoolers are NOT accessible from other cells
@@ -1436,9 +1547,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 					Cell:      "zone1",
 					Name:      "1",
 				},
-				Database:      "db2",
-				TableGroup:    "tg1",
-				Shard:         "-8",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db2",
+					TableGroup: "tg1",
+					Shard:      "-8",
+				},
 				Hostname:      "host1",
 				PortMap:       map[string]int32{"grpc": 8080},
 				Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1450,9 +1563,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 					Cell:      "zone1",
 					Name:      "2",
 				},
-				Database:      "db2",
-				TableGroup:    "tg1",
-				Shard:         "8-",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db2",
+					TableGroup: "tg1",
+					Shard:      "8-",
+				},
 				Hostname:      "host2",
 				PortMap:       map[string]int32{"grpc": 8081},
 				Type:          clustermetadatapb.PoolerType_REPLICA,
@@ -1479,9 +1594,9 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 		require.Len(t, multipoolerInfos, 1)
 
 		// Verify correct multipooler is returned
-		require.Equal(t, "db2", multipoolerInfos[0].Database)
-		require.Equal(t, "tg1", multipoolerInfos[0].TableGroup)
-		require.Equal(t, "-8", multipoolerInfos[0].Shard)
+		require.Equal(t, "db2", multipoolerInfos[0].GetShardKey().GetDatabase())
+		require.Equal(t, "tg1", multipoolerInfos[0].GetShardKey().GetTableGroup())
+		require.Equal(t, "-8", multipoolerInfos[0].GetShardKey().GetShard())
 
 		// Verify cell boundary: multipoolers are NOT accessible from other cells
 		otherCellInfos, err := ts.GetMultiPoolersByCell(ctx, "zone2", nil)
@@ -1527,8 +1642,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "1",
 			},
-			Database:      "db1",
-			Shard:         "-8",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "-8",
+			},
 			Hostname:      "host1",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
@@ -1540,8 +1658,11 @@ func TestGetMultiPoolersByCell_Comprehensive(t *testing.T) {
 				Cell:      "zone2",
 				Name:      "1",
 			},
-			Database:      "db1",
-			Shard:         "-8",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "-8",
+			},
 			Hostname:      "host2",
 			PortMap:       map[string]int32{"grpc": 8081},
 			Type:          clustermetadatapb.PoolerType_REPLICA,

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -819,13 +819,12 @@ type MultiPooler struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// id is the unique identifier of the multipooler in the cluster.
 	Id *ID `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Database name.
-	Database string `protobuf:"bytes,2,opt,name=database,proto3" json:"database,omitempty"`
-	// TableGroup name.
-	TableGroup string `protobuf:"bytes,3,opt,name=table_group,json=tableGroup,proto3" json:"table_group,omitempty"`
-	// Shard name. If range based sharding is used, it should match
-	// key_range.
-	Shard string `protobuf:"bytes,4,opt,name=shard,proto3" json:"shard,omitempty"`
+	// shard_key identifies which shard this pooler belongs to. It is used for
+	// routing requests to the correct pooler and for displaying metadata about
+	// the shard in dashboards. It is not expected to change for the lifetime of
+	// the pooler, but it is not immutable either — if the pooler moves to a
+	// different shard, this field should be updated to reflect the new shard.
+	ShardKey *ShardKey `protobuf:"bytes,2,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"` //
 	// If range based sharding is used, range for the pooler's shard.
 	KeyRange *KeyRange `protobuf:"bytes,5,opt,name=key_range,json=keyRange,proto3" json:"key_range,omitempty"`
 	// PoolerType is the kind of pooler: PRIMARY or REPLICA
@@ -882,25 +881,11 @@ func (x *MultiPooler) GetId() *ID {
 	return nil
 }
 
-func (x *MultiPooler) GetDatabase() string {
+func (x *MultiPooler) GetShardKey() *ShardKey {
 	if x != nil {
-		return x.Database
+		return x.ShardKey
 	}
-	return ""
-}
-
-func (x *MultiPooler) GetTableGroup() string {
-	if x != nil {
-		return x.TableGroup
-	}
-	return ""
-}
-
-func (x *MultiPooler) GetShard() string {
-	if x != nil {
-		return x.Shard
-	}
-	return ""
+	return nil
 }
 
 func (x *MultiPooler) GetKeyRange() *KeyRange {
@@ -2054,13 +2039,10 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\bendpoint\x18\x03 \x01(\tR\bendpoint\x12\x1d\n" +
 	"\n" +
 	"key_prefix\x18\x04 \x01(\tR\tkeyPrefix\x12.\n" +
-	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\x98\x04\n" +
+	"\x13use_env_credentials\x18\x05 \x01(\bR\x11useEnvCredentials\"\xfd\x03\n" +
 	"\vMultiPooler\x12#\n" +
-	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x1a\n" +
-	"\bdatabase\x18\x02 \x01(\tR\bdatabase\x12\x1f\n" +
-	"\vtable_group\x18\x03 \x01(\tR\n" +
-	"tableGroup\x12\x14\n" +
-	"\x05shard\x18\x04 \x01(\tR\x05shard\x126\n" +
+	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x126\n" +
+	"\tshard_key\x18\x02 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x126\n" +
 	"\tkey_range\x18\x05 \x01(\v2\x19.clustermetadata.KeyRangeR\bkeyRange\x12/\n" +
 	"\x04type\x18\x06 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\x04type\x12K\n" +
 	"\x0eserving_status\x18\a \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12\x1a\n" +
@@ -2229,39 +2211,40 @@ var file_clustermetadata_proto_depIdxs = []int32{
 	10, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
 	11, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
 	16, // 6: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	17, // 7: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
-	0,  // 8: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
-	1,  // 9: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	28, // 10: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	16, // 11: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	29, // 12: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	16, // 13: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	30, // 14: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
-	4,  // 15: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
-	2,  // 16: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	19, // 17: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	16, // 18: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	16, // 19: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	18, // 20: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	16, // 21: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	31, // 22: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	20, // 23: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	20, // 24: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
-	16, // 25: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	31, // 26: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	19, // 27: clustermetadata.ExternallyCertifiedRevocation.outgoing_rule_number:type_name -> clustermetadata.RuleNumber
-	23, // 28: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	23, // 29: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	21, // 30: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	22, // 31: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
-	16, // 32: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	3,  // 33: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	26, // 34: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	14, // 7: clustermetadata.MultiPooler.shard_key:type_name -> clustermetadata.ShardKey
+	17, // 8: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	0,  // 9: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
+	1,  // 10: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
+	28, // 11: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	16, // 12: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	29, // 13: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	16, // 14: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	30, // 15: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	4,  // 16: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	2,  // 17: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
+	19, // 18: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	16, // 19: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	16, // 20: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	18, // 21: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	16, // 22: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	31, // 23: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	20, // 24: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
+	20, // 25: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
+	16, // 26: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	31, // 27: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	19, // 28: clustermetadata.ExternallyCertifiedRevocation.outgoing_rule_number:type_name -> clustermetadata.RuleNumber
+	23, // 29: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	23, // 30: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	21, // 31: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	22, // 32: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
+	16, // 33: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	3,  // 34: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	26, // 35: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }

--- a/go/services/multiadmin/backup_test.go
+++ b/go/services/multiadmin/backup_test.go
@@ -174,11 +174,13 @@ func TestGetBackupJobStatus_FallbackToPooler(t *testing.T) {
 			Cell:      "cell1",
 			Name:      "replica-pooler",
 		},
-		Hostname:   "replica-pooler.cell1",
-		PortMap:    map[string]int32{"grpc": 8081},
-		Database:   "testdb",
-		TableGroup: "default",
-		Type:       clustermetadatapb.PoolerType_REPLICA,
+		Hostname: "replica-pooler.cell1",
+		PortMap:  map[string]int32{"grpc": 8081},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+		},
+		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, replicaPooler))
 
@@ -285,11 +287,13 @@ func TestBackup_ForcePrimary(t *testing.T) {
 			Cell:      "cell1",
 			Name:      "primary-pooler",
 		},
-		Hostname:   "primary-pooler.cell1",
-		PortMap:    map[string]int32{"grpc": 8081},
-		Database:   "testdb",
-		TableGroup: "default",
-		Type:       clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "primary-pooler.cell1",
+		PortMap:  map[string]int32{"grpc": 8081},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+		},
+		Type: clustermetadatapb.PoolerType_PRIMARY,
 	}
 	replicaPooler := &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
@@ -297,11 +301,13 @@ func TestBackup_ForcePrimary(t *testing.T) {
 			Cell:      "cell1",
 			Name:      "replica-pooler",
 		},
-		Hostname:   "replica-pooler.cell1",
-		PortMap:    map[string]int32{"grpc": 8081},
-		Database:   "testdb",
-		TableGroup: "default",
-		Type:       clustermetadatapb.PoolerType_REPLICA,
+		Hostname: "replica-pooler.cell1",
+		PortMap:  map[string]int32{"grpc": 8081},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+		},
+		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, primaryPooler))
 	require.NoError(t, ts.CreateMultiPooler(ctx, replicaPooler))
@@ -371,11 +377,13 @@ func TestBackup_ForcePrimary(t *testing.T) {
 				Cell:      "cell2",
 				Name:      "primary-only",
 			},
-			Hostname:   "primary-only.cell2",
-			PortMap:    map[string]int32{"grpc": 8081},
-			Database:   "testdb",
-			TableGroup: "default",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "primary-only.cell2",
+			PortMap:  map[string]int32{"grpc": 8081},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, primaryOnly))
 

--- a/go/services/multiadmin/server_test.go
+++ b/go/services/multiadmin/server_test.go
@@ -386,7 +386,7 @@ func TestMultiAdminServerGetPoolersMultiCell(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Len(t, resp.Poolers, 2) // pool1 and pool2
 		for _, pooler := range resp.Poolers {
-			assert.Equal(t, "db1", pooler.Database)
+			assert.Equal(t, "db1", pooler.GetShardKey().GetDatabase())
 		}
 	})
 
@@ -401,7 +401,7 @@ func TestMultiAdminServerGetPoolersMultiCell(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Len(t, resp.Poolers, 1) // only pool2
 		assert.Equal(t, "cell2", resp.Poolers[0].Id.Cell)
-		assert.Equal(t, "db1", resp.Poolers[0].Database)
+		assert.Equal(t, "db1", resp.Poolers[0].GetShardKey().GetDatabase())
 	})
 
 	t.Run("get poolers filtered by non-existent database", func(t *testing.T) {
@@ -424,7 +424,7 @@ func TestMultiAdminServerGetPoolersMultiCell(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Len(t, resp.Poolers, 1) // only pool3
-		assert.Equal(t, "db2", resp.Poolers[0].Database)
+		assert.Equal(t, "db2", resp.Poolers[0].GetShardKey().GetDatabase())
 		assert.Equal(t, "pool3", resp.Poolers[0].Id.Name)
 	})
 
@@ -586,13 +586,15 @@ func TestMultiAdminServerGetPoolerStatus(t *testing.T) {
 		// Create a pooler in topology
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool1"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "pool1.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "pool1.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)
@@ -635,13 +637,15 @@ func TestMultiAdminServerGetPoolerStatus(t *testing.T) {
 		// Create another pooler
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool2"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
-			Hostname:   "pool2.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_REPLICA,
+			Hostname: "pool2.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)
@@ -740,13 +744,15 @@ func TestMultiAdminServerSetPostgresRestartsEnabled(t *testing.T) {
 		// Create a pooler in topology
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool1"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "pool1.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "pool1.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)
@@ -769,13 +775,15 @@ func TestMultiAdminServerSetPostgresRestartsEnabled(t *testing.T) {
 		// Create another pooler
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool2"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "pool2.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "pool2.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)
@@ -875,13 +883,15 @@ func TestMultiAdminServerSetPostgresRestartsDisabled(t *testing.T) {
 		// Create a pooler in topology
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool1"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "pool1.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "pool1.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)
@@ -904,13 +914,15 @@ func TestMultiAdminServerSetPostgresRestartsDisabled(t *testing.T) {
 		// Create another pooler
 		poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "pool2"}
 		pooler := &clustermetadatapb.MultiPooler{
-			Id:         poolerID,
-			Database:   "db1",
-			TableGroup: "default",
-			Shard:      "0-inf",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "pool2.cell1.svc.cluster.local",
-			PortMap:    map[string]int32{"grpc": 15100},
+			Id: poolerID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "default",
+				Shard:      "0-inf",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "pool2.cell1.svc.cluster.local",
+			PortMap:  map[string]int32{"grpc": 15100},
 		}
 		err := ts.CreateMultiPooler(ctx, pooler)
 		require.NoError(t, err)

--- a/go/services/multigateway/discovery.go
+++ b/go/services/multigateway/discovery.go
@@ -169,8 +169,8 @@ func (pd *CellPoolerDiscovery) processInitialPoolers(initial []*topoclient.Watch
 				"id", poolerID,
 				"hostname", pooler.Hostname,
 				"addr", pooler.Addr(),
-				"database", pooler.Database,
-				"shard", pooler.Shard,
+				"database", pooler.GetShardKey().GetDatabase(),
+				"shard", pooler.GetShardKey().GetShard(),
 				"type", pooler.Type.String())
 		}
 	}
@@ -248,7 +248,7 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 	// This handles the failover case where a new PRIMARY comes up but the old
 	// crashed PRIMARY's record is still present.
 	if pooler.Type == clustermetadatapb.PoolerType_PRIMARY {
-		pd.evictConflictingPrimary(poolerID, pooler.TableGroup, pooler.Shard)
+		pd.evictConflictingPrimary(poolerID, pooler.GetShardKey().GetTableGroup(), pooler.GetShardKey().GetShard())
 	}
 
 	// Check if this is a new pooler
@@ -261,18 +261,18 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 			"id", poolerID,
 			"hostname", pooler.Hostname,
 			"addr", pooler.Addr(),
-			"tableGroup", pooler.TableGroup,
-			"database", pooler.Database,
-			"shard", pooler.Shard,
+			"tableGroup", pooler.GetShardKey().GetTableGroup(),
+			"database", pooler.GetShardKey().GetDatabase(),
+			"shard", pooler.GetShardKey().GetShard(),
 			"type", pooler.Type.String())
 	} else {
 		pd.logger.Info("Pooler updated",
 			"id", poolerID,
 			"hostname", pooler.Hostname,
 			"addr", pooler.Addr(),
-			"tableGroup", pooler.TableGroup,
-			"database", pooler.Database,
-			"shard", pooler.Shard,
+			"tableGroup", pooler.GetShardKey().GetTableGroup(),
+			"database", pooler.GetShardKey().GetDatabase(),
+			"shard", pooler.GetShardKey().GetShard(),
 			"type", pooler.Type.String())
 	}
 
@@ -365,8 +365,8 @@ func (pd *CellPoolerDiscovery) evictConflictingPrimary(newPoolerID, tableGroup, 
 		}
 		// Check if this is a PRIMARY for the same TableGroup/Shard
 		if pooler.Type == clustermetadatapb.PoolerType_PRIMARY &&
-			pooler.TableGroup == tableGroup &&
-			pooler.Shard == shard {
+			pooler.GetShardKey().GetTableGroup() == tableGroup &&
+			pooler.GetShardKey().GetShard() == shard {
 			delete(pd.poolers, poolerID)
 			pd.logger.Info("Evicted stale PRIMARY pooler",
 				"evicted_id", poolerID,

--- a/go/services/multigateway/discovery_test.go
+++ b/go/services/multigateway/discovery_test.go
@@ -105,11 +105,13 @@ func createTestPooler(name, cell, hostname, database, shard string, poolerType c
 			Cell:      cell,
 			Name:      name,
 		},
-		Hostname:   hostname,
-		Database:   database,
-		Shard:      shard,
-		Type:       poolerType,
-		TableGroup: constants.DefaultTableGroup,
+		Hostname: hostname,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      shard,
+		},
+		Type: poolerType,
 		PortMap: map[string]int32{
 			"grpc": 5432,
 		},
@@ -263,15 +265,15 @@ func TestPoolerDiscovery_VerifyPoolerDetails(t *testing.T) {
 	// Verify pooler1
 	require.Contains(t, poolerMap, "pooler1")
 	assert.Equal(t, "primary.example.com", poolerMap["pooler1"].Hostname)
-	assert.Equal(t, "mydb", poolerMap["pooler1"].Database)
-	assert.Equal(t, "shard-01", poolerMap["pooler1"].Shard)
+	assert.Equal(t, "mydb", poolerMap["pooler1"].GetShardKey().GetDatabase())
+	assert.Equal(t, "shard-01", poolerMap["pooler1"].GetShardKey().GetShard())
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, poolerMap["pooler1"].Type)
 
 	// Verify pooler2
 	require.Contains(t, poolerMap, "pooler2")
 	assert.Equal(t, "replica.example.com", poolerMap["pooler2"].Hostname)
-	assert.Equal(t, "mydb", poolerMap["pooler2"].Database)
-	assert.Equal(t, "shard-02", poolerMap["pooler2"].Shard)
+	assert.Equal(t, "mydb", poolerMap["pooler2"].GetShardKey().GetDatabase())
+	assert.Equal(t, "shard-02", poolerMap["pooler2"].GetShardKey().GetShard())
 	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, poolerMap["pooler2"].Type)
 }
 

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -140,7 +140,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 		// Invalidate seed if type changed away from PRIMARY
 		if oldType == clustermetadatapb.PoolerType_PRIMARY && newType != clustermetadatapb.PoolerType_PRIMARY {
-			key := shardKey{tableGroup: pooler.GetTableGroup(), shard: pooler.GetShard()}
+			key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
 			if cached, ok := lb.cachedPrimaries[key]; ok && cached.conn == conn && cached.term == 0 {
 				delete(lb.cachedPrimaries, key)
 				lb.logger.Debug("invalidated seeded primary cache on type change",
@@ -150,7 +150,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 		// Seed if type changed to PRIMARY
 		if oldType != clustermetadatapb.PoolerType_PRIMARY && newType == clustermetadatapb.PoolerType_PRIMARY {
-			key := shardKey{tableGroup: pooler.GetTableGroup(), shard: pooler.GetShard()}
+			key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
 			if existing, ok := lb.cachedPrimaries[key]; !ok || existing.term == 0 {
 				lb.cachedPrimaries[key] = &cachedPrimary{conn: conn, term: 0}
 				lb.logger.Debug("seeded primary cache on type change",
@@ -171,7 +171,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	// Seed primary cache from discovery type (term 0 = unconfirmed).
 	// Health stream callbacks will overwrite with real term data.
 	if pooler.Type == clustermetadatapb.PoolerType_PRIMARY {
-		key := shardKey{tableGroup: pooler.GetTableGroup(), shard: pooler.GetShard()}
+		key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
 		if existing, ok := lb.cachedPrimaries[key]; !ok || existing.term == 0 {
 			lb.cachedPrimaries[key] = &cachedPrimary{conn: conn, term: 0}
 			lb.logger.Debug("seeded primary cache from discovery",
@@ -471,12 +471,12 @@ func matchesShardTarget(conn *PoolerConnection, target *query.Target) bool {
 	poolerInfo := conn.PoolerInfo()
 
 	// Check tablegroup match
-	if target.TableGroup != poolerInfo.GetTableGroup() {
+	if target.TableGroup != poolerInfo.GetShardKey().GetTableGroup() {
 		return false
 	}
 
 	// Check shard match (empty target shard matches any)
-	if target.Shard != "" && target.Shard != poolerInfo.GetShard() {
+	if target.Shard != "" && target.Shard != poolerInfo.GetShardKey().GetShard() {
 		return false
 	}
 

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -43,10 +43,12 @@ func createTestMultiPooler(name, cell, tableGroup, shard string, poolerType clus
 			Cell:      cell,
 			Name:      name,
 		},
-		Hostname:   name + ".example.com",
-		TableGroup: tableGroup,
-		Shard:      shard,
-		Type:       poolerType,
+		Hostname: name + ".example.com",
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: tableGroup,
+			Shard:      shard,
+		},
+		Type: poolerType,
 		PortMap: map[string]int32{
 			"grpc": 50051,
 		},
@@ -251,8 +253,8 @@ func simulateHealthUpdate(conn *PoolerConnection, status clustermetadatapb.Poole
 	info := conn.PoolerInfo()
 	conn.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
 		Target: &query.Target{
-			TableGroup: info.GetTableGroup(),
-			Shard:      info.GetShard(),
+			TableGroup: info.GetShardKey().GetTableGroup(),
+			Shard:      info.GetShardKey().GetShard(),
 			PoolerType: info.Type,
 		},
 		PoolerId:          info.Id,

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -186,8 +186,8 @@ func NewPoolerConnection(
 
 	// Initialize health state to NOT_SERVING until health stream provides data.
 	initialTarget := &query.Target{
-		TableGroup: pooler.GetTableGroup(),
-		Shard:      pooler.GetShard(),
+		TableGroup: pooler.GetShardKey().GetTableGroup(),
+		Shard:      pooler.GetShardKey().GetShard(),
 		PoolerType: pooler.Type,
 	}
 

--- a/go/services/multigateway/poolergateway/pooler_connection_test.go
+++ b/go/services/multigateway/poolergateway/pooler_connection_test.go
@@ -69,10 +69,12 @@ func TestPoolerConnection_TelemetryAttributes(t *testing.T) {
 			Cell:      "test-cell",
 			Name:      "test-pooler",
 		},
-		Hostname:   "127.0.0.1",
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      "0",
-		Type:       clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "127.0.0.1",
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      "0",
+		},
+		Type: clustermetadatapb.PoolerType_PRIMARY,
 		PortMap: map[string]int32{
 			"grpc": int32(lis.Addr().(*net.TCPAddr).Port),
 		},

--- a/go/services/multigateway/poolergateway/pooler_streaming_test.go
+++ b/go/services/multigateway/poolergateway/pooler_streaming_test.go
@@ -130,10 +130,12 @@ func setupStreamingTestWithCallback(
 			Cell:      "test-cell",
 			Name:      "test-pooler",
 		},
-		Hostname:   "127.0.0.1",
-		TableGroup: "default",
-		Shard:      "0",
-		Type:       clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "127.0.0.1",
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Type: clustermetadatapb.PoolerType_PRIMARY,
 		PortMap: map[string]int32{
 			"grpc": int32(port),
 		},

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -84,7 +84,7 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 		for _, pooler := range cs.Poolers {
 			cellStatus.Poolers = append(cellStatus.Poolers, PoolerStatus{
 				Name:     pooler.Id.GetName(),
-				Database: pooler.GetDatabase(),
+				Database: pooler.GetShardKey().GetDatabase(),
 				Type:     pooler.GetType().String(),
 			})
 		}

--- a/go/services/multiorch/consensus/leader_appointment.go
+++ b/go/services/multiorch/consensus/leader_appointment.go
@@ -315,7 +315,7 @@ func (c *Coordinator) recruitNodes(ctx context.Context, cohort []*multiorchdatap
 			req := &consensusdatapb.BeginTermRequest{
 				Term:        term,
 				CandidateId: c.coordinatorID,
-				ShardId:     n.MultiPooler.Shard,
+				ShardId:     n.MultiPooler.GetShardKey().GetShard(),
 				Action:      action,
 			}
 			rpcCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)

--- a/go/services/multiorch/consensus/leader_appointment_prevote_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_prevote_test.go
@@ -41,11 +41,13 @@ func createPoolerForPreVote(name string, isHealthy bool, termNumber int64, lastA
 	}
 
 	pooler := &clustermetadatapb.MultiPooler{
-		Id:         poolerID,
-		Database:   "testdb",
-		TableGroup: "default",
-		Shard:      "0",
-		Hostname:   "localhost",
+		Id: poolerID,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Hostname: "localhost",
 		PortMap: map[string]int32{
 			"grpc": 9000,
 		},

--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/topoclient"
 	commontypes "github.com/multigres/multigres/go/common/types"
@@ -136,9 +138,7 @@ func (a *AppointLeaderAction) getCohort(shardKey *clustermetadatapb.ShardKey) []
 			return true // continue
 		}
 
-		if pooler.MultiPooler.Database == shardKey.Database &&
-			pooler.MultiPooler.TableGroup == shardKey.TableGroup &&
-			pooler.MultiPooler.Shard == shardKey.Shard {
+		if proto.Equal(pooler.MultiPooler.GetShardKey(), shardKey) {
 			cohort = append(cohort, pooler)
 		}
 

--- a/go/services/multiorch/recovery/actions/demote_stale_leader.go
+++ b/go/services/multiorch/recovery/actions/demote_stale_leader.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -184,9 +186,7 @@ func (a *DemoteStaleLeaderAction) findCorrectLeader(shardKey *clustermetadatapb.
 		}
 
 		// Only consider poolers in the same shard
-		if pooler.MultiPooler.Database != shardKey.Database ||
-			pooler.MultiPooler.TableGroup != shardKey.TableGroup ||
-			pooler.MultiPooler.Shard != shardKey.Shard {
+		if !proto.Equal(pooler.MultiPooler.GetShardKey(), shardKey) {
 			return true // continue
 		}
 

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -104,11 +104,13 @@ func TestFixReplicationAction_ExecuteNoPrimary(t *testing.T) {
 	}
 	poolerStore.Set("multipooler-cell1-replica1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replicaID,
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 	})
 
@@ -164,11 +166,13 @@ func TestFixReplicationAction_ExecuteUnsupportedProblemCode(t *testing.T) {
 	}
 	poolerStore.Set("multipooler-cell1-replica1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replicaID,
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 	})
 	poolerStore.Set("multipooler-cell1-primary", &multiorchdatapb.PoolerHealthState{
@@ -178,12 +182,14 @@ func TestFixReplicationAction_ExecuteUnsupportedProblemCode(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "primary",
 			},
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "primary.example.com",
-			PortMap:    map[string]int32{"postgres": 5432},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "primary.example.com",
+			PortMap:  map[string]int32{"postgres": 5432},
 		},
 	})
 
@@ -256,11 +262,13 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 	}
 	poolerStore.Set("multipooler-cell1-replica1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replicaID,
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 	})
 	poolerStore.Set("multipooler-cell1-primary", &multiorchdatapb.PoolerHealthState{
@@ -270,12 +278,14 @@ func TestFixReplicationAction_ExecuteSuccessNotReplicating(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "primary",
 			},
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "primary.example.com",
-			PortMap:    map[string]int32{"postgres": 5432},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "primary.example.com",
+			PortMap:  map[string]int32{"postgres": 5432},
 		},
 	})
 
@@ -346,11 +356,13 @@ func TestFixReplicationAction_ExecuteAlreadyConfigured(t *testing.T) {
 	}
 	poolerStore.Set("multipooler-cell1-replica1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replicaID,
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 	})
 	poolerStore.Set("multipooler-cell1-primary", &multiorchdatapb.PoolerHealthState{
@@ -360,12 +372,14 @@ func TestFixReplicationAction_ExecuteAlreadyConfigured(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "primary",
 			},
-			Database:   "testdb",
-			TableGroup: "default",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "primary.example.com",
-			PortMap:    map[string]int32{"postgres": 5432},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "default",
+				Shard:      "0",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "primary.example.com",
+			PortMap:  map[string]int32{"postgres": 5432},
 		},
 	})
 
@@ -544,11 +558,13 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 		Name:      "replica1",
 	}
 	replica := &clustermetadatapb.MultiPooler{
-		Id:         replicaID,
-		Database:   "testdb",
-		TableGroup: "default",
-		Shard:      "0",
-		Type:       clustermetadatapb.PoolerType_REPLICA,
+		Id: replicaID,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Type: clustermetadatapb.PoolerType_REPLICA,
 	}
 	primary := &clustermetadatapb.MultiPooler{
 		Id: &clustermetadatapb.ID{
@@ -556,12 +572,14 @@ func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 			Cell:      "cell1",
 			Name:      "primary",
 		},
-		Database:   "testdb",
-		TableGroup: "default",
-		Shard:      "0",
-		Type:       clustermetadatapb.PoolerType_PRIMARY,
-		Hostname:   "primary.example.com",
-		PortMap:    map[string]int32{"postgres": 5432},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Type:     clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "primary.example.com",
+		PortMap:  map[string]int32{"postgres": 5432},
 	}
 
 	// Create in topology for markPoolerDrained to work

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -167,9 +169,7 @@ func (a *ShardInitAction) getInitializedPoolers(shardKey *clustermetadatapb.Shar
 		if pooler == nil || pooler.MultiPooler == nil || pooler.MultiPooler.Id == nil {
 			return true
 		}
-		if pooler.MultiPooler.Database != shardKey.Database ||
-			pooler.MultiPooler.TableGroup != shardKey.TableGroup ||
-			pooler.MultiPooler.Shard != shardKey.Shard {
+		if !proto.Equal(pooler.MultiPooler.GetShardKey(), shardKey) {
 			return true
 		}
 		if len(pooler.GetStatus().GetCohortMembers()) > 0 {

--- a/go/services/multiorch/recovery/actions/shard_init_action_test.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action_test.go
@@ -89,9 +89,11 @@ func makePoolerState(cell, name, db, tableGroup, shard string, initialized bool,
 				Cell:      cell,
 				Name:      name,
 			},
-			Database:   db,
-			TableGroup: tableGroup,
-			Shard:      shard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   db,
+				TableGroup: tableGroup,
+				Shard:      shard,
+			},
 		},
 	}
 }

--- a/go/services/multiorch/recovery/analysis/generator.go
+++ b/go/services/multiorch/recovery/analysis/generator.go
@@ -126,9 +126,9 @@ func (g *AnalysisGenerator) buildPoolersByShard() PoolersByShard {
 			return true // skip nil entries
 		}
 
-		database := pooler.MultiPooler.Database
-		tableGroup := pooler.MultiPooler.TableGroup
-		shard := pooler.MultiPooler.Shard
+		database := pooler.MultiPooler.GetShardKey().GetDatabase()
+		tableGroup := pooler.MultiPooler.GetShardKey().GetTableGroup()
+		shard := pooler.MultiPooler.GetShardKey().GetShard()
 
 		// Initialize nested maps if needed
 		if poolersByShard[database] == nil {
@@ -162,9 +162,9 @@ func (g *AnalysisGenerator) GetPoolersInShard(poolerIDStr string) ([]string, err
 		return nil, fmt.Errorf("pooler or ID is nil: %s", poolerIDStr)
 	}
 
-	database := pooler.MultiPooler.Database
-	tableGroup := pooler.MultiPooler.TableGroup
-	shard := pooler.MultiPooler.Shard
+	database := pooler.MultiPooler.GetShardKey().GetDatabase()
+	tableGroup := pooler.MultiPooler.GetShardKey().GetTableGroup()
+	shard := pooler.MultiPooler.GetShardKey().GetShard()
 
 	// Use cached poolersByShard for efficient lookup
 	poolers, ok := g.poolersByShard[database][tableGroup][shard]
@@ -192,9 +192,9 @@ func (g *AnalysisGenerator) GenerateAnalysisForPooler(poolerIDStr string) (*Shar
 		return nil, fmt.Errorf("pooler or ID is nil: %s", poolerIDStr)
 	}
 
-	database := pooler.MultiPooler.Database
-	tableGroup := pooler.MultiPooler.TableGroup
-	shard := pooler.MultiPooler.Shard
+	database := pooler.MultiPooler.GetShardKey().GetDatabase()
+	tableGroup := pooler.MultiPooler.GetShardKey().GetTableGroup()
+	shard := pooler.MultiPooler.GetShardKey().GetShard()
 
 	poolers, ok := g.poolersByShard[database][tableGroup][shard]
 	if !ok || len(poolers) == 0 {

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -66,11 +66,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_SinglePrimary(t *testing.T) {
 
 	primary := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         primaryID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			Id: primaryID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -123,12 +125,14 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 	// Add primary
 	primary := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         primaryID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
-			Hostname:   "primary.example.com",
+			Id: primaryID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
+			Hostname: "primary.example.com",
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -148,11 +152,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 	// Add replica 1 (replicating)
 	replica1 := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replica1ID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replica1ID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -170,11 +176,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_PrimaryWithReplicas(t *testing.
 	// Add replica 2 (lagging)
 	replica2 := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replica2ID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replica2ID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -225,11 +233,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 	// Add primary
 	primary := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         primaryID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			Id: primaryID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -245,11 +255,13 @@ func TestAnalysisGenerator_GenerateShardAnalyses_Replica(t *testing.T) {
 	// Add replica
 	replica := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replicaID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -293,10 +305,12 @@ func TestAnalysisGenerator_GenerateShardAnalyses_MultipleTableGroups(t *testing.
 				Cell:      "cell1",
 				Name:      "tg1-primary",
 			},
-			Database:   "testdb",
-			TableGroup: "tg1",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "tg1",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -314,10 +328,12 @@ func TestAnalysisGenerator_GenerateShardAnalyses_MultipleTableGroups(t *testing.
 				Cell:      "cell1",
 				Name:      "tg2-primary",
 			},
-			Database:   "testdb",
-			TableGroup: "tg2",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "tg2",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -358,9 +374,11 @@ func TestGenerateShardAnalyses_SkipsNilEntries(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "valid",
 			},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "shard1",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "shard1",
+			},
 		},
 		IsLastCheckValid: true,
 		Status: &multipoolermanagerdatapb.Status{
@@ -388,9 +406,11 @@ func TestPopulatePrimaryInfo_NoPrimaryInShard(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "replica",
 			},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "shard1",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "shard1",
+			},
 		},
 		IsLastCheckValid: true,
 		Status: &multipoolermanagerdatapb.Status{
@@ -425,9 +445,11 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "primary",
 			},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "shard1",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "shard1",
+			},
 		},
 		IsLastCheckValid: true,
 		Status: &multipoolermanagerdatapb.Status{
@@ -444,9 +466,11 @@ func TestPopulatePrimaryInfo_PrimaryPostgresDown(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "replica",
 			},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "shard1",
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "shard1",
+			},
 		},
 		IsLastCheckValid: true,
 		Status: &multipoolermanagerdatapb.Status{
@@ -482,10 +506,12 @@ func TestPopulatePrimaryInfo_DemotedViaBeginTermRevoke(t *testing.T) {
 				Cell:      "cell1",
 				Name:      "replica",
 			},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "shard1",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "shard1",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		Status: &multipoolermanagerdatapb.Status{
@@ -508,11 +534,13 @@ func TestPopulatePrimaryInfo_DemotedViaBeginTermRevoke(t *testing.T) {
 		}
 		ps.Set("multipooler-cell1-primary", &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         formerPrimaryID,
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Type:       clustermetadatapb.PoolerType_PRIMARY, // etcd updated when promoted
+				Id: formerPrimaryID,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Type: clustermetadatapb.PoolerType_PRIMARY, // etcd updated when promoted
 			},
 			IsLastCheckValid: true,
 			ConsensusStatus:  primaryConsensusStatus(formerPrimaryID, 4),
@@ -545,11 +573,13 @@ func TestPopulatePrimaryInfo_DemotedViaBeginTermRevoke(t *testing.T) {
 		}
 		ps.Set("multipooler-cell1-former-primary", &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         formerPrimaryID,
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Type:       clustermetadatapb.PoolerType_REPLICA, // stale etcd: never updated
+				Id: formerPrimaryID,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Type: clustermetadatapb.PoolerType_REPLICA, // stale etcd: never updated
 			},
 			IsLastCheckValid: true,
 			ConsensusStatus:  primaryConsensusStatus(formerPrimaryID, 4),
@@ -669,11 +699,13 @@ func TestIsInStandbyList(t *testing.T) {
 			// Set up pooler store with primary
 			ps.Set("multipooler-cell1-primary-1", &multiorchdatapb.PoolerHealthState{
 				MultiPooler: &clustermetadatapb.MultiPooler{
-					Id:         primaryID,
-					Database:   "testdb",
-					TableGroup: "testtg",
-					Shard:      "0",
-					Type:       clustermetadatapb.PoolerType_PRIMARY,
+					Id: primaryID,
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "testdb",
+						TableGroup: "testtg",
+						Shard:      "0",
+					},
+					Type: clustermetadatapb.PoolerType_PRIMARY,
 				},
 				IsLastCheckValid: true,
 				IsUpToDate:       true,
@@ -712,11 +744,13 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid:      true,
 			LastPostgresReadyTime: timestamppb.New(respondedAt),
@@ -733,9 +767,11 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -768,11 +804,13 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: false, // Pooler unreachable
 			Status: &multipoolermanagerdatapb.Status{
@@ -788,9 +826,11 @@ func TestPopulatePrimaryInfo_PrimaryHealthFields(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -823,11 +863,13 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: false, // Primary pooler is down
 			Status: &multipoolermanagerdatapb.Status{
@@ -846,9 +888,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica1",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -873,9 +917,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica2",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -913,11 +959,13 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: false,
 			Status: &multipoolermanagerdatapb.Status{
@@ -934,9 +982,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica1",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -961,9 +1011,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica2",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -994,11 +1046,13 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: false,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1015,9 +1069,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica1",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: false, // Replica unreachable
 			Status: &multipoolermanagerdatapb.Status{
@@ -1045,11 +1101,13 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1079,11 +1137,13 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "primary",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			IsLastCheckValid: false,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1100,9 +1160,11 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 					Cell:      "cell1",
 					Name:      "replica",
 				},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1134,12 +1196,14 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
@@ -1149,10 +1213,12 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 		for _, status := range []string{"", "starting", "waiting", "stopping"} {
 			ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
 				MultiPooler: &clustermetadatapb.MultiPooler{
-					Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
-					Database:   "db1",
-					TableGroup: "tg1",
-					Shard:      "shard1",
+					Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
+					ShardKey: &clustermetadatapb.ShardKey{
+						Database:   "db1",
+						TableGroup: "tg1",
+						Shard:      "shard1",
+					},
 				},
 				IsLastCheckValid: true,
 				Status: &multipoolermanagerdatapb.Status{
@@ -1185,12 +1251,14 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
@@ -1202,10 +1270,12 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1240,12 +1310,14 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
@@ -1259,10 +1331,12 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1298,12 +1372,14 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
@@ -1319,10 +1395,12 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1360,12 +1438,14 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(primaryID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
-				Hostname:   "primary-host",
-				PortMap:    map[string]int32{"postgres": 5432},
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "primary"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
+				Hostname: "primary-host",
+				PortMap:  map[string]int32{"postgres": 5432},
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: clustermetadatapb.PoolerType_PRIMARY,
@@ -1374,10 +1454,12 @@ func TestAllReplicasConnectedToLeader(t *testing.T) {
 
 		ps.Set(replicaID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
-				Database:   "db1",
-				TableGroup: "tg1",
-				Shard:      "shard1",
+				Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica"},
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "db1",
+					TableGroup: "tg1",
+					Shard:      "shard1",
+				},
 			},
 			IsLastCheckValid: true,
 			Status: &multipoolermanagerdatapb.Status{
@@ -1426,11 +1508,13 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 	// Add primary with replica1 in standby list
 	ps.Set("multipooler-cell1-primary-1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         primaryID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_PRIMARY,
+			Id: primaryID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -1451,11 +1535,13 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 	// Add replica1 (in standby list)
 	ps.Set("multipooler-cell1-replica-1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replica1ID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replica1ID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -1472,11 +1558,13 @@ func TestPopulatePrimaryInfo_IsInPrimaryStandbyList(t *testing.T) {
 	// Add replica2 (not in standby list)
 	ps.Set("multipooler-cell2-replica-2", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         replica2ID,
-			Database:   "testdb",
-			TableGroup: "testtg",
-			Shard:      "0",
-			Type:       clustermetadatapb.PoolerType_REPLICA,
+			Id: replica2ID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testtg",
+				Shard:      "0",
+			},
+			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		IsUpToDate:       true,
@@ -1534,8 +1622,9 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 
 	shardConfig := func(id *clustermetadatapb.ID) *clustermetadatapb.MultiPooler {
 		return &clustermetadatapb.MultiPooler{
-			Id: id, Database: "testdb", TableGroup: "default", Shard: "0",
-			Type: clustermetadatapb.PoolerType_PRIMARY,
+			Id:       id,
+			ShardKey: &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"},
+			Type:     clustermetadatapb.PoolerType_PRIMARY,
 		}
 	}
 
@@ -1584,8 +1673,9 @@ func TestPopulatePrimaryInfo_PicksHighestPrimaryTerm(t *testing.T) {
 	// Replica.
 	ps.Set("multipooler-cell1-replica-1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id: replicaID, Database: "testdb", TableGroup: "default", Shard: "0",
-			Type: clustermetadatapb.PoolerType_REPLICA,
+			Id:       replicaID,
+			ShardKey: &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "0"},
+			Type:     clustermetadatapb.PoolerType_REPLICA,
 		},
 		IsLastCheckValid: true,
 		LastSeen:         timestamppb.Now(),
@@ -1812,12 +1902,14 @@ func setupMultiplePrimariesStoreWithReachability(t *testing.T, primaries []prima
 		}
 		poolerState := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         id,
-				Database:   "testdb",
-				TableGroup: "default",
-				Shard:      "0",
-				Type:       clustermetadatapb.PoolerType_PRIMARY,
-				Hostname:   "localhost",
+				Id: id,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "testdb",
+					TableGroup: "default",
+					Shard:      "0",
+				},
+				Type:     clustermetadatapb.PoolerType_PRIMARY,
+				Hostname: "localhost",
 			},
 			IsLastCheckValid: p.reachable,
 			IsUpToDate:       true,
@@ -1847,11 +1939,9 @@ func TestGenerateShardAnalyses_GroupsByShardKey(t *testing.T) {
 	makePooler := func(name, db, tg, shard string, typ clustermetadatapb.PoolerType) *multiorchdatapb.PoolerHealthState {
 		return &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
-				Id:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: name},
-				Database:   db,
-				TableGroup: tg,
-				Shard:      shard,
-				Type:       typ,
+				Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: name},
+				ShardKey: &clustermetadatapb.ShardKey{Database: db, TableGroup: tg, Shard: shard},
+				Type:     typ,
 			},
 			Status: &multipoolermanagerdatapb.Status{
 				PoolerType: typ,
@@ -1892,8 +1982,12 @@ func TestGenerateShardAnalysis_ReturnsAllPoolersInShard(t *testing.T) {
 
 	ps.Set("multipooler-c1-primary", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: "primary"},
-			Database: "db", TableGroup: "tg", Shard: "0",
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: "primary"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db",
+				TableGroup: "tg",
+				Shard:      "0",
+			},
 			Type: clustermetadatapb.PoolerType_PRIMARY,
 		},
 		Status: &multipoolermanagerdatapb.Status{
@@ -1902,8 +1996,12 @@ func TestGenerateShardAnalysis_ReturnsAllPoolersInShard(t *testing.T) {
 	})
 	ps.Set("multipooler-c1-replica", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: "replica"},
-			Database: "db", TableGroup: "tg", Shard: "0",
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "c1", Name: "replica"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db",
+				TableGroup: "tg",
+				Shard:      "0",
+			},
 			Type: clustermetadatapb.PoolerType_REPLICA,
 		},
 		Status: &multipoolermanagerdatapb.Status{

--- a/go/services/multiorch/recovery/bookkeeping.go
+++ b/go/services/multiorch/recovery/bookkeeping.go
@@ -88,11 +88,7 @@ func (re *Engine) forgetLongUnseenInstances() {
 			return true // continue iteration
 		}
 
-		shardKey := &clustermetadatapb.ShardKey{
-			Database:   poolerInfo.MultiPooler.Database,
-			TableGroup: poolerInfo.MultiPooler.TableGroup,
-			Shard:      poolerInfo.MultiPooler.Shard,
-		}
+		shardKey := poolerInfo.MultiPooler.ShardKey
 
 		// Get timestamps as time.Time
 		lastSeen := time.Time{}

--- a/go/services/multiorch/recovery/bookkeeping_test.go
+++ b/go/services/multiorch/recovery/bookkeeping_test.go
@@ -66,9 +66,11 @@ func TestForgetLongUnseenInstances_NeverSeen(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "old-pooler",
 			},
-			Database:   "db1",
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      "-",
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "db1",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
 		},
 		LastCheckAttempted: timestamppb.New(now.Add(-threshold - time.Hour)), // > 4 hours ago
 		LastSeen:           nil,                                              // nil = never seen
@@ -83,7 +85,11 @@ func TestForgetLongUnseenInstances_NeverSeen(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "recent-pooler",
 			},
-			Database: "db1",
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "db1",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
 		},
 		LastCheckAttempted: timestamppb.New(now.Add(-time.Hour)), // Only 1 hour ago
 		LastSeen:           nil,                                  // nil = never seen
@@ -98,7 +104,11 @@ func TestForgetLongUnseenInstances_NeverSeen(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "no-attempts",
 			},
-			Database: "db1",
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "db1",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
 		},
 		LastCheckAttempted: nil, // No attempts yet
 		LastSeen:           nil, // Never seen
@@ -139,7 +149,11 @@ func TestForgetLongUnseenInstances_LongUnseen(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "old-healthy",
 			},
-			Database: "db1",
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "db1",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
 		},
 		LastSeen:            timestamppb.New(now.Add(-threshold - time.Hour)), // > 4 hours ago
 		LastCheckAttempted:  timestamppb.New(now.Add(-threshold - time.Hour)),
@@ -156,7 +170,11 @@ func TestForgetLongUnseenInstances_LongUnseen(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "recent-healthy",
 			},
-			Database: "db1",
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "db1",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
 		},
 		LastSeen:            timestamppb.New(now.Add(-time.Hour)), // Only 1 hour ago
 		LastCheckAttempted:  timestamppb.New(now.Add(-time.Hour)),

--- a/go/services/multiorch/recovery/discovery_test.go
+++ b/go/services/multiorch/recovery/discovery_test.go
@@ -77,12 +77,20 @@ func TestDiscovery_DatabaseLevelWatch(t *testing.T) {
 
 	// Initial state: 2 poolers in different tablegroups
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "mydb", TableGroup: "tg2", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		},
 	}))
 
 	// First watch event - should discover both
@@ -96,8 +104,12 @@ func TestDiscovery_DatabaseLevelWatch(t *testing.T) {
 
 	// Add new tablegroup with pooler
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "mydb", TableGroup: "tg3", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg3",
+			Shard:      "0",
+		},
 	}))
 
 	// Second watch event - should discover new tablegroup's pooler
@@ -109,8 +121,12 @@ func TestDiscovery_DatabaseLevelWatch(t *testing.T) {
 
 	// Add new shard in existing tablegroup
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
-		Database: "mydb", TableGroup: "tg1", Shard: "1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "1",
+		},
 	}))
 
 	// Third watch event - should discover new shard's pooler
@@ -156,12 +172,20 @@ func TestDiscovery_TablegroupLevelWatch(t *testing.T) {
 
 	// Initial state: poolers in tg1 and tg2
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "mydb", TableGroup: "tg2", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		},
 	}))
 
 	// First watch event - should only discover tg1
@@ -176,8 +200,12 @@ func TestDiscovery_TablegroupLevelWatch(t *testing.T) {
 
 	// Add new shard in tg1
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "mydb", TableGroup: "tg1", Shard: "1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "1",
+		},
 	}))
 
 	// Second watch event - should discover new shard in tg1
@@ -189,8 +217,12 @@ func TestDiscovery_TablegroupLevelWatch(t *testing.T) {
 
 	// Add new tablegroup tg3 with pooler
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
-		Database: "mydb", TableGroup: "tg3", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg3",
+			Shard:      "0",
+		},
 	}))
 
 	// Third watch event - should NOT discover new tablegroup
@@ -227,16 +259,28 @@ func TestDiscovery_ShardLevelWatch(t *testing.T) {
 
 	// Initial state: poolers in different shards and tablegroups
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "mydb", TableGroup: "tg1", Shard: "1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "1",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "mydb", TableGroup: "tg2", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		},
 	}))
 
 	// First watch event - should only discover tg1/shard0
@@ -253,8 +297,12 @@ func TestDiscovery_ShardLevelWatch(t *testing.T) {
 
 	// Add another pooler to the watched shard
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 
 	// Second watch event - should discover new pooler in same shard
@@ -266,8 +314,12 @@ func TestDiscovery_ShardLevelWatch(t *testing.T) {
 
 	// Add new shard in same tablegroup
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler5"},
-		Database: "mydb", TableGroup: "tg1", Shard: "2",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler5"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "2",
+		},
 	}))
 
 	// Third watch event - should NOT discover new shard
@@ -279,8 +331,12 @@ func TestDiscovery_ShardLevelWatch(t *testing.T) {
 
 	// Add new tablegroup
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler6"},
-		Database: "mydb", TableGroup: "tg3", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler6"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg3",
+			Shard:      "0",
+		},
 	}))
 
 	// Fourth watch event - should NOT discover new tablegroup
@@ -316,8 +372,12 @@ func TestDiscovery_PreservesTimestamps(t *testing.T) {
 
 	// Add initial pooler
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 		Hostname: "host1",
 	}))
 
@@ -394,28 +454,52 @@ func TestDiscovery_MultipleWatchTargets(t *testing.T) {
 
 	// Add poolers for different watch targets
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "db1", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db1",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "db1", TableGroup: "tg2", Shard: "1", // Should be discovered (db1 watch)
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db1",
+			TableGroup: "tg2",
+			Shard:      "1",
+		}, // Should be discovered (db1 watch)
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "db2", TableGroup: "tg1", Shard: "0", // Should be discovered (db2/tg1 watch)
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db2",
+			TableGroup: "tg1",
+			Shard:      "0",
+		}, // Should be discovered (db2/tg1 watch)
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
-		Database: "db2", TableGroup: "tg2", Shard: "0", // Should NOT be discovered
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler4"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db2",
+			TableGroup: "tg2",
+			Shard:      "0",
+		}, // Should NOT be discovered
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler5"},
-		Database: "db3", TableGroup: "tg1", Shard: "0", // Should be discovered (db3/tg1/0 watch)
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler5"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db3",
+			TableGroup: "tg1",
+			Shard:      "0",
+		}, // Should be discovered (db3/tg1/0 watch)
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler6"},
-		Database: "db3", TableGroup: "tg1", Shard: "1", // Should NOT be discovered
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler6"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "db3",
+			TableGroup: "tg1",
+			Shard:      "1",
+		}, // Should NOT be discovered
 	}))
 
 	// Wait for expected 4 poolers: pooler1, pooler2, pooler3, pooler5
@@ -465,8 +549,12 @@ func TestDiscovery_EmptyTopology(t *testing.T) {
 
 	// Add a pooler
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 
 	require.True(t, waitForCondition(t, 5*time.Second, poolerStoreIs(1)), "expected 1 pooler after adding to topology")
@@ -500,12 +588,20 @@ func TestPoolerWatcher_DirectDiscovery(t *testing.T) {
 
 	// Add a matching pooler and a non-matching pooler simultaneously
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "mydb", TableGroup: "tg2", Shard: "0", // filtered out
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		}, // filtered out
 	}))
 
 	require.True(t, waitForCondition(t, 5*time.Second, poolerStoreAtLeast(1)), "expected at least 1 pooler in store")
@@ -519,8 +615,12 @@ func TestPoolerWatcher_DirectDiscovery(t *testing.T) {
 
 	// Verify a new pooler discovered via watcher triggers the onNewPooler callback.
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "mydb", TableGroup: "tg1", Shard: "1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "1",
+		},
 	}))
 
 	require.True(t, waitForCondition(t, 5*time.Second, poolerStoreIs(2)), "expected pooler3 to be discovered")

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -453,8 +453,8 @@ func (re *Engine) collectStreamHealthData() []StreamHealthData {
 		}
 		data = append(data, StreamHealthData{
 			PoolerID:          topoclient.MultiPoolerIDString(state.MultiPooler.Id),
-			DBNamespace:       state.MultiPooler.Database,
-			Shard:             state.MultiPooler.Shard,
+			DBNamespace:       state.MultiPooler.GetShardKey().GetDatabase(),
+			Shard:             state.MultiPooler.GetShardKey().GetShard(),
 			Connected:         state.StreamConnected,
 			SnapshotsReceived: state.StreamSnapshotsReceived,
 		})

--- a/go/services/multiorch/recovery/engine_test.go
+++ b/go/services/multiorch/recovery/engine_test.go
@@ -416,16 +416,28 @@ func TestRecoveryEngine_DiscoveryLoop_Integration(t *testing.T) {
 
 	// Add poolers to topology BEFORE starting engine
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database: "mydb", TableGroup: "tg1", Shard: "1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "1",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
-		Database: "mydb", TableGroup: "tg2", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler3"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		},
 	}))
 
 	// Create engine with short refresh interval for testing
@@ -495,8 +507,12 @@ func TestRecoveryEngine_BookkeepingLoop_Integration(t *testing.T) {
 	oldTime := time.Now().Add(-5 * time.Hour) // 5 hours ago (> 4 hour threshold)
 	oldPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "old-pooler"},
-			Database: "mydb", TableGroup: "tg1", Shard: "0",
+			Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "old-pooler"},
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "mydb",
+				TableGroup: "tg1",
+				Shard:      "0",
+			},
 		},
 		LastSeen:            timestamppb.New(oldTime),
 		LastCheckAttempted:  timestamppb.New(oldTime),
@@ -508,8 +524,12 @@ func TestRecoveryEngine_BookkeepingLoop_Integration(t *testing.T) {
 
 	neverSeenPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "never-seen"},
-			Database: "mydb", TableGroup: "tg1", Shard: "1",
+			Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "never-seen"},
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "mydb",
+				TableGroup: "tg1",
+				Shard:      "1",
+			},
 		},
 		LastCheckAttempted: timestamppb.New(oldTime),
 		LastSeen:           nil, // Never seen
@@ -522,8 +542,12 @@ func TestRecoveryEngine_BookkeepingLoop_Integration(t *testing.T) {
 
 	healthyPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "healthy-pooler"},
-			Database: "mydb", TableGroup: "tg1", Shard: "2",
+			Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "healthy-pooler"},
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "mydb",
+				TableGroup: "tg1",
+				Shard:      "2",
+			},
 		},
 		LastSeen:            timestamppb.New(recentTime),
 		LastCheckAttempted:  timestamppb.New(recentTime),
@@ -583,8 +607,12 @@ func TestRecoveryEngine_FullIntegration(t *testing.T) {
 
 	// Add pooler to topology BEFORE starting
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "new-pooler"},
-		Database: "mydb", TableGroup: "tg1", Shard: "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "new-pooler"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 		Hostname: "host1",
 	}))
 
@@ -594,8 +622,12 @@ func TestRecoveryEngine_FullIntegration(t *testing.T) {
 
 	oldPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id:       &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "old-pooler"},
-			Database: "mydb", TableGroup: "tg1", Shard: "1",
+			Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "old-pooler"},
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "mydb",
+				TableGroup: "tg1",
+				Shard:      "1",
+			},
 		},
 		LastSeen:            timestamppb.New(oldTime),
 		LastCheckAttempted:  timestamppb.New(oldTime),

--- a/go/services/multiorch/recovery/health_stream_test.go
+++ b/go/services/multiorch/recovery/health_stream_test.go
@@ -78,13 +78,15 @@ func seedPooler(poolerStore *store.PoolerStore, poolerID *clustermetadata.ID, po
 	key := topoclient.MultiPoolerIDString(poolerID)
 	poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id:         poolerID,
-			Database:   "mydb",
-			TableGroup: "tg1",
-			Shard:      "0",
-			Type:       poolerType,
-			Hostname:   "host1",
-			PortMap:    map[string]int32{"grpc": 5432},
+			Id: poolerID,
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "mydb",
+				TableGroup: "tg1",
+				Shard:      "0",
+			},
+			Type:     poolerType,
+			Hostname: "host1",
+			PortMap:  map[string]int32{"grpc": 5432},
 		},
 	})
 	return key
@@ -284,7 +286,7 @@ func TestHealthStream_Disconnect(t *testing.T) {
 	key := topoclient.MultiPoolerIDString(poolerID)
 	poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadata.MultiPooler{
-			Id: poolerID, Database: "mydb", TableGroup: "tg1", Shard: "0",
+			Id: poolerID, ShardKey: &clustermetadata.ShardKey{Database: "mydb", TableGroup: "tg1", Shard: "0"},
 			Type: clustermetadata.PoolerType_PRIMARY, Hostname: "host1",
 			PortMap: map[string]int32{"grpc": 5432},
 		},
@@ -467,7 +469,7 @@ func TestHealthStream_LastPostgresReadyTime(t *testing.T) {
 		lastReadyTime := timestamppb.New(time.Now().Add(-10 * time.Second))
 		poolerStore.Set(key, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadata.MultiPooler{
-				Id: poolerID, Database: "mydb", TableGroup: "tg1", Shard: "0",
+				Id: poolerID, ShardKey: &clustermetadata.ShardKey{Database: "mydb", TableGroup: "tg1", Shard: "0"},
 				Type: clustermetadata.PoolerType_PRIMARY, Hostname: "host2",
 				PortMap: map[string]int32{"grpc": 5432},
 			},

--- a/go/services/multiorch/recovery/metrics_test.go
+++ b/go/services/multiorch/recovery/metrics_test.go
@@ -298,18 +298,22 @@ func TestEngine_CollectStreamHealthData(t *testing.T) {
 	// Populate the store with two poolers with different stream states.
 	engine.poolerStore.Set("zone1/pooler1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-			Database: "testdb",
-			Shard:    "shard1",
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database: "testdb",
+				Shard:    "shard1",
+			},
 		},
 		StreamConnected:         true,
 		StreamSnapshotsReceived: 42,
 	})
 	engine.poolerStore.Set("zone1/pooler2", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-			Database: "testdb",
-			Shard:    "shard1",
+			Id: &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database: "testdb",
+				Shard:    "shard1",
+			},
 		},
 		StreamConnected:         false,
 		StreamSnapshotsReceived: 7,

--- a/go/services/multiorch/recovery/pooler_watcher.go
+++ b/go/services/multiorch/recovery/pooler_watcher.go
@@ -423,9 +423,9 @@ func (cw *cellPoolerWatcher) handlePoolerEvent(wd *topoclient.WatchDataRecursive
 		cw.onNewPooler(pooler.Id)
 		cw.logger.Info("new pooler discovered via watcher",
 			"pooler_id", poolerID,
-			"database", pooler.Database,
-			"tablegroup", pooler.TableGroup,
-			"shard", pooler.Shard,
+			"database", pooler.GetShardKey().GetDatabase(),
+			"tablegroup", pooler.GetShardKey().GetTableGroup(),
+			"shard", pooler.GetShardKey().GetShard(),
 			"type", pooler.Type.String(),
 		)
 	}
@@ -435,7 +435,7 @@ func (cw *cellPoolerWatcher) handlePoolerEvent(wd *topoclient.WatchDataRecursive
 // configured WatchTargets.
 func (cw *cellPoolerWatcher) matchesAnyTarget(pooler *clustermetadatapb.MultiPooler) bool {
 	for _, target := range cw.targets() {
-		if target.MatchesShard(pooler.Database, pooler.TableGroup, pooler.Shard) {
+		if target.MatchesShard(pooler.GetShardKey().GetDatabase(), pooler.GetShardKey().GetTableGroup(), pooler.GetShardKey().GetShard()) {
 			return true
 		}
 	}

--- a/go/services/multiorch/recovery/pooler_watcher_test.go
+++ b/go/services/multiorch/recovery/pooler_watcher_test.go
@@ -90,20 +90,24 @@ func TestPoolerWatcher_InitialDiscovery(t *testing.T) {
 
 	// Pre-populate topology before watcher starts
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
-		Type:       clustermetadata.PoolerType_PRIMARY,
-		Hostname:   "host1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		Type:     clustermetadata.PoolerType_PRIMARY,
+		Hostname: "host1",
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
-		Type:       clustermetadata.PoolerType_REPLICA,
-		Hostname:   "host2",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		Type:     clustermetadata.PoolerType_REPLICA,
+		Hostname: "host2",
 	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -152,12 +156,14 @@ func TestPoolerWatcher_NewPoolerAddedAfterStart(t *testing.T) {
 
 	// Add a pooler after the watcher has started
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
-		Type:       clustermetadata.PoolerType_PRIMARY,
-		Hostname:   "host1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		Type:     clustermetadata.PoolerType_PRIMARY,
+		Hostname: "host1",
 	}))
 
 	ok := waitForCondition(t, 5*time.Second, func() bool {
@@ -180,12 +186,14 @@ func TestPoolerWatcher_PoolerMetadataUpdate(t *testing.T) {
 	defer ts.Close()
 
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
-		Type:       clustermetadata.PoolerType_PRIMARY,
-		Hostname:   "host1",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		Type:     clustermetadata.PoolerType_PRIMARY,
+		Hostname: "host1",
 	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -249,22 +257,28 @@ func TestPoolerWatcher_WatchTargetFiltering(t *testing.T) {
 
 	// Add poolers in different databases/tablegroups
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "watched"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "watched"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "other-db"},
-		Database:   "otherdb",
-		TableGroup: "tg1",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "other-db"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "otherdb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "other-tg"},
-		Database:   "mydb",
-		TableGroup: "tg2",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "other-tg"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg2",
+			Shard:      "0",
+		},
 	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -309,10 +323,12 @@ func TestPoolerWatcher_NewCellDiscovered(t *testing.T) {
 
 	// Add a pooler in zone1
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 
 	ok := waitForCondition(t, 5*time.Second, func() bool {
@@ -323,10 +339,12 @@ func TestPoolerWatcher_NewCellDiscovered(t *testing.T) {
 	// Add zone2 cell and a pooler in it
 	require.NoError(t, factory.AddCell(ctx, ts, "zone2"))
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone2", Name: "pooler2"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone2", Name: "pooler2"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 
 	ok = waitForCondition(t, 5*time.Second, func() bool {
@@ -349,10 +367,12 @@ func TestPoolerWatcher_PoolerDeletedFromTopology(t *testing.T) {
 	defer ts.Close()
 
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
-		Database:   "mydb",
-		TableGroup: "tg1",
-		Shard:      "0",
+		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
 	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/go/services/multiorch/recovery/recovery_loop_test.go
+++ b/go/services/multiorch/recovery/recovery_loop_test.go
@@ -724,7 +724,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		primaryPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
 				Id:       primaryID,
-				Database: "db1", TableGroup: "tg1", Shard: "0",
+				ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 				Type:     clustermetadatapb.PoolerType_PRIMARY,
 				Hostname: "primary-host",
 			},
@@ -746,7 +746,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		replicaPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
 				Id:       replicaID,
-				Database: "db1", TableGroup: "tg1", Shard: "0",
+				ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 				Type:     clustermetadatapb.PoolerType_REPLICA,
 				Hostname: "replica-host",
 			},
@@ -794,7 +794,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		primaryPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
 				Id:       primaryID,
-				Database: "db1", TableGroup: "tg1", Shard: "0",
+				ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 				Type:     clustermetadatapb.PoolerType_PRIMARY,
 				Hostname: "primary-host",
 			},
@@ -807,7 +807,7 @@ func TestProcessShardProblems_DependencyEnforcement(t *testing.T) {
 		replicaPooler := &multiorchdatapb.PoolerHealthState{
 			MultiPooler: &clustermetadatapb.MultiPooler{
 				Id:       replicaID,
-				Database: "db1", TableGroup: "tg1", Shard: "0",
+				ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 				Type:     clustermetadatapb.PoolerType_REPLICA,
 				Hostname: "replica-host",
 			},
@@ -900,7 +900,7 @@ func TestRecoveryLoop_ValidationPreventsStaleRecovery(t *testing.T) {
 	replicaPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replicaID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica-host",
 		},
@@ -1051,7 +1051,7 @@ func TestRecoveryLoop_PostRecoveryRefresh(t *testing.T) {
 	primaryPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       primaryID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_PRIMARY,
 			Hostname: "primary-host",
 		},
@@ -1074,7 +1074,7 @@ func TestRecoveryLoop_PostRecoveryRefresh(t *testing.T) {
 	replica1Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica1ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica1-host",
 		},
@@ -1088,7 +1088,7 @@ func TestRecoveryLoop_PostRecoveryRefresh(t *testing.T) {
 	replica2Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica2ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica2-host",
 		},
@@ -1241,7 +1241,7 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 	primaryPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       primaryID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_PRIMARY,
 			Hostname: "primary-host",
 		},
@@ -1254,7 +1254,7 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 	replica1Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica1ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica1-host",
 		},
@@ -1273,7 +1273,7 @@ func TestRecoveryLoop_FullCycle(t *testing.T) {
 	replica2Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica2ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica2-host",
 		},
@@ -1445,7 +1445,7 @@ func TestRecoveryLoop_PriorityOrdering(t *testing.T) {
 	replicaPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replicaID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica-host",
 		},
@@ -1565,7 +1565,7 @@ func TestRecoveryLoop_TracingSpans(t *testing.T) {
 	replicaPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replicaID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica-host",
 		},
@@ -1693,7 +1693,7 @@ func TestRecoveryLoop_GracePeriodIntegration(t *testing.T) {
 	primaryPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       primaryID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_PRIMARY,
 			Hostname: "primary-host",
 		},
@@ -1706,7 +1706,7 @@ func TestRecoveryLoop_GracePeriodIntegration(t *testing.T) {
 	replicaPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replicaID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica-host",
 		},
@@ -1824,7 +1824,7 @@ func TestRecoveryLoop_DeadlineResetAfterSuccess(t *testing.T) {
 	replicaPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replicaID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica-host",
 		},
@@ -2000,7 +2000,7 @@ func TestRecoveryLoop_PerPoolerGracePeriod(t *testing.T) {
 	primaryPooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       primaryID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_PRIMARY,
 			Hostname: "primary-host",
 		},
@@ -2013,7 +2013,7 @@ func TestRecoveryLoop_PerPoolerGracePeriod(t *testing.T) {
 	replica1Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica1ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica1-host",
 		},
@@ -2026,7 +2026,7 @@ func TestRecoveryLoop_PerPoolerGracePeriod(t *testing.T) {
 	replica2Pooler := &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
 			Id:       replica2ID,
-			Database: "db1", TableGroup: "tg1", Shard: "0",
+			ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "tg1", Shard: "0"},
 			Type:     clustermetadatapb.PoolerType_REPLICA,
 			Hostname: "replica2-host",
 		},

--- a/go/services/multiorch/store/pooler_store.go
+++ b/go/services/multiorch/store/pooler_store.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"log/slog"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/rpcclient"
 
@@ -113,9 +115,7 @@ func (s *PoolerStore) FindPoolersInShard(shardKey *clustermetadatapb.ShardKey) [
 			return true // continue
 		}
 
-		if pooler.MultiPooler.Database == shardKey.Database &&
-			pooler.MultiPooler.TableGroup == shardKey.TableGroup &&
-			pooler.MultiPooler.Shard == shardKey.Shard {
+		if proto.Equal(pooler.MultiPooler.GetShardKey(), shardKey) {
 			poolers = append(poolers, pooler)
 		}
 

--- a/go/services/multiorch/store/pooler_store_test.go
+++ b/go/services/multiorch/store/pooler_store_test.go
@@ -36,26 +36,32 @@ func TestPoolerStore_FindPoolersInShard(t *testing.T) {
 	// Add poolers to different shards
 	poolerStore.Set("pooler1", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "0",
+			Id: &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "0",
+			},
 		},
 	})
 	poolerStore.Set("pooler2", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         &clustermetadatapb.ID{Cell: "cell1", Name: "pooler2"},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "0",
+			Id: &clustermetadatapb.ID{Cell: "cell1", Name: "pooler2"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "0",
+			},
 		},
 	})
 	poolerStore.Set("pooler3", &multiorchdatapb.PoolerHealthState{
 		MultiPooler: &clustermetadatapb.MultiPooler{
-			Id:         &clustermetadatapb.ID{Cell: "cell2", Name: "pooler3"},
-			Database:   "db1",
-			TableGroup: "tg1",
-			Shard:      "1", // different shard
+			Id: &clustermetadatapb.ID{Cell: "cell2", Name: "pooler3"},
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "db1",
+				TableGroup: "tg1",
+				Shard:      "1",
+			}, // different shard
 		},
 	})
 

--- a/go/services/multiorch/store/store_test.go
+++ b/go/services/multiorch/store/store_test.go
@@ -40,10 +40,12 @@ func TestProtoStore_BasicOperations(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "multipooler-1",
 			},
-			Database:   "postgres",
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      "-",
-			Type:       clustermetadata.PoolerType_PRIMARY,
+			ShardKey: &clustermetadata.ShardKey{
+				Database:   "postgres",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      "-",
+			},
+			Type: clustermetadata.PoolerType_PRIMARY,
 		},
 		LastSeen:         timestamppb.Now(),
 		IsUpToDate:       true,
@@ -56,7 +58,7 @@ func TestProtoStore_BasicOperations(t *testing.T) {
 	retrieved, ok := store.Get(poolerID)
 	require.True(t, ok)
 	require.Equal(t, info.MultiPooler.Id.Name, retrieved.MultiPooler.Id.Name)
-	require.Equal(t, info.MultiPooler.Database, retrieved.MultiPooler.Database)
+	require.Equal(t, info.MultiPooler.GetShardKey().GetDatabase(), retrieved.MultiPooler.GetShardKey().GetDatabase())
 
 	// Get non-existent key
 	_, ok = store.Get("nonexistent")
@@ -138,7 +140,9 @@ func TestProtoStore_Range(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "pooler1",
 			},
-			Database: "db1",
+			ShardKey: &clustermetadata.ShardKey{
+				Database: "db1",
+			},
 		},
 	})
 	store.Set("key2", &multiorchdatapb.PoolerHealthState{
@@ -148,7 +152,9 @@ func TestProtoStore_Range(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "pooler2",
 			},
-			Database: "db2",
+			ShardKey: &clustermetadata.ShardKey{
+				Database: "db2",
+			},
 		},
 	})
 	store.Set("key3", &multiorchdatapb.PoolerHealthState{
@@ -158,7 +164,9 @@ func TestProtoStore_Range(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "pooler3",
 			},
-			Database: "db3",
+			ShardKey: &clustermetadata.ShardKey{
+				Database: "db3",
+			},
 		},
 	})
 
@@ -249,30 +257,32 @@ func TestProtoStore_CloningBehavior(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "pooler1",
 			},
-			Database: "original_db",
+			ShardKey: &clustermetadata.ShardKey{
+				Database: "original_db",
+			},
 		},
 		IsUpToDate: true,
 	}
 	store.Set("key1", original)
 
 	// Modify original after storing - should not affect stored value
-	original.MultiPooler.Database = "modified_db"
+	original.MultiPooler.ShardKey.Database = "modified_db"
 	original.IsUpToDate = false
 
 	// Get should return clone of original stored value, not the modified one
 	retrieved, ok := store.Get("key1")
 	require.True(t, ok)
-	require.Equal(t, "original_db", retrieved.MultiPooler.Database)
+	require.Equal(t, "original_db", retrieved.MultiPooler.GetShardKey().GetDatabase())
 	require.True(t, retrieved.IsUpToDate)
 
 	// Modify retrieved value - should not affect stored value
-	retrieved.MultiPooler.Database = "retrieved_modified"
+	retrieved.MultiPooler.ShardKey.Database = "retrieved_modified"
 	retrieved.IsUpToDate = false
 
 	// Get again - should still return original stored value
 	retrieved2, ok := store.Get("key1")
 	require.True(t, ok)
-	require.Equal(t, "original_db", retrieved2.MultiPooler.Database)
+	require.Equal(t, "original_db", retrieved2.MultiPooler.GetShardKey().GetDatabase())
 	require.True(t, retrieved2.IsUpToDate)
 }
 
@@ -287,14 +297,16 @@ func TestProtoStore_RangeCloningBehavior(t *testing.T) {
 				Cell:      "zone1",
 				Name:      "pooler1",
 			},
-			Database: "original_db",
+			ShardKey: &clustermetadata.ShardKey{
+				Database: "original_db",
+			},
 		},
 		IsUpToDate: true,
 	})
 
 	// Modify value during Range iteration
 	store.Range(func(key string, value *multiorchdatapb.PoolerHealthState) bool {
-		value.MultiPooler.Database = "modified_in_range"
+		value.MultiPooler.ShardKey.Database = "modified_in_range"
 		value.IsUpToDate = false
 		return true
 	})
@@ -302,7 +314,7 @@ func TestProtoStore_RangeCloningBehavior(t *testing.T) {
 	// Get should still return original value (Range returns clones)
 	retrieved, ok := store.Get("key1")
 	require.True(t, ok)
-	require.Equal(t, "original_db", retrieved.MultiPooler.Database)
+	require.Equal(t, "original_db", retrieved.MultiPooler.GetShardKey().GetDatabase())
 	require.True(t, retrieved.IsUpToDate)
 }
 

--- a/go/services/multipooler/grpcconsensusservice/service_test.go
+++ b/go/services/multipooler/grpcconsensusservice/service_test.go
@@ -70,13 +70,15 @@ func TestConsensusService_BeginTerm(t *testing.T) {
 	}
 	multipooler := &clustermetadata.MultiPooler{
 		Id:            serviceID,
-		Database:      "testdb",
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadata.PoolerType_REPLICA,
 		ServingStatus: clustermetadata.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "testdb",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -163,13 +165,15 @@ func TestConsensusService_Status(t *testing.T) {
 	}
 	multipooler := &clustermetadata.MultiPooler{
 		Id:            serviceID,
-		Database:      "testdb",
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadata.PoolerType_REPLICA,
 		ServingStatus: clustermetadata.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "testdb",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -245,13 +249,15 @@ func TestConsensusService_AllMethods(t *testing.T) {
 	}
 	multipooler := &clustermetadata.MultiPooler{
 		Id:            serviceID,
-		Database:      "testdb",
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadata.PoolerType_REPLICA,
 		ServingStatus: clustermetadata.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "testdb",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 

--- a/go/services/multipooler/grpcmanagerservice/service_test.go
+++ b/go/services/multipooler/grpcmanagerservice/service_test.go
@@ -50,12 +50,14 @@ func TestManagerServiceMethods_ManagerNotReady(t *testing.T) {
 	}
 
 	multipooler := &clustermetadata.MultiPooler{
-		Id:         serviceID,
-		Database:   "testdb",
-		Hostname:   "localhost",
-		PortMap:    map[string]int32{"grpc": 8080},
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      constants.DefaultShard,
+		Id:       serviceID,
+		Hostname: "localhost",
+		PortMap:  map[string]int32{"grpc": 8080},
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "testdb",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 
 	config := &manager.Config{

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -294,9 +294,11 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 	multipooler.PortMap["http"] = int32(mp.senv.GetHTTPPort())
 	multipooler.PortMap["postgres"] = int32(mp.pgPort.Get())
 	multipooler.PortMap["pgbackrest"] = int32(mp.pgBackRestPort.Get())
-	multipooler.Database = mp.database.Get()
-	multipooler.TableGroup = mp.tableGroup.Get()
-	multipooler.Shard = mp.shard.Get()
+	multipooler.ShardKey = &clustermetadatapb.ShardKey{
+		Database:   mp.database.Get(),
+		TableGroup: mp.tableGroup.Get(),
+		Shard:      mp.shard.Get(),
+	}
 	multipooler.ServingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
 	multipooler.PoolerDir = mp.poolerDir.Get()
 	multipooler.PgDataDir = os.Getenv(constants.PgDataDirEnvVar)

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -208,10 +208,10 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	if multiPooler == nil {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "multiPooler is required")
 	}
-	if multiPooler.TableGroup == "" {
+	if multiPooler.GetShardKey().GetTableGroup() == "" {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "TableGroup is required")
 	}
-	if multiPooler.Shard == "" {
+	if multiPooler.GetShardKey().GetShard() == "" {
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "Shard is required")
 	}
 	if multiPooler.Id == nil {
@@ -223,7 +223,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	}
 
 	// MVP validation: fail fast if tablegroup/shard are not the MVP defaults
-	if err := constants.ValidateMVPTableGroupAndShard(multiPooler.TableGroup, multiPooler.Shard); err != nil {
+	if err := constants.ValidateMVPTableGroupAndShard(multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard()); err != nil {
 		return nil, mterrors.Wrap(err, "MVP validation failed")
 	}
 
@@ -267,7 +267,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		connPoolMgr:            connPoolMgr,
 		readyChan:              make(chan struct{}),
 		pgMonitor:              monitorRunner,
-		healthStreamer:         newHealthStreamer(logger, multiPooler.Id, multiPooler.TableGroup, multiPooler.Shard),
+		healthStreamer:         newHealthStreamer(logger, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard()),
 		// We create a dummy context because some unit tests need them.
 		// These will be overwritten when Open gets called.
 		ctx:    ctx,
@@ -290,7 +290,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	if config.ConnPoolConfig != nil {
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
-	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.TableGroup, multiPooler.Shard, pm, drainGracePeriod)
+	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod)
 	pm.rules = newRuleStore(pm.logger, pm.qsc.InternalQueryService())
 
 	// The health streamer must wait for the query server to update its type before
@@ -512,7 +512,7 @@ func (pm *MultiPoolerManager) openConnectionsLocked() {
 		connConfig := &connpoolmanager.ConnectionConfig{
 			SocketFile: pm.config.SocketFilePath,
 			Port:       pgPort,
-			Database:   pm.multipooler.Database,
+			Database:   pm.multipooler.GetShardKey().GetDatabase(),
 		}
 		// When no Unix socket is configured, fall back to a TCP dial against
 		// the multipooler's own hostname. Postgres is colocated with pgctld on
@@ -646,11 +646,7 @@ func (pm *MultiPoolerManager) getPoolerType() clustermetadatapb.PoolerType {
 
 // shardKey returns a ShardKey identifying this pooler's shard.
 func (pm *MultiPoolerManager) shardKey() *clustermetadatapb.ShardKey {
-	return &clustermetadatapb.ShardKey{
-		Database:   pm.multipooler.Database,
-		TableGroup: pm.multipooler.TableGroup,
-		Shard:      pm.multipooler.Shard,
-	}
+	return pm.multipooler.ShardKey
 }
 
 // checkReady returns an error if the manager is not in Ready state
@@ -819,7 +815,7 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 		}
 		// Successfully loaded multipooler record
 		// Now load the backup location from the database topology
-		database := pm.multipooler.Database
+		database := pm.multipooler.GetShardKey().GetDatabase()
 		if database == "" {
 			pm.setStateError(errors.New("database name not set in multipooler"))
 			return
@@ -841,7 +837,7 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 		}
 
 		// Verify we can compute the full backup path
-		_, err = backupConfig.FullPath(database, pm.multipooler.TableGroup, pm.multipooler.Shard)
+		_, err = backupConfig.FullPath(database, pm.multipooler.GetShardKey().GetTableGroup(), pm.multipooler.GetShardKey().GetShard())
 		if err != nil {
 			pm.setStateError(fmt.Errorf("failed to compute backup path: %w", err))
 			return

--- a/go/services/multipooler/manager/manager_test.go
+++ b/go/services/multipooler/manager/manager_test.go
@@ -51,7 +51,7 @@ func TestManagerState_InitialState(t *testing.T) {
 	}
 
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -86,7 +86,7 @@ func TestManagerState_LoadFailureTimeout(t *testing.T) {
 	factory.AddOperationError(memorytopo.Get, poolerPath, assert.AnError)
 
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -129,7 +129,7 @@ func TestManagerState_CancellationDuringLoad(t *testing.T) {
 	factory.AddOperationError(memorytopo.Get, poolerPath, assert.AnError)
 
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -182,13 +182,15 @@ func TestManagerState_RetryUntilSuccess(t *testing.T) {
 	}
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -198,7 +200,7 @@ func TestManagerState_RetryUntilSuccess(t *testing.T) {
 	factory.AddOneTimeOperationError(memorytopo.Get, poolerPath, assert.AnError)
 
 	multiPoolerObj := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPoolerObj.Shard = constants.DefaultShard
+	multiPoolerObj.ShardKey.Shard = constants.DefaultShard
 	multiPoolerObj.PoolerDir = poolerDir
 
 	config := &Config{
@@ -231,10 +233,12 @@ func TestManagerState_NilServiceID(t *testing.T) {
 
 	// Create MultiPooler with nil Id to test validation
 	multiPooler := &clustermetadatapb.MultiPooler{
-		Id:         nil, // Nil ID for testing
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      constants.DefaultShard,
-		PoolerDir:  "/tmp/test",
+		Id: nil, // Nil ID for testing
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+		PoolerDir: "/tmp/test",
 	}
 
 	config := &Config{
@@ -339,14 +343,16 @@ func TestValidateAndUpdateTerm(t *testing.T) {
 
 			multipooler := &clustermetadatapb.MultiPooler{
 				Id:            serviceID,
-				Database:      database,
 				Hostname:      "localhost",
 				PortMap:       map[string]int32{"grpc": 8080},
 				Type:          clustermetadatapb.PoolerType_PRIMARY,
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-				TableGroup:    constants.DefaultTableGroup,
-				Shard:         constants.DefaultShard,
-				PoolerDir:     poolerDir,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   database,
+					TableGroup: constants.DefaultTableGroup,
+					Shard:      constants.DefaultShard,
+				},
+				PoolerDir: poolerDir,
 			}
 			require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -413,11 +419,13 @@ func TestGetBackupLocation(t *testing.T) {
 		Name:      "test-service",
 	}
 	multiPooler := &clustermetadatapb.MultiPooler{
-		Id:         serviceID,
-		Database:   database,
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      constants.DefaultShard,
-		PoolerDir:  filepath.Join(tmpDir, "pooler"),
+		Id: serviceID,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+		PoolerDir: filepath.Join(tmpDir, "pooler"),
 	}
 	config := &Config{
 		TopoClient: ts,
@@ -462,11 +470,13 @@ func TestGetBackupLocation_S3(t *testing.T) {
 		Name:      "test-service",
 	}
 	multiPooler := &clustermetadatapb.MultiPooler{
-		Id:         serviceID,
-		Database:   database,
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      constants.DefaultShard,
-		PoolerDir:  filepath.Join(tmpDir, "pooler"),
+		Id: serviceID,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+		PoolerDir: filepath.Join(tmpDir, "pooler"),
 	}
 	config := &Config{
 		TopoClient: ts,
@@ -514,7 +524,7 @@ func TestWaitUntilReady_Success(t *testing.T) {
 		Name: "test-service",
 	}
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -548,7 +558,7 @@ func TestWaitUntilReady_Error(t *testing.T) {
 		Name: "test-service",
 	}
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -583,7 +593,7 @@ func TestWaitUntilReady_Timeout(t *testing.T) {
 		Name: "test-service",
 	}
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -614,7 +624,7 @@ func TestWaitUntilReady_ConcurrentCalls(t *testing.T) {
 		Name: "test-service",
 	}
 	multiPooler := topoclient.NewMultiPooler(serviceID.Name, serviceID.Cell, "localhost", constants.DefaultTableGroup)
-	multiPooler.Shard = constants.DefaultShard
+	multiPooler.ShardKey.Shard = constants.DefaultShard
 	multiPooler.PoolerDir = "/tmp/test"
 
 	config := &Config{
@@ -710,13 +720,15 @@ func TestNewMultiPoolerManager_MVPValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			multiPooler := &clustermetadatapb.MultiPooler{
-				Id:         serviceID,
-				Database:   "testdb",
-				Hostname:   "localhost",
-				PortMap:    map[string]int32{"grpc": 8080},
-				TableGroup: tt.tableGroup,
-				Shard:      tt.shard,
-				PoolerDir:  "/tmp/test",
+				Id:        serviceID,
+				Hostname:  "localhost",
+				PortMap:   map[string]int32{"grpc": 8080},
+				PoolerDir: "/tmp/test",
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   "testdb",
+					TableGroup: tt.tableGroup,
+					Shard:      tt.shard,
+				},
 			}
 
 			config := &Config{

--- a/go/services/multipooler/manager/pg_multischema.go
+++ b/go/services/multipooler/manager/pg_multischema.go
@@ -88,8 +88,8 @@ func (pm *MultiPoolerManager) createSidecarSchema(ctx context.Context, policy *c
 // pooler. For simplicity in the MVP, we do this as part of InitializePrimary since
 // we only support a single tablegroup/shard for now.
 func (pm *MultiPoolerManager) initializeMultischemaData(ctx context.Context) error {
-	tableGroup := pm.multipooler.TableGroup
-	shard := pm.multipooler.Shard
+	tableGroup := pm.multipooler.GetShardKey().GetTableGroup()
+	shard := pm.multipooler.GetShardKey().GetShard()
 
 	// MVP validation: only default tablegroup with shard 0-inf is supported
 	// This is an extra guardrail. Multipoolers shouldn't start unless they

--- a/go/services/multipooler/manager/pg_multischema_test.go
+++ b/go/services/multipooler/manager/pg_multischema_test.go
@@ -69,8 +69,10 @@ func newTestManagerWithMock(tableGroup, shard string) (*MultiPoolerManager, *moc
 	topoStore := memorytopo.NewServer(ctx, "test-cell")
 
 	multiPooler := &clustermetadatapb.MultiPooler{
-		TableGroup: tableGroup,
-		Shard:      shard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: tableGroup,
+			Shard:      shard,
+		},
 	}
 
 	svcID := &clustermetadatapb.ID{Cell: "test-cell", Name: "test-pooler"}

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -124,8 +124,8 @@ func (pm *MultiPoolerManager) backupLockedInner(ctx context.Context, forcePrimar
 		return "", err
 	}
 
-	tableGroup := pm.multipooler.TableGroup
-	shard := pm.multipooler.Shard
+	tableGroup := pm.multipooler.GetShardKey().GetTableGroup()
+	shard := pm.multipooler.GetShardKey().GetShard()
 	multipoolerID := topoclient.MultiPoolerIDString(pm.multipooler.Id)
 	multipoolerName := pm.multipooler.Id.Name
 
@@ -536,7 +536,7 @@ func (pm *MultiPoolerManager) listBackups(ctx context.Context) ([]*multipoolerma
 	}
 
 	// Get current pooler's table_group and shard for filtering
-	currentTableGroup := pm.multipooler.TableGroup
+	currentTableGroup := pm.multipooler.GetShardKey().GetTableGroup()
 	currentShard := pm.getShardID()
 
 	// Extract backups from the first stanza (should be the only one)

--- a/go/services/multipooler/manager/rpc_backup_test.go
+++ b/go/services/multipooler/manager/rpc_backup_test.go
@@ -64,12 +64,14 @@ func createTestManagerWithBackupLocation(poolerDir, tableGroup, shard string, po
 	}
 
 	multipoolerProto := &clustermetadatapb.MultiPooler{
-		Id:         multipoolerID,
-		Type:       poolerType,
-		TableGroup: tableGroup,
-		Shard:      shard,
-		Database:   database,
-		PoolerDir:  poolerDir,
+		Id:        multipoolerID,
+		Type:      poolerType,
+		PoolerDir: poolerDir,
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: tableGroup,
+			Shard:      shard,
+			Database:   database,
+		},
 	}
 
 	// Create a topology store with backup location if provided
@@ -1218,12 +1220,14 @@ exit 0
 				serviceID:  multipoolerID,
 				topoClient: ts,
 				multipooler: &clustermetadatapb.MultiPooler{
-					Id:         multipoolerID,
-					Type:       clustermetadatapb.PoolerType_PRIMARY,
-					TableGroup: tt.tableGroup,
-					Shard:      tt.shard,
-					Database:   "test-database",
-					PoolerDir:  poolerDir,
+					Id:        multipoolerID,
+					Type:      clustermetadatapb.PoolerType_PRIMARY,
+					PoolerDir: poolerDir,
+					ShardKey: &clustermetadatapb.ShardKey{
+						TableGroup: tt.tableGroup,
+						Shard:      tt.shard,
+						Database:   "test-database",
+					},
 				},
 				state:                ManagerStateReady,
 				backupConfig:         backupConfig,

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -137,13 +137,15 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	}
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1089,13 +1091,15 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 			}
 			multipooler := &clustermetadatapb.MultiPooler{
 				Id:            serviceID,
-				Database:      database,
 				Hostname:      "localhost",
 				PortMap:       map[string]int32{"grpc": 8080, "postgres": 5432},
 				Type:          clustermetadatapb.PoolerType_PRIMARY, // Starting as PRIMARY
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-				TableGroup:    constants.DefaultTableGroup,
-				Shard:         constants.DefaultShard,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   database,
+					TableGroup: constants.DefaultTableGroup,
+					Shard:      constants.DefaultShard,
+				},
 			}
 			require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 

--- a/go/services/multipooler/manager/rpc_first_backup.go
+++ b/go/services/multipooler/manager/rpc_first_backup.go
@@ -240,14 +240,14 @@ func (pm *MultiPoolerManager) runStanzaCreate(ctx context.Context) error {
 
 // loadDurabilityPolicy reads the bootstrap durability policy from the topology database record.
 func (pm *MultiPoolerManager) loadDurabilityPolicy(ctx context.Context) (*clustermetadatapb.DurabilityPolicy, error) {
-	db, err := pm.topoClient.GetDatabase(ctx, pm.multipooler.Database)
+	db, err := pm.topoClient.GetDatabase(ctx, pm.multipooler.GetShardKey().GetDatabase())
 	if err != nil {
-		return nil, mterrors.Wrapf(err, "failed to get database %s from topology", pm.multipooler.Database)
+		return nil, mterrors.Wrapf(err, "failed to get database %s from topology", pm.multipooler.GetShardKey().GetDatabase())
 	}
 
 	if db.BootstrapDurabilityPolicy == nil {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-			"database %s has no durability_policy configured", pm.multipooler.Database)
+			"database %s has no durability_policy configured", pm.multipooler.GetShardKey().GetDatabase())
 	}
 
 	return db.BootstrapDurabilityPolicy, nil

--- a/go/services/multipooler/manager/rpc_first_backup_test.go
+++ b/go/services/multipooler/manager/rpc_first_backup_test.go
@@ -132,7 +132,7 @@ func TestLoadDurabilityPolicy(t *testing.T) {
 
 	pm := &MultiPoolerManager{
 		topoClient:  store,
-		multipooler: &clustermetadatapb.MultiPooler{Database: dbName},
+		multipooler: &clustermetadatapb.MultiPooler{ShardKey: &clustermetadatapb.ShardKey{Database: dbName}},
 	}
 
 	got, err := pm.loadDurabilityPolicy(ctx)
@@ -159,7 +159,7 @@ func TestLoadDurabilityPolicy_NoPolicyConfigured(t *testing.T) {
 
 	pm := &MultiPoolerManager{
 		topoClient:  store,
-		multipooler: &clustermetadatapb.MultiPooler{Database: dbName},
+		multipooler: &clustermetadatapb.MultiPooler{ShardKey: &clustermetadatapb.ShardKey{Database: dbName}},
 	}
 
 	_, err = pm.loadDurabilityPolicy(ctx)
@@ -194,10 +194,12 @@ func TestCreateFirstBackupAndInitialize_NoDurabilityPolicy(t *testing.T) {
 		actionLock:   NewActionLock(),
 		pgctldClient: &stubPgctldClient{},
 		multipooler: &clustermetadatapb.MultiPooler{
-			Database:   dbName,
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-			PoolerDir:  poolerDir,
+			PoolerDir: poolerDir,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   dbName,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		},
 		config: &Config{},
 	}
@@ -235,10 +237,12 @@ func TestCreateFirstBackupAndInitialize_DataDirExists(t *testing.T) {
 		actionLock:   NewActionLock(),
 		pgctldClient: &stubPgctldClient{},
 		multipooler: &clustermetadatapb.MultiPooler{
-			Database:   "testdb",
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-			PoolerDir:  poolerDir,
+			PoolerDir: poolerDir,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		},
 		config: &Config{},
 	}
@@ -282,10 +286,12 @@ func TestCreateFirstBackupAndInitialize_InitDataDirFails(t *testing.T) {
 		actionLock:   NewActionLock(),
 		pgctldClient: &stubPgctldClient{}, // InitDataDir returns UNAVAILABLE
 		multipooler: &clustermetadatapb.MultiPooler{
-			Database:   dbName,
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-			PoolerDir:  poolerDir,
+			PoolerDir: poolerDir,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   dbName,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		},
 		config: &Config{},
 	}
@@ -328,10 +334,12 @@ func TestCreateFirstBackupAndInitialize_CleansUpAfterLaterFailure(t *testing.T) 
 		actionLock:   NewActionLock(),
 		pgctldClient: pgctld,
 		multipooler: &clustermetadatapb.MultiPooler{
-			Database:   dbName,
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-			PoolerDir:  poolerDir,
+			PoolerDir: poolerDir,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   dbName,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		},
 		config: &Config{},
 		// pgBackRestConfigPath deliberately empty → configureArchiveMode will fail,
@@ -388,10 +396,12 @@ func TestCreateFirstBackupAndInitialize_StaleSentinelCleansUpDataDir(t *testing.
 		actionLock:   NewActionLock(),
 		pgctldClient: &stubPgctldClient{},
 		multipooler: &clustermetadatapb.MultiPooler{
-			Database:   dbName,
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      constants.DefaultShard,
-			PoolerDir:  poolerDir,
+			PoolerDir: poolerDir,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   dbName,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		},
 		config: &Config{},
 	}

--- a/go/services/multipooler/manager/rpc_initialization.go
+++ b/go/services/multipooler/manager/rpc_initialization.go
@@ -196,12 +196,12 @@ func (pm *MultiPoolerManager) getShardID() string {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	if pm.multipooler.Shard != "" {
-		return pm.multipooler.Shard
+	if pm.multipooler.GetShardKey().GetShard() != "" {
+		return pm.multipooler.GetShardKey().GetShard()
 	}
 
 	// Fall back to MultiPooler - always available and authoritative
-	return pm.multipooler.Shard
+	return pm.multipooler.GetShardKey().GetShard()
 }
 
 // removeDataDirectory removes the PostgreSQL data directory

--- a/go/services/multipooler/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/manager/rpc_initialization_test.go
@@ -47,9 +47,11 @@ func NewTestMultiPoolerManager(t *testing.T) *MultiPoolerManager {
 			Cell:      "test-cell",
 			Name:      "test-pooler",
 		},
-		TableGroup: "default",
-		Shard:      "0-inf",
-		PoolerDir:  t.TempDir(),
+		ShardKey: &clustermetadatapb.ShardKey{
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		PoolerDir: t.TempDir(),
 	}
 	pm, err := NewMultiPoolerManager(slog.Default(), mp, &Config{})
 	require.NoError(t, err)
@@ -162,10 +164,12 @@ func TestHelperMethods(t *testing.T) {
 		}
 
 		multipooler := &clustermetadatapb.MultiPooler{
-			Id:         serviceID,
-			Database:   "testdb",
-			TableGroup: "testgroup",
-			Shard:      "shard-123",
+			Id: serviceID,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   "testdb",
+				TableGroup: "testgroup",
+				Shard:      "shard-123",
+			},
 		}
 
 		pm := &MultiPoolerManager{

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -122,13 +122,15 @@ func TestPrimaryPosition(t *testing.T) {
 
 			multipooler := &clustermetadatapb.MultiPooler{
 				Id:            serviceID,
-				Database:      database,
 				Hostname:      "localhost",
 				PortMap:       map[string]int32{"grpc": 8080},
 				Type:          tt.poolerType,
 				ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-				TableGroup:    constants.DefaultTableGroup,
-				Shard:         constants.DefaultShard,
+				ShardKey: &clustermetadatapb.ShardKey{
+					Database:   database,
+					TableGroup: constants.DefaultTableGroup,
+					Shard:      constants.DefaultShard,
+				},
 			}
 			require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -199,13 +201,15 @@ func TestActionLock_MutationMethodsTimeout(t *testing.T) {
 	// Create PRIMARY multipooler for testing
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -410,13 +414,15 @@ func setupPromoteTestManager(t *testing.T, mockQueryService *mock.QueryService, 
 	// Create as REPLICA (ready for promotion)
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_REPLICA,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1066,13 +1072,15 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_REPLICA,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1165,13 +1173,15 @@ func TestSetPrimaryConnInfo_StoresPrimaryPoolerID(t *testing.T) {
 	// Create REPLICA multipooler
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080},
 		Type:          clustermetadatapb.PoolerType_REPLICA,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1292,13 +1302,15 @@ func TestReplicationStatus(t *testing.T) {
 		// Create PRIMARY multipooler
 		multipooler := &clustermetadatapb.MultiPooler{
 			Id:            serviceID,
-			Database:      database,
 			Hostname:      "localhost",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			TableGroup:    constants.DefaultTableGroup,
-			Shard:         constants.DefaultShard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   database,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1369,13 +1381,15 @@ func TestReplicationStatus(t *testing.T) {
 		// Create REPLICA multipooler
 		multipooler := &clustermetadatapb.MultiPooler{
 			Id:            serviceID,
-			Database:      database,
 			Hostname:      "localhost",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_REPLICA,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			TableGroup:    constants.DefaultTableGroup,
-			Shard:         constants.DefaultShard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   database,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1458,13 +1472,15 @@ func TestReplicationStatus(t *testing.T) {
 		// Create PRIMARY multipooler (but PG will be in standby mode - mismatch!)
 		multipooler := &clustermetadatapb.MultiPooler{
 			Id:            serviceID,
-			Database:      database,
 			Hostname:      "localhost",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			TableGroup:    constants.DefaultTableGroup,
-			Shard:         constants.DefaultShard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   database,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1539,13 +1555,15 @@ func TestReplicationStatus(t *testing.T) {
 
 		multipooler := &clustermetadatapb.MultiPooler{
 			Id:            serviceID,
-			Database:      database,
 			Hostname:      "localhost",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_PRIMARY,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			TableGroup:    constants.DefaultTableGroup,
-			Shard:         constants.DefaultShard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   database,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1613,13 +1631,15 @@ func TestReplicationStatus(t *testing.T) {
 		// Create REPLICA multipooler (but PG will be in primary mode - mismatch!)
 		multipooler := &clustermetadatapb.MultiPooler{
 			Id:            serviceID,
-			Database:      database,
 			Hostname:      "localhost",
 			PortMap:       map[string]int32{"grpc": 8080},
 			Type:          clustermetadatapb.PoolerType_REPLICA,
 			ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-			TableGroup:    constants.DefaultTableGroup,
-			Shard:         constants.DefaultShard,
+			ShardKey: &clustermetadatapb.ShardKey{
+				Database:   database,
+				TableGroup: constants.DefaultTableGroup,
+				Shard:      constants.DefaultShard,
+			},
 		}
 		require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1705,13 +1725,15 @@ func TestConfigureSynchronousReplication_HistoryFailurePreventGUCUpdates(t *test
 
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080, "postgres": 5432},
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1813,13 +1835,15 @@ func TestUpdateSynchronousStandbyList_HistoryFailurePreventsGUCUpdate(t *testing
 
 	multipooler := &clustermetadatapb.MultiPooler{
 		Id:            serviceID,
-		Database:      database,
 		Hostname:      "localhost",
 		PortMap:       map[string]int32{"grpc": 8080, "postgres": 5432},
 		Type:          clustermetadatapb.PoolerType_PRIMARY,
 		ServingStatus: clustermetadatapb.PoolerServingStatus_SERVING,
-		TableGroup:    constants.DefaultTableGroup,
-		Shard:         constants.DefaultShard,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   database,
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
 	}
 	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
 
@@ -1917,14 +1941,16 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 	}
 
 	multipooler := &clustermetadatapb.MultiPooler{
-		Id:         serviceID,
-		PoolerDir:  poolerDir,
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      constants.DefaultShard,
-		Type:       clustermetadatapb.PoolerType_REPLICA,
-		Database:   "postgres",
+		Id:        serviceID,
+		PoolerDir: poolerDir,
+		Type:      clustermetadatapb.PoolerType_REPLICA,
 		PortMap: map[string]int32{
 			"postgres": 5432,
+		},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
 		},
 	}
 

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -374,9 +374,9 @@ func checkMultipoolerTopoRegistration(etcdAddress, globalRootPath, cellName, exp
 
 	// Check that at least one multipooler has the correct database, tablegroup, and shard
 	for _, info := range multipoolerInfos {
-		if info.Database == expectedDatabase &&
-			info.TableGroup == expectedTableGroup &&
-			info.Shard == expectedShard {
+		if info.GetShardKey().GetDatabase() == expectedDatabase &&
+			info.GetShardKey().GetTableGroup() == expectedTableGroup &&
+			info.GetShardKey().GetShard() == expectedShard {
 			// Found a multipooler with the expected registration
 			return nil
 		}
@@ -386,7 +386,7 @@ func checkMultipoolerTopoRegistration(etcdAddress, globalRootPath, cellName, exp
 	var found []string
 	for _, info := range multipoolerInfos {
 		found = append(found, fmt.Sprintf("{database: '%s', tablegroup: '%s', shard: '%s'}",
-			info.Database, info.TableGroup, info.Shard))
+			info.GetShardKey().GetDatabase(), info.GetShardKey().GetTableGroup(), info.GetShardKey().GetShard()))
 	}
 
 	return fmt.Errorf("expected to find multipooler with database='%s', tablegroup='%s', shard='%s' but found: [%s]",

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -134,15 +134,12 @@ message MultiPooler {
   // id is the unique identifier of the multipooler in the cluster.
   ID id = 1;
 
-  // Database name.
-  string database = 2;
-
-  // TableGroup name.
-  string table_group = 3;
-
-  // Shard name. If range based sharding is used, it should match
-  // key_range.
-  string shard = 4;
+  // shard_key identifies which shard this pooler belongs to. It is used for
+  // routing requests to the correct pooler and for displaying metadata about
+  // the shard in dashboards. It is not expected to change for the lifetime of
+  // the pooler, but it is not immutable either — if the pooler moves to a
+  // different shard, this field should be updated to reflect the new shard.
+  ShardKey shard_key = 2; //
 
   // If range based sharding is used, range for the pooler's shard.
   KeyRange key_range = 5;


### PR DESCRIPTION
Move database, table_group, and shard fields out of MultiPooler into a dedicated ShardKey sub-message (field 2), matching the ShardKey type already used elsewhere. Update all call sites across production code and tests to use the nested accessor pattern, and replace field-by-field shard equality checks with proto.Equal() where all three fields are compared.