### PR TITLE
refactor(consensus): make externally certified discovery more crisp

### DIFF
--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -52,6 +52,27 @@ type RecruitmentResult struct {
 	EligibleLeaders []*clustermetadatapb.ConsensusStatus
 }
 
+// discoverer reduces a recruited set to the eligible-leader candidates.
+// Each proposal-building flow supplies its own discoverer; the strategy
+// encapsulates which nodes are safe to elect for that flow:
+//
+//   - discoverMostAdvancedTimeline (default for BuildSafeProposal /
+//     CheckProposalPossible): nodes tied at the highest (rule, LSN) among
+//     recruits. Safe because buildProposalCore's outgoing-cohort quorum check
+//     (run before discovery) guarantees the non-recruited set is too small to
+//     have committed anything beyond the most-advanced recruit.
+//   - newExternallyCertifiedDiscoverer(cert) (for BuildExternallyCertifiedProposal /
+//     CheckExternallyCertifiedProposalPossible): nodes whose LSN ≥
+//     cert.frozen_lsn, then tie-broken by LSN. Safe because the cert
+//     externally certifies the freezing point of the outgoing cohort.
+//
+// The discoverer's safety contract lives with its implementation, not its
+// callers. buildProposalCore is agnostic to which strategy is in use.
+type discoverer func(
+	recruited []*clustermetadatapb.ConsensusStatus,
+	outgoingRule *clustermetadatapb.ShardRule,
+) []*clustermetadatapb.ConsensusStatus
+
 // quorumMode controls which quorum requirements are enforced before calling
 // buildProposal. Both modes require an incoming-cohort quorum after the
 // proposal is built (so the new cohort can make durable writes); they differ
@@ -106,7 +127,7 @@ func BuildSafeProposal(
 	if len(recruited) == 0 {
 		return nil, errors.New("no nodes accepted the requested term revocation")
 	}
-	return buildProposalCore(revocation, recruited, requireTransitionQuorum, nil, buildProposal)
+	return buildProposalCore(revocation, recruited, requireTransitionQuorum, discoverMostAdvancedTimeline, buildProposal)
 }
 
 // CheckProposalPossible checks whether a safe leadership proposal is possible
@@ -128,7 +149,7 @@ func CheckProposalPossible(
 	if len(candidates) == 0 {
 		return errors.New("no nodes could accept the proposed revocation")
 	}
-	_, err := buildProposalCore(revocation, candidates, requireTransitionQuorum, nil, buildProposal)
+	_, err := buildProposalCore(revocation, candidates, requireTransitionQuorum, discoverMostAdvancedTimeline, buildProposal)
 	return err
 }
 
@@ -153,11 +174,11 @@ func CheckExternallyCertifiedProposalPossible(
 	if len(candidates) == 0 {
 		return errors.New("no nodes could accept the proposed revocation")
 	}
-	leaderFilter, err := certLeaderFilter(cert, candidates)
+	discover, err := newExternallyCertifiedDiscoverer(cert, candidates)
 	if err != nil {
 		return err
 	}
-	_, err = buildProposalCore(revocation, candidates, onlyRequireIncomingQuorum, leaderFilter, buildProposal)
+	_, err = buildProposalCore(revocation, candidates, onlyRequireIncomingQuorum, discover, buildProposal)
 	return err
 }
 
@@ -191,51 +212,65 @@ func BuildExternallyCertifiedProposal(
 	if len(recruited) == 0 {
 		return nil, errors.New("no nodes accepted the requested term revocation")
 	}
-	leaderFilter, err := certLeaderFilter(cert, recruited)
+	discover, err := newExternallyCertifiedDiscoverer(cert, recruited)
 	if err != nil {
 		return nil, err
 	}
-	return buildProposalCore(revocation, recruited, onlyRequireIncomingQuorum, leaderFilter, buildProposal)
+	return buildProposalCore(revocation, recruited, onlyRequireIncomingQuorum, discover, buildProposal)
 }
 
