### PR TITLE
feat(multiorch): support bootstrap via Recruit/Propose flow

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -53,6 +53,29 @@ func CompareRuleNumbers(a, b *clustermetadatapb.RuleNumber) int {
 	return 0
 }
 
+// MostAdvancedPosition returns the highest-ranked PoolerPosition among the
+// given statuses. Rule number takes precedence; LSN breaks ties within the
+// same rule. Returns nil if no status has a parseable LSN.
+//
+// This is the cached-snapshot analogue of discoverMostAdvancedTimeline, which
+// runs over recruited statuses and returns the eligible-leader set. Callers
+// that need to derive an ExternallyCertifiedRevocation from cached cohort
+// state — e.g. the bootstrap path before recruitment — use this to obtain the
+// outgoing rule number and frozen LSN.
+func MostAdvancedPosition(statuses []*clustermetadatapb.ConsensusStatus) *clustermetadatapb.PoolerPosition {
+	var best *clustermetadatapb.PoolerPosition
+	for _, cs := range statuses {
+		pos := cs.GetCurrentPosition()
+		if _, err := pgutil.ParseLSN(pos.GetLsn()); err != nil {
+			continue
+		}
+		if best == nil || comparePosition(pos, best) > 0 {
+			best = pos
+		}
+	}
+	return best
+}
+
 // comparePosition returns negative, zero, or positive based on whether a is
 // behind, equal to, or ahead of b. Rule number takes precedence; LSN breaks
 // ties within the same rule. A missing or unparsable LSN is treated as less

--- a/go/services/multiorch/config/config.go
+++ b/go/services/multiorch/config/config.go
@@ -236,7 +236,7 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			EnvVars:  []string{"MT_LEADER_POSTGRES_RESPONSE_THRESHOLD"},
 		}),
 		useNewConsensusFlow: viperutil.Configure(reg, "use-new-consensus-flow", viperutil.Options[bool]{
-			Default:  false,
+			Default:  true,
 			FlagName: "use-new-consensus-flow",
 			Dynamic:  false,
 			EnvVars:  []string{"MT_USE_NEW_CONSENSUS_FLOW"},

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -222,6 +222,58 @@ func (c *Coordinator) AppointInitialLeader(ctx context.Context, shardID string, 
 		return mterrors.Wrap(err, "failed to load durability policy from topology")
 	}
 
+	if c.useNewFlow {
+		// Bootstrap has no outgoing cohort to recruit consent from, so we use
+		// the externally-certified path. The "external" certification is the
+		// most-advanced timeline observed across the cohort's cached statuses:
+		// its rule number caps how far the outgoing cohort could have
+		// progressed, and its LSN is the frozen point any new leader must
+		// match. This handles partial bootstraps too — if any cohort member
+		// already carries a rule, we surface its rule number rather than
+		// falsely claiming term 0.
+		var cohortStatuses []*clustermetadatapb.ConsensusStatus
+		for _, p := range cohort {
+			if cs := p.GetConsensusStatus(); cs != nil {
+				cohortStatuses = append(cohortStatuses, cs)
+			}
+		}
+
+		// This is the discovery phase of coordinator-led rule changes. For externallly-certified
+		// rule changes, the client (this method) is responsible for discovery.
+		mostAdvanced := commonconsensus.MostAdvancedPosition(cohortStatuses)
+		if mostAdvanced == nil {
+			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"cannot bootstrap shard %s: no cohort member has a known WAL position", shardID)
+		}
+		outgoingRule := mostAdvanced.GetRule().GetRuleNumber()
+		if outgoingRule == nil {
+			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
+				"cannot bootstrap shard %s: db initialization didn't set up consensus rules", shardID)
+		}
+
+		poolerByID, _ := buildCohortMaps(cohort)
+		cohortIDs := poolerIDs(cohort)
+		buildProposalFn := func(result commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+			return buildBootstrapProposal(result, cohortIDs, policy, poolerByID)
+		}
+		certFor := func(rev *clustermetadatapb.TermRevocation) *clustermetadatapb.ExternallyCertifiedRevocation {
+			return &clustermetadatapb.ExternallyCertifiedRevocation{
+				TermRevocation:     rev,
+				OutgoingRuleNumber: outgoingRule,
+				FrozenLsn:          mostAdvanced.GetLsn(),
+			}
+		}
+		return c.newRuleChange(
+			"ShardInit",
+			func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
+				return commonconsensus.BuildExternallyCertifiedProposal(certFor(rev), statuses, buildProposalFn)
+			},
+			func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
+				return commonconsensus.CheckExternallyCertifiedProposalPossible(certFor(rev), statuses, buildProposalFn)
+			},
+		).Run(ctx, cohort)
+	}
+
 	// Freshly bootstrapped shards start at term 0; skip discoverMaxTerm (which
 	// would return 0 for brand-new nodes) and use term 1 directly.
 	return c.appointLeaderWithTerm(ctx, shardID, cohort, policy, 1 /* initialTerm */, "ShardInit")

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -28,6 +28,7 @@ import (
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
+	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 )
 
 // Coordinator orchestrates consensus-based leader election for shards.
