### PR TITLE
perf(multigateway): demote per-query log to DEBUG with sampling

### DIFF
--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/multigres/multigres/go/common/constants"
@@ -99,6 +100,16 @@ type MultiGatewayHandler struct {
 	// targetReplica is set to true for the replica-port listener. When true,
 	// new connection states target replicas so the planner routes queries there.
 	targetReplica bool
+
+	// normalQueryLogSampleRate controls 1/N sampling for normal-path query
+	// logs. 0 disables sampling (handler level alone governs emission); 1
+	// emits every normal query; N>1 emits every Nth. Normal queries always
+	// log at DEBUG, so the default INFO-level handler drops them entirely.
+	normalQueryLogSampleRate uint64
+	// normalQueryLogSamplingCursor is the 1/N modulo cursor. It is only
+	// touched when sampleRate > 1; emission counts are exposed via the
+	// queryLogEmits OTel counter on h.metrics.
+	normalQueryLogSamplingCursor atomic.Uint64
 }
 
 // NewMultiGatewayHandler creates a new PostgreSQL protocol handler.
@@ -116,6 +127,14 @@ func NewMultiGatewayHandler(executor Executor, logger *slog.Logger, statementTim
 		slowThreshold:    constants.DefaultSlowQueryThreshold,
 		notifMgr:         DefaultNotificationManager(),
 	}
+}
+
+// SetNormalQueryLogSampleRate sets the 1/N sampling rate for normal-path
+// query logs. 0 disables sampling (handler level alone governs); 1 emits
+// every query; N>1 emits every Nth. Normal queries always log at DEBUG.
+// Must be called before connections are accepted.
+func (h *MultiGatewayHandler) SetNormalQueryLogSampleRate(rate uint64) {
+	h.normalQueryLogSampleRate = rate
 }
 
 // SetTargetReplica configures whether connections accepted by this handler
@@ -622,7 +641,7 @@ func (h *MultiGatewayHandler) recordQueryCompletion(
 		Error:         err,
 		SQLSTATE:      errorType,
 		ErrorSource:   mterrors.ClassifyErrorSource(err),
-	}, h.slowThreshold)
+	}, h.slowThreshold, h.normalQueryLogSampleRate, &h.normalQueryLogSamplingCursor, h.metrics.queryLogEmits)
 }
 
 // Ensure MultiGatewayHandler implements server.Handler interface.

--- a/go/services/multigateway/handler/metrics.go
+++ b/go/services/multigateway/handler/metrics.go
@@ -41,6 +41,7 @@ type HandlerMetrics struct {
 	queryErrors   QueryErrors
 	rowsReturned  RowsReturned
 	tableQueries  TableQueries
+	queryLogEmits QueryLogEmits
 }
 
 // QueryDuration wraps a Float64Histogram for recording query durations.
@@ -113,6 +114,20 @@ func (m RowsReturned) Record(
 			attribute.String("db.operation.name", operationName),
 			attribute.String("query.fingerprint", queryFingerprint),
 		))
+}
+
+// QueryLogEmits wraps an Int64Counter for counting per-query log records
+// emitted by emitQueryLog. The `level` attribute distinguishes WARN (errored
+// or slow) emissions from normal-path DEBUG emissions, so operators can size
+// log volume and verify that --query-log-sample-rate is having the expected
+// effect on the normal path.
+type QueryLogEmits struct {
+	metric.Int64Counter
+}
+
+// Add increments the per-query-log emission counter with a `level` attribute.
+func (m QueryLogEmits) Add(ctx context.Context, level string) {
+	m.Int64Counter.Add(ctx, 1, metric.WithAttributes(attribute.String("level", level)))
 }
 
 // TableQueries wraps an Int64Counter for counting queries per table.
@@ -191,6 +206,18 @@ func NewHandlerMetrics() (*HandlerMetrics, error) {
 		m.tableQueries = TableQueries{noop.Int64Counter{}}
 	} else {
 		m.tableQueries = TableQueries{tq}
+	}
+
+	qle, err := meter.Int64Counter(
+		"mg.gateway.query.log.emits",
+		metric.WithDescription("Per-query log records emitted, labeled by slog level"),
+		metric.WithUnit("{record}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.query.log.emits counter: %w", err))
+		m.queryLogEmits = QueryLogEmits{noop.Int64Counter{}}
+	} else {
+		m.queryLogEmits = QueryLogEmits{qle}
 	}
 
 	if len(errs) > 0 {

--- a/go/services/multigateway/handler/querylog.go
+++ b/go/services/multigateway/handler/querylog.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 )
 
