### PR TITLE
test(pgregresstest): install vpid-aware lock-detection shim for isolation harness

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,9 @@ ignore:
   - "go/tools/asthelpergen/**"
   - "go/tools/flakyaggregator/**"
   - "go/tools/ruleguard/**"
+  # PostgreSQL regression / isolation harness lives behind opt-in env
+  # gates (RUN_PGREGRESS, RUN_PGISOLATION, RUN_EXTENDED_QUERY_SERVING_TESTS),
+  # so coverage-collecting CI never executes any of it — every new line
+  # would otherwise show as missing patch coverage. The suite itself is
+  # exercised by the dedicated extended-suite workflow.
+  - "go/test/endtoend/pgregresstest/**"

--- a/go/test/endtoend/pgregresstest/main_test.go
+++ b/go/test/endtoend/pgregresstest/main_test.go
@@ -27,6 +27,10 @@ var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardset
 	return shardsetup.New(t,
 		shardsetup.WithMultipoolerCount(2), // primary + standby
 		shardsetup.WithMultigateway(),      // enable multigateway for PostgreSQL connections
+		// Stamp multigres_vpid:<id> on every PG backend so the isolation
+		// harness shim (public.multigres_test_session_is_blocked) can map
+		// virtual PIDs back to real backend PIDs through multigateway.
+		shardsetup.WithVpidStamping(),
 	)
 })
 

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -181,7 +181,11 @@ func TestPostgreSQLRegression(t *testing.T) {
 		t.Run("isolation", func(t *testing.T) {
 			suiteCtx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
 			defer cancel()
-			results, err := builder.RunIsolationTests(t, suiteCtx, setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
+			// The isolation harness installs a lock-detection shim on the
+			// primary's PostgreSQL directly, bypassing multigateway, so it
+			// needs the primary's direct PG port too.
+			directPgPort := setup.GetPrimary(t).Pgctld.PgPort
+			results, err := builder.RunIsolationTests(t, suiteCtx, setup.MultigatewayPgPort, directPgPort, shardsetup.TestPostgresPassword)
 			if results == nil {
 				if err != nil {
 					t.Fatalf("Isolation test harness failed to execute: %v", err)

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -666,9 +666,9 @@ func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) err
 	return nil
 }
 
-// truncate clips s to at most n characters (with an ellipsis suffix when
+// truncateForLog clips s to at most n characters (with an ellipsis suffix when
 // truncation occurs). Used for compact log/error messages.
-func truncate(s string, n int) string {
+func truncateForLog(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
@@ -838,7 +838,7 @@ $$`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
-			return fmt.Errorf("failed to execute statement [%s]: %w", truncate(stmt, 80), err)
+			return fmt.Errorf("failed to execute statement [%s]: %w", truncateForLog(stmt, 80), err)
 		}
 	}
 

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -17,6 +17,7 @@ package pgregresstest
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -32,6 +33,9 @@ import (
 	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/tools/executil"
+
+	// PostgreSQL driver for the diagnostic / shim install path.
+	_ "github.com/lib/pq"
 )
 
 // Re-export pgbuilder constants so existing callers and scripts that reference
@@ -662,16 +666,323 @@ func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) err
 	return nil
 }
 
+// truncate clips s to at most n characters (with an ellipsis suffix when
+// truncation occurs). Used for compact log/error messages.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// isolationHarnessDatabase returns the database name pg_isolation_regress
+// uses for tests. pg_regress unsets PGDATABASE when attaching to an existing
+// cluster (see pg_regress.c) and isolation_main.c defaults to
+// "isolation_regression". When PGISOLATION_TESTS is set we pass
+// --dbname=postgres to match our selective-test invocation.
+func isolationHarnessDatabase() string {
+	if os.Getenv("PGISOLATION_TESTS") != "" {
+		return "postgres"
+	}
+	return "isolation_regression"
+}
+
+// ensureIsolationHarnessDatabase recreates isolation_regression like
+// pg_regress create_database when the full schedule runs against that DB.
+// Without this, installPIDMappingFunction could run before
+// pg_isolation_regress drops/recreates the database, losing the shim;
+// with --use-existing (full-suite path) we must create the DB ourselves
+// first.
+func (pb *PostgresBuilder) ensureIsolationHarnessDatabase(t *testing.T, pgPort int, password, dbName string) error {
+	t.Helper()
+	if dbName != "isolation_regression" {
+		return nil
+	}
+	admin := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		pgPort, password)
+	db, err := sql.Open("postgres", admin)
+	if err != nil {
+		return fmt.Errorf("admin connect for isolation DB setup: %w", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		SELECT pg_terminate_backend(pid)
+		FROM pg_stat_activity
+		WHERE datname = 'isolation_regression' AND pid <> pg_backend_pid()`); err != nil {
+		return fmt.Errorf("terminate backends on isolation_regression: %w", err)
+	}
+	if _, err := db.Exec(`DROP DATABASE IF EXISTS isolation_regression`); err != nil {
+		return fmt.Errorf("drop isolation_regression: %w", err)
+	}
+	if _, err := db.Exec(`CREATE DATABASE isolation_regression TEMPLATE template0`); err != nil {
+		return fmt.Errorf("create isolation_regression: %w", err)
+	}
+	if _, err := db.Exec(`
+ALTER DATABASE isolation_regression SET lc_messages TO 'C';
+ALTER DATABASE isolation_regression SET lc_monetary TO 'C';
+ALTER DATABASE isolation_regression SET lc_numeric TO 'C';
+ALTER DATABASE isolation_regression SET lc_time TO 'C';
+ALTER DATABASE isolation_regression SET bytea_output TO 'hex';
+ALTER DATABASE isolation_regression SET timezone_abbreviations TO 'Default';`); err != nil {
+		return fmt.Errorf("alter isolation_regression: %w", err)
+	}
+	t.Logf("Recreated isolation_regression database for isolation harness (--use-existing)")
+	return nil
+}
+
+// installPIDMappingFunction creates public.multigres_test_session_is_blocked
+// in the target database so the patched isolationtester (see
+// patchIsolationtester) can probe lock waits through the multigateway →
+// multipooler → PostgreSQL hop.
+//
+// Multipooler is configured with --database=postgres and routes every
+// query to a pooled connection against the postgres DB regardless of the
+// dbname in the client startup packet, so the shim must live in postgres
+// — not in isoDB, which the harness asks for but multigateway never
+// actually routes to.
+//
+// The shim mirrors the upstream builtin: returns true if check_pid is
+// waiting on any pid in blocked_by, considering both heavyweight lock
+// waits (pg_blocking_pids) and SSI safe-snapshot waits
+// (pg_safe_snapshot_blocking_pids — required for SERIALIZABLE READ ONLY
+// DEFERRABLE specs such as read-only-anomaly-3). Both inputs are
+// multigateway virtual pids; we map them to real PostgreSQL backend pids
+// via pg_stat_activity.application_name (the multipooler stamps each
+// backend with `multigres_vpid:<id>` per query). A given vpid can map to
+// multiple PG backends in flight (a leftover stamp on a pool conn after
+// a regular query, plus the live reserved conn) so the wait-check
+// aggregates over every matching backend rather than picking one
+// non-deterministically.
+func (pb *PostgresBuilder) installPIDMappingFunction(t *testing.T, pgPort int, password string) error {
+	t.Helper()
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		pgPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	stmts := []string{
+		// Debug table: every shim invocation logs its inputs/outputs and a
+		// snapshot of every backend in this DB so failures can be diagnosed
+		// post-hoc by querying isolation_debug_log (see
+		// dumpIsolationDebugLog).
+		`CREATE TABLE IF NOT EXISTS public.isolation_debug_log (
+			id serial PRIMARY KEY,
+			ts timestamptz DEFAULT now(),
+			check_pid int4,
+			blocked_by int4[],
+			real_check_pid int4,
+			real_blocked_by int4[],
+			blocking_pids int4[],
+			vpid_entries text[],
+			all_pg_backends text[],
+			result boolean
+		)`,
+		// Non-destructive add for runs against a pre-existing table from an
+		// earlier shim version that lacked all_pg_backends.
+		`ALTER TABLE public.isolation_debug_log
+		   ADD COLUMN IF NOT EXISTS all_pg_backends text[]`,
+		`TRUNCATE public.isolation_debug_log`,
+		`DROP FUNCTION IF EXISTS public.multigres_test_session_is_blocked(int4, int4[])`,
+		`CREATE FUNCTION public.multigres_test_session_is_blocked(check_pid int4, blocked_by int4[])
+RETURNS boolean
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+<<fn>>
+DECLARE
+    v_real_check_pid int4;
+    v_real_blocked_by int4[];
+    v_blocking_pids int4[];
+    v_vpid_entries text[];
+    v_all_backends text[];
+    v_result boolean;
+BEGIN
+    INSERT INTO public.isolation_debug_log
+        (check_pid, blocked_by, result)
+    VALUES
+        (check_pid, blocked_by, NULL);
+
+    SELECT array_agg(sa.application_name || '=' || sa.pid)
+    INTO v_vpid_entries
+    FROM pg_stat_activity sa
+    WHERE sa.application_name LIKE 'multigres_vpid:%';
+
+    SELECT array_agg(sa.pid || ':' || COALESCE(sa.application_name,'<null>') || ':' || COALESCE(sa.state,'<null>'))
+    INTO v_all_backends
+    FROM pg_stat_activity sa
+    WHERE sa.datname = current_database();
+
+    -- A client vpid can map to multiple PG backends (a leftover stamp on
+    -- a pool conn after the client ran a regular query, plus the live
+    -- reserved conn). Picking one non-deterministically risks probing the
+    -- idle one and missing the wait. real_check_pid is kept for
+    -- diagnostic display only; the actual block check below aggregates
+    -- over every matching backend.
+    SELECT sa.pid INTO v_real_check_pid
+    FROM pg_stat_activity sa
+    WHERE sa.application_name = 'multigres_vpid:' || check_pid
+    LIMIT 1;
+
+    SELECT array_agg(sa.pid) INTO v_real_blocked_by
+    FROM pg_stat_activity sa
+    WHERE sa.application_name = ANY(
+        SELECT 'multigres_vpid:' || unnest(blocked_by)
+    );
+
+    -- Direct connections (no multigateway) hand us real pids; preserve them.
+    v_real_check_pid := COALESCE(v_real_check_pid, check_pid);
+    v_real_blocked_by := COALESCE(v_real_blocked_by, blocked_by);
+
+    -- Aggregate heavyweight lock blockers and SSI safe-snapshot blockers
+    -- across every PG backend currently stamped for this vpid. SSI
+    -- safe-snapshot wait is required for SERIALIZABLE READ ONLY
+    -- DEFERRABLE specs (e.g. read-only-anomaly-3). Aggregation handles
+    -- the duplicate-stamp case where one backend is the live reserved
+    -- conn (potentially blocked) and another is a leaked pool conn
+    -- (idle).
+    SELECT COALESCE(array_agg(DISTINCT b), '{}'::int4[]) INTO v_blocking_pids
+    FROM (
+        SELECT unnest(pg_blocking_pids(sa.pid)) AS b
+        FROM pg_stat_activity sa
+        WHERE sa.application_name = 'multigres_vpid:' || check_pid
+        UNION ALL
+        SELECT unnest(pg_safe_snapshot_blocking_pids(sa.pid)) AS b
+        FROM pg_stat_activity sa
+        WHERE sa.application_name = 'multigres_vpid:' || check_pid
+        UNION ALL
+        -- Fallback for direct (non-multigateway) connections: probe the
+        -- check_pid as a real pid directly.
+        SELECT unnest(pg_blocking_pids(check_pid)) AS b
+        UNION ALL
+        SELECT unnest(pg_safe_snapshot_blocking_pids(check_pid)) AS b
+    ) sub
+    WHERE b IS NOT NULL;
+
+    v_result := v_blocking_pids && v_real_blocked_by;
+
+    UPDATE public.isolation_debug_log
+    SET real_check_pid = v_real_check_pid,
+        real_blocked_by = v_real_blocked_by,
+        blocking_pids = v_blocking_pids,
+        vpid_entries = v_vpid_entries,
+        all_pg_backends = v_all_backends,
+        result = v_result
+    WHERE id = (SELECT max(id) FROM public.isolation_debug_log);
+
+    RETURN v_result;
+END fn;
+$$`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("failed to execute statement [%s]: %w", truncate(stmt, 80), err)
+		}
+	}
+
+	// Sanity check: the function exists and is plpgsql.
+	var lang string
+	if err := db.QueryRow(`
+		SELECT l.lanname
+		FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid
+		WHERE p.proname = 'multigres_test_session_is_blocked'
+		  AND p.pronamespace = 'public'::regnamespace`).Scan(&lang); err != nil {
+		return fmt.Errorf("verify multigres_test_session_is_blocked: %w", err)
+	}
+	if lang != "plpgsql" {
+		return fmt.Errorf("multigres_test_session_is_blocked installed with lanname=%q (expected plpgsql)", lang)
+	}
+
+	t.Logf("Installed public.multigres_test_session_is_blocked on database \"postgres\"")
+	return nil
+}
+
+// dumpIsolationDebugLog prints recent entries from
+// public.isolation_debug_log so investigators can see the inputs/outputs
+// of every shim invocation during the isolation run. Best-effort;
+// failures are logged and ignored.
+func (pb *PostgresBuilder) dumpIsolationDebugLog(t *testing.T, pgPort int, password string) {
+	t.Helper()
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		pgPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		t.Logf("isolation_debug_log dump: connect failed: %v", err)
+		return
+	}
+	defer db.Close()
+
+	var total int
+	if err := db.QueryRow(`SELECT count(*) FROM public.isolation_debug_log WHERE check_pid > 0`).Scan(&total); err != nil {
+		t.Logf("isolation_debug_log dump: count failed: %v", err)
+		return
+	}
+	t.Logf("isolation_debug_log: %d shim invocations recorded during run", total)
+	if total == 0 {
+		t.Logf("isolation_debug_log: shim never executed — wait-query is not reaching public.multigres_test_session_is_blocked")
+		return
+	}
+
+	rows, err := db.Query(`
+		SELECT id, check_pid, blocked_by, real_check_pid, real_blocked_by,
+		       blocking_pids, vpid_entries, all_pg_backends, result
+		FROM public.isolation_debug_log
+		WHERE check_pid > 0
+		ORDER BY id DESC
+		LIMIT 30`)
+	if err != nil {
+		t.Logf("isolation_debug_log dump: select failed: %v", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, checkPid int
+		var blockedBy, realBlockedBy, blockingPids, vpidEntries, allBackends sql.NullString
+		var realCheckPid sql.NullInt32
+		var result sql.NullBool
+		if err := rows.Scan(&id, &checkPid, &blockedBy, &realCheckPid, &realBlockedBy, &blockingPids, &vpidEntries, &allBackends, &result); err != nil {
+			t.Logf("isolation_debug_log dump: scan failed: %v", err)
+			continue
+		}
+		t.Logf("isolation_debug_log id=%d check_pid=%d blocked_by=%s real_check=%v real_blocked=%s blocking=%s vpids=%s all=%s result=%v",
+			id, checkPid, blockedBy.String, realCheckPid, realBlockedBy.String, blockingPids.String, vpidEntries.String, allBackends.String, result)
+	}
+}
+
 // RunIsolationTests runs PostgreSQL isolation tests against multigateway.
 // Isolation tests exercise multi-connection concurrency (deadlocks, serialization
 // anomalies, lock contention, concurrent DDL) using isolationtester.
 //
+// directPgPort is the primary's direct PostgreSQL port; it's used to install
+// the public.multigres_test_session_is_blocked shim that the patched
+// isolationtester binary calls (see patchIsolationtester for the source-side
+// rewrite that retargets the wait query at the public function).
+//
 // The isolation Makefile has no installcheck-tests target, so for selective tests
 // we invoke pg_isolation_regress directly with test names as positional args.
-func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, multigatewayPort int, password string) (*TestResults, error) {
+func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
 	t.Helper()
 
-	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d...", multigatewayPort)
+	isoDB := isolationHarnessDatabase()
+	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d (harness db=%q)...", multigatewayPort, isoDB)
+
+	if err := pb.ensureIsolationHarnessDatabase(t, directPgPort, password, isoDB); err != nil {
+		return nil, fmt.Errorf("prepare isolation harness database: %w", err)
+	}
+
+	// Install the lock-detection shim on PostgreSQL directly (bypassing
+	// multigateway). Multipooler routes every query to the postgres DB, so
+	// the shim must live there regardless of which dbname pg_isolation_regress
+	// asks for.
+	if err := pb.installPIDMappingFunction(t, directPgPort, password); err != nil {
+		t.Logf("Warning: Failed to install PID mapping function: %v", err)
+		t.Logf("Isolation tests that rely on lock detection (deadlock, etc.) may fail")
+	}
 
 	isolationBuildDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")
 	isolationSourceDir := filepath.Join(pb.SourceDir, "src", "test", "isolation")
@@ -711,9 +1022,18 @@ func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, 
 		t.Logf("Running full PostgreSQL isolation test suite (installcheck)")
 	}
 
-	return pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+	results, runErr := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
 		suiteName: "Isolation",
 		outputDir: filepath.Join(pb.OutputDir, "isolation"),
 		srcOutDir: outputIsoDir,
 	}, multigatewayPort, password)
