### PR TITLE
ci: upload JUnit test results to Codecov on main

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -64,6 +64,7 @@ jobs:
             --rerun-fails-max-failures=10 \
             --packages="./go/test/endtoend/..." \
             --jsonfile=integration-test-results.jsonl \
+            --junitfile=integration-test-results.xml \
             -- \
             -skip TestPostgreSQLRegression -timeout=30m
 
@@ -75,7 +76,9 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: integration-test-logs
-          path: integration-test-results.jsonl
+          path: |
+            integration-test-results.jsonl
+            integration-test-results.xml
           retention-days: 14
 
       - name: Test Report
@@ -85,3 +88,14 @@ jobs:
           name: Integration Tests
           path: integration-test-results.jsonl
           reporter: golang-json
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./integration-test-results.xml
+          report_type: test_results
+          flags: integration
+          fail_ci_if_error: false

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -89,8 +89,12 @@ jobs:
           path: integration-test-results.jsonl
           reporter: golang-json
 
+      # Only upload test results from main-branch pushes. On PRs, Codecov's
+      # test-results comment template replaces the coverage comment when any
+      # test fails, displacing the coverage diff that PR authors actually want
+      # to see. Flake tracking only needs main-branch history anyway.
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         continue-on-error: true
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -73,8 +73,12 @@ jobs:
           path: short-test-results.jsonl
           reporter: golang-json
 
+      # Only upload test results from main-branch pushes. On PRs, Codecov's
+      # test-results comment template replaces the coverage comment when any
+      # test fails, displacing the coverage diff that PR authors actually want
+      # to see. Flake tracking only needs main-branch history anyway.
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         continue-on-error: true
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -51,6 +51,7 @@ jobs:
             --rerun-fails-max-failures=10 \
             --packages="./..." \
             --jsonfile=short-test-results.jsonl \
+            --junitfile=short-test-results.xml \
             -- \
             -short -timeout=20m
 
@@ -59,7 +60,9 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: short-test-logs
-          path: short-test-results.jsonl
+          path: |
+            short-test-results.jsonl
+            short-test-results.xml
           retention-days: 14
 
       - name: Test Report
@@ -69,3 +72,14 @@ jobs:
           name: Unit Tests
           path: short-test-results.jsonl
           reporter: golang-json
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./short-test-results.xml
+          report_type: test_results
+          flags: short
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 ignore:
   - "go/pb/**"
-  - "go/common/parser/ast/**"
   - "go/common/parser/goyacc/**"
   - "go/tools/asthelpergen/**"
   - "go/tools/flakyaggregator/**"

--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -39,5 +39,9 @@ func LeaderTerm(cs *clustermetadatapb.ConsensusStatus) int64 {
 	if !IsLeader(cs) {
 		return 0
 	}
+	// DO NOT SUBMIT
+	if cs.GetId().GetName() == "unreached code" {
+		panic("This should be unreachable")
+	}
 	return cs.GetCurrentPosition().GetRule().GetRuleNumber().GetCoordinatorTerm()
 }

--- a/go/common/consensus/pooler.go
+++ b/go/common/consensus/pooler.go
@@ -39,9 +39,5 @@ func LeaderTerm(cs *clustermetadatapb.ConsensusStatus) int64 {
 	if !IsLeader(cs) {
 		return 0
 	}
-	// DO NOT SUBMIT
-	if cs.GetId().GetName() == "unreached code" {
-		panic("This should be unreachable")
-	}
 	return cs.GetCurrentPosition().GetRule().GetRuleNumber().GetCoordinatorTerm()
 }


### PR DESCRIPTION
## Summary
This could help with tracking flaky tests or generally tracking how long different test cases take

- Add `--junitfile` to the gotestsum invocations in `test-short.yml` and `test-integration.yml`
- Push the JUnit XML to Codecov
- Gate the Codecov test_results upload on `github.event_name == 'push'`, i.e. main-branch runs only.

## Why limit test_results uploads to main?
Codecov's PR comment doesn't seem to be able to comment on both coverage and test results, so for PRs we can stay focused on coverage which seems like a better thing to remind people of.