@@ -41,16 +42,42 @@ type queryLogEntry struct {
 // emitQueryLog writes a structured query log entry using slog.LogAttrs for
 // minimal allocation on the latency-sensitive query path.
 //
-// Log levels:
-//   - WARN  when the query errored or exceeded slowThreshold
-//   - INFO  for normal queries
+// Errored or slow queries always log at WARN. Normal queries log at DEBUG
+// (so the default INFO-level handler drops them) after 1/sampleRate sampling
+// (sampleRate==0 disables sampling and lets the handler level alone govern).
 //
 // The slog-OTel bridge (configured in telemetry.go) automatically injects
 // trace_id and span_id from the context.
-func emitQueryLog(ctx context.Context, logger *slog.Logger, entry queryLogEntry, slowThreshold time.Duration) {
-	level := slog.LevelInfo
-	if entry.Error != nil || entry.TotalDuration >= slowThreshold {
+func emitQueryLog(
+	ctx context.Context,
+	logger *slog.Logger,
+	entry queryLogEntry,
+	slowThreshold time.Duration,
+	sampleRate uint64,
+	samplingCursor *atomic.Uint64,
+	emitsMetric QueryLogEmits,
+) {
+	isWarn := entry.Error != nil || entry.TotalDuration >= slowThreshold
+
+	if !isWarn {
+		// Check sampling before logger.Enabled so the disabled-handler path
+		// also benefits from sampling skipping work.
+		if sampleRate > 1 {
+			n := samplingCursor.Add(1)
+			if n%sampleRate != 0 {
+				return
+			}
+		}
+		if !logger.Enabled(ctx, slog.LevelDebug) {
+			return
+		}
+	}
+
+	level := slog.LevelDebug
+	levelLabel := "debug"
+	if isWarn {
 		level = slog.LevelWarn
+		levelLabel = "warn"
 	}
 
 	attrs := []slog.Attr{
@@ -85,4 +112,5 @@ func emitQueryLog(ctx context.Context, logger *slog.Logger, entry queryLogEntry,
 	}
 
 	logger.LogAttrs(ctx, level, "query completed", attrs...)
+	emitsMetric.Add(ctx, levelLabel)
 }

--- a/go/services/multigateway/handler/querylog_test.go
+++ b/go/services/multigateway/handler/querylog_test.go
@@ -19,15 +19,47 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
+
+// noopEmits returns a QueryLogEmits backed by a no-op counter for tests that
+// don't care about the metric value.
+func noopEmits() QueryLogEmits { return QueryLogEmits{noop.Int64Counter{}} }
+
+// countingHandler records every Handle call and the level it was called at.
+// It honors a minimum level via Enabled so we can simulate operator-set
+// handler filtering.
+type countingHandler struct {
+	minLevel slog.Level
+	calls    int
+	levels   []slog.Level
+	records  []slog.Record
+}
+
+func (h *countingHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.minLevel
+}
+
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.calls++
+	h.levels = append(h.levels, r.Level)
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *countingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(_ string) slog.Handler      { return h }
 
 func TestEmitQueryLog_NormalQuery(t *testing.T) {
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	entry := queryLogEntry{
 		User:          "testuser",
@@ -40,16 +72,16 @@ func TestEmitQueryLog_NormalQuery(t *testing.T) {
 		RowCount:      10,
 	}
 
-	emitQueryLog(context.Background(), logger, entry, time.Second)
+	var cursor atomic.Uint64
+	emitQueryLog(context.Background(), logger, entry, time.Second, 1, &cursor, noopEmits())
 
 	output := buf.String()
-	require.Contains(t, output, "level=INFO")
+	require.Contains(t, output, "level=DEBUG")
 	require.Contains(t, output, "query completed")
 	require.Contains(t, output, "db.namespace=testdb")
 	require.Contains(t, output, "db.operation.name=SELECT")
 	require.Contains(t, output, "db.query.protocol=simple")
 	require.Contains(t, output, "rows_returned=10")
-	// Should not contain error fields for successful queries
 	require.NotContains(t, output, "sqlstate")
 }
 
@@ -68,7 +100,8 @@ func TestEmitQueryLog_ErrorQuery(t *testing.T) {
 		ErrorSource:   "client",
 	}
 
-	emitQueryLog(context.Background(), logger, entry, time.Second)
+	var cursor atomic.Uint64
+	emitQueryLog(context.Background(), logger, entry, time.Second, 0, &cursor, noopEmits())
 
 	output := buf.String()
 	require.Contains(t, output, "level=WARN")
@@ -89,9 +122,176 @@ func TestEmitQueryLog_SlowQuery(t *testing.T) {
 		RowCount:      1000,
 	}
 
-	emitQueryLog(context.Background(), logger, entry, time.Second)
+	var cursor atomic.Uint64
+	emitQueryLog(context.Background(), logger, entry, time.Second, 0, &cursor, noopEmits())
 
 	output := buf.String()
 	require.Contains(t, output, "level=WARN")
 	require.Contains(t, output, "slow_query=true")
+}
+
+// Errors always log at WARN even when the handler would drop the DEBUG-level
+// normal path and sampling is disabled.
+func TestEmitQueryLog_ErrorAlwaysWarn(t *testing.T) {
+	h := &countingHandler{minLevel: slog.LevelInfo}
+	logger := slog.New(h)
+
+	entry := queryLogEntry{
+		User:          "u",
+		Database:      "d",
+		OperationName: "SELECT",
+		Protocol:      "simple",
+		TotalDuration: 10 * time.Millisecond,
+		Error:         errors.New("boom"),
+		SQLSTATE:      "XX000",
+		ErrorSource:   "client",
+	}
+
+	var cursor atomic.Uint64
+	emitQueryLog(context.Background(), logger, entry, time.Second, 0, &cursor, noopEmits())
+
+	require.Equal(t, 1, h.calls)
+	require.Equal(t, slog.LevelWarn, h.levels[0])
+
+	var sawError bool
+	h.records[0].Attrs(func(a slog.Attr) bool {
+		if a.Key == "error" && a.Value.String() == "boom" {
+			sawError = true
+		}
+		return true
+	})
+	require.True(t, sawError, "expected error attr to be present")
+}
+
+// Slow queries always log at WARN even when the handler would drop DEBUG
+// and sampling is disabled.
+func TestEmitQueryLog_SlowAlwaysWarn(t *testing.T) {
+	h := &countingHandler{minLevel: slog.LevelInfo}
+	logger := slog.New(h)
+
+	entry := queryLogEntry{
+		User:          "u",
+		Database:      "d",
+		OperationName: "SELECT",
+		Protocol:      "simple",
+		TotalDuration: 2 * time.Second,
+		RowCount:      1,
+	}
+
+	var cursor atomic.Uint64
+	emitQueryLog(context.Background(), logger, entry, time.Second, 0, &cursor, noopEmits())
+
+	require.Equal(t, 1, h.calls)
+	require.Equal(t, slog.LevelWarn, h.levels[0])
+
+	var slow bool
+	h.records[0].Attrs(func(a slog.Attr) bool {
+		if a.Key == "slow_query" && a.Value.Bool() {
+			slow = true
+		}
+		return true
+	})
+	require.True(t, slow, "expected slow_query=true attr")
+}
+
+// With the default config (sampling disabled) and an INFO-level handler, the
+// DEBUG-level normal path must short-circuit before Handle is ever called.
+func TestEmitQueryLog_NormalPathSilentByDefault(t *testing.T) {
+	h := &countingHandler{minLevel: slog.LevelInfo}
+	logger := slog.New(h)
+
+	entry := queryLogEntry{
+		User:          "u",
+		Database:      "d",
+		OperationName: "SELECT",
+		Protocol:      "simple",
+		TotalDuration: 10 * time.Millisecond,
+		RowCount:      1,
+	}
+
+	var cursor atomic.Uint64
+	for range 50 {
+		emitQueryLog(context.Background(), logger, entry, time.Second, 0, &cursor, noopEmits())
+	}
+
+	require.Equal(t, 0, h.calls, "Handle must not be invoked on the disabled normal path")
+}
+
+// Sampling: with rate=4 and a DEBUG-level handler, exactly 12/4=3 of 12
+// normal-path calls emit, all at DEBUG.
+func TestEmitQueryLog_Sampling(t *testing.T) {
+	h := &countingHandler{minLevel: slog.LevelDebug}
+	logger := slog.New(h)
+
+	entry := queryLogEntry{
+		User:          "u",
+		Database:      "d",
+		OperationName: "SELECT",
+		Protocol:      "simple",
+		TotalDuration: 10 * time.Millisecond,
+		RowCount:      1,
+	}
+
+	var cursor atomic.Uint64
+	for range 12 {
+		emitQueryLog(context.Background(), logger, entry, time.Second, 4, &cursor, noopEmits())
+	}
+
+	require.Equal(t, 3, h.calls)
+	for _, lvl := range h.levels {
+		require.Equal(t, slog.LevelDebug, lvl)
+	}
+}
+
+// The QueryLogEmits counter is bumped per emitted record and labels each
+// data point with its level. Sampled-out normal queries do not increment.
+func TestEmitQueryLog_EmitsMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	c, err := mp.Meter("test").Int64Counter("mg.gateway.query.log.emits")
+	require.NoError(t, err)
+	emits := QueryLogEmits{c}
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	normal := queryLogEntry{
+		User: "u", Database: "d", OperationName: "SELECT", Protocol: "simple",
+		TotalDuration: 10 * time.Millisecond,
+	}
+	errored := queryLogEntry{
+		User: "u", Database: "d", OperationName: "SELECT", Protocol: "simple",
+		TotalDuration: 10 * time.Millisecond, Error: errors.New("boom"),
+		SQLSTATE: "XX000", ErrorSource: "client",
+	}
+
+	var cursor atomic.Uint64
+	// 12 normal queries with rate=4 → 3 debug emits.
+	for range 12 {
+		emitQueryLog(context.Background(), logger, normal, time.Second, 4, &cursor, emits)
+	}
+	// 2 errors → 2 warn emits (sampling does not apply).
+	emitQueryLog(context.Background(), logger, errored, time.Second, 4, &cursor, emits)
+	emitQueryLog(context.Background(), logger, errored, time.Second, 4, &cursor, emits)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	counts := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "mg.gateway.query.log.emits" {
+				continue
+			}
+			sum := m.Data.(metricdata.Sum[int64])
+			for _, dp := range sum.DataPoints {
+				lvl, _ := dp.Attributes.Value("level")
+				counts[lvl.AsString()] = dp.Value
+			}
+		}
+	}
+
+	require.Equal(t, int64(3), counts["debug"], "expected 3 debug emits (12 normal queries / sample rate 4)")
+	require.Equal(t, int64(2), counts["warn"], "expected 2 warn emits (errors bypass sampling)")
 }

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -107,6 +107,8 @@ type MultiGateway struct {
 	// queryMetricsSQLMaxBytes is the maximum bytes of representative normalized
 	// SQL stored per tracked fingerprint.
 	queryMetricsSQLMaxBytes viperutil.Value[int]
+	// queryLogSampleRate is the 1/N sampling rate for normal-path query logs.
+	queryLogSampleRate viperutil.Value[uint64]
 	// queryRegistry tracks per-fingerprint query statistics; shared across
 	// primary and replica handlers so metrics aggregate to the same bucket.
 	queryRegistry *queryregistry.Registry
@@ -182,6 +184,12 @@ func NewMultiGateway() *MultiGateway {
 			Dynamic:  false,
 			EnvVars:  []string{"MT_QUERY_METRICS_SQL_MAX_BYTES"},
 		}),
+		queryLogSampleRate: viperutil.Configure(reg, "query-log-sample-rate", viperutil.Options[uint64]{
+			Default:  0,
+			FlagName: "query-log-sample-rate",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_QUERY_LOG_SAMPLE_RATE"},
+		}),
 		pgTLSCertFile: viperutil.Configure(reg, "pg-tls-cert-file", viperutil.Options[string]{
 			Default:  "",
 			FlagName: "pg-tls-cert-file",
@@ -255,6 +263,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int("plan-cache-memory", mg.planCacheMemory.Default(), "maximum memory in bytes for the query plan cache; 0 disables caching")
 	fs.Int("query-metrics-memory", mg.queryMetricsMemory.Default(), "memory budget (bytes) for per-query-shape metrics tracking; 0 disables per-query metrics and the registry RPC")
 	fs.Int("query-metrics-sql-max-bytes", mg.queryMetricsSQLMaxBytes.Default(), "maximum bytes of representative normalized SQL stored per tracked fingerprint")
+	fs.Uint64("query-log-sample-rate", mg.queryLogSampleRate.Default(), "1/N sampling rate for normal-path per-query logs. Normal queries log at DEBUG, so visibility also requires --log-level=debug. 0 disables sampling (level alone governs); 1 emits every query; N>1 emits every Nth.")
 	viperutil.BindFlags(fs,
 		mg.cell,
 		mg.serviceID,
@@ -270,6 +279,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.planCacheMemory,
 		mg.queryMetricsMemory,
 		mg.queryMetricsSQLMaxBytes,
+		mg.queryLogSampleRate,
 	)
 	mg.bufferConfig.RegisterFlags(fs)
 	mg.senv.RegisterFlags(fs)
@@ -439,9 +449,12 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		logger.WarnContext(ctx, "failed to register query info metric", "error", err)
 	}
 
+	queryLogSampleRate := mg.queryLogSampleRate.Get()
+
 	// Create and start PostgreSQL protocol listener
 	mg.pgHandler = handler.NewMultiGatewayHandler(mg.executor, logger, mg.statementTimeout.Get())
 	mg.pgHandler.SetQueryRegistry(mg.queryRegistry)
+	mg.pgHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
 
 	// Wire LISTEN/NOTIFY notification manager.
 	// Uses a lazy client getter that resolves the primary pooler connection
@@ -486,6 +499,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		replicaHandler := handler.NewMultiGatewayHandler(mg.executor, logger, mg.statementTimeout.Get())
 		replicaHandler.SetTargetReplica(true)
 		replicaHandler.SetQueryRegistry(mg.queryRegistry)
+		replicaHandler.SetNormalQueryLogSampleRate(queryLogSampleRate)
 		replicaAddr := fmt.Sprintf("%s:%d", mg.pgBindAddress.Get(), replicaPort)
 		mg.pgReplicaListener, err = server.NewListener(server.ListenerConfig{
 			Address:               replicaAddr,


### PR DESCRIPTION
## Summary

- Per-query structured logging was ~5% of multigateway CPU under load (CPU pprof: `emitQueryLog` + `JSONHandler.Handle` + slog bridge). The hot path built a `[]slog.Attr` and stringified the error for every query even though most operators only care about errors and slow queries.
- `emitQueryLog` now short-circuits before allocating any attrs when the normal path is disabled or sampled out. Normal queries log at `DEBUG`, so the default `INFO`-level slog handler drops them entirely without ever entering `Handle`. Errors and slow queries still log unconditionally at `WARN`.
- New `--query-log-sample-rate` flag (default `0`, i.e. sampling disabled) emits 1/N of normal queries when an operator wants to peek at the stream. Visibility also requires `--log-level=debug`, reusing the existing global level flag rather than introducing a parallel knob.
- Emission counts are exported via a new `mg.gateway.query.log.emits` OTel counter, labeled by level, so operators can size log volume and verify sampling is engaged.

## Description

The CPU win comes from skipping `[]slog.Attr` construction in the steady state. In the default config (no sampling, `INFO`-level handler, normal query), `emitQueryLog` now does a couple of comparisons and a `logger.Enabled` check, then returns — no allocations, no attr building, no error stringification. With sampling enabled, the 99-of-100 sampled-out case adds only a single `atomic.Uint64.Add` for the modulo cursor.

Sampling is deterministic via `counter % rate == 0` on an `atomic.Uint64`; no `math/rand`, no allocation. The cursor stays internal — the observable signal is `mg.gateway.query.log.emits{level=debug|warn}`, which is incremented exactly once per record actually handed to slog.

To re-enable full per-query logging on demand:

```
multigateway --log-level=debug --query-log-sample-rate=1 ...
```

Or with sampling at 1%:

```
multigateway --log-level=debug --query-log-sample-rate=100 ...
```

Untouched on the hot path: metrics recording (`queryDuration`, `rowsReturned`, `tableQueries`, `queryErrors`), query-registry recording, span enrichment, and the slow-query threshold logic. The shape of `queryLogEntry` is unchanged.

## Test plan

- [x] `go test ./go/services/multigateway/handler/...` — 8 tests pass, including a new `TestEmitQueryLog_EmitsMetric` that wires up `sdkmetric.NewManualReader` and asserts the OTel counter values for both `debug` (sampled emissions) and `warn` (errored/slow) data points.
- [x] `go build ./...` clean.
- [x] `go vet ./go/services/multigateway/...` clean.
- [x] Manual smoke: run multigateway with `--log-level=info` (default) and verify no per-query log spam; rerun with `--log-level=debug --query-log-sample-rate=1` and verify per-query records appear.