### PR TITLE
feat(telemetry): expose shared Prometheus metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pganalyze/pg_query_go/v6 v6.2.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
@@ -43,6 +44,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0
 	go.opentelemetry.io/contrib/samplers/probability/consistent v0.33.0
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.61.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
@@ -111,7 +113,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
@@ -136,7 +137,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
-	go.opentelemetry.io/otel/exporters/prometheus v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.15.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.39.0 // indirect

--- a/go/common/servenv/pages.go
+++ b/go/common/servenv/pages.go
@@ -72,5 +72,7 @@ func (sv *ServEnv) RegisterCommonHTTPEndpoints() {
 		_ = web.Templates.ExecuteTemplate(w, "isok.html", true)
 	})
 
+	sv.HTTPHandle("/metrics", sv.telemetry.PrometheusHandler())
+
 	sv.HTTPHandleFunc("/config", viperdebug.HandlerFunc(sv.reg))
 }

--- a/go/common/servenv/telemetry_test.go
+++ b/go/common/servenv/telemetry_test.go
@@ -17,8 +17,10 @@ package servenv
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -267,6 +269,31 @@ func TestServEnvTelemetryIntegration(t *testing.T) {
 		// Verify specific HTTP client and server metrics
 		assert.True(t, metricNames["http.client.request.duration"], "should have http.client.request.duration metric")
 		assert.True(t, metricNames["http.server.request.duration"], "should have http.server.request.duration metric")
+	})
+
+	t.Run("Prometheus_MetricsEndpoint", func(t *testing.T) {
+		ctx := context.Background()
+
+		meter := otel.Meter("servenv-prometheus-test")
+		counter, err := meter.Int64Counter("multigres.test.prometheus.requests")
+		require.NoError(t, err)
+		counter.Add(ctx, 7)
+
+		resp, err := http.Get(httpURL + "/metrics")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		metrics := string(body)
+
+		require.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
+		require.Contains(t, metrics, "go_goroutines")
+		require.Contains(t, metrics, "process_cpu_seconds_total")
+		require.Contains(t, metrics, "target_info")
+		require.Contains(t, metrics, "multigres_test_prometheus_requests_total")
+		require.True(t, strings.Contains(metrics, " 7\n") || strings.Contains(metrics, " 7.0\n"), "scrape should include recorded counter value:\n%s", metrics)
 	})
 
 	t.Run("GRPC_TracePropagation", func(t *testing.T) {

--- a/go/tools/telemetry/telemetry.go
+++ b/go/tools/telemetry/telemetry.go
@@ -52,6 +52,9 @@ import (
 	"os"
 	"sync"
 
+	promclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
@@ -59,6 +62,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -87,6 +91,7 @@ type Telemetry struct {
 	tracerProvider *sdktrace.TracerProvider
 	meterProvider  *sdkmetric.MeterProvider
 	loggerProvider *sdklog.LoggerProvider
+	promRegistry   *promclient.Registry
 	initialized    bool
 
 	// Test overrides (only used in tests)
@@ -230,7 +235,7 @@ func (t *Telemetry) initTracing(ctx context.Context, res *resource.Resource) err
 	return nil
 }
 
-// initMetrics initializes the MeterProvider with dual exporters (autoexport + Prometheus)
+// initMetrics initializes the MeterProvider with dual exporters (autoexport + Prometheus).
 func (t *Telemetry) initMetrics(ctx context.Context, res *resource.Resource) error {
 	var metricReader sdkmetric.Reader
 	var err error
@@ -251,10 +256,23 @@ func (t *Telemetry) initMetrics(ctx context.Context, res *resource.Resource) err
 		}
 	}
 
+	t.promRegistry = promclient.NewRegistry()
+	if err := t.promRegistry.Register(collectors.NewGoCollector()); err != nil {
+		return fmt.Errorf("failed to register prometheus Go collector: %w", err)
+	}
+	if err := t.promRegistry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
+		return fmt.Errorf("failed to register prometheus process collector: %w", err)
+	}
+
+	promExporter, err := otelprometheus.New(otelprometheus.WithRegisterer(t.promRegistry))
+	if err != nil {
+		return fmt.Errorf("failed to create prometheus exporter: %w", err)
+	}
+
 	t.meterProvider = sdkmetric.NewMeterProvider(
-		// TODO(dweitzman): Add an additional prometheus exporter that's always at /metrics for debugging
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(metricReader), // Configured via env vars or test reader
+		sdkmetric.WithReader(promExporter),
 	)
 
 	// Set global meter provider
@@ -305,6 +323,21 @@ func (t *Telemetry) initLogs(ctx context.Context, res *resource.Resource) error 
 	)
 
 	return nil
+}
+
+// PrometheusHandler returns an HTTP handler that exposes the current MeterProvider
+// through Prometheus' text exposition format.
+func (t *Telemetry) PrometheusHandler() http.Handler {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.promRegistry == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "OpenTelemetry metrics are not initialized", http.StatusServiceUnavailable)
+		})
+	}
+
+	return promhttp.HandlerFor(t.promRegistry, promhttp.HandlerOpts{})
 }
 
 // WithEnvTraceparent parses the TRACEPARENT env variable and returns a context within that


### PR DESCRIPTION
## Description

this PR adds shared Prometheus-compatible `/metrics` exposure for Multigres Go services through the common servenv runtime layer. Services that initialise through servenv, including multipooler, multigateway, multiorch, and pgctld, now expose the same scrape endpoint without each service needing its own metrics handler, so the operator can use it to scrape service, runtime, and process metrics for dashboards and alerts.

This is not a replacement for the existing OTel autoexport/OTLP configuration.

## Main Changes

- Add `/metrics` to the common servenv HTTP endpoints so multipooler, multigateway, multiorch, and pgctld inherit the same scrape path.
- Add an OTel Prometheus exporter as an additional metric reader, preserving the existing autoexport/OTLP metric path.
- Register Go runtime and process collectors in a service-local Prometheus registry so scrapes include go_*, process_*, and OTel service metrics.

## Testing
Adds coverage in the servenv telemetry integration test to exercise the full scrape path. The test records a counter through OpenTelemetry, scrapes /metrics, and verifies that the recorded metric appears in Prometheus output.

The test also verifies that the shared endpoint includes Go runtime and process collector metrics, proving the scrape output contains both Multigres service metrics and baseline process health metrics.