### PR TITLE
feat(consensus): record outgoing rule in TermRevocation

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -69,18 +69,62 @@ func MostAdvancedPosition(statuses []*clustermetadatapb.ConsensusStatus) *cluste
 		if _, err := pgutil.ParseLSN(pos.GetLsn()); err != nil {
 			continue
 		}
-		if best == nil || comparePosition(pos, best) > 0 {
+		if best == nil || ComparePosition(pos, best) > 0 {
 			best = pos
 		}
 	}
 	return best
 }
 
-// comparePosition returns negative, zero, or positive based on whether a is
+// ReplicationPrimaryMatches reports whether a pooler's published
+// ReplicationPrimary already names target as its primary at a rule no older
+// than targetRule. Coordinators use this to skip Inform RPCs that wouldn't
+// change anything on the pooler.
+//
+// Returns false when:
+//   - rp is nil
+//   - the published rule is strictly older than targetRule
+//   - the published primary is missing
+//   - the published primary's (id, hostname, postgres port) differs from
+//     target's
+//
+// target and targetRule are required; passing nil for either returns false.
+// Only the contact-info fields of MultiPooler are compared — pooler type,
+// serving status, and other operational state are ignored.
+func ReplicationPrimaryMatches(rp *clustermetadatapb.ReplicationPrimary, target *clustermetadatapb.MultiPooler, targetRule *clustermetadatapb.ShardRule) bool {
+	if rp == nil || target == nil || targetRule == nil {
+		return false
+	}
+	if CompareRuleNumbers(rp.GetRule().GetRuleNumber(), targetRule.GetRuleNumber()) < 0 {
+		return false
+	}
+	rpPrimary := rp.GetPrimary()
+	if rpPrimary == nil {
+		return false
+	}
+	if !idsEqual(rpPrimary.GetId(), target.GetId()) {
+		return false
+	}
+	if rpPrimary.GetHostname() != target.GetHostname() {
+		return false
+	}
+	if rpPrimary.GetPortMap()["postgres"] != target.GetPortMap()["postgres"] {
+		return false
+	}
+	return true
+}
+
+func idsEqual(a, b *clustermetadatapb.ID) bool {
+	return a.GetComponent() == b.GetComponent() &&
+		a.GetCell() == b.GetCell() &&
+		a.GetName() == b.GetName()
+}
+
+// ComparePosition returns negative, zero, or positive based on whether a is
 // behind, equal to, or ahead of b. Rule number takes precedence; LSN breaks
 // ties within the same rule. A missing or unparsable LSN is treated as less
 // than any valid LSN.
-func comparePosition(a, b *clustermetadatapb.PoolerPosition) int {
+func ComparePosition(a, b *clustermetadatapb.PoolerPosition) int {
 	if cmp := CompareRuleNumbers(a.GetRule().GetRuleNumber(), b.GetRule().GetRuleNumber()); cmp != 0 {
 		return cmp
 	}

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -56,6 +56,153 @@ func TestCompareRuleNumbers(t *testing.T) {
 	}
 }
 
+func TestMostAdvancedPosition(t *testing.T) {
+	mkID := func(name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Name:      name,
+		}
+	}
+	status := func(name string, p *clustermetadatapb.PoolerPosition) *clustermetadatapb.ConsensusStatus {
+		return &clustermetadatapb.ConsensusStatus{Id: mkID(name), CurrentPosition: p}
+	}
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		got := MostAdvancedPosition(nil)
+		assert.Nil(t, got)
+	})
+
+	t.Run("all statuses have unparsable LSN: returns nil", func(t *testing.T) {
+		got := MostAdvancedPosition([]*clustermetadatapb.ConsensusStatus{
+			status("a", pos(3, "")),
+			status("b", pos(3, "bad-lsn")),
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("highest rule wins regardless of LSN", func(t *testing.T) {
+		got := MostAdvancedPosition([]*clustermetadatapb.ConsensusStatus{
+			status("a", pos(2, "0/9000000")),
+			status("b", pos(4, "0/100")),
+			status("c", pos(3, "0/500000")),
+		})
+		assert.Equal(t, int64(4), got.GetRule().GetRuleNumber().GetCoordinatorTerm())
+		assert.Equal(t, "0/100", got.GetLsn())
+	})
+
+	t.Run("same rule highest LSN wins", func(t *testing.T) {
+		got := MostAdvancedPosition([]*clustermetadatapb.ConsensusStatus{
+			status("a", pos(3, "0/100")),
+			status("b", pos(3, "0/300")),
+			status("c", pos(3, "0/200")),
+		})
+		assert.Equal(t, "0/300", got.GetLsn())
+	})
+
+	t.Run("skips statuses with unparsable LSN", func(t *testing.T) {
+		got := MostAdvancedPosition([]*clustermetadatapb.ConsensusStatus{
+			status("a", pos(5, "bad-lsn")),
+			status("b", pos(3, "0/100")),
+		})
+		// pooler-a's rule is higher (5) but its LSN is unparsable, so it's
+		// filtered out and pooler-b wins despite the lower rule.
+		assert.Equal(t, int64(3), got.GetRule().GetRuleNumber().GetCoordinatorTerm())
+		assert.Equal(t, "0/100", got.GetLsn())
+	})
+}
+
+func TestReplicationPrimaryMatches(t *testing.T) {
+	mkID := func(name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Name:      name,
+		}
+	}
+	mkPooler := func(name, host string, pgPort int32) *clustermetadatapb.MultiPooler {
+		return &clustermetadatapb.MultiPooler{
+			Id:       mkID(name),
+			Hostname: host,
+			PortMap:  map[string]int32{"postgres": pgPort, "grpc": 9000},
+		}
+	}
+	mkRule := func(term int64) *clustermetadatapb.ShardRule {
+		return &clustermetadatapb.ShardRule{RuleNumber: rn(term, 0)}
+	}
+	mkRP := func(rule *clustermetadatapb.ShardRule, primary *clustermetadatapb.MultiPooler) *clustermetadatapb.ReplicationPrimary {
+		return &clustermetadatapb.ReplicationPrimary{Rule: rule, Primary: primary}
+	}
+
+	target := mkPooler("primary-1", "host-a", 5432)
+	targetRule := mkRule(3)
+
+	t.Run("nil rp returns false", func(t *testing.T) {
+		assert.False(t, ReplicationPrimaryMatches(nil, target, targetRule))
+	})
+
+	t.Run("nil target returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, target)
+		assert.False(t, ReplicationPrimaryMatches(rp, nil, targetRule))
+	})
+
+	t.Run("nil targetRule returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, target)
+		assert.False(t, ReplicationPrimaryMatches(rp, target, nil))
+	})
+
+	t.Run("published rule older than targetRule returns false", func(t *testing.T) {
+		rp := mkRP(mkRule(2), target)
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("published primary missing returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, nil)
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("primary id mismatch returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, mkPooler("primary-2", "host-a", 5432))
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("primary id different cell returns false", func(t *testing.T) {
+		other := mkPooler("primary-1", "host-a", 5432)
+		other.Id.Cell = "zone2"
+		rp := mkRP(targetRule, other)
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("primary id different component returns false", func(t *testing.T) {
+		other := mkPooler("primary-1", "host-a", 5432)
+		other.Id.Component = clustermetadatapb.ID_MULTIGATEWAY
+		rp := mkRP(targetRule, other)
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("primary hostname mismatch returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, mkPooler("primary-1", "host-b", 5432))
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("primary port mismatch returns false", func(t *testing.T) {
+		rp := mkRP(targetRule, mkPooler("primary-1", "host-a", 5433))
+		assert.False(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("exact match returns true", func(t *testing.T) {
+		rp := mkRP(targetRule, target)
+		assert.True(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+
+	t.Run("published rule newer than targetRule still matches", func(t *testing.T) {
+		// Coordinator's targetRule may lag the pooler's published rule —
+		// "no older than" means published >= target.
+		rp := mkRP(mkRule(5), target)
+		assert.True(t, ReplicationPrimaryMatches(rp, target, targetRule))
+	})
+}
+
 func TestComparePosition(t *testing.T) {
 	tests := []struct {
 		name string
@@ -88,7 +235,7 @@ func TestComparePosition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := comparePosition(tt.a, tt.b)
+			got := ComparePosition(tt.a, tt.b)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -194,8 +194,9 @@ func CheckExternallyCertifiedProposalPossible(
 // recruited members, ensuring the new cluster can make durable writes.
 //
 // Two additional checks enforce the cert's guarantees:
-//   - No recruited node may have a rule beyond cert.outgoing_rule_number; if
-//     one does, the outgoing cohort was not actually frozen at the certified point.
+//   - No recruited node may have a rule beyond revocation.outgoing_rule; if
+//     one does, the outgoing cohort was not actually frozen at the certified
+//     point. (Enforced inside buildProposalCore.)
 //   - Only nodes with an LSN at or above cert.frozen_lsn are eligible to be
 //     leader. Nodes below that threshold still count toward quorum — they can
 //     endorse the proposal — but cannot be selected as the new leader.
@@ -224,40 +225,33 @@ func BuildExternallyCertifiedProposal(
 // cert.frozen_lsn as a floor on leader eligibility, then delegates the
 // most-advanced-LSN tie-break to discoverMostAdvancedTimeline.
 //
-// Both outgoing_rule_number and frozen_lsn are required on the cert: without
-// them, the cert provides no real guarantee about what the outgoing cohort
-// was frozen at. Bootstrap callers must set them explicitly (e.g. term 0
-// and "0/0"). The factory also rejects the cert if any of the given nodes
-// has advanced past cert.outgoing_rule_number — the cert is stale or wrong
-// in that case, and the factory surfaces it as a specific error rather than
-// returning a discoverer that would yield "no eligible leaders".
+// frozen_lsn is required on the cert: without it, the cert provides no real
+// guarantee about what the outgoing cohort was frozen at. Bootstrap callers
+// must set it explicitly (e.g. "0/0"). The outgoing rule itself comes from
+// cert.term_revocation.outgoing_rule, and buildProposalCore enforces that no
+// recruit reports a strictly newer rule — surfaced as a specific error rather
+// than returning a discoverer that would yield "no eligible leaders".
 //
 // Safety contract: the cert externally certifies that no durable writes
-// occurred beyond frozen_lsn under cert.outgoing_rule_number. Any node whose
-// LSN ≥ frozen_lsn therefore holds every committed transaction up to that
-// frozen point — which is why buildProposalCore is safe to skip the
+// occurred beyond frozen_lsn under term_revocation.outgoing_rule. Any node
+// whose LSN ≥ frozen_lsn therefore holds every committed transaction up to
+// that frozen point — which is why buildProposalCore is safe to skip the
 // outgoing-cohort quorum check for this discoverer (onlyRequireIncomingQuorum).
 func newExternallyCertifiedDiscoverer(
 	cert *clustermetadatapb.ExternallyCertifiedRevocation,
 	nodes []*clustermetadatapb.ConsensusStatus,
 ) (discoverer, error) {
-	certRule := cert.GetOutgoingRuleNumber()
-	if certRule == nil {
-		return nil, errors.New("cert is missing outgoing_rule_number")
+	if cert.GetTermRevocation().GetOutgoingRule() == nil {
+		return nil, errors.New("cert.term_revocation.outgoing_rule is required")
 	}
 	if cert.GetFrozenLsn() == "" {
 		return nil, errors.New("cert is missing frozen_lsn")
 	}
 	for _, cs := range nodes {
-		rule := cs.GetCurrentPosition().GetRule()
-		if rule == nil {
+		if cs.GetCurrentPosition().GetRule() == nil {
 			// Recruited nodes should always carry a rule.
 			return nil, fmt.Errorf("node %s has no recorded rule; consensus state may be uninitialized",
 				topoclient.ClusterIDString(cs.GetId()))
-		}
-		if CompareRuleNumbers(rule.GetRuleNumber(), certRule) > 0 {
-			return nil, fmt.Errorf("node %s is at rule term %d but certified outgoing rule is term %d",
-				topoclient.ClusterIDString(cs.GetId()), rule.GetRuleNumber().GetCoordinatorTerm(), certRule.GetCoordinatorTerm())
 		}
 	}
 	minLSN, err := pgutil.ParseLSN(cert.GetFrozenLsn())
@@ -301,12 +295,31 @@ func buildProposalCore(
 		return nil, errors.New("all recruited nodes reported an invalid or missing WAL position")
 	}
 
-	// Find the best recorded rule (highest RuleNumber) across all statuses,
-	// from their WAL-backed current_position.rule.
+	// The revocation's outgoing_rule is the rule the coordinator committed to
+	// transitioning from when it authored the revocation. Bind this proposal
+	// to that view: no recruit may report a strictly newer rule, and we look
+	// up the full ShardRule (cohort_members + durability_policy) by matching
+	// a recruit whose rule number equals it.
+	expectedOutgoing := revocation.GetOutgoingRule()
+	if expectedOutgoing == nil {
+		return nil, errors.New("revocation.outgoing_rule is required (use NewTermRevocation to construct revocations)")
+	}
 	var outgoingRule *clustermetadatapb.ShardRule
 	for _, cs := range recruitedStatuses {
 		rule := cs.GetCurrentPosition().GetRule()
-		if rule != nil && (outgoingRule == nil || CompareRuleNumbers(rule.GetRuleNumber(), outgoingRule.GetRuleNumber()) > 0) {
+		if rule == nil {
+			continue
+		}
+		cmp := CompareRuleNumbers(rule.GetRuleNumber(), expectedOutgoing)
+		if cmp > 0 {
+			return nil, fmt.Errorf(
+				"recruit %s reports rule %v strictly greater than revocation.outgoing_rule %v; coordinator view is stale, re-discover",
+				topoclient.ClusterIDString(cs.GetId()),
+				rule.GetRuleNumber(),
+				expectedOutgoing,
+			)
+		}
+		if cmp == 0 && outgoingRule == nil {
 			outgoingRule = rule
 		}
 	}
@@ -315,9 +328,14 @@ func buildProposalCore(
 	case requireTransitionQuorum:
 		// Validate revocation of the outgoing cohort: no parallel quorum can still
 		// form among the non-recruited nodes. outgoingRule must be known to identify
-		// the cohort.
+		// the cohort. A nil here means no recruit reported a rule matching the
+		// coordinator's expected outgoing rule — the cohort has progressed past
+		// our view (or never reached it), and we need to re-discover.
 		if outgoingRule == nil {
-			return nil, errors.New("no recorded rule found among recruited nodes; cannot determine cohort for quorum check")
+			return nil, fmt.Errorf(
+				"no recruit reports the expected outgoing rule %v; cannot determine cohort for quorum check",
+				expectedOutgoing,
+			)
 		}
 		outgoingPolicy, err := NewPolicyFromProto(outgoingRule.GetDurabilityPolicy())
 		if err != nil {
@@ -525,7 +543,7 @@ func deduplicateStatuses(statuses []*clustermetadatapb.ConsensusStatus) []*clust
 			continue
 		}
 		key := topoclient.ClusterIDString(cs.GetId())
-		if prev, exists := best[key]; !exists || comparePosition(cs.GetCurrentPosition(), prev.GetCurrentPosition()) > 0 {
+		if prev, exists := best[key]; !exists || ComparePosition(cs.GetCurrentPosition(), prev.GetCurrentPosition()) > 0 {
 			best[key] = cs
 		}
 	}

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -107,19 +107,26 @@ func proposeFirstEligible(rule *clustermetadatapb.ShardRule) func(RecruitmentRes
 	}
 }
 
-// revocation builds a *TermRevocation at the given term. Use inline so each
-// test makes its term explicit.
-func revocation(term int64) *clustermetadatapb.TermRevocation {
-	return &clustermetadatapb.TermRevocation{RevokedBelowTerm: term}
+// revocation builds a *TermRevocation at the given term with the given
+// outgoing rule. Use inline so each test makes its term and outgoing rule
+// explicit. Pass &clustermetadatapb.RuleNumber{} for the "no prior rule" case.
+func revocation(term int64, outgoingRule *clustermetadatapb.RuleNumber) *clustermetadatapb.TermRevocation {
+	return &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm: term,
+		OutgoingRule:     outgoingRule,
+	}
 }
 
 // coordRevocation builds a *TermRevocation with coordinator fields populated.
 // Used by tests exercising ValidateRevocation / CheckProposalPossible.
-func coordRevocation(term int64) *clustermetadatapb.TermRevocation {
+// outgoingRule is required; pass &clustermetadatapb.RuleNumber{} for the
+// "no prior rule" case.
+func coordRevocation(term int64, outgoingRule *clustermetadatapb.RuleNumber) *clustermetadatapb.TermRevocation {
 	return &clustermetadatapb.TermRevocation{
 		RevokedBelowTerm:       term,
 		AcceptedCoordinatorId:  makeID("zone1", "coord-1"),
 		CoordinatorInitiatedAt: timestamppb.Now(),
+		OutgoingRule:           outgoingRule,
 	}
 }
 
@@ -188,11 +195,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "all 3 recruited: success, pooler-a is first eligible leader",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantLeader:    "pooler-a",
@@ -204,9 +211,9 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "no current_position: filtered by filterByValidPosition",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					{Id: zone1.a, TermRevocation: revocation(5)}, // no current_position → no LSN
+					{Id: zone1.a, TermRevocation: revocation(5, ruleNum(3, 0))}, // no current_position → no LSN
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "all recruited nodes reported an invalid or missing WAL position",
@@ -219,9 +226,9 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "1 of 3 recruited: insufficient outgoing cohort",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
@@ -234,11 +241,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "callback proposes outsider: not among eligible leaders",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					outsider := makeID("zone1", "outsider")
@@ -258,11 +265,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "proposed cohort has unrecruited member but passes (outsider not recruited, a+b satisfy AT_LEAST_2)",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					outsider := makeID("zone1", "outsider")
@@ -282,10 +289,10 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "2 of 3 recruited, dead leader stays in proposed cohort",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -304,11 +311,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "proposed cohort has new members not recruited",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					d := makeID("zone1", "pooler-d")
@@ -329,11 +336,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "callback returns error",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return nil, errors.New("no suitable candidate")
@@ -348,11 +355,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "callback returns nil proposal",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return nil, nil
@@ -369,11 +376,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "mixed rule numbers: higher rule is outgoing, lagging node excluded from eligibles",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5)), // behind
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0))), // behind
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -397,11 +404,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "proposed cohort too small for AT_LEAST_2",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -420,10 +427,10 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "extra non-cohort node does not inflate outgoing quorum count",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(makeID("zone1", "extra-node"), rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(makeID("zone1", "extra-node"), rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
@@ -436,11 +443,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "LSN tiebreaker: highest LSN is sole eligible leader",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/3000000"), // highest
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"), // highest
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -463,11 +470,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "LSN tie at max: two nodes tied at highest LSN both eligible",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/3000000"), // tied with a
-					makeStatusWithLSN(zone1.c, rule, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/3000000"), // tied with a
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -492,11 +499,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "rule takes priority: node at old rule excluded despite higher LSN",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/5000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.c, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5), "0/4000000"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/5000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.c, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0)), "0/4000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -519,10 +526,10 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "duplicate status: same pooler twice counts once toward quorum",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.a, rule, revocation(5)), // duplicate — must not inflate quorum
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))), // duplicate — must not inflate quorum
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
@@ -537,12 +544,12 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "duplicate: rule number wins over LSN when deduplicating",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/1000000"),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/1000000"),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantLeader:    "pooler-a",
@@ -559,11 +566,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "all accepted nodes have empty LSN: invalid WAL position",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), ""),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), ""),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), ""),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), ""),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), ""),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), ""),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "all recruited nodes reported an invalid or missing WAL position",
@@ -576,11 +583,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "all accepted nodes have unparsable LSN: invalid WAL position",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "not-an-lsn"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "not-an-lsn"),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), "not-an-lsn"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "not-an-lsn"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "not-an-lsn"),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), "not-an-lsn"),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "all recruited nodes reported an invalid or missing WAL position",
@@ -593,11 +600,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "node with invalid LSN excluded: remaining 2 satisfy AT_LEAST_2",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), ""),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), ""),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantLeader:    "pooler-a",
@@ -610,11 +617,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "invalid LSN causes quorum failure: 1 valid of 3",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), ""),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), "not-an-lsn"),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), ""),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), "not-an-lsn"),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
@@ -627,11 +634,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "node with invalid LSN cannot be proposed as leader",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, rule, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, rule, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.c, rule, revocation(5), ""),
+					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, rule, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.c, rule, revocation(5, ruleNum(3, 0)), ""),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -652,10 +659,10 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "cohort expansion: only 2 of 5 new-cohort members respond",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(4, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.d, rule, revocation(5), "0/4000000"),
-					makeStatusWithLSN(zone1.e, rule, revocation(5), "0/4000000"),
+					makeStatusWithLSN(zone1.d, rule, revocation(5, ruleNum(4, 0)), "0/4000000"),
+					makeStatusWithLSN(zone1.e, rule, revocation(5, ruleNum(4, 0)), "0/4000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -678,11 +685,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "outgoing rule has unknown quorum type: failed to parse",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, unknownRule, revocation(5)),
-					makeStatus(zone1.b, unknownRule, revocation(5)),
-					makeStatus(zone1.c, unknownRule, revocation(5)),
+					makeStatus(zone1.a, unknownRule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, unknownRule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, unknownRule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
 				wantErr:       "failed to parse durability policy from rule: unsupported quorum type: QUORUM_TYPE_UNKNOWN",
@@ -694,13 +701,13 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "outgoing mode, no recorded rule among recruited nodes",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, nil, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.b, nil, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.b, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)),
-				wantErr:       "no recorded rule found among recruited nodes; cannot determine cohort for quorum check",
+				wantErr:       "no recruit reports the expected outgoing rule coordinator_term:3; cannot determine cohort for quorum check",
 			}
 		}(),
 		func() tc {
@@ -710,15 +717,15 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "validate proposal: mismatched term revocation",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
-						TermRevocation: revocation(99),
+						TermRevocation: revocation(99, ruleNum(0, 0)),
 						ProposalLeader: &consensusdatapb.ProposalLeader{Id: zone1.a},
 						ProposedRule:   rule,
 					}, nil
