### PR TITLE
feat(protoutil): add RESERVATION_REASON_LOGICAL_REPLICATION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ super-linter-output/
 .claude/settings.local.json
 .claude/commands/*.local.md
 .claude/scheduled_tasks/
+.claude/scheduled_tasks.lock
 .claude/worktrees/
 CLAUDE.local.md
 

--- a/go/common/fakepgserver/handler.go
+++ b/go/common/fakepgserver/handler.go
@@ -177,6 +177,13 @@ func (h *fakeHandler) HandleSync(ctx context.Context, conn *server.Conn) error {
 	return nil
 }
 
+// ConnectionEstablished records the replication mode of the freshly
+// authenticated connection so tests can assert on it via
+// Server.LastReplicationMode.
+func (h *fakeHandler) ConnectionEstablished(conn *server.Conn) {
+	h.server.recordReplicationMode(conn.ReplicationMode())
+}
+
 // ConnectionClosed handles connection cleanup.
 func (h *fakeHandler) ConnectionClosed(conn *server.Conn) {}
 

--- a/go/common/fakepgserver/server.go
+++ b/go/common/fakepgserver/server.go
@@ -85,6 +85,18 @@ type Server struct {
 
 	// queryPatternUserCallback stores optional callbacks when a query with a pattern is called.
 	queryPatternUserCallback map[*regexp.Regexp]func(string)
+
+	// credentialProvider is the optional inner CredentialProvider used by
+	// the listener's auth path. Tests that exercise replication startup
+	// (replication=true / replication=database) must install one whose
+	// IsReplicationRole is true; without it, verifyReplicationRole fails
+	// closed for the trust-auth path.
+	credentialProvider server.CredentialProvider
+
+	// lastReplicationMode is the parsed `replication` startup parameter
+	// of the most recently established connection. Recorded via the
+	// ConnectionEstablishedHandler hook.
+	lastReplicationMode server.ReplicationMode
 }
 
 type exprResult struct {
@@ -102,6 +114,55 @@ type trustAllProvider struct{}
 // AllowTrustAuth always returns true, allowing all connections without password.
 func (p *trustAllProvider) AllowTrustAuth(_ context.Context, _, _ string) bool {
 	return true
+}
+
+// GetCredentials dispatches to the test-installed CredentialProvider when one
+// is set. Trust-auth replication startups invoke this path inside
+// verifyReplicationRole (server/startup.go) when the auth-time SCRAM lookup
+// was skipped. Without an installed provider, replication startups are
+// rejected — which is the right default for a fake server.
+func (s *Server) GetCredentials(ctx context.Context, user, database string) (*server.Credentials, error) {
+	s.mu.Lock()
+	provider := s.credentialProvider
+	s.mu.Unlock()
+	if provider == nil {
+		return nil, fmt.Errorf("fakepgserver: no credential provider configured for %q", user)
+	}
+	return provider.GetCredentials(ctx, user, database)
+}
+
+// SetCredentialProvider installs a server.CredentialProvider that the
+// listener's auth path will consult. Tests that exercise replication startup
+// (replication=true / replication=database) must call this with a provider
+// whose Credentials carry IsReplicationRole=true, otherwise the post-auth
+// gate rejects the connection.
+func (s *Server) SetCredentialProvider(provider server.CredentialProvider) *Server {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.credentialProvider = provider
+	return s
+}
+
+// LastReplicationMode returns the replication mode of the most recently
+// established connection. Returns ReplicationOff if no connection has
+// completed startup, or the last connection was a normal (non-replication)
+// session.
+//
+// The `replication` startup parameter is stripped from GetStartupParams()
+// after parsing, so tests must use this accessor to verify wire-level
+// replication mode.
+func (s *Server) LastReplicationMode() server.ReplicationMode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastReplicationMode
+}
+
+// recordReplicationMode is invoked by the handler's ConnectionEstablished
+// hook to stash the most recent connection's mode for test assertions.
+func (s *Server) recordReplicationMode(mode server.ReplicationMode) {
+	s.mu.Lock()
+	s.lastReplicationMode = mode
+	s.mu.Unlock()
 }
 
 // ExpectedExecuteFetch defines for an expected query the to be faked output.
@@ -135,13 +196,18 @@ func New(t testing.TB) *Server {
 	// Create the handler.
 	handler := &fakeHandler{server: s}
 
-	// Create listener on random port with trust auth (simulates Unix socket trust auth).
+	// Create listener on random port with trust auth (simulates Unix socket
+	// trust auth). The server itself is wired as the CredentialProvider so
+	// tests can install one at runtime via SetCredentialProvider — required
+	// for replication-mode startups, which post-auth gate on the role's
+	// IsReplicationRole flag.
 	var err error
 	s.listener, err = server.NewListener(server.ListenerConfig{
-		Address:           "127.0.0.1:0", // Random available port.
-		Handler:           handler,
-		TrustAuthProvider: &trustAllProvider{},
-		Logger:            slog.Default(),
+		Address:            "127.0.0.1:0", // Random available port.
+		Handler:            handler,
+		TrustAuthProvider:  &trustAllProvider{},
+		CredentialProvider: s,
+		Logger:             slog.Default(),
 	})
 	if err != nil {
 		t.Fatalf("fakepgserver: failed to create listener: %v", err)

--- a/go/common/fakepgserver/server.go
+++ b/go/common/fakepgserver/server.go
@@ -97,6 +97,27 @@ type Server struct {
 	// of the most recently established connection. Recorded via the
 	// ConnectionEstablishedHandler hook.
 	lastReplicationMode server.ReplicationMode
+
+	// rejectNextReplStartup, when armed, causes the next replication-mode
+	// startup (replication=true / replication=database) to be rejected with
+	// FATAL 42501 as if the role lacked the REPLICATION attribute. One-shot:
+	// consumed via CompareAndSwap so it auto-resets after the first matching
+	// startup. Non-replication startups are unaffected. Used by tests to
+	// assert dial-failure cleanup paths.
+	//
+	// We piggyback on verifyReplicationRole's GetCredentials path (see the
+	// GetCredentials method below) rather than introducing a new
+	// startup-rejection hook so the fake's failure modes stay aligned with
+	// production rolreplication-rejection plumbing — tests exercise the same
+	// post-auth gate real postgres uses, not a parallel error path.
+	//
+	// Listener-config qualifier: this scoping works because GetCredentials is
+	// reached only from verifyReplicationRole under fakepgserver's hardcoded
+	// trust auth. If fakepgserver ever grows SCRAM (which calls
+	// GetCredentials for every login, not just replication startups), this
+	// toggle would broaden to non-replication startups and the logic in
+	// GetCredentials would need to gate on replication mode explicitly.
+	rejectNextReplStartup atomic.Bool
 }
 
 type exprResult struct {
@@ -128,7 +149,33 @@ func (s *Server) GetCredentials(ctx context.Context, user, database string) (*se
 	if provider == nil {
 		return nil, fmt.Errorf("fakepgserver: no credential provider configured for %q", user)
 	}
-	return provider.GetCredentials(ctx, user, database)
+	creds, err := provider.GetCredentials(ctx, user, database)
+	if err != nil {
+		return nil, err
+	}
+	// One-shot rejection toggle: clear IsReplicationRole so the post-auth
+	// gate in verifyReplicationRole rejects this connection with a FATAL
+	// 42501, matching production rolreplication-rejection plumbing rather
+	// than a parallel error path. Trust-auth replication startups are the
+	// only path that reaches here under fakepgserver's current listener
+	// config, so non-replication sessions are unaffected. See the
+	// rejectNextReplStartup field comment for the SCRAM caveat.
+	if s.rejectNextReplStartup.CompareAndSwap(true, false) {
+		out := *creds
+		out.IsReplicationRole = false
+		return &out, nil
+	}
+	return creds, nil
+}
+
+// SetRejectNextReplicationStartup arms a one-shot toggle that causes the
+// next replication-mode startup (replication=true / replication=database)
+// to be rejected at the rolreplication gate. The toggle auto-resets after
+// firing, so subsequent replication startups succeed again. Pass false to
+// disarm explicitly. Tests use this to exercise dial-failure cleanup
+// without dropping the listener.
+func (s *Server) SetRejectNextReplicationStartup(reject bool) {
+	s.rejectNextReplStartup.Store(reject)
 }
 
 // SetCredentialProvider installs a server.CredentialProvider that the

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -359,6 +359,13 @@ func (c *Conn) ScramServerKey() []byte {
 	return c.scramServerKey
 }
 
+// ReplicationMode returns the parsed `replication` startup parameter for this
+// connection. ReplicationOff means the client did not request a replication
+// connection (or sent replication=false).
+func (c *Conn) ReplicationMode() ReplicationMode {
+	return c.replicationMode
+}
+
 // GetStartupParams returns the startup parameters sent by the client,
 // excluding 'user' and 'database' which are handled separately.
 func (c *Conn) GetStartupParams() map[string]string {

--- a/go/common/pgprotocol/server/handler.go
+++ b/go/common/pgprotocol/server/handler.go
@@ -128,3 +128,15 @@ type Handler interface {
 	// EXECUTE) without type-asserting to a concrete handler implementation.
 	GetPreparedStatementInfo(connID uint32, name string) *preparedstatement.PreparedStatementInfo
 }
+
+// ConnectionEstablishedHandler is an optional interface a Handler may
+// implement to be notified when a client connection completes the startup
+// phase (authentication and any post-auth role-attribute gates have passed).
+// The hook is invoked via interface assertion, so existing Handler
+// implementations do not need to opt in.
+//
+// Typical use is in test fixtures that need to observe per-connection
+// startup state (replication mode, startup parameters) once it is settled.
+type ConnectionEstablishedHandler interface {
+	ConnectionEstablished(conn *Conn)
+}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -523,6 +523,14 @@ func (c *Conn) finishAuth() error {
 		return fmt.Errorf("failed to send ParameterStatus messages: %w", err)
 	}
 
+	// Notify handlers that opted into the established hook *before*
+	// sending ReadyForQuery. Otherwise the client returns from Connect
+	// as soon as it sees ReadyForQuery, races ahead, and may observe
+	// the conn before the hook records per-connection startup state.
+	if h, ok := c.handler.(ConnectionEstablishedHandler); ok {
+		h.ConnectionEstablished(c)
+	}
+
 	// Send ReadyForQuery to indicate we're ready to receive commands.
 	if err := c.sendReadyForQuery(); err != nil {
 		return fmt.Errorf("failed to send ReadyForQuery: %w", err)

--- a/go/common/protoutil/reservation.go
+++ b/go/common/protoutil/reservation.go
@@ -23,7 +23,7 @@ import (
 )
 
 // validReasonsMask is the bitmask of all known reservation reasons.
-const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen
+const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen | ReasonLogicalReplication
 
 // Reason constants as uint32 for bitmask operations.
 // These match the ReservationReason enum values.
@@ -33,6 +33,25 @@ const (
 	ReasonPortal      = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_PORTAL)      // 4
 	ReasonCopy        = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_COPY)        // 8
 	ReasonListen      = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_LISTEN)      // 16
+
+	// ReasonLogicalReplication indicates the connection has logical-replication
+	// session state (an owned slot or an active replication-protocol stream)
+	// and must stay pinned to its current Postgres backend for the session's
+	// lifetime.
+	//
+	// Today this bit is set only at connection-open time, by the
+	// reserved.Pool.NewLogicalReplicationConn factory for connections that
+	// requested `replication=database` in the startup parameters.
+	//
+	// TODO: also set this bit mid-session when the planner observes
+	// pg_create_logical_replication_slot(...) on a plain SQL connection
+	// (polling / CDC-RLS path). This will mirror how ReasonTempTable is set
+	// when CREATE TEMP TABLE is observed (see
+	// go/services/multigateway/handler/connection_state.go for the
+	// PendingTempTableReservation precedent). Until that lands, polling
+	// consumers must cooperate by setting an application_name that
+	// multigateway recognizes (also future work).
+	ReasonLogicalReplication = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_LOGICAL_REPLICATION) // 32
 )
 
 // ValidateReasons returns an error if any unknown bits are set in the reasons bitmask.
@@ -71,6 +90,11 @@ func HasCopyReason(reasons uint32) bool {
 // HasListenReason returns true if the reasons bitmask includes LISTEN/NOTIFY.
 func HasListenReason(reasons uint32) bool {
 	return HasReason(reasons, ReasonListen)
+}
+
+// HasLogicalReplicationReason returns true if the reasons bitmask includes a logical-replication session.
+func HasLogicalReplicationReason(reasons uint32) bool {
+	return HasReason(reasons, ReasonLogicalReplication)
 }
 
 // AddReason adds a reason to the bitmask and returns the new value.
@@ -150,6 +174,9 @@ func ReasonsString(reasons uint32) string {
 	}
 	if HasListenReason(reasons) {
 		parts = append(parts, "listen")
+	}
+	if HasLogicalReplicationReason(reasons) {
+		parts = append(parts, "logical_replication")
 	}
 	if len(parts) == 0 {
 		return "unknown"

--- a/go/common/protoutil/reservation_test.go
+++ b/go/common/protoutil/reservation_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReasonLogicalReplication(t *testing.T) {
+	// Value must be the next power of two after the existing reasons.
+	assert.Equal(t, uint32(32), ReasonLogicalReplication)
+
+	// Must be part of the valid reasons mask so ValidateReasons accepts it.
+	assert.NoError(t, ValidateReasons(ReasonLogicalReplication))
+
+	// Helper introspection.
+	assert.True(t, HasLogicalReplicationReason(ReasonLogicalReplication))
+	assert.False(t, HasLogicalReplicationReason(ReasonTransaction))
+
+	// Combined with other reasons should still work.
+	combined := AddReason(ReasonTransaction, ReasonLogicalReplication)
+	assert.True(t, HasLogicalReplicationReason(combined))
+	assert.True(t, HasTransactionReason(combined))
+
+	// String representation.
+	assert.Equal(t, "logical_replication", ReasonsString(ReasonLogicalReplication))
+	assert.Equal(t, "transaction|logical_replication", ReasonsString(combined))
+}

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -60,6 +60,9 @@ const (
 	ReservationReason_RESERVATION_REASON_COPY ReservationReason = 8 // 0b1000
 	// Connection is reserved for LISTEN/NOTIFY (dedicated PubSubListener connection)
 	ReservationReason_RESERVATION_REASON_LISTEN ReservationReason = 16 // 0b10000
+	// Connection is reserved for a logical-replication session (CREATE_REPLICATION_SLOT,
+	// START_REPLICATION, etc.). Pinned to a single backend for the session's lifetime.
+	ReservationReason_RESERVATION_REASON_LOGICAL_REPLICATION ReservationReason = 32 // 0b100000
 )
 
 // Enum value maps for ReservationReason.
@@ -71,14 +74,16 @@ var (
 		4:  "RESERVATION_REASON_PORTAL",
 		8:  "RESERVATION_REASON_COPY",
 		16: "RESERVATION_REASON_LISTEN",
+		32: "RESERVATION_REASON_LOGICAL_REPLICATION",
 	}
 	ReservationReason_value = map[string]int32{
-		"RESERVATION_REASON_UNSPECIFIED": 0,
-		"RESERVATION_REASON_TRANSACTION": 1,
-		"RESERVATION_REASON_TEMP_TABLE":  2,
-		"RESERVATION_REASON_PORTAL":      4,
-		"RESERVATION_REASON_COPY":        8,
-		"RESERVATION_REASON_LISTEN":      16,
+		"RESERVATION_REASON_UNSPECIFIED":         0,
+		"RESERVATION_REASON_TRANSACTION":         1,
+		"RESERVATION_REASON_TEMP_TABLE":          2,
+		"RESERVATION_REASON_PORTAL":              4,
+		"RESERVATION_REASON_COPY":                8,
+		"RESERVATION_REASON_LISTEN":              16,
+		"RESERVATION_REASON_LOGICAL_REPLICATION": 32,
 	}
 )
 
@@ -1973,14 +1978,15 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x12\x1a\n" +
 	"\bchannels\x18\x02 \x03(\tR\bchannels\"X\n" +
 	"\x1bStreamNotificationsResponse\x129\n" +
-	"\fnotification\x18\x01 \x01(\v2\x15.query.PgNotificationR\fnotification*\xd9\x01\n" +
+	"\fnotification\x18\x01 \x01(\v2\x15.query.PgNotificationR\fnotification*\x85\x02\n" +
 	"\x11ReservationReason\x12\"\n" +
 	"\x1eRESERVATION_REASON_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eRESERVATION_REASON_TRANSACTION\x10\x01\x12!\n" +
 	"\x1dRESERVATION_REASON_TEMP_TABLE\x10\x02\x12\x1d\n" +
 	"\x19RESERVATION_REASON_PORTAL\x10\x04\x12\x1b\n" +
 	"\x17RESERVATION_REASON_COPY\x10\b\x12\x1d\n" +
-	"\x19RESERVATION_REASON_LISTEN\x10\x10*\x87\x01\n" +
+	"\x19RESERVATION_REASON_LISTEN\x10\x10\x12*\n" +
+	"&RESERVATION_REASON_LOGICAL_REPLICATION\x10 *\x87\x01\n" +
 	"\x15TransactionConclusion\x12&\n" +
 	"\"TRANSACTION_CONCLUSION_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dTRANSACTION_CONCLUSION_COMMIT\x10\x01\x12#\n" +

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -467,6 +467,20 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 	})
 }
 
+// NewLogicalReplicationConn returns a Postgres connection opened in
+// replication mode (replication=database) and tagged with
+// ReasonLogicalReplication, on the specified user's reserved pool. SCRAM
+// passthrough key semantics match NewReservedConn.
+//
+// TODO: see UserPool.NewLogicalReplicationConn — replication connections
+// should eventually live in their own per-user capacity bucket so they
+// don't compete with regular query traffic.
+func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
+	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+		return pool.NewLogicalReplicationConn(ctx)
+	})
+}
+
 // evictUserPool removes stale from the snapshot and closes it. Used when a
 // pool's cached SCRAM keys no longer match pg_authid — typically because the
 // user rotated their PostgreSQL password — so the next getOrCreateUserPool

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -471,10 +471,6 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 // replication mode (replication=database) and tagged with
 // ReasonLogicalReplication, on the specified user's reserved pool. SCRAM
 // passthrough key semantics match NewReservedConn.
-//
-// TODO: see UserPool.NewLogicalReplicationConn — replication connections
-// should eventually live in their own per-user capacity bucket so they
-// don't compete with regular query traffic.
 func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
 	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewLogicalReplicationConn(ctx)

--- a/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+	pgserver "github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
+)
+
+// fakeReplicationCredentialProvider returns IsReplicationRole=true for every
+// role so fakepgserver accepts replication-mode startup parameters.
+type fakeReplicationCredentialProvider struct{}
+
+func (fakeReplicationCredentialProvider) GetCredentials(_ context.Context, _, _ string) (*pgserver.Credentials, error) {
+	return &pgserver.Credentials{
+		Hash:              &scram.ScramHash{},
+		IsReplicationRole: true,
+	}, nil
+}
+
+func TestManagerNewLogicalReplicationConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	mgr := newTestManager(t, server)
+	defer mgr.Close()
+
+	const user = "test_user"
+	conn, err := mgr.NewLogicalReplicationConn(context.Background(), user, nil, nil)
+	require.NoError(t, err)
+	defer conn.Release(reserved.ReleaseError)
+
+	assert.True(t, protoutil.HasLogicalReplicationReason(conn.RemainingReasons()),
+		"replication conn must be tagged with ReasonLogicalReplication")
+	assert.Equal(t, pgserver.ReplicationLogical, server.LastReplicationMode(),
+		"replication=database must have been sent in the startup message")
+
+	// The factory must create a per-user pool, not place the replication conn
+	// on the shared admin pool.
+	assert.True(t, mgr.HasUserPool(user),
+		"replication conn must be checked out from the user's pool, not the admin pool")
+}

--- a/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
@@ -17,6 +17,7 @@ package connpoolmanager
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,7 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/scram"
 	pgserver "github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 )
 
@@ -61,4 +63,65 @@ func TestManagerNewLogicalReplicationConn(t *testing.T) {
 	// on the shared admin pool.
 	assert.True(t, mgr.HasUserPool(user),
 		"replication conn must be checked out from the user's pool, not the admin pool")
+}
+
+// TestManager_LogicalReplicationSharesReservedCap proves at the Manager API
+// that replication conns and transactional reserved conns share a single
+// per-user reserved-pool capacity. Filling the cap via NewReservedConn must
+// block subsequent NewLogicalReplicationConn calls, and releasing one reserved
+// conn must unblock replication. This is the higher-layer regression that
+// guards the wiring fixed in Task 1.
+func TestManager_LogicalReplicationSharesReservedCap(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	mgr := newTestManager(t, server)
+	defer mgr.Close()
+
+	const user = "repl_user"
+	ctx := context.Background()
+
+	// Force the per-user pool into existence and pin its reserved cap to 2
+	// so the test is deterministic regardless of the default reservedRatio.
+	pool, err := mgr.getOrCreateUserPool(user, nil, nil)
+	require.NoError(t, err)
+	// Pin reserved cap to 2. Regular cap is irrelevant for this test —
+	// reserved conns and replication conns share the reserved pool only.
+	require.NoError(t, pool.SetCapacity(ctx, 4, 2))
+
+	// Fill the reserved cap with transactional reserved conns.
+	r1, err := mgr.NewReservedConn(ctx, nil, user, nil, nil)
+	require.NoError(t, err)
+	r2, err := mgr.NewReservedConn(ctx, nil, user, nil, nil)
+	require.NoError(t, err)
+
+	// Sanity-check that the rebalancer hasn't moved the reserved cap out
+	// from under us between SetCapacity and the blocking call below.
+	stats := pool.Stats()
+	require.Equal(t, int64(2), stats.Reserved.RegularPool.Capacity,
+		"reserved cap drifted from pinned 2 — rebalancer may have run")
+
+	// A replication request must now block on the cap. Use a short ctx so
+	// the test fails fast rather than hanging if cap-sharing is broken.
+	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	blocked, err := mgr.NewLogicalReplicationConn(shortCtx, user, nil, nil)
+	require.Error(t, err, "replication conn must not be created while the user's reserved cap is full")
+	// Pin the failure mode to the cap-acquire timeout path. The underlying
+	// connpool returns ErrTimeout when waitForConn() exits due to ctx
+	// expiration, so a regression that fails earlier (e.g. dial error,
+	// auth error) would no longer satisfy this assertion.
+	require.ErrorIs(t, err, connpool.ErrTimeout,
+		"blocking must be due to cap-acquire timing out, not some unrelated error")
+	assert.Nil(t, blocked)
+
+	// Releasing one reserved conn must free a slot and unblock replication.
+	r1.Release(reserved.ReleaseCommit)
+
+	rl, err := mgr.NewLogicalReplicationConn(ctx, user, nil, nil)
+	require.NoError(t, err, "releasing a reserved conn must let a replication conn through")
+	require.NotNil(t, rl)
+	defer rl.Release(reserved.ReleaseError)
+	defer r2.Release(reserved.ReleaseCommit)
 }

--- a/go/services/multipooler/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/connpoolmanager/user_pool.go
@@ -244,6 +244,25 @@ func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Sett
 	return p.reservedPool.NewConn(ctx, settings, opts...)
 }
 
+// NewLogicalReplicationConn returns a Postgres connection opened with
+// replication=database in startup parameters and tagged with
+// ReasonLogicalReplication. The connection is checked out from this user's
+// reserved pool and authenticates as this user — required because the
+// replication=database startup parameter is rejected for roles without the
+// REPLICATION attribute.
+//
+// TODO: logical-replication connections should not consume the user's
+// regular pool capacity. They are long-lived (hours-to-days), session-pinned,
+// and qualitatively different from transactional reserved connections. A
+// future change should give them their own per-user pool/quota (or a
+// dedicated capacity reservation inside UserPool) so a tenant running N
+// active replication sessions doesn't see their regular-query throughput
+// shrink by N.
+func (p *UserPool) NewLogicalReplicationConn(ctx context.Context) (*reserved.Conn, error) {
+	p.touchActivity()
+	return p.reservedPool.NewLogicalReplicationConn(ctx)
+}
+
 // GetReservedConn retrieves an existing reserved connection by ID.
 // Returns nil, false if the connection is not found or has timed out.
 func (p *UserPool) GetReservedConn(connID int64) (*reserved.Conn, bool) {

--- a/go/services/multipooler/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/connpoolmanager/user_pool.go
@@ -250,14 +250,6 @@ func (p *UserPool) NewReservedConn(ctx context.Context, settings *connstate.Sett
 // reserved pool and authenticates as this user — required because the
 // replication=database startup parameter is rejected for roles without the
 // REPLICATION attribute.
-//
-// TODO: logical-replication connections should not consume the user's
-// regular pool capacity. They are long-lived (hours-to-days), session-pinned,
-// and qualitatively different from transactional reserved connections. A
-// future change should give them their own per-user pool/quota (or a
-// dedicated capacity reservation inside UserPool) so a tenant running N
-// active replication sessions doesn't see their regular-query throughput
-// shrink by N.
 func (p *UserPool) NewLogicalReplicationConn(ctx context.Context) (*reserved.Conn, error) {
 	p.touchActivity()
 	return p.reservedPool.NewLogicalReplicationConn(ctx)

--- a/go/services/multipooler/pools/reserved/logical_replication.go
+++ b/go/services/multipooler/pools/reserved/logical_replication.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reserved
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
+)
+
+// logicalReplicationClientConfig returns a copy of base with the `replication`
+// startup parameter set to `database`, requesting a logical-replication-
+// capable backend. The base config is not modified; the Parameters map is
+// copied so callers can keep using base for non-replication connections.
+func logicalReplicationClientConfig(base client.Config) client.Config {
+	cfg := base
+	cfg.Parameters = make(map[string]string, len(base.Parameters)+1)
+	maps.Copy(cfg.Parameters, base.Parameters)
+	cfg.Parameters["replication"] = "database"
+	return cfg
+}
+
+// NewLogicalReplicationConn opens a Postgres connection with `replication=database`
+// in its startup parameters and tags it with ReasonLogicalReplication so the
+// reservation bitmask treats it as a session-pinned connection.
+//
+// The connection bypasses the regular pool entirely. A `replication=database`
+// walsender is a real backend that accepts SQL as well as replication-protocol
+// commands, so it *could* technically be returned to a pool — but it carries
+// long-lived session state (an in-flight replication stream, an owned slot)
+// that must stay pinned to this specific backend for the session's
+// lifetime. Handing it to another caller mid-flight would lose that affinity.
+// Per-session direct dial sidesteps the question. The returned *Conn is
+// registered in p.active so Get(connID) still works.
+//
+// The caller must call Release when the session ends. Because the Pooled
+// wrapper holds pool == nil, every Release reason closes the underlying
+// socket — there is no recycle path for a replication-mode conn.
+//
+// Asymmetry with NewConn: this factory does not take a *connstate.Settings.
+// The intended callers (replication-protocol streaming, slot management) issue
+// walsender-protocol commands that ignore session settings. A
+// `replication=database` walsender is still a real backend session, so plain
+// SQL run over it would observe search_path / work_mem / etc.; callers needing
+// those should apply them on the returned conn via Conn().Query(ctx, "SET ...")
+// before the settings-sensitive SQL. If a caller materializes a real need for
+// atomic acquire-with-settings, add an overload — don't bake it in
+// speculatively.
+func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, errors.New("reserved pool is closed")
+	}
+	p.mu.Unlock()
+
+	cfg := logicalReplicationClientConfig(*p.config.RegularPoolConfig.ClientConfig)
+	clientConn, err := client.Connect(ctx, p.ctx, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("dial replication connection: %w", err)
+	}
+	rc := regular.NewConn(clientConn, p.config.RegularPoolConfig.AdminPool)
+
+	// pool == nil makes Recycle close the conn directly (see
+	// connpool/pooled.go), which is what we want for a session-pinned conn
+	// that cannot re-enter a pool.
+	pooled := &connpool.Pooled[*regular.Conn]{Conn: rc}
+
+	connID := p.lastID.Add(1)
+	c := newConn(pooled, connID, p)
+	c.AddReservationReason(protoutil.ReasonLogicalReplication)
+
+	// Deliberately leave inactivityTimeout = 0 so the reserved pool's idleKiller
+	// never evicts this connection. Idle teardown for replication-mode sessions
+	// is Postgres' job via wal_sender_timeout (default 60s) — the walsender
+	// backend kills the stream itself, and the resulting socket error tears the
+	// connection down here. A second multipooler-side timer would only race.
+
+	p.mu.Lock()
+	if p.closed {
+		// Pool closed between our earlier check and registration. Tear down
+		// the freshly opened socket rather than orphaning it in a closed pool.
+		p.mu.Unlock()
+		_ = clientConn.Close()
+		return nil, errors.New("reserved pool is closed")
+	}
+	p.active[connID] = c
+	p.mu.Unlock()
+
+	p.reserveCount.Add(1)
+	if p.config.OnReserve != nil {
+		p.config.OnReserve()
+	}
+	p.logger.DebugContext(ctx, "logical replication connection created",
+		"conn_id", connID,
+		"process_id", c.ProcessID())
+	return c, nil
+}

--- a/go/services/multipooler/pools/reserved/logical_replication.go
+++ b/go/services/multipooler/pools/reserved/logical_replication.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
-	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
 )
 
@@ -42,18 +41,18 @@ func logicalReplicationClientConfig(base client.Config) client.Config {
 // in its startup parameters and tags it with ReasonLogicalReplication so the
 // reservation bitmask treats it as a session-pinned connection.
 //
-// The connection bypasses the regular pool entirely. A `replication=database`
-// walsender is a real backend that accepts SQL as well as replication-protocol
-// commands, so it *could* technically be returned to a pool — but it carries
-// long-lived session state (an in-flight replication stream, an owned slot)
-// that must stay pinned to this specific backend for the session's
-// lifetime. Handing it to another caller mid-flight would lose that affinity.
-// Per-session direct dial sidesteps the question. The returned *Conn is
-// registered in p.active so Get(connID) still works.
+// The connection consumes one slot in the underlying regular pool, sharing the
+// per-user cap (and block-on-full, waiter metrics, and demand tracking) with
+// transactional reserved conns. Because `replication=database` is a startup-
+// time parameter that cannot be flipped on an existing backend, we acquire a
+// slot, discard the regular socket it gave us, and swap in a fresh replication-
+// mode socket into the same Pooled wrapper. The session-pinned semantics still
+// hold: the wrapper is tainted at release time so Recycle closes the socket
+// instead of returning it to the idle list.
 //
-// The caller must call Release when the session ends. Because the Pooled
-// wrapper holds pool == nil, every Release reason closes the underlying
-// socket — there is no recycle path for a replication-mode conn.
+// The caller must call Release when the session ends. Every Release reason
+// taints the wrapper (see Pool.release) before Recycle so the underlying
+// socket is closed and the cap slot freed.
 //
 // Asymmetry with NewConn: this factory does not take a *connstate.Settings.
 // The intended callers (replication-protocol streaming, slot management) issue
@@ -72,17 +71,33 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 	}
 	p.mu.Unlock()
 
+	// Acquire a slot in the underlying connpool. This is the same path
+	// transactional reserved conns take, so we share the per-user cap,
+	// block-and-wait behavior, and demand/wait metrics.
+	pooled, err := p.conns.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire reserved slot for replication conn: %w", err)
+	}
+
+	// Discard the pooled socket. Replication mode is set in the startup
+	// packet and cannot be turned on for an existing backend, so we swap a
+	// fresh replication-mode socket into the same Pooled wrapper to keep
+	// the slot accounted for.
+	pooled.Conn.Close()
+
 	cfg := logicalReplicationClientConfig(*p.config.RegularPoolConfig.ClientConfig)
 	clientConn, err := client.Connect(ctx, p.ctx, &cfg)
 	if err != nil {
+		pooled.Taint()
+		pooled.Recycle()
 		return nil, fmt.Errorf("dial replication connection: %w", err)
 	}
-	rc := regular.NewConn(clientConn, p.config.RegularPoolConfig.AdminPool)
+	pooled.Conn = regular.NewConn(clientConn, p.config.RegularPoolConfig.AdminPool)
 
-	// pool == nil makes Recycle close the conn directly (see
-	// connpool/pooled.go), which is what we want for a session-pinned conn
-	// that cannot re-enter a pool.
-	pooled := &connpool.Pooled[*regular.Conn]{Conn: rc}
+	// IMPORTANT: do NOT call pooled.Taint() here. Taint immediately frees
+	// the slot via p.pool.put(nil) — see connpool/pooled.go. The slot must
+	// stay held for the session's lifetime, so we leave pool intact and
+	// let reserved.Pool.release() Taint right before Recycle.
 
 	connID := p.lastID.Add(1)
 	c := newConn(pooled, connID, p)
@@ -99,7 +114,8 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 		// Pool closed between our earlier check and registration. Tear down
 		// the freshly opened socket rather than orphaning it in a closed pool.
 		p.mu.Unlock()
-		_ = clientConn.Close()
+		pooled.Taint()
+		pooled.Recycle()
 		return nil, errors.New("reserved pool is closed")
 	}
 	p.active[connID] = c

--- a/go/services/multipooler/pools/reserved/logical_replication_test.go
+++ b/go/services/multipooler/pools/reserved/logical_replication_test.go
@@ -17,6 +17,7 @@ package reserved
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,8 @@ import (
 	"github.com/multigres/multigres/go/common/pgprotocol/scram"
 	pgserver "github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
+	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
 )
 
 // fakeReplicationCredentialProvider is a test CredentialProvider that
@@ -98,4 +101,112 @@ func TestNewLogicalReplicationConnIsExemptFromIdleKiller(t *testing.T) {
 		"replication conn must carry inactivityTimeout=0 so the idle killer skips it; "+
 			"idle teardown is Postgres' wal_sender_timeout's job")
 	assert.False(t, conn.IsTimedOut())
+}
+
+func TestNewLogicalReplicationConnBlocksWhenCapFull(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := NewPool(context.Background(), &PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig:   server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{Capacity: 2, MaxIdleCount: 2},
+		},
+	})
+	defer pool.Close()
+
+	c1, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	c2, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+
+	shortCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	c3, err := pool.NewLogicalReplicationConn(shortCtx)
+	require.Error(t, err, "third replication conn must not be created while cap=2 is full")
+	assert.Nil(t, c3)
+
+	c1.Release(ReleaseError)
+	c4, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err, "releasing a slot must let a new replication conn through")
+	defer c4.Release(ReleaseError)
+	defer c2.Release(ReleaseError)
+}
+
+// TestNewLogicalReplicationConnDialFailureFreesSlot exercises the
+// dial-failure cleanup branch in Pool.NewLogicalReplicationConn. With
+// cap=1, we succeed once (and release), then arm the fake server to
+// reject the next replication startup; the failed acquire must surface
+// an error and must NOT leak the slot. The discriminator is the
+// short-context third acquire: if the slot leaked, Get would block on
+// the empty pool until the short context fires; if it was freed, the
+// fresh dial succeeds well within the deadline.
+func TestNewLogicalReplicationConnDialFailureFreesSlot(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := NewPool(context.Background(), &PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig:   server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{Capacity: 1, MaxIdleCount: 1},
+		},
+	})
+	defer pool.Close()
+
+	// Baseline: first open succeeds and releases the slot back to the pool.
+	ok, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	ok.Release(ReleaseError)
+
+	// Arm the one-shot: the next replication-mode startup will be
+	// rejected at the rolreplication gate. The toggle auto-resets so
+	// the third acquire below is unaffected.
+	server.SetRejectNextReplicationStartup(true)
+
+	bad, err := pool.NewLogicalReplicationConn(context.Background())
+	require.Error(t, err, "dial failure must surface as an error")
+	assert.Nil(t, bad)
+
+	// If the slot leaked, the next acquire would block on Get until the
+	// short context fires. Use a tight deadline so a regression here
+	// fails fast and visibly rather than waiting on the default timeout.
+	shortCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	recovered, err := pool.NewLogicalReplicationConn(shortCtx)
+	require.NoError(t, err, "slot from failed dial must be freed")
+	recovered.Release(ReleaseError)
+}
+
+func TestPoolStatsLogicalReplicationActive(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+	server.SetNeverFail(true) // needed for the plain NewConn path
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	assert.Equal(t, 0, pool.Stats().LogicalReplicationActive)
+
+	c1, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	c2, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	plain, err := pool.NewConn(context.Background(), nil)
+	require.NoError(t, err)
+
+	s := pool.Stats()
+	assert.Equal(t, 2, s.LogicalReplicationActive, "only replication conns should be counted")
+	assert.Equal(t, 3, s.Active, "Active still totals all reserved conns")
+
+	c1.Release(ReleaseError)
+	s = pool.Stats()
+	assert.Equal(t, 1, s.LogicalReplicationActive)
+
+	c2.Release(ReleaseError)
+	plain.Release(ReleaseCommit)
 }

--- a/go/services/multipooler/pools/reserved/logical_replication_test.go
+++ b/go/services/multipooler/pools/reserved/logical_replication_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reserved
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+	pgserver "github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/protoutil"
+)
+
+// fakeReplicationCredentialProvider is a test CredentialProvider that
+// reports every role as having the REPLICATION attribute. Used to let
+// fakepgserver accept replication-mode startup parameters.
+type fakeReplicationCredentialProvider struct{}
+
+func (fakeReplicationCredentialProvider) GetCredentials(_ context.Context, _, _ string) (*pgserver.Credentials, error) {
+	return &pgserver.Credentials{
+		Hash:              &scram.ScramHash{},
+		IsReplicationRole: true,
+	}, nil
+}
+
+func TestLogicalReplicationConfigAddsStartupParameter(t *testing.T) {
+	base := client.Config{
+		Parameters: map[string]string{"application_name": "multipooler"},
+	}
+
+	cfg := logicalReplicationClientConfig(base)
+
+	assert.Equal(t, "database", cfg.Parameters["replication"])
+	assert.Equal(t, "multipooler", cfg.Parameters["application_name"],
+		"existing parameters must be preserved")
+
+	_, baseHas := base.Parameters["replication"]
+	assert.False(t, baseHas, "must not mutate caller's config")
+}
+
+func TestLogicalReplicationConfigHandlesNilParameters(t *testing.T) {
+	base := client.Config{}
+
+	cfg := logicalReplicationClientConfig(base)
+
+	assert.Equal(t, "database", cfg.Parameters["replication"])
+	assert.Nil(t, base.Parameters, "must not mutate caller's config")
+}
+
+func TestNewLogicalReplicationConnTagsReasonAndStartupParam(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	conn, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	defer conn.Release(ReleaseError) // Pooled wrapper has pool=nil → closes the underlying socket.
+
+	assert.True(t, protoutil.HasLogicalReplicationReason(conn.RemainingReasons()),
+		"replication conn must be tagged with ReasonLogicalReplication")
+	assert.Equal(t, pgserver.ReplicationLogical, server.LastReplicationMode(),
+		"replication=database must have been parsed by the server")
+}
+
+func TestNewLogicalReplicationConnIsExemptFromIdleKiller(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := newTestPool(t, server)
+	defer pool.Close()
+
+	conn, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	defer conn.Release(ReleaseError)
+
+	assert.Zero(t, conn.InactivityTimeout(),
+		"replication conn must carry inactivityTimeout=0 so the idle killer skips it; "+
+			"idle teardown is Postgres' wal_sender_timeout's job")
+	assert.False(t, conn.IsTimedOut())
+}

--- a/go/services/multipooler/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/pools/reserved/reserved_pool.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/services/multipooler/connstate"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
@@ -361,6 +362,14 @@ func (p *Pool) release(rc *Conn, reason ReleaseReason) {
 		rc.pooled.Taint()
 	}
 
+	// Replication conns cannot be returned to the pool: their socket has
+	// replication=database in its startup packet and is bound to a walsender
+	// backend that may own a slot. Taint regardless of release reason so the
+	// upcoming Recycle frees the cap slot AND closes the socket.
+	if rc.reservedProps != nil && protoutil.HasLogicalReplicationReason(rc.reservedProps.Reasons) {
+		rc.pooled.Taint()
+	}
+
 	// Return the underlying connection to the pool.
 	// If the connection is in a bad state, the caller should have tainted it.
 	rc.pooled.Recycle()
@@ -406,17 +415,24 @@ func (p *Pool) Close() {
 func (p *Pool) Stats() PoolStats {
 	p.mu.Lock()
 	active := len(p.active)
+	var replActive int
+	for _, rc := range p.active {
+		if rc.reservedProps != nil && protoutil.HasLogicalReplicationReason(rc.reservedProps.Reasons) {
+			replActive++
+		}
+	}
 	p.mu.Unlock()
 
 	return PoolStats{
-		Active:          active,
-		ReserveCount:    p.reserveCount.Load(),
-		ReleaseCount:    p.releaseCount.Load(),
-		KillCount:       p.killCount.Load(),
-		TimeoutCount:    p.timeoutCount.Load(),
-		TxCommitCount:   p.txCommitCount.Load(),
-		TxRollbackCount: p.txRollbackCount.Load(),
-		RegularPool:     p.conns.Stats(),
+		Active:                   active,
+		LogicalReplicationActive: replActive,
+		ReserveCount:             p.reserveCount.Load(),
+		ReleaseCount:             p.releaseCount.Load(),
+		KillCount:                p.killCount.Load(),
+		TimeoutCount:             p.timeoutCount.Load(),
+		TxCommitCount:            p.txCommitCount.Load(),
+		TxRollbackCount:          p.txRollbackCount.Load(),
+		RegularPool:              p.conns.Stats(),
 	}
 }
 
@@ -457,6 +473,10 @@ func (p *Pool) GetCount() int64 {
 type PoolStats struct {
 	// Active is the number of currently reserved connections.
 	Active int
+
+	// LogicalReplicationActive is the number of active reserved conns that
+	// have ReasonLogicalReplication set. Sub-count of Active.
+	LogicalReplicationActive int
 
 	// ReserveCount is the total number of reservations.
 	ReserveCount int64

--- a/go/test/endtoend/multipooler/logical_replication_conn_test.go
+++ b/go/test/endtoend/multipooler/logical_replication_conn_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// dialReplicationConn opens a Postgres connection in logical-replication mode
+// against the shared test fixture's primary. It mirrors what
+// reserved.Pool.NewLogicalReplicationConn does inside multipooler: copies the
+// caller's client.Config and sets `replication=database` in the startup
+// parameters. The factory's bookkeeping (Pooled wrapper with pool=nil,
+// ReasonLogicalReplication, idleKiller exemption) is unit-tested in
+// reserved/logical_replication_test.go; the wire-level claim — that the
+// startup parameter survives the libpq-format encoder and that real Postgres
+// accepts it on a multigres-provisioned cluster — is what this test verifies.
+//
+// The Manager.NewLogicalReplicationConn entry point is not exercised here
+// because it expects SCRAM passthrough keys derived during a client's SCRAM
+// handshake at multigateway; computing those from a static password requires
+// a separate round-trip to fetch the server's salt and iteration count, which
+// is exactly the wire-level work this test already exercises via direct
+// client.Connect. Manager wiring is covered by the unit test in
+// connpoolmanager/manager_logical_replication_test.go against fakepgserver.
+func dialReplicationConn(t *testing.T, port int) *client.Conn {
+	t.Helper()
+	ctx := utils.WithTimeout(t, 10*time.Second)
+
+	cfg := client.Config{
+		Host:        "localhost",
+		Port:        port,
+		User:        constants.DefaultPostgresUser,
+		Password:    testPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+		Parameters:  map[string]string{"replication": "database"},
+	}
+	conn, err := client.Connect(ctx, ctx, &cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// TestLogicalReplicationConnIdentifySystem opens a replication-mode Postgres
+// connection and issues IDENTIFY_SYSTEM — the simplest replication-protocol
+// command — to prove the connection is usable for the replication protocol
+// end-to-end against a multigres-provisioned cluster.
+func TestLogicalReplicationConnIdentifySystem(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	rows, err := conn.Query(ctx, "IDENTIFY_SYSTEM")
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "IDENTIFY_SYSTEM returns one result set")
+	require.Len(t, rows[0].Rows, 1, "IDENTIFY_SYSTEM returns one row")
+
+	row := rows[0].Rows[0]
+	// Columns: systemid (text), timeline (int4), xlogpos (text), dbname (text)
+	require.GreaterOrEqual(t, len(row.Values), 4, "IDENTIFY_SYSTEM row has at least 4 columns")
+	assert.NotEmpty(t, string(row.Values[0]), "system identifier present")
+	assert.NotEmpty(t, string(row.Values[1]), "timeline present")
+	assert.Regexp(t, regexp.MustCompile(`^[0-9A-Fa-f]+/[0-9A-Fa-f]+$`), string(row.Values[2]),
+		"xlogpos must be an LSN")
+}
+
+// TestLogicalReplicationConnPinning verifies that a replication-mode connection
+// is session-pinned: consecutive replication-protocol commands on the same
+// socket land on the same Postgres walsender backend. This is the load-bearing
+// invariant for logical replication — the replication slot (once created)
+// lives on a specific backend; if subsequent commands routed to a different
+// backend, the slot would be invisible.
+//
+// In replication mode the available probes are limited (SELECT
+// pg_backend_pid() and most catalog queries are restricted), so we use the
+// startup-time ProcessID (BackendKeyData) and the systemid returned by
+// IDENTIFY_SYSTEM as stable identifiers. Both are determined at backend-
+// startup and are constant for the lifetime of one walsender process.
+func TestLogicalReplicationConnPinning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup := getSharedTestSetup(t)
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	startupPID := conn.ProcessID()
+	require.NotZero(t, startupPID, "BackendKeyData missing — startup is broken")
+
+	ctx := utils.WithTimeout(t, 15*time.Second)
+	var firstSystemID string
+	for i := range 5 {
+		rows, err := conn.Query(ctx, "IDENTIFY_SYSTEM")
+		require.NoError(t, err, "IDENTIFY_SYSTEM iteration %d", i)
+		require.Len(t, rows, 1)
+		require.Len(t, rows[0].Rows, 1, "IDENTIFY_SYSTEM iteration %d", i)
+
+		systemID := string(rows[0].Rows[0].Values[0])
+		require.NotEmpty(t, systemID, "iteration %d", i)
+		if i == 0 {
+			firstSystemID = systemID
+			continue
+		}
+		require.Equal(t, firstSystemID, systemID,
+			"system identifier must be stable across queries on a pinned conn (iteration %d)", i)
+	}
+
+	// ProcessID is read at startup and never updated by client.Conn, so this
+	// is a sanity check that the BackendKeyData we received is what we'll
+	// keep using to identify the backend (e.g., for cancel requests on this
+	// session). Together with stable systemid, this proves we're talking to
+	// the same walsender across all five queries.
+	require.Equal(t, startupPID, conn.ProcessID(),
+		"backend ProcessID must remain the connection's identifier")
+}

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -337,6 +337,9 @@ enum ReservationReason {
   RESERVATION_REASON_COPY = 8;         // 0b1000
   // Connection is reserved for LISTEN/NOTIFY (dedicated PubSubListener connection)
   RESERVATION_REASON_LISTEN = 16;      // 0b10000
+  // Connection is reserved for a logical-replication session (CREATE_REPLICATION_SLOT,
+  // START_REPLICATION, etc.). Pinned to a single backend for the session's lifetime.
+  RESERVATION_REASON_LOGICAL_REPLICATION = 32;  // 0b100000
 }
 
 // TransactionConclusion specifies how to conclude a transaction.


### PR DESCRIPTION
Multipooler can now open a Postgres connection with `replication=database` in the startup parameters, tagged `RESERVATION_REASON_LOGICAL_REPLICATION` so it's treated as session-pinned. Replication conns consume one slot in the per-user reserved-pool cap — no new knob, no new pool.

### Mechanics

- `reserved.Pool.NewLogicalReplicationConn` acquires a slot via the underlying connpool semaphore (blocks on full, ctx-cancellable), then swaps a fresh `replication=database` socket into the `Pooled` wrapper. The slot is held for the session's lifetime.
- `Pooled.Taint()` would free the slot synchronously, so it's deferred to `reserved.Pool.release()`, which taints replication-tagged conns on every release path (Commit/Rollback/Timeout/Kill/Error).
- `inactivityTimeout = 0` so the reserved-pool idleKiller skips replication conns — Postgres' `wal_sender_timeout` owns idle teardown.
- `Manager.NewLogicalReplicationConn` / `UserPool.NewLogicalReplicationConn` mirror the `NewReservedConn` shape; replication conns live on the per-user reserved pool because the `replication=database` startup is rejected for roles without REPLICATION.
- `reserved.PoolStats.LogicalReplicationActive` exposes the sub-count of active tagged conns.

### Surface area

- proto + Go: `RESERVATION_REASON_LOGICAL_REPLICATION` (32), `ReasonLogicalReplication`, `HasLogicalReplicationReason`.
- fakepgserver: `SetCredentialProvider`, `LastReplicationMode`, `ReplicationMode()` on `server.Conn`, optional `ConnectionEstablishedHandler` hook, and one-shot `SetRejectNextReplicationStartup` for dial-failure tests.

### Tests

- Unit (reserved): cap-blocking, dial-failure frees slot, stats counting, factory tagging, idleKiller exemption.
- Manager-layer: cap shared between `NewReservedConn` and `NewLogicalReplicationConn`; failure pinned to `connpool.ErrTimeout`; rebalancer-race guard.
- Endtoend: IDENTIFY_SYSTEM against real Postgres; replication conn is session-pinned (stable ProcessID and systemid).