### PR TITLE
feat(scram): capture per-conn TLS cert for SCRAM-SHA-256-PLUS under SNI

### DIFF
--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -265,6 +265,14 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 	}
 	l.bufPool = bufpool.New(16*1024, 64*1024*1024) // 16 KB to 64 MB
 
+	// Warn when TLS is configured but no path will yield a server certificate.
+	// crypto/tls would fail the handshake in this state, but the SCRAM-SHA-256-
+	// PLUS advertisement would also silently disappear, so surface this early
+	// instead of letting it look like a channel-binding regression at runtime.
+	if config.TLSConfig != nil && !tlsConfigYieldsServerCert(config.TLSConfig) {
+		logger.Warn("TLS config has no Certificates, GetCertificate, or GetConfigForClient; SCRAM-SHA-256-PLUS will not be advertised and TLS handshakes will fail")
+	}
+
 	logger.Info("PostgreSQL listener started", "address", config.Address)
 
 	return l, nil

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -177,8 +177,15 @@ func (c *Conn) handleSSLRequest() error {
 		return fmt.Errorf("received unencrypted data after SSL request: possible man-in-the-middle attack (buffered %d bytes)", c.bufferedReader.Buffered())
 	}
 
+	// Wrap the TLS config so dynamic-cert deployments (GetCertificate /
+	// GetConfigForClient, typical for SNI multi-tenant edges) capture the
+	// actually-selected leaf cert into c.tlsServerCert during the handshake.
+	// Static Certificates[0] deployments are handled by the post-handshake
+	// fallback below and skip the wrapper.
+	handshakeCfg := wrapTLSConfigForCertCapture(c.tlsConfig, c.captureTLSServerCert)
+
 	// Perform TLS handshake.
-	tlsConn := tls.Server(c.conn, c.tlsConfig)
+	tlsConn := tls.Server(c.conn, handshakeCfg)
 	if err := tlsConn.Handshake(); err != nil {
 		return fmt.Errorf("TLS handshake failed: %w", err)
 	}