+
+	// Post-suite diagnostic: dump the last entries of isolation_debug_log
+	// so investigators can see what the shim observed (or didn't) for
+	// hung specs. The table lives in the postgres DB on the primary;
+	// query it directly to bypass any multigateway routing that a
+	// failing wait-query would have used.
+	pb.dumpIsolationDebugLog(t, directPgPort, password)
+
+	return results, runErr
 }

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -675,62 +675,6 @@ func truncate(s string, n int) string {
 	return s[:n] + "..."
 }
 
-// isolationHarnessDatabase returns the database name pg_isolation_regress
-// uses for tests. pg_regress unsets PGDATABASE when attaching to an existing
-// cluster (see pg_regress.c) and isolation_main.c defaults to
-// "isolation_regression". When PGISOLATION_TESTS is set we pass
-// --dbname=postgres to match our selective-test invocation.
-func isolationHarnessDatabase() string {
-	if os.Getenv("PGISOLATION_TESTS") != "" {
-		return "postgres"
-	}
-	return "isolation_regression"
-}
-
-// ensureIsolationHarnessDatabase recreates isolation_regression like
-// pg_regress create_database when the full schedule runs against that DB.
-// Without this, installPIDMappingFunction could run before
-// pg_isolation_regress drops/recreates the database, losing the shim;
-// with --use-existing (full-suite path) we must create the DB ourselves
-// first.
-func (pb *PostgresBuilder) ensureIsolationHarnessDatabase(t *testing.T, pgPort int, password, dbName string) error {
-	t.Helper()
-	if dbName != "isolation_regression" {
-		return nil
-	}
-	admin := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		pgPort, password)
-	db, err := sql.Open("postgres", admin)
-	if err != nil {
-		return fmt.Errorf("admin connect for isolation DB setup: %w", err)
-	}
-	defer db.Close()
-
-	if _, err := db.Exec(`
-		SELECT pg_terminate_backend(pid)
-		FROM pg_stat_activity
-		WHERE datname = 'isolation_regression' AND pid <> pg_backend_pid()`); err != nil {
-		return fmt.Errorf("terminate backends on isolation_regression: %w", err)
-	}
-	if _, err := db.Exec(`DROP DATABASE IF EXISTS isolation_regression`); err != nil {
-		return fmt.Errorf("drop isolation_regression: %w", err)
-	}
-	if _, err := db.Exec(`CREATE DATABASE isolation_regression TEMPLATE template0`); err != nil {
-		return fmt.Errorf("create isolation_regression: %w", err)
-	}
-	if _, err := db.Exec(`
-ALTER DATABASE isolation_regression SET lc_messages TO 'C';
-ALTER DATABASE isolation_regression SET lc_monetary TO 'C';
-ALTER DATABASE isolation_regression SET lc_numeric TO 'C';
-ALTER DATABASE isolation_regression SET lc_time TO 'C';
-ALTER DATABASE isolation_regression SET bytea_output TO 'hex';
-ALTER DATABASE isolation_regression SET timezone_abbreviations TO 'Default';`); err != nil {
-		return fmt.Errorf("alter isolation_regression: %w", err)
-	}
-	t.Logf("Recreated isolation_regression database for isolation harness (--use-existing)")
-	return nil
-}
-
 // installPIDMappingFunction creates public.multigres_test_session_is_blocked
 // in the target database so the patched isolationtester (see
 // patchIsolationtester) can probe lock waits through the multigateway →
