### PR TITLE
feat(test): add the ability to run multiadmin in the tests setup

### DIFF
--- a/go/test/endtoend/multiadmin/main_test.go
+++ b/go/test/endtoend/multiadmin/main_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package multiadmin contains end-to-end tests that exercise the multiadmin
+// service started via shardsetup's WithMultiadmin() option, covering its
+// gRPC API, HTTP/REST grpc-gateway, and the multigres CLI that talks to it.
+package multiadmin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// setupManager manages a shared test cluster (multipoolers + multigateway +
+// multiadmin) so all tests in this package share the same multiadmin process.
+var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardsetup.ShardSetup {
+	return shardsetup.New(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultiadmin(),
+	)
+})
+
+func TestMain(m *testing.M) {
+	exitCode := shardsetup.RunTestMain(m)
+	if exitCode != 0 {
+		setupManager.DumpLogs()
+	}
+	setupManager.Cleanup()
+	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+}
+
+// getSharedSetup returns the shared cluster setup for tests in this package.
+func getSharedSetup(t *testing.T) *shardsetup.ShardSetup {
+	t.Helper()
+	return setupManager.Get(t)
+}

--- a/go/test/endtoend/multiadmin/multiadmin_test.go
+++ b/go/test/endtoend/multiadmin/multiadmin_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// newAdminClient dials the multiadmin gRPC server on localhost. Caller must
+// Close() the returned connection.
+func newAdminClient(t *testing.T, grpcPort int) (multiadminpb.MultiAdminServiceClient, *grpc.ClientConn) {
+	t.Helper()
+	addr := fmt.Sprintf("localhost:%d", grpcPort)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "failed to dial multiadmin at %s", addr)
+	return multiadminpb.NewMultiAdminServiceClient(conn), conn
+}
+
+// TestMultiadminProcessRunning smoke-tests that the multiadmin process is up
+// and that the harness recorded its ports.
+func TestMultiadminProcessRunning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+
+	require.NotNil(t, setup.Multiadmin, "WithMultiadmin() should have created a multiadmin instance")
+	require.True(t, setup.Multiadmin.IsRunning(), "multiadmin process should be running")
+	require.NotZero(t, setup.MultiadminHttpPort, "MultiadminHttpPort should be set")
+	require.NotZero(t, setup.MultiadminGrpcPort, "MultiadminGrpcPort should be set")
+}
+
+// TestMultiadminLiveReady verifies that the /live and /ready HTTP endpoints
+// served by the embedded servenv mux return 200.
+func TestMultiadminLiveReady(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	base := fmt.Sprintf("http://localhost:%d", setup.MultiadminHttpPort)
+
+	for _, path := range []string{"/live", "/ready"} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+path, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err, "GET %s failed", path)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "GET %s should return 200", path)
+		})
+	}
+}
+
+// TestMultiadminGRPC exercises the main read-only gRPC RPCs against the
+// shared cluster. These are the same RPCs the multigres CLI calls.
+func TestMultiadminGRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	client, conn := newAdminClient(t, setup.MultiadminGrpcPort)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	t.Run("GetCellNames", func(t *testing.T) {
+		resp, err := client.GetCellNames(ctx, &multiadminpb.GetCellNamesRequest{})
+		require.NoError(t, err)
+		assert.Contains(t, resp.GetNames(), setup.CellName, "expected configured cell to be returned")
+	})
+
+	t.Run("GetDatabaseNames", func(t *testing.T) {
+		resp, err := client.GetDatabaseNames(ctx, &multiadminpb.GetDatabaseNamesRequest{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.GetNames(), "expected at least one database in the topology")
+	})
+
+	t.Run("GetCell", func(t *testing.T) {
+		resp, err := client.GetCell(ctx, &multiadminpb.GetCellRequest{Name: setup.CellName})
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCell(), "expected cell info")
+		assert.NotEmpty(t, resp.GetCell().GetServerAddresses(), "cell should have etcd server addresses")
+	})
+
+	t.Run("GetPoolers", func(t *testing.T) {
+		resp, err := client.GetPoolers(ctx, &multiadminpb.GetPoolersRequest{Cells: []string{setup.CellName}})
+		require.NoError(t, err)
+		// The shared cluster runs MultipoolerCount=2 poolers in the configured cell.
+		assert.Len(t, resp.GetPoolers(), 2, "expected both multipoolers to be reported")
+	})
+
+	t.Run("GetGateways", func(t *testing.T) {
+		resp, err := client.GetGateways(ctx, &multiadminpb.GetGatewaysRequest{Cells: []string{setup.CellName}})
+		require.NoError(t, err)
+		assert.Len(t, resp.GetGateways(), 1, "expected the single multigateway to be reported")
+	})
+}
+
+// TestMultiadminHTTPAPI hits the grpc-gateway REST endpoints exposed under
+// /api/v1/ on the multiadmin HTTP port — this is what the Next.js UI talks to.
+func TestMultiadminHTTPAPI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	base := fmt.Sprintf("http://localhost:%d/api/v1", setup.MultiadminHttpPort)
+
+	getJSON := func(t *testing.T, path string) map[string]any {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+path, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err, "GET %s failed", path)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s status=%d body=%s", path, resp.StatusCode, string(body))
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(body, &out), "invalid JSON from %s: %s", path, string(body))
+		return out
+	}
+
+	t.Run("cells", func(t *testing.T) {
+		out := getJSON(t, "/cells")
+		names, ok := out["names"].([]any)
+		require.True(t, ok, "expected 'names' array, got %v", out)
+		assert.Contains(t, names, setup.CellName)
+	})
+
+	t.Run("databases", func(t *testing.T) {
+		out := getJSON(t, "/databases")
+		names, ok := out["names"].([]any)
+		require.True(t, ok, "expected 'names' array, got %v", out)
+		assert.NotEmpty(t, names)
+	})
+
+	t.Run("poolers", func(t *testing.T) {
+		out := getJSON(t, "/poolers?cells="+setup.CellName)
+		poolers, ok := out["poolers"].([]any)
+		require.True(t, ok, "expected 'poolers' array, got %v", out)
+		assert.Len(t, poolers, 2)
+	})
+
+	t.Run("gateways", func(t *testing.T) {
+		out := getJSON(t, "/gateways?cells="+setup.CellName)
+		gateways, ok := out["gateways"].([]any)
+		require.True(t, ok, "expected 'gateways' array, got %v", out)
+		assert.Len(t, gateways, 1)
+	})
+}
+
+// TestMultiadminCLI exercises the multigres CLI against the running
+// multiadmin server via --admin-server. This is the integration path users
+// actually take (and the one the localprovisioner test only covered when an
+// end-to-end "multigres up" cluster was provisioned).
+func TestMultiadminCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	adminServer := fmt.Sprintf("localhost:%d", setup.MultiadminGrpcPort)
+
+	run := func(t *testing.T, subcmd string, extraArgs ...string) string {
+		t.Helper()
+		args := append([]string{subcmd, "--admin-server", adminServer}, extraArgs...)
+		ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+		defer cancel()
+		out, err := executil.Command(ctx, "multigres", args...).CombinedOutput()
+		require.NoError(t, err, "multigres %s failed: %s", subcmd, string(out))
+		return string(out)
+	}
+
+	t.Run("getcellnames", func(t *testing.T) {
+		out := run(t, "getcellnames")
+		assert.Contains(t, out, setup.CellName, "getcellnames should include the configured cell")
+	})
+
+	t.Run("getdatabasenames", func(t *testing.T) {
+		out := run(t, "getdatabasenames")
+		// Output is JSON: {"names": [...]}. We don't pin the exact name, just
+		// require non-empty names.
+		assert.Contains(t, out, "\"names\"")
+	})
+
+	t.Run("getpoolers", func(t *testing.T) {
+		out := run(t, "getpoolers", "--cells", setup.CellName)
+		assert.Contains(t, out, "\"poolers\"", "getpoolers output should be a JSON object with a 'poolers' field")
+		// Both pooler service IDs should appear in the response payload.
+		for name := range setup.Multipoolers {
+			assert.Contains(t, out, name, "getpoolers output should mention pooler %q", name)
+		}
+	})
+
+	t.Run("getgateways", func(t *testing.T) {
+		out := run(t, "getgateways", "--cells", setup.CellName)
+		assert.Contains(t, out, "\"gateways\"")
+	})
+}

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -80,6 +80,13 @@ type ShardSetup struct {
 	MultigatewayPgPort        int // PostgreSQL protocol port for multigateway
 	MultigatewayReplicaPgPort int // PostgreSQL replica-reads port for multigateway (0 = disabled)
 
+	// Multiadmin instance (optional, enabled via WithMultiadmin).
+	// The HTTP port is what the Next.js web UI in web/multiadmin/ talks to;
+	// point it via MULTIADMIN_API_URL=http://localhost:<MultiadminHttpPort>.
+	Multiadmin         *ProcessInstance
+	MultiadminHttpPort int
+	MultiadminGrpcPort int
+
 	// PgBackRestCertPaths stores the paths to pgBackRest TLS certificates
 	PgBackRestCertPaths *local.PgBackRestCertPaths
 
@@ -415,6 +422,31 @@ func (s *ShardSetup) CreateMultigatewayInstance(t *testing.T, name string, pgPor
 	return inst
 }
 
+// CreateMultiadminInstance creates a multiadmin process instance.
+// Returns the created ProcessInstance. Does not start the process.
+func (s *ShardSetup) CreateMultiadminInstance(t *testing.T, name string, httpPort, grpcPort int) *ProcessInstance {
+	t.Helper()
+
+	inst := &ProcessInstance{
+		Name:        name,
+		Binary:      "multiadmin",
+		Cell:        s.CellName,
+		ServiceID:   fmt.Sprintf("%s-%s", name, s.CellName),
+		HttpPort:    httpPort,
+		GrpcPort:    grpcPort,
+		EtcdAddr:    s.EtcdClientAddr,
+		GlobalRoot:  "/multigres/global",
+		LogFile:     filepath.Join(s.TempDir, name+".log"),
+		Environment: os.Environ(),
+	}
+
+	s.Multiadmin = inst
+	s.MultiadminHttpPort = httpPort
+	s.MultiadminGrpcPort = grpcPort
+
+	return inst
+}
+
 // WaitForMultigatewayQueryServing waits for multigateway to be able to execute queries.
 // This verifies that multigateway has discovered poolers from topology and can route queries.
 // Should be called AFTER bootstrap completes.
@@ -498,6 +530,9 @@ func (s *ShardSetup) Cleanup(testsFailed bool) {
 	}
 	if s.Multigateway != nil {
 		s.Multigateway.TerminateGracefully(logf, 5*time.Second)
+	}
+	if s.Multiadmin != nil {
+		s.Multiadmin.TerminateGracefully(logf, 5*time.Second)
 	}
 	for _, mo := range s.MultiOrchInstances {
 		mo.TerminateGracefully(logf, 5*time.Second)
@@ -593,6 +628,11 @@ func (s *ShardSetup) CheckSharedProcesses(t *testing.T) {
 	// Check multigateway
 	if s.Multigateway != nil && !s.Multigateway.IsRunning() {
 		dead = append(dead, "multigateway")
+	}
+
+	// Check multiadmin
+	if s.Multiadmin != nil && !s.Multiadmin.IsRunning() {
+		dead = append(dead, "multiadmin")
 	}
 
 	// Check multipooler instances

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -134,6 +134,8 @@ func (p *ProcessInstance) Start(ctx context.Context, t *testing.T) error {
 		return p.startMultiOrch(ctx, t)
 	case "multigateway":
 		return p.startMultigateway(ctx, t)
+	case "multiadmin":
+		return p.startMultiadmin(ctx, t)
 	}
 	return fmt.Errorf("unknown binary type: %s", p.Binary)
 }
@@ -390,6 +392,53 @@ func (p *ProcessInstance) startMultigateway(ctx context.Context, t *testing.T) e
 	}
 	t.Logf("Multigateway is ready")
 
+	return nil
+}
+
+// startMultiadmin starts a multiadmin instance pointed at the harness's etcd.
+// The HTTP port serves both the JSON API used by the Next.js web UI in
+// web/multiadmin/ and the gRPC-gateway endpoints; the gRPC port is used by
+// the multigres CLI (admin-server flag).
+func (p *ProcessInstance) startMultiadmin(ctx context.Context, t *testing.T) error {
+	t.Helper()
+
+	t.Logf("Starting %s: binary '%s', HTTP port %d, gRPC port %d", p.Name, p.Binary, p.HttpPort, p.GrpcPort)
+
+	args := []string{
+		"--http-port", strconv.Itoa(p.HttpPort),
+		"--grpc-port", strconv.Itoa(p.GrpcPort),
+		"--topo-global-server-addresses", p.EtcdAddr,
+		"--topo-global-root", p.GlobalRoot,
+		"--service-map", "grpc-multiadmin",
+		"--hostname", "localhost",
+		"--log-level", p.logLevelOrDefault(),
+	}
+
+	p.Process = executil.Command(ctx, p.Binary, args...).WithProcessGroup()
+
+	if len(p.Environment) > 0 {
+		p.Process.SetEnv(p.Environment)
+	}
+
+	if p.LogFile != "" {
+		logF, err := os.Create(p.LogFile)
+		if err != nil {
+			return fmt.Errorf("failed to create log file: %w", err)
+		}
+		p.Process.SetStdout(logF)
+		p.Process.SetStderr(logF)
+	}
+
+	if err := p.Process.Start(); err != nil {
+		return fmt.Errorf("failed to start multiadmin: %w", err)
+	}
+	t.Logf("Started multiadmin (pid: %d, http: %d, grpc: %d, log: %s)",
+		p.Process.Process.Pid, p.HttpPort, p.GrpcPort, p.LogFile)
+
+	if err := WaitForPortReady(t, "multiadmin", p.GrpcPort, 15*time.Second); err != nil {
+		return err
+	}
+	t.Logf("Multiadmin is ready")
 	return nil
 }
 

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -58,6 +58,7 @@ type SetupConfig struct {
 	MultipoolerCount                   int
 	MultiOrchCount                     int
 	EnableMultigateway                 bool // Enable multigateway (opt-in, default: false)
+	EnableMultiadmin                   bool // Enable multiadmin (opt-in, default: false)
 	EnableMultigatewayTLS              bool // Enable TLS for multigateway PostgreSQL listener
 	EnableMultipoolerPGTLS             bool // Provision postgres with TLS and point multipooler at it via verify-full
 	Database                           string
@@ -144,6 +145,17 @@ func WithDeferredMultipoolerStart() SetupOption {
 func WithMultigateway() SetupOption {
 	return func(c *SetupConfig) {
 		c.EnableMultigateway = true
+	}
+}
+
+// WithMultiadmin enables multiadmin in the test setup (default: disabled).
+// Multiadmin is started after shard bootstrap and exposes HTTP + gRPC APIs
+// against the same etcd topology used by the rest of the cluster. The
+// Next.js web UI in web/multiadmin/ can be pointed at the resulting HTTP
+// port via MULTIADMIN_API_URL=http://localhost:<port> pnpm dev.
+func WithMultiadmin() SetupOption {
+	return func(c *SetupConfig) {
+		c.EnableMultiadmin = true
 	}
 }
 
@@ -378,6 +390,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		attribute.String("shard", config.Shard),
 		attribute.String("cell", config.CellName),
 		attribute.Bool("enable.multigateway", config.EnableMultigateway),
+		attribute.Bool("enable.multiadmin", config.EnableMultiadmin),
 		attribute.Bool("enable.multigateway.tls", config.EnableMultigatewayTLS),
 		attribute.Bool("skip.initialization", config.SkipInitialization),
 	)
@@ -606,6 +619,24 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 			t.Fatalf("failed to start multigateway: %v", err)
 		}
 		t.Logf("Started multigateway")
