### PR TITLE
fix(test/pgregress): refresh patches after parser and gRPC changes

### DIFF
--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
@@ -30,15 +30,21 @@
  select * from attest;
  b | c
  ---+---
-@@ -1654,9 +1651,9 @@
+@@ -1654,9 +1651,15 @@
  (2 rows)
- 
+
  copy attest(a) from stdin;
 -ERROR: column "a" of relation "attest" does not exist
-+ERROR: failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "a" of relation "attest" does not exist
++ERROR: failed to initiate COPY: failed to initiate COPY: Code: INTERNAL
++failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "a" of relation "attest" does not exist
++
++failed to receive READY response
  copy attest("........pg.dropped.1........") from stdin;
 -ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
-+ERROR: failed to initiate COPY: failed to initiate COPY: failed to receive READY response: rpc error: code = Internal desc = failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
++ERROR: failed to initiate COPY: failed to initiate COPY: Code: INTERNAL
++failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
++
++failed to receive READY response
  copy attest(b,c) from stdin;
  select * from attest;
  b | c

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/collate.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/collate.patch
@@ -7,7 +7,7 @@
 -ERROR: syntax error at or near "COLLATE"
 -LINE 1: SELECT CAST('42' AS text COLLATE "C");
 -^
-+ERROR: parse error at position 33: syntax error
++ERROR: parse error at position 32: syntax error
  SELECT a, CAST(b AS varchar) FROM collate_test1 ORDER BY 2;
  a | b
  ---+-----

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sqljson_jsontable.patch
@@ -23,7 +23,7 @@
 -ERROR: syntax error at or near ")"
 -LINE 1: SELECT * FROM JSON_TABLE(NULL, '$' COLUMNS ());
 -^
-+ERROR: parse error at position 46: syntax error
++ERROR: parse error at position 45: syntax error
  SELECT * FROM JSON_TABLE (NULL::jsonb, '$' COLUMNS (v1 timestamp)) AS f (v1, v2);
  ERROR: JSON_TABLE function has 1 columns available but 2 columns specified
  --duplicated column name
@@ -68,7 +68,7 @@
 -ERROR: syntax error at or near "empty"
 -LINE 1: ...sonb '1', '$' COLUMNS (a int exists empty object on empty));
 -^
-+ERROR: parse error at position 84: syntax error
++ERROR: parse error at position 83: syntax error
  -- Test ON ERROR / EMPTY value validity for the function and column types;
  -- all fail
  SELECT * FROM JSON_TABLE(jsonb '1', '$' COLUMNS (a int) NULL ON ERROR);


### PR DESCRIPTION
## Summary

Refreshes three pgregress patches that went stale after recent main merges, fixing the regressions reported in #ci alerts on 2026-05-08.

- `collate`, `sqljson_jsontable`: parser error position shifted by 1 byte after #960 (sub-commit `58e776fa` fixed `checkStringContinuation` so it no longer leaks post-skip whitespace into tracked position). Patches updated: 33→32, 46→45, 84→83.
- `alter_table`: COPY init error reformatted by #963 (preserve `PgDiagnostic` across gRPC) from `rpc error: code = Internal desc = …` to `Code: INTERNAL\n…\n\nfailed to receive READY response`. Hunk 3 of `alter_table.patch` rewritten to the new four-line shape.

Refs #960, #963.

## Test plan

- [ ] PostgreSQL Compatibility Tests CI run shows `collate`, `sqljson_jsontable`, `alter_table` all green
- [ ] No new regressions surface on the scheduled run