### PR TITLE
fix(parser): lexer must reject malformed input that PostgreSQL rejects

### DIFF
--- a/go/common/parser/context.go
+++ b/go/common/parser/context.go
@@ -40,6 +40,7 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -991,6 +992,17 @@ func (ctx *ParseContext) ScanBuf() []byte {
 	buf := make([]byte, len(ctx.scanBuf))
 	copy(buf, ctx.scanBuf)
 	return buf
+}
+
+// HasPrefixAtScanPos reports whether scanBuf at the current scan position
+// starts with needle. Avoids copying the entire buffer (as ScanBuf does) so
+// repeated lookups inside hot scanning loops stay zero-alloc.
+func (ctx *ParseContext) HasPrefixAtScanPos(needle []byte) bool {
+	pos := ctx.scanPos
+	if len(ctx.scanBuf)-pos < len(needle) {
+		return false
+	}
+	return bytes.Equal(ctx.scanBuf[pos:pos+len(needle)], needle)
 }
 
 func (ctx *ParseContext) SetScanPos(pos int) {

--- a/go/common/parser/context.go
+++ b/go/common/parser/context.go
@@ -437,6 +437,17 @@ func (ctx *ParseContext) CurrentChar() rune {
 	return r
 }
 
+// CurrentRune returns the current character at ScanPos along with its byte
+// length. Unlike CurrentChar + utf8.RuneLen, this preserves the size that
+// utf8.DecodeRune actually consumed, so invalid UTF-8 sequences advance by
+// exactly one byte instead of overshooting by re-encoding U+FFFD as 3 bytes.
+func (ctx *ParseContext) CurrentRune() (rune, int) {
+	if ctx.scanPos >= len(ctx.scanBuf) {
+		return 0, 0
+	}
+	return utf8.DecodeRune(ctx.scanBuf[ctx.scanPos:])
+}
+
 // PeekChar returns the next character without advancing
 func (ctx *ParseContext) PeekChar() rune {
 	if ctx.scanPos >= len(ctx.scanBuf) {

--- a/go/common/parser/context.go
+++ b/go/common/parser/context.go
@@ -40,7 +40,6 @@
 package parser
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -997,12 +996,15 @@ func (ctx *ParseContext) ScanBuf() []byte {
 // HasPrefixAtScanPos reports whether scanBuf at the current scan position
 // starts with needle. Avoids copying the entire buffer (as ScanBuf does) so
 // repeated lookups inside hot scanning loops stay zero-alloc.
-func (ctx *ParseContext) HasPrefixAtScanPos(needle []byte) bool {
+// needle is taken as a string so callers don't have to allocate a []byte:
+// `string(byteSlice) == stringLit` lowers to a direct memcmp in the Go
+// compiler with no heap allocation.
+func (ctx *ParseContext) HasPrefixAtScanPos(needle string) bool {
 	pos := ctx.scanPos
 	if len(ctx.scanBuf)-pos < len(needle) {
 		return false
 	}
-	return bytes.Equal(ctx.scanBuf[pos:pos+len(needle)], needle)
+	return string(ctx.scanBuf[pos:pos+len(needle)]) == needle
 }
 
 func (ctx *ParseContext) SetScanPos(pos int) {

--- a/go/common/parser/lexer.go
+++ b/go/common/parser/lexer.go
@@ -1699,8 +1699,9 @@ func (l *Lexer) parseBinaryInteger(s string, start int) (uint32, bool) {
 
 	for ptr < len(s) {
 		c := s[ptr]
-		switch c {
-		case '0', '1':
+		// Use if/else (not switch) so the trailing `break` exits the loop;
+		// `break` inside a switch only exits the switch and would spin here.
+		if c == '0' || c == '1' { //nolint:staticcheck // QF1003: switch would defeat the point
 			// Check for overflow before shifting
 			if val > 0xFFFFFFFF/2 {
 				return 0, true
@@ -1708,13 +1709,13 @@ func (l *Lexer) parseBinaryInteger(s string, start int) (uint32, bool) {
 			val = val*2 + uint32(c-'0')
 			hasDigits = true
 			ptr++
-		case '_':
+		} else if c == '_' {
 			// Underscore must be followed by more binary digits
 			ptr++
 			if ptr >= len(s) || (s[ptr] != '0' && s[ptr] != '1') {
 				return 0, false // Invalid syntax
 			}
-		default:
+		} else {
 			break
 		}
 	}

--- a/go/common/parser/lexer.go
+++ b/go/common/parser/lexer.go
@@ -263,9 +263,12 @@ func (l *Lexer) isValidUescapeChar(escape byte) bool {
 	return true
 }
 
-// decodeUnicodeString decodes Unicode escape sequences in a string
-// Implements the same logic as PostgreSQL's str_udeescape function
-// Equivalent to postgres/src/backend/parser/parser.c:371-527 (str_udeescape)
+// decodeUnicodeString decodes Unicode escape sequences in a string.
+// Mirrors PostgreSQL's str_udeescape (postgres/src/backend/parser/parser.c:371-527)
+// including surrogate-pair pairing, code-point range validation, and rejection
+// of lone or out-of-order surrogates. Errors emitted here surface as
+// `invalid Unicode surrogate pair` / `invalid Unicode escape value` /
+// `invalid Unicode escape sequence` matching upstream wording.
 func (l *Lexer) decodeUnicodeString(input string, escapeChar byte) (string, error) {
 	if len(input) == 0 {
 		return input, nil
@@ -273,38 +276,80 @@ func (l *Lexer) decodeUnicodeString(input string, escapeChar byte) (string, erro
 
 	result := make([]byte, 0, len(input))
 	i := 0
+	var pairFirst rune // non-zero while awaiting low surrogate; 0 otherwise
+
+	emit := func(cp rune) error {
+		if cp > 0x10FFFF {
+			return errors.New("invalid Unicode escape value")
+		}
+		result = append(result, []byte(string(cp))...)
+		return nil
+	}
 
 	for i < len(input) {
-		if input[i] == escapeChar {
-			if i+1 < len(input) && input[i+1] == escapeChar {
-				// Escaped escape character
-				result = append(result, escapeChar)
-				i += 2
-			} else if i+4 < len(input) && l.isHexSequence(input[i+1:i+5]) {
-				// 4-digit hex escape: \XXXX
-				codepoint, err := l.parseHexCodepoint(input[i+1 : i+5])
-				if err != nil {
-					return "", err
-				}
-				utf8Bytes := l.codepointToUTF8(codepoint)
-				result = append(result, utf8Bytes...)
-				i += 5
-			} else if i+7 < len(input) && input[i+1] == '+' && l.isHexSequence(input[i+2:i+8]) {
-				// 6-digit hex escape: \+XXXXXX
-				codepoint, err := l.parseHexCodepoint(input[i+2 : i+8])
-				if err != nil {
-					return "", err
-				}
-				utf8Bytes := l.codepointToUTF8(codepoint)
-				result = append(result, utf8Bytes...)
-				i += 8
-			} else {
-				return "", errors.New("invalid Unicode escape sequence")
+		if input[i] != escapeChar {
+			if pairFirst != 0 {
+				// High surrogate not followed by another \ escape sequence.
+				return "", errors.New("invalid Unicode surrogate pair")
 			}
-		} else {
 			result = append(result, input[i])
 			i++
+			continue
 		}
+
+		// Escape sequence. First handle doubled escape char: literal char.
+		if i+1 < len(input) && input[i+1] == escapeChar {
+			if pairFirst != 0 {
+				return "", errors.New("invalid Unicode surrogate pair")
+			}
+			result = append(result, escapeChar)
+			i += 2
+			continue
+		}
+
+		var codepoint rune
+		var consumed int
+		switch {
+		case i+4 < len(input) && l.isHexSequence(input[i+1:i+5]):
+			cp, err := l.parseHexCodepoint(input[i+1 : i+5])
+			if err != nil {
+				return "", err
+			}
+			codepoint, consumed = cp, 5
+		case i+7 < len(input) && input[i+1] == '+' && l.isHexSequence(input[i+2:i+8]):
+			cp, err := l.parseHexCodepoint(input[i+2 : i+8])
+			if err != nil {
+				return "", err
+			}
+			codepoint, consumed = cp, 8
+		default:
+			return "", errors.New("invalid Unicode escape sequence")
+		}
+
+		switch {
+		case pairFirst != 0:
+			combined, ok := validateSurrogatePair(pairFirst, codepoint)
+			if !ok {
+				return "", errors.New("invalid Unicode surrogate pair")
+			}
+			if err := emit(combined); err != nil {
+				return "", err
+			}
+			pairFirst = 0
+		case isUTF16SurrogateFirst(codepoint):
+			pairFirst = codepoint
+		case isUTF16SurrogateSecond(codepoint):
+			return "", errors.New("invalid Unicode surrogate pair")
+		default:
+			if err := emit(codepoint); err != nil {
+				return "", err
+			}
+		}
+		i += consumed
+	}
+
+	if pairFirst != 0 {
+		return "", errors.New("invalid Unicode surrogate pair")
 	}
 
 	return string(result), nil
@@ -337,19 +382,6 @@ func (l *Lexer) parseHexCodepoint(hex string) (rune, error) {
 		}
 	}
 	return codepoint, nil
-}
-
-// codepointToUTF8 converts a Unicode codepoint to UTF-8 bytes
-func (l *Lexer) codepointToUTF8(codepoint rune) []byte {
-	if codepoint < 0 || codepoint > 0x10FFFF {
-		// Invalid codepoint, return replacement character
-		return []byte{0xEF, 0xBF, 0xBD} // UTF-8 for U+FFFD
-	}
-
-	result := make([]byte, 4)
-	n := len(string(codepoint))
-	copy(result[:n], []byte(string(codepoint)))
-	return result[:n]
 }
 
 // truncateIdentifier truncates an identifier to PostgreSQL's maximum length

--- a/go/common/parser/lexer.go
+++ b/go/common/parser/lexer.go
@@ -1789,6 +1789,14 @@ func (l *Lexer) scanSpecialInteger(startPos, startScanPos int, digitChecker func
 		return NewStringToken(ICONST, text, startPos, text), nil
 	}
 
+	// Reject identifier-continuation chars immediately after the radix body.
+	// Upstream emits this via the {hexinteger}{identifier} junk pattern at
+	// scan.l:1066, so e.g. `0x0o` errors instead of tokenizing as `0x0` AS `o`.
+	if err := l.checkTrailingJunk(); err != nil {
+		text := l.context.GetCurrentText(startScanPos)
+		return NewStringToken(ICONST, text, startPos, text), nil //nolint:nilerr // Error is collected via context, not returned
+	}
+
 	text := l.context.GetCurrentText(startScanPos)
 	return l.processIntegerLiteral(text, startPos), nil
 }

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -255,6 +255,21 @@ func TestDollarQuotedStrings(t *testing.T) {
 			expected:  "content $aa$ more content",
 			tokenType: SCONST,
 		},
+		{
+			// Multi-byte UTF-8 characters (common in function bodies) must
+			// advance by their full rune length, not 1 byte.
+			name:      "Dollar-quoted string with multi-byte UTF-8 char",
+			input:     "$$\xe4\xb8\x96\xe7\x95\x8c$$",
+			expected:  "\xe4\xb8\x96\xe7\x95\x8c",
+			tokenType: SCONST,
+		},
+		{
+			// Invalid UTF-8 must be preserved verbatim, not re-encoded as U+FFFD.
+			name:      "Dollar-quoted string with invalid UTF-8 byte",
+			input:     "$$a\x80b$$",
+			expected:  "a\x80b",
+			tokenType: SCONST,
+		},
 	}
 
 	for _, tt := range tests {
@@ -514,6 +529,20 @@ func TestStringConcatenation(t *testing.T) {
 			name:      "Mixed string types with newline",
 			input:     "'hello'\nE'\\nworld'",
 			expected:  "hello\nworld",
+			tokenType: SCONST,
+		},
+		{
+			// Continuation path also needs DecodeRune-aware advancement so that
+			// multi-byte UTF-8 in the second part isn't truncated.
+			name:      "Continuation string with multi-byte UTF-8",
+			input:     "'hello'\n'\xe4\xb8\x96\xe7\x95\x8c'",
+			expected:  "hello\xe4\xb8\x96\xe7\x95\x8c",
+			tokenType: SCONST,
+		},
+		{
+			name:      "Continuation string with invalid UTF-8 byte",
+			input:     "'hello'\n'a\x80b'",
+			expected:  "helloa\x80b",
 			tokenType: SCONST,
 		},
 	}

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -365,6 +365,66 @@ func TestHexStrings(t *testing.T) {
 	}
 }
 
+// TestUnicodeStringEscapeValidation covers the U&'...' escape paths that
+// PostgreSQL rejects: surrogate pairing rules and codepoint range. Mirrors
+// the validation in postgres/src/backend/parser/parser.c:str_udeescape.
+func TestUnicodeStringEscapeValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		errMsg  string
+		wantErr bool
+	}{
+		// Valid surrogate pair encodes 😀 (U+1F600). No error.
+		{"valid surrogate pair", `U&'\D83D\DE00'`, "", false},
+		// Lone high surrogate with no following escape.
+		{"lone high surrogate", `U&'\D800'`, "invalid Unicode surrogate pair", true},
+		// High surrogate followed by non-low-surrogate escape.
+		{"high then non-surrogate", `U&'wrong: \+00DB99\+000061'`, "invalid Unicode surrogate pair", true},
+		// Lone low surrogate.
+		{"lone low surrogate", `U&'\DC00'`, "invalid Unicode surrogate pair", true},
+		// High surrogate followed by literal char (non-escape).
+		{"high then literal", `U&'\D800x'`, "invalid Unicode surrogate pair", true},
+		// Codepoint above U+10FFFF.
+		{"codepoint over max", `U&'\+110000'`, "invalid Unicode escape value", true},
+		// Codepoint at the boundary remains valid.
+		{"codepoint at max", `U&'\+10FFFF'`, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lexer := NewLexer(tc.input)
+			tok := lexer.NextToken()
+			require.NotNil(t, tok)
+
+			errs := lexer.GetContext().GetErrors()
+			if tc.wantErr {
+				require.NotEmpty(t, errs)
+				assert.Contains(t, errs[0].Message, tc.errMsg)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+// TestUnicodeStringUnsafeWithoutSCS verifies that U&'...' is rejected when
+// standard_conforming_strings is off, matching scan.l:578-583.
+func TestUnicodeStringUnsafeWithoutSCS(t *testing.T) {
+	opts := DefaultParseOptions()
+	opts.StandardConformingStrings = false
+
+	ctx := NewParseContext(`U&'\0061'`, opts)
+	lexer := &Lexer{context: ctx}
+
+	tok := lexer.NextToken()
+	require.NotNil(t, tok)
+
+	errs := ctx.GetErrors()
+	require.NotEmpty(t, errs)
+	assert.Equal(t, "unsafe use of string constant with Unicode escapes", errs[0].Message)
+}
+
 // TestStringConcatenation tests string concatenation across whitespace
 // NOTE: Updated to match PostgreSQL behavior - concatenation requires newline
 func TestStringConcatenation(t *testing.T) {

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -564,6 +564,14 @@ func TestStringConcatenation(t *testing.T) {
 			expected:  "a",
 			tokenType: SCONST,
 		},
+		{
+			// PG's newline pattern is `\n|\r|\r\n`, so a bare CR also
+			// satisfies the "saw a newline" requirement.
+			name:      "Continuation across bare CR",
+			input:     "'a'\r'b'",
+			expected:  "ab",
+			tokenType: SCONST,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -291,6 +291,15 @@ func TestBitStrings(t *testing.T) {
 			tokenType: BCONST,
 		},
 		{
+			// Multi-byte UTF-8 chars must advance by their full rune length;
+			// stripping only one byte would leave continuation bytes to be
+			// re-read as garbled replacement characters.
+			name:      "Bit string with multi-byte UTF-8 char preserved",
+			input:     "B'10\xe4\xb8\xad01'",
+			expected:  "b10\xe4\xb8\xad01",
+			tokenType: BCONST,
+		},
+		{
 			name:      "Case insensitive B prefix",
 			input:     "b'101010'",
 			expected:  "b101010",
@@ -337,6 +346,13 @@ func TestHexStrings(t *testing.T) {
 			name:      "Hex string with whitespace preserved verbatim",
 			input:     "X'dead beef'",
 			expected:  "xdead beef",
+			tokenType: XCONST,
+		},
+		{
+			// Multi-byte UTF-8 chars must advance by their full rune length.
+			name:      "Hex string with multi-byte UTF-8 char preserved",
+			input:     "X'de\xe4\xb8\xadad'",
+			expected:  "xde\xe4\xb8\xadad",
 			tokenType: XCONST,
 		},
 		{

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -282,9 +282,12 @@ func TestBitStrings(t *testing.T) {
 			tokenType: BCONST,
 		},
 		{
-			name:      "Bit string with whitespace",
+			// xbinside accepts any non-quote char verbatim; the backend
+			// `bit_in` routine validates digits and reports
+			// `" " is not a valid binary digit` at type-conversion time.
+			name:      "Bit string with whitespace preserved verbatim",
 			input:     "B'1010 1010'",
-			expected:  "b10101010", // Whitespace should be skipped
+			expected:  "b1010 1010",
 			tokenType: BCONST,
 		},
 		{
@@ -328,9 +331,12 @@ func TestHexStrings(t *testing.T) {
 			tokenType: XCONST,
 		},
 		{
-			name:      "Hex string with whitespace",
+			// xhinside accepts any non-quote char verbatim; the backend
+			// `varbit_in` routine validates digits and reports
+			// `" " is not a valid hexadecimal digit` at type-conversion time.
+			name:      "Hex string with whitespace preserved verbatim",
 			input:     "X'dead beef'",
-			expected:  "xdeadbeef", // Whitespace should be skipped
+			expected:  "xdead beef",
 			tokenType: XCONST,
 		},
 		{

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -300,6 +300,14 @@ func TestBitStrings(t *testing.T) {
 			tokenType: BCONST,
 		},
 		{
+			// Invalid UTF-8 (lone continuation byte) must advance by exactly
+			// one byte and be preserved verbatim, not re-encoded as U+FFFD.
+			name:      "Bit string with invalid UTF-8 byte preserved verbatim",
+			input:     "B'10\x8001'",
+			expected:  "b10\x8001",
+			tokenType: BCONST,
+		},
+		{
 			name:      "Case insensitive B prefix",
 			input:     "b'101010'",
 			expected:  "b101010",
@@ -353,6 +361,14 @@ func TestHexStrings(t *testing.T) {
 			name:      "Hex string with multi-byte UTF-8 char preserved",
 			input:     "X'de\xe4\xb8\xadad'",
 			expected:  "xde\xe4\xb8\xadad",
+			tokenType: XCONST,
+		},
+		{
+			// Invalid UTF-8 (lone continuation byte) must advance by one byte
+			// and be preserved verbatim, not re-encoded as U+FFFD.
+			name:      "Hex string with invalid UTF-8 byte preserved verbatim",
+			input:     "X'de\x80ad'",
+			expected:  "xde\x80ad",
 			tokenType: XCONST,
 		},
 		{

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -90,6 +90,14 @@ func TestStandardStrings(t *testing.T) {
 			tokenType:   SCONST, // PostgreSQL converts USCONST→SCONST, but regular strings generate SCONST directly
 			shouldError: false,  // Returns SCONST token, doesn't error
 		},
+		{
+			// Invalid UTF-8 (lone continuation byte) must advance one byte and
+			// be preserved verbatim rather than re-encoded as U+FFFD.
+			name:      "String with invalid UTF-8 byte preserved verbatim",
+			input:     "'a\x80b'",
+			expected:  "a\x80b",
+			tokenType: SCONST,
+		},
 	}
 
 	for _, tt := range tests {

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -555,12 +555,13 @@ func TestStringConcatenation(t *testing.T) {
 			tokenType: SCONST,
 		},
 		{
-			// Multi-byte Unicode whitespace (U+00A0 NBSP) between continuation
-			// parts must be advanced by its full rune length. A bare \n must
-			// also still be present, otherwise concatenation is disallowed.
-			name:      "Continuation across NBSP plus newline",
+			// PostgreSQL only treats `[ \t\n\r\f]` as whitespace between
+			// continuation parts (scan.l), so a non-ASCII space like NBSP
+			// breaks the lookahead before the newline is even seen and the
+			// scanner returns just the first part.
+			name:      "Continuation does not honor NBSP as whitespace",
 			input:     "'a'\xc2\xa0\n'b'",
-			expected:  "ab",
+			expected:  "a",
 			tokenType: SCONST,
 		},
 	}

--- a/go/common/parser/lexer_strings_test.go
+++ b/go/common/parser/lexer_strings_test.go
@@ -270,6 +270,15 @@ func TestDollarQuotedStrings(t *testing.T) {
 			expected:  "a\x80b",
 			tokenType: SCONST,
 		},
+		{
+			// Multi-byte tag chars (e.g. À = U+00C0 = 0xC3 0x80) must be
+			// preserved byte-wise so that the closing delimiter compares equal
+			// to the opening one.
+			name:      "Dollar-quoted string with multi-byte tag",
+			input:     "$\xc3\x80$body$\xc3\x80$",
+			expected:  "body",
+			tokenType: SCONST,
+		},
 	}
 
 	for _, tt := range tests {
@@ -543,6 +552,15 @@ func TestStringConcatenation(t *testing.T) {
 			name:      "Continuation string with invalid UTF-8 byte",
 			input:     "'hello'\n'a\x80b'",
 			expected:  "helloa\x80b",
+			tokenType: SCONST,
+		},
+		{
+			// Multi-byte Unicode whitespace (U+00A0 NBSP) between continuation
+			// parts must be advanced by its full rune length. A bare \n must
+			// also still be present, otherwise concatenation is disallowed.
+			name:      "Continuation across NBSP plus newline",
+			input:     "'a'\xc2\xa0\n'b'",
+			expected:  "ab",
 			tokenType: SCONST,
 		},
 	}

--- a/go/common/parser/numeric_test.go
+++ b/go/common/parser/numeric_test.go
@@ -328,6 +328,17 @@ func TestNumericJunkPatterns(t *testing.T) {
 		// real_junk: {real}{identifier}
 		{"scientific followed by letter", "1E10abc", "trailing junk after numeric literal", FCONST, "1E10abc", "real_junk"},
 		{"float exp followed by ident", "3.14E10xyz", "trailing junk after numeric literal", FCONST, "3.14E10xyz", "real_junk"},
+
+		// hex_junk / oct_junk / bin_junk: {hexinteger}{identifier} etc.
+		// postgres/src/backend/parser/scan.l:1066-1076. Identifier-continuation
+		// chars (letter, underscore) trigger the junk error; digit-suffixes that
+		// aren't valid in the radix split into two tokens (handled by the
+		// invalid-digit cases in TestNumericEdgeCases).
+		{"hex invalid letter digit", "0x123g456", "trailing junk after numeric literal", ICONST, "0x123g456", "hex_junk"},
+		{"hex letter alias", "0x0o", "trailing junk after numeric literal", ICONST, "0x0o", "hex_junk"},
+		{"hex y alias", "0x0y", "trailing junk after numeric literal", ICONST, "0x0y", "hex_junk"},
+		{"octal letter alias", "0o0x", "trailing junk after numeric literal", ICONST, "0o0x", "oct_junk"},
+		{"binary letter alias", "0b0x", "trailing junk after numeric literal", ICONST, "0b0x", "bin_junk"},
 	}
 
 	for _, tt := range tests {
@@ -398,14 +409,9 @@ func TestNumericEdgeCases(t *testing.T) {
 			"double underscore parsed as single token with junk error",
 		},
 
-		// Mixed numeric formats
-		{
-			"hex invalid digit",
-			"0x123g456",
-			[]TokenType{ICONST, IDENT},
-			[]string{"0x123", "g456"},
-			"invalid hex digit breaks token",
-		},
+		// Mixed-radix invalid-digit cases that split into two tokens (digit
+		// suffix that isn't valid in the radix). Letter/underscore suffixes
+		// trigger the junk error and are covered in TestNumericJunkPatterns.
 		{
 			"octal invalid digit",
 			"0o1238",

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -320,31 +320,31 @@ func (l *Lexer) parseDollarDelimiter() (string, error) {
 	return delimiter.String(), nil
 }
 
-// isDollarQuoteStartChar checks if character can start a dollar-quote tag
-// Equivalent to dolq_start pattern - postgres/src/backend/parser/scan.l:290
+// isDollarQuoteStartChar checks if character can start a dollar-quote tag.
+// Equivalent to the dolq_start pattern in postgres/src/backend/parser/scan.l:290:
+// `[A-Za-z\200-\377_]`. PG's `\377` is the OCTAL escape for byte 0xFF, so the
+// high range covers single-byte high-ASCII (0x80..0xFF) — not Unicode
+// codepoints up to U+0377.
 func (l *Lexer) isDollarQuoteStartChar(ch rune) bool {
-	return unicode.IsLetter(ch) || ch == '_' || (ch >= 0x80 && ch <= 0x377)
+	return unicode.IsLetter(ch) || ch == '_' || (ch >= 0x80 && ch <= 0xFF)
 }
 
-// isDollarQuoteCont checks if character can continue a dollar-quote tag
-// Equivalent to dolq_cont pattern - postgres/src/backend/parser/scan.l:291
+// isDollarQuoteCont checks if character can continue a dollar-quote tag.
+// Equivalent to the dolq_cont pattern in postgres/src/backend/parser/scan.l:291.
+// See the note in isDollarQuoteStartChar about the 0xFF upper bound.
 func (l *Lexer) isDollarQuoteCont(ch rune) bool {
-	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || (ch >= 0x80 && ch <= 0x377)
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || (ch >= 0x80 && ch <= 0xFF)
 }
 
 // matchesDollarDelimiter reports whether the bytes at the current scan
 // position are exactly equal to expectedDelimiter. Comparison is byte-wise:
 // `range` over a Go string yields decoded runes which would mismatch the raw
 // byte slice for multi-byte tag chars, so use a direct byte comparison.
+//
+// Hot path inside scanDollarQuotedString — every `$` triggers a call. Use the
+// zero-alloc HasPrefixAtScanPos helper to avoid copying the whole buffer.
 func (l *Lexer) matchesDollarDelimiter(expectedDelimiter string) bool {
-	ctx := l.context
-
-	pos := ctx.ScanPos()
-	buf := ctx.ScanBuf()
-	if len(buf)-pos < len(expectedDelimiter) {
-		return false
-	}
-	return string(buf[pos:pos+len(expectedDelimiter)]) == expectedDelimiter
+	return l.context.HasPrefixAtScanPos([]byte(expectedDelimiter))
 }
 
 // scanEscapeSequence processes backslash escape sequences in extended strings
@@ -558,29 +558,30 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 		// Skip whitespace to look for continuation
 		// SQL requires at least one newline in the whitespace for string concatenation
 		savedPos := ctx.ScanPos()
+		savedTrackedPos, savedLine, savedCol := ctx.GetCurrentPosition()
+		restoreLookahead := func() {
+			ctx.SetScanPos(savedPos)
+			ctx.SetCurrentPosition(savedTrackedPos, savedLine, savedCol)
+		}
 		hasNewline := false
 
-		// Skip whitespace and check for newline. Multi-byte spaces (NBSP,
-		// en-quad, etc.) decode as a single rune but span several bytes, so
-		// advance by the size DecodeRune actually consumed instead of always
-		// stepping one byte.
+		// Skip whitespace and check for newline. Match PostgreSQL's whitespace
+		// definition (`[ \t\n\r\f]`, scan.l space rule) — explicitly ASCII so
+		// multi-byte Unicode spaces like NBSP do not gate continuation.
 		for !ctx.AtEOF() {
-			ch, size := ctx.CurrentRune()
-			if !unicode.IsSpace(ch) {
+			ch, _ := ctx.CurrentRune()
+			if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' && ch != '\f' {
 				break
 			}
 			if ch == '\n' {
 				hasNewline = true
 			}
-			if size <= 0 {
-				size = 1
-			}
-			ctx.AdvanceBy(size)
+			ctx.AdvanceBy(1)
 		}
 
 		// If no newline was found, string concatenation is not allowed
 		if !hasNewline {
-			ctx.SetScanPos(savedPos)
+			restoreLookahead()
 			ctx.SetState(StateInitial)
 
 			// Set final literal and return
@@ -606,7 +607,7 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 				ctx.AdvanceBy(1) // Skip '
 			} else {
 				// No continuation found
-				ctx.SetScanPos(savedPos)
+				restoreLookahead()
 				ctx.SetState(StateInitial)
 
 				// Set final literal and return
@@ -676,7 +677,7 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 		}
 
 		// No continuation found - restore position and return final token
-		ctx.SetScanPos(savedPos)
+		restoreLookahead()
 		ctx.SetState(StateInitial)
 
 		// Set final literal and return

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -283,15 +283,29 @@ func (l *Lexer) parseDollarDelimiter() (string, error) {
 	// Parse optional tag - postgres/src/backend/parser/scan.l:290-303
 	// dolq_start: [A-Za-z\200-\377_]
 	// dolq_cont: [A-Za-z\200-\377_0-9]
-	if !ctx.AtEOF() && l.isDollarQuoteStartChar(ctx.CurrentChar()) {
-		// Tag starts with valid character
-		delimiter.WriteRune(ctx.CurrentChar())
-		ctx.AdvanceBy(1)
+	// Append raw bytes (size from DecodeRune) so multi-byte tag chars are
+	// preserved verbatim and the scan position advances by the full rune
+	// length. matchesDollarDelimiter compares bytes against the same buffer,
+	// so the stored delimiter must hold raw bytes too.
+	if !ctx.AtEOF() {
+		if ch, size := ctx.CurrentRune(); l.isDollarQuoteStartChar(ch) {
+			if size <= 0 {
+				size = 1
+			}
+			delimiter.Write(ctx.PeekBytes(size))
+			ctx.AdvanceBy(size)
 
-		// Continue with valid tag characters
-		for !ctx.AtEOF() && l.isDollarQuoteCont(ctx.CurrentChar()) {
-			delimiter.WriteRune(ctx.CurrentChar())
-			ctx.AdvanceBy(1)
+			for !ctx.AtEOF() {
+				ch, size := ctx.CurrentRune()
+				if !l.isDollarQuoteCont(ch) {
+					break
+				}
+				if size <= 0 {
+					size = 1
+				}
+				delimiter.Write(ctx.PeekBytes(size))
+				ctx.AdvanceBy(size)
+			}
 		}
 	}
 
@@ -318,27 +332,19 @@ func (l *Lexer) isDollarQuoteCont(ch rune) bool {
 	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || (ch >= 0x80 && ch <= 0x377)
 }
 
-// matchesDollarDelimiter checks if current position has matching dollar delimiter
+// matchesDollarDelimiter reports whether the bytes at the current scan
+// position are exactly equal to expectedDelimiter. Comparison is byte-wise:
+// `range` over a Go string yields decoded runes which would mismatch the raw
+// byte slice for multi-byte tag chars, so use a direct byte comparison.
 func (l *Lexer) matchesDollarDelimiter(expectedDelimiter string) bool {
 	ctx := l.context
 
-	// Check if we have enough characters remaining
-	remaining := len(ctx.ScanBuf()) - ctx.ScanPos()
-	if remaining < len(expectedDelimiter) {
+	pos := ctx.ScanPos()
+	buf := ctx.ScanBuf()
+	if len(buf)-pos < len(expectedDelimiter) {
 		return false
 	}
-
-	// Check character by character
-	for i, expectedChar := range expectedDelimiter {
-		if ctx.ScanPos()+i >= len(ctx.ScanBuf()) {
-			return false
-		}
-		if rune(ctx.ScanBuf()[ctx.ScanPos()+i]) != expectedChar {
-			return false
-		}
-	}
-
-	return true
+	return string(buf[pos:pos+len(expectedDelimiter)]) == expectedDelimiter
 }
 
 // scanEscapeSequence processes backslash escape sequences in extended strings
@@ -554,12 +560,22 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 		savedPos := ctx.ScanPos()
 		hasNewline := false
 
-		// Skip whitespace and check for newline
-		for !ctx.AtEOF() && unicode.IsSpace(ctx.CurrentChar()) {
-			if ctx.CurrentChar() == '\n' {
+		// Skip whitespace and check for newline. Multi-byte spaces (NBSP,
+		// en-quad, etc.) decode as a single rune but span several bytes, so
+		// advance by the size DecodeRune actually consumed instead of always
+		// stepping one byte.
+		for !ctx.AtEOF() {
+			ch, size := ctx.CurrentRune()
+			if !unicode.IsSpace(ch) {
+				break
+			}
+			if ch == '\n' {
 				hasNewline = true
 			}
-			ctx.AdvanceBy(1)
+			if size <= 0 {
+				size = 1
+			}
+			ctx.AdvanceBy(size)
 		}
 
 		// If no newline was found, string concatenation is not allowed

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -103,16 +103,15 @@ func (l *Lexer) scanStandardStringWithType(startPos, startScanPos int, isUnicode
 				return nil, err
 			}
 		} else {
-			// Regular character - use proper UTF-8 handling
-			ctx.AddLiteral(string(ch))
-			// Calculate the byte size of this rune to advance correctly
-			runeSize := utf8.RuneLen(ch)
-			if runeSize > 0 {
-				ctx.AdvanceBy(runeSize)
-			} else {
-				// Invalid rune, advance by 1 byte
-				ctx.AdvanceBy(1)
+			// Regular character: copy the raw bytes that DecodeRune actually
+			// consumed so invalid UTF-8 (which decodes as RuneError + size 1)
+			// is preserved verbatim instead of being re-encoded as U+FFFD.
+			_, size := ctx.CurrentRune()
+			if size <= 0 {
+				size = 1
 			}
+			ctx.AddLiteral(string(ctx.PeekBytes(size)))
+			ctx.AdvanceBy(size)
 		}
 	}
 
@@ -170,16 +169,15 @@ func (l *Lexer) scanExtendedString(startPos, startScanPos int) (*Token, error) {
 				return nil, err
 			}
 		} else {
-			// Regular character - use proper UTF-8 handling
-			ctx.AddLiteral(string(ch))
-			// Calculate the byte size of this rune to advance correctly
-			runeSize := utf8.RuneLen(ch)
-			if runeSize > 0 {
-				ctx.AdvanceBy(runeSize)
-			} else {
-				// Invalid rune, advance by 1 byte
-				ctx.AdvanceBy(1)
+			// Regular character: copy the raw bytes that DecodeRune actually
+			// consumed so invalid UTF-8 is preserved verbatim instead of being
+			// re-encoded as U+FFFD.
+			_, size := ctx.CurrentRune()
+			if size <= 0 {
+				size = 1
 			}
+			ctx.AddLiteral(string(ctx.PeekBytes(size)))
+			ctx.AdvanceBy(size)
 		}
 	}
 

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -242,9 +242,16 @@ func (l *Lexer) scanDollarQuotedString(startPos, startScanPos int) (*Token, erro
 				ctx.AdvanceBy(1)
 			}
 		} else {
-			// Literal character - no escape processing in dollar-quoted strings
-			ctx.AddLiteral(string(ch))
-			ctx.AdvanceBy(1)
+			// Literal character - no escape processing in dollar-quoted strings.
+			// Copy the raw bytes that DecodeRune actually consumed so multi-byte
+			// UTF-8 (common in function bodies) advances correctly and invalid
+			// sequences are preserved verbatim.
+			_, size := ctx.CurrentRune()
+			if size <= 0 {
+				size = 1
+			}
+			ctx.AddLiteral(string(ctx.PeekBytes(size)))
+			ctx.AdvanceBy(size)
 		}
 	}
 
@@ -627,9 +634,15 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 						return nil, err
 					}
 				} else {
-					// Regular character
-					ctx.AddLiteral(string(ch))
-					ctx.AdvanceBy(1)
+					// Regular character: copy raw bytes that DecodeRune actually
+					// consumed so multi-byte UTF-8 advances by its full width
+					// and invalid sequences are preserved verbatim.
+					_, size := ctx.CurrentRune()
+					if size <= 0 {
+						size = 1
+					}
+					ctx.AddLiteral(string(ctx.PeekBytes(size)))
+					ctx.AdvanceBy(size)
 				}
 			}
 

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -55,9 +55,16 @@ func (l *Lexer) scanStandardString(startPos, startScanPos int) (*Token, error) {
 	return l.scanStandardStringWithType(startPos, startScanPos, false)
 }
 
-// scanUnicodeString processes a Unicode string literal (U&'...')
-// Equivalent to PostgreSQL xus state handling
+// scanUnicodeString processes a Unicode string literal (U&'...').
+// Equivalent to PostgreSQL xus state handling. When standard_conforming_strings
+// is off, upstream rejects the literal entirely with
+// `unsafe use of string constant with Unicode escapes`
+// (postgres/src/backend/parser/scan.l:578-583); record that error and continue
+// scanning so the parse tree still resolves.
 func (l *Lexer) scanUnicodeString(startPos, startScanPos int) (*Token, error) {
+	if !l.context.StandardConformingStrings() {
+		_ = l.context.AddErrorWithType(InvalidUnicodeEscape, "unsafe use of string constant with Unicode escapes")
+	}
 	return l.scanStandardStringWithType(startPos, startScanPos, true)
 }
 

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -669,27 +669,23 @@ func (l *Lexer) scanBitString(startPos, startScanPos int) (*Token, error) {
 	ctx.AdvanceBy(1) // Skip B
 	ctx.AdvanceBy(1) // Skip '
 
+	// xbinside is `[^']*` (scan.l:265) — accept every byte verbatim until the
+	// closing quote. The upstream comment at scan.l:255-263 explicitly chose
+	// not to validate digits here because that swallows characters silently;
+	// instead the input routine (`bit_in`) validates and emits e.g.
+	// `" " is not a valid binary digit`. Preserving the literal lets the
+	// downstream backend produce the canonical error.
 	foundClosingQuote := false
 	for !ctx.AtEOF() {
 		ch := ctx.CurrentChar()
 
 		if ch == '\'' {
-			// End of bit string
 			ctx.AdvanceBy(1)
 			foundClosingQuote = true
 			break
-		} else if ch == '0' || ch == '1' {
-			// Valid bit character
-			ctx.AddLiteral(string(ch))
-			ctx.AdvanceBy(1)
-		} else if unicode.IsSpace(ch) {
-			// Skip whitespace within bit strings
-			ctx.AdvanceBy(1)
-		} else {
-			// Invalid character in bit string
-			_ = ctx.AddErrorWithType(SyntaxError, fmt.Sprintf("invalid bit string character: %c", ch))
-			ctx.AdvanceBy(1)
 		}
+		ctx.AddLiteral(string(ch))
+		ctx.AdvanceBy(1)
 	}
 
 	if !foundClosingQuote {
@@ -719,27 +715,21 @@ func (l *Lexer) scanHexString(startPos, startScanPos int) (*Token, error) {
 	ctx.AdvanceBy(1) // Skip X
 	ctx.AdvanceBy(1) // Skip '
 
+	// xhinside is `[^']*` (scan.l:269) — accept every byte verbatim until the
+	// closing quote. Upstream defers digit validation to the input routine for
+	// the same reason as xbinside (see comment in scanBitString); this lets
+	// `varbit_in` emit `" " is not a valid hexadecimal digit` etc.
 	foundClosingQuote := false
 	for !ctx.AtEOF() {
 		ch := ctx.CurrentChar()
 
 		if ch == '\'' {
-			// End of hex string
 			ctx.AdvanceBy(1)
 			foundClosingQuote = true
 			break
-		} else if (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f') {
-			// Valid hex character
-			ctx.AddLiteral(string(ch))
-			ctx.AdvanceBy(1)
-		} else if unicode.IsSpace(ch) {
-			// Skip whitespace within hex strings
-			ctx.AdvanceBy(1)
-		} else {
-			// Invalid character in hex string
-			_ = ctx.AddErrorWithType(SyntaxError, fmt.Sprintf("invalid hexadecimal string character: %c", ch))
-			ctx.AdvanceBy(1)
 		}
+		ctx.AddLiteral(string(ch))
+		ctx.AdvanceBy(1)
 	}
 
 	if !foundClosingQuote {

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -692,7 +692,12 @@ func (l *Lexer) scanBitString(startPos, startScanPos int) (*Token, error) {
 			break
 		}
 		ctx.AddLiteral(string(ch))
-		ctx.AdvanceBy(1)
+		runeSize := utf8.RuneLen(ch)
+		if runeSize > 0 {
+			ctx.AdvanceBy(runeSize)
+		} else {
+			ctx.AdvanceBy(1)
+		}
 	}
 
 	if !foundClosingQuote {
@@ -736,7 +741,12 @@ func (l *Lexer) scanHexString(startPos, startScanPos int) (*Token, error) {
 			break
 		}
 		ctx.AddLiteral(string(ch))
-		ctx.AdvanceBy(1)
+		runeSize := utf8.RuneLen(ch)
+		if runeSize > 0 {
+			ctx.AdvanceBy(runeSize)
+		} else {
+			ctx.AdvanceBy(1)
+		}
 	}
 
 	if !foundClosingQuote {

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -397,8 +397,17 @@ func (l *Lexer) scanEscapeSequence() error {
 		return l.scanUnicodeEscape(8)
 	default:
 		if ch >= '0' && ch <= '7' {
-			// Octal escape \nnn - postgres/src/backend/parser/scan.l:278
-			ctx.SetScanPos(ctx.ScanPos() - 1) // Back up to reprocess first octal digit
+			// Octal escape \nnn - postgres/src/backend/parser/scan.l:278.
+			// Rewind both scanPos and the tracked currentPosition/column so
+			// scanOctalEscape sees the first digit at the right offset and
+			// downstream error positions stay accurate. The digit is ASCII,
+			// so a single-byte / single-column rewind is sufficient.
+			ctx.SetScanPos(ctx.ScanPos() - 1)
+			pos, line, col := ctx.GetCurrentPosition()
+			if col > 1 {
+				col--
+			}
+			ctx.SetCurrentPosition(pos-1, line, col)
 			return l.scanOctalEscape()
 		} else {
 			// Literal character after backslash

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -684,20 +684,20 @@ func (l *Lexer) scanBitString(startPos, startScanPos int) (*Token, error) {
 	// downstream backend produce the canonical error.
 	foundClosingQuote := false
 	for !ctx.AtEOF() {
-		ch := ctx.CurrentChar()
+		ch, size := ctx.CurrentRune()
 
 		if ch == '\'' {
 			ctx.AdvanceBy(1)
 			foundClosingQuote = true
 			break
 		}
-		ctx.AddLiteral(string(ch))
-		runeSize := utf8.RuneLen(ch)
-		if runeSize > 0 {
-			ctx.AdvanceBy(runeSize)
-		} else {
-			ctx.AdvanceBy(1)
+		if size <= 0 {
+			size = 1
 		}
+		// Append raw bytes so invalid UTF-8 is preserved verbatim instead of
+		// being re-encoded as U+FFFD (which expands to 3 bytes).
+		ctx.AddLiteral(string(ctx.PeekBytes(size)))
+		ctx.AdvanceBy(size)
 	}
 
 	if !foundClosingQuote {
@@ -733,20 +733,20 @@ func (l *Lexer) scanHexString(startPos, startScanPos int) (*Token, error) {
 	// `varbit_in` emit `" " is not a valid hexadecimal digit` etc.
 	foundClosingQuote := false
 	for !ctx.AtEOF() {
-		ch := ctx.CurrentChar()
+		ch, size := ctx.CurrentRune()
 
 		if ch == '\'' {
 			ctx.AdvanceBy(1)
 			foundClosingQuote = true
 			break
 		}
-		ctx.AddLiteral(string(ch))
-		runeSize := utf8.RuneLen(ch)
-		if runeSize > 0 {
-			ctx.AdvanceBy(runeSize)
-		} else {
-			ctx.AdvanceBy(1)
+		if size <= 0 {
+			size = 1
 		}
+		// Append raw bytes so invalid UTF-8 is preserved verbatim instead of
+		// being re-encoded as U+FFFD.
+		ctx.AddLiteral(string(ctx.PeekBytes(size)))
+		ctx.AdvanceBy(size)
 	}
 
 	if !foundClosingQuote {

--- a/go/common/parser/strings.go
+++ b/go/common/parser/strings.go
@@ -344,7 +344,7 @@ func (l *Lexer) isDollarQuoteCont(ch rune) bool {
 // Hot path inside scanDollarQuotedString — every `$` triggers a call. Use the
 // zero-alloc HasPrefixAtScanPos helper to avoid copying the whole buffer.
 func (l *Lexer) matchesDollarDelimiter(expectedDelimiter string) bool {
-	return l.context.HasPrefixAtScanPos([]byte(expectedDelimiter))
+	return l.context.HasPrefixAtScanPos(expectedDelimiter)
 }
 
 // scanEscapeSequence processes backslash escape sequences in extended strings
@@ -577,12 +577,14 @@ func (l *Lexer) checkStringContinuation(tokenType TokenType, startPos, startScan
 		// Skip whitespace and check for newline. Match PostgreSQL's whitespace
 		// definition (`[ \t\n\r\f]`, scan.l space rule) — explicitly ASCII so
 		// multi-byte Unicode spaces like NBSP do not gate continuation.
+		// PG's `newline` token is `\n|\r|\r\n`, so a bare CR also satisfies
+		// the "saw a newline" requirement for continuation.
 		for !ctx.AtEOF() {
 			ch, _ := ctx.CurrentRune()
 			if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' && ch != '\f' {
 				break
 			}
-			if ch == '\n' {
+			if ch == '\n' || ch == '\r' {
 				hasNewline = true
 			}
 			ctx.AdvanceBy(1)

--- a/go/common/parser/testdata/postgres/bit.json
+++ b/go/common/parser/testdata/postgres/bit.json
@@ -72,22 +72,22 @@
   {
     "comment": "bit - Statement 15",
     "query": "SELECT b' 0'",
-    "expected": "SELECT B'0'"
+    "expected": "SELECT B' 0'"
   },
   {
     "comment": "bit - Statement 16",
     "query": "SELECT b'0 '",
-    "expected": "SELECT B'0'"
+    "expected": "SELECT B'0 '"
   },
   {
     "comment": "bit - Statement 17",
     "query": "SELECT x' 0'",
-    "expected": "SELECT X'0'"
+    "expected": "SELECT X' 0'"
   },
   {
     "comment": "bit - Statement 18",
     "query": "SELECT x'0 '",
-    "expected": "SELECT X'0'"
+    "expected": "SELECT X'0 '"
   },
   {
     "comment": "bit - Statement 19",

--- a/go/common/parser/testdata/postgres/collate.icu.utf8.json
+++ b/go/common/parser/testdata/postgres/collate.icu.utf8.json
@@ -492,7 +492,7 @@
   {
     "comment": "collate.icu.utf8 - Statement 115",
     "query": "SELECT CAST('42' AS text COLLATE \"C\")",
-    "error": "parse error at position 33: syntax error"
+    "error": "parse error at position 32: syntax error"
   },
   {
     "comment": "collate.icu.utf8 - Statement 116",

--- a/go/common/parser/testdata/postgres/collate.json
+++ b/go/common/parser/testdata/postgres/collate.json
@@ -343,7 +343,7 @@
   {
     "comment": "collate - Statement 78",
     "query": "SELECT CAST('42' AS text COLLATE \"C\")",
-    "error": "parse error at position 33: syntax error"
+    "error": "parse error at position 32: syntax error"
   },
   {
     "comment": "collate - Statement 79",

--- a/go/common/parser/testdata/postgres/collate.linux.utf8.json
+++ b/go/common/parser/testdata/postgres/collate.linux.utf8.json
@@ -515,7 +515,7 @@
   {
     "comment": "collate.linux.utf8 - Statement 119",
     "query": "SELECT CAST('42' AS text COLLATE \"C\")",
-    "error": "parse error at position 33: syntax error"
+    "error": "parse error at position 32: syntax error"
   },
   {
     "comment": "collate.linux.utf8 - Statement 120",

--- a/go/common/parser/testdata/postgres/collate.windows.win1252.json
+++ b/go/common/parser/testdata/postgres/collate.windows.win1252.json
@@ -391,7 +391,7 @@
   {
     "comment": "collate.windows.win1252 - Statement 91",
     "query": "SELECT CAST('42' AS text COLLATE \"C\")",
-    "error": "parse error at position 33: syntax error"
+    "error": "parse error at position 32: syntax error"
   },
   {
     "comment": "collate.windows.win1252 - Statement 92",

--- a/go/common/parser/testdata/postgres/numerology.json
+++ b/go/common/parser/testdata/postgres/numerology.json
@@ -121,7 +121,7 @@
   {
     "comment": "numerology - Statement 29",
     "query": "SELECT 0x0o",
-    "expected": "SELECT 0 AS o"
+    "error": "trailing junk after numeric literal"
   },
   {
     "comment": "numerology - Statement 30",
@@ -171,7 +171,7 @@
   {
     "comment": "numerology - Statement 39",
     "query": "SELECT 0b0x",
-    "expected": "SELECT 0 AS x"
+    "error": "trailing junk after numeric literal"
   },
   {
     "comment": "numerology - Statement 40",
@@ -186,7 +186,7 @@
   {
     "comment": "numerology - Statement 42",
     "query": "SELECT 0o0x",
-    "expected": "SELECT 0 AS x"
+    "error": "trailing junk after numeric literal"
   },
   {
     "comment": "numerology - Statement 43",
@@ -201,7 +201,7 @@
   {
     "comment": "numerology - Statement 45",
     "query": "SELECT 0x0y",
-    "expected": "SELECT 0 AS y"
+    "error": "trailing junk after numeric literal"
   },
   {
     "comment": "numerology - Statement 46",

--- a/go/common/parser/testdata/postgres/psql.json
+++ b/go/common/parser/testdata/postgres/psql.json
@@ -498,17 +498,17 @@
   {
     "comment": "psql - Statement 107",
     "query": "SELECT 1 AS a '/tmp/output.txt' COPY reload_output(line) FROM :'g_out_file'",
-    "error": "parse error at position 32: syntax error"
+    "error": "parse error at position 31: syntax error"
   },
   {
     "comment": "psql - Statement 108",
     "query": "SELECT 2 AS b; SELECT 3 AS c; SELECT 4 AS d '/tmp/output.txt' COPY reload_output(line) FROM :'g_out_file'",
-    "error": "parse error at position 62: syntax error"
+    "error": "parse error at position 61: syntax error"
   },
   {
     "comment": "psql - Statement 109",
     "query": "COPY (SELECT 'foo') TO STDOUT ; COPY (SELECT 'bar') TO STDOUT '/tmp/output.txt' COPY reload_output(line) FROM :'g_out_file'",
-    "error": "parse error at position 80: syntax error"
+    "error": "parse error at position 79: syntax error"
   },
   {
     "comment": "psql - Statement 110",
@@ -536,7 +536,7 @@
   {
     "comment": "psql - Statement 115",
     "query": "COPY (SELECT 'foo2') TO STDOUT ; COPY (SELECT 'bar2') TO STDOUT '/tmp/output.txt' \\o COPY reload_output(line) FROM :'g_out_file'",
-    "error": "parse error at position 82: syntax error"
+    "error": "parse error at position 81: syntax error"
   },
   {
     "comment": "psql - Statement 116",

--- a/go/common/parser/testdata/postgres/sqljson_jsontable.json
+++ b/go/common/parser/testdata/postgres/sqljson_jsontable.json
@@ -32,7 +32,7 @@
   {
     "comment": "sqljson_jsontable - Statement 7",
     "query": "SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ())",
-    "error": "parse error at position 46: syntax error"
+    "error": "parse error at position 45: syntax error"
   },
   {
     "comment": "sqljson_jsontable - Statement 8",
@@ -503,7 +503,7 @@
   {
     "comment": "sqljson_jsontable - Statement 103",
     "query": "SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int exists empty object on empty))",
-    "error": "parse error at position 84: syntax error"
+    "error": "parse error at position 83: syntax error"
   },
   {
     "comment": "sqljson_jsontable - Statement 104",

--- a/go/common/parser/testdata/postgres/strings.json
+++ b/go/common/parser/testdata/postgres/strings.json
@@ -7,7 +7,7 @@
   {
     "comment": "strings - Statement 2",
     "query": "SELECT 'first line' ' - next line' /* this comment is not allowed here */ ' - third line' AS \"Illegal comment within continuation\"",
-    "error": "parse error at position 36: syntax error"
+    "error": "parse error at position 34: syntax error"
   },
   {
     "comment": "strings - Statement 3",

--- a/go/common/parser/testdata/postgres/strings.json
+++ b/go/common/parser/testdata/postgres/strings.json
@@ -62,32 +62,32 @@
   {
     "comment": "strings - Statement 13",
     "query": "SELECT U\u0026'wrong: \\db99'",
-    "expected": "SELECT 'wrong: �'"
+    "error": "invalid Unicode surrogate pair"
   },
   {
     "comment": "strings - Statement 14",
     "query": "SELECT U\u0026'wrong: \\db99xy'",
-    "expected": "SELECT 'wrong: �xy'"
+    "error": "invalid Unicode surrogate pair"
   },
   {
     "comment": "strings - Statement 15",
     "query": "SELECT U\u0026'wrong: \\db99\\\\'",
-    "expected": "SELECT 'wrong: �\\'"
+    "error": "invalid Unicode surrogate pair"
   },
   {
     "comment": "strings - Statement 16",
     "query": "SELECT U\u0026'wrong: \\db99\\0061'",
-    "expected": "SELECT 'wrong: �a'"
+    "error": "invalid Unicode surrogate pair"
   },
   {
     "comment": "strings - Statement 17",
     "query": "SELECT U\u0026'wrong: \\+00db99\\+000061'",
-    "expected": "SELECT 'wrong: �a'"
+    "error": "invalid Unicode surrogate pair"
   },
   {
     "comment": "strings - Statement 18",
     "query": "SELECT U\u0026'wrong: \\+2FFFFF'",
-    "expected": "SELECT 'wrong: �'"
+    "error": "invalid Unicode escape value"
   },
   {
     "comment": "strings - Statement 19",


### PR DESCRIPTION
## Summary

- Reject trailing identifier-continuation chars after radix integers so `0x0o` errors instead of tokenizing as `0x0` AS `o`.
- Preserve bit/hex literal contents verbatim (xbinside/xhinside semantics) so the backend `bit_in`/`varbit_in` routine can emit `" " is not a valid binary digit` etc.
- Validate `U&'...'` Unicode escapes against `parser.c:str_udeescape` rules: surrogate pairing, codepoint range, and the `standard_conforming_strings = off` guard.

## Problem

Three lexer paths silently accepted input that upstream PostgreSQL rejects, surfacing in pgregress as class-B acceptance bugs (numerology 4, bit 4, strings 15). Examples: `0x0o` parsed as a hex literal aliased `o`; `b' 0'` had its whitespace stripped before reaching PG; `U&'\D800'` produced replacement chars instead of an `invalid Unicode surrogate pair` error.

## Solution

- `scanSpecialInteger` now calls `checkTrailingJunk` after consuming the radix body, mirroring the `{hexinteger}{identifier}` junk pattern at `scan.l:1066`.
- `scanBitString` / `scanHexString` accept any non-quote byte verbatim, matching `scan.l:255-269` and the upstream comment that defers digit validation to the input routine.
- `decodeUnicodeString` is rewritten as a state machine: tracks a pending high surrogate, requires a valid low surrogate via `validateSurrogatePair`, rejects lone or dangling surrogates, and rejects codepoints above U+10FFFF instead of substituting U+FFFD. `scanUnicodeString` errors with `unsafe use of string constant with Unicode escapes` when SCS is off.

Refs MUL-413.