@@ -733,11 +740,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "validate proposal: nil leader ID",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -756,11 +763,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "validate proposal: nil proposed rule",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -779,11 +786,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "validate proposal: nil durability policy",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -806,11 +813,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "validate proposal: proposed rule term above recruitment revocation term",
 				mode:       requireTransitionQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatus(zone1.a, rule, revocation(5)),
-					makeStatus(zone1.b, rule, revocation(5)),
-					makeStatus(zone1.c, rule, revocation(5)),
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					return &consensusdatapb.CoordinatorProposal{
@@ -829,11 +836,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "bootstrap: nil outgoing rule allowed, highest LSN leads",
 				mode:       onlyRequireIncomingQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, nil, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, nil, revocation(5), "0/2000000"),
-					makeStatusWithLSN(zone1.c, nil, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, nil, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.c, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					leader := r.EligibleLeaders[0]
@@ -852,9 +859,9 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "bootstrap: 1 of 3 recruited — cannot achieve durability",
 				mode:       onlyRequireIncomingQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, nil, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					leader := r.EligibleLeaders[0]
@@ -873,11 +880,11 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "bootstrap: unknown quorum type in proposed rule",
 				mode:       onlyRequireIncomingQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, nil, revocation(5), "0/1000000"),
-					makeStatusWithLSN(zone1.b, nil, revocation(5), "0/1000000"),
-					makeStatusWithLSN(zone1.c, nil, revocation(5), "0/1000000"),
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
+					makeStatusWithLSN(zone1.b, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
+					makeStatusWithLSN(zone1.c, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					leader := r.EligibleLeaders[0]
@@ -903,10 +910,10 @@ func TestBuildProposalCore(t *testing.T) {
 			return tc{
 				name:       "bootstrap: proposed cohort achievable but insufficient majority",
 				mode:       onlyRequireIncomingQuorum,
-				revocation: revocation(5),
+				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
-					makeStatusWithLSN(zone1.a, nil, revocation(5), "0/3000000"),
-					makeStatusWithLSN(zone1.b, nil, revocation(5), "0/2000000"),
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, nil, revocation(5, ruleNum(3, 0)), "0/2000000"),
 				},
 				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 					leader := r.EligibleLeaders[0]
@@ -926,7 +933,7 @@ func TestBuildProposalCore(t *testing.T) {
 			// to propagate it is rejected: proposed term (6) < revocation term (7).
 			// See the TODO in validateProposal for the two-round recovery path.
 			cohort := []*clustermetadatapb.ID{poolerIDs.zone1.a, poolerIDs.zone2.b, poolerIDs.zone2.c}
-			rev := revocation(7)
+			rev := revocation(7, ruleNum(6, 0))
 			multiCellRule := makeRule(ruleNum(6, 0), multiCell(2), cohort...)
 			atLeastNRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
 			return tc{
@@ -955,7 +962,7 @@ func TestBuildProposalCore(t *testing.T) {
 		{
 			name:              "empty recruited statuses",
 			mode:              requireTransitionQuorum,
-			revocation:        revocation(5),
+			revocation:        revocation(5, ruleNum(3, 0)),
 			recruitedStatuses: nil,
 			buildProposal:     proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), poolerIDs.zone1.all[:3]...)),
 			wantErr:           "empty list of statuses",
@@ -985,6 +992,23 @@ func TestBuildProposalCore(t *testing.T) {
 			}
 		})
 	}
+
+	// Defensive guard: public wrappers filter via ValidateRevocation first
+	// so a nil outgoing_rule never reaches buildProposalCore in practice.
+	// Exercise the guard directly here.
+	t.Run("revocation with nil outgoing_rule is rejected", func(t *testing.T) {
+		zone1 := poolerIDs.zone1
+		cohort := zone1.all[:3]
+		rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		rev.OutgoingRule = nil
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, rule, rev),
+		}
+		_, err := buildProposalCore(rev, statuses, requireTransitionQuorum, discoverMostAdvancedTimeline,
+			func(RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) { return nil, nil })
+		require.ErrorContains(t, err, "revocation.outgoing_rule is required")
+	})
 }
 
 // TestBuildSafeProposal tests the filterByRevocation wrapper behavior — it only
