### PR TITLE
feat(multigateway): add --pg-require-ssl flag to enforce TLS

### DIFF
--- a/go/common/pgprotocol/server/auth_timeout_test.go
+++ b/go/common/pgprotocol/server/auth_timeout_test.go
@@ -61,6 +61,7 @@ func timeoutTestServer(t *testing.T, authTimeout time.Duration, tlsConfig ...*tl
 		c.handler = listener.handler
 		c.hashProvider = listener.hashProvider
 		c.tlsConfig = listener.tlsConfig
+		c.requireTLS = listener.requireTLS
 		serveErr := c.serve()
 		_ = c.Close()
 		errCh <- serveErr

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -120,6 +120,10 @@ type Conn struct {
 	// When nil, SSLRequest is declined with 'N'.
 	tlsConfig *tls.Config
 
+	// requireTLS rejects a plaintext StartupMessage. Copied from the
+	// listener at accept time. Cancel requests bypass this check.
+	requireTLS bool
+
 	// sslDone indicates that an SSLRequest has already been handled
 	// (accepted or declined) for this connection. Prevents double negotiation.
 	sslDone bool

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -55,6 +55,10 @@ type Listener struct {
 	// When nil, SSLRequest is declined with 'N'.
 	tlsConfig *tls.Config
 
+	// requireTLS rejects plaintext StartupMessage if true. Mirrors PG's
+	// hostssl posture. Validated against tlsConfig at construction.
+	requireTLS bool
+
 	// authenticationTimeout bounds the startup phase (SSL/GSS negotiation,
 	// StartupMessage read, SCRAM exchange) — equivalent to PostgreSQL's
 	// authentication_timeout GUC. Negative disables the timeout. The
@@ -135,6 +139,12 @@ type ListenerConfig struct {
 	// When nil, SSLRequest is declined with 'N' (plaintext only).
 	TLSConfig *tls.Config
 
+	// RequireTLS rejects any client that does not negotiate TLS before
+	// sending a StartupMessage. Mirrors the `hostssl` posture in
+	// PostgreSQL's pg_hba.conf. CancelRequest is still accepted over
+	// plaintext (matches libpq behavior). Requires TLSConfig != nil.
+	RequireTLS bool
+
 	// AuthenticationTimeout bounds the startup phase: SSL/GSS negotiation,
 	// StartupMessage read, and the SCRAM exchange. A stalled or malicious
 	// client cannot pin a goroutine past this deadline. Zero falls back to
@@ -161,6 +171,10 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		return nil, errors.New("hash provider is required (or TrustAuthProvider for testing)")
 	}
 
+	if config.RequireTLS && config.TLSConfig == nil {
+		return nil, errors.New("RequireTLS=true requires TLSConfig to be set")
+	}
+
 	netListener, err := net.Listen("tcp", config.Address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", config.Address, err)
@@ -184,6 +198,7 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		hashProvider:          config.HashProvider,
 		trustAuthProvider:     config.TrustAuthProvider,
 		tlsConfig:             config.TLSConfig,
+		requireTLS:            config.RequireTLS,
 		authenticationTimeout: authTimeout,
 		logger:                logger,
 		gatewayID:             config.GatewayID,
@@ -239,6 +254,7 @@ func (l *Listener) Serve() error {
 		conn.hashProvider = l.hashProvider
 		conn.trustAuthProvider = l.trustAuthProvider
 		conn.tlsConfig = l.tlsConfig
+		conn.requireTLS = l.requireTLS
 
 		// Handle connection in a new goroutine.
 		l.wg.Go(func() {

--- a/go/common/pgprotocol/server/ssl_test.go
+++ b/go/common/pgprotocol/server/ssl_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 )
 
@@ -593,4 +594,160 @@ func TestGSSENCRequest_ThenSSLRequest_WithTLS(t *testing.T) {
 
 	err = <-errCh
 	require.NoError(t, err)
+}
+
+// TestNewListener_RequireTLS_NoTLSConfig asserts that RequireTLS=true is
+// rejected at construction time if no TLSConfig is provided. Multigateway
+// relies on this fail-fast to avoid booting in a state that would refuse
+// every client.
+func TestNewListener_RequireTLS_NoTLSConfig(t *testing.T) {
+	_, err := NewListener(ListenerConfig{
+		Address:      "127.0.0.1:0",
+		Handler:      &mockHandler{},
+		HashProvider: newMockHashProvider("postgres"),
+		RequireTLS:   true,
+		Logger:       testLogger(t),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RequireTLS=true requires TLSConfig")
+}
+
+// TestSSLRequest_RequireTLS_RejectsPlaintext verifies that when RequireTLS
+// is set, a client that sends a StartupMessage without first negotiating
+// TLS is rejected with a FATAL *PgDiagnostic (SQLSTATE 28000) before any
+// authentication work is performed. The error is returned from
+// handleStartup so the listener's serve() error path emits the
+// ErrorResponse and closes the connection.
+func TestSSLRequest_RequireTLS_RejectsPlaintext(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	tlsConfig, _ := generateTestTLSConfig(t)
+	c := newTestConn(t, serverConn, tlsConfig)
+	c.requireTLS = true
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	// Send startup message directly without SSLRequest.
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "plain", "database": "plain"})
+
+	err := <-errCh
+	require.Error(t, err)
+	var diag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &diag)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, mterrors.PgSSInvalidAuthSpec, diag.Code)
+	assert.Contains(t, diag.Message, "TLS is required")
+	assert.Empty(t, c.user, "auth must not have run")
+}
+
+// TestSSLRequest_RequireTLS_RejectsPlaintext_WireLevel drives the full
+// serve() path with RequireTLS=true and asserts the client receives a
+// FATAL ErrorResponse over the wire AND the server closes the
+// connection. Complements the in-process handleStartup test above by
+// covering the listener's error-handling glue.
+func TestSSLRequest_RequireTLS_RejectsPlaintext_WireLevel(t *testing.T) {
+	tlsConfig, _ := generateTestTLSConfig(t)
+
+	cfg := ListenerConfig{
+		Address:      "127.0.0.1:0",
+		Handler:      &mockHandler{},
+		HashProvider: newMockHashProvider("postgres"),
+		TLSConfig:    tlsConfig,
+		RequireTLS:   true,
+		Logger:       testLogger(t),
+	}
+	listener, err := NewListener(cfg)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := listener.listener.Accept()
+		if acceptErr != nil {
+			serverErrCh <- acceptErr
+			return
+		}
+		c := newConn(netConn, listener, 1)
+		c.handler = listener.handler
+		c.hashProvider = listener.hashProvider
+		c.tlsConfig = listener.tlsConfig
+		c.requireTLS = listener.requireTLS
+		serveErr := c.serve()
+		_ = c.Close()
+		serverErrCh <- serveErr
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	// Send StartupMessage without an SSLRequest first.
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber,
+		map[string]string{"user": "plain", "database": "plain"})
+
+	msgType, body := readMessage(t, clientConn)
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"), "severity should be FATAL")
+	assert.True(t, containsErrField(body, 'C', "28000"), "SQLSTATE should be 28000")
+
+	// Server should close after writing the FATAL — next read returns EOF.
+	one := make([]byte, 1)
+	_, readErr := clientConn.Read(one)
+	require.Error(t, readErr, "server must close connection after FATAL")
+
+	// serve() returns the PgDiagnostic error.
+	require.Error(t, <-serverErrCh)
+}
+
+// TestSSLRequest_RequireTLS_AcceptsTLS verifies that with RequireTLS set,
+// a client that negotiates SSL before sending its StartupMessage is
+// admitted as normal.
+func TestSSLRequest_RequireTLS_AcceptsTLS(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			errCh <- acceptErr
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		c.requireTLS = true
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	scramClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+
+	require.NoError(t, <-errCh)
 }

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -74,6 +74,15 @@ func (c *Conn) readAndDispatchStartup() error {
 		return c.handleCancelRequest(&reader)
 
 	case protocol.ProtocolVersionNumber:
+		if c.requireTLS && !c.tlsHandshakeComplete {
+			c.logger.Warn("rejecting plaintext connection: TLS required",
+				"remote_addr", c.RemoteAddr())
+			// Returning a *PgDiagnostic lets serve() emit the FATAL
+			// ErrorResponse via its standard startup-error path (which
+			// also clears the auth deadline and closes the connection).
+			return mterrors.NewPgError("FATAL", mterrors.PgSSInvalidAuthSpec,
+				"no encryption: TLS is required for this connection", "")
+		}
 		return c.handleStartupMessage(protocolCode, &reader)
 
 	default:

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -62,6 +62,8 @@ type MultiGateway struct {
 	pgTLSCertFile viperutil.Value[string]
 	// pgTLSKeyFile is the path to the TLS private key file for PostgreSQL SSL connections.
 	pgTLSKeyFile viperutil.Value[string]
+	// pgRequireSSL rejects plaintext client connections; requires cert + key.
+	pgRequireSSL viperutil.Value[bool]
 	// poolerDiscovery handles discovery of multipoolers across all cells
 	poolerDiscovery *GlobalPoolerDiscovery
 	// poolerGateway manages connections to poolers
@@ -194,6 +196,12 @@ func NewMultiGateway() *MultiGateway {
 			Dynamic:  false,
 			EnvVars:  []string{"MT_PG_TLS_KEY_FILE"},
 		}),
+		pgRequireSSL: viperutil.Configure(reg, "pg-require-ssl", viperutil.Options[bool]{
+			Default:  false,
+			FlagName: "pg-require-ssl",
+			Dynamic:  false,
+			EnvVars:  []string{"MT_PG_REQUIRE_SSL"},
+		}),
 		pgReplicaPort: viperutil.Configure(reg, "pg-replica-port", viperutil.Options[int]{
 			Default:  0,
 			FlagName: "pg-replica-port",
@@ -249,6 +257,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Duration("authentication-timeout", mg.authenticationTimeout.Default(), "Maximum time allowed to complete client authentication (SSL handshake, startup message, SCRAM). Negative disables; 0 uses the protocol default of 60s.")
 	fs.String("pg-tls-cert-file", mg.pgTLSCertFile.Default(), "path to TLS certificate file for PostgreSQL SSL connections")
 	fs.String("pg-tls-key-file", mg.pgTLSKeyFile.Default(), "path to TLS private key file for PostgreSQL SSL connections")
+	fs.Bool("pg-require-ssl", mg.pgRequireSSL.Default(), "require TLS for all client PostgreSQL connections; multigateway fails to start if no cert/key is configured. CancelRequest still permitted over plaintext.")
 	fs.Int("pg-replica-port", mg.pgReplicaPort.Default(), "optional port for replica-reads connections; 0 disables the replica listener")
 	fs.Int("low-replication-lag-ms", mg.pgReplicaLowLagMs.Default(), "replicas at or below this lag (milliseconds) are preferred; 0 treats all replicas equally")
 	fs.Int("high-replication-lag-tolerance-ms", mg.pgReplicaHighLagToleranceMs.Default(), "absolute max lag (milliseconds) for replicas; 0 means no upper bound")
@@ -264,6 +273,7 @@ func (mg *MultiGateway) RegisterFlags(fs *pflag.FlagSet) {
 		mg.authenticationTimeout,
 		mg.pgTLSCertFile,
 		mg.pgTLSKeyFile,
+		mg.pgRequireSSL,
 		mg.pgReplicaPort,
 		mg.pgReplicaLowLagMs,
 		mg.pgReplicaHighLagToleranceMs,
@@ -369,12 +379,17 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	// Build TLS config if cert and key files are provided.
 	certFile := mg.pgTLSCertFile.Get()
 	keyFile := mg.pgTLSKeyFile.Get()
+	requireSSL := mg.pgRequireSSL.Get()
 	pgTLSConfig, err := buildPGTLSConfig(certFile, keyFile)
 	if err != nil {
 		return err
 	}
+	if requireSSL && pgTLSConfig == nil {
+		return errors.New("--pg-require-ssl=true requires --pg-tls-cert-file and --pg-tls-key-file")
+	}
 	if pgTLSConfig != nil {
-		logger.InfoContext(ctx, "TLS configured for PostgreSQL listener", "cert_file", certFile, "key_file", keyFile)
+		logger.InfoContext(ctx, "TLS configured for PostgreSQL listener",
+			"cert_file", certFile, "key_file", keyFile, "require_ssl", requireSSL)
 	}
 
 	// Build the full gateway record. All info (hostname, ports) is available
@@ -473,6 +488,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		GatewayID:             pidPrefix,
 		HashProvider:          hashProvider,
 		TLSConfig:             pgTLSConfig,
+		RequireTLS:            requireSSL,
 		AuthenticationTimeout: mg.authenticationTimeout.Get(),
 		Logger:                logger,
 	})
@@ -493,6 +509,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 			GatewayID:             pidPrefix,
 			HashProvider:          hashProvider,
 			TLSConfig:             pgTLSConfig,
+			RequireTLS:            requireSSL,
 			AuthenticationTimeout: mg.authenticationTimeout.Get(),
 			Logger:                logger,
 		})

--- a/go/test/endtoend/queryserving/main_test.go
+++ b/go/test/endtoend/queryserving/main_test.go
@@ -48,6 +48,15 @@ var tlsSetupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shard
 	)
 })
 
