### PR TITLE
perf(multigateway): cache OTel metric attribute sets per query dimension

### DIFF
--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -543,6 +543,16 @@ func (h *MultiGatewayHandler) ConnectionClosed(conn *server.Conn) {
 	h.psc.RemoveConnection(conn.ConnectionID())
 }
 
+// classifyErrorSource calls mterrors.ClassifyErrorSource only when err is
+// non-nil. The success path is overwhelmingly common, so short-circuiting
+// here avoids a per-query function call + interface check.
+func classifyErrorSource(err error) string {
+	if err == nil {
+		return ""
+	}
+	return mterrors.ClassifyErrorSource(err)
+}
+
 // recordQueryCompletion records all three metrics and emits a structured
 // query log entry. Centralises the instrumentation logic shared by
 // HandleQuery and HandleExecute.
@@ -585,10 +595,12 @@ func (h *MultiGatewayHandler) recordQueryCompletion(
 
 	status := QueryStatusOK
 	errorType := ""
+	errorSource := ""
 	if err != nil {
 		status = QueryStatusError
 		errorType = mterrors.ExtractSQLSTATE(err)
-		h.metrics.queryErrors.Add(ctx, errorType, mterrors.ClassifyErrorSource(err), dbNamespace, operationName, fingerprintLabel)
+		errorSource = classifyErrorSource(err)
+		h.metrics.queryErrors.Add(ctx, errorType, errorSource, dbNamespace, operationName, fingerprintLabel)
 	}
 
 	h.metrics.queryDuration.Record(ctx, totalDuration.Seconds(), dbNamespace, operationName, queryProtocol, errorType, status, fingerprintLabel)
@@ -621,7 +633,7 @@ func (h *MultiGatewayHandler) recordQueryCompletion(
 		TablesUsed:    tablesUsed,
 		Error:         err,
 		SQLSTATE:      errorType,
-		ErrorSource:   mterrors.ClassifyErrorSource(err),
+		ErrorSource:   errorSource,
 	}, h.slowThreshold)
 }
 