@@ -993,108 +1017,128 @@ func TestBuildProposalCore(t *testing.T) {
 func TestBuildSafeProposal(t *testing.T) {
 	zone1 := poolerIDs.zone1
 	cohort := []*clustermetadatapb.ID{zone1.a, zone1.b, zone1.c}
-	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
-	coordID := makeID("zone1", "multiorch-1")
-	rev := &clustermetadatapb.TermRevocation{
-		RevokedBelowTerm:       5,
-		AcceptedCoordinatorId:  coordID,
-		CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000},
-	}
+	t.Run("nil statuses: no nodes accepted", func(t *testing.T) {
+		rev := revocation(5, ruleNum(3, 0))
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		_, err := BuildSafeProposal(rev, nil, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
 
-	tests := []struct {
-		name     string
-		statuses []*clustermetadatapb.ConsensusStatus
-		wantErr  string
-	}{
-		{
-			name:    "nil statuses: no nodes accepted",
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-		{
-			name: "all nodes have old revocation: no nodes accepted",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, revocation(3)),
-				makeStatus(zone1.b, rule, revocation(3)),
-				makeStatus(zone1.c, rule, revocation(3)),
-			},
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-		{
-			name: "partial acceptance, quorum met: 2 of 3 accept exact revocation",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, rev),
-				makeStatus(zone1.b, rule, rev),
-				makeStatus(zone1.c, rule, revocation(3)),
-			},
-		},
-		{
-			name: "partial acceptance, quorum not met: only 1 of 3 accepts",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, rev),
-				makeStatus(zone1.b, rule, revocation(3)),
-				makeStatus(zone1.c, rule, revocation(3)),
-			},
-			wantErr: "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2",
-		},
-		{
-			name: "lower-term revocation does not count",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3, AcceptedCoordinatorId: coordID}),
-				makeStatus(zone1.b, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3, AcceptedCoordinatorId: coordID}),
-				makeStatus(zone1.c, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3, AcceptedCoordinatorId: coordID}),
-			},
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-		{
-			name: "higher-term revocation does not count",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 9, AcceptedCoordinatorId: coordID}),
-				makeStatus(zone1.b, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 9, AcceptedCoordinatorId: coordID}),
-				makeStatus(zone1.c, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 9, AcceptedCoordinatorId: coordID}),
-			},
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-		{
-			name: "rival coordinator ID does not count",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: makeID("zone1", "multiorch-2"), CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000}}),
-				makeStatus(zone1.b, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: makeID("zone1", "multiorch-2"), CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000}}),
-				makeStatus(zone1.c, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: makeID("zone1", "multiorch-2"), CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000}}),
-			},
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-		{
-			name: "stale initiated_at does not count",
-			statuses: []*clustermetadatapb.ConsensusStatus{
-				makeStatus(zone1.a, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: coordID, CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 999}}),
-				makeStatus(zone1.b, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: coordID, CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 999}}),
-				makeStatus(zone1.c, rule, &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5, AcceptedCoordinatorId: coordID, CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 999}}),
-			},
-			wantErr: "no nodes accepted the requested term revocation",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := BuildSafeProposal(rev, tt.statuses, proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)))
-			if tt.wantErr != "" {
-				assert.EqualError(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	t.Run("all nodes have older revocation: no nodes accepted", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		older := revocation(3, ruleNum(0, 0))
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, older),
+			makeStatus(zone1.b, oldRule, older),
+			makeStatus(zone1.c, oldRule, older),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
+
+	t.Run("partial acceptance, quorum met: 2 of 3 accept exact revocation", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, rev),
+			makeStatus(zone1.b, oldRule, rev),
+			makeStatus(zone1.c, oldRule, revocation(3, ruleNum(0, 0))),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		require.NoError(t, err)
+	})
+
+	t.Run("partial acceptance, quorum not met: only 1 of 3 accepts", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, rev),
+			makeStatus(zone1.b, oldRule, revocation(3, ruleNum(0, 0))),
+			makeStatus(zone1.c, oldRule, revocation(3, ruleNum(0, 0))),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2")
+	})
+
+	t.Run("lower-term revocation does not count", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		// Statuses pledge at a lower term — proto.Equal rejects.
+		stale := revocation(3, ruleNum(3, 0))
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, stale),
+			makeStatus(zone1.b, oldRule, stale),
+			makeStatus(zone1.c, oldRule, stale),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
+
+	t.Run("higher-term revocation does not count", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		// Statuses pledge at a higher term — proto.Equal rejects.
+		ahead := revocation(9, ruleNum(3, 0))
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, ahead),
+			makeStatus(zone1.b, oldRule, ahead),
+			makeStatus(zone1.c, oldRule, ahead),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
+
+	t.Run("rival coordinator ID does not count", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		rev.AcceptedCoordinatorId = makeID("zone1", "multiorch-1")
+		// Same term, different coordinator — proto.Equal rejects.
+		rival := revocation(5, ruleNum(3, 0))
+		rival.AcceptedCoordinatorId = makeID("zone1", "multiorch-2")
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, rival),
+			makeStatus(zone1.b, oldRule, rival),
+			makeStatus(zone1.c, oldRule, rival),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
+
+	t.Run("stale initiated_at does not count", func(t *testing.T) {
+		oldRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+		newRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
+		rev := revocation(5, ruleNum(3, 0))
+		rev.CoordinatorInitiatedAt = &timestamppb.Timestamp{Seconds: 1000}
+		// Same term, different initiated_at — proto.Equal rejects.
+		stale := revocation(5, ruleNum(3, 0))
+		stale.CoordinatorInitiatedAt = &timestamppb.Timestamp{Seconds: 999}
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			makeStatus(zone1.a, oldRule, stale),
+			makeStatus(zone1.b, oldRule, stale),
+			makeStatus(zone1.c, oldRule, stale),
+		}
+		_, err := BuildSafeProposal(rev, statuses, proposeFirstEligible(newRule))
+		assert.EqualError(t, err, "no nodes accepted the requested term revocation")
+	})
 }
 
 func TestBuildSafeProposal_NoCommittedRule(t *testing.T) {
 	zone1 := poolerIDs.zone1
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		{Id: zone1.a, TermRevocation: revocation(5)}, // no current_position
+		{Id: zone1.a, TermRevocation: revocation(5, ruleNum(3, 0))}, // no current_position
 	}
 
 	// The proposal callback is never reached (filterByValidPosition fails first),
 	// so the rule passed here is irrelevant beyond satisfying makeRule's invariants.
-	_, err := BuildSafeProposal(revocation(5), statuses, proposeFirstEligible(makeRule(ruleNum(0, 0), atLeast(2), zone1.a)))
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, proposeFirstEligible(makeRule(ruleNum(0, 0), atLeast(2), zone1.a)))
 
 	// A node with no current_position has no parseable LSN, so it is filtered
 	// out by filterByValidPosition before the recorded-rule check fires.
@@ -1108,10 +1152,10 @@ func TestBuildSafeProposal_InsufficientQuorum(t *testing.T) {
 
 	// Only one of three nodes recruited — not enough for AT_LEAST_2 with majority.
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, proposeFirstEligible(makeRule(ruleNum(3, 0), atLeast(2), cohort...)))
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, proposeFirstEligible(makeRule(ruleNum(3, 0), atLeast(2), cohort...)))
 
 	require.EqualError(t, err, "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2")
 }
@@ -1123,9 +1167,9 @@ func TestBuildSafeProposal_InvalidLeader(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	// Callback proposes a node that was not recruited.
@@ -1137,7 +1181,7 @@ func TestBuildSafeProposal_InvalidLeader(t *testing.T) {
 		}, nil
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.EqualError(t, err, "proposal validation: proposed leader zone1_outsider is not among eligible leaders")
 }
@@ -1153,9 +1197,9 @@ func TestBuildSafeProposal_UnrecruitedCohortMemberOK(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	proposedRule := makeRule(ruleNum(5, 0), atLeast(2), zone1.a, zone1.b, outsider)
@@ -1167,7 +1211,7 @@ func TestBuildSafeProposal_UnrecruitedCohortMemberOK(t *testing.T) {
 		}, nil
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.NoError(t, err)
 }
@@ -1183,8 +1227,8 @@ func TestBuildSafeProposal_DeadLeaderRemainsInCohort(t *testing.T) {
 
 	// Only B and C are reachable; A is dead.
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	// Proposed rule keeps A in the cohort (it will rejoin as standby) but promotes B.
@@ -1197,7 +1241,7 @@ func TestBuildSafeProposal_DeadLeaderRemainsInCohort(t *testing.T) {
 		}, nil
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.NoError(t, err)
 }
@@ -1214,9 +1258,9 @@ func TestBuildSafeProposal_InsufficientRecruitedFromProposedCohort(t *testing.T)
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	// Proposed rule replaces b and c with d and e, but d and e were not recruited.
@@ -1229,7 +1273,7 @@ func TestBuildSafeProposal_InsufficientRecruitedFromProposedCohort(t *testing.T)
 		}, nil
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2")
 }
@@ -1240,16 +1284,16 @@ func TestBuildSafeProposal_BuildProposalError(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	buildProposal := func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 		return nil, errors.New("no suitable candidate")
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.EqualError(t, err, "buildProposal: no suitable candidate")
 }
@@ -1263,9 +1307,9 @@ func TestBuildSafeProposal_OutgoingRuleSelected(t *testing.T) {
 	newRule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, newRule, revocation(5)),
-		makeStatus(zone1.b, newRule, revocation(5)),
-		makeStatus(zone1.c, oldRule, revocation(5)), // behind
+		makeStatus(zone1.a, newRule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, newRule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, oldRule, revocation(5, ruleNum(3, 0))), // behind
 	}
 
 	// Only a and b are eligible (at outgoingRule); callback picks a.
@@ -1281,7 +1325,7 @@ func TestBuildSafeProposal_OutgoingRuleSelected(t *testing.T) {
 		}, nil
 	}
 
-	proposal, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	proposal, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.NoError(t, err)
 	require.NotNil(t, proposal)
@@ -1299,12 +1343,12 @@ func TestBuildSafeProposal_BuildProposalNil(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 		return nil, nil
 	})
 
@@ -1317,9 +1361,9 @@ func TestBuildSafeProposal_ProposedPolicyNotAchievable(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	// Proposed rule has AT_LEAST_2 but only one cohort member — not achievable.
@@ -1336,7 +1380,7 @@ func TestBuildSafeProposal_ProposedPolicyNotAchievable(t *testing.T) {
 		}, nil
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, buildProposal)
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, buildProposal)
 
 	require.EqualError(t, err, "proposal validation: recruited proposed cohort cannot achieve durability: durability not achievable: proposed cohort has 1 poolers, required 2")
 }
@@ -1350,11 +1394,11 @@ func TestBuildSafeProposal_DuplicateStatusIgnoredForQuorum(t *testing.T) {
 
 	// Only a responds, but we see its response twice — still only 1 recruited.
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.a, rule, revocation(5)), // duplicate
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))), // duplicate
 	}
 
-	_, err := BuildSafeProposal(revocation(5), statuses, proposeFirstEligible(makeRule(ruleNum(3, 0), atLeast(2), cohort...)))
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, proposeFirstEligible(makeRule(ruleNum(3, 0), atLeast(2), cohort...)))
 
 	require.EqualError(t, err, "insufficient outgoing cohort recruitment: majority not satisfied: recruited 1 of 3 cohort poolers, need at least 2")
 }