+// requireSSLSetupManager manages a shared setup with --pg-require-ssl=true.
+// Plaintext StartupMessage is rejected; only TLS-negotiated clients succeed.
+var requireSSLSetupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardsetup.ShardSetup {
+	return shardsetup.New(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultigatewayRequireSSL(),
+	)
+})
+
 // TestMain sets the path and cleans up after all tests.
 func TestMain(m *testing.M) {
 	exitCode := shardsetup.RunTestMain(m)
@@ -55,10 +64,12 @@ func TestMain(m *testing.M) {
 		setupManager.DumpLogs()
 		replicaSetupManager.DumpLogs()
 		tlsSetupManager.DumpLogs()
+		requireSSLSetupManager.DumpLogs()
 	}
 	setupManager.Cleanup()
 	replicaSetupManager.Cleanup()
 	tlsSetupManager.Cleanup()
+	requireSSLSetupManager.Cleanup()
 	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
 }
 
@@ -72,4 +83,10 @@ func getSharedSetup(t *testing.T) *shardsetup.ShardSetup {
 func getTLSSharedSetup(t *testing.T) *shardsetup.ShardSetup {
 	t.Helper()
 	return tlsSetupManager.Get(t)
+}
+
+// getRequireSSLSharedSetup returns the shared setup with --pg-require-ssl=true.
+func getRequireSSLSharedSetup(t *testing.T) *shardsetup.ShardSetup {
+	t.Helper()
+	return requireSSLSetupManager.Get(t)
 }

--- a/go/test/endtoend/queryserving/ssl_test.go
+++ b/go/test/endtoend/queryserving/ssl_test.go
@@ -333,6 +333,55 @@ func TestMultiGateway_SSL_VerifyFull_HostnameMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "wronghost.test")
 }
 