--- a/go/services/multigateway/handler/metrics.go
+++ b/go/services/multigateway/handler/metrics.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -37,19 +38,45 @@ const (
 // Following the recovery/metrics.go pattern: wrapper types embedding OTel
 // instruments with typed Record() methods that hide attribute key names.
 type HandlerMetrics struct {
-	queryDuration QueryDuration
-	queryErrors   QueryErrors
-	rowsReturned  RowsReturned
-	tableQueries  TableQueries
+	queryDuration *QueryDuration
+	queryErrors   *QueryErrors
+	rowsReturned  *RowsReturned
+	tableQueries  *TableQueries
+}
+
+// The per-instrument caches below memoise the OTel MeasurementOption built
+// from a fixed set of attribute values. Building one requires sorting and
+// deduping the attribute slice inside the SDK; the input dimensions for a
+// given (db, op, ...) tuple are stable across millions of queries, so we pay
+// that cost once per tuple. Cardinality is bounded by the query registry
+// (fingerprint labels are capped and collapsed into __other__/__utility__),
+// by the finite SQLSTATE space, and by the fact that db/table/op names come
+// from authenticated PG protocol fields — no explicit cap needed.
+
+type queryDurationKey struct {
+	db, op, proto, errType, status, fp string
+}
+
+type queryErrorsKey struct {
+	errType, errSource, db, op, fp string
+}
+
+type rowsReturnedKey struct {
+	db, op, fp string
+}
+
+type tableQueriesKey struct {
+	db, table, op string
 }
 
 // QueryDuration wraps a Float64Histogram for recording query durations.
 type QueryDuration struct {
 	metric.Float64Histogram
+	optsCache sync.Map // queryDurationKey -> metric.MeasurementOption
 }
 
 // Record records a query duration with proper OTel attributes.
-func (m QueryDuration) Record(
+func (m *QueryDuration) Record(
 	ctx context.Context,
 	val float64,
 	dbNamespace string,
@@ -59,24 +86,43 @@ func (m QueryDuration) Record(
 	status QueryStatus,
 	queryFingerprint string,
 ) {
-	m.Float64Histogram.Record(ctx, val,
-		metric.WithAttributes(
-			attribute.String("db.namespace", dbNamespace),
-			attribute.String("db.operation.name", operationName),
-			attribute.String("db.query.protocol", protocol),
-			attribute.String("error.type", errorType),
-			attribute.String("status", string(status)),
-			attribute.String("query.fingerprint", queryFingerprint),
-		))
+	key := queryDurationKey{
+		db:      dbNamespace,
+		op:      operationName,
+		proto:   protocol,
+		errType: errorType,
+		status:  string(status),
+		fp:      queryFingerprint,
+	}
+	opt := m.optionFor(key)
+	m.Float64Histogram.Record(ctx, val, opt)
+}
+
+func (m *QueryDuration) optionFor(key queryDurationKey) metric.MeasurementOption {
+	if v, ok := m.optsCache.Load(key); ok {
+		return v.(metric.MeasurementOption)
+	}
+	set := attribute.NewSet(
+		attribute.String("db.namespace", key.db),
+		attribute.String("db.operation.name", key.op),
+		attribute.String("db.query.protocol", key.proto),
+		attribute.String("error.type", key.errType),
+		attribute.String("status", key.status),
+		attribute.String("query.fingerprint", key.fp),
+	)
+	opt := metric.WithAttributeSet(set)
+	actual, _ := m.optsCache.LoadOrStore(key, opt)
+	return actual.(metric.MeasurementOption)
 }
 
 // QueryErrors wraps an Int64Counter for counting query errors.
 type QueryErrors struct {
 	metric.Int64Counter
+	optsCache sync.Map // queryErrorsKey -> metric.MeasurementOption
 }
 
 // Add increments the error counter with proper OTel attributes.
-func (m QueryErrors) Add(
+func (m *QueryErrors) Add(
 	ctx context.Context,
 	errorType string,
 	errorSource string,
@@ -84,55 +130,96 @@ func (m QueryErrors) Add(
 	operationName string,
 	queryFingerprint string,
 ) {
-	m.Int64Counter.Add(ctx, 1,
-		metric.WithAttributes(
-			attribute.String("error.type", errorType),
-			attribute.String("error.source", errorSource),
-			attribute.String("db.namespace", dbNamespace),
-			attribute.String("db.operation.name", operationName),
-			attribute.String("query.fingerprint", queryFingerprint),
-		))
+	key := queryErrorsKey{
+		errType:   errorType,
+		errSource: errorSource,
+		db:        dbNamespace,
+		op:        operationName,
+		fp:        queryFingerprint,
+	}
+	opt := m.optionFor(key)
+	m.Int64Counter.Add(ctx, 1, opt)
+}
+
+func (m *QueryErrors) optionFor(key queryErrorsKey) metric.MeasurementOption {
+	if v, ok := m.optsCache.Load(key); ok {
+		return v.(metric.MeasurementOption)
+	}
+	set := attribute.NewSet(
+		attribute.String("error.type", key.errType),
+		attribute.String("error.source", key.errSource),
+		attribute.String("db.namespace", key.db),
+		attribute.String("db.operation.name", key.op),
+		attribute.String("query.fingerprint", key.fp),
+	)
+	opt := metric.WithAttributeSet(set)
+	actual, _ := m.optsCache.LoadOrStore(key, opt)
+	return actual.(metric.MeasurementOption)
 }
 
 // RowsReturned wraps a Float64Histogram for recording row counts.
 type RowsReturned struct {
 	metric.Float64Histogram
+	optsCache sync.Map // rowsReturnedKey -> metric.MeasurementOption
 }
 
 // Record records a row count with proper OTel attributes.
-func (m RowsReturned) Record(
+func (m *RowsReturned) Record(
 	ctx context.Context,
 	val float64,
 	dbNamespace string,
 	operationName string,
 	queryFingerprint string,
 ) {
-	m.Float64Histogram.Record(ctx, val,
-		metric.WithAttributes(
-			attribute.String("db.namespace", dbNamespace),
-			attribute.String("db.operation.name", operationName),
-			attribute.String("query.fingerprint", queryFingerprint),
-		))
+	key := rowsReturnedKey{db: dbNamespace, op: operationName, fp: queryFingerprint}
+	opt := m.optionFor(key)
+	m.Float64Histogram.Record(ctx, val, opt)
+}
+
+func (m *RowsReturned) optionFor(key rowsReturnedKey) metric.MeasurementOption {
+	if v, ok := m.optsCache.Load(key); ok {
+		return v.(metric.MeasurementOption)
+	}
+	set := attribute.NewSet(
+		attribute.String("db.namespace", key.db),
+		attribute.String("db.operation.name", key.op),
+		attribute.String("query.fingerprint", key.fp),
+	)
+	opt := metric.WithAttributeSet(set)
+	actual, _ := m.optsCache.LoadOrStore(key, opt)
+	return actual.(metric.MeasurementOption)
 }
 
 // TableQueries wraps an Int64Counter for counting queries per table.
 type TableQueries struct {
 	metric.Int64Counter
+	optsCache sync.Map // tableQueriesKey -> metric.MeasurementOption
 }
 
 // Add increments the per-table query counter with proper OTel attributes.
-func (m TableQueries) Add(
+func (m *TableQueries) Add(
 	ctx context.Context,
 	dbNamespace string,
 	tableName string,
 	operationName string,
 ) {
-	m.Int64Counter.Add(ctx, 1,
-		metric.WithAttributes(
-			attribute.String("db.namespace", dbNamespace),
-			attribute.String("db.collection.name", tableName),
-			attribute.String("db.operation.name", operationName),
-		))
+	key := tableQueriesKey{db: dbNamespace, table: tableName, op: operationName}
+	opt := m.optionFor(key)
+	m.Int64Counter.Add(ctx, 1, opt)
+}
+
+func (m *TableQueries) optionFor(key tableQueriesKey) metric.MeasurementOption {
+	if v, ok := m.optsCache.Load(key); ok {
+		return v.(metric.MeasurementOption)
+	}
+	set := attribute.NewSet(
+		attribute.String("db.namespace", key.db),
+		attribute.String("db.collection.name", key.table),
+		attribute.String("db.operation.name", key.op),
+	)
+	opt := metric.WithAttributeSet(set)
+	actual, _ := m.optsCache.LoadOrStore(key, opt)
+	return actual.(metric.MeasurementOption)
 }
 
 // NewHandlerMetrics initialises OTel metrics for the handler.
@@ -140,7 +227,12 @@ func (m TableQueries) Add(
 // and are included in the returned error.
 func NewHandlerMetrics() (*HandlerMetrics, error) {
 	meter := otel.Meter("github.com/multigres/multigres/go/services/multigateway/handler")
-	m := &HandlerMetrics{}
+	m := &HandlerMetrics{
+		queryDuration: &QueryDuration{},
+		queryErrors:   &QueryErrors{},
+		rowsReturned:  &RowsReturned{},
+		tableQueries:  &TableQueries{},
+	}
 	var errs []error
 
 	dur, err := meter.Float64Histogram(
@@ -151,9 +243,9 @@ func NewHandlerMetrics() (*HandlerMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.query.duration histogram: %w", err))
-		m.queryDuration = QueryDuration{noop.Float64Histogram{}}
+		m.queryDuration.Float64Histogram = noop.Float64Histogram{}
 	} else {
-		m.queryDuration = QueryDuration{dur}
+		m.queryDuration.Float64Histogram = dur
 	}
 
 	errCounter, err := meter.Int64Counter(
@@ -163,9 +255,9 @@ func NewHandlerMetrics() (*HandlerMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.query.errors counter: %w", err))
-		m.queryErrors = QueryErrors{noop.Int64Counter{}}
+		m.queryErrors.Int64Counter = noop.Int64Counter{}
 	} else {
-		m.queryErrors = QueryErrors{errCounter}
+		m.queryErrors.Int64Counter = errCounter
 	}
 
 	rows, err := meter.Float64Histogram(
@@ -176,9 +268,9 @@ func NewHandlerMetrics() (*HandlerMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.query.rows_returned histogram: %w", err))
-		m.rowsReturned = RowsReturned{noop.Float64Histogram{}}
+		m.rowsReturned.Float64Histogram = noop.Float64Histogram{}
 	} else {
-		m.rowsReturned = RowsReturned{rows}
+		m.rowsReturned.Float64Histogram = rows
 	}
 
 	tq, err := meter.Int64Counter(
@@ -188,9 +280,9 @@ func NewHandlerMetrics() (*HandlerMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.query.table_queries counter: %w", err))
-		m.tableQueries = TableQueries{noop.Int64Counter{}}
+		m.tableQueries.Int64Counter = noop.Int64Counter{}
 	} else {
-		m.tableQueries = TableQueries{tq}
+		m.tableQueries.Int64Counter = tq
 	}
 
 	if len(errs) > 0 {

--- a/go/services/multigateway/handler/metrics_test.go
+++ b/go/services/multigateway/handler/metrics_test.go
@@ -15,13 +15,379 @@
 package handler
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
 func TestNewHandlerMetrics(t *testing.T) {
 	m, err := NewHandlerMetrics()
 	require.NoError(t, err)
 	require.NotNil(t, m)
+}
+
+// setupHandlerMetrics installs an in-memory metric reader and returns a fresh
+// *HandlerMetrics wired to it. The reader can be used to inspect emitted data
+// points.
+func setupHandlerMetrics(t *testing.T) (*HandlerMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	setup := telemetry.SetupTestTelemetry(t)
+	require.NoError(t, setup.Telemetry.InitTelemetry(t.Context(), "test-multigateway"))
+
+	m, err := NewHandlerMetrics()
+	require.NoError(t, err)
+	return m, setup.MetricReader
+}
+
+// findMetric returns the first metric named `name` across all scope metrics
+// in the collected snapshot.
+func findMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, mm := range sm.Metrics {
+			if mm.Name == name {
+				return mm
+			}
+		}
+	}
+	t.Fatalf("metric %q not found", name)
+	return metricdata.Metrics{}
+}
+
+// attrValue extracts a string attribute by key from an attribute.Set.
+func attrValue(t *testing.T, set attribute.Set, key string) string {
+	t.Helper()
+	v, ok := set.Value(attribute.Key(key))
+	require.True(t, ok, "attribute %q missing", key)
+	return v.AsString()
+}
+
+// cacheSize counts entries in a sync.Map.
+func cacheSize(m *sync.Map) int {
+	n := 0
+	m.Range(func(_, _ any) bool { n++; return true })
+	return n
+}
+
+// TestQueryDuration_CacheHit verifies that identical dimensions reuse the
+// cached MeasurementOption and distinct dimensions get separate entries.
+func TestQueryDuration_CacheHit(t *testing.T) {
+	m, _ := setupHandlerMetrics(t)
+	ctx := t.Context()
+
+	m.queryDuration.Record(ctx, 0.1, "db1", "SELECT", "simple", "", QueryStatusOK, "fp1")
+	key := queryDurationKey{db: "db1", op: "SELECT", proto: "simple", errType: "", status: string(QueryStatusOK), fp: "fp1"}
+	v1, ok := m.queryDuration.optsCache.Load(key)
+	require.True(t, ok, "expected cache entry after first record")
+
+	m.queryDuration.Record(ctx, 0.2, "db1", "SELECT", "simple", "", QueryStatusOK, "fp1")
+	v2, ok := m.queryDuration.optsCache.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, v1, v2, "cache value should be reused for identical dimensions")
+	assert.Equal(t, 1, cacheSize(&m.queryDuration.optsCache))
+
+	m.queryDuration.Record(ctx, 0.3, "db1", "SELECT", "simple", "", QueryStatusOK, "fp2")
+	assert.Equal(t, 2, cacheSize(&m.queryDuration.optsCache),
+		"distinct fingerprints should produce a second cache entry")
+}
+
+func TestQueryErrors_CacheHit(t *testing.T) {
+	m, _ := setupHandlerMetrics(t)
+	ctx := t.Context()
+
+	m.queryErrors.Add(ctx, "42601", "client", "db1", "SELECT", "fp1")
+	key := queryErrorsKey{errType: "42601", errSource: "client", db: "db1", op: "SELECT", fp: "fp1"}
+	v1, ok := m.queryErrors.optsCache.Load(key)
+	require.True(t, ok)
+
+	m.queryErrors.Add(ctx, "42601", "client", "db1", "SELECT", "fp1")
+	v2, ok := m.queryErrors.optsCache.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, v1, v2)
+	assert.Equal(t, 1, cacheSize(&m.queryErrors.optsCache))
+
+	m.queryErrors.Add(ctx, "42601", "backend", "db1", "SELECT", "fp1")
+	assert.Equal(t, 2, cacheSize(&m.queryErrors.optsCache),
+		"distinct error.source should produce a second cache entry")
+}
+
+func TestRowsReturned_CacheHit(t *testing.T) {
+	m, _ := setupHandlerMetrics(t)
+	ctx := t.Context()
+
+	m.rowsReturned.Record(ctx, 5, "db1", "SELECT", "fp1")
+	key := rowsReturnedKey{db: "db1", op: "SELECT", fp: "fp1"}
+	v1, ok := m.rowsReturned.optsCache.Load(key)
+	require.True(t, ok)
+
+	m.rowsReturned.Record(ctx, 10, "db1", "SELECT", "fp1")
+	v2, ok := m.rowsReturned.optsCache.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, v1, v2)
+	assert.Equal(t, 1, cacheSize(&m.rowsReturned.optsCache))
+
+	m.rowsReturned.Record(ctx, 1, "db1", "SELECT", "fp2")
+	assert.Equal(t, 2, cacheSize(&m.rowsReturned.optsCache))
+}
+
+func TestTableQueries_CacheHit(t *testing.T) {
+	m, _ := setupHandlerMetrics(t)
+	ctx := t.Context()
+
+	m.tableQueries.Add(ctx, "db1", "users", "SELECT")
+	key := tableQueriesKey{db: "db1", table: "users", op: "SELECT"}
+	v1, ok := m.tableQueries.optsCache.Load(key)
+	require.True(t, ok)
+
+	m.tableQueries.Add(ctx, "db1", "users", "SELECT")
+	v2, ok := m.tableQueries.optsCache.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, v1, v2)
+	assert.Equal(t, 1, cacheSize(&m.tableQueries.optsCache))
+
+	m.tableQueries.Add(ctx, "db1", "orders", "SELECT")
+	assert.Equal(t, 2, cacheSize(&m.tableQueries.optsCache),
+		"distinct table names should produce a second cache entry")
+}
+
+// TestHandlerMetrics_EmittedAttributes ensures caching does not alter the
+// shape of the emitted metric attributes.
+func TestHandlerMetrics_EmittedAttributes(t *testing.T) {
+	m, reader := setupHandlerMetrics(t)
+	ctx := t.Context()
+
+	m.queryDuration.Record(ctx, 0.05, "ns", "SELECT", "simple", "", QueryStatusOK, "fp1")
+	m.queryErrors.Add(ctx, "08006", "routing", "ns", "SELECT", "fp1")
+	m.rowsReturned.Record(ctx, 42, "ns", "SELECT", "fp1")
+	m.tableQueries.Add(ctx, "ns", "t1", "SELECT")
+
+	dur := findMetric(t, reader, "mg.gateway.query.duration")
+	durHist, ok := dur.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, durHist.DataPoints, 1)
+	dp := durHist.DataPoints[0]
+	assert.Equal(t, "ns", attrValue(t, dp.Attributes, "db.namespace"))
+	assert.Equal(t, "SELECT", attrValue(t, dp.Attributes, "db.operation.name"))
+	assert.Equal(t, "simple", attrValue(t, dp.Attributes, "db.query.protocol"))
+	assert.Equal(t, "", attrValue(t, dp.Attributes, "error.type"))
+	assert.Equal(t, "ok", attrValue(t, dp.Attributes, "status"))
+	assert.Equal(t, "fp1", attrValue(t, dp.Attributes, "query.fingerprint"))
+
+	errs := findMetric(t, reader, "mg.gateway.query.errors")
+	errSum, ok := errs.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, errSum.DataPoints, 1)
+	edp := errSum.DataPoints[0]
+	assert.Equal(t, int64(1), edp.Value)
+	assert.Equal(t, "08006", attrValue(t, edp.Attributes, "error.type"))
+	assert.Equal(t, "routing", attrValue(t, edp.Attributes, "error.source"))
+	assert.Equal(t, "fp1", attrValue(t, edp.Attributes, "query.fingerprint"))
+
+	rows := findMetric(t, reader, "mg.gateway.query.rows_returned")
+	rowsHist, ok := rows.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, rowsHist.DataPoints, 1)
+	rdp := rowsHist.DataPoints[0]
+	assert.Equal(t, "ns", attrValue(t, rdp.Attributes, "db.namespace"))
+	assert.Equal(t, "SELECT", attrValue(t, rdp.Attributes, "db.operation.name"))
+	assert.Equal(t, "fp1", attrValue(t, rdp.Attributes, "query.fingerprint"))
+
+	tq := findMetric(t, reader, "mg.gateway.query.table_queries")
+	tqSum, ok := tq.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, tqSum.DataPoints, 1)
+	tdp := tqSum.DataPoints[0]
+	assert.Equal(t, "ns", attrValue(t, tdp.Attributes, "db.namespace"))
+	assert.Equal(t, "t1", attrValue(t, tdp.Attributes, "db.collection.name"))
+	assert.Equal(t, "SELECT", attrValue(t, tdp.Attributes, "db.operation.name"))
+}
+
+// TestClassifyErrorSource_SkipsOnNil verifies the success-path short-circuit.
+func TestClassifyErrorSource_SkipsOnNil(t *testing.T) {
+	assert.Equal(t, "", classifyErrorSource(nil))
+
+	pgErr := &mterrors.PgDiagnostic{Code: "42601"}
+	assert.Equal(t, "backend", classifyErrorSource(pgErr))
+
+	mtErr := &mterrors.PgDiagnostic{Code: "MTD01"}
+	assert.Equal(t, "internal", classifyErrorSource(mtErr))
+
+	assert.Equal(t, "client", classifyErrorSource(errors.New("opaque")))
+}
+
+// setupBenchMetrics installs an in-memory metric reader for benchmarks.
+// Mirrors setupHandlerMetrics but takes testing.TB so it works with B.
+func setupBenchMetrics(b *testing.B) *HandlerMetrics {
+	b.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	b.Cleanup(func() {
+		_ = mp.Shutdown(context.Background())
+		otel.SetMeterProvider(prev)
+	})
+
+	m, err := NewHandlerMetrics()
+	require.NoError(b, err)
+	return m
+}
+
+// BenchmarkQueryDuration_Cached measures the cached hot path with a stable
+// dimension tuple (the realistic shape: same db/op/fp tuple repeating).
+func BenchmarkQueryDuration_Cached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		m.queryDuration.Record(ctx, 0.001, "db1", "SELECT", "simple", "", QueryStatusOK, "fp1")
+	}
+}
+
+// BenchmarkQueryDuration_Uncached replicates the pre-cache code path:
+// build a fresh []attribute.KeyValue + metric.WithAttributes per call.
+func BenchmarkQueryDuration_Uncached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	h := m.queryDuration.Float64Histogram
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		h.Record(ctx, 0.001, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("db.query.protocol", "simple"),
+			attribute.String("error.type", ""),
+			attribute.String("status", string(QueryStatusOK)),
+			attribute.String("query.fingerprint", "fp1"),
+		))
+	}
+}
+
+// BenchmarkRowsReturned_Cached / _Uncached: smallest key, highest call rate.
+func BenchmarkRowsReturned_Cached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		m.rowsReturned.Record(ctx, 1, "db1", "SELECT", "fp1")
+	}
+}
+
+func BenchmarkRowsReturned_Uncached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	h := m.rowsReturned.Float64Histogram
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		h.Record(ctx, 1, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.operation.name", "SELECT"),
+			attribute.String("query.fingerprint", "fp1"),
+		))
+	}
+}
+
+// BenchmarkTableQueries_Cached / _Uncached: the per-table inner-loop call.
+func BenchmarkTableQueries_Cached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		m.tableQueries.Add(ctx, "db1", "users", "SELECT")
+	}
+}
+
+func BenchmarkTableQueries_Uncached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	c := m.tableQueries.Int64Counter
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		c.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.collection.name", "users"),
+			attribute.String("db.operation.name", "SELECT"),
+		))
+	}
+}
+
+// BenchmarkRecordQueryCompletion_Mixed_Cached approximates real traffic:
+// 16 distinct (op, fingerprint) tuples rotating through the three hot-path
+// instruments per iteration. This exercises the cache under realistic
+// dimension churn rather than the best-case single-tuple shape.
+func BenchmarkRecordQueryCompletion_Mixed_Cached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	ops := []string{"SELECT", "INSERT", "UPDATE", "DELETE"}
+	fps := []string{"fp1", "fp2", "fp3", "fp4"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		op := ops[i&3]
+		fp := fps[(i>>2)&3]
+		m.queryDuration.Record(ctx, 0.001, "db1", op, "simple", "", QueryStatusOK, fp)
+		m.rowsReturned.Record(ctx, 1, "db1", op, fp)
+		m.tableQueries.Add(ctx, "db1", "users", op)
+		i++
+	}
+}
+
+func BenchmarkRecordQueryCompletion_Mixed_Uncached(b *testing.B) {
+	m := setupBenchMetrics(b)
+	ctx := context.Background()
+	dur := m.queryDuration.Float64Histogram
+	rows := m.rowsReturned.Float64Histogram
+	tq := m.tableQueries.Int64Counter
+	ops := []string{"SELECT", "INSERT", "UPDATE", "DELETE"}
+	fps := []string{"fp1", "fp2", "fp3", "fp4"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		op := ops[i&3]
+		fp := fps[(i>>2)&3]
+		dur.Record(ctx, 0.001, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.operation.name", op),
+			attribute.String("db.query.protocol", "simple"),
+			attribute.String("error.type", ""),
+			attribute.String("status", string(QueryStatusOK)),
+			attribute.String("query.fingerprint", fp),
+		))
+		rows.Record(ctx, 1, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.operation.name", op),
+			attribute.String("query.fingerprint", fp),
+		))
+		tq.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("db.namespace", "db1"),
+			attribute.String("db.collection.name", "users"),
+			attribute.String("db.operation.name", op),
+		))
+		i++
+	}
 }