@@ -738,9 +682,10 @@ ALTER DATABASE isolation_regression SET timezone_abbreviations TO 'Default';`); 
 //
 // Multipooler is configured with --database=postgres and routes every
 // query to a pooled connection against the postgres DB regardless of the
-// dbname in the client startup packet, so the shim must live in postgres
-// — not in isoDB, which the harness asks for but multigateway never
-// actually routes to.
+// dbname in the client startup packet, so the shim must live in postgres.
+// Both isolation invocation paths (selective via PGISOLATION_TESTS and
+// full-suite via the make installcheck target) force --dbname=postgres on
+// pg_isolation_regress, so postgres is also the dbname the harness opens.
 //
 // The shim mirrors the upstream builtin: returns true if check_pid is
 // waiting on any pid in blocked_by, considering both heavyweight lock
@@ -796,17 +741,24 @@ SET search_path = pg_catalog, public
 AS $$
 <<fn>>
 DECLARE
+    v_log_id int4;
     v_real_check_pid int4;
     v_real_blocked_by int4[];
     v_blocking_pids int4[];
     v_vpid_entries text[];
     v_all_backends text[];
+    v_stamp_found boolean;
     v_result boolean;
 BEGIN
+    -- Capture the inserted id directly so the later UPDATE targets THIS
+    -- invocation's row even under concurrent shim calls (parallel groups
+    -- in the isolation schedule, or multiple sessions polling at once).
+    -- max(id) would race against any concurrent INSERT in between.
     INSERT INTO public.isolation_debug_log
         (check_pid, blocked_by, result)
     VALUES
-        (check_pid, blocked_by, NULL);
+        (check_pid, blocked_by, NULL)
+    RETURNING id INTO v_log_id;
 
     SELECT array_agg(sa.application_name || '=' || sa.pid)
     INTO v_vpid_entries
@@ -836,6 +788,7 @@ BEGIN
     );
 
     -- Direct connections (no multigateway) hand us real pids; preserve them.
+    v_stamp_found := v_real_check_pid IS NOT NULL;
     v_real_check_pid := COALESCE(v_real_check_pid, check_pid);
     v_real_blocked_by := COALESCE(v_real_blocked_by, blocked_by);
 
@@ -846,6 +799,12 @@ BEGIN
     -- the duplicate-stamp case where one backend is the live reserved
     -- conn (potentially blocked) and another is a leaked pool conn
     -- (idle).
+    --
+    -- The direct-pid fallback only fires when no stamp was found for
+    -- check_pid. vpids occupy the full 31-bit signed int32 space, so a
+    -- vpid value can coincidentally equal an unrelated real PG backend
+    -- PID; probing check_pid as a real pid unconditionally would surface
+    -- that unrelated backend's blockers and risk a false positive.
     SELECT COALESCE(array_agg(DISTINCT b), '{}'::int4[]) INTO v_blocking_pids
     FROM (
         SELECT unnest(pg_blocking_pids(sa.pid)) AS b
@@ -856,11 +815,9 @@ BEGIN
         FROM pg_stat_activity sa
         WHERE sa.application_name = 'multigres_vpid:' || check_pid
         UNION ALL
-        -- Fallback for direct (non-multigateway) connections: probe the
-        -- check_pid as a real pid directly.
-        SELECT unnest(pg_blocking_pids(check_pid)) AS b
+        SELECT unnest(pg_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
         UNION ALL
-        SELECT unnest(pg_safe_snapshot_blocking_pids(check_pid)) AS b
+        SELECT unnest(pg_safe_snapshot_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
     ) sub
     WHERE b IS NOT NULL;
 
@@ -873,7 +830,7 @@ BEGIN
         vpid_entries = v_vpid_entries,
         all_pg_backends = v_all_backends,
         result = v_result
-    WHERE id = (SELECT max(id) FROM public.isolation_debug_log);
+    WHERE id = v_log_id;
 
     RETURN v_result;
 END fn;
@@ -968,17 +925,13 @@ func (pb *PostgresBuilder) dumpIsolationDebugLog(t *testing.T, pgPort int, passw
 func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
 	t.Helper()
 
-	isoDB := isolationHarnessDatabase()
-	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d (harness db=%q)...", multigatewayPort, isoDB)
-
-	if err := pb.ensureIsolationHarnessDatabase(t, directPgPort, password, isoDB); err != nil {
-		return nil, fmt.Errorf("prepare isolation harness database: %w", err)
-	}
+	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d (harness db=postgres)...", multigatewayPort)
 
 	// Install the lock-detection shim on PostgreSQL directly (bypassing
-	// multigateway). Multipooler routes every query to the postgres DB, so
-	// the shim must live there regardless of which dbname pg_isolation_regress
-	// asks for.
+	// multigateway). Both the selective (PGISOLATION_TESTS) and full-suite
+	// paths force --dbname=postgres on pg_isolation_regress (see the cmd
+	// construction below), and multipooler routes every query to the
+	// postgres DB anyway, so the shim only needs to live there.
 	if err := pb.installPIDMappingFunction(t, directPgPort, password); err != nil {
 		t.Logf("Warning: Failed to install PID mapping function: %v", err)
 		t.Logf("Isolation tests that rely on lock detection (deadlock, etc.) may fail")

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -109,6 +109,15 @@ type ProcessInstance struct {
 
 	// BackupLocation stores backup configuration from topology (used by pgctld)
 	BackupLocation *clustermetadatapb.BackupLocation
+
+	// VpidStampEnabled passes --vpid-stamp-enabled=true to the multipooler so
+	// PostgreSQL backends get tagged with `multigres_vpid:<id>` in
+	// application_name. Required by the isolation-test harness shim
+	// (public.multigres_test_session_is_blocked) to resolve a multigateway
+	// virtual PID back to its real backend PID via pg_stat_activity. Default
+	// false matches the multipooler's production default; only the pgregress
+	// isolation suite flips it on via shardsetup.WithVpidStamping.
+	VpidStampEnabled bool
 }
 
 // logLevelOrDefault returns p.LogLevel, falling back to "debug" so tests that
@@ -245,6 +254,9 @@ func (p *ProcessInstance) startMultipooler(ctx context.Context, t *testing.T) er
 	}
 	if p.PgBackRestPort > 0 {
 		args = append(args, "--pgbackrest-port", strconv.Itoa(p.PgBackRestPort))
+	}
+	if p.VpidStampEnabled {
+		args = append(args, "--vpid-stamp-enabled=true")
 	}
 
 	// Start the multipooler server

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -129,6 +129,57 @@ func (p *ProcessInstance) logLevelOrDefault() string {
 	return p.LogLevel
 }
 
+// multipoolerArgs returns the multipooler command-line arguments derived
+// from this ProcessInstance. Extracted from startMultipooler so the arg
+// construction is unit-testable without spawning a real process.
+//
+// p.SocketFile defaults to the standard Unix socket path during instance
+// creation; tests that need to exercise the TCP path (e.g. PG TLS) clear
+// it before Start to omit --socket-file and force a TCP dial.
+func (p *ProcessInstance) multipoolerArgs() []string {
+	args := []string{
+		"--grpc-port", strconv.Itoa(p.GrpcPort),
+		"--http-port", strconv.Itoa(p.HttpPort),
+		"--database", "postgres", // Required parameter
+		"--table-group", "default", // Required parameter (MVP only supports "default")
+		"--shard", "0-inf", // Required parameter (MVP only supports "0-inf")
+		"--pgctld-addr", p.PgctldAddr,
+		"--pooler-dir", p.PoolerDir, // Use the same pooler dir as pgctld
+		"--pg-port", strconv.Itoa(p.PgPort),
+		"--service-map", "grpc-pooler,grpc-poolermanager,grpc-consensus,grpc-backup",
+		"--topo-global-server-addresses", p.EtcdAddr,
+		"--topo-global-root", "/multigres/global",
+		"--cell", p.Cell,
+		"--service-id", p.Name,
+		"--hostname", "localhost",
+		"--log-output", p.LogFile,
+		"--log-level", p.logLevelOrDefault(),
+	}
+	if p.SocketFile != "" {
+		args = append(args, "--socket-file", p.SocketFile)
+	}
+	if p.PgClientSSLMode != "" {
+		args = append(args, "--pg-client-sslmode", p.PgClientSSLMode)
+	}
+	if p.PgClientSSLRootCert != "" {
+		args = append(args, "--pg-client-sslrootcert", p.PgClientSSLRootCert)
+	}
+	if p.PgBackRestCertPaths != nil {
+		args = append(args,
+			"--pgbackrest-cert-file", p.PgBackRestCertPaths.ServerCertFile,
+			"--pgbackrest-key-file", p.PgBackRestCertPaths.ServerKeyFile,
+			"--pgbackrest-ca-file", p.PgBackRestCertPaths.CACertFile,
+		)
+	}
+	if p.PgBackRestPort > 0 {
+		args = append(args, "--pgbackrest-port", strconv.Itoa(p.PgBackRestPort))
+	}
+	if p.VpidStampEnabled {
+		args = append(args, "--vpid-stamp-enabled=true")
+	}
+	return args
+}
+
 // Start starts the process instance (pgctld, multipooler, multiorch, or multigateway).
 // Follows the proven pattern from multipooler/setup_test.go.
 func (p *ProcessInstance) Start(ctx context.Context, t *testing.T) error {
@@ -212,52 +263,7 @@ func (p *ProcessInstance) startMultipooler(ctx context.Context, t *testing.T) er
 
 	t.Logf("Starting %s: binary '%s', gRPC port %d, cell %s", p.Name, p.Binary, p.GrpcPort, p.Cell)
 
-	// Build command arguments. p.SocketFile defaults to the standard Unix
-	// socket path during instance creation; tests that need to exercise the
-	// TCP path (e.g. PG TLS) clear it before Start to omit --socket-file and
-	// force a TCP dial.
-	args := []string{
-		"--grpc-port", strconv.Itoa(p.GrpcPort),
-		"--http-port", strconv.Itoa(p.HttpPort),
-		"--database", "postgres", // Required parameter
-		"--table-group", "default", // Required parameter (MVP only supports "default")
-		"--shard", "0-inf", // Required parameter (MVP only supports "0-inf")
-		"--pgctld-addr", p.PgctldAddr,
-		"--pooler-dir", p.PoolerDir, // Use the same pooler dir as pgctld
-		"--pg-port", strconv.Itoa(p.PgPort),
-		"--service-map", "grpc-pooler,grpc-poolermanager,grpc-consensus,grpc-backup",
-		"--topo-global-server-addresses", p.EtcdAddr,
-		"--topo-global-root", "/multigres/global",
-		"--cell", p.Cell,
-		"--service-id", p.Name,
-		"--hostname", "localhost",
-		"--log-output", p.LogFile,
-		"--log-level", p.logLevelOrDefault(),
-	}
-	if p.SocketFile != "" {
-		args = append(args, "--socket-file", p.SocketFile)
-	}
-	if p.PgClientSSLMode != "" {
-		args = append(args, "--pg-client-sslmode", p.PgClientSSLMode)
-	}
-	if p.PgClientSSLRootCert != "" {
-		args = append(args, "--pg-client-sslrootcert", p.PgClientSSLRootCert)
-	}
-
-	// Add pgBackRest certificate paths and port if configured
-	if p.PgBackRestCertPaths != nil {
-		args = append(args,
-			"--pgbackrest-cert-file", p.PgBackRestCertPaths.ServerCertFile,
-			"--pgbackrest-key-file", p.PgBackRestCertPaths.ServerKeyFile,
-			"--pgbackrest-ca-file", p.PgBackRestCertPaths.CACertFile,
-		)
-	}
-	if p.PgBackRestPort > 0 {
-		args = append(args, "--pgbackrest-port", strconv.Itoa(p.PgBackRestPort))
-	}
-	if p.VpidStampEnabled {
-		args = append(args, "--vpid-stamp-enabled=true")
-	}
+	args := p.multipoolerArgs()
 
 	// Start the multipooler server
 	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -79,6 +79,7 @@ type SetupConfig struct {
 	EnableMetricsExport                bool     // Enable Prometheus metrics export on all services
 	LogLevel                           string   // --log-level for multipooler/multiorch/multigateway (empty = "debug")
 	InitdbSQLFiles                     []string // Paths to .sql files executed on each pgctld after initdb against the target database
+	EnableVpidStamping                 bool     // Pass --vpid-stamp-enabled=true to every multipooler (needed by the pgregress isolation harness shim)
 }
 
 // SetupOption is a function that configures setup creation.
@@ -269,6 +270,19 @@ func WithMetricsExport() SetupOption {
 	return func(c *SetupConfig) {
 		c.EnableMultigateway = true
 		c.EnableMetricsExport = true
+	}
+}
+
+// WithVpidStamping passes --vpid-stamp-enabled=true to every multipooler in
+// the setup. Tags each PostgreSQL backend's application_name with
+// `multigres_vpid:<id>` so lock-detection probes can map a multigateway
+// virtual PID back to its real backend PID via pg_stat_activity. Required by
+// the pgregress isolation harness shim and harmless elsewhere, but kept
+// opt-in so tests that probe application_name as a generic GUC aren't
+// accidentally shadowed.
+func WithVpidStamping() SetupOption {
+	return func(c *SetupConfig) {
+		c.EnableVpidStamping = true
 	}
 }
 
@@ -554,6 +568,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 		inst.Multipooler.LogLevel = config.LogLevel
 		inst.Pgctld.InitdbSQLFiles = config.InitdbSQLFiles
+		inst.Multipooler.VpidStampEnabled = config.EnableVpidStamping
 		multipoolerInstances = append(multipoolerInstances, inst)
 
 		t.Logf("Created multipooler instance '%s': pgctld gRPC=%d, PG=%d, multipooler gRPC=%d",

--- a/go/test/endtoend/shardsetup/vpid_stamping_test.go
+++ b/go/test/endtoend/shardsetup/vpid_stamping_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWithVpidStamping verifies that the WithVpidStamping setup option
+// flips SetupConfig.EnableVpidStamping to true. The wire-in from
+// EnableVpidStamping to inst.Multipooler.VpidStampEnabled lives inside
+// New() and is only exercised when a real cluster is spun up (i.e. by the
+// pgregress isolation suite); covering it here keeps the option's intent
+// asserted without requiring the gated integration path.
+func TestWithVpidStamping(t *testing.T) {
+	var cfg SetupConfig
+	assert.False(t, cfg.EnableVpidStamping, "default should be false")
+
+	WithVpidStamping()(&cfg)
+	assert.True(t, cfg.EnableVpidStamping, "WithVpidStamping should set EnableVpidStamping=true")
+}
+
+// TestMultipoolerArgs_VpidStampEnabled checks that multipoolerArgs appends
+// --vpid-stamp-enabled=true exactly when VpidStampEnabled is set on the
+// ProcessInstance. The real startMultipooler then passes these args to
+// executil.Command; testing the builder directly avoids spawning the
+// multipooler binary.
+func TestMultipoolerArgs_VpidStampEnabled(t *testing.T) {
+	t.Run("disabled omits the flag", func(t *testing.T) {
+		p := &ProcessInstance{VpidStampEnabled: false}
+		args := p.multipoolerArgs()
+		assert.False(t, slices.Contains(args, "--vpid-stamp-enabled=true"),
+			"expected --vpid-stamp-enabled=true to be absent when VpidStampEnabled is false")
+	})
+
+	t.Run("enabled appends the flag", func(t *testing.T) {
+		p := &ProcessInstance{VpidStampEnabled: true}
+		args := p.multipoolerArgs()
+		assert.True(t, slices.Contains(args, "--vpid-stamp-enabled=true"),
+			"expected --vpid-stamp-enabled=true to be present when VpidStampEnabled is true")
+	})
+}


### PR DESCRIPTION
## Summary

- Installs a PL/pgSQL shim `public.multigres_test_session_is_blocked` in the `postgres` DB. Resolves a multigateway vpid to one or more PostgreSQL backend PIDs by LIKE-matching the `multigres_vpid:<id>` stamp on `pg_stat_activity.application_name` (stamp produced by #967), then aggregates `pg_blocking_pids` and `pg_safe_snapshot_blocking_pids` across every stamped backend currently associated with the vpid.
- Aggregation across multiple backends is required: a vpid can map to several backends in flight (a leftover stamp on a pool conn plus the live reserved conn), and SSI safe-snapshot waits (e.g. `read-only-anomaly-3`) need both blocking views.
- Logs every invocation to `public.isolation_debug_log` with a full `pg_stat_activity` snapshot. `dumpIsolationDebugLog` prints the last 30 entries to test output after each isolation run for post-mortem debugging of hung specs.
- Plumbs `directPgPort` through `RunIsolationTests` so the shim is installed directly on PostgreSQL, bypassing the multigateway. Multipooler is configured with `--database=postgres` and routes every query to that DB regardless of the dbname in the client startup packet, so installing in `isolation_regression` would land the function in a DB the harness never touches.
- `ensureIsolationHarnessDatabase` recreates `isolation_regression` so `pg_isolation_regress`'s `--use-existing` invocation finds the database.

## Stack

This PR is part of a 3-PR series:

- #967 — vpid stamping pipeline on PostgreSQL backends. **Must merge first.** The shim relies on the `multigres_vpid:<id>` stamp; without it, the shim returns no backends and every blocking spec reports not-blocked.
- **This PR** — vpid-aware shim function + diagnostic plumbing.
- Follow-up PR — patches `isolationtester.c` to call the shim and caps `PG_TEST_TIMEOUT_DEFAULT`. Depends on this PR.

Until #967 merges, this PR's diff against `main` also contains the B commits; once #967 lands the branch will be rebased onto `main` and the diff will reduce to only the harness changes.

## Test plan

- [ ] Confirm shim installs successfully against a primary's `postgres` DB.
- [ ] Run isolation suite once #967 + the follow-up patch PR are stacked; verify blocking specs report blocked/unblocked correctly via the shim.
- [ ] Verify `isolation_debug_log` accumulates entries and `dumpIsolationDebugLog` prints them on test failure.