### PR TITLE
fix(build): gate Codecov token behind ci environment

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,6 +26,7 @@ jobs:
   test-integration:
     name: Run full integration test suite
     runs-on: ubuntu-24.04
+    environment: ci
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -26,6 +26,7 @@ jobs:
   test-short:
     name: Short Tests
     runs-on: ubuntu-24.04
+    environment: ci
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This was an uncaught merge conflict in https://github.com/multigres/multigres/pull/945

Example error: https://github.com/multigres/multigres/actions/runs/25692103066