### PR TITLE
fix(parser): emit WithClause when deparsing UNION/INTERSECT/EXCEPT

### DIFF
--- a/go/common/parser/ast/statements.go
+++ b/go/common/parser/ast/statements.go
@@ -599,7 +599,14 @@ func (s *SelectStmt) SqlString() string {
 				valueRows = append(valueRows, fmt.Sprintf("(%s)", strings.Join(values, ", ")))
 			}
 		}
-		return "VALUES " + strings.Join(valueRows, ", ")
+		// WITH cte(...) AS (...) VALUES (...) attaches WithClause to the
+		// outer SelectStmt; same drop-on-round-trip class as the set-op
+		// branch above.
+		result := "VALUES " + strings.Join(valueRows, ", ")
+		if s.WithClause != nil {
+			result = s.WithClause.SqlString() + " " + result
+		}
+		return result
 	}
 
 	// Regular SELECT statement

--- a/go/common/parser/ast/statements.go
+++ b/go/common/parser/ast/statements.go
@@ -576,7 +576,15 @@ func (s *SelectStmt) SqlString() string {
 			parts = append(parts, "OFFSET", s.LimitOffset.SqlString())
 		}
 
-		return strings.Join(parts, " ")
+		// WITH clause attaches to the outer set-operation node and must be
+		// prepended here. The non-set-op branch handles WithClause below; the
+		// set-op branch returns early, so without this the CTE is silently
+		// dropped on round-trip and PG sees `relation "cte" does not exist`.
+		result := strings.Join(parts, " ")
+		if s.WithClause != nil {
+			result = s.WithClause.SqlString() + " " + result
+		}
+		return result
 	}
 
 	// Handle VALUES clause

