### PR TITLE
fix(multigateway): error on duplicate PREPARE name in simple protocol

### DIFF
--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -34,6 +34,7 @@ const (
 	PgSSAuthFailed              = "28P01" // invalid_password
 	PgSSInvalidAuthSpec         = "28000" // invalid_authorization_specification
 	PgSSInvalidCursorName       = "34000" // invalid_cursor_name
+	PgSSDuplicatePreparedStmt   = "42P05" // duplicate_prepared_statement
 	PgSSInsufficientPrivilege   = "42501" // insufficient_privilege
 	PgSSSyntaxError             = "42601" // syntax_error
 	PgSSUndefinedObject         = "42704" // undefined_object
@@ -236,6 +237,13 @@ func NewInvalidPreparedStatementError(name string) *PgDiagnostic {
 func NewInvalidPortalError(name string) *PgDiagnostic {
 	return NewPgError("ERROR", PgSSInvalidCursorName,
 		fmt.Sprintf("portal \"%s\" does not exist", name), "")
+}
+
+// NewDuplicatePreparedStatementError creates a PgDiagnostic for a PREPARE
+// that reuses an existing statement name. SQLSTATE 42P05.
+func NewDuplicatePreparedStatementError(name string) *PgDiagnostic {
+	return NewPgError("ERROR", PgSSDuplicatePreparedStmt,
+		fmt.Sprintf("prepared statement \"%s\" already exists", name), "")
 }
 
 // IsErrorCode checks whether err (or a wrapped cause) is a *PgDiagnostic

--- a/go/services/multigateway/engine/prepared_statement_primitive.go
+++ b/go/services/multigateway/engine/prepared_statement_primitive.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -124,11 +125,19 @@ func (p *PreparedStatementPrimitive) StreamExecute(
 }
 
 // executePrepare delegates to HandleParse to register the statement in the consolidator.
+//
+// Unlike the extended Parse message, SQL-level PREPARE must reject a name that is
+// already in use on this session. HandleParse silently replaces existing entries
+// (to tolerate Parse retries after a failed Describe), so we check for the name
+// here before delegating.
 func (p *PreparedStatementPrimitive) executePrepare(
 	ctx context.Context,
 	conn *server.Conn,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
+	if conn.Handler().GetPreparedStatementInfo(conn.ConnectionID(), p.stmtName) != nil {
+		return mterrors.NewDuplicatePreparedStatementError(p.stmtName)
+	}
 	if err := conn.Handler().HandleParse(ctx, conn, p.stmtName, p.innerQuery, p.paramTypes); err != nil {
 		return err
 	}

--- a/go/services/multigateway/planner/prepared_stmt_test.go
+++ b/go/services/multigateway/planner/prepared_stmt_test.go
@@ -179,6 +179,23 @@ func TestPlanPrepareStmt(t *testing.T) {
 	assert.Equal(t, "SELECT 1", psi.Query)
 }
 
+func TestPlanPrepareStmtDuplicateName(t *testing.T) {
+	s := newTestSetup(t)
+
+	_, err := planAndExecute(t, s, "PREPARE myplan AS SELECT 1")
+	require.NoError(t, err)
+
+	_, err = planAndExecute(t, s, "PREPARE myplan AS SELECT 2")
+	require.Error(t, err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSDuplicatePreparedStmt),
+		"expected duplicate_prepared_statement (42P05), got %v", err)
+
+	// The first prepared statement must remain intact.
+	psi := s.psc.GetPreparedStatementInfo(s.conn.Conn.ConnectionID(), "myplan")
+	require.NotNil(t, psi)
+	assert.Equal(t, "SELECT 1", psi.Query)
+}
+
 func TestPlanPrepareStmtWithParams(t *testing.T) {
 	s := newTestSetup(t)
 

--- a/go/test/endtoend/queryserving/prepared_stmt_test.go
+++ b/go/test/endtoend/queryserving/prepared_stmt_test.go
@@ -155,6 +155,24 @@ func TestSimpleProtocolPreparedStatements(t *testing.T) {
 				require.Error(t, err)
 			})
 
+			t.Run("prepare_duplicate_name_fails", func(t *testing.T) {
+				_, err := db.ExecContext(ctx, fmt.Sprintf("PREPARE dup_name AS SELECT id FROM %s WHERE id = 1", tableName))
+				require.NoError(t, err)
+				defer func() { _, _ = db.ExecContext(ctx, "DEALLOCATE dup_name") }()
+
+				_, err = db.ExecContext(ctx, fmt.Sprintf("PREPARE dup_name AS SELECT id FROM %s WHERE id = 2", tableName))
+				require.Error(t, err)
+				var pqErr *pq.Error
+				require.True(t, errors.As(err, &pqErr), "expected *pq.Error, got %T", err)
+				assert.Equal(t, pq.ErrorCode(mterrors.PgSSDuplicatePreparedStmt), pqErr.Code)
+
+				// The original statement must still resolve to its first definition.
+				var id int
+				err = db.QueryRowContext(ctx, "EXECUTE dup_name").Scan(&id)
+				require.NoError(t, err)
+				assert.Equal(t, 1, id)
+			})
+
 			t.Run("prepare_reuse", func(t *testing.T) {
 				_, err := db.ExecContext(ctx, fmt.Sprintf("PREPARE reusable AS SELECT id, value FROM %s ORDER BY id LIMIT 1", tableName))
 				require.NoError(t, err)


### PR DESCRIPTION
## Summary

- SQL-level `PREPARE name AS ...` now errors with `prepared statement "name" already exists` (SQLSTATE 42P05) when the name is already in use on the session, matching upstream PostgreSQL.
- Previously the consolidator silently replaced the existing statement, so a buggy client never saw the conflict and pgregress diffs included ~50 hunks for this case.

## Problem

Multigateway's prepared-statement consolidator replaces any existing entry when a Parse comes in for the same name on the same connection. That behavior is intentional for the extended protocol — clients (notably pq) re-Parse with the same name after a failed Describe, and we need to tolerate that — but it also leaks through to simple-protocol `PREPARE`, where upstream PostgreSQL is required to raise `duplicate_prepared_statement` (42P05). See MUL-388 / MUL-436.

## Solution

Add the duplicate check at the simple-PREPARE boundary instead of inside the consolidator: `PreparedStatementPrimitive.executePrepare` looks up the user-visible name via `Handler.GetPreparedStatementInfo` and returns a new `NewDuplicatePreparedStatementError` if it already exists. `HandleParse`'s replace-on-reparse behavior is left intact so the extended-protocol retry path keeps working.

Also adds:

- `PgSSDuplicatePreparedStmt = "42P05"` and `NewDuplicatePreparedStatementError` in `mterrors`.
- A unit test in the planner package covering the duplicate path.
- A subtest in the existing `TestSimpleProtocolPreparedStatements` comparison harness so the behavior is verified against both direct PostgreSQL and multigateway, and the first statement's definition is confirmed to survive the rejected re-PREPARE.

This addresses defect 3 from MUL-388 (silent re-PREPARE). Defects 1 (user name not surfaced in `pg_prepared_statements`) and 2 (state leak across pooled backend sessions) are intentionally out of scope here.

## Test plan

- [x] `go test ./go/services/multigateway/planner -run TestPlanPrepareStmt -v`
- [x] `go test ./go/test/endtoend/queryserving -run TestSimpleProtocolPreparedStatements -v` (postgres + multigateway, all 16 subtests pass)
- [x] `go test -short ./go/services/multigateway/... ./go/common/mterrors/... ./go/common/preparedstatement/...`