### PR TITLE
fix(multipooler): wait for pg_reload_conf to be processed before returning

### DIFF
--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -27,6 +27,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/services/multipooler/executor"
+	"github.com/multigres/multigres/go/tools/retry"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -455,17 +456,7 @@ func (pm *MultiPoolerManager) resetPrimaryConnInfo(ctx context.Context) error {
 		return mterrors.Wrap(err, "failed to clear primary_conninfo")
 	}
 
-	// Reload PostgreSQL configuration to apply changes (should be quick)
-	pm.logger.InfoContext(ctx, "Reloading PostgreSQL configuration")
-
-	reloadCtx, reloadCancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer reloadCancel()
-	if err := pm.exec(reloadCtx, "SELECT pg_reload_conf()"); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to reload configuration", "error", err)
-		return mterrors.Wrap(err, "failed to reload PostgreSQL configuration")
-	}
-
-	return nil
+	return pm.reloadPostgresConfig(ctx)
 }
 
 // waitForReplayStabilize waits, best effort, for WAL replay to stop making
@@ -708,10 +699,38 @@ func (pm *MultiPoolerManager) resumeWALReplay(ctx context.Context) error {
 	return nil
 }
 
-// reloadPostgresConfig reloads PostgreSQL configuration to apply changes made via ALTER SYSTEM
+// reloadPostgresConfig reloads PostgreSQL configuration to apply changes made via
+// ALTER SYSTEM, and waits for postmaster to finish re-reading the config files
+// before returning.
+//
+// pg_reload_conf() returns immediately after sending SIGHUP to postmaster, well
+// before any of that work has happened. We use pg_conf_load_time() — the
+// timestamp of postmaster's most recent successful config load — as the
+// completion signal: once a follow-up query observes it advance past the
+// pre-reload value, postmaster has re-read postgresql.auto.conf and signalled
+// its child processes.
+//
+// Caveat: this guarantees postmaster has processed the reload, not that every
+// child process has. Backends (the walreceiver, individual query backends)
+// each pick up SIGHUP at their own pace — typically within milliseconds, but
+// not synchronously. Callers that need to observe a child's reaction (e.g.
+// polling pg_stat_wal_receiver for the walreceiver to disconnect after
+// clearing primary_conninfo) should still poll, but they can do so knowing
+// the new config is loaded server-side rather than racing with postmaster's
+// signal handler.
 func (pm *MultiPoolerManager) reloadPostgresConfig(ctx context.Context) error {
-	pm.logger.InfoContext(ctx, "Reloading PostgreSQL configuration")
+	loadTimeCtx, loadTimeCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer loadTimeCancel()
+	result, err := pm.query(loadTimeCtx, "SELECT pg_conf_load_time()")
+	if err != nil {
+		return mterrors.Wrap(err, "failed to read pg_conf_load_time before reload")
+	}
+	var loadTimeBefore string
+	if err := executor.ScanSingleRow(result, &loadTimeBefore); err != nil {
+		return mterrors.Wrap(err, "failed to scan pg_conf_load_time before reload")
+	}
 
+	pm.logger.InfoContext(ctx, "Reloading PostgreSQL configuration")
 	reloadCtx, reloadCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer reloadCancel()
 	if err := pm.exec(reloadCtx, "SELECT pg_reload_conf()"); err != nil {
@@ -719,7 +738,33 @@ func (pm *MultiPoolerManager) reloadPostgresConfig(ctx context.Context) error {
 		return mterrors.Wrap(err, "failed to reload PostgreSQL configuration")
 	}
 
-	return nil
+	// Poll pg_conf_load_time() until it advances. retry.New uses "do work, then
+	// back off" semantics, so the backoff timer starts after the previous query
+	// finishes — a slow query under load doesn't cause back-to-back hammering.
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	r := retry.New(1*time.Millisecond, 20*time.Millisecond)
+	for _, attemptErr := range r.Attempts(waitCtx) {
+		if attemptErr != nil {
+			return mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED,
+				"timeout waiting for pg_conf_load_time to advance after pg_reload_conf")
+		}
+		queryCtx, queryCancel := context.WithTimeout(waitCtx, 500*time.Millisecond)
+		result, err := pm.query(queryCtx, "SELECT pg_conf_load_time()")
+		queryCancel()
+		if err != nil {
+			return mterrors.Wrap(err, "failed to poll pg_conf_load_time after reload")
+		}
+		var loadTimeAfter string
+		if err := executor.ScanSingleRow(result, &loadTimeAfter); err != nil {
+			return mterrors.Wrap(err, "failed to scan pg_conf_load_time after reload")
+		}
+		if loadTimeAfter != loadTimeBefore {
+			return nil
+		}
+	}
+	// Unreachable: r.Attempts only exits via the ctx-cancelled branch above.
+	return mterrors.New(mtrpcpb.Code_INTERNAL, "reload polling loop exited unexpectedly")
 }
 
 // validateExpectedLSN validates that the current replay LSN matches the expected LSN