+// TestMultiGateway_SSL_RequireSSL_RejectsPlaintext exercises the
+// `--pg-require-ssl=true` posture: a client that connects with
+// sslmode=disable must be rejected before authentication. This mirrors
+// PostgreSQL's hostssl behavior in pg_hba.conf.
+func TestMultiGateway_SSL_RequireSSL_RejectsPlaintext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getRequireSSLSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = db.Ping()
+	require.Error(t, err, "plaintext connection must be rejected when --pg-require-ssl=true")
+}
+
+// TestMultiGateway_SSL_RequireSSL_AcceptsTLS verifies that with
+// --pg-require-ssl=true, a client that negotiates TLS (sslmode=require) is
+// admitted and can run queries.
+func TestMultiGateway_SSL_RequireSSL_AcceptsTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getRequireSSLSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=require", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var result int
+	err = db.QueryRow("SELECT 1").Scan(&result)
+	require.NoError(t, err, "sslmode=require must succeed when --pg-require-ssl=true")
+	assert.Equal(t, 1, result)
+}
+
 // TestMultiGateway_SSL_AllowMode tests sslmode=allow against a TLS-enabled multigateway.
 // Per the PG protocol, "allow" means try plaintext first; if rejected, retry with SSL.
 // Since multigateway accepts both, the client connects in plaintext on the first attempt.

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -426,7 +426,15 @@ func (s *ShardSetup) CreateMultigatewayInstance(t *testing.T, name string, pgPor
 func (s *ShardSetup) WaitForMultigatewayQueryServing(t *testing.T) {
 	t.Helper()
 
-	connStr := GetTestUserDSN("localhost", s.MultigatewayPgPort, "sslmode=disable", "connect_timeout=2")
+	// When TLS is configured on the gateway, use sslmode=require so this
+	// readiness probe still works under --pg-require-ssl=true. The probe
+	// only needs an encrypted transport, not certificate verification, so
+	// sslmode=require is sufficient regardless of cert chain.
+	sslMode := "sslmode=disable"
+	if s.MultigatewayTLSCertPaths != nil {
+		sslMode = "sslmode=require"
+	}
+	connStr := GetTestUserDSN("localhost", s.MultigatewayPgPort, sslMode, "connect_timeout=2")
 
 	ctx := utils.WithTimeout(t, 60*time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -165,6 +165,18 @@ func WithMultigatewayTLS() SetupOption {
 	}
 }
 
+// WithMultigatewayRequireSSL enables TLS for the multigateway PostgreSQL
+// listener AND sets --pg-require-ssl=true, so plaintext StartupMessage is
+// rejected. Implies WithMultigatewayTLS(). Exercises the hostssl-equivalent
+// posture end-to-end.
+func WithMultigatewayRequireSSL() SetupOption {
+	return func(c *SetupConfig) {
+		c.EnableMultigateway = true
+		c.EnableMultigatewayTLS = true
+		c.MultigatewayExtraArgs = append(c.MultigatewayExtraArgs, "--pg-require-ssl=true")
+	}
+}
+
 // WithMultipoolerPGTLS provisions postgres with TLS via pgctld's
 // --pg-initdb-extra-conf hook and configures every multipooler in the setup to
 // dial postgres over TCP with sslmode=verify-full and the matching CA bundle.


### PR DESCRIPTION
## Summary

- Add `--pg-require-ssl` (env `MT_PG_REQUIRE_SSL`, default `false`) on multigateway. When `true`, plaintext `StartupMessage` is rejected with `FATAL` `28000` before authentication. `CancelRequest` stays permitted over plaintext for libpq parity.
- Multigateway fails to start if `--pg-require-ssl=true` and `--pg-tls-cert-file` / `--pg-tls-key-file` are unset.
- Mirrors PostgreSQL's `hostssl` posture in `pg_hba.conf`. Closes MUL-421; child of MUL-420 SSL-enforcement RFC.

## Test plan

- [x] Unit: `TestNewListener_RequireTLS_NoTLSConfig`, `TestSSLRequest_RequireTLS_RejectsPlaintext` (+ wire-level variant), `TestSSLRequest_RequireTLS_AcceptsTLS`
- [x] E2E: `TestMultiGateway_SSL_RequireSSL_RejectsPlaintext`, `TestMultiGateway_SSL_RequireSSL_AcceptsTLS`, all 11 existing SSL tests green
- [x] `go test -race`, `golangci-lint`, `go vet` clean