### PR TITLE
feat(scram): advertise SCRAM-SHA-256-PLUS over TLS

### DIFF
--- a/go/common/pgprotocol/scram/authenticator.go
+++ b/go/common/pgprotocol/scram/authenticator.go
@@ -15,6 +15,8 @@
 package scram
 
 import (
+	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -41,7 +43,57 @@ var (
 	// with SQLSTATE 28P01, matching native PostgreSQL's handling of expired
 	// passwords.
 	ErrPasswordExpired = errors.New("password expired")
+
+	// ErrChannelBindingNegotiation indicates the client signaled GS2 flag
+	// "y" while the server actually advertised SCRAM-SHA-256-PLUS — a
+	// classic downgrade attempt. Per PostgreSQL, caller emits SQLSTATE
+	// 28000 with "SCRAM channel binding negotiation error".
+	ErrChannelBindingNegotiation = errors.New("scram: channel binding negotiation error")
+
+	// ErrChannelBindingCheck indicates the cbind data the client echoed
+	// in client-final-message does not match the value the server expects
+	// (gs2-header + cbind-data for PLUS, or "biws"/"eSws" for base). Per
+	// PostgreSQL, caller emits SQLSTATE 28000 with "SCRAM channel binding
+	// check failed".
+	ErrChannelBindingCheck = errors.New("scram: channel binding check failed")
+
+	// ErrSASLProtocol indicates a SCRAM-level protocol violation tied to
+	// channel binding: PLUS mechanism with non-"p=" flag, base mechanism
+	// with "p=" flag, unsupported binding type, malformed messages. Per
+	// PostgreSQL, caller emits SQLSTATE 08P01 with "malformed SCRAM
+	// message" (or the more specific "unsupported SCRAM channel-binding
+	// type" variant) plus an error detail.
+	ErrSASLProtocol = errors.New("scram: protocol violation")
+
+	// ErrAuthzidNotSupported indicates the client included a SASL
+	// authorization identity ("a=...") in its gs2-header. PostgreSQL
+	// rejects this with SQLSTATE 0A000 (feature_not_supported).
+	ErrAuthzidNotSupported = errors.New("scram: authzid not supported")
 )
+
+// SASLProtocolError wraps ErrSASLProtocol with a PG-style detail message so
+// the listener can emit "malformed SCRAM message" with errdetail("...")
+// verbatim — matching libpq-readable output. Use as the wire-facing detail
+// only; the sentinel chain still exposes ErrSASLProtocol via errors.Is.
+type SASLProtocolError struct {
+	// Detail is the PostgreSQL errdetail() string — keep it byte-identical
+	// to the PG source so client-side log parsers (and humans) can't tell
+	// they're talking to multigres.
+	Detail string
+	// Msg overrides the primary errmsg(); empty means "malformed SCRAM
+	// message" (PG's default for cbind protocol errors).
+	Msg string
+}
+
+func (e *SASLProtocolError) Error() string {
+	if e.Msg != "" {
+		return "scram: " + e.Msg + ": " + e.Detail
+	}
+	return "scram: malformed SCRAM message: " + e.Detail
+}
+
+// Unwrap lets errors.Is(err, ErrSASLProtocol) succeed.
+func (e *SASLProtocolError) Unwrap() error { return ErrSASLProtocol }
 
 // authenticatorState tracks the current state of the SCRAM handshake.
 type authenticatorState int
@@ -99,6 +151,31 @@ type ScramAuthenticator struct {
 	// This can be used for SCRAM passthrough authentication to backends.
 	// See RFC 5802: ClientKey = ClientProof XOR ClientSignature.
 	extractedClientKey []byte
+
+	// channelBinding holds the TLS channel binding context. When non-nil and
+	// TLSServerEndPointHash is populated, the authenticator advertises
+	// SCRAM-SHA-256-PLUS in addition to SCRAM-SHA-256.
+	channelBinding *ChannelBinding
+
+	// overTLS records whether the underlying connection is TLS — regardless
+	// of whether cbind material was successfully captured. PG triggers its
+	// "channel binding negotiation error" path on `ssl_in_use`, not on
+	// whether PLUS was actually advertisable. Tracking these independently
+	// ensures the `y`-flag downgrade is still rejected when the server is
+	// over TLS but failed to compute a cbind hash (e.g. unsupported cert
+	// signature algorithm) — otherwise the fallback to base SCRAM would
+	// silently accept a downgrade attempt.
+	overTLS bool
+
+	// selectedMechanism is the SASL mechanism the client picked
+	// (SCRAM-SHA-256 or SCRAM-SHA-256-PLUS). Captured in HandleClientFirst
+	// and used in HandleClientFinal to verify the cbind data the client
+	// echoes back.
+	selectedMechanism string
+
+	// clientGS2Header is the literal gs2-header prefix from the client's
+	// first message. Used to verify cbind data in client-final-message.
+	clientGS2Header string
 }
 
 // NewScramAuthenticator creates a new SCRAM authenticator for the given
@@ -120,17 +197,59 @@ func NewScramAuthenticator(hash *ScramHash, database string) *ScramAuthenticator
 	}
 }
 
+// SetChannelBinding attaches TLS channel binding context to the authenticator.
+// Must be called before StartAuthentication; calling it afterwards panics, as
+// the advertised mechanism list would already be locked in. When the binding
+// hash is non-empty the authenticator advertises SCRAM-SHA-256-PLUS in
+// addition to SCRAM-SHA-256 and enforces the corresponding GS2 flag rules
+// (RFC 5802 §6).
+//
+// Pass nil to clear any previously set binding.
+func (a *ScramAuthenticator) SetChannelBinding(cb *ChannelBinding) {
+	if a.state != stateInitial {
+		panic("scram: SetChannelBinding called after StartAuthentication")
+	}
+	a.channelBinding = cb
+}
+
+// SetOverTLS records that the underlying connection is TLS-encrypted. Must
+// be called before StartAuthentication. This is independent of whether
+// SetChannelBinding succeeded — downgrade detection still needs to fire
+// over TLS even when cbind material couldn't be derived.
+func (a *ScramAuthenticator) SetOverTLS(overTLS bool) {
+	if a.state != stateInitial {
+		panic("scram: SetOverTLS called after StartAuthentication")
+	}
+	a.overTLS = overTLS
+}
+
+// hasChannelBinding reports whether channel binding material is available.
+func (a *ScramAuthenticator) hasChannelBinding() bool {
+	return a.channelBinding != nil && len(a.channelBinding.TLSServerEndPointHash) > 0
+}
+
 // StartAuthentication begins the SCRAM authentication process.
-// Returns the list of supported SASL mechanisms.
+// Returns the list of supported SASL mechanisms. When channel binding is
+// available, SCRAM-SHA-256-PLUS is listed first so libpq-style clients pick
+// the stronger mechanism by default.
 //
 // This corresponds to sending AuthenticationSASL (auth type 10) to the client.
 func (a *ScramAuthenticator) StartAuthentication() []string {
 	a.state = stateStarted
+	if a.hasChannelBinding() {
+		return []string{ScramSHA256PlusMechanism, ScramSHA256Mechanism}
+	}
 	return []string{ScramSHA256Mechanism}
 }
 
 // HandleClientFirst processes the client-first-message from the client.
 // Returns the server-first-message to send back.
+//
+// The mechanism is the SASL mechanism the client selected in the
+// SASLInitialResponse (SCRAM-SHA-256 or SCRAM-SHA-256-PLUS); the
+// authenticator validates it against what StartAuthentication advertised and
+// against the GS2 channel-binding flag the client carries in the
+// client-first-message.
 //
 // The client-first-message comes from SASLInitialResponse and contains
 // the GS2 header and client-first-message-bare (username, client nonce).
