### PR TITLE
feat(multigateway): enforce authentication_timeout on PG startup

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -25,6 +25,7 @@ import (
 // See: https://www.postgresql.org/docs/current/errcodes-appendix.html
 const (
 	PgSSProtocolViolation       = "08P01" // protocol_violation
+	PgSSConnectionFailure       = "08006" // connection_failure
 	PgSSFeatureNotSupported     = "0A000" // feature_not_supported
 	PgSSInvalidParameterValue   = "22023" // invalid_parameter_value
 	PgSSActiveTransaction       = "25001" // active_sql_transaction
@@ -52,6 +53,15 @@ func NewQueryCanceled() *PgDiagnostic {
 func NewStatementTimeout() *PgDiagnostic {
 	return NewPgError("ERROR", PgSSQueryCanceled,
 		"canceling statement due to statement timeout", "")
+}
+
+// NewAuthenticationTimeout creates a PgDiagnostic for an authentication_timeout
+// expiry during the startup phase (SSLRequest, StartupMessage, or SCRAM
+// exchange). SQLSTATE 08006 (connection_failure), severity FATAL — matches
+// the way native PostgreSQL closes the connection when the timeout fires.
+func NewAuthenticationTimeout() *PgDiagnostic {
+	return NewPgError("FATAL", PgSSConnectionFailure,
+		"canceling authentication due to timeout", "")
 }
 
 // MTError defines a Multigres-specific error code for conditions that have no

--- a/go/common/pgprotocol/server/auth_timeout_test.go
+++ b/go/common/pgprotocol/server/auth_timeout_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -31,17 +32,22 @@ import (
 // timeoutTestServer accepts a single connection on a fresh local TCP listener
 // and runs the full server-side serve() loop against it. The auth-timeout
 // path is exercised end-to-end (deadline applied → expiry → PG-format
-// FATAL → connection closed).
-func timeoutTestServer(t *testing.T, authTimeout time.Duration) (clientConn net.Conn, serverErrCh <-chan error, cleanup func()) {
+// FATAL → connection closed). When tlsConfig is non-nil, the listener
+// will accept SSLRequest and upgrade to TLS.
+func timeoutTestServer(t *testing.T, authTimeout time.Duration, tlsConfig ...*tls.Config) (clientConn net.Conn, serverErrCh <-chan error, cleanup func()) {
 	t.Helper()
 
-	listener, err := NewListener(ListenerConfig{
+	cfg := ListenerConfig{
 		Address:               "127.0.0.1:0",
 		Handler:               &mockHandler{},
 		HashProvider:          newMockHashProvider("postgres"),
 		AuthenticationTimeout: authTimeout,
 		Logger:                testLogger(t),
-	})
+	}
+	if len(tlsConfig) > 0 {
+		cfg.TLSConfig = tlsConfig[0]
+	}
+	listener, err := NewListener(cfg)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -236,6 +242,52 @@ func TestAuthenticationTimeout_ConfigDefault(t *testing.T) {
 
 	assert.Equal(t, DefaultAuthenticationTimeout, listener.authenticationTimeout)
 	assert.Equal(t, 60*time.Second, listener.authenticationTimeout)
+}
+
+// TestAuthenticationTimeout_PendingTLSHandshakeSkipsErrorReply verifies the
+// post-SSL-accept-pre-TLS-handshake state: the server has answered 'S' to
+// SSLRequest but the client hasn't completed the TLS handshake. The
+// underlying conn is still plaintext while the client expects encrypted
+// bytes — writing an unencrypted ErrorResponse would surface as garbage
+// on the client. The server must close cleanly without the unencrypted
+// reply.
+func TestAuthenticationTimeout_PendingTLSHandshakeSkipsErrorReply(t *testing.T) {
+	tlsConfig, _ := generateTestTLSConfig(t)
+
+	const timeout = 200 * time.Millisecond
+	clientConn, serverErrCh, cleanup := timeoutTestServer(t, timeout, tlsConfig)
+	defer cleanup()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	// Send SSLRequest, read 'S' acceptance, then stall — never start
+	// the TLS handshake.
+	writeSSLRequest(t, clientConn)
+	resp := readSingleByte(t, clientConn)
+	require.Equal(t, byte('S'), resp)
+
+	// Read until the server closes. We must not see anything that
+	// looks like a PG ErrorResponse byte ('E') here — that would mean
+	// the server wrote unencrypted bytes after promising TLS.
+	buf := make([]byte, 64)
+	n, readErr := clientConn.Read(buf)
+
+	if n > 0 {
+		assert.NotEqual(t, byte(protocol.MsgErrorResponse), buf[0],
+			"server must not send unencrypted ErrorResponse after accepting SSL")
+	}
+	// EOF (or connection-reset) is the expected outcome — server
+	// detected the timeout, skipped the unencrypted reply, and closed.
+	require.Error(t, readErr)
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-serverErrCh:
+			return err != nil
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 // TestAuthenticationTimeout_NegativeDisables verifies that a negative

--- a/go/common/pgprotocol/server/auth_timeout_test.go
+++ b/go/common/pgprotocol/server/auth_timeout_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// timeoutTestServer accepts a single connection on a fresh local TCP listener
+// and runs the full server-side serve() loop against it. The auth-timeout
+// path is exercised end-to-end (deadline applied → expiry → PG-format
+// FATAL → connection closed).
+func timeoutTestServer(t *testing.T, authTimeout time.Duration) (clientConn net.Conn, serverErrCh <-chan error, cleanup func()) {
+	t.Helper()
+
+	listener, err := NewListener(ListenerConfig{
+		Address:               "127.0.0.1:0",
+		Handler:               &mockHandler{},
+		HashProvider:          newMockHashProvider("postgres"),
+		AuthenticationTimeout: authTimeout,
+		Logger:                testLogger(t),
+	})
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := listener.listener.Accept()
+		if acceptErr != nil {
+			errCh <- acceptErr
+			return
+		}
+		c := newConn(netConn, listener, 1)
+		c.handler = listener.handler
+		c.hashProvider = listener.hashProvider
+		c.tlsConfig = listener.tlsConfig
+		serveErr := c.serve()
+		_ = c.Close()
+		errCh <- serveErr
+	}()
+
+	cc, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+
+	cleanup = func() {
+		cc.Close()
+		listener.Close()
+	}
+	return cc, errCh, cleanup
+}
+
+// containsErrField checks whether a PG ErrorResponse body contains a field
+// (1-byte type code followed by a null-terminated string) with the given
+// type code and value. ErrorResponse fields are 'S' (severity), 'C' (code),
+// 'M' (message), etc.
+func containsErrField(body []byte, code byte, value string) bool {
+	for i := 0; i < len(body); {
+		if body[i] == 0 {
+			return false
+		}
+		fieldCode := body[i]
+		i++
+		end := i
+		for end < len(body) && body[end] != 0 {
+			end++
+		}
+		if end >= len(body) {
+			return false
+		}
+		fieldVal := string(body[i:end])
+		if fieldCode == code && fieldVal == value {
+			return true
+		}
+		i = end + 1
+	}
+	return false
+}
+
+// TestAuthenticationTimeout_NoStartupMessage verifies that a client which
+// connects but never sends a StartupMessage is disconnected after the
+// configured timeout, and the server emits a PG-format FATAL ErrorResponse
+// with SQLSTATE 08006 instead of letting the goroutine hang.
+func TestAuthenticationTimeout_NoStartupMessage(t *testing.T) {
+	const timeout = 200 * time.Millisecond
+	clientConn, serverErrCh, cleanup := timeoutTestServer(t, timeout)
+	defer cleanup()
+
+	// Client never writes anything. Server must time out and reply with
+	// a FATAL ErrorResponse (SQLSTATE 08006). Bound the read with a
+	// generous client-side deadline so a buggy server doesn't hang the
+	// test indefinitely.
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	start := time.Now()
+	msgType, body := readMessage(t, clientConn)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"), "severity should be FATAL")
+	assert.True(t, containsErrField(body, 'C', "08006"), "SQLSTATE should be 08006 (connection_failure)")
+	assert.True(t, containsErrField(body, 'M', "canceling authentication due to timeout"))
+	assert.GreaterOrEqual(t, elapsed, timeout-50*time.Millisecond,
+		"server should not respond before the deadline")
+	assert.Less(t, elapsed, 5*time.Second,
+		"server should respond shortly after the deadline")
+
+	// After the error, server should close the connection. serve()
+	// returns the original deadline-exceeded error.
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-serverErrCh:
+			return err != nil
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestAuthenticationTimeout_PartialSCRAM verifies that a client which begins
+// the SCRAM exchange but stalls partway through is disconnected after the
+// timeout. The server-first message has already been sent, so the deadline
+// must apply to the SASLResponse read, not just the initial packet.
+func TestAuthenticationTimeout_PartialSCRAM(t *testing.T) {
+	const timeout = 200 * time.Millisecond
+	clientConn, serverErrCh, cleanup := timeoutTestServer(t, timeout)
+	defer cleanup()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	// Send a valid StartupMessage to advance past the first read.
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "stalluser", "database": "stalldb"})
+
+	// Read AuthenticationSASL — server is now waiting for SASLInitialResponse.
+	msgType, body := readMessage(t, clientConn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	authType := binary.BigEndian.Uint32(body[:4])
+	require.Equal(t, uint32(protocol.AuthSASL), authType)
+
+	// Stall: never send SASLInitialResponse. Server must time out.
+	start := time.Now()
+	msgType, body = readMessage(t, clientConn)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"))
+	assert.True(t, containsErrField(body, 'C', "08006"))
+	assert.True(t, containsErrField(body, 'M', "canceling authentication due to timeout"))
+	assert.GreaterOrEqual(t, elapsed, timeout-100*time.Millisecond,
+		"server should not respond before the deadline")
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-serverErrCh:
+			return err != nil
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestAuthenticationTimeout_SuccessfulAuthClearsDeadline verifies that the
+// startup deadline is removed once authentication completes — an
+// authenticated but idle connection must not be killed by the auth timeout.
+func TestAuthenticationTimeout_SuccessfulAuthClearsDeadline(t *testing.T) {
+	const timeout = 300 * time.Millisecond
+	clientConn, serverErrCh, cleanup := timeoutTestServer(t, timeout)
+	defer cleanup()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(10*time.Second)))
+
+	// Complete the startup + SCRAM handshake.
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "okuser", "database": "okdb"})
+	scramClientHelper(t, clientConn, "okuser", "postgres")
+
+	// Idle longer than the auth timeout. If the deadline weren't cleared,
+	// the server would kill the connection here.
+	time.Sleep(timeout * 2)
+
+	// Connection must still be alive: send a Terminate ('X') and expect
+	// the server to read it and exit cleanly without an ErrorResponse.
+	header := make([]byte, 5)
+	header[0] = byte(protocol.MsgTerminate)
+	binary.BigEndian.PutUint32(header[1:5], 4)
+	_, err := clientConn.Write(header)
+	require.NoError(t, err)
+
+	// Server should return cleanly (Terminate is signaled as io.EOF
+	// inside handleMessage and serve() returns nil).
+	select {
+	case serveErr := <-serverErrCh:
+		// nil is the success signal; io.EOF can also surface if the
+		// client side closes first under the test cleanup.
+		if serveErr != nil && !errors.Is(serveErr, io.EOF) {
+			t.Fatalf("expected clean exit after Terminate, got %v", serveErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not exit after Terminate; deadline may not have been cleared")
+	}
+}
+
+// TestAuthenticationTimeout_ConfigDefault verifies that a zero
+// AuthenticationTimeout in ListenerConfig falls back to the protocol
+// default of 60s (matching PostgreSQL).
+func TestAuthenticationTimeout_ConfigDefault(t *testing.T) {
+	listener, err := NewListener(ListenerConfig{
+		Address:      "127.0.0.1:0",
+		Handler:      &mockHandler{},
+		HashProvider: newMockHashProvider("postgres"),
+		Logger:       testLogger(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	assert.Equal(t, DefaultAuthenticationTimeout, listener.authenticationTimeout)
+	assert.Equal(t, 60*time.Second, listener.authenticationTimeout)
+}
+
+// TestAuthenticationTimeout_NegativeDisables verifies that a negative
+// AuthenticationTimeout disables the deadline entirely (escape hatch for
+// operators who want to opt out of the default).
+func TestAuthenticationTimeout_NegativeDisables(t *testing.T) {
+	listener, err := NewListener(ListenerConfig{
+		Address:               "127.0.0.1:0",
+		Handler:               &mockHandler{},
+		HashProvider:          newMockHashProvider("postgres"),
+		AuthenticationTimeout: -1,
+		Logger:                testLogger(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	assert.Less(t, listener.authenticationTimeout, time.Duration(0),
+		"negative value should be preserved (disables the deadline)")
+}

--- a/go/common/pgprotocol/server/auth_timeout_test.go
+++ b/go/common/pgprotocol/server/auth_timeout_test.go
@@ -290,6 +290,38 @@ func TestAuthenticationTimeout_PendingTLSHandshakeSkipsErrorReply(t *testing.T) 
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
+// TestAuthenticationTimeout_CancelRequestNoSpuriousErrors verifies that a
+// CancelRequest received during the startup phase does not produce
+// spurious Error logs from the deadline-clear path. handleCancelRequest
+// closes the connection and returns nil; serve() must detect that and
+// bail out without trying to clear the deadline on the now-closed fd.
+func TestAuthenticationTimeout_CancelRequestNoSpuriousErrors(t *testing.T) {
+	const timeout = 30 * time.Second
+	clientConn, serverErrCh, cleanup := timeoutTestServer(t, timeout)
+	defer cleanup()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(2*time.Second)))
+
+	// Send a CancelRequest startup packet: length(16) + code + pid + secret.
+	pkt := make([]byte, 16)
+	binary.BigEndian.PutUint32(pkt[0:4], 16)
+	binary.BigEndian.PutUint32(pkt[4:8], protocol.CancelRequestCode)
+	binary.BigEndian.PutUint32(pkt[8:12], 12345)
+	binary.BigEndian.PutUint32(pkt[12:16], 67890)
+	_, err := clientConn.Write(pkt)
+	require.NoError(t, err)
+
+	// Server closes the cancel connection per protocol. serve() must
+	// return nil — no error path triggered.
+	select {
+	case serveErr := <-serverErrCh:
+		require.NoError(t, serveErr,
+			"cancel request must not produce a serve() error (would be a regression on the deadline-clear path)")
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not exit after CancelRequest")
+	}
+}
+
 // TestAuthenticationTimeout_NegativeDisables verifies that a negative
 // AuthenticationTimeout disables the deadline entirely (escape hatch for
 // operators who want to opt out of the default).

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -49,6 +49,14 @@ const (
 // and queryContextError checks it with errors.Is (pointer equality).
 var errQueryCanceled = mterrors.NewQueryCanceled()
 
+// errAuthenticationTimeout is the sentinel returned by serve() when the
+// startup-phase deadline (authentication_timeout) fires. handleConnection
+// matches on this specifically rather than the generic
+// os.ErrDeadlineExceeded so that deadlines added in the future for other
+// reasons (idle timeout, per-query socket deadline, etc.) are not silently
+// suppressed by the same log-noise filter.
+var errAuthenticationTimeout = errors.New("authentication timeout")
+
 // Conn represents the server side connection with a PostgreSQL client.
 // It handles the wire protocol encoding/decoding and connection state management.
 type Conn struct {
@@ -569,7 +577,10 @@ func (c *Conn) serve() error {
 				_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, mterrors.NewAuthenticationTimeout())
 				_ = c.flush()
 			}
-			return err
+			// Return the sentinel so handleConnection can suppress its
+			// redundant Error log without also swallowing unrelated
+			// deadline-exceeded errors that future code paths may surface.
+			return errAuthenticationTimeout
 		}
 		c.logger.Error("startup failed", "error", err)
 		// Try to send an error response before closing.
@@ -587,10 +598,15 @@ func (c *Conn) serve() error {
 
 	// Authentication complete — clear the startup deadline before the
 	// command loop. Subsequent reads must not inherit the auth-phase
-	// deadline (idle clients are normal, not a protocol violation).
+	// deadline (idle clients are normal, not a protocol violation). If
+	// the clear fails (rare — typically only when the fd is already
+	// closed), abort instead of entering the loop with a stale deadline
+	// that would trip the very next read.
 	if startupDeadlineSet {
 		if err := c.conn.SetDeadline(time.Time{}); err != nil {
-			c.logger.Warn("failed to clear startup deadline", "error", err)
+			c.logger.Error("failed to clear startup deadline; tearing down connection",
+				"error", err)
+			return fmt.Errorf("clear startup deadline: %w", err)
 		}
 	}
 

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -116,6 +116,14 @@ type Conn struct {
 	// (accepted or declined) for this connection. Prevents double negotiation.
 	sslDone bool
 
+	// tlsHandshakeComplete is set true once handleSSLRequest has accepted
+	// SSL ('S') AND the TLS handshake has finished — i.e., c.conn has been
+	// reassigned to the *tls.Conn. Used during the auth-timeout error path
+	// to decide whether plaintext writes are still intelligible to the
+	// client. Tracking this explicitly (rather than type-asserting c.conn)
+	// keeps the check robust if c.conn is ever wrapped in instrumentation.
+	tlsHandshakeComplete bool
+
 	// gssDone indicates that a GSSENCRequest has already been handled
 	// for this connection. Prevents double negotiation.
 	gssDone bool
@@ -550,10 +558,8 @@ func (c *Conn) serve() error {
 			// other startup states (raw plaintext or fully upgraded
 			// TLS) the write is intelligible to the client.
 			canReplyCleanly := true
-			if c.sslDone && c.tlsConfig != nil {
-				if _, isTLS := c.conn.(*tls.Conn); !isTLS {
-					canReplyCleanly = false
-				}
+			if c.sslDone && c.tlsConfig != nil && !c.tlsHandshakeComplete {
+				canReplyCleanly = false
 			}
 			if canReplyCleanly {
 				// Brief grace window: long enough to flush the error

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -495,6 +495,17 @@ func (c *Conn) endWriterBuffering() error {
 	return flushErr
 }
 
+// canSendPlaintextStartupError reports whether a best-effort plaintext
+// ErrorResponse during the startup phase would be intelligible to the
+// client. If the client sent SSLRequest and the server already answered
+// 'S' but the TLS handshake hasn't completed, the underlying conn is
+// still plaintext while the client is waiting for encrypted bytes — so
+// any plaintext write would surface as garbage. Every other startup
+// state (raw plaintext or fully upgraded TLS) can carry the reply.
+func (c *Conn) canSendPlaintextStartupError() bool {
+	return !(c.sslDone && c.tlsConfig != nil && !c.tlsHandshakeComplete)
+}
+
 // generateBackendKey generates a cryptographically secure random backend key for cancellation.
 // The backend key is sent to the client in the BackendKeyData message and is used
 // to authenticate query cancellation requests.
@@ -556,20 +567,7 @@ func (c *Conn) serve() error {
 			c.logger.Warn("startup phase timed out",
 				"timeout", c.listener.authenticationTimeout,
 				"remote_addr", c.RemoteAddr())
-			// If the client sent SSLRequest and the server already
-			// answered 'S' but the TLS handshake hasn't completed, the
-			// underlying conn is still plaintext while the client is
-			// waiting for encrypted bytes. Writing an unencrypted
-			// ErrorResponse here would surface as garbage on the
-			// client side, so skip the reply and just close. The
-			// goroutine is still released (return below). For all
-			// other startup states (raw plaintext or fully upgraded
-			// TLS) the write is intelligible to the client.
-			canReplyCleanly := true
-			if c.sslDone && c.tlsConfig != nil && !c.tlsHandshakeComplete {
-				canReplyCleanly = false
-			}
-			if canReplyCleanly {
+			if c.canSendPlaintextStartupError() {
 				// Brief grace window: long enough to flush the error
 				// to a well-behaved client, short enough that a wedged
 				// client can't keep this goroutine pinned.
@@ -584,21 +582,28 @@ func (c *Conn) serve() error {
 		}
 		c.logger.Error("startup failed", "error", err)
 		// Set a brief write-deadline grace window so the best-effort
-		// error reply isn't races against the still-active auth
+		// error reply doesn't race against the still-active auth
 		// deadline (which may fire mid-write on a slow client).
 		if startupDeadlineSet {
 			_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		}
-		// Try to send an error response before closing.
-		// If the error is already a PgDiagnostic (e.g., duplicate SSLRequest
-		// with native SQLSTATE), send it directly. Otherwise, wrap with MTE01.
-		var diag *mterrors.PgDiagnostic
-		if errors.As(err, &diag) {
-			_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, diag)
-		} else {
-			_ = c.writeError(mterrors.MTE01.NewWithDetail(err.Error()))
+		// Try to send an error response before closing — but only if
+		// it would be intelligible. Same SSL-accepted-but-handshake-
+		// pending guard as the timeout path above: a plaintext
+		// ErrorResponse on a connection where the client expects
+		// encrypted bytes would surface as garbage.
+		if c.canSendPlaintextStartupError() {
+			// If the error is already a PgDiagnostic (e.g., duplicate
+			// SSLRequest with native SQLSTATE), send it directly.
+			// Otherwise, wrap with MTE01.
+			var diag *mterrors.PgDiagnostic
+			if errors.As(err, &diag) {
+				_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, diag)
+			} else {
+				_ = c.writeError(mterrors.MTE01.NewWithDetail(err.Error()))
+			}
+			_ = c.flush()
 		}
-		_ = c.flush()
 		return err
 	}
 

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -540,12 +540,29 @@ func (c *Conn) serve() error {
 			c.logger.Warn("startup phase timed out",
 				"timeout", c.listener.authenticationTimeout,
 				"remote_addr", c.RemoteAddr())
-			// Brief grace window: long enough to flush the error to a
-			// well-behaved client, short enough that a wedged client
-			// can't keep this goroutine pinned.
-			_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, mterrors.NewAuthenticationTimeout())
-			_ = c.flush()
+			// If the client sent SSLRequest and the server already
+			// answered 'S' but the TLS handshake hasn't completed, the
+			// underlying conn is still plaintext while the client is
+			// waiting for encrypted bytes. Writing an unencrypted
+			// ErrorResponse here would surface as garbage on the
+			// client side, so skip the reply and just close. The
+			// goroutine is still released (return below). For all
+			// other startup states (raw plaintext or fully upgraded
+			// TLS) the write is intelligible to the client.
+			canReplyCleanly := true
+			if c.sslDone && c.tlsConfig != nil {
+				if _, isTLS := c.conn.(*tls.Conn); !isTLS {
+					canReplyCleanly = false
+				}
+			}
+			if canReplyCleanly {
+				// Brief grace window: long enough to flush the error
+				// to a well-behaved client, short enough that a wedged
+				// client can't keep this goroutine pinned.
+				_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, mterrors.NewAuthenticationTimeout())
+				_ = c.flush()
+			}
 			return err
 		}
 		c.logger.Error("startup failed", "error", err)

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -509,16 +510,43 @@ func generateBackendKey() uint32 {
 // the writer to the pool when the connection genuinely idles between
 // batches.
 func (c *Conn) serve() error {
-	// TODO: Add startup phase timeout (equivalent to PostgreSQL's authentication_timeout).
-	// Set c.conn.SetDeadline() here and clear it after handleStartup() returns.
-	// Without this, a client can hold a goroutine indefinitely by stalling during
-	// SSL handshake, startup packet reading, or SCRAM authentication exchange.
+	// Bound the startup phase (SSL/GSS negotiation, StartupMessage, SCRAM
+	// exchange) — equivalent to PostgreSQL's authentication_timeout. A
+	// stalled or malicious client cannot pin this goroutine past the
+	// deadline. The deadline is cleared once authentication completes so
+	// the main command loop runs without an I/O timeout.
+	startupDeadlineSet := false
+	if d := c.listener.authenticationTimeout; d > 0 {
+		if err := c.conn.SetDeadline(time.Now().Add(d)); err == nil {
+			startupDeadlineSet = true
+		} else {
+			c.logger.Warn("failed to set startup deadline", "error", err)
+		}
+	}
 
 	// First, handle the startup phase.
 	if err := c.handleStartup(); err != nil {
 		if errors.Is(err, io.EOF) {
 			c.logger.Debug("client disconnected before startup")
 			return nil
+		}
+		// Map a deadline-exceeded I/O error during startup to a clean
+		// PG-format FATAL with SQLSTATE 08006 so libpq surfaces it as
+		// "canceling authentication due to timeout" instead of a raw
+		// I/O timeout. The startup deadline is still active here — any
+		// write would inherit the expired deadline and fail — so clear
+		// it first using a brief grace window for the error reply.
+		if startupDeadlineSet && errors.Is(err, os.ErrDeadlineExceeded) {
+			c.logger.Warn("startup phase timed out",
+				"timeout", c.listener.authenticationTimeout,
+				"remote_addr", c.RemoteAddr())
+			// Brief grace window: long enough to flush the error to a
+			// well-behaved client, short enough that a wedged client
+			// can't keep this goroutine pinned.
+			_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			_ = c.writePgDiagnosticResponse(protocol.MsgErrorResponse, mterrors.NewAuthenticationTimeout())
+			_ = c.flush()
+			return err
 		}
 		c.logger.Error("startup failed", "error", err)
 		// Try to send an error response before closing.
@@ -532,6 +560,15 @@ func (c *Conn) serve() error {
 		}
 		_ = c.flush()
 		return err
+	}
+
+	// Authentication complete — clear the startup deadline before the
+	// command loop. Subsequent reads must not inherit the auth-phase
+	// deadline (idle clients are normal, not a protocol violation).
+	if startupDeadlineSet {
+		if err := c.conn.SetDeadline(time.Time{}); err != nil {
+			c.logger.Warn("failed to clear startup deadline", "error", err)
+		}
 	}
 
 	// Main command loop.

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -583,6 +583,12 @@ func (c *Conn) serve() error {
 			return errAuthenticationTimeout
 		}
 		c.logger.Error("startup failed", "error", err)
+		// Set a brief write-deadline grace window so the best-effort
+		// error reply isn't races against the still-active auth
+		// deadline (which may fire mid-write on a slow client).
+		if startupDeadlineSet {
+			_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		}
 		// Try to send an error response before closing.
 		// If the error is already a PgDiagnostic (e.g., duplicate SSLRequest
 		// with native SQLSTATE), send it directly. Otherwise, wrap with MTE01.
@@ -594,6 +600,14 @@ func (c *Conn) serve() error {
 		}
 		_ = c.flush()
 		return err
+	}
+
+	// Cancel requests close the connection inside handleStartup and
+	// return nil — there is no authenticated session to enter the
+	// command loop for, and SetDeadline on the closed fd would fail
+	// and surface as a spurious Error log. Bail out cleanly here.
+	if c.closed.Load() {
+		return nil
 	}
 
 	// Authentication complete — clear the startup deadline before the

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -277,7 +278,15 @@ func (l *Listener) handleConnection(conn *Conn) {
 
 	// Serve the connection (startup + command loop).
 	if err := conn.serve(); err != nil {
-		if !errors.Is(err, io.EOF) {
+		switch {
+		case errors.Is(err, io.EOF):
+			// Client closed cleanly — no log.
+		case errors.Is(err, os.ErrDeadlineExceeded):
+			// Auth timeout already logged at Warn from serve()
+			// with full context (timeout, remote_addr). Skip the
+			// redundant Error log here so a stalled client doesn't
+			// produce two entries per connection.
+		default:
 			conn.logger.Error("connection error", "error", err)
 		}
 	}

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -57,7 +57,9 @@ type Listener struct {
 
 	// authenticationTimeout bounds the startup phase (SSL/GSS negotiation,
 	// StartupMessage read, SCRAM exchange) — equivalent to PostgreSQL's
-	// authentication_timeout GUC. Zero or negative disables the timeout.
+	// authentication_timeout GUC. Negative disables the timeout. The
+	// constructor maps a zero-valued ListenerConfig to
+	// DefaultAuthenticationTimeout, so this field is never zero in practice.
 	authenticationTimeout time.Duration
 
 	// logger for logging.

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/bufpool"
 	"github.com/multigres/multigres/go/common/pgprotocol/pid"
@@ -53,6 +54,11 @@ type Listener struct {
 	// When set, the server accepts SSLRequest and upgrades to TLS.
 	// When nil, SSLRequest is declined with 'N'.
 	tlsConfig *tls.Config
+
+	// authenticationTimeout bounds the startup phase (SSL/GSS negotiation,
+	// StartupMessage read, SCRAM exchange) — equivalent to PostgreSQL's
+	// authentication_timeout GUC. Zero or negative disables the timeout.
+	authenticationTimeout time.Duration
 
 	// logger for logging.
 	logger *slog.Logger
@@ -127,9 +133,20 @@ type ListenerConfig struct {
 	// When nil, SSLRequest is declined with 'N' (plaintext only).
 	TLSConfig *tls.Config
 
+	// AuthenticationTimeout bounds the startup phase: SSL/GSS negotiation,
+	// StartupMessage read, and the SCRAM exchange. A stalled or malicious
+	// client cannot pin a goroutine past this deadline. Zero falls back to
+	// DefaultAuthenticationTimeout (60s, matching PostgreSQL's default).
+	// Negative disables the timeout.
+	AuthenticationTimeout time.Duration
+
 	// Logger for logging (optional, defaults to slog.Default()).
 	Logger *slog.Logger
 }
+
+// DefaultAuthenticationTimeout matches PostgreSQL's authentication_timeout
+// default (60s). Used when ListenerConfig.AuthenticationTimeout is zero.
+const DefaultAuthenticationTimeout = 60 * time.Second
 
 // NewListener creates a new PostgreSQL protocol listener.
 func NewListener(config ListenerConfig) (*Listener, error) {
@@ -152,19 +169,25 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		logger = slog.Default()
 	}
 
+	authTimeout := config.AuthenticationTimeout
+	if authTimeout == 0 {
+		authTimeout = DefaultAuthenticationTimeout
+	}
+
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	l := &Listener{
-		listener:          netListener,
-		handler:           config.Handler,
-		hashProvider:      config.HashProvider,
-		trustAuthProvider: config.TrustAuthProvider,
-		tlsConfig:         config.TLSConfig,
-		logger:            logger,
-		gatewayID:         config.GatewayID,
-		conns:             make(map[uint32]*Conn),
-		ctx:               ctx,
-		cancel:            cancel,
+		listener:              netListener,
+		handler:               config.Handler,
+		hashProvider:          config.HashProvider,
+		trustAuthProvider:     config.TrustAuthProvider,
+		tlsConfig:             config.TLSConfig,
+		authenticationTimeout: authTimeout,
+		logger:                logger,
+		gatewayID:             config.GatewayID,
+		conns:                 make(map[uint32]*Conn),
+		ctx:                   ctx,
+		cancel:                cancel,
 	}
 
 	// Initialize buffer pools.

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -281,11 +280,13 @@ func (l *Listener) handleConnection(conn *Conn) {
 		switch {
 		case errors.Is(err, io.EOF):
 			// Client closed cleanly — no log.
-		case errors.Is(err, os.ErrDeadlineExceeded):
+		case errors.Is(err, errAuthenticationTimeout):
 			// Auth timeout already logged at Warn from serve()
 			// with full context (timeout, remote_addr). Skip the
 			// redundant Error log here so a stalled client doesn't
-			// produce two entries per connection.
+			// produce two entries per connection. Matching on the
+			// dedicated sentinel (rather than os.ErrDeadlineExceeded)
+			// keeps unrelated future deadlines visible.
 		default:
 			conn.logger.Error("connection error", "error", err)
 		}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -131,6 +131,7 @@ func (c *Conn) handleSSLRequest() error {
 	// through TLS.
 	c.conn = tlsConn
 	c.bufferedReader.Reset(tlsConn)
+	c.tlsHandshakeComplete = true
 
 	c.logger.Info("TLS connection established",
 		"version", tlsConn.ConnectionState().Version,

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -95,6 +95,10 @@ type MultiGateway struct {
 	bufferConfig *buffer.Config
 	// statementTimeout is the default statement execution timeout
 	statementTimeout viperutil.Value[time.Duration]
+	// authenticationTimeout bounds the PG startup phase (SSL handshake,
+	// StartupMessage, SCRAM exchange). Equivalent to PostgreSQL's
+	// authentication_timeout GUC.
+	authenticationTimeout viperutil.Value[time.Duration]
 	// planCacheMemory is the maximum memory (bytes) for the plan cache (0 disables)
 	planCacheMemory viperutil.Value[int]
 	// queryMetricsMemory is the maximum memory (bytes) for per-query-shape metrics
@@ -153,6 +157,12 @@ func NewMultiGateway() *MultiGateway {
 			FlagName: "statement-timeout",
 			Dynamic:  false,
 			EnvVars:  []string{"MT_STATEMENT_TIMEOUT"},
+		}),
+		authenticationTimeout: viperutil.Configure(reg, "authentication-timeout", viperutil.Options[time.Duration]{
+			Default:  60 * time.Second,
+			FlagName: "authentication-timeout",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_AUTHENTICATION_TIMEOUT"},
 		}),
 		planCacheMemory: viperutil.Configure(reg, "plan-cache-memory", viperutil.Options[int]{
 			Default:  4 * 1024 * 1024, // 4 MB
@@ -236,6 +246,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int("pg-port", mg.pgPort.Default(), "PostgreSQL protocol listen port")
 	fs.String("pg-bind-address", mg.pgBindAddress.Default(), "address to bind the PostgreSQL listener to")
 	fs.Duration("statement-timeout", mg.statementTimeout.Default(), "Default statement execution timeout. 0 disables.")
+	fs.Duration("authentication-timeout", mg.authenticationTimeout.Default(), "Maximum time allowed to complete client authentication (SSL handshake, startup message, SCRAM). Negative disables; 0 uses the protocol default of 60s.")
 	fs.String("pg-tls-cert-file", mg.pgTLSCertFile.Default(), "path to TLS certificate file for PostgreSQL SSL connections")
 	fs.String("pg-tls-key-file", mg.pgTLSKeyFile.Default(), "path to TLS private key file for PostgreSQL SSL connections")
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
@@ -250,6 +261,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.pgPort,
 		mg.pgBindAddress,
 		mg.statementTimeout,
+		mg.authenticationTimeout,
 		mg.pgTLSCertFile,
 		mg.pgTLSKeyFile,
 		mg.pgReplicaPort,
@@ -456,12 +468,13 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	mg.pgHandler.SetNotificationManager(notifMgr, notifMetrics.NotificationDropped)
 	pgAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), mg.pgPort.Get())
 	mg.pgListener, err = server.NewListener(server.ListenerConfig{
-		Address:      pgAddr,
-		Handler:      mg.pgHandler,
-		GatewayID:    pidPrefix,
-		HashProvider: hashProvider,
-		TLSConfig:    pgTLSConfig,
-		Logger:       logger,
+		Address:               pgAddr,
+		Handler:               mg.pgHandler,
+		GatewayID:             pidPrefix,
+		HashProvider:          hashProvider,
+		TLSConfig:             pgTLSConfig,
+		AuthenticationTimeout: mg.authenticationTimeout.Get(),
+		Logger:                logger,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create PostgreSQL listener on port %d: %w", mg.pgPort.Get(), err)
@@ -475,12 +488,13 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		replicaHandler.SetQueryRegistry(mg.queryRegistry)
 		replicaAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), replicaPort)
 		mg.pgReplicaListener, err = server.NewListener(server.ListenerConfig{
-			Address:      replicaAddr,
-			Handler:      replicaHandler,
-			GatewayID:    pidPrefix,
-			HashProvider: hashProvider,
-			TLSConfig:    pgTLSConfig,
-			Logger:       logger,
+			Address:               replicaAddr,
+			Handler:               replicaHandler,
+			GatewayID:             pidPrefix,
+			HashProvider:          hashProvider,
+			TLSConfig:             pgTLSConfig,
+			AuthenticationTimeout: mg.authenticationTimeout.Get(),
+			Logger:                logger,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create replica PostgreSQL listener on port %d: %w", replicaPort, err)


### PR DESCRIPTION
## Summary

- Bound the PG startup phase (SSL/GSS negotiation, StartupMessage read, SCRAM exchange) with a configurable deadline so a stalled or malicious client cannot pin a goroutine indefinitely.
- New `--authentication-timeout` flag on multigateway (env `MT_AUTHENTICATION_TIMEOUT`), default 60s — matches PostgreSQL's `authentication_timeout` GUC. Negative disables.
- Timeout surfaces as a PG-format FATAL `ErrorResponse` with SQLSTATE `08006` ("canceling authentication due to timeout") rather than a raw I/O timeout, so libpq-compatible clients see a clean reason.
- Deadline is cleared after authentication completes; idle authenticated connections are unaffected.

Closes [MUL-386](https://linear.app/supabase/issue/MUL-386/enforce-authentication-timeout-on-pg-startup-scram-exchange).

## Description

`Conn.serve()` previously had a TODO acknowledging that the startup phase had no timeout. This change applies `c.conn.SetDeadline()` before `handleStartup()` runs and clears it before entering the main command loop. Deadline-exceeded errors during startup are detected via `errors.Is(err, os.ErrDeadlineExceeded)` and remapped to `mterrors.NewAuthenticationTimeout()` (FATAL / 08006). A short write-deadline grace window is set before flushing the error so a wedged client cannot re-block the goroutine on the error reply itself.

The timeout is configured on `ListenerConfig` (`AuthenticationTimeout time.Duration`), with a `DefaultAuthenticationTimeout = 60 * time.Second` constant for the zero-value fallback. Both the primary and replica multigateway listeners read the same flag.

## Test plan

- [x] Unit: client connects and never sends `StartupMessage` → server emits FATAL/08006 after the deadline and closes.
- [x] Unit: client completes `StartupMessage` then stalls mid-SCRAM → server emits FATAL/08006 after the deadline and closes.
- [x] Unit: successful auth + idle longer than the auth timeout → connection still alive (Terminate exits cleanly).
- [x] Unit: zero `AuthenticationTimeout` falls back to 60s; negative disables.
- [x] `go build ./...` and full `go test` for `pgprotocol/server`, `mterrors`, and all `multigateway` packages — green.