### PR TITLE
feat(telemetry): support env resource attributes

### DIFF
--- a/go/tools/telemetry/telemetry.go
+++ b/go/tools/telemetry/telemetry.go
@@ -128,13 +128,20 @@ func (t *Telemetry) InitTelemetry(ctx context.Context, serviceName string, attrs
 		serviceName = envServiceName
 	}
 
-	// Create resource with service name and any additional attributes
-	// Note: We don't merge with resource.Default() to avoid schema version conflicts
+	// Create resource with service name, environment-provided attributes, and any
+	// additional Multigres service identity attributes. We don't merge with
+	// resource.Default() to avoid schema version conflicts.
 	resourceAttrs := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),
 	}
 	resourceAttrs = append(resourceAttrs, attrs...)
-	res := resource.NewWithAttributes(semconv.SchemaURL, resourceAttrs...)
+	res, err := resource.Merge(
+		resource.EnvironmentWithContext(ctx),
+		resource.NewWithAttributes(semconv.SchemaURL, resourceAttrs...),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create telemetry resource: %w", err)
+	}
 
 	if err := t.initTracing(ctx, res); err != nil {
 		return fmt.Errorf("failed to initialize tracing: %w", err)

--- a/go/tools/telemetry/telemetry_test.go
+++ b/go/tools/telemetry/telemetry_test.go
@@ -454,6 +454,76 @@ func TestMetrics_WithResourceAttributes(t *testing.T) {
 	assert.Equal(t, "metrics-zone-b", val.AsString())
 }
 
+func TestMetrics_WithEnvResourceAttributes(t *testing.T) {
+	t.Setenv(
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"service.name=env-resource-service,multigres.project=project-ref-123,multigres.cluster=cluster-a,multigres.component=multipooler",
+	)
+
+	setup := SetupTestTelemetry(t)
+	ctx := context.Background()
+
+	err := setup.Telemetry.InitTelemetry(ctx, "test-metrics-service",
+		semconv.ServiceInstanceID("metrics-instance-789"),
+		semconv.CloudAvailabilityZone("metrics-zone-c"),
+		attribute.String("multigres.shard", "0-inf"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, setup.Telemetry.ShutdownTelemetry(ctx))
+	})
+
+	meter := otel.Meter("test-meter")
+	counter, err := meter.Int64Counter("test_counter")
+	require.NoError(t, err)
+
+	counter.Add(ctx, 1)
+
+	require.NoError(t, setup.ForceFlush(ctx))
+
+	var rm metricdata.ResourceMetrics
+	err = setup.MetricReader.Collect(ctx, &rm)
+	require.NoError(t, err)
+
+	attrs := rm.Resource.Attributes()
+	findAttr := func(key attribute.Key) (attribute.Value, bool) {
+		for _, attr := range attrs {
+			if attr.Key == key {
+				return attr.Value, true
+			}
+		}
+		return attribute.Value{}, false
+	}
+
+	val, found := findAttr(semconv.ServiceNameKey)
+	require.True(t, found, "service.name should be present on metrics")
+	assert.Equal(t, "test-metrics-service", val.AsString())
+
+	val, found = findAttr(semconv.ServiceInstanceIDKey)
+	require.True(t, found, "service.instance.id should be present on metrics")
+	assert.Equal(t, "metrics-instance-789", val.AsString())
+
+	val, found = findAttr(semconv.CloudAvailabilityZoneKey)
+	require.True(t, found, "cloud.availability_zone should be present on metrics")
+	assert.Equal(t, "metrics-zone-c", val.AsString())
+
+	val, found = findAttr("multigres.shard")
+	require.True(t, found, "multigres.shard should be present on metrics")
+	assert.Equal(t, "0-inf", val.AsString())
+
+	val, found = findAttr("multigres.project")
+	require.True(t, found, "multigres.project should be present on metrics")
+	assert.Equal(t, "project-ref-123", val.AsString())
+
+	val, found = findAttr("multigres.cluster")
+	require.True(t, found, "multigres.cluster should be present on metrics")
+	assert.Equal(t, "cluster-a", val.AsString())
+
+	val, found = findAttr("multigres.component")
+	require.True(t, found, "multigres.component should be present on metrics")
+	assert.Equal(t, "multipooler", val.AsString())
+}
+
 func TestWrapSlogHandler_CompositeHandler(t *testing.T) {
 	setup := SetupTestTelemetry(t)
 	ctx := t.Context()


### PR DESCRIPTION
## Description

this pr makes Multigres honour standard OTel resource attributes from `OTEL_RESOURCE_ATTRIBUTES`. Previously, Multigres built its OTel resource manually, so env-provided resource metadata was not attached to exported metrics.

## Main Changes

- Merge `OTEL_RESOURCE_ATTRIBUTES` into the telemetry resource during init.
- Preserve existing service identity attributes added by `servenv`.
- Add test coverage proving env-provided resource attributes appear on exported metrics.