### PR DESCRIPTION
## Summary

- Per-query metric instrumentation in `recordQueryCompletion` showed up at ~7.5% of gateway CPU in pprof, dominated by attribute-set construction (sort + dedupe) inside the OTel SDK on every `Record`/`Add` call.
- Cache a `metric.MeasurementOption` per stable dimension tuple (db, op, fingerprint, …) so that the OTel attribute-set work happens once per tuple instead of once per query.
- Dedupe `mterrors.ClassifyErrorSource`: skip it entirely on the success path and compute it exactly once (then reuse) on the error path. Previously called twice on errors and once on success.
- Adds unit tests for cache reuse + emitted attribute shape, and benchmarks comparing the cached vs. pre-cache path.

## Description

The hot path for every query funnels into three OTel calls — `queryDuration.Record`, `rowsReturned.Record`, and one `tableQueries.Add` per table touched. Each call previously built a fresh `[]attribute.KeyValue` and handed it to `metric.WithAttributes`, which the SDK then sorted and deduplicated into an `attribute.Set`. The attribute *values* for a given (db, op, protocol, fingerprint) tuple are stable across millions of queries, so re-sorting them every time was wasted work.

This PR caches the `MeasurementOption` (which wraps a pre-built `attribute.Set`) on a per-instrument `sync.Map`, keyed by a small struct of the dimensions. The hot path becomes a `sync.Map.Load` followed by a single `Record`/`Add`. Cache misses (cold start, new fingerprint) take a write through `LoadOrStore` and then proceed normally.