-// certLeaderFilter validates cert constraints against the given nodes and
-// returns a leaderFilter to apply in buildProposalCore.
+// newExternallyCertifiedDiscoverer validates cert against the given nodes and returns a
+// discoverer for use in buildProposalCore. The returned discoverer enforces
+// cert.frozen_lsn as a floor on leader eligibility, then delegates the
+// most-advanced-LSN tie-break to discoverMostAdvancedTimeline.
 //
-// Both outgoing_rule_number and frozen_lsn are required: a cert without them
-// provides no real guarantee about what the outgoing cohort was frozen at.
-// Bootstrap callers must set them explicitly (e.g. term 0 and "0/0").
+// Both outgoing_rule_number and frozen_lsn are required on the cert: without
+// them, the cert provides no real guarantee about what the outgoing cohort
+// was frozen at. Bootstrap callers must set them explicitly (e.g. term 0
+// and "0/0"). The factory also rejects the cert if any of the given nodes
+// has advanced past cert.outgoing_rule_number — the cert is stale or wrong
+// in that case, and the factory surfaces it as a specific error rather than
+// returning a discoverer that would yield "no eligible leaders".
 //
-// It rejects any node whose recorded rule exceeds cert.outgoing_rule_number
-// (meaning the outgoing cohort was not actually frozen at the certified point)
-// and returns a filter that restricts leader eligibility to nodes whose LSN is
-// at or above cert.frozen_lsn.
-func certLeaderFilter(
+// Safety contract: the cert externally certifies that no durable writes
+// occurred beyond frozen_lsn under cert.outgoing_rule_number. Any node whose
+// LSN ≥ frozen_lsn therefore holds every committed transaction up to that
+// frozen point — which is why buildProposalCore is safe to skip the
+// outgoing-cohort quorum check for this discoverer (onlyRequireIncomingQuorum).
+func newExternallyCertifiedDiscoverer(
 	cert *clustermetadatapb.ExternallyCertifiedRevocation,
 	nodes []*clustermetadatapb.ConsensusStatus,
-) (func(*clustermetadatapb.ConsensusStatus) bool, error) {
+) (discoverer, error) {
 	certRule := cert.GetOutgoingRuleNumber()
 	if certRule == nil {
 		return nil, errors.New("cert is missing outgoing_rule_number")
 	}
-	frozenLSN := cert.GetFrozenLsn()
-	if frozenLSN == "" {
+	if cert.GetFrozenLsn() == "" {
 		return nil, errors.New("cert is missing frozen_lsn")
 	}
 	for _, cs := range nodes {
-		if rule := cs.GetCurrentPosition().GetRule(); rule != nil {
-			if CompareRuleNumbers(rule.GetRuleNumber(), certRule) > 0 {
-				return nil, fmt.Errorf("node %s is at rule term %d but certified outgoing rule is term %d",
-					topoclient.ClusterIDString(cs.GetId()), rule.GetRuleNumber().GetCoordinatorTerm(), certRule.GetCoordinatorTerm())
-			}
+		rule := cs.GetCurrentPosition().GetRule()
+		if rule == nil {
+			continue
+		}
+		if CompareRuleNumbers(rule.GetRuleNumber(), certRule) > 0 {
+			return nil, fmt.Errorf("node %s is at rule term %d but certified outgoing rule is term %d",
+				topoclient.ClusterIDString(cs.GetId()), rule.GetRuleNumber().GetCoordinatorTerm(), certRule.GetCoordinatorTerm())
 		}
 	}
-	minLSN, err := pgutil.ParseLSN(frozenLSN)
+	minLSN, err := pgutil.ParseLSN(cert.GetFrozenLsn())
 	if err != nil {
 		return nil, fmt.Errorf("invalid frozen_lsn in cert: %w", err)
 	}
-	return func(cs *clustermetadatapb.ConsensusStatus) bool {
-		lsn, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetLsn())
-		return err == nil && lsn >= minLSN
+	return func(recruited []*clustermetadatapb.ConsensusStatus, outgoingRule *clustermetadatapb.ShardRule) []*clustermetadatapb.ConsensusStatus {
+		qualified := make([]*clustermetadatapb.ConsensusStatus, 0, len(recruited))
+		for _, cs := range recruited {
+			lsn, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetLsn())
+			if err == nil && lsn >= minLSN {
+				qualified = append(qualified, cs)
+			}
+		}
+		return discoverMostAdvancedTimeline(qualified, outgoingRule)
 	}, nil
 }
 
@@ -251,7 +286,7 @@ func buildProposalCore(
 	revocation *clustermetadatapb.TermRevocation,
 	recruitedStatuses []*clustermetadatapb.ConsensusStatus,
 	mode quorumMode,
-	leaderFilter func(*clustermetadatapb.ConsensusStatus) bool,
+	discover discoverer,
 	buildProposal func(RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error),
 ) (*consensusdatapb.CoordinatorProposal, error) {
 	if len(recruitedStatuses) == 0 {
@@ -295,7 +330,7 @@ func buildProposalCore(
 		// below after the proposal is built.
 	}
 
-	eligibleLeaders := discoverMostAdvancedTimeline(recruitedStatuses, outgoingRule, leaderFilter)
+	eligibleLeaders := discover(recruitedStatuses, outgoingRule)
 	if len(eligibleLeaders) == 0 {
 		// Unreachable: filterByValidPosition ensures at least one status survives
 		// with a parseable LSN, and outgoingRule (if set) is always derived from one of
@@ -325,22 +360,21 @@ func buildProposalCore(
 	return proposal, nil
 }
 
-// discoverMostAdvancedTimeline returns the recruited nodes eligible to lead.
+// discoverMostAdvancedTimeline is the default discoverer for safe proposals.
+// It returns the recruited nodes tied at the highest LSN — at outgoingRule's
+// rule number if one is known, otherwise across all recruits (fresh bootstrap).
 //
-// When an outgoingRule is known: prefer nodes at outgoingRule's rule number (highest
-// recorded WAL), then break ties by LSN.
-// When no outgoingRule exists (fresh bootstrap): all nodes are candidates;
-// highest LSN wins.
-//
-// An optional leaderFilter further restricts eligibility (used to enforce
-// frozen_lsn from external certs).
+// Safety contract: buildProposalCore's outgoing-cohort quorum check (run with
+// requireTransitionQuorum) guarantees recruits intersect every committing
+// N-subset of the outgoing cohort, so the most-advanced recruit holds every
+// committed transaction. With onlyRequireIncomingQuorum (no outgoing quorum
+// guarantee), this discoverer is unsafe — use newExternallyCertifiedDiscoverer instead.
 //
 // Callers are expected to pre-filter via filterByValidPosition; nodes with
 // unparsable LSNs are skipped here as a defensive fallback.
 func discoverMostAdvancedTimeline(
 	recruitedStatuses []*clustermetadatapb.ConsensusStatus,
 	outgoingRule *clustermetadatapb.ShardRule,
-	leaderFilter func(*clustermetadatapb.ConsensusStatus) bool,
 ) []*clustermetadatapb.ConsensusStatus {
 	var bestLSN pgutil.LSN
 	var eligibleLeaders []*clustermetadatapb.ConsensusStatus
@@ -350,9 +384,6 @@ func discoverMostAdvancedTimeline(
 			if CompareRuleNumbers(ruleNum, outgoingRule.GetRuleNumber()) != 0 {
 				continue
 			}
-		}
-		if leaderFilter != nil && !leaderFilter(cs) {
-			continue
 		}
 		lsn, err := pgutil.ParseLSN(cs.GetCurrentPosition().GetLsn())
 		if err != nil {

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -251,7 +251,9 @@ func newExternallyCertifiedDiscoverer(
 	for _, cs := range nodes {
 		rule := cs.GetCurrentPosition().GetRule()
 		if rule == nil {
-			continue
+			// Recruited nodes should always carry a rule.
+			return nil, fmt.Errorf("node %s has no recorded rule; consensus state may be uninitialized",
+				topoclient.ClusterIDString(cs.GetId()))
 		}
 		if CompareRuleNumbers(rule.GetRuleNumber(), certRule) > 0 {
 			return nil, fmt.Errorf("node %s is at rule term %d but certified outgoing rule is term %d",

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -547,6 +547,9 @@ func filterCohortStatuses(cohort []*clustermetadatapb.ID, statuses []*clustermet
 	for _, cs := range statuses {
 		id := cs.GetId()
 		if id == nil {
+			// Defensive: deduplicateStatuses drops nil-ID entries before any
+			// caller passes statuses here, so this branch is unreachable in
+			// practice. Guards against future callers that don't dedupe first.
 			continue
 		}
 		if _, inCohort := cohortKeys[topoclient.ClusterIDString(id)]; inCohort {

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -956,7 +956,7 @@ func TestBuildProposalCore(t *testing.T) {
 			require.NotNil(t, tt.revocation, "test case must set revocation explicitly")
 			rev := tt.revocation
 			var gotResult RecruitmentResult
-			proposal, err := buildProposalCore(rev, tt.recruitedStatuses, tt.mode, nil,
+			proposal, err := buildProposalCore(rev, tt.recruitedStatuses, tt.mode, discoverMostAdvancedTimeline,
 				func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					gotResult = r
 					return bp(r)
@@ -1588,8 +1588,8 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 
 	// neutralCert covers a fresh-bootstrap scenario: term 0 means "no recorded
 	// rule has ever existed" and "0/0" means "any reported LSN is acceptable".
-	// Both fields are required by certLeaderFilter even when the caller has no
-	// real constraint to express.
+	// Both fields are required by newExternallyCertifiedDiscoverer even when
+	// the caller has no real constraint to express.
 	neutralCert := &clustermetadatapb.ExternallyCertifiedRevocation{
 		TermRevocation:     coordRevocation(5),
 		OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
@@ -1694,8 +1694,8 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 
 	// neutralCert covers a fresh-bootstrap scenario: term 0 means "no recorded
 	// rule has ever existed" and "0/0" means "any reported LSN is acceptable".
-	// Both fields are required by certLeaderFilter even when the caller has no
-	// real constraint to express.
+	// Both fields are required by newExternallyCertifiedDiscoverer even when
+	// the caller has no real constraint to express.
 	neutralCert := &clustermetadatapb.ExternallyCertifiedRevocation{
 		TermRevocation:     revocation(5),
 		OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
@@ -1703,7 +1703,7 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 	}
 
 	t.Run("no nodes accepted the revocation", func(t *testing.T) {
-		// filterByRevocation runs before certLeaderFilter, so we early-return
+		// filterByRevocation runs before newExternallyCertifiedDiscoverer, so we early-return
 		// before the cert is inspected. Use neutralCert anyway for consistency.
 		singleCohort := []*clustermetadatapb.ID{zone1.a}
 		_, err := BuildExternallyCertifiedProposal(neutralCert, []*clustermetadatapb.ConsensusStatus{

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -1572,6 +1572,12 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 	a, b, c := makeID("zone1", "a"), makeID("zone1", "b"), makeID("zone1", "c")
 	cohort := []*clustermetadatapb.ID{a, b, c}
 
+	// initialRule mirrors what createSidecarSchema writes during initdb: term
+	// and subterm both 0, real durability policy. Every recruited node carries
+	// at least this rule, so test fixtures use it rather than nil when no
+	// later rule has been installed.
+	initialRule := makeRule(ruleNum(0, 0), atLeast(2), cohort...)
+
 	bootstrapProposal := func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 		leader := r.EligibleLeaders[0]
 		return &consensusdatapb.CoordinatorProposal{
@@ -1598,9 +1604,9 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 
 	t.Run("bootstrap: nodes at term 0 can accept", func(t *testing.T) {
 		err := CheckExternallyCertifiedProposalPossible(neutralCert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, nil),
-			makeUnrecruitedStatus(b, nil),
-			makeUnrecruitedStatus(c, nil),
+			makeUnrecruitedStatus(a, initialRule),
+			makeUnrecruitedStatus(b, initialRule),
+			makeUnrecruitedStatus(c, initialRule),
 		}, bootstrapProposal)
 		require.NoError(t, err)
 	})
@@ -1618,7 +1624,7 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 			FrozenLsn:      "0/0",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, nil),
+			makeUnrecruitedStatus(a, initialRule),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "cert is missing outgoing_rule_number")
 	})
@@ -1629,7 +1635,7 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, nil),
+			makeUnrecruitedStatus(a, initialRule),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "cert is missing frozen_lsn")
 	})
@@ -1653,7 +1659,7 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 			FrozenLsn:          "bad-lsn",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, nil),
+			makeUnrecruitedStatus(a, initialRule),
 		}, bootstrapProposal)
 		require.ErrorContains(t, err, "invalid frozen_lsn in cert")
 	})
@@ -1665,9 +1671,9 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 			FrozenLsn:          "0/9000000",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, nil),
-			makeUnrecruitedStatus(b, nil),
-			makeUnrecruitedStatus(c, nil),
+			makeUnrecruitedStatus(a, initialRule),
+			makeUnrecruitedStatus(b, initialRule),
+			makeUnrecruitedStatus(c, initialRule),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "no eligible leaders found among recruited nodes")
 	})
@@ -1676,6 +1682,12 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 func TestBuildExternallyCertifiedProposal(t *testing.T) {
 	zone1 := poolerIDs.zone1
 	incomingCohort := []*clustermetadatapb.ID{zone1.a, zone1.b, zone1.c}
+
+	// initialRule mirrors what createSidecarSchema writes during initdb: term
+	// and subterm both 0, real durability policy. Every recruited node carries
+	// at least this rule, so test fixtures use it rather than nil when no
+	// later rule has been installed.
+	initialRule := makeRule(ruleNum(0, 0), atLeast(2), incomingCohort...)
 
 	// bootstrapProposal picks the first eligible leader and proposes the incoming cohort.
 	bootstrapProposal := func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
@@ -1714,9 +1726,9 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 
 	t.Run("bootstrap: no cert constraints, all recruited nodes eligible", func(t *testing.T) {
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, nil, revocation(5)),
-			makeStatus(zone1.b, nil, revocation(5)),
-			makeStatus(zone1.c, nil, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5)),
+			makeStatus(zone1.b, initialRule, revocation(5)),
+			makeStatus(zone1.c, initialRule, revocation(5)),
 		}
 		_, err := BuildExternallyCertifiedProposal(neutralCert, statuses, bootstrapProposal)
 		require.NoError(t, err)
@@ -1728,7 +1740,7 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 			FrozenLsn:      "0/0",
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, nil, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5)),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "cert is missing outgoing_rule_number")
 	})