@@ -975,9 +1020,7 @@ func (pm *MultiPoolerManager) clearSyncReplicationForDemotion(ctx context.Contex
 		return mterrors.Wrap(err, "failed to clear synchronous_standby_names for demotion")
 	}
 
-	// Reload configuration to apply changes immediately
-	if err := pm.exec(execCtx, "SELECT pg_reload_conf()"); err != nil {
-		pm.logger.WarnContext(ctx, "Failed to reload configuration for demotion", "error", err)
+	if err := pm.reloadPostgresConfig(ctx); err != nil {
 		return mterrors.Wrap(err, "failed to reload configuration for demotion")
 	}
 
@@ -999,9 +1042,7 @@ func (pm *MultiPoolerManager) resetSynchronousReplication(ctx context.Context) e
 		return mterrors.Wrap(err, "failed to clear synchronous_standby_names")
 	}
 
-	// Reload configuration to apply changes
-	if err := pm.exec(execCtx, "SELECT pg_reload_conf()"); err != nil {
-		pm.logger.ErrorContext(ctx, "Failed to reload configuration", "error", err)
+	if err := pm.reloadPostgresConfig(ctx); err != nil {
 		return mterrors.Wrap(err, "failed to reload configuration after clearing standby list")
 	}
 

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -34,6 +34,27 @@ import (
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 )
 
+// expectReloadConfig sets up the mock query expectations for one successful call
+// to MultiPoolerManager.reloadPostgresConfig: read pg_conf_load_time (pre), run
+// pg_reload_conf, then read pg_conf_load_time (post) returning a different value
+// so the wait loop exits on the first poll.
+func expectReloadConfig(m *mock.QueryService) {
+	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:01+00"}}))
+}
+
+// expectReloadConfigFailure sets up the mock query expectations for a call to
+// MultiPoolerManager.reloadPostgresConfig where pg_reload_conf itself fails.
+// The wait loop is never entered.
+func expectReloadConfigFailure(m *mock.QueryService, reloadErr error) {
+	m.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:00+00"}}))
+	m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", reloadErr)
+}
+
 // mustPoolerIDFromAppName constructs a poolerID from a "cell_name" application name string.
 // Panics if parsing or construction fails; for use in tests only.
 func mustPoolerIDFromAppName(appName string) poolerID {
@@ -1369,7 +1390,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: true,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
@@ -1389,7 +1410,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: false,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 			},
 			expectError:  false,
 			expectStatus: false,
@@ -1410,7 +1431,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: false,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", errors.New("reload failed"))
+				expectReloadConfigFailure(m, errors.New("reload failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to reload PostgreSQL configuration",
@@ -1421,7 +1442,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: true,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
 				// First query for waitForReceiverDisconnect - consumed after first match
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
@@ -1446,7 +1467,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: false,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
@@ -1472,7 +1493,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: false,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 				m.AddQueryPatternOnceWithError("SELECT COUNT", errors.New("query failed"))
 			},
 			expectError:   true,
@@ -1484,7 +1505,7 @@ func TestPauseReplication(t *testing.T) {
 			wait: false,
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
@@ -1538,7 +1559,7 @@ func TestResetPrimaryConnInfo(t *testing.T) {
 			name: "successful reset",
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 			},
 			expectError: false,
 		},
@@ -1554,7 +1575,7 @@ func TestResetPrimaryConnInfo(t *testing.T) {
 			name: "pg_reload_conf fails",
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", errors.New("reload failed"))
+				expectReloadConfigFailure(m, errors.New("reload failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to reload PostgreSQL configuration",
@@ -1594,7 +1615,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 			name: "successful clear synchronous replication",
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
 			},
 			expectError: false,
 		},
@@ -1610,7 +1631,7 @@ func TestClearSyncReplicationForDemotion(t *testing.T) {
 			name: "pg_reload_conf fails",
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", errors.New("reload failed"))
+				expectReloadConfigFailure(m, errors.New("reload failed"))
 			},
 			expectError:   true,
 			errorContains: "failed to reload configuration for demotion",

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -104,7 +104,7 @@ func expectStandbyRevokeMocks(m *mock.QueryService, lsn string) {
 	m.AddQueryPatternOnce("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 	// pauseReplication: resetPrimaryConnInfo
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
 	// waitForReceiverDisconnect
 	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count"}, [][]any{{int64(0)}}))
 	// queryReplicationStatus (from waitForReceiverDisconnect)
@@ -947,11 +947,11 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
+				expectReloadConfig(m) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries
 				m.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo = 'host=correct-primary-host port=5433 user=postgres application_name=zone1_stale-primary'", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // Second pg_reload_conf call
+				expectReloadConfig(m) // Second pg_reload_conf call
 			},
 			expectedFinalConsensusTerm: 10,
 			expectedLeaderTerm:         0, // Primary term cleared after demotion
@@ -1012,11 +1012,11 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
+				expectReloadConfig(m) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries
 				m.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo = 'host=correct-primary-host port=5433 user=postgres application_name=zone1_stale-primary'", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // Second pg_reload_conf call
+				expectReloadConfig(m) // Second pg_reload_conf call
 			},
 			expectedFinalConsensusTerm: 15, // With force, term is NOT updated when older
 			expectedLeaderTerm:         0,  // Primary term is cleared
@@ -1052,11 +1052,11 @@ func TestDemoteStalePrimary_UpdatesConsensusTerm(t *testing.T) {
 				// resetSynchronousReplication queries
 				m.AddQueryPattern("SELECT pg_is_in_recovery", mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET synchronous_standby_names", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // First pg_reload_conf call
+				expectReloadConfig(m) // First pg_reload_conf call
 
 				// setPrimaryConnInfoLocked queries
 				m.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo = 'host=correct-primary-host port=5433 user=postgres application_name=zone1_stale-primary'", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil)) // Second pg_reload_conf call
+				expectReloadConfig(m) // Second pg_reload_conf call
 			},
 			expectedFinalConsensusTerm: 10,
 			expectedLeaderTerm:         0, // Primary term cleared
@@ -1226,7 +1226,7 @@ func expectStandbyRecruitMocks(m *mock.QueryService, lsn string, savedConnInfo s
 	m.AddQueryPatternOnce("current_setting.*primary_conninfo", mock.MakeQueryResult([]string{"current_setting"}, connInfoRow))
 	// pauseReplication: resetPrimaryConnInfo
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
 	// waitForReceiverDisconnect
 	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count"}, [][]any{{int64(0)}}))
 	// queryReplicationStatus (from waitForReceiverDisconnect)
@@ -1538,7 +1538,7 @@ func expectLeaderProposeMocks(m *mock.QueryService, lsn string) {
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"f"}}))
 	// resetPrimaryConnInfo: clear conninfo + reload
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
-	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
 	// getPrimaryLSN
 	m.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
 		mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{lsn}}))