@@ -1376,16 +1420,16 @@ func TestBuildSafeProposal_DuplicateBestPositionKept(t *testing.T) {
 	// a lower LSN. Rule number wins, so the newRule entry must be kept.
 	// Result: a ends up as the sole eligible leader (highest LSN at newRule).
 	statuses := []*clustermetadatapb.ConsensusStatus{
-		makeStatusWithLSN(zone1.a, oldRule, revocation(5), "0/3000000"), // stale, high LSN
-		makeStatusWithLSN(zone1.a, newRule, revocation(5), "0/2000000"), // fresh, lower LSN
-		makeStatusWithLSN(zone1.b, newRule, revocation(5), "0/1000000"),
-		makeStatusWithLSN(zone1.c, newRule, revocation(5), "0/1000000"),
+		makeStatusWithLSN(zone1.a, oldRule, revocation(5, ruleNum(3, 0)), "0/3000000"), // stale, high LSN
+		makeStatusWithLSN(zone1.a, newRule, revocation(5, ruleNum(3, 0)), "0/2000000"), // fresh, lower LSN
+		makeStatusWithLSN(zone1.b, newRule, revocation(5, ruleNum(3, 0)), "0/1000000"),
+		makeStatusWithLSN(zone1.c, newRule, revocation(5, ruleNum(3, 0)), "0/1000000"),
 	}
 
 	// proposedRule uses the revocation term (5) since validateProposal requires it to match.
 	proposedRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
 	var gotResult RecruitmentResult
-	_, err := BuildSafeProposal(revocation(5), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+	_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 		gotResult = r
 		return &consensusdatapb.CoordinatorProposal{
 			TermRevocation: r.TermRevocation,
@@ -1409,19 +1453,19 @@ func TestBuildProposalCore_EligibleLeadersOrderDeterministic(t *testing.T) {
 	rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 
 	forward := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.a, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.c, rule, revocation(5)),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
 	}
 	reversed := []*clustermetadatapb.ConsensusStatus{
-		makeStatus(zone1.c, rule, revocation(5)),
-		makeStatus(zone1.b, rule, revocation(5)),
-		makeStatus(zone1.a, rule, revocation(5)),
+		makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+		makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
 	}
 
 	collect := func(statuses []*clustermetadatapb.ConsensusStatus) []string {
 		var names []string
-		_, err := BuildSafeProposal(revocation(5), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+		_, err := BuildSafeProposal(revocation(5, ruleNum(3, 0)), statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 			for _, cs := range r.EligibleLeaders {
 				names = append(names, cs.GetId().GetName())
 			}
@@ -1479,13 +1523,20 @@ func TestBuildSafeProposal_CohortReplacementSplitBrain(t *testing.T) {
 
 	// Each coordinator has its own TermRevocation (different accepted_coordinator_id).
 	// B and C accepted coordinator 1; D and E accepted coordinator 2.
+	// Each coordinator's outgoing_rule reflects what its own recruited cohort
+	// reports: coord 1 sees B & C at oldRule (3, 0); coord 2 sees D & E at
+	// newRule (4, 0).
 	revocationCoord1 := &clustermetadatapb.TermRevocation{
-		RevokedBelowTerm:      6,
-		AcceptedCoordinatorId: makeID("zone1", "multiorch-1"),
+		RevokedBelowTerm:       6,
+		AcceptedCoordinatorId:  makeID("zone1", "multiorch-1"),
+		CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000},
+		OutgoingRule:           ruleNum(3, 0),
 	}
 	revocationCoord2 := &clustermetadatapb.TermRevocation{
-		RevokedBelowTerm:      6,
-		AcceptedCoordinatorId: makeID("zone1", "multiorch-2"),
+		RevokedBelowTerm:       6,
+		AcceptedCoordinatorId:  makeID("zone1", "multiorch-2"),
+		CoordinatorInitiatedAt: &timestamppb.Timestamp{Seconds: 1000},
+		OutgoingRule:           ruleNum(4, 0),
 	}
 
 	// All four responding nodes' statuses are in the same pool. The revocation
@@ -1570,7 +1621,7 @@ func TestCheckProposalPossible(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckProposalPossible(coordRevocation(5), tt.statuses, proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)))
+			err := CheckProposalPossible(coordRevocation(5, ruleNum(3, 0)), tt.statuses, proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), cohort...)))
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr)
 			} else {
@@ -1609,9 +1660,8 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 	// Both fields are required by newExternallyCertifiedDiscoverer even when
 	// the caller has no real constraint to express.
 	neutralCert := &clustermetadatapb.ExternallyCertifiedRevocation{
-		TermRevocation:     coordRevocation(5),
-		OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-		FrozenLsn:          "0/0",
+		TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{}),
+		FrozenLsn:      "0/0",
 	}
 
 	t.Run("bootstrap: nodes at term 0 can accept", func(t *testing.T) {
@@ -1630,21 +1680,9 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 		require.EqualError(t, err, "no nodes could accept the proposed revocation")
 	})
 
-	t.Run("cert missing outgoing_rule_number", func(t *testing.T) {
-		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation: coordRevocation(5),
-			FrozenLsn:      "0/0",
-		}
-		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
-			makeUnrecruitedStatus(a, initialRule),
-		}, bootstrapProposal)
-		require.EqualError(t, err, "cert is missing outgoing_rule_number")
-	})
-
 	t.Run("cert missing frozen_lsn", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     coordRevocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
+			TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{}),
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
 			makeUnrecruitedStatus(a, initialRule),
@@ -1652,16 +1690,31 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 		require.EqualError(t, err, "cert is missing frozen_lsn")
 	})
 
-	t.Run("outgoing_rule_number: candidate rule exceeds certified term", func(t *testing.T) {
+	t.Run("outgoing_rule: candidate rule exceeds revocation's outgoing_rule", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     coordRevocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
-			FrozenLsn:          "0/0",
+			TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}),
+			FrozenLsn:      "0/0",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
 			makeUnrecruitedStatus(a, makeRule(ruleNum(3, 0), atLeast(2), cohort...)),
 		}, bootstrapProposal)
-		require.EqualError(t, err, "node zone1_a is at rule term 3 but certified outgoing rule is term 2")
+		require.ErrorContains(t, err, "strictly greater than revocation.outgoing_rule")
+	})
+
+	t.Run("nil cert.term_revocation.outgoing_rule rejected by discoverer", func(t *testing.T) {
+		// Public wrappers filter via ValidateRevocation first, so this
+		// guard is never tripped via CheckExternallyCertifiedProposalPossible
+		// in practice. Direct-call the internal discoverer to exercise it.
+		rev := coordRevocation(5, &clustermetadatapb.RuleNumber{})
+		rev.OutgoingRule = nil
+		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
+			TermRevocation: rev,
+			FrozenLsn:      "0/0",
+		}
+		_, err := newExternallyCertifiedDiscoverer(cert, []*clustermetadatapb.ConsensusStatus{
+			makeUnrecruitedStatus(a, initialRule),
+		})
+		require.ErrorContains(t, err, "cert.term_revocation.outgoing_rule is required")
 	})
 
 	t.Run("nil rule on candidate node → error", func(t *testing.T) {
@@ -1669,9 +1722,8 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 		// (or recruit-eligible) node should carry at least the initial row.
 		// A nil rule surfaces as a specific consensus-state error.
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     coordRevocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "0/0",
+			TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{}),
+			FrozenLsn:      "0/0",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
 			makeUnrecruitedStatus(a, nil),
@@ -1681,9 +1733,8 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 
 	t.Run("frozen_lsn: invalid LSN string", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     coordRevocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "bad-lsn",
+			TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{}),
+			FrozenLsn:      "bad-lsn",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
 			makeUnrecruitedStatus(a, initialRule),
@@ -1693,9 +1744,8 @@ func TestCheckExternallyCertifiedProposalPossible(t *testing.T) {
 
 	t.Run("frozen_lsn: no node at or above threshold", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     coordRevocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "0/9000000",
+			TermRevocation: coordRevocation(5, &clustermetadatapb.RuleNumber{}),
+			FrozenLsn:      "0/9000000",
 		}
 		err := CheckExternallyCertifiedProposalPossible(cert, []*clustermetadatapb.ConsensusStatus{
 			makeUnrecruitedStatus(a, initialRule),
@@ -1736,9 +1786,8 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 	// Both fields are required by newExternallyCertifiedDiscoverer even when
 	// the caller has no real constraint to express.
 	neutralCert := &clustermetadatapb.ExternallyCertifiedRevocation{
-		TermRevocation:     revocation(5),
-		OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-		FrozenLsn:          "0/0",
+		TermRevocation: revocation(5, ruleNum(3, 0)),
+		FrozenLsn:      "0/0",
 	}
 
 	t.Run("no nodes accepted the revocation", func(t *testing.T) {
@@ -1746,71 +1795,63 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 		// before the cert is inspected. Use neutralCert anyway for consistency.
 		singleCohort := []*clustermetadatapb.ID{zone1.a}
 		_, err := BuildExternallyCertifiedProposal(neutralCert, []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, makeRule(ruleNum(3, 0), atLeast(2), singleCohort...), revocation(3)),
+			makeStatus(zone1.a, makeRule(ruleNum(3, 0), atLeast(2), singleCohort...), revocation(3, ruleNum(0, 0))),
 		}, proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), singleCohort...)))
 		require.EqualError(t, err, "no nodes accepted the requested term revocation")
 	})
 
 	t.Run("bootstrap: no cert constraints, all recruited nodes eligible", func(t *testing.T) {
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, initialRule, revocation(5)),
-			makeStatus(zone1.b, initialRule, revocation(5)),
-			makeStatus(zone1.c, initialRule, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5, ruleNum(3, 0))),
+			makeStatus(zone1.b, initialRule, revocation(5, ruleNum(3, 0))),
+			makeStatus(zone1.c, initialRule, revocation(5, ruleNum(3, 0))),
 		}
 		_, err := BuildExternallyCertifiedProposal(neutralCert, statuses, bootstrapProposal)
 		require.NoError(t, err)
 	})
 
-	t.Run("cert missing outgoing_rule_number", func(t *testing.T) {
-		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation: revocation(5),
-			FrozenLsn:      "0/0",
-		}
-		_, err := BuildExternallyCertifiedProposal(cert, []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, initialRule, revocation(5)),
-		}, bootstrapProposal)
-		require.EqualError(t, err, "cert is missing outgoing_rule_number")
-	})
+	// The "cert missing outgoing_rule_number" case is gone — the cert no longer
+	// carries that field. revocation.outgoing_rule = nil is exercised by
+	// TestValidateRevocation directly.
 
 	t.Run("cert missing frozen_lsn", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
+			TermRevocation: revocation(5, ruleNum(3, 0)),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, initialRule, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5, ruleNum(3, 0))),
 		}, bootstrapProposal)
 		require.EqualError(t, err, "cert is missing frozen_lsn")
 	})
 
-	t.Run("outgoing_rule_number: node at certified term is allowed", func(t *testing.T) {
+	t.Run("succeeds if the outgoing rule matches the highest observed node rule", func(t *testing.T) {
 		outgoingRule := makeRule(ruleNum(3, 0), atLeast(2), incomingCohort...)
+		rev := coordRevocation(5, ruleNum(3, 0))
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3},
-			FrozenLsn:          "0/0",
+			TermRevocation: rev,
+			FrozenLsn:      "0/0",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, outgoingRule, revocation(5)),
-			makeStatus(zone1.b, outgoingRule, revocation(5)),
-			makeStatus(zone1.c, outgoingRule, revocation(5)),
+			makeStatus(zone1.a, outgoingRule, rev),
+			makeStatus(zone1.b, outgoingRule, rev),
+			makeStatus(zone1.c, outgoingRule, rev),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.NoError(t, err)
 	})
 