@@ -1739,7 +1751,7 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, nil, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5)),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "cert is missing frozen_lsn")
 	})
@@ -1781,7 +1793,7 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 			FrozenLsn:          "not-an-lsn",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, nil, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5)),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.ErrorContains(t, err, "invalid frozen_lsn in cert")
@@ -1797,9 +1809,9 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 			FrozenLsn:          "0/2000000",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatusWithLSN(zone1.a, nil, revocation(5), "0/1000000"), // below frozen_lsn
-			makeStatusWithLSN(zone1.b, nil, revocation(5), "0/2000000"), // at frozen_lsn → eligible
-			makeStatusWithLSN(zone1.c, nil, revocation(5), "0/3000000"), // above → eligible
+			makeStatusWithLSN(zone1.a, initialRule, revocation(5), "0/1000000"), // below frozen_lsn
+			makeStatusWithLSN(zone1.b, initialRule, revocation(5), "0/2000000"), // at frozen_lsn → eligible
+			makeStatusWithLSN(zone1.c, initialRule, revocation(5), "0/3000000"), // above → eligible
 		}
 		var gotResult RecruitmentResult
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
@@ -1822,9 +1834,9 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 			FrozenLsn:          "0/9000000", // higher than all nodes
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatusWithLSN(zone1.a, nil, revocation(5), "0/1000000"),
-			makeStatusWithLSN(zone1.b, nil, revocation(5), "0/2000000"),
-			makeStatusWithLSN(zone1.c, nil, revocation(5), "0/3000000"),
+			makeStatusWithLSN(zone1.a, initialRule, revocation(5), "0/1000000"),
+			makeStatusWithLSN(zone1.b, initialRule, revocation(5), "0/2000000"),
+			makeStatusWithLSN(zone1.c, initialRule, revocation(5), "0/3000000"),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.EqualError(t, err, "no eligible leaders found among recruited nodes")

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -948,6 +948,18 @@ func TestBuildProposalCore(t *testing.T) {
 				wantErr: "proposal validation: proposed rule term 6 is below the recruitment revocation term 7",
 			}
 		}(),