@@ -192,20 +199,11 @@ func (c *Conn) handleSSLRequest() error {
 	c.bufferedReader.Reset(tlsConn)
 	c.tlsHandshakeComplete = true
 
-	// Capture the leaf certificate offered to the client for SCRAM-SHA-256-PLUS
-	// channel binding. Prefer the pre-parsed Leaf (set when callers populate it),
-	// fall back to parsing Certificate[0] for the common case where Leaf was
-	// left nil. A failure here is non-fatal: we just won't advertise PLUS and
-	// auth will fall back to SCRAM-SHA-256.
-	//
-	// LIMITATION: tlsConfig.Certificates[0] is the canonical cert in this
-	// config slot. If a deployment uses tlsConfig.GetCertificate or
-	// GetConfigForClient (dynamic SNI), the cert actually negotiated for
-	// this handshake may differ — PLUS will then fall back to base SCRAM
-	// because Go's tls.Conn.ConnectionState() does not expose the server-
-	// presented cert. A wrapper-based fix that captures the actually-
-	// selected cert per-Conn before this point is tracked separately.
-	if len(c.tlsConfig.Certificates) > 0 {
+	// Static-cert fallback: when the deployment only populates Certificates,
+	// the dynamic wrapper above is a no-op and the cert was not captured.
+	// Recover it from Certificates[0] here. A parse failure is non-fatal —
+	// auth simply falls back to SCRAM-SHA-256 without channel binding.
+	if c.tlsServerCert == nil && len(c.tlsConfig.Certificates) > 0 {
 		cert := &c.tlsConfig.Certificates[0]
 		switch {
 		case cert.Leaf != nil:

--- a/go/common/pgprotocol/server/tls_cert_capture.go
+++ b/go/common/pgprotocol/server/tls_cert_capture.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+)
+
+// captureTLSServerCert records the leaf certificate that crypto/tls
+// selected for this connection's handshake. Invoked by the GetCertificate
+// / GetConfigForClient wrappers installed by wrapTLSConfigForCertCapture.
+//
+// Prefers the pre-parsed Leaf to avoid re-parsing on hot paths; falls back
+// to parsing Certificate[0] for callers that don't populate Leaf. A parse
+// failure is logged at warn and leaves tlsServerCert nil — auth then falls
+// back to SCRAM-SHA-256 without channel binding rather than failing the
+// handshake.
+//
+// Called synchronously from the handshake goroutine before tls.Handshake
+// returns; the subsequent reader (handleSSLRequest / SCRAM advertisement)
+// runs on the same goroutine, so no synchronization is needed.
+func (c *Conn) captureTLSServerCert(tlsCert *tls.Certificate) {
+	if tlsCert == nil {
+		return
+	}
+	if tlsCert.Leaf != nil {
+		c.tlsServerCert = tlsCert.Leaf
+		return
+	}
+	if len(tlsCert.Certificate) == 0 {
+		return
+	}
+	parsed, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		c.logger.Warn("failed to parse selected TLS leaf cert for channel binding", "err", err)
+		return
+	}
+	c.tlsServerCert = parsed
+}
+
+// wrapTLSConfigForCertCapture returns a clone of base whose certificate
+// selection paths (GetCertificate and GetConfigForClient) are instrumented
+// to invoke capture with the *tls.Certificate that crypto/tls actually
+// presented to the peer. The clone may safely be passed to tls.Server.
+//
+// Why: crypto/tls does not expose the server-presented leaf via
+// (*tls.Conn).ConnectionState(), so a deployment using dynamic cert
+// selection (typical for SNI multi-tenant TLS) cannot recover the cert
+// post-handshake. SCRAM-SHA-256-PLUS channel binding needs that cert
+// (RFC 5929 tls-server-end-point). Capturing during selection is the
+// only stable way to retrieve it.
+//
+// The static Certificates[0] path is intentionally NOT routed through
+// capture here — the caller continues to handle it after the handshake
+// to keep behavior unchanged for the common single-cert deployment.
+//
+// capture is invoked synchronously on the handshake goroutine; the caller
+// must serialize subsequent reads (in this package, capture writes to the
+// owning *Conn which is only read after Handshake returns on the same
+// goroutine).
+func wrapTLSConfigForCertCapture(base *tls.Config, capture func(*tls.Certificate)) *tls.Config {
+	if base == nil || capture == nil {
+		return base
+	}
+	if base.GetCertificate == nil && base.GetConfigForClient == nil {
+		// Pure static deployment — caller's post-handshake fallback
+		// already recovers Certificates[0]. Avoid an unnecessary clone.
+		return base
+	}
+
+	cfg := base.Clone()
+
+	if cfg.GetCertificate != nil {
+		orig := cfg.GetCertificate
+		cfg.GetCertificate = func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := orig(chi)
+			if err == nil && cert != nil {
+				capture(cert)
+			}
+			return cert, err
+		}
+	}
+
+	if cfg.GetConfigForClient != nil {
+		orig := cfg.GetConfigForClient
+		cfg.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+			inner, err := orig(chi)
+			if err != nil {
+				return nil, err
+			}
+			if inner == nil {
+				// crypto/tls falls back to the outer config — already wrapped above.
+				return nil, nil
+			}
+			return wrapInnerCfgForCertCapture(inner, capture), nil
+		}
+	}
+
+	return cfg
+}
+
+// wrapInnerCfgForCertCapture handles the per-handshake *tls.Config returned
+// by a user-supplied GetConfigForClient. crypto/tls uses this returned
+// config for cert selection, so the outer wrapping in
+// wrapTLSConfigForCertCapture does not see the eventual cert — we must
+// wrap the inner config as well.
+func wrapInnerCfgForCertCapture(inner *tls.Config, capture func(*tls.Certificate)) *tls.Config {
+	out := inner.Clone()
+
+	if out.GetCertificate != nil {
+		orig := out.GetCertificate
+		out.GetCertificate = func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := orig(chi)
+			if err == nil && cert != nil {
+				capture(cert)
+			}
+			return cert, err
+		}
+		return out
+	}
+
+	// Inner config has no dynamic getter — crypto/tls will select from
+	// inner.Certificates. Synthesize a GetCertificate that captures the
+	// chosen cert. We replicate crypto/tls's selection rules at a minimum:
+	// honor NameToCertificate if populated, otherwise the first cert that
+	// SupportsCertificate matches, otherwise Certificates[0].
+	if len(out.Certificates) > 0 {
+		out.GetCertificate = func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert := selectCertificate(out, chi)
+			if cert != nil {
+				capture(cert)
+			}
+			return cert, nil
+		}
+	}
+
+	return out
+}
+
+// selectCertificate mirrors the subset of crypto/tls's internal server cert
+// selection we need for inner configs whose user didn't supply a getter.
+// Iterates Certificates picking the first SupportsCertificate match; falls
+// back to Certificates[0] when no match is found, matching crypto/tls
+// behavior. NameToCertificate is intentionally skipped (deprecated in
+// crypto/tls; SupportsCertificate covers the same SNI matching).
+func selectCertificate(cfg *tls.Config, chi *tls.ClientHelloInfo) *tls.Certificate {
+	if len(cfg.Certificates) == 0 {
+		return nil
+	}
+	for i := range cfg.Certificates {
+		cert := &cfg.Certificates[i]
+		if err := chi.SupportsCertificate(cert); err == nil {
+			return cert
+		}
+	}
+	return &cfg.Certificates[0]
+}
+
+// tlsConfigYieldsServerCert reports whether a TLS config will provide a
+// server certificate at handshake time through any supported path:
+// static Certificates, GetCertificate, or GetConfigForClient. Listener
+// init logs a warning when this returns false on a non-nil config so the
+// operator notices the silent SCRAM-SHA-256-PLUS-off state.
+func tlsConfigYieldsServerCert(cfg *tls.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return len(cfg.Certificates) > 0 || cfg.GetCertificate != nil || cfg.GetConfigForClient != nil
+}