+	}
+
+	// Start multiadmin (if enabled). Like multigateway, this is started after
+	// the multipooler instances exist so it can read them from topology.
+	// Multiadmin is a passive observer of topology — order vs. bootstrap
+	// doesn't matter the way it does for multigateway query serving.
+	if config.EnableMultiadmin {
+		httpPort := utils.GetFreePort(t)
+		grpcPort := utils.GetFreePort(t)
+
+		ma := setup.CreateMultiadminInstance(t, "multiadmin", httpPort, grpcPort)
+		ma.LogLevel = config.LogLevel
+		t.Logf("Created multiadmin instance: HTTP=%d, gRPC=%d", httpPort, grpcPort)
+
+		if err := ma.Start(runningCtx, t); err != nil {
+			t.Fatalf("failed to start multiadmin: %v", err)
+		}
+		t.Logf("Started multiadmin (UI base URL: http://localhost:%d)", httpPort)
 	}
 
 	// For uninitialized mode (bootstrap tests), we're done - leave nodes uninitialized


### PR DESCRIPTION
## Summary

- Add an opt-in `WithMultiadmin()` setup option to the end-to-end shard test harness so tests (and local dev against the Next.js web UI) can spin up a real `multiadmin` process alongside the rest of the cluster.
- Wire multiadmin into the harness lifecycle: free-port allocation, start after shard bootstrap, health check on the gRPC port, liveness check in `CheckSharedProcesses`, and graceful termination in `Cleanup`.
- Expose the chosen HTTP/gRPC ports on `ShardSetup` so the Next.js UI in `web/multiadmin/` can be pointed at the harness via `MULTIADMIN_API_URL=http://localhost:<port>`.

## Description

`multiadmin` is started against the same etcd topology used by the rest of the harness, with `--service-map grpc-multiadmin` and `--hostname localhost`. It comes up after multipoolers exist so it can observe them via topology, but unlike multigateway it's a passive observer — startup order vs. bootstrap isn't load-bearing. The process is created via the existing `ProcessInstance` machinery (new `startMultiadmin` + `"multiadmin"` case in `Start`), so logging, env, and process-group handling match the other services. Off by default; existing tests are unaffected.