@@ -117,13 +118,31 @@ func (c *Coordinator) AppointLeader(ctx context.Context, shardID string, cohort 
 }
 
 // runFailover wires the new-flow failover callbacks for a coordinatorLedRuleChange
-// and runs it. The proposal builder picks an eligible non-resigned leader from the
-// outgoing cohort; the tryBuildProposal and checkProposalPossible callbacks delegate to
-// BuildSafeProposal and CheckProposalPossible respectively.
+// and runs it. Poolers that have signaled REQUESTING_DEMOTION are excluded from
+// the cohort entirely: a writing leader's local LSN is always at least as
+// advanced as any replica's (async replication), so including a resigned
+// leader would let it dominate discovery and dead-end the proposal when health
+// check rejects it. The full cohort identity is preserved via OutgoingRule's
+// CohortMembers (replicas carry the same rule), so the consensus layer's
+// outgoing-quorum check still runs against the original cohort size.
 func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb.PoolerHealthState, reason string) error {
-	poolerByID, healthByID := buildCohortMaps(cohort)
+	liveCohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohort))
+	for _, p := range cohort {
+		if types.LeaderNeedsReplacement(p) {
+			c.logger.InfoContext(ctx, "Excluding resigned pooler from failover cohort",
+				"pooler", p.GetMultiPooler().GetId().GetName())
+			continue
+		}
+		liveCohort = append(liveCohort, p)
+	}
+	if len(liveCohort) == 0 {
+		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+			"no non-resigned poolers in cohort; cannot fail over")
+	}
+
+	poolerByID, _ := buildCohortMaps(liveCohort)
 	buildProposal := func(r commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
-		return buildFailoverProposal(ctx, c.logger, r, poolerByID, healthByID)
+		return buildFailoverProposal(r, poolerByID)
 	}
 	tryBuildProposal := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
 		return commonconsensus.BuildSafeProposal(rev, statuses, buildProposal)
@@ -131,7 +150,7 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 	checkProposalPossible := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
 		return commonconsensus.CheckProposalPossible(rev, statuses, buildProposal)
 	}
-	return c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, cohort)
+	return c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, liveCohort)
 }
 
 // appointLeaderWithTerm is the shared core of AppointLeader and AppointInitialLeader.
@@ -238,7 +257,7 @@ func (c *Coordinator) AppointInitialLeader(ctx context.Context, shardID string, 
 			}
 		}
 
-		// This is the discovery phase of coordinator-led rule changes. For externallly-certified
+		// This is the discovery phase of coordinator-led rule changes. For externally-certified
 		// rule changes, the client (this method) is responsible for discovery.
 		mostAdvanced := commonconsensus.MostAdvancedPosition(cohortStatuses)
 		if mostAdvanced == nil {

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -1740,3 +1740,99 @@ func TestAppointInitialLeader(t *testing.T) {
 		require.Contains(t, err.Error(), "pre-vote failed")
 	})
 }