-	t.Run("outgoing_rule_number: node rule exceeds certified term → error", func(t *testing.T) {
-		outgoingRule := makeRule(ruleNum(4, 0), atLeast(2), incomingCohort...) // node progressed past the certified point
+	t.Run("recruit fails if some nodes are beyond the expected outgoing rule", func(t *testing.T) {
+		recruitedRule := makeRule(ruleNum(4, 0), atLeast(2), incomingCohort...) // node progressed past the certified point
+		rev := coordRevocation(5, ruleNum(3, 0))
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3},
-			FrozenLsn:          "0/0",
+			TermRevocation: rev,
+			FrozenLsn:      "0/0",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, outgoingRule, revocation(5)),
+			makeStatus(zone1.a, recruitedRule, rev),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
-		require.EqualError(t, err, "node zone1_pooler-a is at rule term 4 but certified outgoing rule is term 3")
+		require.ErrorContains(t, err, "strictly greater than revocation.outgoing_rule")
 	})
 
 	t.Run("nil rule on recruited node → error", func(t *testing.T) {
@@ -1820,12 +1861,11 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 		// that as a specific error rather than letting the node silently slip
 		// through to a generic "no eligible leaders".
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "0/0",
+			TermRevocation: revocation(5, ruleNum(3, 0)),
+			FrozenLsn:      "0/0",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, nil, revocation(5)),
+			makeStatus(zone1.a, nil, revocation(5, ruleNum(3, 0))),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.EqualError(t, err, "node zone1_pooler-a has no recorded rule; consensus state may be uninitialized")
@@ -1833,12 +1873,11 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 
 	t.Run("frozen_lsn: invalid LSN string → error", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "not-an-lsn",
+			TermRevocation: revocation(5, ruleNum(3, 0)),
+			FrozenLsn:      "not-an-lsn",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatus(zone1.a, initialRule, revocation(5)),
+			makeStatus(zone1.a, initialRule, revocation(5, ruleNum(3, 0))),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.ErrorContains(t, err, "invalid frozen_lsn in cert")
@@ -1849,14 +1888,13 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 		// b and c are at or above — eligible leaders.
 		// All three are recruited so quorum is satisfied for the incoming cohort.
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "0/2000000",
+			TermRevocation: revocation(5, ruleNum(3, 0)),
+			FrozenLsn:      "0/2000000",
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatusWithLSN(zone1.a, initialRule, revocation(5), "0/1000000"), // below frozen_lsn
-			makeStatusWithLSN(zone1.b, initialRule, revocation(5), "0/2000000"), // at frozen_lsn → eligible
-			makeStatusWithLSN(zone1.c, initialRule, revocation(5), "0/3000000"), // above → eligible
+			makeStatusWithLSN(zone1.a, initialRule, revocation(5, ruleNum(3, 0)), "0/1000000"), // below frozen_lsn
+			makeStatusWithLSN(zone1.b, initialRule, revocation(5, ruleNum(3, 0)), "0/2000000"), // at frozen_lsn → eligible
+			makeStatusWithLSN(zone1.c, initialRule, revocation(5, ruleNum(3, 0)), "0/3000000"), // above → eligible
 		}
 		var gotResult RecruitmentResult
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
@@ -1874,14 +1912,13 @@ func TestBuildExternallyCertifiedProposal(t *testing.T) {
 
 	t.Run("frozen_lsn: no node at or above threshold → no eligible leaders", func(t *testing.T) {
 		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
-			TermRevocation:     revocation(5),
-			OutgoingRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 0},
-			FrozenLsn:          "0/9000000", // higher than all nodes
+			TermRevocation: revocation(5, ruleNum(3, 0)),
+			FrozenLsn:      "0/9000000", // higher than all nodes
 		}
 		statuses := []*clustermetadatapb.ConsensusStatus{
-			makeStatusWithLSN(zone1.a, initialRule, revocation(5), "0/1000000"),
-			makeStatusWithLSN(zone1.b, initialRule, revocation(5), "0/2000000"),
-			makeStatusWithLSN(zone1.c, initialRule, revocation(5), "0/3000000"),
+			makeStatusWithLSN(zone1.a, initialRule, revocation(5, ruleNum(3, 0)), "0/1000000"),
+			makeStatusWithLSN(zone1.b, initialRule, revocation(5, ruleNum(3, 0)), "0/2000000"),
+			makeStatusWithLSN(zone1.c, initialRule, revocation(5, ruleNum(3, 0)), "0/3000000"),
 		}
 		_, err := BuildExternallyCertifiedProposal(cert, statuses, bootstrapProposal)
 		require.EqualError(t, err, "no eligible leaders found among recruited nodes")
@@ -1894,7 +1931,7 @@ func TestDeduplicateStatuses_NilIDSkipped(t *testing.T) {
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
 		{Id: nil},
-		makeStatus(a, makeRule(ruleNum(1, 0), atLeast(2), cohort...), revocation(5)),
+		makeStatus(a, makeRule(ruleNum(1, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0))),
 	}
 
 	result := deduplicateStatuses(statuses)
@@ -1908,7 +1945,7 @@ func TestCohortIntersect_NilIDSkipped(t *testing.T) {
 
 	statuses := []*clustermetadatapb.ConsensusStatus{
 		{Id: nil},
-		makeStatus(a, makeRule(ruleNum(1, 0), atLeast(2), cohort...), revocation(5)),
+		makeStatus(a, makeRule(ruleNum(1, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0))),
 	}
 
 	result := cohortIntersect(cohort, statuses)

--- a/go/common/consensus/revocation.go
+++ b/go/common/consensus/revocation.go
@@ -27,27 +27,58 @@ import (
 	"github.com/multigres/multigres/go/tools/pgutil"
 )
 
-// NewTermRevocation constructs a TermRevocation for a new coordinator-led rule
-// change. The revocation term is derived from the highest term observed across
-// the provided ConsensusStatus values — the maximum of each node's accepted
-// revocation term and its recorded rule's coordinator term — incremented by
-// one. If no non-zero terms are found (fresh cluster, no prior elections), term
-// 1 is used.
-func NewTermRevocation(statuses []*clustermetadatapb.ConsensusStatus, coordinatorID *clustermetadatapb.ID) *clustermetadatapb.TermRevocation {
+// NewTermRevocation constructs a TermRevocation for a coordinator-led safe
+// transition. Use this for failover-style rule changes where the
+// coordinator's view of the outgoing rule comes from discovery over the
+// cohort. The revocation term is derived from the highest term observed
+// across the provided ConsensusStatus values — the maximum of each node's
+// accepted revocation term and its recorded rule's coordinator term —
+// incremented by one. outgoing_rule is the highest RuleNumber recorded
+// across the cohort.
+//
+// statuses must be non-empty and at least one status must carry a recorded
+// rule. An empty list or a cohort with no recorded rules indicates the
+// caller has nothing meaningful to transition from — that's a fresh-cluster
+// or bootstrap scenario where the agent (e.g. multiorch's
+// AppointInitialLeader) constructs the TermRevocation directly with an
+// explicit outgoing_rule, rather than going through this helper.
+func NewTermRevocation(
+	statuses []*clustermetadatapb.ConsensusStatus,
+	coordinatorID *clustermetadatapb.ID,
+) (*clustermetadatapb.TermRevocation, error) {
+	if len(statuses) == 0 {
+		return nil, errors.New("NewTermRevocation: statuses must be non-empty")
+	}
 	var maxTerm int64
+	var maxRule *clustermetadatapb.RuleNumber
 	for _, cs := range statuses {
 		if t := cs.GetTermRevocation().GetRevokedBelowTerm(); t > maxTerm {
 			maxTerm = t
 		}
-		if t := cs.GetCurrentPosition().GetRule().GetRuleNumber().GetCoordinatorTerm(); t > maxTerm {
+		ruleNum := cs.GetCurrentPosition().GetRule().GetRuleNumber()
+		if ruleNum == nil {
+			continue
+		}
+		if t := ruleNum.GetCoordinatorTerm(); t > maxTerm {
 			maxTerm = t
 		}
+		// Capture the first non-nil RuleNumber we see; bump only on strictly
+		// greater. The "first non-nil" path matters when the recorded rule
+		// is the zero RuleNumber — CompareRuleNumbers treats zero == nil, so
+		// without the explicit nil check we'd never lift maxRule above nil.
+		if maxRule == nil || CompareRuleNumbers(ruleNum, maxRule) > 0 {
+			maxRule = ruleNum
+		}
+	}
+	if maxRule == nil {
+		return nil, errors.New("NewTermRevocation: no cohort member reports a recorded rule; agent should construct revocation directly with explicit outgoing_rule")
 	}
 	return &clustermetadatapb.TermRevocation{
 		RevokedBelowTerm:       maxTerm + 1,
 		AcceptedCoordinatorId:  coordinatorID,
 		CoordinatorInitiatedAt: timestamppb.Now(),
-	}
+		OutgoingRule:           maxRule,
+	}, nil
 }
 
 // ValidateRevocation reports whether the given revocation is safe for a node
@@ -89,7 +120,22 @@ func ValidateRevocation(status *clustermetadatapb.ConsensusStatus, revocation *c
 	if revocation.GetCoordinatorInitiatedAt() == nil {
 		return errors.New("cannot accept revocation: coordinator_initiated_at is required")
 	}
+	if revocation.GetOutgoingRule() == nil {
+		return errors.New("cannot accept revocation: outgoing_rule is required")
+	}
 	revokedBelowTerm := revocation.GetRevokedBelowTerm()
+	// Invariant: outgoing_rule represents the rule the coordinator is
+	// transitioning from. Its coordinator_term must be strictly less than
+	// revoked_below_term — the new term is by construction max(observed) + 1,
+	// so outgoing_rule.coordinator_term <= max(observed) < revoked_below_term.
+	// A violation indicates a malformed revocation (or future code paths
+	// constructing revocations by hand without using NewTermRevocation).
+	if outTerm := revocation.GetOutgoingRule().GetCoordinatorTerm(); outTerm >= revokedBelowTerm {
+		return fmt.Errorf(
+			"cannot accept revocation: outgoing_rule coordinator_term %d >= revoked_below_term %d",
+			outTerm, revokedBelowTerm,
+		)
+	}
 
 	// Condition 1: WAL position safety.
 	pos := status.GetCurrentPosition()
@@ -106,6 +152,9 @@ func ValidateRevocation(status *clustermetadatapb.ConsensusStatus, revocation *c
 			ruleCoordTerm, revokedBelowTerm,
 		)
 	}
+	// TODO: reject revocations whose outgoing_rule is known to be obsolete.
+	// This may require us to first have more clarity about what's a proposal vs
+	// what's a decision.
 
 	// Conditions 2 and 3: stored-revocation consistency.
 	stored := status.GetTermRevocation()

--- a/go/common/consensus/revocation_test.go
+++ b/go/common/consensus/revocation_test.go
@@ -32,6 +32,11 @@ var (
 
 	ts1 = timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	ts2 = timestamppb.New(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+
+	// zeroOutgoingRule is a placeholder outgoing_rule used in tests where the
+	// specific outgoing rule value doesn't matter — only that it's non-nil so
+	// ValidateRevocation accepts the revocation.
+	zeroOutgoingRule = &clustermetadatapb.RuleNumber{}
 )
 
 func TestValidateRevocation(t *testing.T) {
@@ -39,6 +44,7 @@ func TestValidateRevocation(t *testing.T) {
 		RevokedBelowTerm:       5,
 		AcceptedCoordinatorId:  coordA,
 		CoordinatorInitiatedAt: ts1,
+		OutgoingRule:           zeroOutgoingRule,
 	}
 
 	tests := []struct {
@@ -59,6 +65,7 @@ func TestValidateRevocation(t *testing.T) {
 			revocation: &clustermetadatapb.TermRevocation{
 				RevokedBelowTerm:       5,
 				CoordinatorInitiatedAt: ts1,
+				OutgoingRule:           zeroOutgoingRule,
 			},
 			wantErr: "accepted_coordinator_id is required",
 		},
@@ -68,8 +75,35 @@ func TestValidateRevocation(t *testing.T) {
 			revocation: &clustermetadatapb.TermRevocation{
 				RevokedBelowTerm:      5,
 				AcceptedCoordinatorId: coordA,
+				OutgoingRule:          zeroOutgoingRule,
 			},
 			wantErr: "coordinator_initiated_at is required",
+		},
+		{
+			name:   "NilOutgoingRule_Refused",
+			status: nil,
+			revocation: &clustermetadatapb.TermRevocation{
+				RevokedBelowTerm:       5,
+				AcceptedCoordinatorId:  coordA,
+				CoordinatorInitiatedAt: ts1,
+			},
+			wantErr: "outgoing_rule is required",
+		},
+		{
+			// outgoing_rule.coordinator_term must be strictly less than
+			// revoked_below_term. NewTermRevocation always produces values that
+			// satisfy this, but a hand-built revocation (e.g. from an external
+			// agent constructing a cert) could violate it and ValidateRevocation
+			// catches it on read.
+			name:   "OutgoingRuleTermAtOrAboveRevokedBelow_Refused",
+			status: nil,
+			revocation: &clustermetadatapb.TermRevocation{
+				RevokedBelowTerm:       5,
+				AcceptedCoordinatorId:  coordA,
+				CoordinatorInitiatedAt: ts1,
+				OutgoingRule:           &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+			},
+			wantErr: "outgoing_rule coordinator_term 5 >= revoked_below_term 5",
 		},
 		{
 			name:       "NilStatus_Refused",
@@ -166,6 +200,7 @@ func TestValidateRevocation(t *testing.T) {
 				RevokedBelowTerm:       5,
 				AcceptedCoordinatorId:  coordB,
 				CoordinatorInitiatedAt: ts1,
+				OutgoingRule:           zeroOutgoingRule,
 			},
 			wantErr: "already accepted term 5 from coordinator",
 		},
@@ -183,6 +218,7 @@ func TestValidateRevocation(t *testing.T) {
 				RevokedBelowTerm:       5,
 				AcceptedCoordinatorId:  coordA,
 				CoordinatorInitiatedAt: ts2,
+				OutgoingRule:           zeroOutgoingRule,
 			},
 			wantErr: "different coordinator_initiated_at",
 		},
@@ -229,27 +265,59 @@ func positionAtCoordTerm(coordTerm int64) *clustermetadatapb.PoolerPosition {
 func TestNewTermRevocation(t *testing.T) {
 	coord := &clustermetadatapb.ID{Name: "coord-1"}
 
-	t.Run("fresh cluster - no statuses", func(t *testing.T) {
-		rev := NewTermRevocation(nil, coord)
-		require.Equal(t, int64(1), rev.GetRevokedBelowTerm())
-		require.Equal(t, "coord-1", rev.GetAcceptedCoordinatorId().GetName())
-		require.NotNil(t, rev.GetCoordinatorInitiatedAt())
+	t.Run("empty statuses returns error", func(t *testing.T) {
+		rev, err := NewTermRevocation(nil, coord)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "statuses must be non-empty")
+		require.Nil(t, rev)
 	})
 
-	t.Run("fresh cluster - statuses with no term history", func(t *testing.T) {
+	t.Run("no cohort member has a recorded rule returns error", func(t *testing.T) {
+		// Bootstrap-shaped scenario: cohort visible but nobody reports a
+		// rule. NewTermRevocation refuses; the agent should construct the
+		// revocation directly with an explicit outgoing_rule.
 		statuses := []*clustermetadatapb.ConsensusStatus{{}, {}}
-		rev := NewTermRevocation(statuses, coord)
-		require.Equal(t, int64(1), rev.GetRevokedBelowTerm())
+		rev, err := NewTermRevocation(statuses, coord)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cohort member reports a recorded rule")
+		require.Nil(t, rev)
 	})
 
-	t.Run("uses max of revocation terms", func(t *testing.T) {
+	t.Run("revocation-term-only statuses with no recorded rule return error", func(t *testing.T) {
+		// Same shape: statuses carry a stored revocation but no recorded
+		// rule. NewTermRevocation requires at least one rule to derive
+		// outgoing_rule from.
 		statuses := []*clustermetadatapb.ConsensusStatus{
 			{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3}},
 			{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 7}},
-			{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5}},
 		}
-		rev := NewTermRevocation(statuses, coord)
+		rev, err := NewTermRevocation(statuses, coord)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cohort member reports a recorded rule")
+		require.Nil(t, rev)
+	})
+
+	t.Run("revocation term + recorded rule: max across both", func(t *testing.T) {
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			{
+				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 7},
+				CurrentPosition: positionAtCoordTerm(4),
+			},
+			{
+				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5},
+				CurrentPosition: positionAtCoordTerm(4),
+			},
+			{
+				TermRevocation:  &clustermetadatapb.TermRevocation{RevokedBelowTerm: 3},
+				CurrentPosition: positionAtCoordTerm(4),
+			},
+		}
+		rev, err := NewTermRevocation(statuses, coord)
+		require.NoError(t, err)
 		require.Equal(t, int64(8), rev.GetRevokedBelowTerm())
+		require.Equal(t, "coord-1", rev.GetAcceptedCoordinatorId().GetName())
+		require.NotNil(t, rev.GetCoordinatorInitiatedAt())
+		require.Equal(t, int64(4), rev.GetOutgoingRule().GetCoordinatorTerm())
 	})
 
 	t.Run("uses max of recorded rule terms", func(t *testing.T) {
@@ -257,7 +325,8 @@ func TestNewTermRevocation(t *testing.T) {
 			{CurrentPosition: positionAtCoordTerm(4)},
 			{CurrentPosition: positionAtCoordTerm(9)},
 		}
-		rev := NewTermRevocation(statuses, coord)
+		rev, err := NewTermRevocation(statuses, coord)
+		require.NoError(t, err)
 		require.Equal(t, int64(10), rev.GetRevokedBelowTerm())
 	})
 
@@ -266,7 +335,37 @@ func TestNewTermRevocation(t *testing.T) {
 			{TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 6}},
 			{CurrentPosition: positionAtCoordTerm(11)},
 		}
-		rev := NewTermRevocation(statuses, coord)
+		rev, err := NewTermRevocation(statuses, coord)
+		require.NoError(t, err)
 		require.Equal(t, int64(12), rev.GetRevokedBelowTerm())
+	})
+
+	t.Run("outgoing_rule picks the highest RuleNumber across statuses", func(t *testing.T) {
+		statuses := []*clustermetadatapb.ConsensusStatus{
+			{CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4, LeaderSubterm: 2},
+				},
+				Lsn: "16/B374D848",
+			}},
+			{CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 4, LeaderSubterm: 5},
+				},
+				Lsn: "16/B374D900",
+			}},
+			{CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 3, LeaderSubterm: 9},
+				},
+				Lsn: "16/B374D700",
+			}},
+		}
+		rev, err := NewTermRevocation(statuses, coord)
+		require.NoError(t, err)
+		got := rev.GetOutgoingRule()
+		require.NotNil(t, got)
+		require.Equal(t, int64(4), got.GetCoordinatorTerm())
+		require.Equal(t, int64(5), got.GetLeaderSubterm())
 	})
 }

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1624,42 +1624,47 @@ func (x *PoolerPosition) GetLsn() string {
 	return ""
 }
 
