### PR TITLE
feat(buffer,pooler): add failover capacity-planning metrics

### DIFF
--- a/docs/query_serving/failover_sizing.md
+++ b/docs/query_serving/failover_sizing.md
@@ -155,12 +155,21 @@ After deploying the new values, watch these queries for a week:
 # Should stay flat at zero for healthy operation.
 rate(multigateway_buffer_requests_evicted_total{reason="window_exceeded"}[5m])
 rate(multigateway_buffer_requests_evicted_total{reason="buffer_full"}[5m])
-rate(multigateway_buffer_requests_evicted_total{reason="max_duration"}[5m])
 ```
 
 Any non-zero rate means at least one query failed because of buffer
-limits — either size, per-request window, or shard-level max
-duration. Each maps to a specific flag to raise.
+limits — per-request window timeout or buffer at capacity.
+
+Exceeding `--buffer-max-failover-duration` does not produce an
+eviction. The timer drains buffered entries early, and those entries
+then fail on retry against the still-unavailable primary. Detect
+this by watching `failover.duration` p99 approach the configured
+cap:
+
+```promql
+histogram_quantile(0.99,
+  sum(rate(multigateway_buffer_failover_duration_bucket[1h])) by (le))
+```
 
 ## Worked Example
 
@@ -196,8 +205,9 @@ during a failover:
 # Buffer ran out of capacity.
 rate(multigateway_buffer_requests_evicted_total{reason="buffer_full"}[5m]) > 0
 
-# Failover took longer than --buffer-window or --buffer-max-failover-duration.
-rate(multigateway_buffer_requests_evicted_total{reason=~"window_exceeded|max_duration"}[5m]) > 0
+# Per-request window timeout; usually means failover duration is creeping
+# up toward --buffer-window.
+rate(multigateway_buffer_requests_evicted_total{reason="window_exceeded"}[5m]) > 0
 
 # Pooler drain exceeded grace period and force-closed connections.
 rate(mg_pooler_drain_outcome_total{outcome="force_close"}[1h]) > 0

--- a/docs/query_serving/failover_sizing.md
+++ b/docs/query_serving/failover_sizing.md
@@ -1,0 +1,237 @@
+# Sizing the Failover Buffer and Drain
+
+## Overview
+
+This guide is for operators who need to pick concrete values for the
+failover-related flags so that planned failovers complete without
+client-visible errors. It tells you which metrics to look at, how to
+translate them into flag values, and how to validate that the values
+hold up under your workload.
+
+The two subsystems being sized are:
+
+- The **multigateway failover buffer**, which holds PRIMARY queries
+  while the old pooler is no longer serving and the new one has not
+  taken over yet. See [Failover Buffering](./failover_buffering.md) for
+  the design.
+- The **multipooler graceful drain**, which waits for in-flight
+  reserved connections to finish before completing a `NOT_SERVING`
+  transition. See [Graceful Drain](./graceful_drain_design.md) for the
+  design.
+
+These two systems are coupled: the gateway holds queries for as long
+as the failover lasts, and the pooler drain is part of that failover
+window. Sizing one without the other will produce errors at the
+boundary.
+
+## What You're Sizing
+
+```text
+Total failover window (gateway buffers requests for this long)
+│
+├── Pooler drain time (--connpool-drain-grace-period bounds this)
+│   │
+│   ├── Reserved connections finish naturally  (the graceful case)
+│   └── Reserved connections force-closed      (grace period exceeded)
+│
+└── New-primary election + topology propagation + first health-stream signal
+```
+
+The flags you're setting:
+
+| Flag                                  | Service      | Question it answers                              |
+| ------------------------------------- | ------------ | ------------------------------------------------ |
+| `--connpool-drain-grace-period`       | multipooler  | How long to wait for in-flight queries to finish |
+| `--buffer-window`                     | multigateway | How long a single buffered request waits         |
+| `--buffer-max-failover-duration`      | multigateway | Total time a shard can be in BUFFERING state     |
+| `--buffer-size`                       | multigateway | Max concurrent buffered requests, global         |
+| `--buffer-min-time-between-failovers` | multigateway | Cooldown between failover detections per shard   |
+| `--buffer-drain-concurrency`          | multigateway | Retry parallelism when failover ends             |
+
+The two failure modes you're avoiding:
+
+1. **Buffer overrun** — too many concurrent queries arrive during a
+   failover, exceeding `--buffer-size`, and the oldest get evicted
+   with `MTB01`. Visible to clients as an error.
+2. **Window exceeded** — the failover takes longer than
+   `--buffer-window` or `--buffer-max-failover-duration`, and waiting
+   queries are evicted with `MTB02`. Also visible to clients.
+
+## The Metrics You Need
+
+Run with `--buffer-enabled` and a permissive `--buffer-window` (e.g.
+60s) in a staging environment that mirrors production traffic, then
+trigger several planned failovers to populate the histograms.
+
+### Gateway side
+
+| Metric                                  | Type      | Question it answers                                            |
+| --------------------------------------- | --------- | -------------------------------------------------------------- |
+| `multigateway.buffer.queue.depth`       | Gauge     | How full is the buffer at this instant?                        |
+| `multigateway.buffer.failover.duration` | Histogram | How long did this failover take (gateway-perceived)?           |
+| `multigateway.buffer.wait.duration`     | Histogram | How long did each buffered request wait?                       |
+| `multigateway.buffer.requests.evicted`  | Counter   | How many requests were evicted, by `reason`?                   |
+| `multigateway.buffer.requests.buffered` | Counter   | How many requests entered the buffer (rate of buffer ingress)? |
+| `multigateway.buffer.failovers`         | Counter   | How many failovers were detected per shard?                    |
+
+### Pooler side
+
+| Metric                                  | Type      | Question it answers                               |
+| --------------------------------------- | --------- | ------------------------------------------------- |
+| `mg.pooler.drain.duration`              | Histogram | How long did the drain phase take?                |
+| `mg.pooler.drain.outcome`               | Counter   | Was the drain graceful or force-closed? (by attr) |
+| `mg.pooler.drain.force_closed`          | Counter   | How many reserved connections got force-closed?   |
+| `mg.pooler.reserved.active_connections` | Gauge     | How many reserved connections at drain time?      |
+
+## The Sizing Procedure
+
+Do this in order. Each step depends on the previous one's data.
+
+### Step 1: Pick `--connpool-drain-grace-period`
+
+The pooler's drain time is bounded by this flag. You want it large
+enough that the **graceful** outcome dominates, but not so large that
+a failover stalls for an obviously stuck transaction.
+
+```promql
+# What fraction of drains are getting force-closed today?
+sum(rate(mg_pooler_drain_outcome_total{outcome="force_close"}[1h]))
+/
+sum(rate(mg_pooler_drain_outcome_total[1h]))
+```
+
+- If this ratio is **> 0** for non-pathological drains, raise
+  `--connpool-drain-grace-period`.
+- If it's **always 0** and your drain.duration p99 is well under the
+  grace period, you can lower the grace period to shrink the failover
+  window.
+
+```promql
+# p99 of graceful drain duration
+histogram_quantile(0.99, sum(rate(mg_pooler_drain_duration_bucket[1h])) by (le))
+```
+
+Set `--connpool-drain-grace-period` to roughly `2 × p99(drain.duration)`
+on the graceful path. The 2× gives you margin for traffic spikes.
+
+### Step 2: Pick `--buffer-window` and `--buffer-max-failover-duration`
+
+The gateway needs to buffer for longer than the **entire** failover,
+not just the drain. Use the gateway-side metric directly — it already
+includes drain + election + topology propagation.
+
+```promql
+# p99 of total failover duration as seen by the gateway, per shard
+histogram_quantile(0.99,
+  sum(rate(multigateway_buffer_failover_duration_bucket[1h])) by (le, shard_key))
+```
+
+Pick `--buffer-window` to comfortably exceed this — `2 × p99` is a
+safe starting point.
+
+Pick `--buffer-max-failover-duration` to be `>= --buffer-window`. This
+is enforced by config validation. It's the hard upper bound on how
+long the entire shard's buffer is allowed to wait.
+
+### Step 3: Pick `--buffer-size`
+
+The cap on concurrent buffered queries. Drive this off the gauge:
+
+```promql
+# Peak buffer depth observed during real failovers
+max_over_time(multigateway_buffer_queue_depth[7d])
+```
+
+Set `--buffer-size` to `2 × max_over_time(...)` to leave headroom for
+traffic above the historic peak. Each entry costs ~5-10 KiB of memory
+(goroutine stack + struct overhead + closure-captured SQL); a buffer
+of 10,000 entries is roughly 50-100 MiB.
+
+### Step 4: Validate
+
+After deploying the new values, watch these queries for a week:
+
+```promql
+# Should stay flat at zero for healthy operation.
+rate(multigateway_buffer_requests_evicted_total{reason="window_exceeded"}[5m])
+rate(multigateway_buffer_requests_evicted_total{reason="buffer_full"}[5m])
+rate(multigateway_buffer_requests_evicted_total{reason="max_duration"}[5m])
+```
+
+Any non-zero rate means at least one query failed because of buffer
+limits — either size, per-request window, or shard-level max
+duration. Each maps to a specific flag to raise.
+
+## Worked Example
+
+A workload with ~500 queries/sec on a single shard, planned failovers
+every few weeks.
+
+After 2 weeks of staging with permissive defaults:
+
+| Observation                                            | Value  |
+| ------------------------------------------------------ | ------ |
+| `p99(mg.pooler.drain.duration)` on graceful path       | 600 ms |
+| `force_close` ratio                                    | 0      |
+| `p99(multigateway.buffer.failover.duration)` per shard | 4.2 s  |
+| `max_over_time(queue.depth)` over 7 days               | 950    |
+
+Picks:
+
+- `--connpool-drain-grace-period` = **2s** (≈ 3× p99 graceful drain)
+- `--buffer-window` = **10s** (≈ 2.4× p99 failover duration)
+- `--buffer-max-failover-duration` = **15s** (window + margin)
+- `--buffer-size` = **2000** (≈ 2× observed peak)
+- `--buffer-min-time-between-failovers` = **1m** (default; prevents
+  rapid re-entry under flapping)
+
+Memory budget at peak: `2000 × ~8 KiB ≈ 16 MiB` per gateway instance.
+
+## Continuous Validation
+
+Alert on **any** of these — they all map to client-visible failures
+during a failover:
+
+```promql
+# Buffer ran out of capacity.
+rate(multigateway_buffer_requests_evicted_total{reason="buffer_full"}[5m]) > 0
+
+# Failover took longer than --buffer-window or --buffer-max-failover-duration.
+rate(multigateway_buffer_requests_evicted_total{reason=~"window_exceeded|max_duration"}[5m]) > 0
+
+# Pooler drain exceeded grace period and force-closed connections.
+rate(mg_pooler_drain_outcome_total{outcome="force_close"}[1h]) > 0
+```
+
+For dashboards, track the histograms at p50/p90/p99 over a 24h window
+so you can spot trends before they become alerts.
+
+## Common Pitfalls
+
+- **Sizing from defaults without measurement.** The defaults assume a
+  failover under 10 s; if your consensus layer is slower or your
+  pooler holds long transactions, the defaults will silently produce
+  evictions. Always measure first.
+- **Setting `--buffer-window` smaller than `--connpool-drain-grace-period`.**
+  The gateway buffer must outlast the pooler drain, otherwise queries
+  expire before the new primary is even ready to accept them.
+- **Ignoring `--buffer-min-time-between-failovers`.** During flapping,
+  this flag prevents the gateway from re-entering BUFFERING and
+  thrashing. The default of 1 minute is conservative; lower it only
+  if you have legitimate fast failover scenarios.
+- **Sizing `--buffer-size` from query rate alone.** Depth is rate ×
+  duration, but it also depends on retry concurrency
+  (`--buffer-drain-concurrency`). Measure the gauge — don't compute
+  it from rate.
+- **Confusing `wait.duration` with `failover.duration`.**
+  `wait.duration` is per-request; some requests arrive late in the
+  failover and wait briefly. `failover.duration` is per-shard-per-event.
+  Size `--buffer-window` against `failover.duration`, not
+  `wait.duration`.
+
+## References
+
+- [Failover Buffering design](./failover_buffering.md)
+- [Graceful Drain design](./graceful_drain_design.md)
+- Metric source: `go/services/multigateway/buffer/metrics.go`,
+  `go/services/multipooler/poolerserver/metrics.go`

--- a/go/services/multigateway/buffer/buffer.go
+++ b/go/services/multigateway/buffer/buffer.go
@@ -170,6 +170,9 @@ func (b *Buffer) Shutdown() {
 	b.mu.Lock()
 	b.stopped = true
 	// Evict all queued entries.
+	if n := len(b.queue); n > 0 {
+		b.stats.addQueueDepth(b.ctx, int64(-n))
+	}
 	for _, e := range b.queue {
 		e.err = mterrors.MTB03.New()
 		close(e.done)
@@ -248,6 +251,7 @@ func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 		oldest := b.queue[0]
 		b.queue = b.queue[1:]
 		oldest.err = mterrors.MTB01.New()
+		b.stats.addQueueDepth(b.ctx, -1)
 		close(oldest.done)
 		b.stats.recordEvicted(b.ctx, string(commontypes.FormatShardKey(oldest.shardKey)), "buffer_full")
 		// The evicted entry's semaphore slot is conceptually transferred to us,
@@ -265,6 +269,7 @@ func (b *Buffer) enqueue(shardKey *clustermetadatapb.ShardKey) (*entry, error) {
 		createdAt:    now,
 	}
 	b.queue = append(b.queue, e)
+	b.stats.addQueueDepth(b.ctx, 1)
 	b.stats.recordBuffered(b.ctx, string(commontypes.FormatShardKey(shardKey)))
 
 	// Notify timeout thread only when the queue transitions from empty to
@@ -292,6 +297,7 @@ func (b *Buffer) removeEntry(e *entry) {
 		if qe == e {
 			b.queue = append(b.queue[:i], b.queue[i+1:]...)
 			b.bufferSizeSema.Release(1)
+			b.stats.addQueueDepth(b.ctx, -1)
 			return
 		}
 	}

--- a/go/services/multigateway/buffer/metrics.go
+++ b/go/services/multigateway/buffer/metrics.go
@@ -33,6 +33,13 @@ type stats struct {
 	requestsSkipped  metric.Int64Counter
 	failoverCount    metric.Int64Counter
 	waitDuration     metric.Float64Histogram
+	// queueDepth tracks the number of requests currently held in the buffer.
+	// Used to size the buffer-size cap against observed peak depth.
+	queueDepth metric.Int64UpDownCounter
+	// failoverDuration records the time each failover spent in BUFFERING
+	// before the gateway saw a new PRIMARY and began draining. Used to size
+	// buffer-window against real failover lengths.
+	failoverDuration metric.Float64Histogram
 }
 
 func newStats() *stats {
@@ -91,9 +98,29 @@ func newStats() *stats {
 		"multigateway.buffer.wait.duration",
 		metric.WithDescription("Time requests spent waiting in the buffer"),
 		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.01, 0.1, 0.5, 1, 2, 5, 10, 30),
 	)
 	if err != nil {
 		s.waitDuration = noop.Float64Histogram{}
+	}
+
+	s.queueDepth, err = s.meter.Int64UpDownCounter(
+		"multigateway.buffer.queue.depth",
+		metric.WithDescription("Number of requests currently held in the failover buffer"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		s.queueDepth = noop.Int64UpDownCounter{}
+	}
+
+	s.failoverDuration, err = s.meter.Float64Histogram(
+		"multigateway.buffer.failover.duration",
+		metric.WithDescription("Duration of each failover from BUFFERING start to drain trigger"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120),
+	)
+	if err != nil {
+		s.failoverDuration = noop.Float64Histogram{}
 	}
 
 	return s
@@ -124,4 +151,12 @@ func (s *stats) recordFailover(ctx context.Context, shardKey string) {
 
 func (s *stats) recordWaitDuration(ctx context.Context, seconds float64) {
 	s.waitDuration.Record(ctx, seconds)
+}
+
+func (s *stats) addQueueDepth(ctx context.Context, delta int64) {
+	s.queueDepth.Add(ctx, delta)
+}
+
+func (s *stats) recordFailoverDuration(ctx context.Context, shardKey string, seconds float64) {
+	s.failoverDuration.Record(ctx, seconds, metric.WithAttributes(attribute.String("shard_key", shardKey)))
 }

--- a/go/services/multigateway/buffer/metrics_test.go
+++ b/go/services/multigateway/buffer/metrics_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buffer
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	commontypes "github.com/multigres/multigres/go/common/types"
+	"github.com/multigres/multigres/go/tools/telemetry"
+)
+
+// setupBufferTelemetry installs an in-memory metric reader so tests can
+// assert on the buffer's emitted metrics. It must be called BEFORE
+// buffer.New() because the stats instruments capture the global meter
+// provider at construction time.
+func setupBufferTelemetry(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	setup := telemetry.SetupTestTelemetry(t)
+	require.NoError(t, setup.Telemetry.InitTelemetry(t.Context(), "test-buffer"))
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+	return setup.MetricReader
+}
+
+// readSumInt64 reads the single data point of an Int64 Sum (UpDownCounter)
+// metric. Returns 0 if the instrument has not yet been observed.
+func readSumInt64(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s should be Sum[int64], got %T", name, m.Data)
+			if len(sum.DataPoints) == 0 {
+				return 0
+			}
+			return sum.DataPoints[0].Value
+		}
+	}
+	return 0
+}
+
+// readHistogramFloat64 reads the single data point of a Float64 histogram.
+// Returns nil if the instrument has not yet been observed.
+func readHistogramFloat64(t *testing.T, reader *sdkmetric.ManualReader, name string) *metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			h, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "%s should be Histogram[float64], got %T", name, m.Data)
+			if len(h.DataPoints) == 0 {
+				return nil
+			}
+			return &h.DataPoints[0]
+		}
+	}
+	return nil
+}
+
+// TestQueueDepthMetricTracksDrain verifies the queue.depth gauge follows
+// the buffer occupancy through a happy-path enqueue → drain cycle.
+func TestQueueDepthMetricTracksDrain(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Go(func() {
+			retryDone, err := buf.WaitForFailoverEnd(ctx, shard1Key)
+			assert.NoError(t, err)
+			if retryDone != nil {
+				retryDone()
+			}
+		})
+	}
+	waitForQueueLen(t, buf, 3)
+
+	assert.Equal(t, int64(3), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should equal the number of buffered requests")
+
+	buf.StopBuffering(shard1Key)
+	wg.Wait()
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
+	sb.drainWg.Wait()
+
+	assert.Equal(t, int64(0), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should return to 0 after drain completes")
+}
+
+// TestQueueDepthMetricOnEviction verifies that when an enqueue forces
+// eviction of the oldest entry (slot transfer), the gauge stays at the cap
+// rather than briefly dipping.
+func TestQueueDepthMetricOnEviction(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t, func(c *Config) {
+		c.Size.Set(2)
+		c.Window.Set(30 * time.Second)
+	})
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	// Sequentially enqueue 3; the first is evicted when the third arrives.
+	var firstDone sync.WaitGroup
+	firstDone.Add(1)
+	wg.Go(func() {
+		defer firstDone.Done()
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, shard1Key)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	waitForQueueLen(t, buf, 1)
+	wg.Go(func() {
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, shard1Key)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	waitForQueueLen(t, buf, 2)
+	wg.Go(func() {
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, shard1Key)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	firstDone.Wait() // The eviction has happened by the time the first goroutine returns.
+
+	assert.Equal(t, int64(2), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should stay at the cap after a slot transfer")
+
+	buf.StopBuffering(shard1Key)
+	wg.Wait()
+	sb := buf.buffers[commontypes.FormatShardKey(shard1Key)]
+	sb.drainWg.Wait()
+
+	assert.Equal(t, int64(0), readSumInt64(t, reader, "multigateway.buffer.queue.depth"))
+}
+
+// TestQueueDepthMetricOnWindowTimeout verifies the gauge decrements when an
+// entry is evicted by the window-timeout watcher.
+func TestQueueDepthMetricOnWindowTimeout(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t, func(c *Config) {
+		c.Window.Set(50 * time.Millisecond)
+	})
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	retryDone, err := buf.WaitForFailoverEnd(context.Background(), shard1Key)
+	assert.Error(t, err, "window should expire before any drain trigger")
+	assert.Nil(t, retryDone)
+
+	assert.Equal(t, int64(0), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should drop to 0 after window-timeout eviction")
+}
+
+// TestQueueDepthMetricOnContextCancel verifies the gauge decrements when a
+// waiting request's context is canceled.
+func TestQueueDepthMetricOnContextCancel(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_, _ = buf.WaitForFailoverEnd(ctx, shard1Key)
+	})
+	waitForQueueLen(t, buf, 1)
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, int64(0), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should drop to 0 after a context-canceled removal")
+}
+
+// TestQueueDepthMetricOnShutdown verifies the gauge drops to 0 when
+// Shutdown evicts queued entries.
+func TestQueueDepthMetricOnShutdown(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Go(func() {
+			_, _ = buf.WaitForFailoverEnd(ctx, shard1Key)
+		})
+	}
+	waitForQueueLen(t, buf, 3)
+	assert.Equal(t, int64(3), readSumInt64(t, reader, "multigateway.buffer.queue.depth"))
+
+	buf.Shutdown()
+	wg.Wait()
+
+	assert.Equal(t, int64(0), readSumInt64(t, reader, "multigateway.buffer.queue.depth"),
+		"queue.depth should be 0 after Shutdown evicts all entries")
+}
+
+// TestFailoverDurationMetricRecords verifies the failover.duration histogram
+// records one sample per failover, and the recorded value matches the clock
+// delta between BUFFERING start and the drain trigger.
+func TestFailoverDurationMetricRecords(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	var mu sync.Mutex
+	fakeTime := time.Now()
+	fakeClock := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return fakeTime
+	}
+	advance := func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		fakeTime = fakeTime.Add(d)
+	}
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger(), WithNowFunc(fakeClock))
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		retryDone, err := buf.WaitForFailoverEnd(ctx, shard1Key)
+		assert.NoError(t, err)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	waitForQueueLen(t, buf, 1)
+
+	advance(3 * time.Second)
+	buf.StopBuffering(shard1Key)
+	wg.Wait()
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.failover.duration")
+	require.NotNil(t, hist, "failover.duration should have at least one data point")
+	assert.Equal(t, uint64(1), hist.Count, "expected exactly one failover sample")
+	assert.InDelta(t, 3.0, hist.Sum, 0.001, "recorded duration should match the simulated clock advance")
+}
+
+// TestFailoverDurationMetricBuckets verifies the bucket boundaries are the
+// ones we configured, rather than the OTel default (which is tuned for
+// milliseconds and would collapse seconds-scale data into 1-2 buckets).
+func TestFailoverDurationMetricBuckets(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, shard1Key)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	waitForQueueLen(t, buf, 1)
+	buf.StopBuffering(shard1Key)
+	wg.Wait()
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.failover.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t,
+		[]float64{0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120},
+		hist.Bounds,
+		"failover.duration must use seconds-scale buckets, not the OTel ms default")
+}
+
+// TestWaitDurationMetricBuckets verifies the wait.duration buckets too —
+// this metric had been silently using the OTel ms-default buckets while
+// recording in seconds, making its quantiles useless.
+func TestWaitDurationMetricBuckets(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, shard1Key)
+		if retryDone != nil {
+			retryDone()
+		}
+	})
+	waitForQueueLen(t, buf, 1)
+	buf.StopBuffering(shard1Key)
+	wg.Wait()
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.wait.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t,
+		[]float64{0.001, 0.01, 0.1, 0.5, 1, 2, 5, 10, 30},
+		hist.Bounds,
+		"wait.duration must use seconds-scale buckets, not the OTel ms default")
+}
+
+// TestFailoverDurationBucketDistribution feeds the histogram explicit
+// samples and verifies each sample lands in the bucket the operator would
+// expect from the configured boundaries. Samples are recorded directly via
+// the package-private recorder to keep the test independent of buffer
+// state-machine timing.
+func TestFailoverDurationBucketDistribution(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	// Bounds: 0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120 → 11 buckets.
+	// Per OTel spec, sample <= Bound[i] lands in Bucket[i].
+	samples := []float64{
+		0.05, // (-inf, 0.1]
+		0.3,  // (0.1, 0.5]
+		1.5,  // (1, 2]
+		7,    // (5, 10]
+		25,   // (20, 30]
+		150,  // (120, +inf)
+	}
+	var wantSum float64
+	for _, s := range samples {
+		buf.stats.recordFailoverDuration(ctx, "tg1/shard1", s)
+		wantSum += s
+	}
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.failover.duration")
+	require.NotNil(t, hist)
+	require.Equal(t, []float64{0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120}, hist.Bounds)
+
+	assert.Equal(t,
+		[]uint64{1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1},
+		hist.BucketCounts,
+		"samples should land in expected buckets")
+	assert.Equal(t, uint64(len(samples)), hist.Count)
+	assert.InDelta(t, wantSum, hist.Sum, 0.001)
+}
+
+// TestFailoverDurationBoundaryInclusivity verifies the OTel
+// ExplicitBucketHistogram inclusivity rule: a sample equal to Bound[i]
+// belongs to Bucket[i], not Bucket[i+1].
+func TestFailoverDurationBoundaryInclusivity(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	// Record exact boundary values: 0.1, 0.5, 1, 2.
+	// Expected: bucket 0, 1, 2, 3 each get one sample.
+	for _, s := range []float64{0.1, 0.5, 1, 2} {
+		buf.stats.recordFailoverDuration(ctx, "tg1/shard1", s)
+	}
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.failover.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t,
+		[]uint64{1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0},
+		hist.BucketCounts,
+		"a sample equal to Bound[i] must land in Bucket[i]")
+}
+
+// TestWaitDurationBucketDistribution feeds the wait-duration histogram
+// explicit samples and verifies bucket placement.
+func TestWaitDurationBucketDistribution(t *testing.T) {
+	reader := setupBufferTelemetry(t)
+
+	cfg := testConfig(t)
+	buf := New(context.Background(), cfg, testLogger())
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	// Bounds: 0.001, 0.01, 0.1, 0.5, 1, 2, 5, 10, 30 → 10 buckets.
+	samples := []float64{
+		0.0005, // (-inf, 0.001]
+		0.05,   // (0.01, 0.1]
+		0.7,    // (0.5, 1]
+		4,      // (2, 5]
+		50,     // (30, +inf)
+	}
+	var wantSum float64
+	for _, s := range samples {
+		buf.stats.recordWaitDuration(ctx, s)
+		wantSum += s
+	}
+
+	hist := readHistogramFloat64(t, reader, "multigateway.buffer.wait.duration")
+	require.NotNil(t, hist)
+	require.Equal(t, []float64{0.001, 0.01, 0.1, 0.5, 1, 2, 5, 10, 30}, hist.Bounds)
+
+	assert.Equal(t,
+		[]uint64{1, 0, 1, 0, 1, 0, 1, 0, 0, 1},
+		hist.BucketCounts)
+	assert.Equal(t, uint64(len(samples)), hist.Count)
+	assert.InDelta(t, wantSum, hist.Sum, 0.001)
+}

--- a/go/services/multigateway/buffer/shard_buffer.go
+++ b/go/services/multigateway/buffer/shard_buffer.go
@@ -207,6 +207,11 @@ func (sb *shardBuffer) stopBuffering(reason string, gen uint64) {
 		sb.maxDurationTimer = nil
 	}
 	sb.logger.Info("stopping buffering, draining entries", "reason", reason)
+	sb.buf.stats.recordFailoverDuration(
+		sb.buf.ctx,
+		string(commontypes.FormatShardKey(sb.shardKey)),
+		sb.lastEnd.Sub(sb.lastStart).Seconds(),
+	)
 	sb.mu.Unlock()
 
 	// Extract all entries for this shard from the global queue.
@@ -250,6 +255,8 @@ func (sb *shardBuffer) stopBuffering(reason string, gen uint64) {
 
 // drainEntry signals a single entry to retry and waits for its completion.
 func (sb *shardBuffer) drainEntry(e *entry) {
+	// Decrement before close so waiters never see a stale gauge.
+	sb.buf.stats.addQueueDepth(sb.buf.ctx, -1)
 	// Signal the entry to retry by closing its done channel.
 	close(e.done)
 	sb.buf.stats.recordDrained(sb.buf.ctx, string(commontypes.FormatShardKey(sb.shardKey)))

--- a/go/services/multigateway/buffer/timeout_thread.go
+++ b/go/services/multigateway/buffer/timeout_thread.go
@@ -134,8 +134,10 @@ func (tt *timeoutThread) evictHead() {
 	tt.buf.mu.Unlock()
 
 	head.err = mterrors.MTB02.New()
-	close(head.done)
+	// Decrement before close so waiters never see a stale gauge.
 	tt.buf.bufferSizeSema.Release(1)
+	tt.buf.stats.addQueueDepth(tt.buf.ctx, -1)
+	close(head.done)
 	tt.buf.stats.recordEvicted(tt.buf.ctx, string(commontypes.FormatShardKey(head.shardKey)), "window_exceeded")
 	tt.buf.logger.Debug("evicted entry: window exceeded", "shard_key", commontypes.FormatShardKey(head.shardKey))
 }

--- a/go/services/multipooler/poolerserver/metrics.go
+++ b/go/services/multipooler/poolerserver/metrics.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolerserver
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// drainStats holds OpenTelemetry metrics for graceful-drain observability.
+// Operators use these to size --connpool-drain-grace-period and to
+// decompose the gateway-perceived failover duration into pooler-time vs.
+// new-primary-election time.
+type drainStats struct {
+	meter metric.Meter
+
+	duration    metric.Float64Histogram
+	outcome     metric.Int64Counter
+	forceClosed metric.Int64Counter
+}
+
+func newDrainStats() *drainStats {
+	s := &drainStats{
+		meter: otel.Meter("github.com/multigres/multigres/go/services/multipooler/poolerserver"),
+	}
+
+	var err error
+
+	s.duration, err = s.meter.Float64Histogram(
+		"mg.pooler.drain.duration",
+		metric.WithDescription("Wall-clock duration of graceful drain on NOT_SERVING transition"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.1, 0.5, 1, 2, 5, 10, 30, 60),
+	)
+	if err != nil {
+		s.duration = noop.Float64Histogram{}
+	}
+
+	s.outcome, err = s.meter.Int64Counter(
+		"mg.pooler.drain.outcome",
+		metric.WithDescription("Drain events by outcome (graceful vs. force_close)"),
+		metric.WithUnit("{drain}"),
+	)
+	if err != nil {
+		s.outcome = noop.Int64Counter{}
+	}
+
+	s.forceClosed, err = s.meter.Int64Counter(
+		"mg.pooler.drain.force_closed",
+		metric.WithDescription("Reserved connections force-closed because drain exceeded the grace period"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		s.forceClosed = noop.Int64Counter{}
+	}
+
+	return s
+}
+
+const (
+	drainOutcomeGraceful   = "graceful"
+	drainOutcomeForceClose = "force_close"
+)
+
+// recordDrain records a completed drain event with its wall-clock duration
+// and outcome.
+func (s *drainStats) recordDrain(ctx context.Context, seconds float64, outcome string) {
+	s.duration.Record(ctx, seconds)
+	s.outcome.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+// recordForceClosed adds to the count of connections force-closed across
+// all drain events.
+func (s *drainStats) recordForceClosed(ctx context.Context, n int) {
+	if n <= 0 {
+		return
+	}
+	s.forceClosed.Add(ctx, int64(n))
+}

--- a/go/services/multipooler/poolerserver/metrics_test.go
+++ b/go/services/multipooler/poolerserver/metrics_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package poolerserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/tools/telemetry"
+)
+
+// setupPoolerTelemetry installs an in-memory metric reader and rebuilds the
+// stats so they bind to it. Must be called before any drainStats methods.
+func setupPoolerTelemetry(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	setup := telemetry.SetupTestTelemetry(t)
+	require.NoError(t, setup.Telemetry.InitTelemetry(t.Context(), "test-pooler"))
+	t.Cleanup(func() {
+		_ = setup.Telemetry.ShutdownTelemetry(context.Background())
+	})
+	return setup.MetricReader
+}
+
+func readHistogramFloat64(t *testing.T, reader *sdkmetric.ManualReader, name string) *metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			h, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "%s should be Histogram[float64], got %T", name, m.Data)
+			if len(h.DataPoints) == 0 {
+				return nil
+			}
+			return &h.DataPoints[0]
+		}
+	}
+	return nil
+}
+
+// readCounterByOutcome returns the value of an Int64 counter data point
+// matching the given outcome attribute, or 0 if absent.
+func readCounterByOutcome(t *testing.T, reader *sdkmetric.ManualReader, name, outcome string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s should be Sum[int64], got %T", name, m.Data)
+			for _, dp := range sum.DataPoints {
+				v, hasAttr := dp.Attributes.Value("outcome")
+				if hasAttr && v.AsString() == outcome {
+					return dp.Value
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// readCounterTotal returns the sum of all data points for an Int64 counter.
+func readCounterTotal(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s should be Sum[int64], got %T", name, m.Data)
+			var total int64
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	return 0
+}
+
+// TestDrainMetricGracefulOutcome verifies that a drain that completes
+// before the grace period elapses records outcome=graceful and no
+// force-closed connections.
+func TestDrainMetricGracefulOutcome(t *testing.T) {
+	reader := setupPoolerTelemetry(t)
+
+	mock := newDrainMockPoolManager()
+	pooler := newTestPoolerWithDrain(mock)
+	pooler.gracePeriod = 5 * time.Second
+	ctx := t.Context()
+
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	// No in-flight connections → WaitForDrain returns immediately.
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+
+	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
+	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
+	assert.Equal(t, int64(0), readCounterTotal(t, reader, "mg.pooler.drain.force_closed"))
+
+	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t, uint64(1), hist.Count)
+}
+
+// TestDrainMetricForceCloseOutcome verifies that a drain that times out
+// records outcome=force_close and the force-closed connection count.
+func TestDrainMetricForceCloseOutcome(t *testing.T) {
+	reader := setupPoolerTelemetry(t)
+
+	mock := newDrainMockPoolManager()
+	mock.closeReservedCount = 4 // CloseReservedConnections will report killing 4 connections.
+	pooler := newTestPoolerWithDrain(mock)
+	pooler.gracePeriod = 50 * time.Millisecond
+	ctx := t.Context()
+
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+
+	// Simulate an in-flight connection that never returns → WaitForDrain blocks until grace period.
+	mock.lentAdd(1)
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+
+	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))
+	assert.Equal(t, int64(1), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "force_close"))
+	assert.Equal(t, int64(4), readCounterTotal(t, reader, "mg.pooler.drain.force_closed"))
+
+	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t, uint64(1), hist.Count)
+	assert.GreaterOrEqual(t, hist.Sum, 0.05,
+		"recorded duration should reflect at least the grace period")
+}
+
+// TestDrainMetricDurationBuckets verifies the histogram uses our
+// explicit boundaries rather than the OTel ms-default.
+func TestDrainMetricDurationBuckets(t *testing.T) {
+	reader := setupPoolerTelemetry(t)
+
+	mock := newDrainMockPoolManager()
+	pooler := newTestPoolerWithDrain(mock)
+	pooler.gracePeriod = 50 * time.Millisecond
+	ctx := t.Context()
+
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+
+	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t,
+		[]float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+		hist.Bounds,
+		"drain.duration must use seconds-scale buckets")
+}
+
+// TestDrainMetricBucketDistribution feeds explicit samples and verifies
+// each lands in the expected bucket. Avoids real-time flakiness by
+// calling the recorder directly.
+func TestDrainMetricBucketDistribution(t *testing.T) {
+	reader := setupPoolerTelemetry(t)
+
+	mock := newDrainMockPoolManager()
+	pooler := newTestPoolerWithDrain(mock)
+	ctx := t.Context()
+
+	// Bounds: 0.1, 0.5, 1, 2, 5, 10, 30, 60 → 9 buckets.
+	// Per OTel spec, sample <= Bound[i] lands in Bucket[i].
+	samples := []float64{
+		0.05, // (-inf, 0.1]
+		0.3,  // (0.1, 0.5]
+		1.5,  // (1, 2]
+		7,    // (5, 10]
+		20,   // (10, 30]
+		90,   // (60, +inf)
+	}
+	var wantSum float64
+	for _, s := range samples {
+		pooler.drainStats.recordDrain(ctx, s, drainOutcomeGraceful)
+		wantSum += s
+	}
+
+	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
+	require.NotNil(t, hist)
+	require.Equal(t, []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60}, hist.Bounds)
+	assert.Equal(t,
+		[]uint64{1, 1, 0, 1, 0, 1, 1, 0, 1},
+		hist.BucketCounts,
+		"samples should land in expected buckets")
+	assert.Equal(t, uint64(len(samples)), hist.Count)
+	assert.InDelta(t, wantSum, hist.Sum, 0.001)
+}
+
+// TestDrainMetricBoundaryInclusivity verifies the OTel inclusivity rule:
+// a sample equal to Bound[i] belongs to Bucket[i].
+func TestDrainMetricBoundaryInclusivity(t *testing.T) {
+	reader := setupPoolerTelemetry(t)
+
+	mock := newDrainMockPoolManager()
+	pooler := newTestPoolerWithDrain(mock)
+	ctx := t.Context()
+
+	for _, s := range []float64{0.1, 0.5, 1, 2} {
+		pooler.drainStats.recordDrain(ctx, s, drainOutcomeGraceful)
+	}
+
+	hist := readHistogramFloat64(t, reader, "mg.pooler.drain.duration")
+	require.NotNil(t, hist)
+	assert.Equal(t,
+		[]uint64{1, 1, 1, 1, 0, 0, 0, 0, 0},
+		hist.BucketCounts,
+		"a sample equal to Bound[i] must land in Bucket[i]")
+}

--- a/go/services/multipooler/poolerserver/pooler.go
+++ b/go/services/multipooler/poolerserver/pooler.go
@@ -73,6 +73,9 @@ type QueryPoolerServer struct {
 	// AwaitStateChange blocks on this channel to be notified when the
 	// pooler's type and serving status are updated.
 	stateChanged chan struct{}
+
+	// drainStats holds drain-observability metrics. Never nil.
+	drainStats *drainStats
 }
 
 // NewQueryPoolerServer creates a new QueryPoolerServer instance with the given pool manager
@@ -97,6 +100,7 @@ func NewQueryPoolerServer(logger *slog.Logger, poolManager connpoolmanager.PoolM
 		healthProvider: healthProvider,
 		gracePeriod:    gracePeriod,
 		stateChanged:   make(chan struct{}),
+		drainStats:     newDrainStats(),
 	}
 }
 
@@ -137,6 +141,7 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 	// If gracePeriod > 0, the wait is bounded and reserved connections are force-closed on timeout.
 	// If gracePeriod == 0, the wait is unbounded (drain must complete before transition finishes).
 	if s.poolManager != nil {
+		drainStart := time.Now()
 		drainCtx := ctx
 		if s.gracePeriod > 0 {
 			var cancel context.CancelFunc
@@ -144,18 +149,22 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 			defer cancel()
 		}
 
+		outcome := drainOutcomeGraceful
 		if err := s.poolManager.WaitForDrain(drainCtx); err != nil {
+			outcome = drainOutcomeForceClose
 			s.logger.WarnContext(ctx, "Graceful drain did not complete within grace period, force-closing reserved connections",
 				"grace_period", s.gracePeriod, "error", err)
 			// Force-close all reserved connections to prevent them from being used
 			// in a non-serving state. This kills backend processes and returns
 			// connections to the pool.
 			killed := s.poolManager.CloseReservedConnections(ctx)
+			s.drainStats.recordForceClosed(ctx, killed)
 			if killed > 0 {
 				s.logger.WarnContext(ctx, "Force-closed reserved connections after drain timeout",
 					"killed", killed)
 			}
 		}
+		s.drainStats.recordDrain(ctx, time.Since(drainStart).Seconds(), outcome)
 	}
 
 	// Complete the transition. The poolerType is set here (after drain) so that

--- a/go/services/multipooler/poolerserver/pooler_test.go
+++ b/go/services/multipooler/poolerserver/pooler_test.go
@@ -84,6 +84,7 @@ func newStartRequestTestServer() *QueryPoolerServer {
 		servingStatus: clustermetadatapb.PoolerServingStatus_NOT_SERVING,
 		gracePeriod:   3 * time.Second,
 		stateChanged:  make(chan struct{}),
+		drainStats:    newDrainStats(),
 	}
 }
 
@@ -291,6 +292,7 @@ func newTestPoolerWithDrain(mock *drainMockPoolManager) *QueryPoolerServer {
 		servingStatus: clustermetadatapb.PoolerServingStatus_NOT_SERVING,
 		gracePeriod:   3 * time.Second,
 		stateChanged:  make(chan struct{}),
+		drainStats:    newDrainStats(),
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add the metrics operators need to size `--buffer-size`, `--buffer-window`, and `--connpool-drain-grace-period` against real failover behavior instead of guessing from defaults.
- Gateway side: `multigateway.buffer.queue.depth` gauge and `multigateway.buffer.failover.duration` histogram, plus explicit seconds-scale buckets on the existing `wait.duration` histogram (which had been silently using the OTel ms-default boundaries while recording in seconds).
- Pooler side: `mg.pooler.drain.duration` histogram, `mg.pooler.drain.outcome` counter (graceful / force_close), and `mg.pooler.drain.force_closed` counter.
- New operator guide at `docs/query_serving/failover_sizing.md` walking through the sizing procedure with PromQL examples, a worked example, alert queries, and common pitfalls.

## Description

The previous instrumentation surfaced rate-of-buffer-events (counters) and per-request wait time, but operators had no way to answer the questions that actually matter for tuning: how full does the buffer get at peak, how long does a failover take end-to-end, and how often does the pooler drain hit its grace period.

These metrics fill those gaps. The gateway-side `failover.duration` measures the gateway-perceived failover window per shard; the pooler-side `drain.duration` measures the pooler's contribution to that window. Subtracting one from the other (at matching quantiles) tells you whether the drain or the new-primary election is the bottleneck.

While wiring up the depth gauge I caught a latent race: the depth decrement was happening after `close(e.done)`, which wakes the waiting goroutine. A caller observing the gauge immediately after `WaitForFailoverEnd` returns could see a stale value. Reordered all three release sites (drain, timeout eviction, full-buffer eviction) so the gauge is updated before the wake-up. The new test covering this scenario caught the race on first run.

All new histograms use explicit `WithExplicitBucketBoundaries(...)` sized for their actual data range — both `wait.duration` and `failover.duration` had to be fixed (they're seconds-scale, the OTel default is tuned for HTTP milliseconds).

Tests cover: queue depth tracking across enqueue / drain / eviction / cancel / shutdown; failover-duration recording with simulated clock advance; drain outcome on both graceful and force-close paths; explicit bucket distribution for all three histograms; and OTel boundary-inclusivity (`sample <= Bound[i]` → `Bucket[i]`).