+
+func TestAppointInitialLeader_NewFlow(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	coordID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+
+	fakeClient := rpcclient.NewFakeClient()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	require.NoError(t, ts.CreateDatabase(ctx, "testdb", &clustermetadatapb.Database{
+		Name:                      "testdb",
+		BootstrapDurabilityPolicy: topoclient.AtLeastN(3),
+	}))
+
+	c := NewCoordinator(coordID, ts, fakeClient, logger, true /* useNewFlow */)
+
+	// AT_LEAST_3 forces tryBuild to wait for all three recruits before
+	// quorum forms, making leader selection deterministic regardless of
+	// recruit-RPC completion order.
+	cohortIDs := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "mp1"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "mp2"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "mp3"},
+	}
+	// mp1 has the highest LSN; bootstrap should pick it as leader. Each node
+	// carries the zero-state sentinel rule that createSidecarSchema writes
+	// during db init: term/subterm 0, empty cohort, but a real durability
+	// policy. AppointInitialLeader requires a rule to derive the cert from.
+	sentinelRule := &clustermetadatapb.ShardRule{
+		RuleNumber:       &clustermetadatapb.RuleNumber{},
+		DurabilityPolicy: topoclient.AtLeastN(3),
+	}
+	walPositions := []string{"0/2000000", "0/1500000", "0/1000000"}
+	cohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohortIDs))
+	for i, id := range cohortIDs {
+		mp := createMockNode(fakeClient, id.Name, 0, walPositions[i], true, sentinelRule)
+		mp.Status.IsInitialized = true
+		mp.Status.PostgresReady = true
+		mp.Status.PostgresRunning = true
+		// Cached cohort statuses populate Id and CurrentPosition (with sentinel
+		// rule) so MostAdvancedPosition can derive the cert and pre-vote can
+		// run on real positions. Fresh nodes carry no prior term revocation.
+		mp.ConsensusStatus = &clustermetadatapb.ConsensusStatus{
+			Id: id,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Lsn:  walPositions[i],
+				Rule: sentinelRule,
+			},
+		}
+		key := topoclient.MultiPoolerIDString(id)
+		fakeClient.RecruitResponses[key] = &consensusdatapb.RecruitResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn:  walPositions[i],
+					Rule: sentinelRule,
+				},
+			},
+		}
+		require.NoError(t, ts.CreateMultiPooler(ctx, mp.MultiPooler))
+		cohort = append(cohort, mp)
+	}
+
+	require.NoError(t, c.AppointInitialLeader(ctx, "shard0", cohort, "testdb"))
+
+	// Every node should receive an identical Propose carrying the bootstrap proposal.
+	for _, id := range cohortIDs {
+		key := topoclient.MultiPoolerIDString(id)
+		propReq, ok := fakeClient.ProposeRequests[key]
+		require.True(t, ok, "Propose should be sent to %s", id.Name)
+		require.NotNil(t, propReq.GetProposal())
+		require.Equal(t, "ShardInit", propReq.GetReason())
+		require.Equal(t, "mp1", propReq.GetProposal().GetProposalLeader().GetId().GetName(),
+			"bootstrap should pick mp1 (highest LSN) as leader")
+		// Fresh cluster: max prior term is 0, so the new revocation is term 1.
+		require.Equal(t, int64(1), propReq.GetProposal().GetTermRevocation().GetRevokedBelowTerm(),
+			"bootstrap revocation term should be 1")
+		// Proposed rule carries the bootstrap policy and the full cohort.
+		propRule := propReq.GetProposal().GetProposedRule()
+		require.Equal(t, int64(1), propRule.GetRuleNumber().GetCoordinatorTerm())
+		require.Equal(t, int32(3), propRule.GetDurabilityPolicy().GetRequiredCount())
+		require.Len(t, propRule.GetCohortMembers(), 3)
+	}
+
+	// Legacy promotion path must not have been invoked.
+	for _, id := range cohortIDs {
+		key := topoclient.MultiPoolerIDString(id)
+		_, called := fakeClient.PromoteRequests[key]
+		require.False(t, called, "Promote should not be called in new flow for %s", id.Name)
+	}
+}

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -26,7 +26,6 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
-	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
@@ -267,33 +266,21 @@ func (r *coordinatorLedRuleChange) propose(
 }
 
 // buildFailoverProposal constructs a CoordinatorProposal for normal failover.