-// HighestKnownRule is the most recent ShardRule this pooler is aware of,
-// which could be beyond the end of this pooler's WAL / PoolerPosition.
+// ReplicationPrimary advertises the primary this pooler believes it should be
+// pointed at for replication, along with the rule under which that primary
+// holds leadership. The primary contact info is the main payload — it's how a
+// pooler in a degraded state (partition, mid-bootstrap, Inform-while-postgres-
+// was-down) figures out who to reconnect replication to. The rule is supporting
+// evidence and has secondary uses such as coordinators learning of rules newer
+// than what's in any replica's WAL.
 //
-// If a pooler is disconnected from replication due to network partitions
-// or stale coordinators, the HighestKnownRule helps them fix GUC and reconnect
-// to learn the latest shard state.
-//
-// If a coordinator is still establishing a new term's first rule, the HighestKnownRule
-// may represent a rule that the coordinator is _about_ to write that doesn't exist in
-// any WAL entries yet.
-//
-// HighestKnownRule does not need to be persisted. It's a best-effort attempt to fix GUC
-// settings so that nodes can participate in replication. Nodes with out-of-date information
-// will be re-informed of the latest HighestKnownRule by any coordinator that notices the
-// pooler has incorrect replication settings.
-type HighestKnownRule struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Rule          *ShardRule             `protobuf:"bytes,1,opt,name=rule,proto3" json:"rule,omitempty"`
+// Not persisted across pooler restarts — best-effort, populated by Inform and
+// Propose RPCs. Coordinators that notice a pooler has incorrect replication
+// settings will re-inform it.
+type ReplicationPrimary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The most recent rule under which this primary holds leadership. May be
+	// ahead of the pooler's committed PoolerPosition while replication catches
+	// up. Coordinators compare this to what they would otherwise Inform with —
+	// if (rule, primary) already matches, the Inform is redundant and can be
+	// skipped.
+	Rule *ShardRule `protobuf:"bytes,1,opt,name=rule,proto3" json:"rule,omitempty"`
+	// Contact info for the primary the pooler was last told to use. Snapshot
+	// from the most recent Inform/Propose; treat as "what this pooler currently
+	// believes," not as the canonical primary for the cluster.
+	Primary       *MultiPooler `protobuf:"bytes,2,opt,name=primary,proto3" json:"primary,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *HighestKnownRule) Reset() {
-	*x = HighestKnownRule{}
+func (x *ReplicationPrimary) Reset() {
+	*x = ReplicationPrimary{}
 	mi := &file_clustermetadata_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *HighestKnownRule) String() string {
+func (x *ReplicationPrimary) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*HighestKnownRule) ProtoMessage() {}
+func (*ReplicationPrimary) ProtoMessage() {}
 
-func (x *HighestKnownRule) ProtoReflect() protoreflect.Message {
+func (x *ReplicationPrimary) ProtoReflect() protoreflect.Message {
 	mi := &file_clustermetadata_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1671,14 +1676,21 @@ func (x *HighestKnownRule) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use HighestKnownRule.ProtoReflect.Descriptor instead.
-func (*HighestKnownRule) Descriptor() ([]byte, []int) {
+// Deprecated: Use ReplicationPrimary.ProtoReflect.Descriptor instead.
+func (*ReplicationPrimary) Descriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *HighestKnownRule) GetRule() *ShardRule {
+func (x *ReplicationPrimary) GetRule() *ShardRule {
 	if x != nil {
 		return x.Rule
+	}
+	return nil
+}
+
+func (x *ReplicationPrimary) GetPrimary() *MultiPooler {
+	if x != nil {
+		return x.Primary
 	}
 	return nil
 }
@@ -1715,8 +1727,14 @@ type TermRevocation struct {
 	// recruiting. All poolers that accept the same recruitment store the same value.
 	// TODO: populate once BeginTermRequest carries this timestamp.
 	CoordinatorInitiatedAt *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=coordinator_initiated_at,json=coordinatorInitiatedAt,proto3" json:"coordinator_initiated_at,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// The rule the coordinator observed across the cohort at recruit time —
+	// the "from" side of the transition this recruit was authoring. Used as
+	// an override key during Inform: if a subsequent Inform carries a rule
+	// strictly greater than this, the cluster has demonstrably moved past
+	// the runaway recruit's premise and the revocation is moot.
+	OutgoingRule  *RuleNumber `protobuf:"bytes,4,opt,name=outgoing_rule,json=outgoingRule,proto3" json:"outgoing_rule,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TermRevocation) Reset() {
@@ -1770,6 +1788,13 @@ func (x *TermRevocation) GetCoordinatorInitiatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *TermRevocation) GetOutgoingRule() *RuleNumber {
+	if x != nil {
+		return x.OutgoingRule
+	}
+	return nil
+}
+
 // ExternallyCertifiedRevocation certifies that the outgoing cohort's revocation
 // has been established by an external agent rather than through normal Recruit
 // RPCs. The incoming cohort is still recruited normally via Recruit RPCs.
