### PR TITLE
ci: suppress deployment records for environment: ci jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -167,7 +167,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [coverage-direct, coverage-subprocess]
     if: always()
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -43,7 +43,9 @@ jobs:
   report:
     name: Aggregate flaky tests and post to Slack
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     permissions:
       actions: read
     steps:

--- a/.github/workflows/sync-proto-to-operator.yml
+++ b/.github/workflows/sync-proto-to-operator.yml
@@ -9,7 +9,9 @@ permissions: {}
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     steps:
       - name: Generate GitHub App token for creating a PR
         id: app-token

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,7 +26,9 @@ jobs:
   test-integration:
     name: Run full integration test suite
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-pgbench.yml
+++ b/.github/workflows/test-pgbench.yml
@@ -30,7 +30,9 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'Run Benchmarks')
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -31,7 +31,9 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-short.yml
+++ b/.github/workflows/test-short.yml
@@ -26,7 +26,9 @@ jobs:
   test-short:
     name: Short Tests
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-sqllogictest.yml
+++ b/.github/workflows/test-sqllogictest.yml
@@ -31,7 +31,9 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
     runs-on: ubuntu-24.04
-    environment: ci
+    environment:
+      name: ci
+      deployment: false
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
These workflows declare `environment: ci` purely to satisfy a zizmor lint that wants secret-using jobs gated behind an environment. None of them actually deploy anything, so the resulting deployment records were noise in the Deployments tab and API. Setting `deployment: false` keeps secrets-gating and standard protection rules intact while suppressing the deployment record.