@@ -143,10 +262,23 @@ func (a *ScramAuthenticator) StartAuthentication() []string {
 // The user's password hash was supplied at construction time; this method
 // generates the server-first-message containing the combined nonce, salt,
 // and iteration count from that hash.
-func (a *ScramAuthenticator) HandleClientFirst(clientFirstMessage, startupMessageUsername string) (string, error) {
+func (a *ScramAuthenticator) HandleClientFirst(mechanism, clientFirstMessage, startupMessageUsername string) (string, error) {
 	// Verify state.
 	if a.state != stateStarted {
 		return "", fmt.Errorf("auth: invalid state for HandleClientFirst (expected started, got %d)", a.state)
+	}
+
+	// Validate mechanism against what we advertised.
+	switch mechanism {
+	case ScramSHA256Mechanism:
+	case ScramSHA256PlusMechanism:
+		if !a.hasChannelBinding() {
+			a.state = stateFailed
+			return "", fmt.Errorf("auth: client selected %s but server did not advertise it", ScramSHA256PlusMechanism)
+		}
+	default:
+		a.state = stateFailed
+		return "", fmt.Errorf("auth: unsupported SASL mechanism: %q", mechanism)
 	}
 
 	// Parse the client-first-message.
@@ -155,6 +287,22 @@ func (a *ScramAuthenticator) HandleClientFirst(clientFirstMessage, startupMessag
 		a.state = stateFailed
 		return "", fmt.Errorf("auth: invalid client-first-message: %w", err)
 	}
+
+	// PG rejects SASL authzid outright (see auth-scram.c
+	// read_client_first_message). Mirror that for parity.
+	if parsed.authzid != "" {
+		a.state = stateFailed
+		return "", ErrAuthzidNotSupported
+	}
+
+	// Cross-check the GS2 channel-binding flag against the chosen mechanism.
+	// Enforces RFC 5802 §6 and detects downgrade attempts.
+	if err := a.validateGS2Flag(mechanism, parsed); err != nil {
+		a.state = stateFailed
+		return "", err
+	}
+	a.selectedMechanism = mechanism
+	a.clientGS2Header = parsed.gs2Header
 
 	// PostgreSQL always ignores the username from client-first-message
 	// and uses the startup message username. This is because not all UTF-8
@@ -193,6 +341,78 @@ func (a *ScramAuthenticator) HandleClientFirst(clientFirstMessage, startupMessag
 	return serverFirstMessage, nil
 }
 
+// validateGS2Flag enforces the RFC 5802 §6 rules tying the SASL mechanism
+// the client selected to the GS2 channel-binding flag it sent. Error
+// messages and SQLSTATE classes mirror PostgreSQL 17 (auth-scram.c) so
+// libpq-compatible clients see byte-identical diagnostics.
+func (a *ScramAuthenticator) validateGS2Flag(mechanism string, parsed *clientFirstMessage) error {
+	switch mechanism {
+	case ScramSHA256PlusMechanism:
+		switch parsed.gs2CbindFlag {
+		case "n", "y":
+			return &SASLProtocolError{
+				Detail: "The client selected SCRAM-SHA-256-PLUS, but the SCRAM message does not include channel binding data.",
+			}
+		}
+		if parsed.channelBindingType != ChannelBindingTypeTLSServerEndPoint {
+			return &SASLProtocolError{
+				Msg: fmt.Sprintf("unsupported SCRAM channel-binding type %q", parsed.channelBindingType),
+			}
+		}
+	case ScramSHA256Mechanism:
+		switch parsed.gs2CbindFlag {
+		case "n":
+			// no binding — fine.
+		case "y":
+			if a.overTLS {
+				// Connection is TLS — server can do cbind — but client claims
+				// it didn't advertise. PG returns 28000 here (distinct from
+				// the 08P01 used for other cbind protocol errors).
+				return ErrChannelBindingNegotiation
+			}
+		default:
+			// gs2 flag starts with "p=" → cbind requested without picking PLUS.
+			return &SASLProtocolError{
+				Detail: "The client selected SCRAM-SHA-256 without channel binding, but the SCRAM message includes channel binding data.",
+			}
+		}
+	}
+	return nil
+}
+
+// verifyChannelBinding recomputes the expected c= value the client should
+// have sent and compares it in constant time. Note: the cbind data is not
+// itself secret (the cert hash is public; the gs2-header echoes flags
+// already on the wire) and PG uses a plain strcmp. Constant-time here is
+// defense-in-depth.
+//
+//   - PLUS: base64("p=tls-server-end-point,," || cbind-data). Mismatch is
+//     ErrChannelBindingCheck (28000 "SCRAM channel binding check failed").
+//   - Base SCRAM-SHA-256: PG accepts only the two literals "biws" (= n,,)
+//     and "eSws" (= y,,), each tied to the matching original gs2 flag.
+//     Anything else is a protocol violation (08P01).
+func (a *ScramAuthenticator) verifyChannelBinding(clientCBindB64 string) error {
+	if a.selectedMechanism == ScramSHA256PlusMechanism {
+		expected := append([]byte(a.clientGS2Header), a.channelBinding.TLSServerEndPointHash...)
+		expectedB64 := base64.StdEncoding.EncodeToString(expected)
+		if subtle.ConstantTimeCompare([]byte(clientCBindB64), []byte(expectedB64)) != 1 {
+			return ErrChannelBindingCheck
+		}
+		return nil
+	}
+
+	switch {
+	case clientCBindB64 == "biws" && a.clientGS2Header == "n,,":
+		return nil
+	case clientCBindB64 == "eSws" && a.clientGS2Header == "y,,":
+		return nil
+	default:
+		return &SASLProtocolError{
+			Msg: "unexpected SCRAM channel-binding attribute in client-final-message",
+		}
+	}
+}
+
 // HandleClientFinal processes the client-final-message from the client.
 // Returns the server-final-message to send back on success.
 //
@@ -201,6 +421,9 @@ func (a *ScramAuthenticator) HandleClientFirst(clientFirstMessage, startupMessag
 // the server signature for mutual authentication.
 //
 // Returns ErrAuthenticationFailed if the proof is invalid.
+// Returns ErrChannelBindingCheck (PLUS) or ErrSASLProtocol (base) when the
+// cbind data the client echoes back does not match the gs2-header (+ TLS
+// cert hash for PLUS) the server expects.
 func (a *ScramAuthenticator) HandleClientFinal(clientFinalMessage string) (string, error) {
 	// Verify state.
 	if a.state != stateClientFirstReceived {
@@ -212,6 +435,16 @@ func (a *ScramAuthenticator) HandleClientFinal(clientFinalMessage string) (strin
 	if err != nil {
 		a.state = stateFailed
 		return "", fmt.Errorf("auth: invalid client-final-message: %w", err)
+	}
+
+	// Verify the channel binding data the client echoed back. The client
+	// sends base64(gs2-header [|| cbind-data]); we recompute the same bytes
+	// and compare. Mismatch means either the gs2-header was tampered with
+	// mid-handshake or, for PLUS, the cbind hash diverges from the TLS cert
+	// the client actually saw.
+	if err := a.verifyChannelBinding(parsed.channelBinding); err != nil {
+		a.state = stateFailed
+		return "", err
 	}
 
 	// Verify the nonce matches.
@@ -279,8 +512,15 @@ func (a *ScramAuthenticator) ExtractedKeys() (clientKey, serverKey []byte) {
 }
 
 // Reset clears the authenticator state, allowing it to be reused for
-// another authentication attempt with the same hash.
+// another authentication attempt with the same hash. The channel binding
+// context and overTLS flag are preserved — they're tied to the TLS session,
+// not to a particular handshake attempt. The extracted ClientKey is
+// zeroized before being nilled so a memory dump after Reset cannot recover
+// the previous session's secret.
 func (a *ScramAuthenticator) Reset() {
+	for i := range a.extractedClientKey {
+		a.extractedClientKey[i] = 0
+	}
 	a.state = stateInitial
 	a.username = ""
 	a.clientNonce = ""
@@ -288,4 +528,6 @@ func (a *ScramAuthenticator) Reset() {
 	a.clientFirstMessageBare = ""
 	a.serverFirstMessage = ""
 	a.extractedClientKey = nil
+	a.selectedMechanism = ""
+	a.clientGS2Header = ""
 }

--- a/go/common/pgprotocol/scram/authenticator_plus_test.go
+++ b/go/common/pgprotocol/scram/authenticator_plus_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scram
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPlusAuthenticator(t *testing.T, cbindHash []byte) (*ScramAuthenticator, *ScramHash) {
+	t.Helper()
+	hash := createTestHash("testpassword", []byte("plussalt12345678"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	// Mirror the runtime: PLUS-capable authenticator is always over TLS.
+	auth.SetOverTLS(true)
+	auth.SetChannelBinding(&ChannelBinding{TLSServerEndPointHash: cbindHash})
+	return auth, hash
+}
+
+func TestScramAuthenticator_StartAuthentication_AdvertisesPlus(t *testing.T) {
+	t.Run("advertises PLUS first when binding present", func(t *testing.T) {
+		auth, _ := newPlusAuthenticator(t, []byte("fake-cert-hash-32-bytes--------!!"))
+		mechs := auth.StartAuthentication()
+		require.Equal(t, []string{ScramSHA256PlusMechanism, ScramSHA256Mechanism}, mechs)
+	})
+
+	t.Run("advertises base only when binding absent", func(t *testing.T) {
+		// Fresh authenticator: no binding set, no overTLS.
+		hash := createTestHash("p", []byte("salt-16-bytes---"), 4096)
+		auth := NewScramAuthenticator(hash, "testdb")
+		mechs := auth.StartAuthentication()
+		assert.Equal(t, []string{ScramSHA256Mechanism}, mechs)
+	})
+
+	t.Run("empty hash slice treated as no binding", func(t *testing.T) {
+		auth, _ := newPlusAuthenticator(t, []byte{})
+		mechs := auth.StartAuthentication()
+		assert.Equal(t, []string{ScramSHA256Mechanism}, mechs)
+	})
+}
+
+func TestScramAuthenticator_Plus_HappyPath(t *testing.T) {
+	cbind := []byte("0123456789abcdef0123456789abcdef")
+	auth, _ := newPlusAuthenticator(t, cbind)
+	_ = auth.StartAuthentication()
+
+	client := NewSCRAMClientWithPassword("testuser", "testpassword")
+	client.EnableChannelBinding(cbind)
+
+	clientFirst, err := client.ClientFirstMessage()
+	require.NoError(t, err)
+	require.Equal(t, ScramSHA256PlusMechanism, client.Mechanism())
+
+	serverFirst, err := auth.HandleClientFirst(client.Mechanism(), clientFirst, "testuser")
+	require.NoError(t, err)
+	require.NotEmpty(t, serverFirst)
+
+	clientFinal, err := client.ProcessServerFirst(serverFirst)
+	require.NoError(t, err)
+
+	serverFinal, err := auth.HandleClientFinal(clientFinal)
+	require.NoError(t, err)
+	require.NoError(t, client.VerifyServerFinal(serverFinal))
+	require.True(t, auth.IsAuthenticated())
+}
+
+func TestScramAuthenticator_Plus_TamperedCBindRejected(t *testing.T) {
+	serverCBind := []byte("server-side-cert-hash-32-bytes!!")
+	clientCBind := []byte("attacker-supplied-hash-32-bytes!")
+
+	auth, _ := newPlusAuthenticator(t, serverCBind)
+	_ = auth.StartAuthentication()
+
+	client := NewSCRAMClientWithPassword("testuser", "testpassword")
+	client.EnableChannelBinding(clientCBind)
+
+	clientFirst, err := client.ClientFirstMessage()
+	require.NoError(t, err)
+
+	serverFirst, err := auth.HandleClientFirst(client.Mechanism(), clientFirst, "testuser")
+	require.NoError(t, err)
+
+	clientFinal, err := client.ProcessServerFirst(serverFirst)
+	require.NoError(t, err)
+
+	_, err = auth.HandleClientFinal(clientFinal)
+	require.ErrorIs(t, err, ErrChannelBindingCheck)
+	require.False(t, auth.IsAuthenticated())
+}
+
+func TestScramAuthenticator_Plus_DowngradeYRejected(t *testing.T) {
+	// Server has channel binding (TLS); client sends gs2 flag "y" claiming
+	// the server doesn't support PLUS. Must fail per RFC 5802 §6.
+	cbind := []byte("server-cert-hash-32-bytes------!!")
+	auth, _ := newPlusAuthenticator(t, cbind)
+	_ = auth.StartAuthentication()
+
+	clientFirst := "y,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrChannelBindingNegotiation)
+}
+
+func TestScramAuthenticator_Plus_PSelectsBaseMechanismRejected(t *testing.T) {
+	auth, _ := newPlusAuthenticator(t, []byte("hash-32-bytes--------------------"))
+	_ = auth.StartAuthentication()
+
+	clientFirst := "p=tls-server-end-point,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrSASLProtocol)
+	var sp *SASLProtocolError
+	require.ErrorAs(t, err, &sp)
+	require.Contains(t, sp.Detail, "SCRAM-SHA-256 without channel binding")
+}
+
+func TestScramAuthenticator_Plus_NPlusMechanismRejected(t *testing.T) {
+	auth, _ := newPlusAuthenticator(t, []byte("hash-32-bytes--------------------"))
+	_ = auth.StartAuthentication()
+
+	clientFirst := "n,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	_, err := auth.HandleClientFirst(ScramSHA256PlusMechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrSASLProtocol)
+	var sp *SASLProtocolError
+	require.ErrorAs(t, err, &sp)
+	require.Contains(t, sp.Detail, "does not include channel binding data")
+}
+
+func TestScramAuthenticator_AuthzidRejected(t *testing.T) {
+	hash := createTestHash("p", []byte("salt-16-bytes---"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	_ = auth.StartAuthentication()
+
+	clientFirst := "n,a=other-user,n=testuser,r=nonce"
+	_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrAuthzidNotSupported)
+}
+
+func TestScramAuthenticator_Plus_PlusWithoutBindingMaterial(t *testing.T) {
+	hash := createTestHash("p", []byte("salt-16-bytes---"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	_ = auth.StartAuthentication()
+
+	clientFirst := "p=tls-server-end-point,,n=testuser,r=nonce"
+	_, err := auth.HandleClientFirst(ScramSHA256PlusMechanism, clientFirst, "testuser")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ScramSHA256PlusMechanism)
+}
+
+func TestScramAuthenticator_Plus_UnsupportedCBindType(t *testing.T) {
+	cbind := []byte("hash-32-bytes--------------------")
+	auth, _ := newPlusAuthenticator(t, cbind)
+	_ = auth.StartAuthentication()
+
+	clientFirst := "p=tls-unique,,n=testuser,r=nonce"
+	_, err := auth.HandleClientFirst(ScramSHA256PlusMechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrSASLProtocol)
+	var sp *SASLProtocolError
+	require.ErrorAs(t, err, &sp)
+	require.Contains(t, sp.Msg, "unsupported SCRAM channel-binding type")
+	require.Contains(t, sp.Msg, "tls-unique")
+}
+
+func TestScramAuthenticator_Plus_DowngradeYRejectedWhenTLSButNoCbind(t *testing.T) {
+	hash := createTestHash("testpassword", []byte("plain-salt-16byt"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	auth.SetOverTLS(true) // TLS in use but no cbind material available.
+	_ = auth.StartAuthentication()
+
+	clientFirst := "y,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirst, "testuser")
+	require.ErrorIs(t, err, ErrChannelBindingNegotiation)
+}
+
+func TestScramAuthenticator_SetChannelBinding_PanicsAfterStart(t *testing.T) {
+	hash := createTestHash("p", []byte("salt-16-bytes---"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	_ = auth.StartAuthentication()
+	require.Panics(t, func() {
+		auth.SetChannelBinding(&ChannelBinding{TLSServerEndPointHash: []byte("x")})
+	})
+}
+
+func TestScramAuthenticator_SetOverTLS_PanicsAfterStart(t *testing.T) {
+	hash := createTestHash("p", []byte("salt-16-bytes---"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	_ = auth.StartAuthentication()
+	require.Panics(t, func() {
+		auth.SetOverTLS(true)
+	})
+}
+
+func TestScramAuthenticator_Plaintext_NotAffectedByPlus(t *testing.T) {
+	hash := createTestHash("testpassword", []byte("plain-salt-16byt"), 4096)
+	auth := NewScramAuthenticator(hash, "testdb")
+	mechs := auth.StartAuthentication()
+	require.Equal(t, []string{ScramSHA256Mechanism}, mechs)
+
+	// "y" gs2 flag without binding — must be accepted.
+	yClientFirst := "y,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	serverFirst, err := auth.HandleClientFirst(ScramSHA256Mechanism, yClientFirst, "testuser")
+	require.NoError(t, err)
+	require.NotEmpty(t, serverFirst)
+}
+
+func TestScramAuthenticator_Plus_CBindWiredCorrectly(t *testing.T) {
+	cbind := []byte("specific-hash-32-bytes-----------")
+	auth, hash := newPlusAuthenticator(t, cbind)
+	_ = auth.StartAuthentication()
+
+	clientFirst := "p=tls-server-end-point,,n=testuser,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j"
+	serverFirst, err := auth.HandleClientFirst(ScramSHA256PlusMechanism, clientFirst, "testuser")
+	require.NoError(t, err)
+
+	combinedNonce := ""
+	for part := range strings.SplitSeq(serverFirst, ",") {
+		if strings.HasPrefix(part, "r=") {
+			combinedNonce = part[2:]
+		}
+	}
+	require.NotEmpty(t, combinedNonce)
+
+	expectedCBindB64 := base64.StdEncoding.EncodeToString(append([]byte("p=tls-server-end-point,,"), cbind...))
+
+	wrong := []byte(expectedCBindB64)
+	wrong[0] ^= 0x01
+	clientFinalBad := "c=" + string(wrong) + ",r=" + combinedNonce + ",p=" + base64.StdEncoding.EncodeToString(make([]byte, 32))
+	_, err = auth.HandleClientFinal(clientFinalBad)
+	require.ErrorIs(t, err, ErrChannelBindingCheck)
+
+	// Sanity: matching cbind exits the cbind check (auth then fails on
+	// password proof because we used zero bytes — different error class).
+	auth.state = stateClientFirstReceived
+	auth.hash = hash
+	clientFinalGood := "c=" + expectedCBindB64 + ",r=" + combinedNonce + ",p=" + base64.StdEncoding.EncodeToString(make([]byte, 32))
+	_, err = auth.HandleClientFinal(clientFinalGood)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrChannelBindingCheck)
+}

--- a/go/common/pgprotocol/scram/authenticator_test.go
+++ b/go/common/pgprotocol/scram/authenticator_test.go
@@ -91,7 +91,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 		require.NoError(t, err)
 		clientNonce := extractClientNonce(clientFirstMessage)
 
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "testuser")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.NoError(t, err)
 
 		// Server-first-message should contain: r=<combined-nonce>, s=<salt-b64>, i=<iterations>
@@ -105,7 +105,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 		auth := NewScramAuthenticator(hash, "testdb")
 		auth.StartAuthentication()
 
-		_, err := auth.HandleClientFirst("", "")
+		_, err := auth.HandleClientFirst(ScramSHA256Mechanism, "", "")
 		require.Error(t, err)
 	})
 
@@ -115,7 +115,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 		auth.StartAuthentication()
 
 		// Note: empty username is now allowed (uses fallback), but missing nonce is still an error
-		_, err := auth.HandleClientFirst("n,,n=user", "user")
+		_, err := auth.HandleClientFirst(ScramSHA256Mechanism, "n,,n=user", "user")
 		require.Error(t, err)
 	})
 
@@ -128,7 +128,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 
 		// Client sends empty username in SCRAM, startup message has "startupuser"
 		clientFirstMessage := "n,,n=,r=clientnonce12345"
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "startupuser")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "startupuser")
 		require.NoError(t, err)
 		assert.Contains(t, serverFirstMessage, "r=clientnonce12345") // Combined nonce starts with client nonce
 	})
@@ -140,7 +140,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 
 		// Client sends empty username with no startup message username - should fail
 		clientFirstMessage := "n,,n=,r=clientnonce12345"
-		_, err := auth.HandleClientFirst(clientFirstMessage, "")
+		_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "startup message")
 	})
@@ -155,7 +155,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 		// Client sends "wronguser" in client-first-message but "actualuser" in startup message.
 		// PostgreSQL behavior: ALWAYS use startup message username.
 		clientFirstMessage := "n,,n=wronguser,r=clientnonce12345"
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "actualuser")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "actualuser")
 		require.NoError(t, err)
 		assert.Contains(t, serverFirstMessage, "r=clientnonce12345")
 
@@ -172,7 +172,7 @@ func TestScramAuthenticator_HandleClientFirst(t *testing.T) {
 		// Client requests channel binding (p=tls-server-end-point)
 		clientFirstMessage := "p=tls-server-end-point,,n=testuser,r=clientnonce"
 
-		_, err := auth.HandleClientFirst(clientFirstMessage, "testuser")
+		_, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "channel binding")
 	})
@@ -194,7 +194,7 @@ func TestScramAuthenticator_HandleClientFinal(t *testing.T) {
 		// Step 1: Client first message.
 		clientFirstMessage, err := client.ClientFirstMessage()
 		require.NoError(t, err)
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "testuser")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.NoError(t, err)
 
 		// Step 2: Client final message with correct password.
@@ -229,7 +229,7 @@ func TestScramAuthenticator_HandleClientFinal(t *testing.T) {
 		// Step 1: Client first message.
 		clientFirstMessage, err := client.ClientFirstMessage()
 		require.NoError(t, err)
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "testuser")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.NoError(t, err)
 
 		// Step 2: Client final message with WRONG password.
@@ -253,7 +253,7 @@ func TestScramAuthenticator_HandleClientFinal(t *testing.T) {
 		client := NewSCRAMClientWithPassword("testuser", testPassword)
 		clientFirstMessage, err := client.ClientFirstMessage()
 		require.NoError(t, err)
-		_, err = auth.HandleClientFirst(clientFirstMessage, "testuser")
+		_, err = auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.NoError(t, err)
 
 		_, err = auth.HandleClientFinal("")
@@ -268,7 +268,7 @@ func TestScramAuthenticator_HandleClientFinal(t *testing.T) {
 		client := NewSCRAMClientWithPassword("testuser", testPassword)
 		clientFirstMessage, err := client.ClientFirstMessage()
 		require.NoError(t, err)
-		_, err = auth.HandleClientFirst(clientFirstMessage, "testuser")
+		_, err = auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		require.NoError(t, err)
 
 		// Send a client-final-message with a different nonce (attacker trying to replay).
@@ -310,7 +310,7 @@ func TestScramAuthenticator_FullExchange(t *testing.T) {
 		require.NoError(t, err)
 		clientNonce := extractClientNonce(clientFirstMessage)
 
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, "user")
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "user")
 		require.NoError(t, err)
 
 		// 3. Verify server-first-message format.
@@ -355,7 +355,7 @@ func TestScramAuthenticator_FullExchange(t *testing.T) {
 		clientFirstMessage, err := client.ClientFirstMessage()
 		require.NoError(t, err)
 
-		serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, username)
+		serverFirstMessage, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, username)
 		require.NoError(t, err)
 
 		clientFinalMessage, err := client.ProcessServerFirst(serverFirstMessage)
@@ -385,7 +385,7 @@ func TestScramAuthenticator_Reset(t *testing.T) {
 		auth.StartAuthentication()
 		client := NewSCRAMClientWithPassword("testuser", testPassword)
 		clientFirstMessage, _ := client.ClientFirstMessage()
-		serverFirstMessage, _ := auth.HandleClientFirst(clientFirstMessage, "testuser")
+		serverFirstMessage, _ := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage, "testuser")
 		clientFinalMessage, _ := client.ProcessServerFirst(serverFirstMessage)
 		_, _ = auth.HandleClientFinal(clientFinalMessage)
 
@@ -405,7 +405,7 @@ func TestScramAuthenticator_Reset(t *testing.T) {
 		require.NoError(t, err)
 		clientNonce2 := extractClientNonce(clientFirstMessage2)
 
-		serverFirstMessage2, err := auth.HandleClientFirst(clientFirstMessage2, "testuser")
+		serverFirstMessage2, err := auth.HandleClientFirst(ScramSHA256Mechanism, clientFirstMessage2, "testuser")
 		require.NoError(t, err)
 		assert.Contains(t, serverFirstMessage2, "r="+clientNonce2)
 	})