-// It picks the first non-resigned eligible leader from result.EligibleLeaders
-// and derives the cohort and durability policy from result.OutgoingRule.
+// It picks the first eligible leader from result.EligibleLeaders and derives
+// the cohort and durability policy from result.OutgoingRule. Resigned poolers
+// are expected to have been filtered out upstream (see Coordinator.runFailover);
+// any pooler reaching this point is treated as a valid leader candidate.
 func buildFailoverProposal(
-	ctx context.Context,
-	logger *slog.Logger,
 	result commonconsensus.RecruitmentResult,
 	poolerByID map[string]*clustermetadatapb.MultiPooler,
-	healthByID map[string]*multiorchdatapb.PoolerHealthState,
 ) (*consensusdatapb.CoordinatorProposal, error) {
 	if result.OutgoingRule == nil {
 		return nil, errors.New("no committed rule found; use bootstrap path for fresh clusters")
 	}
-
-	var leader *clustermetadatapb.ConsensusStatus
-	for _, cs := range result.EligibleLeaders {
-		key := topoclient.ClusterIDString(cs.GetId())
-		if health, ok := healthByID[key]; ok && types.LeaderNeedsReplacement(health) {
-			logger.InfoContext(ctx, "Skipping resigned primary during leader selection",
-				"pooler", cs.GetId().GetName())
-			continue
-		}
-		leader = cs
-		break
+	if len(result.EligibleLeaders) == 0 {
+		return nil, errors.New("no eligible leaders for failover proposal")
 	}
-	if leader == nil {
-		return nil, errors.New("all eligible leaders have resigned")
-	}
+	leader := result.EligibleLeaders[0]
 
 	mp, ok := poolerByID[topoclient.ClusterIDString(leader.GetId())]
 	if !ok {

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -316,6 +316,41 @@ func buildFailoverProposal(
 	}, nil
 }
 
+// buildBootstrapProposal constructs a CoordinatorProposal for initial leader
+// appointment on a fresh shard. Unlike buildFailoverProposal, the cohort and
+// durability policy come from the caller — there is no recorded rule to
+// derive them from — and any eligible leader works since none have prior
+// commitments.
+func buildBootstrapProposal(
+	result commonconsensus.RecruitmentResult,
+	cohortIDs []*clustermetadatapb.ID,
+	policy *clustermetadatapb.DurabilityPolicy,
+	poolerByID map[string]*clustermetadatapb.MultiPooler,
+) (*consensusdatapb.CoordinatorProposal, error) {
+	if len(result.EligibleLeaders) == 0 {
+		return nil, errors.New("no eligible leaders for bootstrap proposal")
+	}
+	leader := result.EligibleLeaders[0]
+	mp, ok := poolerByID[topoclient.ClusterIDString(leader.GetId())]
+	if !ok {
+		return nil, fmt.Errorf("leader %s not found in cohort", leader.GetId().GetName())
+	}
+	return &consensusdatapb.CoordinatorProposal{
+		TermRevocation: result.TermRevocation,
+		ProposalLeader: &consensusdatapb.ProposalLeader{
+			Id:           leader.GetId(),
+			Host:         mp.GetHostname(),
+			PostgresPort: mp.GetPortMap()["postgres"],
+		},
+		ProposedRule: &clustermetadatapb.ShardRule{
+			RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: result.TermRevocation.GetRevokedBelowTerm()},
+			CohortMembers:    cohortIDs,
+			DurabilityPolicy: policy,
+			LeaderId:         leader.GetId(),
+		},
+	}, nil
+}
+
 // checkRecentAcceptance returns an error if any node in the cohort recently
 // accepted a term revocation, which may indicate another coordinator is making
 // a rule change.

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -99,9 +99,6 @@ func nopCheckProposalPossible(_ *clustermetadatapb.TermRevocation, _ []*clusterm
 // ---- TestBuildFailoverProposal ----
 
 func TestBuildFailoverProposal(t *testing.T) {
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
 	makeID := func(name string) *clustermetadatapb.ID {
 		return &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
@@ -118,31 +115,6 @@ func TestBuildFailoverProposal(t *testing.T) {
 	}
 	makeCS := func(name string) *clustermetadatapb.ConsensusStatus {
 		return &clustermetadatapb.ConsensusStatus{Id: makeID(name)}
-	}
-	makeHealth := func(name string) *multiorchdatapb.PoolerHealthState {
-		return &multiorchdatapb.PoolerHealthState{MultiPooler: makeMP(name)}
-	}
-	makeResignedHealth := func(name string, primaryTerm int64) *multiorchdatapb.PoolerHealthState {
-		return &multiorchdatapb.PoolerHealthState{
-			MultiPooler: makeMP(name),
-			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
-				Id: makeID(name),
-				CurrentPosition: &clustermetadatapb.PoolerPosition{
-					Rule: &clustermetadatapb.ShardRule{
-						LeaderId: makeID(name),
-						RuleNumber: &clustermetadatapb.RuleNumber{
-							CoordinatorTerm: primaryTerm,
-						},
-					},
-				},
-			},
-			AvailabilityStatus: &clustermetadatapb.AvailabilityStatus{
-				LeadershipStatus: &clustermetadatapb.LeadershipStatus{
-					Signal:     clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
-					LeaderTerm: primaryTerm,
-				},
-			},
-		}
 	}
 
 	outgoingRule := &clustermetadatapb.ShardRule{
@@ -166,49 +138,13 @@ func TestBuildFailoverProposal(t *testing.T) {
 			OutgoingRule:    outgoingRule,
 			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
 		}
-		healthByID := map[string]*multiorchdatapb.PoolerHealthState{
-			"zone1_mp1": makeHealth("mp1"),
-			"zone1_mp2": makeHealth("mp2"),
-		}
 
-		proposal, err := buildFailoverProposal(ctx, logger, result, poolerByID, healthByID)
+		proposal, err := buildFailoverProposal(result, poolerByID)
 		require.NoError(t, err)
 		assert.Equal(t, "mp1", proposal.GetProposalLeader().GetId().GetName())
 		assert.Equal(t, "localhost", proposal.GetProposalLeader().GetHost())
 		assert.Len(t, proposal.GetProposedRule().GetCohortMembers(), 3)
 		assert.Equal(t, "mp1", proposal.GetProposedRule().GetLeaderId().GetName())
-	})
-
-	t.Run("skips resigned primary, picks next eligible leader", func(t *testing.T) {
-		result := commonconsensus.RecruitmentResult{
-			TermRevocation:  rev,
-			OutgoingRule:    outgoingRule,
-			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
-		}
-		healthByID := map[string]*multiorchdatapb.PoolerHealthState{
-			"zone1_mp1": makeResignedHealth("mp1", 4),
-			"zone1_mp2": makeHealth("mp2"),
-		}
-
-		proposal, err := buildFailoverProposal(ctx, logger, result, poolerByID, healthByID)
-		require.NoError(t, err)
-		assert.Equal(t, "mp2", proposal.GetProposalLeader().GetId().GetName())
-	})
-
-	t.Run("all eligible leaders resigned returns error", func(t *testing.T) {
-		result := commonconsensus.RecruitmentResult{
-			TermRevocation:  rev,
-			OutgoingRule:    outgoingRule,
-			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
-		}
-		healthByID := map[string]*multiorchdatapb.PoolerHealthState{
-			"zone1_mp1": makeResignedHealth("mp1", 4),
-			"zone1_mp2": makeResignedHealth("mp2", 4),
-		}
-
-		_, err := buildFailoverProposal(ctx, logger, result, poolerByID, healthByID)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "all eligible leaders have resigned")
 	})
 
 	t.Run("no OutgoingRule returns error", func(t *testing.T) {
@@ -217,13 +153,22 @@ func TestBuildFailoverProposal(t *testing.T) {
 			OutgoingRule:    nil,
 			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1")},
 		}
-		healthByID := map[string]*multiorchdatapb.PoolerHealthState{
-			"zone1_mp1": makeHealth("mp1"),
-		}
 
-		_, err := buildFailoverProposal(ctx, logger, result, poolerByID, healthByID)
+		_, err := buildFailoverProposal(result, poolerByID)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no committed rule found")
+	})
+
+	t.Run("no EligibleLeaders returns error", func(t *testing.T) {
+		result := commonconsensus.RecruitmentResult{
+			TermRevocation:  rev,
+			OutgoingRule:    outgoingRule,
+			EligibleLeaders: nil,
+		}
+
+		_, err := buildFailoverProposal(result, poolerByID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no eligible leaders")
 	})
 }
 


### PR DESCRIPTION
Wires AppointInitialLeader to the new flow when useNewFlow is set. Bootstrap has no outgoing cohort to recruit consent from, so it uses BuildExternallyCertifiedProposal / CheckExternallyCertifiedProposalPossible with a cert derived from the cohort's cached state — discovery, but on the snapshot rather than recruit responses.

Discovery surfaces both the most-advanced rule number and the most-advanced LSN. The rule number caps how far the outgoing cohort could have progressed; the LSN is the frozen point any new leader must match. This handles partial bootstraps too — if any cohort member already carries a rule, we surface its rule number rather than falsely claiming term 0 (which certLeaderFilter would then reject).

Adds a MostAdvancedPosition helper to go/common/consensus, a buildBootstrapProposal builder analogous to buildFailoverProposal, and TestAppointInitialLeader_NewFlow exercising the wiring end-to-end.