--- a/go/common/pgprotocol/server/tls_cert_capture.go
+++ b/go/common/pgprotocol/server/tls_cert_capture.go
@@ -63,6 +63,14 @@ func (c *Conn) captureTLSServerCert(tlsCert *tls.Certificate) {
 // (RFC 5929 tls-server-end-point). Capturing during selection is the
 // only stable way to retrieve it.
 //
+// TODO(go-stdlib): the wrapper-of-getters pattern below — and this
+// whole file — exists only because crypto/tls has no asymmetric
+// counterpart to ConnectionState.PeerCertificates for the local
+// (server) side. The open proposal is golang/go#24673
+// ("crypto/tls: provide a way to access local certificate used to
+// set up a connection"). Delete this file when that lands and read
+// the leaf directly from (*tls.Conn).ConnectionState().
+//
 // The static Certificates[0] path is intentionally NOT routed through
 // capture here — the caller continues to handle it after the handshake
 // to keep behavior unchanged for the common single-cert deployment.
@@ -118,6 +126,14 @@ func wrapTLSConfigForCertCapture(base *tls.Config, capture func(*tls.Certificate
 // wrapTLSConfigForCertCapture does not see the eventual cert — we must
 // wrap the inner config as well.
 func wrapInnerCfgForCertCapture(inner *tls.Config, capture func(*tls.Certificate)) *tls.Config {
+	// Skip cloning when neither cert-selection path is populated — the
+	// clone would be returned unmodified and crypto/tls would still fall
+	// back to the outer (already-wrapped) config. Parallels the static
+	// short-circuit in wrapTLSConfigForCertCapture.
+	if inner.GetCertificate == nil && len(inner.Certificates) == 0 {
+		return inner
+	}
+
 	out := inner.Clone()
 
 	if out.GetCertificate != nil {
@@ -135,16 +151,15 @@ func wrapInnerCfgForCertCapture(inner *tls.Config, capture func(*tls.Certificate
 	// Inner config has no dynamic getter — crypto/tls will select from
 	// inner.Certificates. Synthesize a GetCertificate that captures the
 	// chosen cert. We replicate crypto/tls's selection rules at a minimum:
-	// honor NameToCertificate if populated, otherwise the first cert that
-	// SupportsCertificate matches, otherwise Certificates[0].
-	if len(out.Certificates) > 0 {
-		out.GetCertificate = func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			cert := selectCertificate(out, chi)
-			if cert != nil {
-				capture(cert)
-			}
-			return cert, nil
+	// the first cert that SupportsCertificate matches, otherwise
+	// Certificates[0]. NameToCertificate is intentionally skipped (see
+	// selectCertificate doc-comment).
+	out.GetCertificate = func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cert := selectCertificate(out, chi)
+		if cert != nil {
+			capture(cert)
 		}
+		return cert, nil
 	}
 
 	return out
@@ -156,6 +171,13 @@ func wrapInnerCfgForCertCapture(inner *tls.Config, capture func(*tls.Certificate
 // back to Certificates[0] when no match is found, matching crypto/tls
 // behavior. NameToCertificate is intentionally skipped (deprecated in
 // crypto/tls; SupportsCertificate covers the same SNI matching).
+//
+// This is the most fragile piece of the file: it re-implements stdlib
+// selection rules, so drift in crypto/tls (new TLS version, new
+// SupportsCertificate constraint) would silently break SCRAM-PLUS
+// for the GetConfigForClient-with-static-inner deployment shape.
+// See the TODO on wrapTLSConfigForCertCapture — when golang/go#24673
+// lands, this helper goes away with the rest of the file.
 func selectCertificate(cfg *tls.Config, chi *tls.ClientHelloInfo) *tls.Certificate {
 	if len(cfg.Certificates) == 0 {
 		return nil

--- a/go/common/pgprotocol/server/tls_cert_capture_test.go
+++ b/go/common/pgprotocol/server/tls_cert_capture_test.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// newTestCA generates an ephemeral CA. Returned together so signLeafCert
+// can issue multiple distinct leaves (for SNI dispatch tests) without
+// re-creating trust roots.
+func newTestCA(t *testing.T) (caCert *x509.Certificate, caKey *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "MUL-434 Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return parsed, key
+}
+
+// signLeafCert issues a leaf cert under ca for the given DNS name. Each
+// leaf carries a fresh serial so two leaves under the same CA produce
+// distinguishable channel-binding material.
+func signLeafCert(t *testing.T, ca *x509.Certificate, caKey *rsa.PrivateKey, dnsName string, serial int64) tls.Certificate {
+	t.Helper()
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: dnsName},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{dnsName},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, ca, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  leafKey,
+	}
+}
+
+// runSCRAMPlusServerOnce accepts one connection on ln, drives the SCRAM-
+// SHA-256-PLUS server side via newTestConn + tlsConfig, and forwards the
+// startup result to errCh. Mirrors the pattern used by ssl_scram_plus_test.
+func runSCRAMPlusServerOnce(t *testing.T, ln net.Listener, tlsConfig *tls.Config, errCh chan<- error) {
+	t.Helper()
+	go func() {
+		netConn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		errCh <- c.handleStartup()
+	}()
+}
+
+// TestSSL_SCRAMPlus_GetCertificatePath verifies that when the listener's
+// tls.Config uses GetCertificate (no static Certificates), the wrapper
+// captures the chosen leaf and SCRAM-SHA-256-PLUS advertises and completes
+// end-to-end. Regression target for MUL-434: prior to the wrapper,
+// c.tlsServerCert stayed nil and PLUS silently fell back to base SCRAM.
+func TestSSL_SCRAMPlus_GetCertificatePath(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	leaf := signLeafCert(t, ca, caKey, "localhost", 2)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca)
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &leaf, nil
+		},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	runSCRAMPlusServerOnce(t, ln, tlsConfig, errCh)
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	scramPlusClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestSSL_SCRAMPlus_GetConfigForClientPath covers the dynamic-config
+// branch: the listener's tls.Config has GetConfigForClient returning a
+// per-handshake *tls.Config that itself only carries static Certificates.
+// crypto/tls runs cert selection against the inner config, so the outer
+// wrapper alone wouldn't see the chosen cert — this exercises
+// wrapInnerCfgForCertCapture.
+func TestSSL_SCRAMPlus_GetConfigForClientPath(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	leaf := signLeafCert(t, ca, caKey, "localhost", 3)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca)
+
+	innerCfg := &tls.Config{
+		Certificates: []tls.Certificate{leaf},
+		MinVersion:   tls.VersionTLS12,
+	}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+			return innerCfg, nil
+		},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	errCh := make(chan error, 1)
+	runSCRAMPlusServerOnce(t, ln, tlsConfig, errCh)
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	writeSSLRequest(t, clientConn)
+	require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+	tlsClientConn := tls.Client(clientConn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	require.NoError(t, tlsClientConn.Handshake())
+
+	writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "tlsuser",
+		"database": "tlsdb",
+	})
+	scramPlusClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestSSL_SCRAMPlus_SNIDispatch_DistinctCBindPerConn drives two sequential
+// connections at the same listener with different SNI names; each conn
+// must receive the cert matching its SNI, and the SCRAM-PLUS channel
+// binding hash therefore differs per conn. Verifies that
+// captureTLSServerCert records the right leaf per handshake rather than
+// pinning to a single listener-wide cert.
+func TestSSL_SCRAMPlus_SNIDispatch_DistinctCBindPerConn(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	certA := signLeafCert(t, ca, caKey, "tenant-a.localhost", 10)
+	certB := signLeafCert(t, ca, caKey, "tenant-b.localhost", 11)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(ca)
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			switch chi.ServerName {
+			case "tenant-a.localhost":
+				return &certA, nil
+			case "tenant-b.localhost":
+				return &certB, nil
+			default:
+				return &certA, nil
+			}
+		},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	serials := make(map[string]*big.Int)
+	for _, sni := range []string{"tenant-a.localhost", "tenant-b.localhost"} {
+		errCh := make(chan error, 1)
+		runSCRAMPlusServerOnce(t, ln, tlsConfig, errCh)
+
+		clientConn, err := net.Dial("tcp", ln.Addr().String())
+		require.NoError(t, err)
+
+		writeSSLRequest(t, clientConn)
+		require.Equal(t, byte('S'), readSingleByte(t, clientConn))
+
+		tlsClientConn := tls.Client(clientConn, &tls.Config{
+			RootCAs:    caPool,
+			ServerName: sni,
+			MinVersion: tls.VersionTLS12,
+		})
+		require.NoError(t, tlsClientConn.Handshake())
+
+		// Capture the cert SNI selected. SCRAM-PLUS will use this same
+		// cert's tls-server-end-point hash; scramPlusClientHelper below
+		// would fail if the server-side capture wired up a different leaf.
+		peerCerts := tlsClientConn.ConnectionState().PeerCertificates
+		require.NotEmpty(t, peerCerts)
+		serials[sni] = peerCerts[0].SerialNumber
+
+		writeStartupPacketToPipe(t, tlsClientConn, protocol.ProtocolVersionNumber, map[string]string{
+			"user":     "tlsuser",
+			"database": "tlsdb",
+		})
+		scramPlusClientHelper(t, tlsClientConn, "tlsuser", "postgres")
+		require.NoError(t, <-errCh)
+		_ = clientConn.Close()
+	}
+
+	require.Len(t, serials, 2)
+	require.Equal(t, big.NewInt(10), serials["tenant-a.localhost"])
+	require.Equal(t, big.NewInt(11), serials["tenant-b.localhost"])
+	assert.NotEqual(t, serials["tenant-a.localhost"].String(), serials["tenant-b.localhost"].String(),
+		"each SNI must surface a distinct leaf cert")
+}
+
+// TestTLSConfigYieldsServerCert covers the listener init warning logic.
+// Each path that ought to yield a cert is recognized; the empty case
+// (which would silently disable SCRAM-SHA-256-PLUS) is flagged.
+func TestTLSConfigYieldsServerCert(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *tls.Config
+		want bool
+	}{
+		{name: "nil", cfg: nil, want: false},
+		{name: "empty", cfg: &tls.Config{MinVersion: tls.VersionTLS12}, want: false},
+		{
+			name: "static_certs",
+			cfg:  &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{{}}},
+			want: true,
+		},
+		{
+			name: "get_certificate",
+			cfg: &tls.Config{MinVersion: tls.VersionTLS12, GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return nil, nil
+			}},
+			want: true,
+		},
+		{
+			name: "get_config_for_client",
+			cfg: &tls.Config{MinVersion: tls.VersionTLS12, GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+				return nil, nil
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tlsConfigYieldsServerCert(tt.cfg))
+		})
+	}
+}
+
+// TestWrapTLSConfigForCertCapture_StaticPathBypasses asserts the helper
+// returns the same *tls.Config (not a clone) when no dynamic getter is
+// set. The static path is handled by handleSSLRequest's post-handshake
+// Certificates[0] fallback; cloning would be wasted work on the hot path.
+func TestWrapTLSConfigForCertCapture_StaticPathBypasses(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{{}}}
+	got := wrapTLSConfigForCertCapture(cfg, func(*tls.Certificate) {})
+	assert.Same(t, cfg, got, "static-only config must not be cloned")
+}
+
+// TestWrapTLSConfigForCertCapture_NilInputs guards the early returns:
+// nil base or nil capture must be no-op regardless.
+func TestWrapTLSConfigForCertCapture_NilInputs(t *testing.T) {
+	assert.Nil(t, wrapTLSConfigForCertCapture(nil, func(*tls.Certificate) {}))
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12, GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return nil, nil
+	}}
+	assert.Same(t, cfg, wrapTLSConfigForCertCapture(cfg, nil),
+		"nil capture must return base unchanged")
+}

