### PR TITLE
ci(sqllogictest): run weekly, alert on any pg/mg divergence

### DIFF
--- a/.github/workflows/test-sqllogictest.yml
+++ b/.github/workflows/test-sqllogictest.yml
@@ -16,8 +16,7 @@ name: SQLLogicTest Differential Suite
 
 on: # yamllint disable-line rule:truthy
   schedule:
-    - cron: "30 3 * * *" # Nightly at 3:30 AM UTC (offset from pgregress at 3:00)
-    - cron: "30 9 * * 1" # Weekly summary: Monday 9:30 AM UTC
+    - cron: "30 9 * * 1" # Weekly: Monday 9:30 AM UTC
   pull_request:
     types: [labeled]
   workflow_dispatch:
@@ -59,19 +58,6 @@ jobs:
       - name: Build
         run: make build
 
-      # Only nightly cron runs save to the baseline (see "Save current
-      # results as new baseline" below), so restore only from the
-      # nightly-scoped key prefix. PR-labeled runs, weekly summary runs,
-      # and workflow_dispatch runs all read the latest nightly result
-      # without being able to pollute it.
-      - name: Restore baseline results
-        id: baseline
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: /tmp/sqllogictest-baseline/results.json
-          key: sqllogictest-baseline-nightly-dummy
-          restore-keys: sqllogictest-baseline-nightly-
-
       - name: Start port pool server
         run: |
           ./bin/portpoolserver --socket /tmp/multigres-port-pool.sock &
@@ -103,25 +89,28 @@ jobs:
             echo "No results.json found"
           fi
 
-      - name: Detect regressions
-        id: regressions
+      - name: Detect divergences
+        id: divergences
         if: ${{ !cancelled() && steps.results.outputs.path != '' }}
         env:
           RESULTS_PATH: ${{ steps.results.outputs.path }}
         run: |
-          exit_code=0
-          .github/scripts/detect-regressions.sh \
-            /tmp/sqllogictest-baseline/results.json \
-            "$RESULTS_PATH" \
-            /tmp/sqllogictest-regressions \
-            || exit_code=$?
+          # A divergence is any file that passes on postgres but fails on
+          # multigateway. We treat every such file as something to flag —
+          # there is no baseline comparison anymore.
+          jq -r '
+            [ .[] as $s
+              | $s.tests[]
+              | select(.postgres.passed == true and .multigateway.passed == false)
+              | {suite: $s.name, test: .name}
+            ]
+          ' "$RESULTS_PATH" > /tmp/sqllogictest-divergences.json
 
-          if [[ "$exit_code" -eq 0 ]]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          elif [[ "$exit_code" -eq 1 ]]; then
+          count=$(jq 'length' /tmp/sqllogictest-divergences.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [[ "$count" -gt 0 ]]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Regression detection script failed with exit code $exit_code"
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -133,19 +122,19 @@ jobs:
           path: /tmp/multigres_pg_cache/results/**/*
           if-no-files-found: warn
 
-      - name: Notify Slack on regression
+      - name: Notify Slack on divergence
         if: >-
           !cancelled() &&
-          steps.regressions.outputs.found == 'true' &&
+          steps.divergences.outputs.found == 'true' &&
           github.event_name == 'schedule'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}
         run: |
           if [[ -z "$SLACK_WEBHOOK_URL" ]]; then echo "No webhook configured, skipping"; exit 0; fi
 
-          regressions=$(cat /tmp/sqllogictest-regressions/regressions.json)
-          count=$(echo "$regressions" | jq 'length')
-          test_list=$(echo "$regressions" | jq -r '.[] | "- [\(.suite)] \(.test)"' | head -20)
+          divergences=$(cat /tmp/sqllogictest-divergences.json)
+          count=$(echo "$divergences" | jq 'length')
+          test_list=$(echo "$divergences" | jq -r '.[] | "- [\(.suite)] \(.test)"' | head -20)
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           payload=$(jq -n \
@@ -154,8 +143,8 @@ jobs:
             --arg url "$run_url" \
             '{
               blocks: [
-                {type: "header", text: {type: "plain_text", text: (":rotating_light: " + $count + " sqllogictest regression(s) detected")}},
-                {type: "section", text: {type: "mrkdwn", text: ("Files that were passing but now fail:\n```\n" + $tests + "\n```")}},
+                {type: "header", text: {type: "plain_text", text: (":rotating_light: " + $count + " sqllogictest divergence(s) detected")}},
+                {type: "section", text: {type: "mrkdwn", text: ("Files that pass on postgres but fail on multigateway:\n```\n" + $tests + "\n```")}},
                 {type: "section", text: {type: "mrkdwn", text: ("<" + $url + "|View CI run>")}}
               ]
             }')
@@ -167,7 +156,7 @@ jobs:
       - name: Notify Slack weekly summary
         if: >-
           !cancelled() &&