+		// Defensive guard: public callers all check for empty input first, but
+		// buildProposalCore independently guards against the same condition so
+		// any new internal caller surfaces a clear error rather than fall
+		// through to the misleading "invalid or missing WAL position" branch.
+		{
+			name:              "empty recruited statuses",
+			mode:              requireTransitionQuorum,
+			revocation:        revocation(5),
+			recruitedStatuses: nil,
+			buildProposal:     proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), poolerIDs.zone1.all[:3]...)),
+			wantErr:           "empty list of statuses",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1652,6 +1664,21 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 		require.EqualError(t, err, "node zone1_a is at rule term 3 but certified outgoing rule is term 2")
 	})
 
+	t.Run("nil rule on candidate node → error", func(t *testing.T) {
+		// Same contract as BuildExternallyCertifiedProposal: every recruited
+		// (or recruit-eligible) node should carry at least the initial row.
+		// A nil rule surfaces as a specific consensus-state error.
+		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
+			TermRevocation:     coordRevocation(5),
+			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
+			FrozenLsn:          "0/0",
+		}
+		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
+			makeUnrecruitedStatus(a, nil),
+		}, bootstrapProposal)
+		require.EqualError(t, err, "node zone1_a has no recorded rule; consensus state may be uninitialized")
+	})
+
 	t.Run("frozen_lsn: invalid LSN string", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
 			TermRevocation:     coordRevocation(5),
@@ -1784,6 +1811,24 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.EqualError(t, err, "node zone1_pooler-a is at rule term 4 but certified outgoing rule is term 3")
+	})
+
+	t.Run("nil rule on recruited node → error", func(t *testing.T) {
+		// Recruited nodes always carry at least the initial row written during
+		// initdb. A nil rule here means consensus state is broken (e.g. the
+		// sidecar schema never ran), and the discoverer factory must surface
+		// that as a specific error rather than letting the node silently slip
+		// through to a generic "no eligible leaders".
+		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
+			TermRevocation:     revocation(5),
+			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
+			FrozenLsn:          "0/0",
+		}
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, nil, revocation(5)),
+		}
+		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
+		require.EqualError(t, err, "node zone1_pooler-a has no recorded rule; consensus state may be uninitialized")
 	})
 
 	t.Run("frozen_lsn: invalid LSN string → error", func(t *testing.T) {

--- a/go/services/multipooler/manager/rpc_first_backup.go
+++ b/go/services/multipooler/manager/rpc_first_backup.go
@@ -75,7 +75,7 @@ func (pm *MultiPoolerManager) createFirstBackupAndInitializeLocked(ctx context.C
 
 	// Read the durability policy from topology before doing any expensive work.
 	// A misconfigured database (missing durability_policy) should fail fast.
-	// The policy is also written into the sentinel row of current_rule so all
+	// The policy is also written into the initial row of current_rule so all
 	// subsequent rule reads carry a non-nil DurabilityPolicy.
 	policy, err := pm.loadDurabilityPolicy(ctx)
 	if err != nil {
@@ -144,7 +144,7 @@ func (pm *MultiPoolerManager) createFirstBackupAndInitializeLocked(ctx context.C
 		return false, false, mterrors.Wrap(err, "failed to initialize multischema data")
 	}
 
-	// The zero-state sentinel row (term=0, empty cohort) was already inserted by
+	// The initial row (term=0, empty cohort) was already inserted by
 	// createRuleTables via createSidecarSchema above. This signals to multiorch
 	// that the shard has been initialized but not yet had its cohort established.
 

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -34,13 +34,13 @@ import (
 // *ruleStore implements this; tests use fakeRuleStore.
 type ruleStorer interface {
 	// observePosition reads the current rule and WAL LSN from postgres.
-	// Always returns a non-nil position when err is nil (the sentinel row guarantees a row exists).
+	// Always returns a non-nil position when err is nil (the initial row guarantees a row exists).
 	observePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error)
 	updateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error)
 	// createRuleTables creates multigres.current_rule and multigres.rule_history
-	// if they do not already exist, and inserts the zero-state sentinel row for
-	// the default shard initialized with the given durability policy. It is
-	// idempotent and safe to call multiple times.
+	// if they do not already exist, and inserts the initial row for the default
+	// shard, populated with the given durability policy. It is idempotent and
+	// safe to call multiple times.
 	createRuleTables(ctx context.Context, policy *clustermetadatapb.DurabilityPolicy) error
 	// cachedPosition returns the most recently observed or written PoolerPosition
 	// from memory, without querying postgres. Returns nil if no position has been
@@ -182,15 +182,15 @@ func (b *ruleUpdateBuilder) withPreviousRule(coordinatorTerm, leaderSubterm int6
 // ----------------------------------------------------------------------------
 
 // createRuleTables creates multigres.current_rule and multigres.rule_history if
-// they do not already exist, then inserts the zero-state sentinel row for the
-// default shard. It is idempotent and safe to call multiple times.
+// they do not already exist, then inserts the initial row for the default
+// shard. It is idempotent and safe to call multiple times.
 //
 // current_rule holds a single row per shard representing the current cluster rule.
 // It is used as a locking target (SELECT FOR UPDATE) to serialise concurrent
 // writes; rule_history provides the append-only audit log.
 //
-// coordinator_term=0 in the sentinel row means no rule has been applied yet.
-// policy is written into the sentinel row so all subsequent rule reads have a
+// coordinator_term=0 in the initial row means no rule has been applied yet.
+// policy is written into the initial row so all subsequent rule reads have a
 // non-nil DurabilityPolicy; operations that do not change the policy (e.g.
 // Promote) carry it forward via COALESCE in updateRule.
 func (rs *ruleStore) createRuleTables(ctx context.Context, policy *clustermetadatapb.DurabilityPolicy) error {
@@ -265,7 +265,7 @@ var errRuleConflict = errors.New("rule conflict: current rule version mismatch")
 
 // observePosition reads the current rule and WAL LSN from postgres.
 // Always returns a non-nil position when err is nil.
-// Returns an error if postgres is unreachable or the sentinel row is missing.
+// Returns an error if postgres is unreachable or the initial row is missing.
 func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.PoolerPosition, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
@@ -284,7 +284,7 @@ func (rs *ruleStore) observePosition(ctx context.Context) (*clustermetadatapb.Po
 		return nil, mterrors.Wrap(err, "failed to query current position")
 	}
 	if len(result.Rows) == 0 {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule sentinel row missing for shard 0: tables may not be initialized")
+		return nil, mterrors.Errorf(mtrpcpb.Code_INTERNAL, "current_rule initial row missing for shard 0: tables may not be initialized")
 	}
 
 	var coordinatorTerm, leaderSubterm int64

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -253,7 +253,7 @@ func newTestRuleStore(ctx context.Context, t *testing.T) (*ruleStore, *client.Co
 }
 
 // resetRuleStoreTables truncates and re-initialises the rule tables so each test
-// starts from the zero-state sentinel row.
+// starts from the initial row.
 func resetRuleStoreTables(ctx context.Context, t *testing.T) {
 	t.Helper()
 	conn, err := pgTestFixture.newClientConn(ctx)
@@ -302,18 +302,18 @@ func TestRuleStorePG_ObservePosition_FreshState(t *testing.T) {
 	pos, err := rs.observePosition(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, pos, "fresh state should still return a position with the current LSN")
-	assert.Equal(t, int64(0), pos.GetRule().GetRuleNumber().GetCoordinatorTerm(), "fresh sentinel row has coordinator_term=0")
+	assert.Equal(t, int64(0), pos.GetRule().GetRuleNumber().GetCoordinatorTerm(), "fresh initial row has coordinator_term=0")
 	assert.NotEmpty(t, pos.GetLsn(), "fresh state should include the current WAL LSN")
 
-	// The sentinel row written by createRuleTables must carry the bootstrap durability policy.
+	// The initial row written by createRuleTables must carry the bootstrap durability policy.
 	dp := pos.GetRule().GetDurabilityPolicy()
-	require.NotNil(t, dp, "sentinel row must carry the bootstrap durability policy")
+	require.NotNil(t, dp, "initial row must carry the bootstrap durability policy")
 	assert.Equal(t, testBootstrapPolicy().PolicyName, dp.PolicyName)
 	assert.Equal(t, testBootstrapPolicy().QuorumType, dp.QuorumType)
 	assert.Equal(t, testBootstrapPolicy().RequiredCount, dp.RequiredCount)
 }
 
-func TestRuleStorePG_ObservePosition_SentinelPolicyCarriedThroughUpdate(t *testing.T) {
+func TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate(t *testing.T) {
 	skipIfNoPG(t)
 	ctx := t.Context()
 	resetRuleStoreTables(ctx, t)
@@ -323,7 +323,7 @@ func TestRuleStorePG_ObservePosition_SentinelPolicyCarriedThroughUpdate(t *testi
 
 	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
 
-	// Write a rule without specifying a durability policy — the sentinel row's policy must carry forward.
+	// Write a rule without specifying a durability policy — the initial row's policy must carry forward.
 	_, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "initial", time.Now()))
 	require.NoError(t, err)
 
@@ -331,7 +331,7 @@ func TestRuleStorePG_ObservePosition_SentinelPolicyCarriedThroughUpdate(t *testi
 	require.NoError(t, err)
 
 	dp := pos.GetRule().GetDurabilityPolicy()
-	require.NotNil(t, dp, "sentinel policy must carry forward through updateRule without withDurabilityPolicy")
+	require.NotNil(t, dp, "initial policy must carry forward through updateRule without withDurabilityPolicy")
 	assert.Equal(t, testBootstrapPolicy().PolicyName, dp.PolicyName)
 	assert.Equal(t, testBootstrapPolicy().QuorumType, dp.QuorumType)
 	assert.Equal(t, testBootstrapPolicy().RequiredCount, dp.RequiredCount)
@@ -567,14 +567,14 @@ func TestRuleStorePG_UpdateRule_CASConflict(t *testing.T) {
 	coordinatorID := testPoolerID(t, "zone1", "coordinator-1")
 	now := time.Now()
 
-	// Write once to advance past the sentinel.
+	// Write once to advance past the initial row's coordinates.
 	_, err := rs.updateRule(ctx, newRuleUpdate(1, coordinatorID, "promotion", "first", now))
 	require.NoError(t, err)
 
 	// CAS with stale coordinates should fail with errRuleConflict.
 	_, err = rs.updateRule(ctx,
 		newRuleUpdate(1, coordinatorID, "config_change", "stale cas", now).
-			withPreviousRule(0, 0), // sentinel coordinates no longer current
+			withPreviousRule(0, 0), // initial-row coordinates no longer current
 	)
 	require.ErrorIs(t, err, errRuleConflict, "CAS with wrong term/subterm must return errRuleConflict")
 }

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -313,6 +313,24 @@ func TestRuleStorePG_ObservePosition_FreshState(t *testing.T) {
 	assert.Equal(t, testBootstrapPolicy().RequiredCount, dp.RequiredCount)
 }
 
+func TestRuleStorePG_ObservePosition_InitialRowMissing(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := t.Context()
+	resetRuleStoreTables(ctx, t)
+
+	rs, conn := newTestRuleStore(ctx, t)
+	defer conn.Close()
+
+	// Wipe the initial row that resetRuleStoreTables just inserted. observePosition
+	// must surface a specific error rather than returning a nil position.
+	_, err := conn.Query(ctx, "DELETE FROM multigres.current_rule")
+	require.NoError(t, err)
+
+	_, err = rs.observePosition(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "current_rule initial row missing for shard 0")
+}
+
 func TestRuleStorePG_ObservePosition_InitialPolicyCarriedThroughUpdate(t *testing.T) {
 	skipIfNoPG(t)
 	ctx := t.Context()


### PR DESCRIPTION
This is a pure refactoring -- no intended behavior change.

The leaderFilter parameter on buildProposalCore feels like a potential mistake waiting to happen, so this PR reframes it as a discovery function. For externally certified proposals, discovery is based on the frozen LSN. For safe proposals, it's the most advanced timeline among recruited poolers.

In the future we could do something like say that it's possible to recruit a resigning leader but choose to ignore it for discovery if it has transactions that are provably not durable.