@@ -1777,8 +1802,8 @@ func (x *TermRevocation) GetCoordinatorInitiatedAt() *timestamppb.Timestamp {
 // The external actor certifies:
 //
 //  1. No pooler in the outgoing cohort can make progress beyond frozen_lsn
-//     under outgoing_rule_number — all durable transactions at the time of
-//     revocation are captured at or below that position.
+//     under term_revocation.outgoing_rule — all durable transactions at the
+//     time of revocation are captured at or below that position.
 //
 //  2. The term in term_revocation is globally unique; no other coordinator has
 //     used or will use it.
@@ -1787,18 +1812,17 @@ func (x *TermRevocation) GetCoordinatorInitiatedAt() *timestamppb.Timestamp {
 // it is acting on an external request.
 type ExternallyCertifiedRevocation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The rule number being superseded. Identifies which outgoing cohort is frozen.
-	OutgoingRuleNumber *RuleNumber `protobuf:"bytes,1,opt,name=outgoing_rule_number,json=outgoingRuleNumber,proto3" json:"outgoing_rule_number,omitempty"`
+	// Records the unique coordinator term for this proposal, the coordinator
+	// facilitating the request, and the outgoing_rule the cohort is being
+	// transitioned from. The coordinator fills this in even though it is acting
+	// on behalf of an external operator request.
+	TermRevocation *TermRevocation `protobuf:"bytes,1,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
 	// The LSN at which the outgoing cohort's progress is frozen. No durable writes
-	// occurred beyond this position under outgoing_rule_number. The chosen leader's
-	// WAL position must meet or exceed this LSN.
-	FrozenLsn string `protobuf:"bytes,2,opt,name=frozen_lsn,json=frozenLsn,proto3" json:"frozen_lsn,omitempty"`
-	// Records the unique coordinator term for this proposal and the coordinator
-	// facilitating the request. The coordinator fills this in even though it is
-	// acting on behalf of an external operator request.
-	TermRevocation *TermRevocation `protobuf:"bytes,3,opt,name=term_revocation,json=termRevocation,proto3" json:"term_revocation,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// occurred beyond this position under term_revocation.outgoing_rule. The chosen
+	// leader's WAL position must meet or exceed this LSN.
+	FrozenLsn     string `protobuf:"bytes,2,opt,name=frozen_lsn,json=frozenLsn,proto3" json:"frozen_lsn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExternallyCertifiedRevocation) Reset() {
@@ -1831,9 +1855,9 @@ func (*ExternallyCertifiedRevocation) Descriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *ExternallyCertifiedRevocation) GetOutgoingRuleNumber() *RuleNumber {
+func (x *ExternallyCertifiedRevocation) GetTermRevocation() *TermRevocation {
 	if x != nil {
-		return x.OutgoingRuleNumber
+		return x.TermRevocation
 	}
 	return nil
 }
@@ -1843,13 +1867,6 @@ func (x *ExternallyCertifiedRevocation) GetFrozenLsn() string {
 		return x.FrozenLsn
 	}
 	return ""
-}
-
-func (x *ExternallyCertifiedRevocation) GetTermRevocation() *TermRevocation {
-	if x != nil {
-		return x.TermRevocation
-	}
-	return nil
 }
 
 // ConsensusStatus is a pooler's complete view of its position in the distributed
@@ -1863,10 +1880,10 @@ func (x *ExternallyCertifiedRevocation) GetTermRevocation() *TermRevocation {
 //     The highest ShardRule committed to local WAL (from rule_history) and the
 //     current LSN. Authoritative because postgres WAL is durable and ordered.
 //
-//  3. highest_known_rule (best-effort, coordinator-provided)
-//     The most recent rule the coordinator is about to establish or has recently
-//     established. May be ahead of current_position; not persisted and may be
-//     stale after restarts.
+//  3. replication_primary (best-effort, coordinator-provided)
+//     The primary this pooler should be pointed at for replication, plus the
+//     rule under which that primary holds leadership. May be ahead of
+//     current_position; not persisted and may be stale after restarts.
 type ConsensusStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// term_revocation records the highest coordinator term this pooler has revoked for.
@@ -1874,10 +1891,11 @@ type ConsensusStatus struct {
 	// current_position is the highest rule this pooler has committed to local WAL
 	// and the latest WAL position.
 	CurrentPosition *PoolerPosition `protobuf:"bytes,2,opt,name=current_position,json=currentPosition,proto3" json:"current_position,omitempty"`
-	// highest_known_rule is the most recent rule this pooler is aware of. May be
-	// ahead of current_position when the pooler has forward knowledge of an
-	// upcoming rule that has not yet been replicated or written.
-	HighestKnownRule *HighestKnownRule `protobuf:"bytes,3,opt,name=highest_known_rule,json=highestKnownRule,proto3" json:"highest_known_rule,omitempty"`
+	// replication_primary is the pooler's best-effort view of who its primary
+	// should be (and under what rule). May reflect a rule ahead of
+	// current_position when the pooler has been informed of a newer rule that
+	// has not yet been replicated through WAL.
+	ReplicationPrimary *ReplicationPrimary `protobuf:"bytes,3,opt,name=replication_primary,json=replicationPrimary,proto3" json:"replication_primary,omitempty"`
 	// id identifies the pooler that produced this status. Makes ConsensusStatus
 	// self-describing when passed around without a surrounding envelope.
 	Id            *ID `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
@@ -1929,9 +1947,9 @@ func (x *ConsensusStatus) GetCurrentPosition() *PoolerPosition {
 	return nil
 }
 
-func (x *ConsensusStatus) GetHighestKnownRule() *HighestKnownRule {
+func (x *ConsensusStatus) GetReplicationPrimary() *ReplicationPrimary {
 	if x != nil {
-		return x.HighestKnownRule
+		return x.ReplicationPrimary
 	}
 	return nil
 }
@@ -2229,22 +2247,23 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\rcreation_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\fcreationTime\"R\n" +
 	"\x0ePoolerPosition\x12.\n" +
 	"\x04rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\x04rule\x12\x10\n" +
-	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"B\n" +
-	"\x10HighestKnownRule\x12.\n" +
-	"\x04rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\x04rule\"\xe1\x01\n" +
+	"\x03lsn\x18\x02 \x01(\tR\x03lsn\"|\n" +
+	"\x12ReplicationPrimary\x12.\n" +
+	"\x04rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\x04rule\x126\n" +
+	"\aprimary\x18\x02 \x01(\v2\x1c.clustermetadata.MultiPoolerR\aprimary\"\xa3\x02\n" +
 	"\x0eTermRevocation\x12,\n" +
 	"\x12revoked_below_term\x18\x01 \x01(\x03R\x10revokedBelowTerm\x12K\n" +
 	"\x17accepted_coordinator_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\x15acceptedCoordinatorId\x12T\n" +
-	"\x18coordinator_initiated_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x16coordinatorInitiatedAt\"\xd7\x01\n" +
-	"\x1dExternallyCertifiedRevocation\x12M\n" +
-	"\x14outgoing_rule_number\x18\x01 \x01(\v2\x1b.clustermetadata.RuleNumberR\x12outgoingRuleNumber\x12\x1d\n" +
+	"\x18coordinator_initiated_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x16coordinatorInitiatedAt\x12@\n" +
+	"\routgoing_rule\x18\x04 \x01(\v2\x1b.clustermetadata.RuleNumberR\foutgoingRule\"\x88\x01\n" +
+	"\x1dExternallyCertifiedRevocation\x12H\n" +
+	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12\x1d\n" +
 	"\n" +
-	"frozen_lsn\x18\x02 \x01(\tR\tfrozenLsn\x12H\n" +
-	"\x0fterm_revocation\x18\x03 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\"\x9d\x02\n" +
+	"frozen_lsn\x18\x02 \x01(\tR\tfrozenLsn\"\xa2\x02\n" +
 	"\x0fConsensusStatus\x12H\n" +
 	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12J\n" +
-	"\x10current_position\x18\x02 \x01(\v2\x1f.clustermetadata.PoolerPositionR\x0fcurrentPosition\x12O\n" +
-	"\x12highest_known_rule\x18\x03 \x01(\v2!.clustermetadata.HighestKnownRuleR\x10highestKnownRule\x12#\n" +
+	"\x10current_position\x18\x02 \x01(\v2\x1f.clustermetadata.PoolerPositionR\x0fcurrentPosition\x12T\n" +
+	"\x13replication_primary\x18\x03 \x01(\v2#.clustermetadata.ReplicationPrimaryR\x12replicationPrimary\x12#\n" +
 	"\x02id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\x02id\"n\n" +
 	"\x10LeadershipStatus\x12\x1f\n" +
 	"\vleader_term\x18\x01 \x01(\x03R\n" +
@@ -2319,7 +2338,7 @@ var file_clustermetadata_proto_goTypes = []any{
 	(*RuleNumber)(nil),                    // 20: clustermetadata.RuleNumber
 	(*ShardRule)(nil),                     // 21: clustermetadata.ShardRule
 	(*PoolerPosition)(nil),                // 22: clustermetadata.PoolerPosition
-	(*HighestKnownRule)(nil),              // 23: clustermetadata.HighestKnownRule
+	(*ReplicationPrimary)(nil),            // 23: clustermetadata.ReplicationPrimary
 	(*TermRevocation)(nil),                // 24: clustermetadata.TermRevocation
 	(*ExternallyCertifiedRevocation)(nil), // 25: clustermetadata.ExternallyCertifiedRevocation
 	(*ConsensusStatus)(nil),               // 26: clustermetadata.ConsensusStatus
@@ -2357,24 +2376,25 @@ var file_clustermetadata_proto_depIdxs = []int32{
 	17, // 22: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
 	33, // 23: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
 	21, // 24: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	21, // 25: clustermetadata.HighestKnownRule.rule:type_name -> clustermetadata.ShardRule
-	17, // 26: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	33, // 27: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	20, // 28: clustermetadata.ExternallyCertifiedRevocation.outgoing_rule_number:type_name -> clustermetadata.RuleNumber
-	24, // 29: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	24, // 30: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	22, // 31: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	23, // 32: clustermetadata.ConsensusStatus.highest_known_rule:type_name -> clustermetadata.HighestKnownRule
-	17, // 33: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	3,  // 34: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	27, // 35: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	29, // 36: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
-	4,  // 37: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
-	38, // [38:38] is the sub-list for method output_type
-	38, // [38:38] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	21, // 25: clustermetadata.ReplicationPrimary.rule:type_name -> clustermetadata.ShardRule
+	13, // 26: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.MultiPooler
+	17, // 27: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	33, // 28: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	20, // 29: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
+	24, // 30: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	24, // 31: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	22, // 32: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	23, // 33: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	17, // 34: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	3,  // 35: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	27, // 36: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	29, // 37: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	4,  // 38: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -140,6 +140,19 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 			"no non-resigned poolers in cohort; cannot fail over")
 	}
 
+	// Failover constructs the revocation via NewTermRevocation: outgoing_rule
+	// is the highest RuleNumber discovered across cohort statuses.
+	var liveStatuses []*clustermetadatapb.ConsensusStatus
+	for _, p := range liveCohort {
+		if cs := p.GetConsensusStatus(); cs != nil {
+			liveStatuses = append(liveStatuses, cs)
+		}
+	}
+	revocation, err := commonconsensus.NewTermRevocation(liveStatuses, c.coordinatorID)
+	if err != nil {
+		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION, "%v", err)
+	}
+
 	poolerByID, _ := buildCohortMaps(liveCohort)
 	buildProposal := func(r commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 		return buildFailoverProposal(r, poolerByID)
@@ -150,7 +163,7 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 	checkProposalPossible := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
 		return commonconsensus.CheckProposalPossible(rev, statuses, buildProposal)
 	}
-	return c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, liveCohort)
+	return c.newRuleChange(reason, tryBuildProposal, checkProposalPossible).Run(ctx, liveCohort, revocation)
 }
 
 // appointLeaderWithTerm is the shared core of AppointLeader and AppointInitialLeader.
@@ -257,17 +270,24 @@ func (c *Coordinator) AppointInitialLeader(ctx context.Context, shardID string, 
 			}
 		}
 
-		// This is the discovery phase of coordinator-led rule changes. For externally-certified
-		// rule changes, the client (this method) is responsible for discovery.
+		// This is the discovery phase of coordinator-led rule changes. For
+		// externally-certified rule changes, the agent (this method) is
+		// responsible for choosing the outgoing rule and authoring the
+		// revocation; common/consensus consumes the cert without re-deriving.
 		mostAdvanced := commonconsensus.MostAdvancedPosition(cohortStatuses)
 		if mostAdvanced == nil {
 			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 				"cannot bootstrap shard %s: no cohort member has a known WAL position", shardID)
 		}
-		outgoingRule := mostAdvanced.GetRule().GetRuleNumber()
-		if outgoingRule == nil {
-			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
-				"cannot bootstrap shard %s: db initialization didn't set up consensus rules", shardID)
+
+		revocation, err := commonconsensus.NewTermRevocation(cohortStatuses, c.coordinatorID)
+		if err != nil {
+			return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION, "%v", err)
+		}
+
+		cert := &clustermetadatapb.ExternallyCertifiedRevocation{
+			TermRevocation: revocation,
+			FrozenLsn:      mostAdvanced.GetLsn(),
 		}
 
 		poolerByID, _ := buildCohortMaps(cohort)
@@ -275,22 +295,15 @@ func (c *Coordinator) AppointInitialLeader(ctx context.Context, shardID string, 
 		buildProposalFn := func(result commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
 			return buildBootstrapProposal(result, cohortIDs, policy, poolerByID)
 		}
-		certFor := func(rev *clustermetadatapb.TermRevocation) *clustermetadatapb.ExternallyCertifiedRevocation {
-			return &clustermetadatapb.ExternallyCertifiedRevocation{
-				TermRevocation:     rev,
-				OutgoingRuleNumber: outgoingRule,
-				FrozenLsn:          mostAdvanced.GetLsn(),
-			}
-		}
 		return c.newRuleChange(
 			"ShardInit",
-			func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
-				return commonconsensus.BuildExternallyCertifiedProposal(certFor(rev), statuses, buildProposalFn)
+			func(_ *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
+				return commonconsensus.BuildExternallyCertifiedProposal(cert, statuses, buildProposalFn)
 			},
-			func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
-				return commonconsensus.CheckExternallyCertifiedProposalPossible(certFor(rev), statuses, buildProposalFn)
+			func(_ *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) error {
+				return commonconsensus.CheckExternallyCertifiedProposalPossible(cert, statuses, buildProposalFn)
 			},
-		).Run(ctx, cohort)
+		).Run(ctx, cohort, revocation)
 	}
 
 	// Freshly bootstrapped shards start at term 0; skip discoverMaxTerm (which

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -56,20 +56,34 @@ func (c *Coordinator) newRuleChange(
 	}
 }
 
-// Run executes the rule change: derive term, pre-validate, recruit all nodes
-// concurrently, and propose as soon as a viable proposal can be assembled.
-// Each node receives its Propose immediately once it has been recruited and
-// the proposal is ready — there is no unnecessary waiting between the two.
-func (r *coordinatorLedRuleChange) Run(ctx context.Context, cohort []*multiorchdatapb.PoolerHealthState) error {
-	// Extract cached consensus statuses to derive the revocation term.
+// Run executes the rule change: pre-validate, recruit all nodes concurrently,
+// and propose as soon as a viable proposal can be assembled. Each node
+// receives its Propose immediately once it has been recruited and the
+// proposal is ready — there is no unnecessary waiting between the two.
+//
+// revocation is the authoritative term revocation the coordinator is
+// proposing. Callers own its construction:
+//   - For safe coordinator-led transitions (failover), use
+//     commonconsensus.NewTermRevocation to derive it from cohort statuses.
+//   - For externally-certified transitions (bootstrap, operator override),
+//     construct the cert and pass cert.GetTermRevocation() — the agent
+//     defines revoked_below_term and outgoing_rule, not local discovery.
+func (r *coordinatorLedRuleChange) Run(
+	ctx context.Context,
+	cohort []*multiorchdatapb.PoolerHealthState,
+	revocation *clustermetadatapb.TermRevocation,
+) error {
+	if revocation == nil {
+		return mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "Run: revocation is required")
+	}
+
+	// Extract cached consensus statuses for the pre-vote feasibility check.
 	var initialStatuses []*clustermetadatapb.ConsensusStatus
 	for _, p := range cohort {
 		if cs := p.GetConsensusStatus(); cs != nil {
 			initialStatuses = append(initialStatuses, cs)
 		}
 	}
-
-	revocation := commonconsensus.NewTermRevocation(initialStatuses, r.coordinator.coordinatorID)
 
 	r.coordinator.logger.InfoContext(ctx, "Starting rule change",
 		"proposed_term", revocation.GetRevokedBelowTerm(),

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -37,6 +37,10 @@ import (
 )
 
 // makePoolerState creates a PoolerHealthState with the given cell/name.
+// A minimal ConsensusStatus carrying a zero-valued recorded rule is attached
+// so the state is suitable as a cohort member: NewTermRevocation requires
+// at least one cohort member to report a recorded rule. Tests that need
+// richer status state overwrite the field after construction.
 func makePoolerState(cell, name string) *multiorchdatapb.PoolerHealthState {
 	id := &clustermetadatapb.ID{
 		Component: clustermetadatapb.ID_MULTIPOOLER,
@@ -50,7 +54,32 @@ func makePoolerState(cell, name string) *multiorchdatapb.PoolerHealthState {
 			PortMap:  map[string]int32{"postgres": 5432, "grpc": 9000},
 		},
 		IsLastCheckValid: true,
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			Id: id,
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{},
+				},
+			},
+		},
 	}
+}
+
+// newTestRevocation builds a TermRevocation suitable for rule_change.Run from
+// the given cohort. Tests that don't care about specific revocation contents
+// (term, outgoing_rule, etc.) use this to satisfy Run's "revocation is required"
+// contract; tests that need richer state construct their own.
+func newTestRevocation(t *testing.T, coord *Coordinator, cohort []*multiorchdatapb.PoolerHealthState) *clustermetadatapb.TermRevocation {
+	t.Helper()
+	var statuses []*clustermetadatapb.ConsensusStatus
+	for _, p := range cohort {
+		if cs := p.GetConsensusStatus(); cs != nil {
+			statuses = append(statuses, cs)
+		}
+	}
+	rev, err := commonconsensus.NewTermRevocation(statuses, coord.coordinatorID)
+	require.NoError(t, err)
+	return rev
 }
 
 // setRecruitOK configures the fake client to return a successful Recruit response
@@ -208,7 +237,7 @@ func TestRun_Success(t *testing.T) {
 	}
 
 	rc := c.newRuleChange("test", fixedProposal(2, proposal), nopCheckProposalPossible)
-	require.NoError(t, rc.Run(ctx, cohort))
+	require.NoError(t, rc.Run(ctx, cohort, newTestRevocation(t, c, cohort)))
 
 	// Both nodes should have received a Propose request.
 	mp1Key := topoclient.MultiPoolerIDString(mp1.MultiPooler.Id)