--- a/go/common/parser/testdata/postgres/sqljson.json
+++ b/go/common/parser/testdata/postgres/sqljson.json
@@ -662,8 +662,7 @@
   },
   {
     "comment": "sqljson - Statement 138",
-    "query": "SELECT JSON_ARRAY(WITH x AS (SELECT 1) VALUES (TRUE))",
-    "expected": "SELECT JSON_ARRAY(VALUES (TRUE))"
+    "query": "SELECT JSON_ARRAY(WITH x AS (SELECT 1) VALUES (TRUE))"
   },
   {
     "comment": "sqljson - Statement 139",

--- a/go/common/parser/testdata/postgres/union.json
+++ b/go/common/parser/testdata/postgres/union.json
@@ -467,12 +467,12 @@
   {
     "comment": "union - Statement 98",
     "query": "with cte as materialized (select s from generate_series(1,5) s) select from cte union select from cte",
-    "expected": "SELECT FROM cte UNION SELECT FROM cte"
+    "expected": "WITH cte AS MATERIALIZED (SELECT s FROM generate_series(1, 5) AS s) SELECT FROM cte UNION SELECT FROM cte"
   },
   {
     "comment": "union - Statement 99",
     "query": "with cte as not materialized (select s from generate_series(1,5) s) select from cte union select from cte",
-    "expected": "SELECT FROM cte UNION SELECT FROM cte"
+    "expected": "WITH cte AS NOT MATERIALIZED (SELECT s FROM generate_series(1, 5) AS s) SELECT FROM cte UNION SELECT FROM cte"
   },
   {
     "comment": "union - Statement 100",

--- a/go/common/parser/testdata/postgres/with.json
+++ b/go/common/parser/testdata/postgres/with.json
@@ -7,7 +7,7 @@
   {
     "comment": "with - Statement 2",
     "query": "SELECT count(*) FROM ( WITH q1(x) AS (SELECT random() FROM generate_series(1, 5)) SELECT * FROM q1 UNION SELECT * FROM q1 ) ss",
-    "expected": "SELECT COUNT(*) FROM (SELECT * FROM q1 UNION SELECT * FROM q1) AS ss"
+    "expected": "SELECT COUNT(*) FROM (WITH q1(x) AS (SELECT random() FROM generate_series(1, 5)) SELECT * FROM q1 UNION SELECT * FROM q1) AS ss"
   },
   {
     "comment": "with - Statement 3",
@@ -74,7 +74,7 @@
   {
     "comment": "with - Statement 16",
     "query": "WITH RECURSIVE outermost(x) AS ( SELECT 1 UNION (WITH innermost1 AS ( SELECT 2 UNION (WITH innermost2 AS ( SELECT 3 UNION (WITH innermost3 AS ( SELECT 4 UNION (WITH innermost4 AS ( SELECT 5 UNION (WITH innermost5 AS ( SELECT 6 UNION (WITH innermost6 AS (SELECT 7) SELECT * FROM innermost6)) SELECT * FROM innermost5)) SELECT * FROM innermost4)) SELECT * FROM innermost3)) SELECT * FROM innermost2)) SELECT * FROM outermost UNION SELECT * FROM innermost1) ) SELECT * FROM outermost ORDER BY 1",
-    "expected": "WITH RECURSIVE outermost(x) AS (SELECT 1 UNION (SELECT * FROM outermost UNION SELECT * FROM innermost1)) SELECT * FROM outermost ORDER BY 1"
+    "expected": "WITH RECURSIVE outermost(x) AS (SELECT 1 UNION (WITH innermost1 AS (SELECT 2 UNION (WITH innermost2 AS (SELECT 3 UNION (WITH innermost3 AS (SELECT 4 UNION (WITH innermost4 AS (SELECT 5 UNION (WITH innermost5 AS (SELECT 6 UNION (WITH innermost6 AS (SELECT 7) SELECT * FROM innermost6)) SELECT * FROM innermost5)) SELECT * FROM innermost4)) SELECT * FROM innermost3)) SELECT * FROM innermost2)) SELECT * FROM outermost UNION SELECT * FROM innermost1)) SELECT * FROM outermost ORDER BY 1"
   },
   {
     "comment": "with - Statement 17",
@@ -584,12 +584,12 @@
   {
     "comment": "with - Statement 121",
     "query": "WITH RECURSIVE x(n) AS ( WITH x1 AS (SELECT 1 AS n) SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x",
-    "expected": "WITH RECURSIVE x(n) AS (SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x"
+    "expected": "WITH RECURSIVE x(n) AS (WITH x1 AS (SELECT 1 AS n) SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x"
   },
   {
     "comment": "with - Statement 122",
     "query": "WITH RECURSIVE x(n) AS ( WITH x1 AS (SELECT 1 FROM x) SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x",
-    "expected": "WITH RECURSIVE x(n) AS (SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x"
+    "expected": "WITH RECURSIVE x(n) AS (WITH x1 AS (SELECT 1 FROM x) SELECT 0 UNION SELECT * FROM x1) SELECT * FROM x"
   },
   {
     "comment": "with - Statement 123",
@@ -724,27 +724,27 @@
   {
     "comment": "with - Statement 149",
     "query": "WITH RECURSIVE t(j) AS ( WITH RECURSIVE s(i) AS ( VALUES (1) UNION ALL SELECT i+1 FROM s WHERE i \u003c 10 ) SELECT i FROM s UNION ALL SELECT j+1 FROM t WHERE j \u003c 10 ) SELECT * FROM t",
-    "expected": "WITH RECURSIVE t(j) AS (SELECT i FROM s UNION ALL (SELECT j + 1 FROM t WHERE j \u003c 10)) SELECT * FROM t"
+    "expected": "WITH RECURSIVE t(j) AS (WITH RECURSIVE s(i) AS (VALUES (1) UNION ALL (SELECT i + 1 FROM s WHERE i \u003c 10)) SELECT i FROM s UNION ALL (SELECT j + 1 FROM t WHERE j \u003c 10)) SELECT * FROM t"
   },
   {
     "comment": "with - Statement 150",
     "query": "WITH outermost(x) AS ( SELECT 1 UNION (WITH innermost as (SELECT 2) SELECT * FROM innermost UNION SELECT 3) ) SELECT * FROM outermost ORDER BY 1",
-    "expected": "WITH outermost(x) AS (SELECT 1 UNION (SELECT * FROM innermost UNION SELECT 3)) SELECT * FROM outermost ORDER BY 1"
+    "expected": "WITH outermost(x) AS (SELECT 1 UNION (WITH innermost AS (SELECT 2) SELECT * FROM innermost UNION SELECT 3)) SELECT * FROM outermost ORDER BY 1"
   },
   {
     "comment": "with - Statement 151",
     "query": "WITH outermost(x) AS ( SELECT 1 UNION (WITH innermost as (SELECT 2) SELECT * FROM outermost UNION SELECT * FROM innermost) ) SELECT * FROM outermost ORDER BY 1",
-    "expected": "WITH outermost(x) AS (SELECT 1 UNION (SELECT * FROM outermost UNION SELECT * FROM innermost)) SELECT * FROM outermost ORDER BY 1"
+    "expected": "WITH outermost(x) AS (SELECT 1 UNION (WITH innermost AS (SELECT 2) SELECT * FROM outermost UNION SELECT * FROM innermost)) SELECT * FROM outermost ORDER BY 1"
   },
   {
     "comment": "with - Statement 152",
     "query": "WITH RECURSIVE outermost(x) AS ( SELECT 1 UNION (WITH innermost as (SELECT 2) SELECT * FROM outermost UNION SELECT * FROM innermost) ) SELECT * FROM outermost ORDER BY 1",
-    "expected": "WITH RECURSIVE outermost(x) AS (SELECT 1 UNION (SELECT * FROM outermost UNION SELECT * FROM innermost)) SELECT * FROM outermost ORDER BY 1"
+    "expected": "WITH RECURSIVE outermost(x) AS (SELECT 1 UNION (WITH innermost AS (SELECT 2) SELECT * FROM outermost UNION SELECT * FROM innermost)) SELECT * FROM outermost ORDER BY 1"
   },
   {
     "comment": "with - Statement 153",
     "query": "WITH RECURSIVE outermost(x) AS ( WITH innermost as (SELECT 2 FROM outermost) SELECT * FROM innermost UNION SELECT * from outermost ) SELECT * FROM outermost ORDER BY 1",
-    "expected": "WITH RECURSIVE outermost(x) AS (SELECT * FROM innermost UNION SELECT * FROM outermost) SELECT * FROM outermost ORDER BY 1"
+    "expected": "WITH RECURSIVE outermost(x) AS (WITH innermost AS (SELECT 2 FROM outermost) SELECT * FROM innermost UNION SELECT * FROM outermost) SELECT * FROM outermost ORDER BY 1"
   },
   {
     "comment": "with - Statement 154",
@@ -754,12 +754,12 @@
   {
     "comment": "with - Statement 155",
     "query": "WITH RECURSIVE tab(id_key,link) AS (VALUES (1,17), (2,17), (3,17), (4,17), (6,17), (5,17)), iter (id_key, row_type, link) AS ( SELECT 0, 'base', 17 UNION ALL ( WITH remaining(id_key, row_type, link, min) AS ( SELECT tab.id_key, 'true'::text, iter.link, MIN(tab.id_key) OVER () FROM tab INNER JOIN iter USING (link) WHERE tab.id_key \u003e iter.id_key ), first_remaining AS ( SELECT id_key, row_type, link FROM remaining WHERE id_key=min ), effect AS ( SELECT tab.id_key, 'new'::text, tab.link FROM first_remaining e INNER JOIN tab ON e.id_key=tab.id_key WHERE e.row_type = 'false' ) SELECT * FROM first_remaining UNION ALL SELECT * FROM effect ) ) SELECT * FROM iter",
-    "expected": "WITH RECURSIVE tab(id_key, link) AS (VALUES (1, 17), (2, 17), (3, 17), (4, 17), (6, 17), (5, 17)), iter(id_key, row_type, link) AS (SELECT 0, 'base', 17 UNION ALL (SELECT * FROM first_remaining UNION ALL SELECT * FROM effect)) SELECT * FROM iter"
+    "expected": "WITH RECURSIVE tab(id_key, link) AS (VALUES (1, 17), (2, 17), (3, 17), (4, 17), (6, 17), (5, 17)), iter(id_key, row_type, link) AS (SELECT 0, 'base', 17 UNION ALL (WITH remaining(id_key, row_type, link, min) AS (SELECT tab.id_key, CAST('true' AS TEXT), iter.link, MIN(tab.id_key) OVER () FROM tab INNER JOIN iter USING (link) WHERE tab.id_key \u003e iter.id_key), first_remaining AS (SELECT id_key, row_type, link FROM remaining WHERE id_key = min), effect AS (SELECT tab.id_key, CAST('new' AS TEXT), tab.link FROM first_remaining AS e INNER JOIN tab ON e.id_key = tab.id_key WHERE e.row_type = 'false') SELECT * FROM first_remaining UNION ALL SELECT * FROM effect)) SELECT * FROM iter"
   },
   {
     "comment": "with - Statement 156",
     "query": "WITH RECURSIVE tab(id_key,link) AS (VALUES (1,17), (2,17), (3,17), (4,17), (6,17), (5,17)), iter (id_key, row_type, link) AS ( SELECT 0, 'base', 17 UNION ( WITH remaining(id_key, row_type, link, min) AS ( SELECT tab.id_key, 'true'::text, iter.link, MIN(tab.id_key) OVER () FROM tab INNER JOIN iter USING (link) WHERE tab.id_key \u003e iter.id_key ), first_remaining AS ( SELECT id_key, row_type, link FROM remaining WHERE id_key=min ), effect AS ( SELECT tab.id_key, 'new'::text, tab.link FROM first_remaining e INNER JOIN tab ON e.id_key=tab.id_key WHERE e.row_type = 'false' ) SELECT * FROM first_remaining UNION ALL SELECT * FROM effect ) ) SELECT * FROM iter",
-    "expected": "WITH RECURSIVE tab(id_key, link) AS (VALUES (1, 17), (2, 17), (3, 17), (4, 17), (6, 17), (5, 17)), iter(id_key, row_type, link) AS (SELECT 0, 'base', 17 UNION (SELECT * FROM first_remaining UNION ALL SELECT * FROM effect)) SELECT * FROM iter"
+    "expected": "WITH RECURSIVE tab(id_key, link) AS (VALUES (1, 17), (2, 17), (3, 17), (4, 17), (6, 17), (5, 17)), iter(id_key, row_type, link) AS (SELECT 0, 'base', 17 UNION (WITH remaining(id_key, row_type, link, min) AS (SELECT tab.id_key, CAST('true' AS TEXT), iter.link, MIN(tab.id_key) OVER () FROM tab INNER JOIN iter USING (link) WHERE tab.id_key \u003e iter.id_key), first_remaining AS (SELECT id_key, row_type, link FROM remaining WHERE id_key = min), effect AS (SELECT tab.id_key, CAST('new' AS TEXT), tab.link FROM first_remaining AS e INNER JOIN tab ON e.id_key = tab.id_key WHERE e.row_type = 'false') SELECT * FROM first_remaining UNION ALL SELECT * FROM effect)) SELECT * FROM iter"
   },
   {
     "comment": "with - Statement 157",
@@ -779,7 +779,7 @@
   {
     "comment": "with - Statement 160",
     "query": "WITH RECURSIVE t AS ( INSERT INTO y SELECT a+5 FROM t2 WHERE a \u003e 5 RETURNING * ), t2 AS ( UPDATE y SET a=a-11 RETURNING * ) SELECT * FROM t UNION ALL SELECT * FROM t2",
-    "expected": "SELECT * FROM t UNION ALL SELECT * FROM t2"
+    "expected": "WITH RECURSIVE t AS (INSERT INTO y (SELECT a + 5 FROM t2 WHERE a \u003e 5) RETURNING *), t2 AS (UPDATE y SET a = a - 11 RETURNING *) SELECT * FROM t UNION ALL SELECT * FROM t2"
   },
   {
     "comment": "with - Statement 161",

--- a/go/common/parser/testdata/postgres/with.json
+++ b/go/common/parser/testdata/postgres/with.json
@@ -704,7 +704,7 @@
   {
     "comment": "with - Statement 145",
     "query": "with cte(foo) as ( values(42) ) values((select foo from cte))",
-    "expected": "VALUES ((SELECT foo FROM cte))"
+    "expected": "WITH cte(foo) AS (VALUES (42)) VALUES ((SELECT foo FROM cte))"
   },
   {
     "comment": "with - Statement 146",
@@ -719,7 +719,7 @@
   {
     "comment": "with - Statement 148",
     "query": "select ( with cte(foo) as ( values(f1) ) values((select foo from cte)) ) from int4_tbl",
-    "expected": "SELECT (VALUES ((SELECT foo FROM cte))) FROM int4_tbl"
+    "expected": "SELECT (WITH cte(foo) AS (VALUES (f1)) VALUES ((SELECT foo FROM cte))) FROM int4_tbl"
   },
   {
     "comment": "with - Statement 149",
@@ -1142,7 +1142,7 @@
   {
     "comment": "with - Statement 236",
     "query": "WITH RECURSIVE t AS ( INSERT INTO y SELECT * FROM t ) VALUES(FALSE)",
-    "expected": "VALUES (FALSE)"
+    "expected": "WITH RECURSIVE t AS (INSERT INTO y SELECT * FROM t) VALUES (FALSE)"
   },
   {
     "comment": "with - Statement 237",
@@ -1167,7 +1167,7 @@
   {
     "comment": "with - Statement 241",
     "query": "WITH t AS ( INSERT INTO y VALUES(0) ) VALUES(FALSE)",
-    "expected": "VALUES (FALSE)"
+    "expected": "WITH t AS (INSERT INTO y VALUES (0)) VALUES (FALSE)"
   },
   {
     "comment": "with - Statement 242",

--- a/go/common/parser/testdata/postgres/xml.json
+++ b/go/common/parser/testdata/postgres/xml.json
@@ -1151,12 +1151,12 @@
   {
     "comment": "xml - Statement 243",
     "query": "WITH x AS (SELECT proname, proowner, procost::numeric, pronargs, array_to_string(proargnames,',') as proargnames, case when proargtypes \u003c\u003e '' then array_to_string(proargtypes::oid[],',') end as proargtypes FROM pg_proc WHERE proname = 'f_leak'), y AS (SELECT xmlelement(name proc, xmlforest(proname, proowner, procost, pronargs, proargnames, proargtypes)) as proc FROM x), z AS (SELECT xmltable.* FROM y, LATERAL xmltable('/proc' PASSING proc COLUMNS proname name, proowner oid, procost float, pronargs int, proargnames text, proargtypes text)) SELECT * FROM z EXCEPT SELECT * FROM x",
-    "expected": "SELECT * FROM z EXCEPT SELECT * FROM x"
+    "expected": "WITH x AS (SELECT proname, proowner, CAST(procost AS NUMERIC), pronargs, array_to_string(proargnames, ',') AS proargnames, CASE WHEN proargtypes \u003c\u003e '' THEN array_to_string(CAST(proargtypes AS oid[]), ',') END AS proargtypes FROM pg_proc WHERE proname = 'f_leak'), y AS (SELECT XMLELEMENT(NAME proc, XMLFOREST(proname, proowner, procost, pronargs, proargnames, proargtypes)) AS proc FROM x), z AS (SELECT xmltable.* FROM y, LATERAL XMLTABLE('/proc' PASSING proc COLUMNS proname name, proowner oid, procost FLOAT8, pronargs INT, proargnames TEXT, proargtypes TEXT)) SELECT * FROM z EXCEPT SELECT * FROM x"
   },
   {
     "comment": "xml - Statement 244",
     "query": "WITH x AS (SELECT proname, proowner, procost::numeric, pronargs, array_to_string(proargnames,',') as proargnames, case when proargtypes \u003c\u003e '' then array_to_string(proargtypes::oid[],',') end as proargtypes FROM pg_proc), y AS (SELECT xmlelement(name data, xmlagg(xmlelement(name proc, xmlforest(proname, proowner, procost, pronargs, proargnames, proargtypes)))) as doc FROM x), z AS (SELECT xmltable.* FROM y, LATERAL xmltable('/data/proc' PASSING doc COLUMNS proname name, proowner oid, procost float, pronargs int, proargnames text, proargtypes text)) SELECT * FROM z EXCEPT SELECT * FROM x",
-    "expected": "SELECT * FROM z EXCEPT SELECT * FROM x"
+    "expected": "WITH x AS (SELECT proname, proowner, CAST(procost AS NUMERIC), pronargs, array_to_string(proargnames, ',') AS proargnames, CASE WHEN proargtypes \u003c\u003e '' THEN array_to_string(CAST(proargtypes AS oid[]), ',') END AS proargtypes FROM pg_proc), y AS (SELECT XMLELEMENT(NAME data, xmlagg(XMLELEMENT(NAME proc, XMLFOREST(proname, proowner, procost, pronargs, proargnames, proargtypes)))) AS doc FROM x), z AS (SELECT xmltable.* FROM y, LATERAL XMLTABLE('/data/proc' PASSING doc COLUMNS proname name, proowner oid, procost FLOAT8, pronargs INT, proargnames TEXT, proargtypes TEXT)) SELECT * FROM z EXCEPT SELECT * FROM x"
   },
   {
     "comment": "xml - Statement 245",

--- a/go/common/parser/testdata/select_cases.json
+++ b/go/common/parser/testdata/select_cases.json
@@ -2364,5 +2364,9 @@
   {
     "comment": "Multiple CTEs with UNION at top level (MUL-391)",
     "query": "WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS x) SELECT x FROM a UNION SELECT x FROM b"
+  },
+  {
+    "comment": "WITH CTE referenced from VALUES at top level (MUL-391)",
+    "query": "WITH cte(foo) AS (VALUES (42)) VALUES ((SELECT foo FROM cte))"
   }
 ]

--- a/go/common/parser/testdata/select_cases.json
+++ b/go/common/parser/testdata/select_cases.json
@@ -2340,5 +2340,29 @@
     "comment": "CASE ELSE with interval typecast - verifies :: binds tighter than +",
     "query": "SELECT CASE WHEN x = 1 THEN y ELSE (z + '01:00:00'::interval) END FROM t",
     "expected": "SELECT CASE WHEN x = 1 THEN y ELSE (z + CAST('01:00:00' AS INTERVAL)) END FROM t"
+  },
+  {
+    "comment": "WITH CTE referenced from both branches of UNION (MUL-391)",
+    "query": "WITH cte AS (SELECT 1 AS x) SELECT x FROM cte UNION SELECT x FROM cte"
+  },
+  {
+    "comment": "WITH CTE referenced from both branches of UNION ALL (MUL-391)",
+    "query": "WITH cte AS (SELECT 1 AS x) SELECT x FROM cte UNION ALL SELECT x FROM cte"
+  },
+  {
+    "comment": "WITH CTE referenced from both branches of INTERSECT (MUL-391)",
+    "query": "WITH cte AS (SELECT 1 AS x) SELECT x FROM cte INTERSECT SELECT x FROM cte"
+  },
+  {
+    "comment": "WITH CTE referenced from both branches of EXCEPT (MUL-391)",
+    "query": "WITH cte AS (SELECT 1 AS x) SELECT x FROM cte EXCEPT SELECT x FROM cte"
+  },
+  {
+    "comment": "WITH MATERIALIZED CTE with UNION at top level (MUL-391)",
+    "query": "WITH cte AS MATERIALIZED (SELECT 1 AS x) SELECT x FROM cte UNION SELECT x FROM cte"
+  },
+  {
+    "comment": "Multiple CTEs with UNION at top level (MUL-391)",
+    "query": "WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS x) SELECT x FROM a UNION SELECT x FROM b"
   }
 ]


### PR DESCRIPTION
## Summary

- `SelectStmt.SqlString` returned early on the set-operation branch without emitting `s.WithClause`, silently dropping the outer CTE on round-trip.
- Multigateway's normalizer and `ReconstructSQL` both go through `SqlString`, so cacheable `WITH cte AS (...) SELECT FROM cte UNION SELECT FROM cte` reached PostgreSQL as `SELECT FROM cte UNION SELECT FROM cte` and errored `relation "cte" does not exist`.
- Fix: prepend `s.WithClause.SqlString()` before the SetOp branch's return, mirroring the non-SetOp path. Updates parser testdata expectations recorded against the prior buggy output (most severe: `with.json` Statement 160 was losing entire `INSERT/UPDATE` CTE bodies).

Fixes [MUL-391](https://linear.app/supabase/issue/MUL-391).

## Test plan

- [x] `go test -short ./go/common/parser/...` — parser round-trip green
- [x] `go test -short ./go/services/multigateway/...` — planner/executor green
- [x] `RUN_PGREGRESS=1` full suite — `subselect` now passes; `union.out` and `with.out` no longer have CTE-on-UNION drops (remaining diffs are unrelated: `FOR NO KEY UPDATE` handling and error caret positioning)