Cardinality is bounded by external invariants — the query registry caps fingerprint labels into `__other__` / `__utility__`, SQLSTATE / status / protocol are enum-shaped, and `db.namespace` / `db.operation.name` / `db.collection.name` come from authenticated PG protocol fields rather than arbitrary user input. A short comment in `metrics.go` notes this so no one reaches for an explicit cap reflexively.

### Benchmarks (Apple M4, single-tuple warm cache)

```
BenchmarkQueryDuration_Cached            ~115 ns/op    16 B/op   1 allocs/op
BenchmarkQueryDuration_Uncached          ~430 ns/op   808 B/op   4 allocs/op   (3.7×)

BenchmarkRowsReturned_Cached              ~84 ns/op    16 B/op   1 allocs/op
BenchmarkRowsReturned_Uncached           ~253 ns/op   424 B/op   4 allocs/op   (3.0×)

BenchmarkTableQueries_Cached              ~75 ns/op    16 B/op   1 allocs/op
BenchmarkTableQueries_Uncached           ~246 ns/op   424 B/op   4 allocs/op   (3.3×)

BenchmarkRecordQueryCompletion_Mixed_Cached    ~320 ns/op    48 B/op    3 allocs/op
BenchmarkRecordQueryCompletion_Mixed_Uncached ~1035 ns/op  1656 B/op   12 allocs/op   (3.2×)
```

The Mixed benchmark rotates across 16 distinct (op, fingerprint) tuples per iteration, so the speedup isn't artifact of best-case single-tuple replay.

### Notes for reviewers

- Metric names, descriptions, units, bucket boundaries, and attribute *keys* are unchanged — dashboards continue to see the same shape. `TestHandlerMetrics_EmittedAttributes` asserts this end-to-end via a `sdkmetric.ManualReader`.
- Wrapper types (`QueryDuration`, `QueryErrors`, `RowsReturned`, `TableQueries`) moved to pointer receivers because they now hold a `sync.Map`. `HandlerMetrics` correspondingly holds pointers. No external callers were affected.

## Test plan

- [x] `go test ./go/services/multigateway/handler/...` passes
- [x] `go build ./...` passes
- [x] `golangci-lint run ./go/services/multigateway/handler/...` clean
- [x] New cache-hit tests verify identical dimensions reuse the entry and distinct dimensions add separate entries
- [x] End-to-end attribute-shape test via `sdkmetric.ManualReader` confirms emitted metric data points carry the same attributes as before
- [ ] Re-run the original pprof capture (select-only + tpcb-like, c=100) against this branch to confirm the projected ~1.5% gateway CPU drop