@@ -259,7 +288,7 @@ func TestRun_EarlyExit(t *testing.T) {
 	}
 
 	rc := c.newRuleChange("test", tryBuildProposal, nopCheckProposalPossible)
-	require.NoError(t, rc.Run(ctx, cohort))
+	require.NoError(t, rc.Run(ctx, cohort, newTestRevocation(t, c, cohort)))
 }
 
 func TestRun_InsufficientRecruitment(t *testing.T) {
@@ -279,7 +308,7 @@ func TestRun_InsufficientRecruitment(t *testing.T) {
 	}
 
 	rc := c.newRuleChange("test", tryBuildProposal, nopCheckProposalPossible)
-	err := rc.Run(ctx, cohort)
+	err := rc.Run(ctx, cohort, newTestRevocation(t, c, cohort))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "recruitment failed")
 }
@@ -291,16 +320,14 @@ func TestRun_BackoffOnRecentAcceptance(t *testing.T) {
 	c := newRuleChangeCoordinator(t, fc)
 
 	mp1 := makePoolerState("zone1", "mp1")
-	mp1.ConsensusStatus = &clustermetadatapb.ConsensusStatus{
-		TermRevocation: &clustermetadatapb.TermRevocation{
-			RevokedBelowTerm:       5,
-			CoordinatorInitiatedAt: timestamppb.New(time.Now().Add(-500 * time.Millisecond)),
-		},
+	mp1.ConsensusStatus.TermRevocation = &clustermetadatapb.TermRevocation{
+		RevokedBelowTerm:       5,
+		CoordinatorInitiatedAt: timestamppb.New(time.Now().Add(-500 * time.Millisecond)),
 	}
 	cohort := []*multiorchdatapb.PoolerHealthState{mp1}
 
 	rc := c.newRuleChange("test", fixedProposal(1, &consensusdatapb.CoordinatorProposal{}), nopCheckProposalPossible)
-	err := rc.Run(ctx, cohort)
+	err := rc.Run(ctx, cohort, newTestRevocation(t, c, cohort))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "another coordinator started recruiting recently")
 	assert.Empty(t, fc.GetCallLog(), "no RPCs should be made when backing off for recent acceptance")
@@ -323,7 +350,7 @@ func TestRun_PreValidateFails(t *testing.T) {
 	}
 
 	rc := c.newRuleChange("test", fixedProposal(1, &consensusdatapb.CoordinatorProposal{}), checkProposalPossible)
-	err := rc.Run(ctx, cohort)
+	err := rc.Run(ctx, cohort, newTestRevocation(t, c, cohort))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pre-vote failed")
 	assert.Contains(t, err.Error(), preValidateErr.Error())
@@ -381,7 +408,7 @@ func TestRun_LeaderProposeFails(t *testing.T) {
 	}
 
 	rc := c.newRuleChange("test", tryBuildProposal, nopCheckProposalPossible)
-	err := rc.Run(ctx, cohort)
+	err := rc.Run(ctx, cohort, newTestRevocation(t, c, cohort))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to accept proposal")
 }
@@ -434,7 +461,7 @@ func TestRun_NonLeaderProposeFails(t *testing.T) {
 
 	// With mp2 failing Recruit, only mp1 recruits — use minNodes=1.
 	rc := c.newRuleChange("test", fixedProposal(1, proposal), nopCheckProposalPossible)
-	require.NoError(t, rc.Run(ctx, cohort))
+	require.NoError(t, rc.Run(ctx, cohort, newTestRevocation(t, c, cohort)))
 
 	// Leader (mp1) received Propose.
 	mp1Key := topoclient.MultiPoolerIDString(mp1.MultiPooler.Id)

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -1300,6 +1300,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       5,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks:                 func(m *mock.QueryService) {},
@@ -1317,6 +1318,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       5,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks:                 func(m *mock.QueryService) {},
@@ -1335,6 +1337,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       7,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks: func(m *mock.QueryService) {
@@ -1350,6 +1353,7 @@ func TestRecruit(t *testing.T) {
 				RevokedBelowTerm:       7,
 				AcceptedCoordinatorId:  coordinatorA,
 				CoordinatorInitiatedAt: recruitTS,
+				OutgoingRule:           &clustermetadatapb.RuleNumber{},
 			},
 			ruleStore: &fakeRuleStore{pos: makeRulePosition(0)},
 			req: &consensusdatapb.RecruitRequest{
@@ -1357,6 +1361,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       7,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks: func(m *mock.QueryService) {
@@ -1379,6 +1384,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       7,
 					AcceptedCoordinatorId:  coordinatorB,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			// ValidateRevocation rejects at step 1 — postgres is never touched.
@@ -1398,6 +1404,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       5,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			// ValidateRevocation rejects at step 1 — postgres is never touched.
@@ -1416,6 +1423,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       7,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks: func(m *mock.QueryService) {
@@ -1439,6 +1447,7 @@ func TestRecruit(t *testing.T) {
 					RevokedBelowTerm:       7,
 					AcceptedCoordinatorId:  coordinatorA,
 					CoordinatorInitiatedAt: recruitTS,
+					OutgoingRule:           &clustermetadatapb.RuleNumber{},
 				},
 			},
 			setupMocks: func(m *mock.QueryService) {
@@ -1509,6 +1518,7 @@ func TestRecruit(t *testing.T) {
 				RevokedBelowTerm:       7,
 				AcceptedCoordinatorId:  &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "coord"},
 				CoordinatorInitiatedAt: recruitTS,
+				OutgoingRule:           &clustermetadatapb.RuleNumber{},
 			},
 		}
 		_, err := pm.Recruit(t.Context(), req)
@@ -1589,6 +1599,7 @@ func TestPropose(t *testing.T) {
 		RevokedBelowTerm:       7,
 		AcceptedCoordinatorId:  coordinatorA,
 		CoordinatorInitiatedAt: recruitTS,
+		OutgoingRule:           &clustermetadatapb.RuleNumber{},
 	}
 	validProposedRule := &clustermetadatapb.ShardRule{
 		CohortMembers: []*clustermetadatapb.ID{selfID, otherPooler},
@@ -1728,6 +1739,7 @@ func TestPropose(t *testing.T) {
 						RevokedBelowTerm:       7,
 						AcceptedCoordinatorId:  coordinatorB,
 						CoordinatorInitiatedAt: recruitTS,
+						OutgoingRule:           &clustermetadatapb.RuleNumber{},
 					},
 					ProposalLeader: &consensusdatapb.ProposalLeader{Id: selfID, PostgresPort: 5432},
 					ProposedRule:   validProposedRule,

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -379,23 +379,29 @@ message PoolerPosition {
   string lsn = 2;
 }
 
-// HighestKnownRule is the most recent ShardRule this pooler is aware of,
-// which could be beyond the end of this pooler's WAL / PoolerPosition.
+// ReplicationPrimary advertises the primary this pooler believes it should be
+// pointed at for replication, along with the rule under which that primary
+// holds leadership. The primary contact info is the main payload — it's how a
+// pooler in a degraded state (partition, mid-bootstrap, Inform-while-postgres-
+// was-down) figures out who to reconnect replication to. The rule is supporting
+// evidence and has secondary uses such as coordinators learning of rules newer
+// than what's in any replica's WAL.
 //
-// If a pooler is disconnected from replication due to network partitions
-// or stale coordinators, the HighestKnownRule helps them fix GUC and reconnect
-// to learn the latest shard state.
-//
-// If a coordinator is still establishing a new term's first rule, the HighestKnownRule
-// may represent a rule that the coordinator is _about_ to write that doesn't exist in
-// any WAL entries yet.
-//
-// HighestKnownRule does not need to be persisted. It's a best-effort attempt to fix GUC
-// settings so that nodes can participate in replication. Nodes with out-of-date information
-// will be re-informed of the latest HighestKnownRule by any coordinator that notices the
-// pooler has incorrect replication settings.
-message HighestKnownRule {
+// Not persisted across pooler restarts — best-effort, populated by Inform and
+// Propose RPCs. Coordinators that notice a pooler has incorrect replication
+// settings will re-inform it.
+message ReplicationPrimary {
+  // The most recent rule under which this primary holds leadership. May be
+  // ahead of the pooler's committed PoolerPosition while replication catches
+  // up. Coordinators compare this to what they would otherwise Inform with —
+  // if (rule, primary) already matches, the Inform is redundant and can be
+  // skipped.
   ShardRule rule = 1;
+
+  // Contact info for the primary the pooler was last told to use. Snapshot
+  // from the most recent Inform/Propose; treat as "what this pooler currently
+  // believes," not as the canonical primary for the cluster.
+  MultiPooler primary = 2;
 }
 
 // TermRevocation records that this pooler has revoked participation in all terms
@@ -431,6 +437,13 @@ message TermRevocation {
   // recruiting. All poolers that accept the same recruitment store the same value.
   // TODO: populate once BeginTermRequest carries this timestamp.
   google.protobuf.Timestamp coordinator_initiated_at = 3;
+
+  // The rule the coordinator observed across the cohort at recruit time —
+  // the "from" side of the transition this recruit was authoring. Used as
+  // an override key during Inform: if a subsequent Inform carries a rule
+  // strictly greater than this, the cluster has demonstrably moved past
+  // the runaway recruit's premise and the revocation is moot.
+  RuleNumber outgoing_rule = 4;
 }
 
 // ExternallyCertifiedRevocation certifies that the outgoing cohort's revocation
@@ -440,8 +453,8 @@ message TermRevocation {
 // The external actor certifies:
 //
 //  1. No pooler in the outgoing cohort can make progress beyond frozen_lsn
-//     under outgoing_rule_number — all durable transactions at the time of
-//     revocation are captured at or below that position.
+//     under term_revocation.outgoing_rule — all durable transactions at the
+//     time of revocation are captured at or below that position.
 //
 //  2. The term in term_revocation is globally unique; no other coordinator has
 //     used or will use it.
@@ -449,18 +462,16 @@ message TermRevocation {
 // The coordinator names itself as the initiator in term_revocation even though
 // it is acting on an external request.
 message ExternallyCertifiedRevocation {
-  // The rule number being superseded. Identifies which outgoing cohort is frozen.
-  RuleNumber outgoing_rule_number = 1;
+  // Records the unique coordinator term for this proposal, the coordinator
+  // facilitating the request, and the outgoing_rule the cohort is being
+  // transitioned from. The coordinator fills this in even though it is acting
+  // on behalf of an external operator request.
+  TermRevocation term_revocation = 1;
 
   // The LSN at which the outgoing cohort's progress is frozen. No durable writes
-  // occurred beyond this position under outgoing_rule_number. The chosen leader's
-  // WAL position must meet or exceed this LSN.
+  // occurred beyond this position under term_revocation.outgoing_rule. The chosen
+  // leader's WAL position must meet or exceed this LSN.
   string frozen_lsn = 2;
-
-  // Records the unique coordinator term for this proposal and the coordinator
-  // facilitating the request. The coordinator fills this in even though it is
-  // acting on behalf of an external operator request.
-  TermRevocation term_revocation = 3;
 }
 
 // ConsensusStatus is a pooler's complete view of its position in the distributed
@@ -474,10 +485,10 @@ message ExternallyCertifiedRevocation {
 //     The highest ShardRule committed to local WAL (from rule_history) and the
 //     current LSN. Authoritative because postgres WAL is durable and ordered.
 //
-//  3. highest_known_rule (best-effort, coordinator-provided)
-//     The most recent rule the coordinator is about to establish or has recently
-//     established. May be ahead of current_position; not persisted and may be
-//     stale after restarts.
+//  3. replication_primary (best-effort, coordinator-provided)
+//     The primary this pooler should be pointed at for replication, plus the
+//     rule under which that primary holds leadership. May be ahead of
+//     current_position; not persisted and may be stale after restarts.
 message ConsensusStatus {
   // term_revocation records the highest coordinator term this pooler has revoked for.
   TermRevocation term_revocation = 1;
@@ -486,10 +497,11 @@ message ConsensusStatus {
   // and the latest WAL position.
   PoolerPosition current_position = 2;
 
-  // highest_known_rule is the most recent rule this pooler is aware of. May be
-  // ahead of current_position when the pooler has forward knowledge of an
-  // upcoming rule that has not yet been replicated or written.
-  HighestKnownRule highest_known_rule = 3;
+  // replication_primary is the pooler's best-effort view of who its primary
+  // should be (and under what rule). May reflect a rule ahead of
+  // current_position when the pooler has been informed of a newer rule that
+  // has not yet been replicated through WAL.
+  ReplicationPrimary replication_primary = 3;
 
   // id identifies the pooler that produced this status. Makes ConsensusStatus
   // self-describing when passed around without a surrounding envelope.


### PR DESCRIPTION
This should be a mostly pure refactoring, it's for two purposes:

- Future recruit-time staleness rejection. A pooler should not accept a Recruit() and revoke replication if the request is from a coordinator operating on an out-of-date view of the shard state. I've added a TODO about this in revocation.go since we may need to have a clearer distinction between proposals vs decisions before enforcing that decisions override impossible proposals.
- Future SetTermLeader RPC. A higher rule version should override a revocation with a lower expected starting point.

This is all based around the idea that a coordinator doesn't begin recruitment until it has a clear sense of the outgoing rule and never changes its mind midway through a rule change.