### PR TITLE
refactor(multipooler): remove dead transaction-status reconciliation

### DIFF
--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -357,8 +357,7 @@ func (e *Executor) reserveAndStreamExecute(
 // streamExecuteOnReservedConn executes a query on an existing reserved
 // connection. It optionally promotes the reservation by adding new reasons
 // (e.g., starting a transaction on a temp-table-reserved connection) before
-// running the query, and reconciles the in-memory transaction tracking against
-// PG's actual transaction status afterwards.
+// running the query.
 //
 // Defined over reservedConnAPI rather than *reserved.Conn so that unit tests
 // can substitute a mock and exercise this path without a live PG connection.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 
 	"github.com/multigres/multigres/go/common/mterrors"
-	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
@@ -396,18 +395,6 @@ func (e *Executor) streamExecuteOnReservedConn(
 	if err := rc.QueryStreaming(ctx, sql, callback); err != nil {
 		// Query failed but connection still exists — return current state
 		return e.buildReservedStateFromAPI(rc), wrapQueryError(err)
-	}
-
-	// Sync our in-memory transaction tracking with PG's actual state. The SQL
-	// itself may contain transaction control statements (e.g., a simple-query
-	// payload like "BEGIN; SELECT 1; COMMIT;") that change PG's transaction
-	// status without going through ReservationOptions, so we reconcile against
-	// the ReadyForQuery transaction indicator after the query completes.
-	if rc.TxnStatus() == protocol.TxnStatusInBlock && !rc.IsInTransaction() {
-		rc.AddReservationReason(protoutil.ReasonTransaction)
-	} else if rc.TxnStatus() == protocol.TxnStatusIdle && rc.IsInTransaction() {
-		// Transaction ended via inline COMMIT/ROLLBACK — remove the reason.
-		rc.RemoveReservationReason(protoutil.ReasonTransaction)
 	}
 
 	return e.buildReservedStateFromAPI(rc), nil

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -34,7 +33,6 @@ import (
 type mockReservedConn struct {
 	connID           int64
 	inTxn            bool
-	txnStatus        protocol.TransactionStatus
 	remainingReasons uint32
 
 	beginCalls      []string
@@ -47,10 +45,9 @@ type mockReservedConn struct {
 	streamingErr error
 }
 
-func (m *mockReservedConn) ConnID() int64                         { return m.connID }
-func (m *mockReservedConn) RemainingReasons() uint32              { return m.remainingReasons }
-func (m *mockReservedConn) IsInTransaction() bool                 { return m.inTxn }
-func (m *mockReservedConn) TxnStatus() protocol.TransactionStatus { return m.txnStatus }
+func (m *mockReservedConn) ConnID() int64            { return m.connID }
+func (m *mockReservedConn) RemainingReasons() uint32 { return m.remainingReasons }
+func (m *mockReservedConn) IsInTransaction() bool    { return m.inTxn }
 
 func (m *mockReservedConn) BeginWithQuery(_ context.Context, q string) error {
 	m.beginCalls = append(m.beginCalls, q)
@@ -101,7 +98,6 @@ func noopCallback(_ context.Context, _ *sqltypes.Result) error { return nil }
 func TestStreamExecuteOnReservedConn_AddsTransactionViaBegin(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,
-		txnStatus:        protocol.TxnStatusInBlock,
 		remainingReasons: protoutil.ReasonTempTable,
 	}
 	e := newTestExecutor()
@@ -136,7 +132,6 @@ func TestStreamExecuteOnReservedConn_SkipsBeginIfAlreadyInTxn(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,
 		inTxn:            true,
-		txnStatus:        protocol.TxnStatusInBlock,
 		remainingReasons: protoutil.ReasonTransaction,
 	}
 	e := newTestExecutor()
@@ -157,8 +152,7 @@ func TestStreamExecuteOnReservedConn_SkipsBeginIfAlreadyInTxn(t *testing.T) {
 // BEGIN entirely and just record the reason on the connection.
 func TestStreamExecuteOnReservedConn_AddsTempTableReasonOnly(t *testing.T) {
 	rc := &mockReservedConn{
-		connID:    42,
-		txnStatus: protocol.TxnStatusIdle,
+		connID: 42,
 	}
 	e := newTestExecutor()
 
@@ -181,7 +175,6 @@ func TestStreamExecuteOnReservedConn_AddsTempTableReasonOnly(t *testing.T) {
 func TestStreamExecuteOnReservedConn_BeginErrorPropagates(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,
-		txnStatus:        protocol.TxnStatusIdle,
 		remainingReasons: protoutil.ReasonTempTable,
 		beginErr:         errors.New("boom"),
 	}
@@ -205,7 +198,6 @@ func TestStreamExecuteOnReservedConn_BeginErrorPropagates(t *testing.T) {
 func TestStreamExecuteOnReservedConn_DefaultBeginQueryWhenEmpty(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,
-		txnStatus:        protocol.TxnStatusInBlock,
 		remainingReasons: protoutil.ReasonTempTable,
 	}
 	e := newTestExecutor()
@@ -228,7 +220,6 @@ func TestStreamExecuteOnReservedConn_NoReservationOptions(t *testing.T) {
 	rc := &mockReservedConn{
 		connID:           42,
 		inTxn:            true,
-		txnStatus:        protocol.TxnStatusInBlock,
 		remainingReasons: protoutil.ReasonTransaction,
 	}
 	e := newTestExecutor()
@@ -241,50 +232,6 @@ func TestStreamExecuteOnReservedConn_NoReservationOptions(t *testing.T) {
 	require.Empty(t, rc.beginCalls)
 	require.Equal(t, uint32(0), rc.addedReasons)
 	require.True(t, rc.streamingCalled)
-}
-
-// TestStreamExecuteOnReservedConn_ReconcilesInlineCommit covers the
-// after-the-fact reconciliation: if the SQL itself contained a COMMIT (e.g.
-// "COMMIT" sent as a raw query), PG returns to TxnStatusIdle and the helper
-// should drop the transaction reason from in-memory tracking.
-func TestStreamExecuteOnReservedConn_ReconcilesInlineCommit(t *testing.T) {
-	rc := &mockReservedConn{
-		connID:           42,
-		inTxn:            true,
-		txnStatus:        protocol.TxnStatusIdle, // PG is no longer in a transaction
-		remainingReasons: protoutil.ReasonTransaction,
-	}
-	e := newTestExecutor()
-
-	_, err := e.streamExecuteOnReservedConn(
-		context.Background(), rc, "COMMIT", nil, noopCallback,
-	)
-
-	require.NoError(t, err)
-	require.Equal(t, protoutil.ReasonTransaction, rc.removedReasons,
-		"helper should drop the transaction reason when PG reports idle")
-}
-
-// TestStreamExecuteOnReservedConn_ReconcilesInlineBegin covers the symmetric
-// case: SQL like "BEGIN; SELECT 1;" leaves PG in TxnStatusInBlock without
-// having gone through ReservationOptions, so the helper must add the reason
-// back so DiscardTempTables / ConcludeTransaction can find it.
-func TestStreamExecuteOnReservedConn_ReconcilesInlineBegin(t *testing.T) {
-	rc := &mockReservedConn{
-		connID:           42,
-		inTxn:            false,
-		txnStatus:        protocol.TxnStatusInBlock, // PG entered a transaction mid-payload
-		remainingReasons: protoutil.ReasonTempTable,
-	}
-	e := newTestExecutor()
-
-	_, err := e.streamExecuteOnReservedConn(
-		context.Background(), rc, "BEGIN; SELECT 1;", nil, noopCallback,
-	)
-
-	require.NoError(t, err)
-	require.Equal(t, protoutil.ReasonTransaction, rc.addedReasons,
-		"helper should add the transaction reason when PG reports in-block")
 }
 
 func TestScramKeysFromOptions(t *testing.T) {

--- a/go/services/multipooler/executor/reserved_conn.go
+++ b/go/services/multipooler/executor/reserved_conn.go
@@ -17,7 +17,6 @@ package executor
 import (
 	"context"
 
-	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 )
@@ -34,7 +33,6 @@ type reservedConnAPI interface {
 	AddReservationReason(reason uint32)
 	RemoveReservationReason(reason uint32) bool
 	QueryStreaming(ctx context.Context, sql string, callback func(context.Context, *sqltypes.Result) error) error
-	TxnStatus() protocol.TransactionStatus
 }
 
 // Compile-time check that *reserved.Conn satisfies reservedConnAPI.


### PR DESCRIPTION
## Summary

- Deletes the post-`StreamExecute` reconciliation block in `streamExecuteOnReservedConn` that synced in-memory `ReasonTransaction` against PG's `ReadyForQuery` transaction status indicator.
- That block existed to catch simple-query payloads like `"BEGIN; SELECT 1; COMMIT;"` where transaction control was bundled inline and bypassed `ReservationOptions`. The gateway now parses multi-statement payloads into individual `ast.Stmt`s and dispatches one statement per RPC (`executeWithImplicitTransaction` in `transaction_helpers.go`), so the pooler only ever sees a single statement and `ReservationOptions` is always authoritative.
- Also drops `TxnStatus()` from the `reservedConnAPI` interface (no remaining caller in the executor) and removes the two reconciliation-specific unit tests.

## Problem

`executor.go` reconciled `rc.TxnStatus()` against `rc.IsInTransaction()` after every `StreamExecute` on a reserved connection. The accompanying comment explained the case it guarded: bundled transaction control in a simple-query payload, where the SQL itself changed PG's transaction status without going through `ReservationOptions`. That case can no longer reach the pooler — the gateway's per-statement dispatch makes the reconciliation a no-op on all current traffic.

## Solution

Delete the reconciliation block and the now-unused `TxnStatus()` member of `reservedConnAPI`. No defense-in-depth assertion was added: per the repo guidance we avoid validation for scenarios that can't reach the code, and a gateway regression would surface as a stuck reserved connection — visible without a custom log path.

## Test plan

- [x] `go test -short ./go/services/multipooler/executor/...` — passes.
- [x] `go test ./go/test/endtoend/queryserving/...` — all four packages pass (`queryserving`, `benchmarking`, `pgparity`, `sqllogictest`).