@@ -1554,7 +1554,7 @@ func expectReplicaProposeMocks(m *mock.QueryService) {
 	// SET primary_conninfo
 	m.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo", mock.MakeQueryResult(nil, nil))
 	// reload config
-	m.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(m)
 }
 
 func TestPropose(t *testing.T) {
@@ -1894,7 +1894,7 @@ func TestPropose(t *testing.T) {
 				m.AddQueryPatternOnce("SELECT pg_is_in_recovery",
 					mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 				m.AddQueryPatternOnce("ALTER SYSTEM SET primary_conninfo", mock.MakeQueryResult(nil, nil))
-				m.AddQueryPatternOnceWithError("SELECT pg_reload_conf", errors.New("reload failed"))
+				expectReloadConfigFailure(m, errors.New("reload failed"))
 			},
 			expectError:       true,
 			expectErrContains: "failed to reload PostgreSQL configuration",

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -621,8 +621,7 @@ func TestPromoteIdempotency_InconsistentStateFixedWithForce(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// Mock: Get final LSN
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
@@ -678,8 +677,7 @@ func TestPromoteIdempotency_NothingCompleteYet(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// Mock: Get final LSN
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
@@ -787,8 +785,7 @@ func TestPromoteIdempotency_SecondCallSucceedsAfterCompletion(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// Mock: Get current LSN (called twice - once after first promote, once in second call)
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
@@ -846,8 +843,7 @@ func TestPromoteIdempotency_EmptyExpectedLSNSkipsValidation(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// Mock: Get final LSN
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
@@ -900,8 +896,7 @@ func TestPromote_WithElectionMetadata(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	fakeRules := &fakeRuleStore{}
 	pm, _ := setupPromoteTestManager(t, mockQueryService, fakeRules)
@@ -975,8 +970,7 @@ func TestPromote_RuleHistoryErrorFailsPromotion(t *testing.T) {
 	// Mock: Clear primary_conninfo after promotion (executed before updateRule)
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// updateRule fails (e.g., sync replication timeout)
 	fakeRules := &fakeRuleStore{updateErr: mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for synchronous replication")}
@@ -1040,8 +1034,7 @@ func TestPromote_TopologyUpdateFailureDoesNotFailPromotion(t *testing.T) {
 	// Clear primary_conninfo after promotion
 	mockQueryService.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo",
 		mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf",
-		mock.MakeQueryResult(nil, nil))
+	expectReloadConfig(mockQueryService)
 
 	// Get final LSN
 	mockQueryService.AddQueryPatternOnce("SELECT pg_current_wal_lsn",
@@ -1210,7 +1203,7 @@ func TestSetPrimaryConnInfo_StoresPrimaryPoolerID(t *testing.T) {
 		func(sql string) { capturedConnInfoSQL = sql },
 	)
 	// SetPrimaryConnInfo executes pg_reload_conf()
-	mockQueryService.AddQueryPatternOnce("SELECT pg_reload_conf", mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
+	expectReloadConfig(mockQueryService)
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
 	pm.rules = newRuleStore(logger, mockQueryService)
 


### PR DESCRIPTION
pg_reload_conf() returns immediately after sending SIGHUP to postmaster. We can't determine if the config was reloaded on every backend process, but we can at least determine if it's been loaded on more than zero processes.

This PR also centralizes config reloading into a single helper.