### PR TITLE
ci(coverage): add Codecov upload alongside Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -205,6 +205,7 @@ jobs:
           path: coverage-merged.txt
           retention-days: 7
       - name: Upload coverage to Codecov
+        if: success() || failure()
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -222,7 +223,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [coverage-direct, coverage-subprocess, merge-and-upload]
     if: always()
-    permissions: {}
+    permissions:
+      pull-requests: write
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -204,6 +204,11 @@ jobs:
           name: coverage-merged
           path: coverage-merged.txt
           retention-days: 7
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-merged.txt
       - name: Upload coverage to Coveralls
         if: success() || failure()
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "go/pb/**"
+  - "go/common/parser/ast/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
 ignore:
   - "go/pb/**"
   - "go/common/parser/ast/**"
+  - "go/common/parser/goyacc/**"
+  - "go/tools/asthelpergen/**"
+  - "go/tools/flakyaggregator/**"
+  - "go/tools/ruleguard/**"


### PR DESCRIPTION
Coveralls hasn't been sending PR comments and it's not obvious to me why. Codecov seems to work fine, so we can enable that and either figure out how to fix or remove coveralls later