-          (github.event.schedule == '30 9 * * 1' || github.event_name == 'workflow_dispatch') &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
           steps.results.outputs.path != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}
@@ -230,7 +219,7 @@ jobs:
             '{
               blocks: [
                 {type: "header", text: {type: "plain_text", text: "sqllogictest suite failed to produce results"}},
-                {type: "section", text: {type: "mrkdwn", text: "The nightly sqllogictest run did not produce a `results.json`. The test infrastructure likely failed (e.g. cluster bootstrap timeout, build failure)."}},
+                {type: "section", text: {type: "mrkdwn", text: "The weekly sqllogictest run did not produce a `results.json`. The test infrastructure likely failed (e.g. cluster bootstrap timeout, build failure)."}},
                 {type: "section", text: {type: "mrkdwn", text: ("<" + $url + "|View CI run>")}}
               ]
             }')
@@ -238,27 +227,6 @@ jobs:
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "$payload" \
             "$SLACK_WEBHOOK_URL"
-
-      - name: Prepare baseline for cache save
-        if: ${{ !cancelled() && steps.results.outputs.path != '' }}
-        env:
-          RESULTS_PATH: ${{ steps.results.outputs.path }}
-        run: |
-          mkdir -p /tmp/sqllogictest-baseline
-          cp "$RESULTS_PATH" /tmp/sqllogictest-baseline/results.json
-
-      # Only the nightly cron run (`30 3 * * *`) updates the baseline. PR-
-      # labeled runs and workflow_dispatch can read the baseline but never
-      # overwrite it, so a bad PR can't poison the next run's regression
-      # diff. The weekly summary cron is deliberately skipped too — it
-      # runs against the same multigres tree a couple of days later and
-      # shouldn't be treated as a fresher baseline than Monday's.
-      - name: Save current results as new baseline
-        if: ${{ !cancelled() && steps.results.outputs.path != '' && github.event.schedule == '30 3 * * *' }}
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: /tmp/sqllogictest-baseline/results.json
-          key: sqllogictest-baseline-nightly-${{ github.run_id }}
 
       # Note: the Go test writes the pass/fail summary (including shields.io
       # badge) directly to GITHUB_STEP_SUMMARY via report.go.

--- a/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
+++ b/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
@@ -36,7 +36,7 @@ const (
 	// defaultPerFileTimeout bounds how long any single .test file can run
 	// against one target on one protocol. A single slow file cannot starve
 	// the whole suite.
-	defaultPerFileTimeout = 5 * time.Minute
+	defaultPerFileTimeout = 10 * time.Minute
 
 	// defaultBuildTimeout bounds the PostgreSQL source build.
 	defaultBuildTimeout = 10 * time.Minute
@@ -73,8 +73,8 @@ var protocols = []protocolConfig{
 //
 // This test is deliberately tolerant of failures. It does not fail the Go
 // test on proxy divergence or upstream corpus failures; it records per-
-// file, per-protocol pass/fail counts over time (like pgregresstest). CI
-// compares against a cached baseline; regressions surface there.
+// file, per-protocol pass/fail counts. CI inspects results.json and alerts
+// when any file passes on postgres but fails on multigateway.
 //
 // Skipped by default. Set RUN_EXTENDED_QUERY_SERVING_TESTS=1 to run.
 //
@@ -83,7 +83,7 @@ var protocols = []protocolConfig{
 //	RUN_EXTENDED_QUERY_SERVING_TESTS=1  — enable the test (required)
 //	SLT_CORPUS_DIR=<dir>                — use an external corpus instead of testdata/
 //	SLT_CORPUS_GLOB=<glob>              — scope which corpus files run (default: **/*.slt)
-//	SLT_PER_FILE_TIMEOUT=<d>            — Go duration, e.g. "90s" (default: 5m)
+//	SLT_PER_FILE_TIMEOUT=<d>            — Go duration, e.g. "90s" (default: 10m)
 func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 


### PR DESCRIPTION
## Summary

- Drop the nightly cron and switch the sqllogictest differential suite to a single weekly run (Mondays, 09:30 UTC).
- Remove the cached-baseline + `detect-regressions.sh` machinery. The weekly run now Slack-alerts whenever any file passes on postgres but fails on multigateway, with no diff against prior runs.
- Bump the per-file timeout from 5m to 10m to absorb the occasional slow file.

## Description

Now that the suite is stable, daily runs were overkill — the signal we actually want is "did any file regress relative to postgres?", which is fully derivable from a single run's `results.json`. Removing the baseline cache also eliminates a class of confusion (stale baselines, PR-labeled runs reading old data) and makes the workflow easier to reason about. The Slack alert wording was updated from "regression" to "divergence" to match the new semantics. The `detect-regressions.sh` script is still used by `test-pgregress.yml`, so it's left in place.