--- a/go/common/pgprotocol/server/tls_cert_capture_test.go
+++ b/go/common/pgprotocol/server/tls_cert_capture_test.go
@@ -15,13 +15,17 @@
 package server
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
+	"log/slog"
 	"math/big"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -325,4 +329,187 @@ func TestWrapTLSConfigForCertCapture_NilInputs(t *testing.T) {
 	}}
 	assert.Same(t, cfg, wrapTLSConfigForCertCapture(cfg, nil),
 		"nil capture must return base unchanged")
+}
+
+// minimalCaptureConn returns a Conn populated only with what
+// captureTLSServerCert touches (logger + the tlsServerCert writeback).
+// Avoids spinning a listener for pure-helper unit coverage.
+func minimalCaptureConn(t *testing.T) *Conn {
+	t.Helper()
+	return &Conn{logger: testLogger(t)}
+}
+
+// TestCaptureTLSServerCert_NilArgIsNoop ensures the helper tolerates the
+// crypto/tls case where selection returned (nil, nil); we must not panic
+// nor store anything.
+func TestCaptureTLSServerCert_NilArgIsNoop(t *testing.T) {
+	c := minimalCaptureConn(t)
+	c.captureTLSServerCert(nil)
+	assert.Nil(t, c.tlsServerCert)
+}
+
+// TestCaptureTLSServerCert_PrefersLeafField verifies the fast path:
+// callers that pre-parse and set tls.Certificate.Leaf skip x509 parsing.
+func TestCaptureTLSServerCert_PrefersLeafField(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	leaf := signLeafCert(t, ca, caKey, "localhost", 42)
+	parsed, err := x509.ParseCertificate(leaf.Certificate[0])
+	require.NoError(t, err)
+	leaf.Leaf = parsed
+	// Clobber DER so a parse-fallback would fail; this proves Leaf is used.
+	leaf.Certificate = [][]byte{{0x00}}
+
+	c := minimalCaptureConn(t)
+	c.captureTLSServerCert(&leaf)
+	require.NotNil(t, c.tlsServerCert)
+	assert.Equal(t, big.NewInt(42), c.tlsServerCert.SerialNumber)
+}
+
+// TestCaptureTLSServerCert_EmptyCertificateBytes covers the guard before
+// x509.ParseCertificate: an empty Certificate slice with nil Leaf must
+// leave tlsServerCert nil rather than indexing into an empty slice.
+func TestCaptureTLSServerCert_EmptyCertificateBytes(t *testing.T) {
+	c := minimalCaptureConn(t)
+	c.captureTLSServerCert(&tls.Certificate{})
+	assert.Nil(t, c.tlsServerCert)
+}
+
+// TestCaptureTLSServerCert_ParseErrorIsNonFatal covers the warn-and-leave-nil
+// branch: garbage DER must not crash and must not be stored. SCRAM falls
+// back to non-PLUS in this case.
+func TestCaptureTLSServerCert_ParseErrorIsNonFatal(t *testing.T) {
+	c := minimalCaptureConn(t)
+	c.captureTLSServerCert(&tls.Certificate{Certificate: [][]byte{{0x00, 0x01, 0x02}}})
+	assert.Nil(t, c.tlsServerCert)
+}
+
+// TestWrapTLSConfigForCertCapture_GetConfigForClientError forwards the
+// user-supplied getter's error verbatim without invoking capture.
+func TestWrapTLSConfigForCertCapture_GetConfigForClientError(t *testing.T) {
+	sentinel := errors.New("boom")
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			return nil, sentinel
+		},
+	}
+	called := false
+	wrapped := wrapTLSConfigForCertCapture(cfg, func(*tls.Certificate) { called = true })
+	inner, err := wrapped.GetConfigForClient(&tls.ClientHelloInfo{})
+	assert.Nil(t, inner)
+	assert.ErrorIs(t, err, sentinel)
+	assert.False(t, called, "capture must not run when getter errors")
+}
+
+// TestWrapTLSConfigForCertCapture_GetConfigForClientNilInner covers the
+// crypto/tls "fall back to outer config" contract: returning nil from
+// GetConfigForClient must propagate untouched (outer config is already
+// wrapped, so re-wrapping would double-invoke capture).
+func TestWrapTLSConfigForCertCapture_GetConfigForClientNilInner(t *testing.T) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			return nil, nil
+		},
+	}
+	wrapped := wrapTLSConfigForCertCapture(cfg, func(*tls.Certificate) {})
+	inner, err := wrapped.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	assert.Nil(t, inner)
+}
+
+// TestWrapInnerCfgForCertCapture_InnerHasGetCertificate covers the inner
+// dynamic-getter branch: when GetConfigForClient returns a config that
+// itself has GetCertificate, that getter is the one crypto/tls uses, so
+// it must be wrapped to invoke capture.
+func TestWrapInnerCfgForCertCapture_InnerHasGetCertificate(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	leaf := signLeafCert(t, ca, caKey, "localhost", 100)
+
+	var captured *tls.Certificate
+	inner := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &leaf, nil
+		},
+	}
+
+	wrapped := wrapInnerCfgForCertCapture(inner, func(c *tls.Certificate) { captured = c })
+	require.NotSame(t, inner, wrapped, "inner must be cloned before mutating GetCertificate")
+	got, err := wrapped.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Same(t, &leaf, captured, "capture must receive the cert that crypto/tls would present")
+}
+
+// TestWrapInnerCfgForCertCapture_InnerGetCertificateError surfaces the
+// user-supplied getter's error without capturing.
+func TestWrapInnerCfgForCertCapture_InnerGetCertificateError(t *testing.T) {
+	sentinel := errors.New("inner-boom")
+	inner := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return nil, sentinel
+		},
+	}
+	called := false
+	wrapped := wrapInnerCfgForCertCapture(inner, func(*tls.Certificate) { called = true })
+	got, err := wrapped.GetCertificate(&tls.ClientHelloInfo{})
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, sentinel)
+	assert.False(t, called, "capture must not run when getter errors")
+}
+
+// TestSelectCertificate_EmptyList covers the early return for a config
+// with no Certificates — should be nil, not a panic from indexing.
+func TestSelectCertificate_EmptyList(t *testing.T) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	assert.Nil(t, selectCertificate(cfg, &tls.ClientHelloInfo{}))
+}
+
+// TestSelectCertificate_FallsBackToFirst covers the final return when
+// SupportsCertificate matches no entry. Mirrors crypto/tls's behavior of
+// using Certificates[0] as a last resort. The ClientHelloInfo here names
+// an SNI neither leaf supports, so both SupportsCertificate calls fail.
+func TestSelectCertificate_FallsBackToFirst(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	leafA := signLeafCert(t, ca, caKey, "tenant-a.localhost", 50)
+	leafB := signLeafCert(t, ca, caKey, "tenant-b.localhost", 51)
+	cfg := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{leafA, leafB},
+	}
+
+	chi := &tls.ClientHelloInfo{
+		ServerName:        "mismatch.localhost",
+		CipherSuites:      []uint16{tls.TLS_AES_128_GCM_SHA256},
+		SupportedVersions: []uint16{tls.VersionTLS13},
+	}
+	got := selectCertificate(cfg, chi)
+	require.NotNil(t, got)
+	assert.Same(t, &cfg.Certificates[0], got, "fallback must be Certificates[0]")
+}
+
+// TestNewListener_WarnsWhenTLSConfigYieldsNoCert exercises the listener-
+// init warn path: a non-nil TLSConfig with no cert source would silently
+// disable SCRAM-SHA-256-PLUS and break handshakes at runtime, so init
+// must emit a Warn record. Captures the slog text output and asserts on
+// the marker phrase.
+func TestNewListener_WarnsWhenTLSConfigYieldsNoCert(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	listener, err := NewListener(ListenerConfig{
+		Address:            "localhost:0",
+		Handler:            &mockHandler{},
+		CredentialProvider: newMockCredentialProvider("postgres"),
+		Logger:             logger,
+		TLSConfig:          &tls.Config{MinVersion: tls.VersionTLS12}, // no Certificates, no getters
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	out := buf.String()
+	assert.True(t, strings.Contains(out, "SCRAM-SHA-256-PLUS will not be advertised"),
+		"expected warn about disabled SCRAM-PLUS; got: %s", out)
 }

--- a/go/common/pgprotocol/server/tls_cert_capture_test.go
+++ b/go/common/pgprotocol/server/tls_cert_capture_test.go
@@ -418,6 +418,17 @@ func TestWrapTLSConfigForCertCapture_GetConfigForClientNilInner(t *testing.T) {
 	assert.Nil(t, inner)
 }
 
+// TestWrapInnerCfgForCertCapture_NoGetterNoCertsBypasses asserts the
+// short-circuit: an inner config with neither GetCertificate nor any
+// Certificates is returned unchanged (no clone). crypto/tls falls back
+// to the outer config in this case, which is already wrapped by
+// wrapTLSConfigForCertCapture.
+func TestWrapInnerCfgForCertCapture_NoGetterNoCertsBypasses(t *testing.T) {
+	inner := &tls.Config{MinVersion: tls.VersionTLS12}
+	got := wrapInnerCfgForCertCapture(inner, func(*tls.Certificate) {})
+	assert.Same(t, inner, got, "empty inner config must not be cloned")
+}
+
 // TestWrapInnerCfgForCertCapture_InnerHasGetCertificate covers the inner
 // dynamic-getter branch: when GetConfigForClient returns a config that
 // itself has GetCertificate, that getter is the one crypto/tls uses, so


### PR DESCRIPTION
## Summary

- Capture the leaf certificate that crypto/tls actually presents during the handshake so SCRAM-SHA-256-PLUS channel binding works under dynamic-cert deployments (SNI multi-tenant edges).
- Wrap the listener's `tls.Config` to instrument `GetCertificate` and `GetConfigForClient`; static `Certificates[0]` deployments keep the existing post-handshake recovery and skip the wrapper.
- Warn at listener init when a non-nil `TLSConfig` yields no cert via any path, so the silent PLUS-off state is visible to operators.
- Cover the new paths end-to-end: GetCertificate, GetConfigForClient (including the per-handshake inner config), SNI dispatch with distinct leaves, predicate, static bypass, nil guards.

## Problem

SCRAM-SHA-256-PLUS (RFC 5929 `tls-server-end-point`) requires the server leaf certificate that was actually presented to the client. Prior to this change the server recovered it from `tlsConfig.Certificates[0]` after the handshake, which only works for static-cert deployments. Any deployment using `tls.Config.GetCertificate` or `GetConfigForClient` — the typical pattern for SNI-based multi-tenant TLS — left `tlsServerCert` nil and silently fell back to base SCRAM-SHA-256 even though TLS was negotiated. crypto/tls does not expose the server-presented leaf via `(*tls.Conn).ConnectionState()`, so there is no post-handshake way to recover it.

## Solution

Wrap the listener's `tls.Config` before calling `tls.Server` so the dynamic cert-selection paths invoke a capture hook with the `*tls.Certificate` crypto/tls is about to present. The captured leaf is stored on the `Conn` for the SCRAM advertisement that follows on the same goroutine, so no synchronization is required.

`GetConfigForClient` is handled by also wrapping the per-handshake inner `*tls.Config` it returns, since crypto/tls runs cert selection against that inner config. When the inner config carries only static `Certificates`, a synthetic `GetCertificate` is installed that mirrors crypto/tls's `SupportsCertificate`-based SNI matching so the chosen leaf is captured.

The static-only path is left untouched — the wrapper short-circuits and returns the original config without cloning, and the post-handshake `Certificates[0]` recovery still runs (now gated on `tlsServerCert == nil` so the dynamic path takes precedence when it has already captured).

Listener init validates that a non-nil `TLSConfig` will yield a server certificate via at least one supported path; otherwise it logs a warning, because the handshake would fail at runtime and PLUS would be silently disabled without one.