### PR TITLE
feat(multipooler): stamp multigres_vpid on PG backend application_name

### DIFF
--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -996,8 +996,15 @@ type ReservedState struct {
 	// reservation_reasons is a bitmask of ReservationReason values indicating why the connection
 	// is still reserved. Zero means the connection was released.
 	ReservationReasons uint32 `protobuf:"varint,3,opt,name=reservation_reasons,json=reservationReasons,proto3" json:"reservation_reasons,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// backend_process_id is the real PostgreSQL backend process ID for this
+	// reserved connection — the PID visible in pg_stat_activity / pg_locks.
+	// Used to bridge the gap between multigateway's virtual PIDs and
+	// PostgreSQL's real PIDs so lock-detection functions like
+	// pg_isolation_test_session_is_blocked() can map vpid → real pid through
+	// the proxy.
+	BackendProcessId uint32 `protobuf:"varint,4,opt,name=backend_process_id,json=backendProcessId,proto3" json:"backend_process_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ReservedState) Reset() {
@@ -1051,6 +1058,13 @@ func (x *ReservedState) GetReservationReasons() uint32 {
 	return 0
 }
 
+func (x *ReservedState) GetBackendProcessId() uint32 {
+	if x != nil {
+		return x.BackendProcessId
+	}
+	return 0
+}
+
 // ExecuteOptions contains execution options for query execution.
 // This includes session state like prepared statements and portals that
 // need to be available on the connection where the query is executed.
@@ -1089,9 +1103,15 @@ type ExecuteOptions struct {
 	// authenticate to the backing PostgreSQL as the session's real user
 	// instead of relying on trust on the local connection. Unset for
 	// sessions that did not authenticate via SCRAM.
-	UserAuth      *UserAuth `protobuf:"bytes,7,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	UserAuth *UserAuth `protobuf:"bytes,7,opt,name=user_auth,json=userAuth,proto3" json:"user_auth,omitempty"`
+	// client_connection_id is the multigateway's virtual PID for this client
+	// connection. The multipooler stamps it onto the underlying PostgreSQL
+	// backend's application_name as `multigres_vpid:<id>` so lock-detection
+	// functions can map virtual PIDs (visible to clients) back to real
+	// backend PIDs via pg_stat_activity.
+	ClientConnectionId uint32 `protobuf:"varint,8,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1164,6 +1184,13 @@ func (x *ExecuteOptions) GetUserAuth() *UserAuth {
 		return x.UserAuth
 	}
 	return nil
+}
+
+func (x *ExecuteOptions) GetClientConnectionId() uint32 {
+	if x != nil {
+		return x.ClientConnectionId
+	}
+	return 0
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM
@@ -1380,18 +1407,20 @@ const file_query_proto_rawDesc = "" +
 	"\rparam_lengths\x18\x03 \x03(\x12R\fparamLengths\x12!\n" +
 	"\fparam_values\x18\x04 \x01(\fR\vparamValues\x12#\n" +
 	"\rparam_formats\x18\x05 \x03(\x05R\fparamFormats\x12%\n" +
-	"\x0eresult_formats\x18\x06 \x03(\x05R\rresultFormats\"\xa8\x01\n" +
+	"\x0eresult_formats\x18\x06 \x03(\x05R\rresultFormats\"\xd6\x01\n" +
 	"\rReservedState\x124\n" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
-	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\"\x87\x03\n" +
+	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\x12,\n" +
+	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xb9\x03\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
 	"\bmax_rows\x18\x04 \x01(\x04R\amaxRows\x124\n" +
 	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12G\n" +
 	"\x12prepared_statement\x18\x06 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x12,\n" +
-	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x1aB\n" +
+	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
+	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -178,10 +178,11 @@ func (sc *ScatterConn) StreamExecute(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
-		UserAuth:          userAuthFrom(conn),
-		User:              conn.User(),
-		SessionSettings:   state.GetSessionSettings(),
-		PreparedStatement: preparedStatement,
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		ClientConnectionId: conn.ConnectionID(),
+		SessionSettings:    state.GetSessionSettings(),
+		PreparedStatement:  preparedStatement,
 	}
 
 	ss := state.GetMatchingShardState(target)
@@ -330,10 +331,11 @@ func (sc *ScatterConn) PortalStreamExecute(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
-		UserAuth:        userAuthFrom(conn),
-		User:            conn.User(),
-		MaxRows:         uint64(maxRows),
-		SessionSettings: state.GetSessionSettings(),
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		ClientConnectionId: conn.ConnectionID(),
+		MaxRows:            uint64(maxRows),
+		SessionSettings:    state.GetSessionSettings(),
 	}
 
 	// When the protocol layer folded a Describe('P') into this Execute, ask
@@ -377,9 +379,10 @@ func (sc *ScatterConn) PortalStreamExecute(
 			"reasons", protoutil.ReasonsString(reasons))
 
 		noopEo := &querypb.ExecuteOptions{
-			UserAuth:        userAuthFrom(conn),
-			User:            conn.User(),
-			SessionSettings: state.GetSessionSettings(),
+			UserAuth:           userAuthFrom(conn),
+			User:               conn.User(),
+			ClientConnectionId: conn.ConnectionID(),
+			SessionSettings:    state.GetSessionSettings(),
 		}
 		reservationOpts := &querypb.ReservationOptions{Reasons: reasons}
 		if state.PendingBeginQuery != "" {
@@ -453,9 +456,10 @@ func (sc *ScatterConn) Describe(
 	target := sc.buildTarget(tableGroup, shard, state)
 
 	eo := &querypb.ExecuteOptions{
-		UserAuth:        userAuthFrom(conn),
-		User:            conn.User(),
-		SessionSettings: state.GetSessionSettings(),
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		ClientConnectionId: conn.ConnectionID(),
+		SessionSettings:    state.GetSessionSettings(),
 	}
 	var preparedStatement *querypb.PreparedStatement
 	var portal *querypb.Portal
@@ -561,6 +565,7 @@ func (sc *ScatterConn) ConcludeTransaction(
 		eo := &querypb.ExecuteOptions{
 			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
+			ClientConnectionId:   conn.ConnectionID(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 		}
@@ -666,6 +671,7 @@ func (sc *ScatterConn) DiscardTempTables(
 		eo := &querypb.ExecuteOptions{
 			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
+			ClientConnectionId:   conn.ConnectionID(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 		}
@@ -763,9 +769,10 @@ func (sc *ScatterConn) CopyInitiate(
 
 	// Create execute options
 	execOptions := &querypb.ExecuteOptions{
-		UserAuth:        userAuthFrom(conn),
-		User:            conn.User(),
-		SessionSettings: state.GetSessionSettings(),
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		ClientConnectionId: conn.ConnectionID(),
+		SessionSettings:    state.GetSessionSettings(),
 	}
 
 	// If there's already a reserved connection for this target (e.g., in a transaction),
@@ -838,6 +845,7 @@ func (sc *ScatterConn) CopySendData(
 	copyOptions := &querypb.ExecuteOptions{
 		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
+		ClientConnectionId:   conn.ConnectionID(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 	}
@@ -894,6 +902,7 @@ func (sc *ScatterConn) CopyFinalize(
 	copyOptions := &querypb.ExecuteOptions{
 		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
+		ClientConnectionId:   conn.ConnectionID(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 	}
@@ -958,6 +967,7 @@ func (sc *ScatterConn) CopyAbort(
 	copyOptions := &querypb.ExecuteOptions{
 		UserAuth:             userAuthFrom(conn),
 		User:                 conn.User(),
+		ClientConnectionId:   conn.ConnectionID(),
 		SessionSettings:      state.GetSessionSettings(),
 		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 	}
@@ -994,6 +1004,7 @@ func (sc *ScatterConn) ReleaseAllReservedConnections(
 		eo := &querypb.ExecuteOptions{
 			UserAuth:             userAuthFrom(conn),
 			User:                 conn.User(),
+			ClientConnectionId:   conn.ConnectionID(),
 			SessionSettings:      state.GetSessionSettings(),
 			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
 		}

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
@@ -47,6 +48,60 @@ type Executor struct {
 	poolerID           *clustermetadatapb.ID
 }
 
+// sessionSettingsForPool returns a copy of settings safe to apply to a pooled
+// (regular or reserved) PostgreSQL connection.
+//
+// It excludes application_name. The pool's connstate cache must never track a
+// client-supplied application_name: when SetApplicationName is later called
+// out-of-band on the same connection (to stamp `multigres_vpid:<id>` for
+// lock-detection mapping), connstate is unaware of the new value, and a
+// subsequent ApplySettings diff between connstate.current (still holding the
+// client's app_name) and the desired settings on the next query emits a
+// RESET application_name that wipes the stamp before the query runs.
+// Filtering here prevents that ABA on every code path that pushes
+// SessionSettings into the pool.
+func sessionSettingsForPool(settings map[string]string) map[string]string {
+	if settings == nil {
+		return nil
+	}
+	out := make(map[string]string, len(settings))
+	for k, v := range settings {
+		if strings.EqualFold(k, "application_name") {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// stampVpidOnReserved tags a reserved connection's PostgreSQL backend with
+// `multigres_vpid:<client_connection_id>` in application_name so
+// lock-detection functions (e.g. an override of
+// pg_isolation_test_session_is_blocked) can map a multigateway virtual PID
+// back to the real backend PID via pg_stat_activity. Best-effort: a SET
+// failure does not block the actual query — only lock detection through the
+// proxy depends on the tag.
+func stampVpidOnReserved(ctx context.Context, conn *reserved.Conn, options *query.ExecuteOptions) {
+	if options == nil || options.ClientConnectionId == 0 {
+		return
+	}
+	_ = conn.SetApplicationName(ctx, fmt.Sprintf("multigres_vpid:%d", options.ClientConnectionId))
+}
+
+// stampVpidOnRegular tags a pooled regular connection with the same
+// `multigres_vpid:<id>` marker. Pooled connections are shared across clients,
+// so the next checkout will overwrite this stamp; for the duration of the
+// current query the backend is correctly attributed to its client vpid.
+func stampVpidOnRegular(ctx context.Context, conn *regular.Conn, options *query.ExecuteOptions) {
+	if options == nil || options.ClientConnectionId == 0 {
+		return
+	}
+	_ = conn.SetApplicationName(ctx, fmt.Sprintf("multigres_vpid:%d", options.ClientConnectionId))
+}
+
 // NewExecutor creates a new Executor instance.
 func NewExecutor(logger *slog.Logger, poolManager connpoolmanager.PoolManager, poolerID *clustermetadatapb.ID) *Executor {
 	return &Executor{
@@ -70,6 +125,7 @@ func (e *Executor) buildReservedStateFromAPI(rc reservedConnAPI) *query.Reserved
 		ReservedConnectionId: uint64(rc.ConnID()),
 		PoolerId:             e.poolerID,
 		ReservationReasons:   rc.RemainingReasons(),
+		BackendProcessId:     rc.ProcessID(),
 	}
 }
 
@@ -98,11 +154,17 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 			return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 
+		// Re-stamp multigres_vpid:<id> on the backend so lock-detection
+		// functions can resolve vpid → real pid via pg_stat_activity. The
+		// SET runs out-of-band; sessionSettingsForPool ensures the pool's
+		// connstate cache never RESETs application_name on the next query.
+		stampVpidOnReserved(ctx, reservedConn, options)
+
 		// Apply settings if they changed (e.g., SET inside a transaction).
 		// Reserved connections bypass the pool's normal ApplySettings mechanism,
 		// so we must explicitly apply settings changes here.
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), options.SessionSettings); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return nil, e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -122,7 +184,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	// Get session settings from options
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get a connection from the pool for this user
@@ -132,6 +194,11 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 		return nil, nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
 	defer conn.Recycle()
+
+	// Stamp multigres_vpid on this pooled regular conn too — the next
+	// client to draw from the pool will overwrite it, but for the duration
+	// of the current query the backend is correctly tagged.
+	stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// Execute the query - the regular.Conn.QueryWithRetry returns []*sqltypes.Result
 	// with proper field info, rows, and command tags already populated.
@@ -196,12 +263,16 @@ func (e *Executor) StreamExecute(
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 
+		// Re-stamp multigres_vpid:<id> on the backend so lock-detection
+		// functions can resolve vpid → real pid via pg_stat_activity.
+		stampVpidOnReserved(ctx, reservedConn, options)
+
 		// Apply settings if they changed (e.g., SET inside a transaction).
 		// Reserved connections bypass the pool's normal ApplySettings mechanism,
 		// so we must explicitly apply settings changes here. This step depends
 		// on the underlying *regular.Conn so it stays out of the helper.
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), options.SessionSettings); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -229,7 +300,7 @@ func (e *Executor) StreamExecute(
 	// Case 3: Use regular pooled connection
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get a connection from the pool for this user
@@ -239,6 +310,9 @@ func (e *Executor) StreamExecute(
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
 	defer conn.Recycle()
+
+	// Stamp multigres_vpid on this pooled regular conn for lock-detection.
+	stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// When a PreparedStatement is provided we cannot use the retry-on-connection-error
 	// variant of QueryStreaming: reconnect wipes per-connection prepared-statement state
@@ -276,7 +350,7 @@ func (e *Executor) reserveAndStreamExecute(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get the reasons bitmask and determine if we need to execute BEGIN
@@ -312,6 +386,11 @@ func (e *Executor) reserveAndStreamExecute(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
+
+	// Stamp multigres_vpid on the freshly reserved backend so subsequent
+	// lock-detection probes can map vpid → real pid. Done before BEGIN so
+	// the value is in place for the entire transaction lifecycle.
+	stampVpidOnReserved(ctx, reservedConn, options)
 
 	// Apply all reservation reasons to the reserved connection.
 	// BeginWithQuery below adds ReasonTransaction internally, but non-transaction
@@ -447,7 +526,7 @@ func (e *Executor) PortalStreamExecute(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	maxRows := int32(0)
@@ -478,7 +557,7 @@ func (e *Executor) PortalStreamExecute(
 
 	// Use regular connection for non-suspended execution with no existing reservation
 	clientKey, serverKey := scramKeysFromOptions(options)
-	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, includeDescribe, clientKey, serverKey, paramFormats, resultFormats, callback)
+	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, includeDescribe, clientKey, serverKey, paramFormats, resultFormats, options, callback)
 }
 
 // portalExecuteWithReserved executes a portal using a reserved connection.
@@ -574,6 +653,7 @@ func (e *Executor) portalExecuteWithRegular(
 	includeDescribe bool,
 	clientKey, serverKey []byte,
 	paramFormats, resultFormats []int16,
+	options *query.ExecuteOptions,
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
@@ -581,6 +661,9 @@ func (e *Executor) portalExecuteWithRegular(
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
 	defer conn.Recycle()
+
+	// Stamp multigres_vpid on this pooled regular conn for lock-detection.
+	stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// Ensure the statement is prepared on this connection (with consolidation)
 	canonicalName, err := e.ensurePrepared(ctx, conn.Conn, preparedStatement)
@@ -625,7 +708,7 @@ func (e *Executor) Describe(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	e.logger.DebugContext(ctx, "describe",
@@ -645,7 +728,7 @@ func (e *Executor) Describe(
 		}
 
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), options.SessionSettings); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return nil, fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -773,7 +856,7 @@ func (e *Executor) CopyReady(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = options.SessionSettings
+		settings = sessionSettingsForPool(options.SessionSettings)
 	}
 
 	e.logger.DebugContext(ctx, "initiating COPY FROM STDIN",

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -154,12 +154,6 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 			return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 
-		// Re-stamp multigres_vpid:<id> on the backend so lock-detection
-		// functions can resolve vpid → real pid via pg_stat_activity. The
-		// SET runs out-of-band; sessionSettingsForPool ensures the pool's
-		// connstate cache never RESETs application_name on the next query.
-		stampVpidOnReserved(ctx, reservedConn, options)
-
 		// Apply settings if they changed (e.g., SET inside a transaction).
 		// Reserved connections bypass the pool's normal ApplySettings mechanism,
 		// so we must explicitly apply settings changes here.
@@ -168,6 +162,14 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 				return nil, e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
+
+		// Stamp multigres_vpid:<id> AFTER ApplySettingsToConn. When the
+		// filtered desired settings collapse to nil (e.g. the only client
+		// setting was application_name), ApplySettings issues RESET ALL on
+		// the reserved conn — which would wipe a stamp set earlier in this
+		// function. Restamping after the reset ensures the tag is in place
+		// for the actual query.
+		stampVpidOnReserved(ctx, reservedConn, options)
 
 		results, err := reservedConn.Query(ctx, sql)
 		if err != nil {
@@ -263,10 +265,6 @@ func (e *Executor) StreamExecute(
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
 
-		// Re-stamp multigres_vpid:<id> on the backend so lock-detection
-		// functions can resolve vpid → real pid via pg_stat_activity.
-		stampVpidOnReserved(ctx, reservedConn, options)
-
 		// Apply settings if they changed (e.g., SET inside a transaction).
 		// Reserved connections bypass the pool's normal ApplySettings mechanism,
 		// so we must explicitly apply settings changes here. This step depends
@@ -276,6 +274,11 @@ func (e *Executor) StreamExecute(
 				return e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
+
+		// Stamp multigres_vpid:<id> AFTER ApplySettingsToConn so a RESET
+		// ALL emitted by the empty-desired-settings path doesn't wipe it
+		// (see the matching ordering in ExecuteQuery).
+		stampVpidOnReserved(ctx, reservedConn, options)
 
 		// If the query references a gateway-managed prepared statement
 		// (wrapped EXECUTE forms), ensure it is parsed on this backend
@@ -599,6 +602,12 @@ func (e *Executor) portalExecuteWithReserved(
 			return nil, fmt.Errorf("failed to create reserved connection for user %s: %w", user, err)
 		}
 	}
+
+	// Stamp multigres_vpid:<id> on the (possibly fresh, possibly resumed)
+	// reserved conn. Done unconditionally — both branches above can return
+	// a backend without the tag (a freshly created reservation, or an
+	// existing one whose tag was wiped by a prior ApplySettings RESET ALL).
+	stampVpidOnReserved(ctx, reservedConn, options)
 
 	// Ensure the statement is prepared on this connection (with consolidation).
 	// For the new-conn branch this is a no-op because the validate hook above

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -46,21 +46,34 @@ type Executor struct {
 	poolManager        connpoolmanager.PoolManager
 	poolerConsolidator *preparedstatement.PoolerConsolidator
 	poolerID           *clustermetadatapb.ID
+
+	// vpidStampEnabled toggles the multigres_vpid:<id> stamping on PostgreSQL
+	// backends and the matching application_name filter in
+	// sessionSettingsForPool. Both must move together: stamping without
+	// filtering lets ApplySettings wipe the stamp via RESET application_name;
+	// filtering without stamping silently swallows client-set application_name.
+	vpidStampEnabled bool
 }
 
 // sessionSettingsForPool returns a copy of settings safe to apply to a pooled
 // (regular or reserved) PostgreSQL connection.
 //
-// It excludes application_name. The pool's connstate cache must never track a
-// client-supplied application_name: when SetApplicationName is later called
-// out-of-band on the same connection (to stamp `multigres_vpid:<id>` for
-// lock-detection mapping), connstate is unaware of the new value, and a
-// subsequent ApplySettings diff between connstate.current (still holding the
-// client's app_name) and the desired settings on the next query emits a
-// RESET application_name that wipes the stamp before the query runs.
-// Filtering here prevents that ABA on every code path that pushes
-// SessionSettings into the pool.
-func sessionSettingsForPool(settings map[string]string) map[string]string {
+// When vpid stamping is enabled, it excludes application_name. The pool's
+// connstate cache must never track a client-supplied application_name: when
+// SetApplicationName is later called out-of-band on the same connection (to
+// stamp `multigres_vpid:<id>` for lock-detection mapping), connstate is
+// unaware of the new value, and a subsequent ApplySettings diff between
+// connstate.current (still holding the client's app_name) and the desired
+// settings on the next query emits a RESET application_name that wipes the
+// stamp before the query runs. Filtering here prevents that ABA on every code
+// path that pushes SessionSettings into the pool.
+//
+// When stamping is disabled, settings pass through unchanged so client-set
+// application_name reaches the backend normally.
+func (e *Executor) sessionSettingsForPool(settings map[string]string) map[string]string {
+	if !e.vpidStampEnabled {
+		return settings
+	}
 	if settings == nil {
 		return nil
 	}
@@ -83,9 +96,9 @@ func sessionSettingsForPool(settings map[string]string) map[string]string {
 // pg_isolation_test_session_is_blocked) can map a multigateway virtual PID
 // back to the real backend PID via pg_stat_activity. Best-effort: a SET
 // failure does not block the actual query — only lock detection through the
-// proxy depends on the tag.
-func stampVpidOnReserved(ctx context.Context, conn *reserved.Conn, options *query.ExecuteOptions) {
-	if options == nil || options.ClientConnectionId == 0 {
+// proxy depends on the tag. No-op when vpid stamping is disabled.
+func (e *Executor) stampVpidOnReserved(ctx context.Context, conn *reserved.Conn, options *query.ExecuteOptions) {
+	if !e.vpidStampEnabled || options == nil || options.ClientConnectionId == 0 {
 		return
 	}
 	_ = conn.SetApplicationName(ctx, fmt.Sprintf("multigres_vpid:%d", options.ClientConnectionId))
@@ -95,20 +108,25 @@ func stampVpidOnReserved(ctx context.Context, conn *reserved.Conn, options *quer
 // `multigres_vpid:<id>` marker. Pooled connections are shared across clients,
 // so the next checkout will overwrite this stamp; for the duration of the
 // current query the backend is correctly attributed to its client vpid.
-func stampVpidOnRegular(ctx context.Context, conn *regular.Conn, options *query.ExecuteOptions) {
-	if options == nil || options.ClientConnectionId == 0 {
+// No-op when vpid stamping is disabled.
+func (e *Executor) stampVpidOnRegular(ctx context.Context, conn *regular.Conn, options *query.ExecuteOptions) {
+	if !e.vpidStampEnabled || options == nil || options.ClientConnectionId == 0 {
 		return
 	}
 	_ = conn.SetApplicationName(ctx, fmt.Sprintf("multigres_vpid:%d", options.ClientConnectionId))
 }
 
 // NewExecutor creates a new Executor instance.
-func NewExecutor(logger *slog.Logger, poolManager connpoolmanager.PoolManager, poolerID *clustermetadatapb.ID) *Executor {
+// vpidStampEnabled controls whether multigres_vpid:<id> is stamped on
+// PostgreSQL backends and whether application_name is filtered from pool
+// SessionSettings.
+func NewExecutor(logger *slog.Logger, poolManager connpoolmanager.PoolManager, poolerID *clustermetadatapb.ID, vpidStampEnabled bool) *Executor {
 	return &Executor{
 		logger:             logger,
 		poolManager:        poolManager,
 		poolerConsolidator: preparedstatement.NewPoolerConsolidator(),
 		poolerID:           poolerID,
+		vpidStampEnabled:   vpidStampEnabled,
 	}
 }
 
@@ -158,7 +176,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 		// Reserved connections bypass the pool's normal ApplySettings mechanism,
 		// so we must explicitly apply settings changes here.
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), e.sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return nil, e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -169,7 +187,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 		// the reserved conn — which would wipe a stamp set earlier in this
 		// function. Restamping after the reset ensures the tag is in place
 		// for the actual query.
-		stampVpidOnReserved(ctx, reservedConn, options)
+		e.stampVpidOnReserved(ctx, reservedConn, options)
 
 		results, err := reservedConn.Query(ctx, sql)
 		if err != nil {
@@ -186,7 +204,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	// Get session settings from options
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get a connection from the pool for this user
@@ -200,7 +218,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	// Stamp multigres_vpid on this pooled regular conn too — the next
 	// client to draw from the pool will overwrite it, but for the duration
 	// of the current query the backend is correctly tagged.
-	stampVpidOnRegular(ctx, conn.Conn, options)
+	e.stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// Execute the query - the regular.Conn.QueryWithRetry returns []*sqltypes.Result
 	// with proper field info, rows, and command tags already populated.
@@ -270,7 +288,7 @@ func (e *Executor) StreamExecute(
 		// so we must explicitly apply settings changes here. This step depends
 		// on the underlying *regular.Conn so it stays out of the helper.
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), e.sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return e.buildReservedState(reservedConn), fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -278,7 +296,7 @@ func (e *Executor) StreamExecute(
 		// Stamp multigres_vpid:<id> AFTER ApplySettingsToConn so a RESET
 		// ALL emitted by the empty-desired-settings path doesn't wipe it
 		// (see the matching ordering in ExecuteQuery).
-		stampVpidOnReserved(ctx, reservedConn, options)
+		e.stampVpidOnReserved(ctx, reservedConn, options)
 
 		// If the query references a gateway-managed prepared statement
 		// (wrapped EXECUTE forms), ensure it is parsed on this backend
@@ -303,7 +321,7 @@ func (e *Executor) StreamExecute(
 	// Case 3: Use regular pooled connection
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get a connection from the pool for this user
@@ -315,7 +333,7 @@ func (e *Executor) StreamExecute(
 	defer conn.Recycle()
 
 	// Stamp multigres_vpid on this pooled regular conn for lock-detection.
-	stampVpidOnRegular(ctx, conn.Conn, options)
+	e.stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// When a PreparedStatement is provided we cannot use the retry-on-connection-error
 	// variant of QueryStreaming: reconnect wipes per-connection prepared-statement state
@@ -353,7 +371,7 @@ func (e *Executor) reserveAndStreamExecute(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	// Get the reasons bitmask and determine if we need to execute BEGIN
@@ -393,7 +411,7 @@ func (e *Executor) reserveAndStreamExecute(
 	// Stamp multigres_vpid on the freshly reserved backend so subsequent
 	// lock-detection probes can map vpid → real pid. Done before BEGIN so
 	// the value is in place for the entire transaction lifecycle.
-	stampVpidOnReserved(ctx, reservedConn, options)
+	e.stampVpidOnReserved(ctx, reservedConn, options)
 
 	// Apply all reservation reasons to the reserved connection.
 	// BeginWithQuery below adds ReasonTransaction internally, but non-transaction
@@ -529,7 +547,7 @@ func (e *Executor) PortalStreamExecute(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	maxRows := int32(0)
@@ -607,7 +625,7 @@ func (e *Executor) portalExecuteWithReserved(
 	// reserved conn. Done unconditionally — both branches above can return
 	// a backend without the tag (a freshly created reservation, or an
 	// existing one whose tag was wiped by a prior ApplySettings RESET ALL).
-	stampVpidOnReserved(ctx, reservedConn, options)
+	e.stampVpidOnReserved(ctx, reservedConn, options)
 
 	// Ensure the statement is prepared on this connection (with consolidation).
 	// For the new-conn branch this is a no-op because the validate hook above
@@ -672,7 +690,7 @@ func (e *Executor) portalExecuteWithRegular(
 	defer conn.Recycle()
 
 	// Stamp multigres_vpid on this pooled regular conn for lock-detection.
-	stampVpidOnRegular(ctx, conn.Conn, options)
+	e.stampVpidOnRegular(ctx, conn.Conn, options)
 
 	// Ensure the statement is prepared on this connection (with consolidation)
 	canonicalName, err := e.ensurePrepared(ctx, conn.Conn, preparedStatement)
@@ -717,7 +735,7 @@ func (e *Executor) Describe(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	e.logger.DebugContext(ctx, "describe",
@@ -737,7 +755,7 @@ func (e *Executor) Describe(
 		}
 
 		if options.SessionSettings != nil {
-			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), sessionSettingsForPool(options.SessionSettings)); err != nil {
+			if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), e.sessionSettingsForPool(options.SessionSettings)); err != nil {
 				return nil, fmt.Errorf("failed to apply settings to reserved connection: %w", err)
 			}
 		}
@@ -865,7 +883,7 @@ func (e *Executor) CopyReady(
 	user := e.getUserFromOptions(options)
 	var settings map[string]string
 	if options != nil {
-		settings = sessionSettingsForPool(options.SessionSettings)
+		settings = e.sessionSettingsForPool(options.SessionSettings)
 	}
 
 	e.logger.DebugContext(ctx, "initiating COPY FROM STDIN",

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -908,6 +908,11 @@ func (e *Executor) CopyReady(
 		// regular pool), so PostgreSQL's idle timeout cannot have closed
 		// the socket between uses. InitiateCopyFromStdin runs directly
 		// here without a stale-socket retry hop.
+		// Stamp the vpid before entering COPY mode: once
+		// InitiateCopyFromStdin succeeds the backend rejects SET until
+		// CopyDone/CopyFail, so this is the only window to tag the
+		// backend for lock-detection during long-running COPYs.
+		e.stampVpidOnReserved(ctx, reservedConn, options)
 		format, columnFormats, err = reservedConn.Conn().InitiateCopyFromStdin(ctx, copyQuery)
 		if err != nil {
 			reservedConn.Release(reserved.ReleaseError)
@@ -931,6 +936,11 @@ func (e *Executor) CopyReady(
 					return fmt.Errorf("failed to begin transaction for COPY: %w", err)
 				}
 			}
+			// Stamp vpid before InitiateCopyFromStdin: SET is rejected
+			// once the backend enters COPY mode, and the *regular.Conn
+			// is the same underlying socket that NewReservedConn will
+			// promote to a *reserved.Conn, so the tag carries through.
+			e.stampVpidOnRegular(ctx, conn, options)
 			var initErr error
 			format, columnFormats, initErr = conn.InitiateCopyFromStdin(ctx, copyQuery)
 			if initErr != nil {

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -19,14 +19,21 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
+	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 )
 
 // mockReservedConn is a hand-rolled stub satisfying reservedConnAPI for unit tests.
@@ -427,4 +434,79 @@ func TestStampVpidOnRegular_NoOpGuards(t *testing.T) {
 			e.stampVpidOnRegular(ctx, nil, tc.options)
 		})
 	}
+}
+
+// --- stampVpid* happy-path tests ---
+//
+// These wire a real *regular.Conn / *reserved.Conn against a fakepgserver and
+// verify that the helper issues the expected SET application_name when
+// stamping is enabled and ClientConnectionId is non-zero. This is the only
+// behaviour the early-return tests above don't cover.
+
+func TestStampVpidOnRegular_HappyPath(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	ctx := context.Background()
+	clientConn, err := client.Connect(ctx, ctx, server.ClientConfig())
+	require.NoError(t, err)
+	conn := regular.NewConn(clientConn, nil)
+	defer conn.Close()
+
+	e := &Executor{vpidStampEnabled: true}
+	server.ResetQueryLog()
+	e.stampVpidOnRegular(ctx, conn, &query.ExecuteOptions{ClientConnectionId: 99})
+
+	assert.Equal(t, "set application_name = 'multigres_vpid:99'", server.QueryLog())
+}
+
+func TestStampVpidOnReserved_HappyPath(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := reserved.NewPool(context.Background(), &reserved.PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig: server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{
+				Capacity:     2,
+				MaxIdleCount: 2,
+			},
+		},
+	})
+	defer pool.Close()
+
+	ctx := context.Background()
+	rconn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	defer rconn.Release(reserved.ReleaseCommit)
+
+	e := &Executor{vpidStampEnabled: true}
+	server.ResetQueryLog()
+	e.stampVpidOnReserved(ctx, rconn, &query.ExecuteOptions{ClientConnectionId: 123})
+
+	assert.Equal(t, "set application_name = 'multigres_vpid:123'", server.QueryLog())
+}
+
+// --- NewExecutor smoke test ---
+
+func TestNewExecutor(t *testing.T) {
+	logger := slog.Default()
+	poolerID := &clustermetadatapb.ID{Cell: "cell1", Name: "pooler1"}
+
+	t.Run("stamp enabled", func(t *testing.T) {
+		e := NewExecutor(logger, nil, poolerID, true)
+		require.NotNil(t, e)
+		assert.True(t, e.vpidStampEnabled)
+		assert.Equal(t, poolerID, e.poolerID)
+		assert.NotNil(t, e.poolerConsolidator, "constructor must initialise the consolidator")
+	})
+
+	t.Run("stamp disabled", func(t *testing.T) {
+		e := NewExecutor(logger, nil, poolerID, false)
+		require.NotNil(t, e)
+		assert.False(t, e.vpidStampEnabled)
+	})
 }

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -48,6 +48,7 @@ type mockReservedConn struct {
 }
 
 func (m *mockReservedConn) ConnID() int64                         { return m.connID }
+func (m *mockReservedConn) ProcessID() uint32                     { return 0 }
 func (m *mockReservedConn) RemainingReasons() uint32              { return m.remainingReasons }
 func (m *mockReservedConn) IsInTransaction() bool                 { return m.inTxn }
 func (m *mockReservedConn) TxnStatus() protocol.TransactionStatus { return m.txnStatus }

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -326,3 +326,105 @@ func TestScramKeysFromOptions(t *testing.T) {
 		})
 	}
 }
+
+// --- sessionSettingsForPool tests ---
+
+func TestSessionSettingsForPool_DisabledPassthrough(t *testing.T) {
+	e := &Executor{vpidStampEnabled: false}
+
+	t.Run("nil settings", func(t *testing.T) {
+		require.Nil(t, e.sessionSettingsForPool(nil))
+	})
+
+	t.Run("application_name preserved", func(t *testing.T) {
+		in := map[string]string{"application_name": "client-app", "search_path": "public"}
+		got := e.sessionSettingsForPool(in)
+		require.Equal(t, in, got)
+	})
+}
+
+func TestSessionSettingsForPool_EnabledFiltersAppName(t *testing.T) {
+	e := &Executor{vpidStampEnabled: true}
+
+	t.Run("nil settings stays nil", func(t *testing.T) {
+		require.Nil(t, e.sessionSettingsForPool(nil))
+	})
+
+	t.Run("only application_name collapses to nil", func(t *testing.T) {
+		require.Nil(t, e.sessionSettingsForPool(map[string]string{"application_name": "x"}))
+	})
+
+	t.Run("mixed settings drops application_name only", func(t *testing.T) {
+		got := e.sessionSettingsForPool(map[string]string{
+			"application_name":  "client-app",
+			"search_path":       "public",
+			"statement_timeout": "1000",
+		})
+		require.Equal(t, map[string]string{
+			"search_path":       "public",
+			"statement_timeout": "1000",
+		}, got)
+	})
+
+	t.Run("case-insensitive match on application_name", func(t *testing.T) {
+		got := e.sessionSettingsForPool(map[string]string{
+			"Application_Name": "client-app",
+			"APPLICATION_NAME": "other",
+			"search_path":      "public",
+		})
+		require.Equal(t, map[string]string{"search_path": "public"}, got)
+	})
+
+	t.Run("no application_name returns equivalent map", func(t *testing.T) {
+		in := map[string]string{"search_path": "public"}
+		got := e.sessionSettingsForPool(in)
+		require.Equal(t, in, got)
+	})
+}
+
+// --- stampVpid* early-return tests ---
+//
+// The happy-path SET application_name issue is covered by integration tests
+// (it requires a real pool connection). Here we lock in the guard semantics:
+// the helpers must be safe no-ops when stamping is disabled, options is nil,
+// or ClientConnectionId is zero. A nil conn is intentionally passed to prove
+// the helpers return before touching it.
+
+func TestStampVpidOnReserved_NoOpGuards(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		enabled bool
+		options *query.ExecuteOptions
+	}{
+		{"disabled with options", false, &query.ExecuteOptions{ClientConnectionId: 5}},
+		{"enabled with nil options", true, nil},
+		{"enabled with zero id", true, &query.ExecuteOptions{ClientConnectionId: 0}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Executor{vpidStampEnabled: tc.enabled}
+			// nil conn would panic on SetApplicationName — guard must short-circuit first.
+			e.stampVpidOnReserved(ctx, nil, tc.options)
+		})
+	}
+}
+
+func TestStampVpidOnRegular_NoOpGuards(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		enabled bool
+		options *query.ExecuteOptions
+	}{
+		{"disabled with options", false, &query.ExecuteOptions{ClientConnectionId: 5}},
+		{"enabled with nil options", true, nil},
+		{"enabled with zero id", true, &query.ExecuteOptions{ClientConnectionId: 0}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Executor{vpidStampEnabled: tc.enabled}
+			e.stampVpidOnRegular(ctx, nil, tc.options)
+		})
+	}
+}

--- a/go/services/multipooler/executor/reserved_conn.go
+++ b/go/services/multipooler/executor/reserved_conn.go
@@ -28,6 +28,7 @@ import (
 // PostgreSQL connection. *reserved.Conn satisfies this interface.
 type reservedConnAPI interface {
 	ConnID() int64
+	ProcessID() uint32
 	RemainingReasons() uint32
 	IsInTransaction() bool
 	BeginWithQuery(ctx context.Context, beginQuery string) error

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -157,7 +157,7 @@ func NewMultiPooler(telemetry *telemetry.Telemetry) *MultiPooler {
 			Dynamic:  false,
 		}),
 		vpidStampEnabled: viperutil.Configure(reg, "vpid-stamp-enabled", viperutil.Options[bool]{
-			Default:  true,
+			Default:  false,
 			FlagName: "vpid-stamp-enabled",
 			Dynamic:  false,
 		}),

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -56,6 +56,10 @@ type MultiPooler struct {
 	pgBackRestKeyFile  viperutil.Value[string]
 	pgBackRestCAFile   viperutil.Value[string]
 	pgBackRestPort     viperutil.Value[int]
+	// vpidStampEnabled controls stamping of multigres_vpid:<id> on PostgreSQL
+	// backends so lock-detection can map a multigateway virtual PID to the
+	// real backend PID via pg_stat_activity.application_name.
+	vpidStampEnabled viperutil.Value[bool]
 	// GrpcServer is the grpc server
 	grpcServer *servenv.GrpcServer
 	// Senv is the serving environment
@@ -152,6 +156,11 @@ func NewMultiPooler(telemetry *telemetry.Telemetry) *MultiPooler {
 			FlagName: "pgbackrest-port",
 			Dynamic:  false,
 		}),
+		vpidStampEnabled: viperutil.Configure(reg, "vpid-stamp-enabled", viperutil.Options[bool]{
+			Default:  true,
+			FlagName: "vpid-stamp-enabled",
+			Dynamic:  false,
+		}),
 		grpcServer:     servenv.NewGrpcServer(reg),
 		senv:           servenv.NewServEnvWithConfig(reg, servenv.NewLogger(reg, telemetry), viperutil.NewViperConfig(reg), telemetry),
 		telemetry:      telemetry,
@@ -187,6 +196,7 @@ func (mp *MultiPooler) RegisterFlags(flags *pflag.FlagSet) {
 	flags.String("pgbackrest-key-file", mp.pgBackRestKeyFile.Default(), "TLS client key for connecting to primary's pgBackRest server")
 	flags.String("pgbackrest-ca-file", mp.pgBackRestCAFile.Default(), "TLS CA certificate for validating primary's pgBackRest server")
 	flags.Int("pgbackrest-port", mp.pgBackRestPort.Default(), "pgBackRest TLS server port")
+	flags.Bool("vpid-stamp-enabled", mp.vpidStampEnabled.Default(), "Stamp multigres_vpid:<id> on PostgreSQL backend application_name for vpid-to-PID mapping used by lock detection. Reserves application_name from client-set values when enabled.")
 
 	viperutil.BindFlags(flags,
 		mp.pgctldAddr,
@@ -203,6 +213,7 @@ func (mp *MultiPooler) RegisterFlags(flags *pflag.FlagSet) {
 		mp.pgBackRestKeyFile,
 		mp.pgBackRestCAFile,
 		mp.pgBackRestPort,
+		mp.vpidStampEnabled,
 	)
 
 	mp.grpcServer.RegisterFlags(flags)
@@ -317,6 +328,7 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 		PgBackRestCertFile: mp.pgBackRestCertFile.Get(),
 		PgBackRestKeyFile:  mp.pgBackRestKeyFile.Get(),
 		PgBackRestCAFile:   mp.pgBackRestCAFile.Get(),
+		VpidStampEnabled:   mp.vpidStampEnabled.Get(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create multipooler: %w", err)

--- a/go/services/multipooler/manager/config.go
+++ b/go/services/multipooler/manager/config.go
@@ -32,4 +32,7 @@ type Config struct {
 	PgBackRestCertFile string // TLS client certificate file path
 	PgBackRestKeyFile  string // TLS client key file path
 	PgBackRestCAFile   string // TLS CA certificate file path
+	// VpidStampEnabled toggles stamping of multigres_vpid:<id> on PostgreSQL
+	// backends (and the matching application_name filter on pool settings).
+	VpidStampEnabled bool
 }

--- a/go/services/multipooler/manager/health_provider_test.go
+++ b/go/services/multipooler/manager/health_provider_test.go
@@ -313,7 +313,7 @@ func TestHealthStreamer_WaitsForQueryServerOnServing(t *testing.T) {
 	hs := newHealthStreamer(logger, nil, "tg1", "0")
 
 	// Create a real QueryPoolerServer to use as the gate.
-	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0)
+	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
 	hs.SetQueryServer(qps)
 
 	// Subscribe to health updates.
@@ -362,7 +362,7 @@ func TestHealthStreamer_DoesNotWaitOnNotServing(t *testing.T) {
 	hs := newHealthStreamer(logger, nil, "tg1", "0")
 
 	// Create a query server that is PRIMARY/SERVING.
-	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0)
+	qps := poolerserver.NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
 	require.NoError(t, qps.OnStateChange(t.Context(), clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 	hs.SetQueryServer(qps)
 

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -290,7 +290,7 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 	if config.ConnPoolConfig != nil {
 		drainGracePeriod = config.ConnPoolConfig.DrainGracePeriod()
 	}
-	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod)
+	pm.qsc = poolerserver.NewQueryPoolerServer(logger, connPoolMgr, multiPooler.Id, multiPooler.GetShardKey().GetTableGroup(), multiPooler.GetShardKey().GetShard(), pm, drainGracePeriod, config.VpidStampEnabled)
 	pm.rules = newRuleStore(pm.logger, pm.qsc.InternalQueryService())
 
 	// The health streamer must wait for the query server to update its type before

--- a/go/services/multipooler/poolerserver/pooler.go
+++ b/go/services/multipooler/poolerserver/pooler.go
@@ -84,10 +84,10 @@ type QueryPoolerServer struct {
 // The health provider is used by StreamPoolerHealth to provide health updates to clients.
 // gracePeriod controls how long OnStateChange waits for in-flight connections to drain
 // during NOT_SERVING transitions before force-closing reserved connections.
-func NewQueryPoolerServer(logger *slog.Logger, poolManager connpoolmanager.PoolManager, poolerID *clustermetadatapb.ID, tableGroup, shard string, healthProvider HealthProvider, gracePeriod time.Duration) *QueryPoolerServer {
+func NewQueryPoolerServer(logger *slog.Logger, poolManager connpoolmanager.PoolManager, poolerID *clustermetadatapb.ID, tableGroup, shard string, healthProvider HealthProvider, gracePeriod time.Duration, vpidStampEnabled bool) *QueryPoolerServer {
 	var exec *executor.Executor
 	if poolManager != nil {
-		exec = executor.NewExecutor(logger, poolManager, poolerID)
+		exec = executor.NewExecutor(logger, poolManager, poolerID, vpidStampEnabled)
 	}
 
 	return &QueryPoolerServer{

--- a/go/services/multipooler/poolerserver/pooler_test.go
+++ b/go/services/multipooler/poolerserver/pooler_test.go
@@ -36,7 +36,7 @@ func TestNewQueryPoolerServer_NilPoolManager(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	// Creating with nil pool manager should work but executor will be nil
-	pooler := NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0)
+	pooler := NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
 
 	assert.NotNil(t, pooler)
 	assert.Equal(t, logger, pooler.logger)
@@ -49,7 +49,7 @@ func TestNewQueryPoolerServer_NilPoolManager(t *testing.T) {
 
 func TestIsHealthy_NotInitialized(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	pooler := NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0)
+	pooler := NewQueryPoolerServer(logger, nil, nil, "", "", nil, 0, false)
 
 	// IsHealthy should fail since the pool manager is not initialized
 	err := pooler.IsHealthy()
@@ -66,7 +66,7 @@ func TestNewQueryPoolerServer_WithPoolManager(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	mockMgr := &mockPoolManager{}
-	pooler := NewQueryPoolerServer(logger, mockMgr, nil, "", "", nil, 0)
+	pooler := NewQueryPoolerServer(logger, mockMgr, nil, "", "", nil, 0, false)
 
 	require.NotNil(t, pooler)
 	assert.Equal(t, logger, pooler.logger)

--- a/go/services/multipooler/pools/regular/regular_conn.go
+++ b/go/services/multipooler/pools/regular/regular_conn.go
@@ -215,8 +215,7 @@ func (c *Conn) State() *connstate.ConnectionState {
 // pg_stat_activity. Must be re-applied on every client hand-off for pooled
 // connections since the backend is shared across clients.
 func (c *Conn) SetApplicationName(ctx context.Context, name string) error {
-	escaped := strings.ReplaceAll(name, "'", "''")
-	_, err := c.conn.Query(ctx, fmt.Sprintf("SET application_name = '%s'", escaped))
+	_, err := c.conn.Query(ctx, "SET application_name = "+ast.QuoteStringLiteral(name))
 	return err
 }
 

--- a/go/services/multipooler/pools/regular/regular_conn.go
+++ b/go/services/multipooler/pools/regular/regular_conn.go
@@ -208,6 +208,18 @@ func (c *Conn) State() *connstate.ConnectionState {
 
 // --- Query execution ---
 
+// SetApplicationName sets application_name on the underlying PostgreSQL
+// connection. Used to tag the backend with the client's virtual PID so
+// lock-detection functions (e.g. an override of
+// pg_isolation_test_session_is_blocked) can map vpid → real pid via
+// pg_stat_activity. Must be re-applied on every client hand-off for pooled
+// connections since the backend is shared across clients.
+func (c *Conn) SetApplicationName(ctx context.Context, name string) error {
+	escaped := strings.ReplaceAll(name, "'", "''")
+	_, err := c.conn.Query(ctx, fmt.Sprintf("SET application_name = '%s'", escaped))
+	return err
+}
+
 // Query executes a simple query and returns all results.
 // If the context is cancelled, the backend query is cancelled via adminPool.
 func (c *Conn) Query(ctx context.Context, sql string) ([]*sqltypes.Result, error) {

--- a/go/services/multipooler/pools/regular/regular_conn_test.go
+++ b/go/services/multipooler/pools/regular/regular_conn_test.go
@@ -707,3 +707,45 @@ func TestPool_ClosedConnectionRecycled_CapacityPreserved(t *testing.T) {
 	stats = pool.Stats()
 	assert.Equal(t, int64(2), stats.Capacity, "capacity should still be unchanged")
 }
+
+// --- SetApplicationName tests ---
+
+func TestSetApplicationName(t *testing.T) {
+	t.Run("issues SET with quoted literal", func(t *testing.T) {
+		server := fakepgserver.New(t)
+		defer server.Close()
+		server.SetNeverFail(true)
+
+		conn := newTestDirectConn(t, server)
+		defer conn.Close()
+
+		server.ResetQueryLog()
+		require.NoError(t, conn.SetApplicationName(context.Background(), "multigres_vpid:42"))
+		assert.Equal(t, "set application_name = 'multigres_vpid:42'", server.QueryLog())
+	})
+
+	t.Run("escapes embedded single quotes", func(t *testing.T) {
+		server := fakepgserver.New(t)
+		defer server.Close()
+		server.SetNeverFail(true)
+
+		conn := newTestDirectConn(t, server)
+		defer conn.Close()
+
+		server.ResetQueryLog()
+		require.NoError(t, conn.SetApplicationName(context.Background(), "weird'name"))
+		assert.Equal(t, "set application_name = 'weird''name'", server.QueryLog())
+	})
+
+	t.Run("propagates query error", func(t *testing.T) {
+		server := fakepgserver.New(t)
+		defer server.Close()
+		// neverFail not set: unmatched query returns an error.
+
+		conn := newTestDirectConn(t, server)
+		defer conn.Close()
+
+		err := conn.SetApplicationName(context.Background(), "vpid:1")
+		require.Error(t, err)
+	})
+}

--- a/go/services/multipooler/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/pools/reserved/reserved_conn.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -310,6 +311,20 @@ func (c *Conn) SecretKey() uint32 {
 }
 
 // --- Query execution ---
+
+// SetApplicationName sets the application_name on the underlying PostgreSQL
+// connection. Used to tag the backend with the client's virtual PID for
+// lock-detection mapping via pg_stat_activity.
+func (c *Conn) SetApplicationName(ctx context.Context, name string) error {
+	_, err := c.pooled.Conn.Query(ctx, "SET application_name = "+quoteStringLiteral(name))
+	return err
+}
+
+// quoteStringLiteral quotes a string as a PostgreSQL string literal: single
+// quotes around the value, embedded single quotes doubled.
+func quoteStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
 
 // Query executes a simple query and returns all results.
 func (c *Conn) Query(ctx context.Context, sql string) ([]*sqltypes.Result, error) {

--- a/go/services/multipooler/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/pools/reserved/reserved_conn.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -314,16 +313,10 @@ func (c *Conn) SecretKey() uint32 {
 
 // SetApplicationName sets the application_name on the underlying PostgreSQL
 // connection. Used to tag the backend with the client's virtual PID for
-// lock-detection mapping via pg_stat_activity.
+// lock-detection mapping via pg_stat_activity. Delegates to the underlying
+// regular.Conn so quoting/escaping lives in one place.
 func (c *Conn) SetApplicationName(ctx context.Context, name string) error {
-	_, err := c.pooled.Conn.Query(ctx, "SET application_name = "+quoteStringLiteral(name))
-	return err
-}
-
-// quoteStringLiteral quotes a string as a PostgreSQL string literal: single
-// quotes around the value, embedded single quotes doubled.
-func quoteStringLiteral(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+	return c.pooled.Conn.SetApplicationName(ctx, name)
 }
 
 // Query executes a simple query and returns all results.

--- a/go/services/multipooler/pools/reserved/reserved_pool_test.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool_test.go
@@ -837,3 +837,53 @@ func TestPool_NewConnAfterPoolRecreation(t *testing.T) {
 		conn.Release(ReleaseCommit)
 	}
 }
+
+func TestConn_SetApplicationName(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	t.Run("issues SET with quoted literal", func(t *testing.T) {
+		conn, err := pool.NewConn(ctx, nil)
+		require.NoError(t, err)
+		defer conn.Release(ReleaseCommit)
+
+		server.ResetQueryLog()
+		require.NoError(t, conn.SetApplicationName(ctx, "multigres_vpid:7"))
+		assert.Equal(t, "set application_name = 'multigres_vpid:7'", server.QueryLog())
+	})
+
+	t.Run("escapes embedded single quotes", func(t *testing.T) {
+		conn, err := pool.NewConn(ctx, nil)
+		require.NoError(t, err)
+		defer conn.Release(ReleaseCommit)
+
+		server.ResetQueryLog()
+		require.NoError(t, conn.SetApplicationName(ctx, "weird'name"))
+		assert.Equal(t, "set application_name = 'weird''name'", server.QueryLog())
+	})
+}
+
+func TestConn_SetApplicationName_PropagatesError(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	// neverFail not set: unmatched query returns an error.
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	ctx := context.Background()
+	// pool.NewConn issues BEGIN-less acquire — leave neverFail off so the SET fails
+	// but the conn itself can still be created (NewConn does no setup queries
+	// when reservationOptions is nil and validate is nil).
+	conn, err := pool.NewConn(ctx, nil)
+	require.NoError(t, err)
+	defer conn.Release(ReleaseError)
+
+	require.Error(t, conn.SetApplicationName(ctx, "vpid:1"))
+}

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -104,16 +104,20 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 
 	// Test 3: Connection pooling with settings
 	t.Run("connection pooling with settings", func(t *testing.T) {
-		// Set a distinctive value
-		_, err := db.ExecContext(ctx, "SET application_name = 'test_app_1'")
-		require.NoError(t, err, "failed to SET application_name")
+		// Use search_path here. application_name is reserved for the
+		// multipooler's per-query lock-detection stamp (multigres_vpid:<id>),
+		// so SHOW application_name does not return what the client SET; this
+		// scenario covers session-state persistence across queries on the
+		// same logical connection, and search_path does that just as well.
+		_, err := db.ExecContext(ctx, "SET search_path = 'test_path_1'")
+		require.NoError(t, err, "failed to SET search_path")
 
 		// Execute 100 queries - all should see the same setting
 		for i := range 100 {
-			var appName string
-			err = db.QueryRowContext(ctx, "SHOW application_name").Scan(&appName)
-			require.NoError(t, err, "failed to SHOW application_name on iteration %d", i)
-			require.Equal(t, "test_app_1", appName, "iteration %d: expected consistent app name", i)
+			var searchPath string
+			err = db.QueryRowContext(ctx, "SHOW search_path").Scan(&searchPath)
+			require.NoError(t, err, "failed to SHOW search_path on iteration %d", i)
+			require.Equal(t, "test_path_1", searchPath, "iteration %d: expected consistent search_path", i)
 
 			// Interleave with other queries
 			var one int
@@ -151,21 +155,23 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 
 	// Test 5: RESET ALL clears all variables
 	t.Run("RESET ALL clears all variables", func(t *testing.T) {
-		// Set multiple variables
+		// Set multiple variables. application_name is reserved for the
+		// multipooler's per-query stamp (multigres_vpid:<id>) so we use
+		// only client-settable GUCs here.
 		_, err := db.ExecContext(ctx, "SET work_mem = '512MB'")
 		require.NoError(t, err, "failed to SET work_mem")
 
 		_, err = db.ExecContext(ctx, "SET search_path = 'myschema'")
 		require.NoError(t, err, "failed to SET search_path")
 
-		_, err = db.ExecContext(ctx, "SET application_name = 'test_app'")
-		require.NoError(t, err, "failed to SET application_name")
+		_, err = db.ExecContext(ctx, "SET client_min_messages = 'warning'")
+		require.NoError(t, err, "failed to SET client_min_messages")
 
 		// Verify custom values are set
-		var appName string
-		err = db.QueryRowContext(ctx, "SHOW application_name").Scan(&appName)
-		require.NoError(t, err, "failed to SHOW application_name")
-		assert.Equal(t, "test_app", appName, "should show custom application_name before RESET ALL")
+		var clientMin string
+		err = db.QueryRowContext(ctx, "SHOW client_min_messages").Scan(&clientMin)
+		require.NoError(t, err, "failed to SHOW client_min_messages")
+		assert.Equal(t, "warning", clientMin, "should show custom client_min_messages before RESET ALL")
 
 		// Execute RESET ALL
 		_, err = db.ExecContext(ctx, "RESET ALL")
@@ -177,10 +183,10 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 		require.NoError(t, err, "failed to SHOW search_path after RESET ALL")
 		assert.NotEqual(t, "myschema", searchPath, "search_path should not be custom value after RESET ALL")
 
-		// Application name should be reset to empty or default
-		err = db.QueryRowContext(ctx, "SHOW application_name").Scan(&appName)
-		require.NoError(t, err, "failed to SHOW application_name after RESET ALL")
-		assert.NotEqual(t, "test_app", appName, "application_name should not be custom value after RESET ALL")
+		// client_min_messages should revert to its default (notice).
+		err = db.QueryRowContext(ctx, "SHOW client_min_messages").Scan(&clientMin)
+		require.NoError(t, err, "failed to SHOW client_min_messages after RESET ALL")
+		assert.NotEqual(t, "warning", clientMin, "client_min_messages should not be custom value after RESET ALL")
 	})
 
 	// Test 6: Different value types
@@ -252,40 +258,44 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 		_, err = db2.ExecContext(ctx, "RESET ALL")
 		require.NoError(t, err, "failed to RESET ALL in db2")
 
-		// Set value in connection 1
-		_, err = db1.ExecContext(ctx, "SET application_name = 'conn1_app'")
+		// Set value in connection 1. Use search_path here:
+		// application_name is reserved for the multipooler's lock-detection
+		// stamp (multigres_vpid:<id>) so SHOW application_name does not
+		// reflect what the client SET. The cross-connection isolation
+		// invariant we want to verify is identical for any other GUC.
+		_, err = db1.ExecContext(ctx, "SET search_path = 'conn1_path'")
 		require.NoError(t, err, "failed to SET in db1")
 
 		// Verify connection 1 sees it multiple times (ensures consistent bucket routing)
 		for i := range 100 {
-			var app1 string
-			err = db1.QueryRowContext(ctx, "SHOW application_name").Scan(&app1)
+			var path1 string
+			err = db1.QueryRowContext(ctx, "SHOW search_path").Scan(&path1)
 			require.NoError(t, err, "failed to SHOW in db1 iteration %d", i)
-			require.Equal(t, "conn1_app", app1, "db1 should see conn1_app on iteration %d", i)
+			require.Equal(t, "conn1_path", path1, "db1 should see conn1_path on iteration %d", i)
 		}
 
 		// Set different value in connection 2
-		_, err = db2.ExecContext(ctx, "SET application_name = 'conn2_app'")
+		_, err = db2.ExecContext(ctx, "SET search_path = 'conn2_path'")
 		require.NoError(t, err, "failed to SET in db2")
 
 		// Verify connection 2 sees its own value
 		for i := range 100 {
-			var app2 string
-			err = db2.QueryRowContext(ctx, "SHOW application_name").Scan(&app2)
+			var path2 string
+			err = db2.QueryRowContext(ctx, "SHOW search_path").Scan(&path2)
 			require.NoError(t, err, "failed to SHOW in db2 iteration %d", i)
-			require.Equal(t, "conn2_app", app2, "db2 should see conn2_app on iteration %d", i)
+			require.Equal(t, "conn2_path", path2, "db2 should see conn2_path on iteration %d", i)
 		}
 
 		// Verify both connections STILL have their independent values after cross-execution
-		var app1Final string
-		err = db1.QueryRowContext(ctx, "SHOW application_name").Scan(&app1Final)
+		var path1Final string
+		err = db1.QueryRowContext(ctx, "SHOW search_path").Scan(&path1Final)
 		require.NoError(t, err, "failed to SHOW in db1 after all operations")
-		require.Equal(t, "conn1_app", app1Final, "db1 should still see conn1_app after all operations")
+		require.Equal(t, "conn1_path", path1Final, "db1 should still see conn1_path after all operations")
 
-		var app2Final string
-		err = db2.QueryRowContext(ctx, "SHOW application_name").Scan(&app2Final)
+		var path2Final string
+		err = db2.QueryRowContext(ctx, "SHOW search_path").Scan(&path2Final)
 		require.NoError(t, err, "failed to SHOW in db2 after all operations")
-		require.Equal(t, "conn2_app", app2Final, "db2 should still see conn2_app after all operations")
+		require.Equal(t, "conn2_path", path2Final, "db2 should still see conn2_path after all operations")
 	})
 
 	// Test 8: Extended query protocol with pgx

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -264,6 +264,14 @@ message ReservedState {
   // reservation_reasons is a bitmask of ReservationReason values indicating why the connection
   // is still reserved. Zero means the connection was released.
   uint32 reservation_reasons = 3;
+
+  // backend_process_id is the real PostgreSQL backend process ID for this
+  // reserved connection — the PID visible in pg_stat_activity / pg_locks.
+  // Used to bridge the gap between multigateway's virtual PIDs and
+  // PostgreSQL's real PIDs so lock-detection functions like
+  // pg_isolation_test_session_is_blocked() can map vpid → real pid through
+  // the proxy.
+  uint32 backend_process_id = 4;
 }
 
 // ExecuteOptions contains execution options for query execution.
@@ -309,6 +317,13 @@ message ExecuteOptions {
   // instead of relying on trust on the local connection. Unset for
   // sessions that did not authenticate via SCRAM.
   UserAuth user_auth = 7;
+
+  // client_connection_id is the multigateway's virtual PID for this client
+  // connection. The multipooler stamps it onto the underlying PostgreSQL
+  // backend's application_name as `multigres_vpid:<id>` so lock-detection
+  // functions can map virtual PIDs (visible to clients) back to real
+  // backend PIDs via pg_stat_activity.
+  uint32 client_connection_id = 8;
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM


### PR DESCRIPTION
## Summary

- Plumb the multigateway client connection's virtual PID (vpid) to the multipooler over gRPC via a new `ExecuteOptions.client_connection_id` field.
- Multipooler stamps `multigres_vpid:<id>` on the PostgreSQL backend's `application_name` for every reserved and regular pool connection, so observability and lock-detection code can map a multigateway vpid back to the real backend PID via `pg_stat_activity`.
- Surface the real PostgreSQL backend PID on `ReservedState.backend_process_id` so the gateway can answer pid-bearing queries (`pg_stat_activity`, etc.) without an extra RPC.
- Switch the session-settings end-to-end test off `application_name`, which is now reserved for the vpid stamp; honest client-visible `application_name` round-tripping is tracked separately.

## Description

### Proto

`proto/query.proto` gains two pure additive fields:

- `ExecuteOptions.client_connection_id` (uint32, field 8) — the gateway's vpid for the client connection.
- `ReservedState.backend_process_id` (uint32, field 4) — the real PG backend PID for a reserved connection.

No behaviour change until callers wire them.

### Pools

`pools/regular` and `pools/reserved` each grow a `SetApplicationName(ctx, name)` method that issues a session-level `SET application_name = '<escaped>'` on the underlying connection, with correct single-quote escaping. This is the only place the rest of the multipooler should set `application_name` on a backend.

### Executor

Three coupled pieces:

- `sessionSettingsForPool` filters `application_name` (case-insensitive) out of any client-supplied `options.SessionSettings` before they reach the pool. Without this, the pool's connstate cache would track a client `application_name`; a later `ApplySettings` diff against the filtered desired map would emit `RESET application_name` and wipe the vpid stamp set out-of-band by `SetApplicationName`.
- `stampVpidOnReserved` / `stampVpidOnRegular` helpers issue `SET application_name = 'multigres_vpid:<id>'` on a freshly acquired pool conn. Called at every acquire point: `ExecuteQuery` / `StreamExecute` (reserved + regular), `reserveAndStreamExecute` for fresh reservations, and `portalExecuteWithReserved` (both new-reservation and existing-reservation branches, after `ApplySettingsToConn` so the stamp survives any `RESET ALL` it might issue).
- `buildReservedStateFromAPI` populates `BackendProcessId` from the underlying pgx conn via a new `ProcessID()` method on the `reservedConnAPI` interface; the test mock is updated to match.

### Scatterconn

Every `ExecuteOptions` constructed in `go/services/multigateway/scatterconn` (eleven sites covering read/write execute, portal execute, copy ready/data/finalize, etc.) now carries `ClientConnectionId: conn.ConnectionID()` so every shard request to the multipooler carries the vpid.

### Tests

`go/test/endtoend/queryserving/session_settings_test.go` previously used `application_name` as a generic GUC probe in three sub-tests (session-pool persistence, `RESET ALL` semantics, cross-connection isolation). Those sub-tests exercise generic GUC behaviour, not anything specific to `application_name`, so they switch to `search_path` and `client_min_messages`, which behave identically for these scenarios and are not shadowed by the multipooler.