@@ -417,7 +417,7 @@ func TestScramAuthenticatorState(t *testing.T) {
 		auth := NewScramAuthenticator(hash, "testdb")
 
 		// Cannot call HandleClientFirst before StartAuthentication.
-		_, err := auth.HandleClientFirst("n,,n=user,r=nonce", "user")
+		_, err := auth.HandleClientFirst(ScramSHA256Mechanism, "n,,n=user,r=nonce", "user")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "state")
 
@@ -430,11 +430,11 @@ func TestScramAuthenticatorState(t *testing.T) {
 		assert.Contains(t, err.Error(), "state")
 
 		// Now proceed normally.
-		_, err = auth.HandleClientFirst("n,,n=user,r=clientnonce", "user")
+		_, err = auth.HandleClientFirst(ScramSHA256Mechanism, "n,,n=user,r=clientnonce", "user")
 		require.NoError(t, err)
 
 		// Cannot call HandleClientFirst again.
-		_, err = auth.HandleClientFirst("n,,n=user,r=anothernonce", "user")
+		_, err = auth.HandleClientFirst(ScramSHA256Mechanism, "n,,n=user,r=anothernonce", "user")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "state")
 	})

--- a/go/common/pgprotocol/scram/channel_binding.go
+++ b/go/common/pgprotocol/scram/channel_binding.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scram
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"hash"
+)
+
+// ChannelBindingTypeTLSServerEndPoint is the channel binding type defined in
+// RFC 5929 §4: a hash of the TLS server's certificate. This is the type
+// PostgreSQL advertises for SCRAM-SHA-256-PLUS.
+const ChannelBindingTypeTLSServerEndPoint = "tls-server-end-point"
+
+// ChannelBinding carries TLS channel binding context into the SCRAM
+// authenticator. When non-nil and TLSServerEndPointHash is populated, the
+// authenticator advertises SCRAM-SHA-256-PLUS in addition to SCRAM-SHA-256.
+type ChannelBinding struct {
+	// TLSServerEndPointHash is the hash of the server's TLS certificate, as
+	// defined for the tls-server-end-point channel binding type (RFC 5929).
+	// Compute it with ComputeTLSServerEndPointHash.
+	TLSServerEndPointHash []byte
+}
+
+// ComputeTLSServerEndPointHash computes the tls-server-end-point channel
+// binding data for a TLS server certificate per RFC 5929 §4: the hash of the
+// DER-encoded certificate, using the certificate signature algorithm's hash
+// function — with one PostgreSQL-compatible quirk: certificates signed with
+// MD5 or SHA-1 are hashed with SHA-256 instead (mirroring PG's
+// be_tls_get_certificate_hash). This is what libpq expects, so any client
+// computing the binding the same way will interoperate.
+func ComputeTLSServerEndPointHash(cert *x509.Certificate) ([]byte, error) {
+	if cert == nil {
+		return nil, errors.New("scram: TLS certificate is nil")
+	}
+	h, err := tlsServerEndPointHasher(cert.SignatureAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+	h.Write(cert.Raw)
+	return h.Sum(nil), nil
+}
+
+// tlsServerEndPointHasher returns the hash function to use for a given cert
+// signature algorithm. MD5- and SHA-1-signed certs map to SHA-256 to match
+// PostgreSQL (be_tls_get_certificate_hash). Ed25519 is intentionally NOT
+// listed: PG's OpenSSL-based path cannot derive a digest for it and refuses
+// to advertise PLUS, so accepting Ed25519 here would diverge from libpq's
+// expected hash and break the cbind check.
+func tlsServerEndPointHasher(sigAlgo x509.SignatureAlgorithm) (hash.Hash, error) {
+	switch sigAlgo {
+	case x509.MD2WithRSA,
+		x509.MD5WithRSA,
+		x509.SHA1WithRSA,
+		x509.DSAWithSHA1,
+		x509.ECDSAWithSHA1,
+		x509.SHA256WithRSA,
+		x509.DSAWithSHA256,
+		x509.ECDSAWithSHA256,
+		x509.SHA256WithRSAPSS:
+		return sha256.New(), nil
+	case x509.SHA384WithRSA,
+		x509.ECDSAWithSHA384,
+		x509.SHA384WithRSAPSS:
+		return sha512.New384(), nil
+	case x509.SHA512WithRSA,
+		x509.ECDSAWithSHA512,
+		x509.SHA512WithRSAPSS:
+		return sha512.New(), nil
+	default:
+		return nil, fmt.Errorf("scram: unsupported certificate signature algorithm %s for tls-server-end-point binding", sigAlgo)
+	}
+}

--- a/go/common/pgprotocol/scram/channel_binding_test.go
+++ b/go/common/pgprotocol/scram/channel_binding_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scram
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCert produces a self-signed certificate using a specified
+// signature algorithm. Returns the parsed certificate (with Raw populated).
+func generateTestCert(t *testing.T, sigAlgo x509.SignatureAlgorithm) *x509.Certificate {
+	t.Helper()
+
+	template := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "scram-cbind-test"},
+		NotBefore:          time.Now().Add(-time.Hour),
+		NotAfter:           time.Now().Add(time.Hour),
+		SignatureAlgorithm: sigAlgo,
+	}
+
+	var (
+		certDER []byte
+		err     error
+	)
+
+	switch sigAlgo {
+	case x509.SHA256WithRSA, x509.SHA384WithRSA, x509.SHA512WithRSA:
+		key, kerr := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, kerr)
+		certDER, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	case x509.ECDSAWithSHA256:
+		key, kerr := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, kerr)
+		certDER, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	case x509.ECDSAWithSHA384:
+		key, kerr := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		require.NoError(t, kerr)
+		certDER, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	case x509.ECDSAWithSHA512:
+		key, kerr := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		require.NoError(t, kerr)
+		certDER, err = x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	default:
+		t.Fatalf("unsupported sigAlgo for test: %s", sigAlgo)
+	}
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	return cert
+}
+
+func TestComputeTLSServerEndPointHash(t *testing.T) {
+	t.Run("nil cert is rejected", func(t *testing.T) {
+		_, err := ComputeTLSServerEndPointHash(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("RSA-SHA256 hashes whole cert with SHA-256", func(t *testing.T) {
+		cert := generateTestCert(t, x509.SHA256WithRSA)
+		got, err := ComputeTLSServerEndPointHash(cert)
+		require.NoError(t, err)
+		want := sha256.Sum256(cert.Raw)
+		assert.Equal(t, want[:], got)
+	})
+
+	t.Run("RSA-SHA384 → SHA-384 hash", func(t *testing.T) {
+		cert := generateTestCert(t, x509.SHA384WithRSA)
+		got, err := ComputeTLSServerEndPointHash(cert)
+		require.NoError(t, err)
+		want := sha512.Sum384(cert.Raw)
+		assert.Equal(t, want[:], got)
+	})
+
+	t.Run("RSA-SHA512 → SHA-512 hash", func(t *testing.T) {
+		cert := generateTestCert(t, x509.SHA512WithRSA)
+		got, err := ComputeTLSServerEndPointHash(cert)
+		require.NoError(t, err)
+		want := sha512.Sum512(cert.Raw)
+		assert.Equal(t, want[:], got)
+	})
+
+	t.Run("ECDSA variants use matching hash", func(t *testing.T) {
+		cases := []struct {
+			algo x509.SignatureAlgorithm
+			size int
+		}{
+			{x509.ECDSAWithSHA256, sha256.Size},
+			{x509.ECDSAWithSHA384, sha512.Size384},
+			{x509.ECDSAWithSHA512, sha512.Size},
+		}
+		for _, tc := range cases {
+			cert := generateTestCert(t, tc.algo)
+			got, err := ComputeTLSServerEndPointHash(cert)
+			require.NoError(t, err)
+			assert.Len(t, got, tc.size, "algo=%s", tc.algo)
+		}
+	})
+
+	t.Run("unsupported sig algo is rejected", func(t *testing.T) {
+		cert := generateTestCert(t, x509.SHA256WithRSA)
+		cert.SignatureAlgorithm = x509.UnknownSignatureAlgorithm
+		_, err := ComputeTLSServerEndPointHash(cert)
+		require.Error(t, err)
+	})
+
+	// MD5- and SHA-1-signed certs are obsolete (modern Go won't even sign
+	// with them) but PG explicitly upgrades them to SHA-256 for cbind. We
+	// mirror that quirk. Test by parsing a normal cert and then poking the
+	// SignatureAlgorithm enum to MD5/SHA-1 — sufficient because our hasher
+	// only consults the enum.
+	t.Run("PG quirk: MD5/SHA-1 signed certs hash with SHA-256", func(t *testing.T) {
+		cases := []x509.SignatureAlgorithm{
+			x509.MD2WithRSA,
+			x509.MD5WithRSA,
+			x509.SHA1WithRSA,
+			x509.DSAWithSHA1,
+			x509.ECDSAWithSHA1,
+		}
+		for _, algo := range cases {
+			cert := generateTestCert(t, x509.SHA256WithRSA)
+			cert.SignatureAlgorithm = algo
+			got, err := ComputeTLSServerEndPointHash(cert)
+			require.NoError(t, err, "algo=%s", algo)
+			want := sha256.Sum256(cert.Raw)
+			require.Equal(t, want[:], got, "algo=%s should hash with SHA-256", algo)
+		}
+	})
+
+	t.Run("Ed25519 is rejected (PG cannot derive digest)", func(t *testing.T) {
+		// PG's be_tls_get_certificate_hash returns NULL for Ed25519, so PG
+		// won't advertise PLUS for Ed25519 certs. Our code must reject too
+		// to avoid client/server hash divergence.
+		cert := generateTestCert(t, x509.SHA256WithRSA)
+		cert.SignatureAlgorithm = x509.PureEd25519
+		_, err := ComputeTLSServerEndPointHash(cert)
+		require.Error(t, err)
+	})
+}

--- a/go/common/pgprotocol/scram/doc.go
+++ b/go/common/pgprotocol/scram/doc.go
@@ -59,23 +59,32 @@
 //
 //   - ScramAuthenticator: Stateful server-side authenticator handling the protocol exchange
 //   - SCRAMClient: Client-side authenticator supporting password and passthrough modes
+//   - ScramHash: PostgreSQL pg_authid SCRAM-SHA-256 hash (salt, iterations, StoredKey, ServerKey)
 //   - Cryptographic functions: RFC 5802 compliant key derivation and verification
 //   - Protocol parsers/generators: Message construction and parsing (unexported)
 //
 // # Usage Example
 //
-//	// Server-side authentication: the caller looks up the hash before
-//	// constructing the authenticator so one credential fetch can also
-//	// satisfy any post-auth role-attribute checks.
-//	hash, err := lookupScramHash(ctx, "myuser", "mydb")
+//	// Server-side authentication. The caller looks up the user's
+//	// SCRAM hash up front (e.g. via a credential provider) and passes
+//	// it to NewScramAuthenticator.
+//	hash := fetchScramHashForUser(user, db)
 //	auth := scram.NewScramAuthenticator(hash, "mydb")
+//
+//	// Optional: enable SCRAM-SHA-256-PLUS (channel binding) over TLS.
+//	auth.SetOverTLS(true)
+//	auth.SetChannelBinding(&scram.ChannelBinding{
+//	    TLSServerEndPointHash: certHash, // see ComputeTLSServerEndPointHash
+//	})
 //
 //	// Start SASL negotiation
 //	mechanisms := auth.StartAuthentication()
 //	// Send AuthenticationSASL with mechanisms...
 //
-//	// Handle client-first-message
-//	serverFirst, err := auth.HandleClientFirst(clientFirstMsg, startupMessageUsername)
+//	// Handle client-first-message. `mechanism` is the SASL mechanism the
+//	// client picked in SASLInitialResponse; `startupUser` is the username
+//	// from the StartupMessage (used when the SCRAM message itself has none).
+//	serverFirst, err := auth.HandleClientFirst(mechanism, clientFirstMsg, startupUser)
 //	// Send AuthenticationSASLContinue with serverFirst...
 //
 //	// Handle client-final-message
@@ -110,13 +119,13 @@
 //
 //	SCRAM-SHA-256$<iterations>:<salt>$<StoredKey>:<ServerKey>
 //
-// Callers are responsible for fetching the hash from storage (pg_authid, a
-// cache, a remote credential service) before constructing a
-// ScramAuthenticator. Coupling the fetch to the SCRAM state machine forced
-// callers that also needed other per-role attributes to make a second
-// lookup; pushing the fetch out keeps SCRAM purely a state machine and
-// lets one credential lookup serve both the password hash and any
-// follow-up role-attribute checks.
+// The caller looks up the user's SCRAM hash (typically via a credential
+// provider that wraps the storage backend) and passes the parsed *ScramHash
+// to NewScramAuthenticator. Storage backends can:
+//   - Query PostgreSQL's pg_authid directly
+//   - Use a credential cache with TTL and invalidation
+//   - Fetch from a centralized credential service
+//   - Combine multiple sources with fallback logic
 //
 // # Future Directions
 //
@@ -180,13 +189,18 @@
 //
 // This implementation is compatible with:
 //   - PostgreSQL 10+ SCRAM-SHA-256 authentication
+//   - PostgreSQL 11+ SCRAM-SHA-256-PLUS channel binding (tls-server-end-point,
+//     RFC 5929). Advertised alongside SCRAM-SHA-256 on TLS connections.
 //   - Standard PostgreSQL client libraries (psql, libpq, pgx, etc.)
 //   - PostgreSQL's pg_authid password hash format
 //   - PostgreSQL's SASLprep implementation (RFC 4013)
 //
 // Not currently supported:
 //   - SCRAM-SHA-1 (deprecated, not used by PostgreSQL)
-//   - Channel binding (SCRAM-SHA-256-PLUS)
+//   - tls-unique channel binding (deprecated; TLS 1.3 removed it)
+//   - Channel binding with TLS configs that use GetCertificate/SNI dynamic
+//     certs without populating tlsConfig.Certificates[0]; PLUS falls back to
+//     SCRAM-SHA-256 in that case
 //   - Custom iteration counts (uses hash's iteration count)
 //
 // # References

--- a/go/common/pgprotocol/scram/scram.go
+++ b/go/common/pgprotocol/scram/scram.go
@@ -27,6 +27,11 @@ const (
 	// ScramSHA256Mechanism is the SASL mechanism name for SCRAM-SHA-256.
 	ScramSHA256Mechanism = "SCRAM-SHA-256"
 
+	// ScramSHA256PlusMechanism is the SASL mechanism name for SCRAM-SHA-256
+	// with channel binding (RFC 5802 §6 + PostgreSQL convention). Advertised
+	// only over TLS, alongside ScramSHA256Mechanism.
+	ScramSHA256PlusMechanism = "SCRAM-SHA-256-PLUS"
+
 	// serverNonceLength is the number of random bytes to add to the client nonce.
 	serverNonceLength = 18
 )
@@ -36,11 +41,20 @@ const (
 // Where gs2-header = gs2-cbind-flag "," [authzid] ","
 // And client-first-message-bare = username "," nonce ["," extensions]
 type clientFirstMessage struct {
-	// gs2CbindFlag is the channel binding flag ('n', 'y', or 'p').
-	// 'n' = client doesn't support channel binding
-	// 'y' = client supports but server doesn't advertise
-	// 'p' = client requires channel binding
+	// gs2CbindFlag is the raw channel binding flag from the wire:
+	//   "n"      — client doesn't support channel binding
+	//   "y"      — client supports but believes server doesn't advertise it
+	//   "p=<t>"  — client requires channel binding of type <t>
 	gs2CbindFlag string
+
+	// channelBindingType is the parsed binding type when gs2CbindFlag has
+	// the "p=" form (e.g. "tls-server-end-point"). Empty for "n"/"y".
+	channelBindingType string
+
+	// gs2Header is the literal "gs2-cbind-flag,[authzid]," prefix as it
+	// appeared on the wire. Required to verify the cbind data the client
+	// sends back in client-final-message.
+	gs2Header string
 
 	// authzid is the optional authorization identity.
 	authzid string
@@ -89,16 +103,20 @@ func parseClientFirstMessage(msg string) (*clientFirstMessage, error) {
 		return nil, errors.New("invalid client-first-message: expected at least 3 comma-separated parts")
 	}
 
-	// Parse GS2 header.
+	// Parse GS2 header. Note the channel binding decision (use/reject/downgrade)
+	// is the authenticator's job — here we only parse the wire form.
 	gs2CbindFlag := parts[0]
+	var channelBindingType string
 	switch {
 	case gs2CbindFlag == "n":
 		// Client doesn't support channel binding.
 	case gs2CbindFlag == "y":
 		// Client supports channel binding but thinks server doesn't.
 	case strings.HasPrefix(gs2CbindFlag, "p="):
-		// Client requires channel binding.
-		return nil, fmt.Errorf("channel binding not supported (client requested %q)", gs2CbindFlag)
+		channelBindingType = gs2CbindFlag[2:]
+		if channelBindingType == "" {
+			return nil, errors.New("invalid GS2 channel binding flag: missing type after 'p='")
+		}
 	default:
 		return nil, fmt.Errorf("invalid GS2 channel binding flag: %q", gs2CbindFlag)
 	}
@@ -111,6 +129,9 @@ func parseClientFirstMessage(msg string) (*clientFirstMessage, error) {
 	} else if authzidPart != "" {
 		return nil, fmt.Errorf("invalid authzid part: %q", authzidPart)
 	}
+
+	// Preserve the literal gs2-header prefix for later cbind verification.
+	gs2Header := gs2CbindFlag + "," + authzidPart + ","
 
 	// The rest is the client-first-message-bare.
 	clientFirstMessageBare := parts[2]
@@ -132,6 +153,8 @@ func parseClientFirstMessage(msg string) (*clientFirstMessage, error) {
 
 	return &clientFirstMessage{
 		gs2CbindFlag:           gs2CbindFlag,
+		channelBindingType:     channelBindingType,
+		gs2Header:              gs2Header,
 		authzid:                authzid,
 		username:               username,
 		clientNonce:            clientNonce,
@@ -147,15 +170,30 @@ func parseClientFinalMessage(msg string) (*clientFinalMessage, error) {
 		return nil, errors.New("empty client-final-message")
 	}
 
-	// Parse attributes.
+	// Parse attributes. The RFC permits each attribute at most once; an
+	// attacker repeating "c=" with a different value could otherwise slip
+	// a tampered binding past a last-write-wins parse. Reject duplicates.
 	var channelBinding, nonce, proofB64 string
+	var sawC, sawR, sawP bool
 	for attr := range strings.SplitSeq(msg, ",") {
 		switch {
 		case strings.HasPrefix(attr, "c="):
+			if sawC {
+				return nil, errors.New("duplicate channel binding attribute in client-final-message")
+			}
+			sawC = true
 			channelBinding = attr[2:]
 		case strings.HasPrefix(attr, "r="):
+			if sawR {
+				return nil, errors.New("duplicate nonce attribute in client-final-message")
+			}
+			sawR = true
 			nonce = attr[2:]
 		case strings.HasPrefix(attr, "p="):
+			if sawP {
+				return nil, errors.New("duplicate proof attribute in client-final-message")
+			}
+			sawP = true
 			proofB64 = attr[2:]
 		}
 	}

--- a/go/common/pgprotocol/scram/scram_client.go
+++ b/go/common/pgprotocol/scram/scram_client.go
@@ -30,6 +30,10 @@ import (
 // Passthrough mode enables SCRAM key passthrough: after a proxy verifies a client,
 // it can extract the ClientKey and use it to authenticate to the backend database
 // without knowing the plaintext password.
+//
+// When constructed with EnableChannelBinding, the client speaks
+// SCRAM-SHA-256-PLUS instead, embedding the supplied tls-server-end-point
+// hash into its messages.
 type SCRAMClient struct {
 	// Username for authentication.
 	username string
@@ -39,9 +43,15 @@ type SCRAMClient struct {
 	clientKey []byte // For passthrough mode
 	serverKey []byte // For passthrough mode (to verify server signature)
 
+	// channelBindingHash is the tls-server-end-point hash to bind to. When
+	// non-nil the client uses gs2 flag "p=tls-server-end-point" and includes
+	// the hash in the cbind data; when nil it sends "n,,".
+	channelBindingHash []byte
+
 	// State from the SCRAM exchange.
 	clientNonce            string
 	clientFirstMessageBare string
+	gs2Header              string
 	authMessage            string
 }
 
@@ -72,6 +82,22 @@ func NewSCRAMClientWithKeys(username string, clientKey, serverKey []byte) *SCRAM
 // 24 bytes provides 192 bits of entropy, base64-encoded to 32 characters.
 const clientNonceLength = 24
 
+// EnableChannelBinding configures the client to negotiate SCRAM-SHA-256-PLUS
+// using the tls-server-end-point binding type, with the supplied hash as the
+// cbind-data. Call before ClientFirstMessage. Pass nil to clear.
+func (c *SCRAMClient) EnableChannelBinding(tlsServerEndPointHash []byte) {
+	c.channelBindingHash = tlsServerEndPointHash
+}
+
+// Mechanism returns the SASL mechanism name the client will use, based on
+// whether channel binding has been enabled.
+func (c *SCRAMClient) Mechanism() string {
+	if c.channelBindingHash != nil {
+		return ScramSHA256PlusMechanism
+	}
+	return ScramSHA256Mechanism
+}
+
 // ClientFirstMessage generates the client-first-message to send to the server.
 // This starts the SCRAM authentication handshake.
 // Returns the full message including the GS2 header.
@@ -86,9 +112,15 @@ func (c *SCRAMClient) ClientFirstMessage() (string, error) {
 	// Build client-first-message-bare: n=<username>,r=<nonce>
 	c.clientFirstMessageBare = "n=" + encodeSaslName(c.username) + ",r=" + c.clientNonce
 
-	// Full client-first-message with GS2 header.
-	// "n,," means: no channel binding, no authorization identity
-	return "n,," + c.clientFirstMessageBare, nil
+	// GS2 header: "p=tls-server-end-point,," when channel binding is on,
+	// "n,," otherwise. The authzid slot stays empty in both cases.
+	if c.channelBindingHash != nil {
+		c.gs2Header = "p=" + ChannelBindingTypeTLSServerEndPoint + ",,"
+	} else {
+		c.gs2Header = "n,,"
+	}
+
+	return c.gs2Header + c.clientFirstMessageBare, nil
 }
 
 // ProcessServerFirst processes the server-first-message and generates the client-final-message.
@@ -106,9 +138,12 @@ func (c *SCRAMClient) ProcessServerFirst(serverFirst string) (string, error) {
 		return "", errors.New("server nonce does not start with client nonce (possible attack)")
 	}
 
-	// Build client-final-message-without-proof.
-	// Channel binding data for "n,," is "biws" (base64 of "n,,").
-	channelBinding := base64.StdEncoding.EncodeToString([]byte("n,,"))
+	// Build cbind data: gs2-header || cbind-data (PLUS) or just gs2-header.
+	cbind := []byte(c.gs2Header)
+	if c.channelBindingHash != nil {
+		cbind = append(cbind, c.channelBindingHash...)
+	}
+	channelBinding := base64.StdEncoding.EncodeToString(cbind)
 	clientFinalWithoutProof := "c=" + channelBinding + ",r=" + combinedNonce
 
 	// Build AuthMessage.

--- a/go/common/pgprotocol/scram/scram_test.go
+++ b/go/common/pgprotocol/scram/scram_test.go
@@ -82,12 +82,22 @@ func TestParseClientFirstMessage(t *testing.T) {
 		assert.Contains(t, err.Error(), "GS2")
 	})
 
-	t.Run("channel binding requested but not supported", func(t *testing.T) {
-		// 'p' means channel binding is required
-		msg := "p=tls-unique,,n=user,r=nonce"
+	t.Run("channel binding flag is parsed", func(t *testing.T) {
+		// 'p=<type>' is valid wire syntax — the authenticator decides
+		// whether the type is acceptable for the selected mechanism.
+		msg := "p=tls-server-end-point,,n=user,r=nonce"
+		parsed, err := parseClientFirstMessage(msg)
+		require.NoError(t, err)
+		assert.Equal(t, "p=tls-server-end-point", parsed.gs2CbindFlag)
+		assert.Equal(t, "tls-server-end-point", parsed.channelBindingType)
+		assert.Equal(t, "p=tls-server-end-point,,", parsed.gs2Header)
+	})
+
+	t.Run("empty channel binding type is rejected", func(t *testing.T) {
+		msg := "p=,,n=user,r=nonce"
 		_, err := parseClientFirstMessage(msg)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "channel binding")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing type")
 	})
 
 	t.Run("missing username attribute - valid (fallback handled later)", func(t *testing.T) {

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -143,6 +144,12 @@ type Conn struct {
 	// client. Tracking this explicitly (rather than type-asserting c.conn)
 	// keeps the check robust if c.conn is ever wrapped in instrumentation.
 	tlsHandshakeComplete bool
+
+	// tlsServerCert is the parsed leaf certificate offered to the client
+	// during the TLS handshake. Captured once at handshake completion and
+	// used to compute the tls-server-end-point channel binding hash for
+	// SCRAM-SHA-256-PLUS. Nil for plaintext connections.
+	tlsServerCert *x509.Certificate
 
 	// gssDone indicates that a GSSENCRequest has already been handled
 	// for this connection. Prevents double negotiation.

--- a/go/common/pgprotocol/server/packet_test.go
+++ b/go/common/pgprotocol/server/packet_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
 )
 
 func TestMessageReaderReadByte(t *testing.T) {
@@ -245,8 +246,10 @@ func TestReadSASLInitialResponseReleasesBuffer(t *testing.T) {
 		bufferedReader: bufio.NewReader(&w),
 	}
 
-	got, err := conn.readSASLInitialResponse()
+	advertised := map[string]struct{}{scram.ScramSHA256Mechanism: {}}
+	gotMech, got, err := conn.readSASLInitialResponse(advertised)
 	require.NoError(t, err)
+	assert.Equal(t, scram.ScramSHA256Mechanism, gotMech)
 	assert.Equal(t, string(saslData), got)
 	assert.Nil(t, conn.inboundPoolBuf,
 		"readSASLInitialResponse must release its read buffer via defer")

--- a/go/common/pgprotocol/server/ssl_scram_plus_test.go
+++ b/go/common/pgprotocol/server/ssl_scram_plus_test.go
@@ -1,0 +1,435 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+)
+
+// readSASLMechanisms parses the mechanism list from an AuthenticationSASL
+// message body (skipping the 4-byte auth code prefix). Mechanisms are
+// null-terminated strings followed by an empty terminator.
+func readSASLMechanisms(t *testing.T, body []byte) []string {
+	t.Helper()
+	// body[:4] is the AuthSASL int32. Mechanism list follows.
+	rest := body[4:]
+	var out []string
+	for {
+		idx := bytes.IndexByte(rest, 0)
+		require.GreaterOrEqual(t, idx, 0, "malformed AuthenticationSASL: no null terminator")
+		if idx == 0 {
+			return out
+		}
+		out = append(out, string(rest[:idx]))
+		rest = rest[idx+1:]
+	}
+}
+
+// scramPlusClientHelper drives a SCRAM-SHA-256-PLUS handshake from the
+// client side using the channel binding hash derived from the TLS peer cert.
+// Fails the test if the server doesn't advertise PLUS or if the handshake
+// doesn't complete.
+func scramPlusClientHelper(t *testing.T, conn *tls.Conn, username, password string) {
+	t.Helper()
+
+	// AuthenticationSASL: read advertised mechanisms.
+	msgType, body := readMessage(t, conn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthSASL), binary.BigEndian.Uint32(body[:4]))
+	mechs := readSASLMechanisms(t, body)
+	require.Contains(t, mechs, scram.ScramSHA256PlusMechanism,
+		"server must advertise %s over TLS", scram.ScramSHA256PlusMechanism)
+
+	// Compute tls-server-end-point hash from the server cert the TLS handshake
+	// actually surfaced — this is what a real libpq client does.
+	state := conn.ConnectionState()
+	require.NotEmpty(t, state.PeerCertificates)
+	cbHash, err := scram.ComputeTLSServerEndPointHash(state.PeerCertificates[0])
+	require.NoError(t, err)
+
+	client := scram.NewSCRAMClientWithPassword(username, password)
+	client.EnableChannelBinding(cbHash)
+
+	clientFirst, err := client.ClientFirstMessage()
+	require.NoError(t, err)
+	writeSASLInitialResponse(t, conn, scram.ScramSHA256PlusMechanism, clientFirst)
+
+	msgType, body = readMessage(t, conn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthSASLContinue), binary.BigEndian.Uint32(body[:4]))
+	serverFirst := string(body[4:])
+
+	clientFinal, err := client.ProcessServerFirst(serverFirst)
+	require.NoError(t, err)
+	writeSASLResponse(t, conn, clientFinal)
+
+	msgType, body = readMessage(t, conn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthSASLFinal), binary.BigEndian.Uint32(body[:4]))
+	require.NoError(t, client.VerifyServerFinal(string(body[4:])))
+
+	msgType, body = readMessage(t, conn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthOk), binary.BigEndian.Uint32(body[:4]))
+
+	for {
+		mt, _ := readMessage(t, conn)
+		if mt == byte(protocol.MsgReadyForQuery) {
+			return
+		}
+	}
+}
+
+// TestSSL_SCRAMPlus_HappyPath verifies the full PostgreSQL-parity flow over
+// TLS: server advertises SCRAM-SHA-256-PLUS, client negotiates it using the
+// tls-server-end-point hash of the server cert, and auth completes.
+func TestSSL_SCRAMPlus_HappyPath(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	scramPlusClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestSSL_SCRAMPlus_TamperedCBindRejected feeds the server a wrong
+// tls-server-end-point hash and expects a FATAL ErrorResponse with SQLSTATE
+// 28000 — matching PG's "channel binding authentication failed" class.
+func TestSSL_SCRAMPlus_TamperedCBindRejected(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+
+	// AuthenticationSASL.
+	msgType, body := readMessage(t, tlsClientConn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthSASL), binary.BigEndian.Uint32(body[:4]))
+
+	// Use a hash that has nothing to do with the real cert.
+	bogusHash := bytes.Repeat([]byte{0xAA}, 32)
+	client := scram.NewSCRAMClientWithPassword("tlsuser", "postgres")
+	client.EnableChannelBinding(bogusHash)
+	clientFirst, err := client.ClientFirstMessage()
+	require.NoError(t, err)
+	writeSASLInitialResponse(t, tlsClientConn, scram.ScramSHA256PlusMechanism, clientFirst)
+
+	// Server-first (cbind validation happens in client-final, so we still
+	// get a normal continue here).
+	_, body = readMessage(t, tlsClientConn)
+	clientFinal, err := client.ProcessServerFirst(string(body[4:]))
+	require.NoError(t, err)
+	writeSASLResponse(t, tlsClientConn, clientFinal)
+
+	// Expect ErrorResponse FATAL/28000 with PG-verbatim "SCRAM channel
+	// binding check failed" (matches PG17 auth-scram.c).
+	msgType, body = readMessage(t, tlsClientConn)
+	require.Equal(t, byte('E'), msgType, "expected ErrorResponse, got %c", msgType)
+	bodyStr := string(body)
+	require.Contains(t, bodyStr, "28000", "expected SQLSTATE 28000, body=%q", bodyStr)
+	require.Contains(t, bodyStr, "SCRAM channel binding check failed",
+		"expected PG-style message, body=%q", bodyStr)
+
+	// Server emits the ErrorResponse and returns from handleStartup. The
+	// FATAL is communicated to the client via wire, not via a Go error
+	// (mirrors how the other auth-failure paths behave).
+	<-errCh
+}
+
+// TestSSL_SCRAMPlus_DowngradeYRejected: over TLS, the client picks plain
+// SCRAM-SHA-256 with the "y" gs2 flag (claiming the server doesn't support
+// cbind). Per RFC 5802 §6 this is a downgrade attempt and must fail.
+func TestSSL_SCRAMPlus_DowngradeYRejected(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+
+	// AuthenticationSASL — read but ignore advertised list.
+	_, _ = readMessage(t, tlsClientConn)
+
+	// Hand-craft a client-first with the "y" downgrade flag.
+	clientFirst := "y,,n=tlsuser,r=fyko+d2lbbFgONRv9qkxdawL"
+	writeSASLInitialResponse(t, tlsClientConn, scram.ScramSHA256Mechanism, clientFirst)
+
+	// Expect FATAL ErrorResponse with PG-verbatim 28000 / "SCRAM channel
+	// binding negotiation error" immediately — before any continue.
+	msgType, body := readMessage(t, tlsClientConn)
+	require.Equal(t, byte('E'), msgType, "expected ErrorResponse, got %c", msgType)
+	bodyStr := string(body)
+	assert.Contains(t, bodyStr, "28000")
+	assert.Contains(t, bodyStr, "SCRAM channel binding negotiation error")
+
+	// Server emits ErrorResponse via wire and returns from handleStartup.
+	<-errCh
+}
+
+// TestSSL_SCRAM_AuthzidRejected: client sets SASL authzid in gs2-header.
+// PG rejects with 0A000 "client uses authorization identity, but it is not
+// supported". Mirror that exactly.
+func TestSSL_SCRAM_AuthzidRejected(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+
+	// Read AuthenticationSASL.
+	_, _ = readMessage(t, clientConn)
+
+	// Hand-craft a client-first with authzid.
+	clientFirst := "n,a=evil-authz,n=tlsuser,r=nonce"
+	writeSASLInitialResponse(t, clientConn, scram.ScramSHA256Mechanism, clientFirst)
+
+	msgType, body := readMessage(t, clientConn)
+	require.Equal(t, byte('E'), msgType)
+	bodyStr := string(body)
+	assert.Contains(t, bodyStr, "0A000", "expected SQLSTATE 0A000, body=%q", bodyStr)
+	assert.Contains(t, bodyStr, "client uses authorization identity")
+	<-errCh
+}
+
+// TestSSL_SCRAM_SingleErrorAfterCBindFatal asserts that after sending the
+// FATAL ErrorResponse for a cbind protocol error, the server does NOT write
+// a second wrapper ErrorResponse. PG protocol says no bytes follow a FATAL;
+// a regression here would surface as a duplicate "ErrorResponse" message
+// on the wire, which would confuse libpq's error parsing.
+func TestSSL_SCRAM_SingleErrorAfterCBindFatal(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		// Drive the full conn lifecycle (handleStartup + serve()'s error
+		// path) so any double-write would appear on the wire.
+		_ = c.handleStartup()
+		errCh <- nil
+	}()
+
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	_, _ = readMessage(t, clientConn) // AuthenticationSASL
+
+	// Send a protocol-violating client-first (authzid → 0A000).
+	writeSASLInitialResponse(t, clientConn, scram.ScramSHA256Mechanism,
+		"n,a=evil,n=tlsuser,r=nonce")
+
+	// First message must be the FATAL with 0A000.
+	mt, body := readMessage(t, clientConn)
+	require.Equal(t, byte('E'), mt)
+	require.Contains(t, string(body), "0A000")
+
+	// Drain any subsequent bytes the server might send within a short
+	// deadline. PG sends nothing after FATAL, so the read must return EOF
+	// (pipe close) and no extra ErrorResponse must precede it.
+	type readResult struct {
+		mt   byte
+		body []byte
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		header := make([]byte, 5)
+		_, err := io.ReadFull(clientConn, header)
+		if err != nil {
+			done <- readResult{err: err}
+			return
+		}
+		length := binary.BigEndian.Uint32(header[1:5]) - 4
+		body := make([]byte, length)
+		_, err = io.ReadFull(clientConn, body)
+		done <- readResult{mt: header[0], body: body, err: err}
+	}()
+
+	// Close the server side after a brief grace window so the read can
+	// resolve to EOF if no extra bytes were written.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = serverConn.Close()
+	}()
+
+	select {
+	case rr := <-done:
+		require.Error(t, rr.err, "expected EOF after FATAL, got extra message type=%c body=%q", rr.mt, string(rr.body))
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for connection close after FATAL")
+	}
+	<-errCh
+}
+
+// TestSSL_NoPlusAdvertisedWithoutTLS asserts that on a plaintext connection,
+// the server advertises ONLY SCRAM-SHA-256 — never PLUS.
+func TestSSL_NoPlusAdvertisedWithoutTLS(t *testing.T) {
+	serverConn, clientConn := newPipeConnPair()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := newTestConn(t, serverConn, nil) // no TLS config
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.handleStartup()
+	}()
+
+	writeStartupPacketToPipe(t, clientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "plainuser",
+		"database": "plaindb",
+	})
+
+	msgType, body := readMessage(t, clientConn)
+	require.Equal(t, byte(protocol.MsgAuthenticationRequest), msgType)
+	require.Equal(t, uint32(protocol.AuthSASL), binary.BigEndian.Uint32(body[:4]))
+	mechs := readSASLMechanisms(t, body)
+	require.Equal(t, []string{scram.ScramSHA256Mechanism}, mechs,
+		"plaintext connection must NOT advertise SCRAM-SHA-256-PLUS")
+
+	// Complete auth so the server goroutine exits cleanly.
+	client := scram.NewSCRAMClientWithPassword("plainuser", "postgres")
+	clientFirst, err := client.ClientFirstMessage()
+	require.NoError(t, err)
+	writeSASLInitialResponse(t, clientConn, scram.ScramSHA256Mechanism, clientFirst)
+	_, body = readMessage(t, clientConn)
+	clientFinal, err := client.ProcessServerFirst(string(body[4:]))
+	require.NoError(t, err)
+	writeSASLResponse(t, clientConn, clientFinal)
+	for {
+		mt, _ := readMessage(t, clientConn)
+		if mt == byte(protocol.MsgReadyForQuery) {
+			break
+		}
+	}
+	require.NoError(t, <-errCh)
+}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"maps"
@@ -190,6 +191,33 @@ func (c *Conn) handleSSLRequest() error {
 	c.conn = tlsConn
 	c.bufferedReader.Reset(tlsConn)
 	c.tlsHandshakeComplete = true
+
+	// Capture the leaf certificate offered to the client for SCRAM-SHA-256-PLUS
+	// channel binding. Prefer the pre-parsed Leaf (set when callers populate it),
+	// fall back to parsing Certificate[0] for the common case where Leaf was
+	// left nil. A failure here is non-fatal: we just won't advertise PLUS and
+	// auth will fall back to SCRAM-SHA-256.
+	//
+	// LIMITATION: tlsConfig.Certificates[0] is the canonical cert in this
+	// config slot. If a deployment uses tlsConfig.GetCertificate or
+	// GetConfigForClient (dynamic SNI), the cert actually negotiated for
+	// this handshake may differ — PLUS will then fall back to base SCRAM
+	// because Go's tls.Conn.ConnectionState() does not expose the server-
+	// presented cert. A wrapper-based fix that captures the actually-
+	// selected cert per-Conn before this point is tracked separately.
+	if len(c.tlsConfig.Certificates) > 0 {
+		cert := &c.tlsConfig.Certificates[0]
+		switch {
+		case cert.Leaf != nil:
+			c.tlsServerCert = cert.Leaf
+		case len(cert.Certificate) > 0:
+			if parsed, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
+				c.tlsServerCert = parsed
+			} else {
+				c.logger.Warn("failed to parse TLS leaf cert for channel binding", "err", err)
+			}
+		}
+	}
 
 	c.logger.Info("TLS connection established",
 		"version", tlsConn.ConnectionState().Version,
@@ -623,8 +651,34 @@ func (c *Conn) authenticateSCRAM() error {
 	// Create the SCRAM authenticator with the pre-fetched hash.
 	auth := scram.NewScramAuthenticator(creds.Hash, c.database)
 
+	// Tell the authenticator whether we're over TLS regardless of whether
+	// we manage to compute a cbind hash — the downgrade-attempt detection
+	// (gs2 flag "y") must fire on any TLS connection.
+	auth.SetOverTLS(c.tlsHandshakeComplete)
+
+	// Attach channel binding context when the connection is over TLS so the
+	// authenticator advertises SCRAM-SHA-256-PLUS in addition to SCRAM-SHA-256.
+	// Plaintext sessions skip this and continue to advertise SCRAM-SHA-256 only.
+	if c.tlsServerCert != nil {
+		cbHash, hashErr := scram.ComputeTLSServerEndPointHash(c.tlsServerCert)
+		if hashErr != nil {
+			// Don't fail the connection — log and fall back to plain
+			// SCRAM-SHA-256 so unusual certs (e.g. unsupported signature
+			// algorithms) still permit auth, matching PG's permissive
+			// behavior. The downgrade-detection gate on overTLS still
+			// fires here.
+			c.logger.Warn("failed to compute tls-server-end-point hash, falling back to SCRAM-SHA-256 only", "err", hashErr)
+		} else {
+			auth.SetChannelBinding(&scram.ChannelBinding{TLSServerEndPointHash: cbHash})
+		}
+	}
+
 	// Send AuthenticationSASL with supported mechanisms.
 	mechanisms := auth.StartAuthentication()
+	advertised := make(map[string]struct{}, len(mechanisms))
+	for _, m := range mechanisms {
+		advertised[m] = struct{}{}
+	}
 	if err := c.sendAuthenticationSASL(mechanisms); err != nil {
 		return fmt.Errorf("failed to send AuthenticationSASL: %w", err)
 	}
@@ -632,8 +686,8 @@ func (c *Conn) authenticateSCRAM() error {
 		return fmt.Errorf("failed to flush AuthenticationSASL: %w", err)
 	}
 
-	// Read SASLInitialResponse (contains client-first-message).
-	clientFirstMessage, err := c.readSASLInitialResponse()
+	// Read SASLInitialResponse (chosen mechanism + client-first-message).
+	selectedMechanism, clientFirstMessage, err := c.readSASLInitialResponse(advertised)
 	if err != nil {
 		return fmt.Errorf("failed to read SASLInitialResponse: %w", err)
 	}
@@ -641,8 +695,12 @@ func (c *Conn) authenticateSCRAM() error {
 	// Process client-first-message and generate server-first-message.
 	// Pass the username from the startup message as fallback for clients that
 	// send empty username in SCRAM (like pgx).
-	serverFirstMessage, err := auth.HandleClientFirst(clientFirstMessage, c.user)
+	serverFirstMessage, err := auth.HandleClientFirst(selectedMechanism, clientFirstMessage, c.user)
 	if err != nil {
+		if handled, ferr := c.mapSCRAMProtocolError(err); handled {
+			c.logger.Warn("authentication failed: SCRAM protocol violation in client-first", "user", c.user, "err", err)
+			return ferr
+		}
 		return fmt.Errorf("failed to handle client-first-message: %w", err)
 	}
 
@@ -666,6 +724,10 @@ func (c *Conn) authenticateSCRAM() error {
 		if errors.Is(err, scram.ErrAuthenticationFailed) {
 			c.logger.Warn("authentication failed: invalid password", "user", c.user)
 			return c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
+		}
+		if handled, ferr := c.mapSCRAMProtocolError(err); handled {
+			c.logger.Warn("authentication failed: SCRAM protocol violation in client-final", "user", c.user, "err", err)
+			return ferr
 		}
 		return fmt.Errorf("failed to handle client-final-message: %w", err)
 	}
@@ -719,24 +781,27 @@ func (c *Conn) sendAuthenticationSASLFinal(data string) error {
 }
 
 // readSASLInitialResponse reads SASLInitialResponse from the client.
-// Returns the SASL data (client-first-message for SCRAM).
-func (c *Conn) readSASLInitialResponse() (string, error) {
+// Returns the SASL mechanism the client picked and the SASL data
+// (client-first-message for SCRAM). The mechanism is validated against the
+// set the server advertised — anything else is rejected so a malicious or
+// confused client can't downgrade past what was offered.
+func (c *Conn) readSASLInitialResponse(advertised map[string]struct{}) (string, string, error) {
 	msgType, err := c.ReadMessageType()
 	if err != nil {
-		return "", fmt.Errorf("failed to read message type: %w", err)
+		return "", "", fmt.Errorf("failed to read message type: %w", err)
 	}
 	if msgType != protocol.MsgPasswordMsg {
-		return "", fmt.Errorf("expected SASLInitialResponse ('p'), got '%c'", msgType)
+		return "", "", fmt.Errorf("expected SASLInitialResponse ('p'), got '%c'", msgType)
 	}
 
 	length, err := c.ReadMessageLength()
 	if err != nil {
-		return "", fmt.Errorf("failed to read message length: %w", err)
+		return "", "", fmt.Errorf("failed to read message length: %w", err)
 	}
 
 	body, err := c.readMessageBody(length)
 	if err != nil {
-		return "", fmt.Errorf("failed to read message body: %w", err)
+		return "", "", fmt.Errorf("failed to read message body: %w", err)
 	}
 	defer c.returnReadBuffer()
 
@@ -745,34 +810,34 @@ func (c *Conn) readSASLInitialResponse() (string, error) {
 	// Read mechanism name.
 	mechanism, err := reader.ReadString()
 	if err != nil {
-		return "", fmt.Errorf("failed to read mechanism: %w", err)
+		return "", "", fmt.Errorf("failed to read mechanism: %w", err)
 	}
-	if mechanism != scram.ScramSHA256Mechanism {
-		return "", fmt.Errorf("unsupported SASL mechanism: %s", mechanism)
+	if _, ok := advertised[mechanism]; !ok {
+		return "", "", fmt.Errorf("unsupported SASL mechanism: %s", mechanism)
 	}
 
 	// Read data length.
 	dataLen, err := reader.ReadInt32()
 	if err != nil {
-		return "", fmt.Errorf("failed to read data length: %w", err)
+		return "", "", fmt.Errorf("failed to read data length: %w", err)
 	}
 
 	// Handle case where client sends no initial data (length = -1).
 	// This shouldn't happen for SCRAM-SHA-256, but some clients may do this.
 	if dataLen == -1 {
-		return "", errors.New("client sent SASLInitialResponse with no initial data (length=-1)")
+		return "", "", errors.New("client sent SASLInitialResponse with no initial data (length=-1)")
 	}
 	if dataLen < 0 {
-		return "", fmt.Errorf("invalid SASL data length: %d", dataLen)
+		return "", "", fmt.Errorf("invalid SASL data length: %d", dataLen)
 	}
 
 	// Read SASL data.
 	data, err := reader.ReadBytes(int(dataLen))
 	if err != nil {
-		return "", fmt.Errorf("failed to read SASL data: %w", err)
+		return "", "", fmt.Errorf("failed to read SASL data: %w", err)
 	}
 
-	return string(data), nil
+	return mechanism, string(data), nil
 }
 
 // readSASLResponse reads SASLResponse from the client.
@@ -821,6 +886,61 @@ func (c *Conn) sendAuthError(message string) error {
 func (c *Conn) sendLoginDisabledError() error {
 	msg := "role \"" + c.user + "\" is not permitted to log in"
 	if err := c.writeError(mterrors.NewPgError("FATAL", mterrors.PgSSInvalidAuthSpec, msg, "")); err != nil {
+		return err
+	}
+	if err := c.flush(); err != nil {
+		return err
+	}
+	return errAuthRejected
+}
+
+// mapSCRAMProtocolError converts a SCRAM authenticator error into the exact
+// PostgreSQL-style FATAL the client expects to see on the wire.
+//
+// Returns handled=true iff the error matched a SCRAM protocol class and a
+// FATAL has been written. The caller MUST then return ferr up the stack so
+// authenticate() short-circuits — ferr is errAuthRejected on success, or the
+// underlying write error on failure.
+//
+// Returns handled=false, nil when the error is not a SCRAM protocol error
+// — caller should continue with other classifications.
+//
+// SQLSTATE + message mapping comes straight from PG17 auth-scram.c so libpq
+// and any other PG-compatible client see identical diagnostics.
+func (c *Conn) mapSCRAMProtocolError(err error) (handled bool, ferr error) {
+	if err == nil {
+		return false, nil
+	}
+	switch {
+	case errors.Is(err, scram.ErrChannelBindingNegotiation):
+		return true, c.sendScramFatal(mterrors.PgSSInvalidAuthSpec,
+			"SCRAM channel binding negotiation error",
+			"The client supports SCRAM channel binding but thinks the server does not.  However, this server does support channel binding.")
+	case errors.Is(err, scram.ErrChannelBindingCheck):
+		return true, c.sendScramFatal(mterrors.PgSSInvalidAuthSpec,
+			"SCRAM channel binding check failed", "")
+	case errors.Is(err, scram.ErrAuthzidNotSupported):
+		return true, c.sendScramFatal(mterrors.PgSSFeatureNotSupported,
+			"client uses authorization identity, but it is not supported", "")
+	case errors.Is(err, scram.ErrSASLProtocol):
+		var sp *scram.SASLProtocolError
+		if errors.As(err, &sp) {
+			msg := sp.Msg
+			if msg == "" {
+				msg = "malformed SCRAM message"
+			}
+			return true, c.sendScramFatal(mterrors.PgSSProtocolViolation, msg, sp.Detail)
+		}
+		return true, c.sendScramFatal(mterrors.PgSSProtocolViolation, "malformed SCRAM message", "")
+	}
+	return false, nil
+}
+
+// sendScramFatal emits a FATAL ErrorResponse with the supplied SQLSTATE,
+// errmsg, and (optional) errdetail. Returns errAuthRejected on success so
+// authenticate() short-circuits, matching the sendAuthError pattern.
+func (c *Conn) sendScramFatal(sqlState, msg, detail string) error {
+	if err := c.writeError(mterrors.NewPgError("FATAL", sqlState, msg, detail)); err != nil {
 		return err
 	}
 	if err := c.flush(); err != nil {


### PR DESCRIPTION
## Summary

- Multigateway now advertises `SCRAM-SHA-256-PLUS` alongside `SCRAM-SHA-256` over TLS, mirroring native PostgreSQL.
- Implements `tls-server-end-point` channel binding (RFC 5929) with PG's MD5/SHA-1 → SHA-256 quirk; Ed25519 rejected to match PG.
- Enforces GS2 flag ↔ mechanism agreement, rejects `y`-flag downgrade attempts, rejects SASL authzid.
- SQLSTATEs (28000 / 08P01 / 0A000) and error messages match PG17 `auth-scram.c` verbatim — libpq-compatible clients see identical diagnostics.

Closes [MUL-371](https://linear.app/supabase/issue/MUL-371).

## Test plan

- [x] Unit tests in `scram/`: cbind hash compute (RSA/ECDSA at SHA-256/384/512, MD5/SHA-1 quirk, Ed25519 reject), PLUS handshake happy path, tampered cbind, downgrade, authzid, protocol violations, state guards.
- [x] Wire-level tests in `server/`: TLS+PLUS handshake end-to-end via real `tls.Conn`, tampered cbind FATAL 28000, downgrade FATAL 28000, authzid FATAL 0A000, plaintext never advertises PLUS.
- [x] `go test -race -count=5 ./go/common/pgprotocol/...` — clean.
- [x] Downstream `go/services/...` race tests — no regressions.
- [x] Manual smoke with real `psql --set=channel_binding=require` against a local cluster — relaunched zone1 `multigateway` with `--pg-tls-cert-file`/`--pg-tls-key-file` (self-signed RSA cert), then verified four scenarios over `sslmode=require`: `channel_binding=require` (PLUS selected, query OK), `channel_binding=prefer` (PLUS picked, query OK), `channel_binding=disable` (base SCRAM-SHA-256 used, query OK), and `channel_binding=require` against a plaintext port (libpq aborts with `channel binding required, but SSL not in use`).