### PR TITLE
feat(multigateway): make application_name a gateway-managed GUC

### DIFF
--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -167,6 +167,7 @@ func (s *ApplySessionState) executeReset(
 		state.ResetAllSessionVariables()
 		// Also reset gateway-managed variables that live outside SessionSettings.
 		state.ResetStatementTimeout()
+		state.ResetApplicationName()
 	default:
 		return mterrors.NewFeatureNotSupported(fmt.Sprintf("RESET kind %d is not supported", s.VariableStmt.Kind))
 	}

--- a/go/services/multigateway/engine/gateway_session_state.go
+++ b/go/services/multigateway/engine/gateway_session_state.go
@@ -43,6 +43,7 @@ type GatewaySessionState struct {
 	// Typed fields for each gateway-managed variable.
 	// Only the field matching `variable` is used.
 	statementTimeout time.Duration
+	applicationName  string
 
 	// The (isReset, isLocal) flags map to the four user-visible variants:
 	//
@@ -71,6 +72,19 @@ func NewStatementTimeoutSet(sql string, statementTimeout time.Duration, isLocal 
 		variable:         "statement_timeout",
 		statementTimeout: statementTimeout,
 		isLocal:          isLocal,
+	}
+}
+
+// NewApplicationNameSet creates a primitive that SETs `application_name`.
+// The value is stored verbatim (no parsing needed). When isLocal is true, the
+// value is treated as a transaction-local override (SET LOCAL), cleared on
+// COMMIT/ROLLBACK.
+func NewApplicationNameSet(sql string, applicationName string, isLocal bool) *GatewaySessionState {
+	return &GatewaySessionState{
+		sql:             sql,
+		variable:        "application_name",
+		applicationName: applicationName,
+		isLocal:         isLocal,
 	}
 }
 
@@ -146,6 +160,17 @@ func (g *GatewaySessionState) StreamExecute(
 			state.SetLocalStatementTimeout(g.statementTimeout)
 		default:
 			state.SetStatementTimeout(g.statementTimeout)
+		}
+	case "application_name":
+		switch {
+		case g.isReset && g.isLocal:
+			state.SetLocalApplicationNameToDefault()
+		case g.isReset:
+			state.ResetApplicationName()
+		case g.isLocal:
+			state.SetLocalApplicationName(g.applicationName)
+		default:
+			state.SetApplicationName(g.applicationName)
 		}
 	default:
 		// Unreachable: the planner validates the variable name before creating

--- a/go/services/multigateway/engine/gateway_show_variable.go
+++ b/go/services/multigateway/engine/gateway_show_variable.go
@@ -57,6 +57,8 @@ func (g *GatewayShowVariable) StreamExecute(
 	switch g.variable {
 	case "statement_timeout":
 		value = state.ShowStatementTimeout()
+	case "application_name":
+		value = state.ShowApplicationName()
 	default:
 		// Unreachable: the planner validates the variable name before creating
 		// this primitive. If we get here, there's a code bug (new variable added

--- a/go/services/multigateway/handler/application_name_test.go
+++ b/go/services/multigateway/handler/application_name_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionState_ApplicationName(t *testing.T) {
+	t.Run("returns default when not set", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		require.Equal(t, "startup-val", s.GetApplicationName())
+		require.Equal(t, "startup-val", s.ShowApplicationName())
+	})
+
+	t.Run("empty default mirrors PG default", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("")
+		require.Equal(t, "", s.GetApplicationName())
+		require.Equal(t, "", s.ShowApplicationName())
+	})
+
+	t.Run("set overrides default", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("myapp")
+		require.Equal(t, "myapp", s.GetApplicationName())
+		require.Equal(t, "myapp", s.ShowApplicationName())
+	})
+
+	t.Run("set empty string is honoured", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("")
+		require.Equal(t, "", s.GetApplicationName(),
+			"explicit SET to empty string overrides non-empty default")
+	})
+
+	t.Run("reset reverts to default", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("myapp")
+		s.ResetApplicationName()
+		require.Equal(t, "startup-val", s.GetApplicationName())
+	})
+
+	t.Run("set local overrides session and shows local value", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("session-val")
+		s.SetLocalApplicationName("local-val")
+		require.Equal(t, "local-val", s.GetApplicationName())
+		require.Equal(t, "local-val", s.ShowApplicationName())
+	})
+
+	t.Run("ResetAllLocalGUCs clears local but keeps session", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("session-val")
+		s.SetLocalApplicationName("local-val")
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, "session-val", s.GetApplicationName())
+	})
+
+	t.Run("ResetAllLocalGUCs reverts to default when no session set", func(t *testing.T) {
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetLocalApplicationName("local-val")
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, "startup-val", s.GetApplicationName())
+	})
+
+	t.Run("session set supersedes active local override", func(t *testing.T) {
+		// Mirrors PG: SET inside a transaction with a prior SET LOCAL
+		// supersedes the LOCAL — effective value is the new session value.
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetLocalApplicationName("local-val")
+		s.SetApplicationName("session-val")
+		require.Equal(t, "session-val", s.GetApplicationName())
+	})
+
+	t.Run("session reset supersedes active local override", func(t *testing.T) {
+		// Mirrors PG: RESET inside a transaction with a prior SET LOCAL
+		// supersedes the LOCAL — effective value is the default.
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("session-val")
+		s.SetLocalApplicationName("local-val")
+		s.ResetApplicationName()
+		require.Equal(t, "startup-val", s.GetApplicationName())
+	})
+
+	t.Run("SetLocalApplicationNameToDefault masks session", func(t *testing.T) {
+		// PG semantics: SET LOCAL var TO DEFAULT installs a transaction-scoped
+		// override equal to the default, masking the session value during the
+		// transaction. The session value must be preserved for restoration on
+		// COMMIT/ROLLBACK (when ResetAllLocalGUCs fires).
+		s := NewMultiGatewayConnectionState()
+		s.InitApplicationName("startup-val")
+		s.SetApplicationName("session-val")
+
+		s.SetLocalApplicationNameToDefault()
+		require.Equal(t, "startup-val", s.GetApplicationName(),
+			"during txn: effective value is the default")
+
+		s.ResetAllLocalGUCs()
+		require.Equal(t, "session-val", s.GetApplicationName(),
+			"after txn end: session value is restored, not lost")
+	})
+}
+
+// --- Cross-GMV savepoint / transaction lifecycle tests ---
+//
+// These verify that the gmvs registry keeps every gateway-managed variable's
+// snapshot stack in lockstep with the connection-state savepoint stack. If a
+// new GMV is added but not registered, these tests catch the omission.
+
+func TestConnectionState_ApplicationNameRollbackToSavepoint(t *testing.T) {
+	s := NewMultiGatewayConnectionState()
+	s.InitApplicationName("startup-val")
+	s.BeginTransaction()
+	s.SetLocalApplicationName("outer")
+
+	s.PushSavepoint("sp")
+	s.SetLocalApplicationName("inner")
+	require.Equal(t, "inner", s.GetApplicationName())
+
+	s.RollbackToSavepoint("sp")
+	require.Equal(t, "outer", s.GetApplicationName(),
+		"ROLLBACK TO sp must restore the pre-savepoint LOCAL value")
+}
+
+func TestConnectionState_ApplicationNameCommitClearsLocal(t *testing.T) {
+	s := NewMultiGatewayConnectionState()
+	s.InitApplicationName("startup-val")
+	s.BeginTransaction()
+	s.SetApplicationName("session-val")
+	s.SetLocalApplicationName("local-val")
+	require.Equal(t, "local-val", s.GetApplicationName())
+
+	s.CommitTransaction()
+
+	require.Equal(t, "session-val", s.GetApplicationName(),
+		"after COMMIT, session-level SET persists; LOCAL is cleared")
+}
+
+func TestConnectionState_ApplicationNameRollbackRevertsNonLocal(t *testing.T) {
+	s := NewMultiGatewayConnectionState()
+	s.InitApplicationName("startup-val")
+	s.SetApplicationName("pre-txn")
+
+	s.BeginTransaction()
+	s.SetApplicationName("in-txn")
+	require.Equal(t, "in-txn", s.GetApplicationName())
+
+	s.RollbackTransaction()
+
+	require.Equal(t, "pre-txn", s.GetApplicationName(),
+		"ROLLBACK must revert non-LOCAL SET to pre-BEGIN session value")
+}
+
+func TestConnectionState_AllGMVsInLockstep(t *testing.T) {
+	// Both statement_timeout and application_name are gateway-managed; the
+	// registry must drive both through the same lifecycle in a single pass.
+	s := NewMultiGatewayConnectionState()
+	s.InitStatementTimeout(30 * time.Second)
+	s.InitApplicationName("startup-val")
+
+	s.SetStatementTimeout(5 * time.Second)
+	s.SetApplicationName("session-val")
+
+	s.BeginTransaction()
+	s.SetStatementTimeout(10 * time.Second)
+	s.SetApplicationName("in-txn")
+
+	s.PushSavepoint("sp")
+	s.SetStatementTimeout(20 * time.Second)
+	s.SetApplicationName("after-sp")
+	require.Equal(t, 20*time.Second, s.GetStatementTimeout())
+	require.Equal(t, "after-sp", s.GetApplicationName())
+
+	s.RollbackToSavepoint("sp")
+	require.Equal(t, 10*time.Second, s.GetStatementTimeout(),
+		"statement_timeout rolled back in lockstep")
+	require.Equal(t, "in-txn", s.GetApplicationName(),
+		"application_name rolled back in lockstep")
+
+	s.RollbackTransaction()
+	require.Equal(t, 5*time.Second, s.GetStatementTimeout(),
+		"statement_timeout reverted to pre-BEGIN session value")
+	require.Equal(t, "session-val", s.GetApplicationName(),
+		"application_name reverted to pre-BEGIN session value")
+}
+
+func TestConnectionState_ResetAllLocalGUCs_ClearsAllVariables(t *testing.T) {
+	// ResetAllLocalGUCs must clear LOCAL on every registered GMV, not just one.
+	s := NewMultiGatewayConnectionState()
+	s.InitStatementTimeout(30 * time.Second)
+	s.InitApplicationName("startup-val")
+
+	s.SetStatementTimeout(5 * time.Second)
+	s.SetApplicationName("session-val")
+
+	s.SetLocalStatementTimeout(100 * time.Millisecond)
+	s.SetLocalApplicationName("local-val")
+
+	s.ResetAllLocalGUCs()
+	require.Equal(t, 5*time.Second, s.GetStatementTimeout())
+	require.Equal(t, "session-val", s.GetApplicationName())
+}

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -107,20 +107,37 @@ type MultiGatewayConnectionState struct {
 	// Parsed at SET time to avoid repeated parsing on every query.
 	statementTimeout GatewayManagedVariable[time.Duration]
 
+	// applicationName is the session-level application_name override set via
+	// SET application_name. Managed entirely by the gateway and NOT forwarded
+	// to PostgreSQL — the multipooler keeps stamping `multigres_vpid:<id>` on
+	// the backend application_name for lock detection, while SHOW and the
+	// gateway-tracked session state expose the client-supplied value.
+	// The default is initialized from the application_name startup parameter
+	// (if present) or the PostgreSQL default (empty string).
+	// Note: `current_setting('application_name')` inside arbitrary SQL still
+	// returns the multipooler stamp; full transparency would require AST-level
+	// rewriting and is out of scope.
+	applicationName GatewayManagedVariable[string]
+
+	// gmvs is the registry of every gateway-managed variable on this struct.
+	// Lifecycle methods (pushFrameLocked, ReleaseSavepoint, RollbackToSavepoint,
+	// BeginTransaction, CommitTransaction, RollbackTransaction, ResetAllLocalGUCs)
+	// iterate this registry to keep all variables' snapshot stacks in lockstep
+	// with savepoints. Populated once in NewMultiGatewayConnectionState; entries
+	// hold pointers to the addressable field values, so reassigning a variable
+	// via Init* does not invalidate the registry.
+	gmvs []gmvLifecycle
+
 	// savepoints is the stack of per-savepoint snapshots driving GUC revert
 	// semantics on ROLLBACK / ROLLBACK TO. Each frame captures SessionSettings;
 	// gateway-managed variables maintain parallel snapshot stacks of equal depth
 	// (lockstep invariant). Index 0, when present, is the BEGIN-level frame
 	// (name=""); indices 1+ correspond to user SAVEPOINTs.
 	//
-	// MAINTENANCE CONTRACT: every gateway-managed variable on this struct (e.g.
-	// statementTimeout) must be wired into all six lifecycle methods —
-	// pushFrameLocked, ReleaseSavepoint, RollbackToSavepoint, BeginTransaction,
-	// CommitTransaction, RollbackTransaction — or revert semantics break for
-	// the missing variable. When a second GMV is added, refactor to a
-	// non-generic `gmvLifecycle` interface ({Snapshot, RestoreFromDepth(int),
-	// PopFrom(int), ClearSnapshots}) and iterate a `[]gmvLifecycle` registry
-	// instead of naming each variable explicitly.
+	// MAINTENANCE CONTRACT: every gateway-managed variable on this struct must
+	// implement gmvLifecycle and be registered in the gmvs slice at construction
+	// time (see NewMultiGatewayConnectionState). Lifecycle methods iterate the
+	// registry instead of naming each variable explicitly.
 	savepoints []savepointFrame
 
 	// targetReplica is true when this connection arrived on the replica-reads
@@ -147,11 +164,15 @@ type ShardState struct {
 }
 
 // NewMultiGatewayConnectionState creates a new MultiGatewayConnectionState.
+// The gmvs registry holds pointers to each gateway-managed variable field so
+// lifecycle methods can drive all of them in lockstep with a single loop.
 func NewMultiGatewayConnectionState() *MultiGatewayConnectionState {
-	return &MultiGatewayConnectionState{
+	s := &MultiGatewayConnectionState{
 		mu:      sync.Mutex{},
 		Portals: make(map[string]*preparedstatement.PortalInfo),
 	}
+	s.gmvs = []gmvLifecycle{&s.statementTimeout, &s.applicationName}
+	return s
 }
 
 // StorePortalInfo stores the portal information.
@@ -305,7 +326,9 @@ func (m *MultiGatewayConnectionState) SetLocalStatementTimeoutToDefault() {
 func (m *MultiGatewayConnectionState) ResetAllLocalGUCs() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.statementTimeout.ResetLocal()
+	for _, v := range m.gmvs {
+		v.ResetLocal()
+	}
 }
 
 // snapshotSessionSettingsLocked returns a copy of SessionSettings (or nil if
@@ -339,7 +362,9 @@ func (m *MultiGatewayConnectionState) pushFrameLocked(name string) {
 		name:            name,
 		sessionSettings: m.snapshotSessionSettingsLocked(),
 	})
-	m.statementTimeout.Snapshot()
+	for _, v := range m.gmvs {
+		v.Snapshot()
+	}
 }
 
 // BeginTransaction pushes a BEGIN-level snapshot frame so that a subsequent
@@ -356,7 +381,9 @@ func (m *MultiGatewayConnectionState) BeginTransaction() {
 		return
 	}
 	m.savepoints = m.savepoints[:0]
-	m.statementTimeout.ClearSnapshots()
+	for _, v := range m.gmvs {
+		v.ClearSnapshots()
+	}
 	m.pushFrameLocked("")
 }
 
@@ -381,7 +408,9 @@ func (m *MultiGatewayConnectionState) ReleaseSavepoint(name string) {
 		return
 	}
 	m.savepoints = m.savepoints[:idx]
-	m.statementTimeout.PopFrom(idx)
+	for _, v := range m.gmvs {
+		v.PopFrom(idx)
+	}
 }
 
 // RollbackToSavepoint restores SessionSettings and every gateway-managed
@@ -402,7 +431,9 @@ func (m *MultiGatewayConnectionState) RollbackToSavepoint(name string) {
 		maps.Copy(m.SessionSettings, m.savepoints[idx].sessionSettings)
 	}
 	m.savepoints = m.savepoints[:idx+1]
-	m.statementTimeout.RestoreFromDepth(idx)
+	for _, v := range m.gmvs {
+		v.RestoreFromDepth(idx)
+	}
 }
 
 // CommitTransaction drops all savepoint frames (current values become
@@ -412,8 +443,10 @@ func (m *MultiGatewayConnectionState) CommitTransaction() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.savepoints = nil
-	m.statementTimeout.ClearSnapshots()
-	m.statementTimeout.ResetLocal()
+	for _, v := range m.gmvs {
+		v.ClearSnapshots()
+		v.ResetLocal()
+	}
 }
 
 // RollbackTransaction reverts all SET / RESET commands issued inside the
@@ -424,7 +457,9 @@ func (m *MultiGatewayConnectionState) RollbackTransaction() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if len(m.savepoints) == 0 {
-		m.statementTimeout.ResetLocal()
+		for _, v := range m.gmvs {
+			v.ResetLocal()
+		}
 		return
 	}
 	m.SessionSettings = nil
@@ -432,9 +467,11 @@ func (m *MultiGatewayConnectionState) RollbackTransaction() {
 		m.SessionSettings = make(map[string]string, len(m.savepoints[0].sessionSettings))
 		maps.Copy(m.SessionSettings, m.savepoints[0].sessionSettings)
 	}
-	m.statementTimeout.RestoreFromDepth(0)
-	m.statementTimeout.ClearSnapshots()
-	m.statementTimeout.ResetLocal()
+	for _, v := range m.gmvs {
+		v.RestoreFromDepth(0)
+		v.ClearSnapshots()
+		v.ResetLocal()
+	}
 	m.savepoints = nil
 }
 
@@ -470,6 +507,69 @@ func (m *MultiGatewayConnectionState) InitStatementTimeout(defaultValue time.Dur
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.statementTimeout = NewGatewayManagedVariable(defaultValue)
+}
+
+// SetApplicationName sets the session-level application_name override.
+func (m *MultiGatewayConnectionState) SetApplicationName(v string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applicationName.Set(v)
+}
+
+// ResetApplicationName clears both the session-level override and any active
+// transaction-local override, reverting to the default (from startup params or
+// the PostgreSQL default of empty string). Matches PostgreSQL: RESET inside a
+// transaction with a prior SET LOCAL supersedes the LOCAL — effective value
+// becomes the default.
+func (m *MultiGatewayConnectionState) ResetApplicationName() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applicationName.Reset()
+}
+
+// SetLocalApplicationName stores a transaction-local application_name override
+// (from SET LOCAL application_name). Cleared on COMMIT/ROLLBACK via
+// ResetAllLocalGUCs.
+func (m *MultiGatewayConnectionState) SetLocalApplicationName(v string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applicationName.SetLocal(v)
+}
+
+// SetLocalApplicationNameToDefault installs a transaction-local override equal
+// to the connection default (from SET LOCAL application_name TO DEFAULT). This
+// masks any session-level override for the duration of the transaction without
+// destroying it; the session value is restored on COMMIT/ROLLBACK via
+// ResetAllLocalGUCs.
+func (m *MultiGatewayConnectionState) SetLocalApplicationNameToDefault() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applicationName.SetLocalToDefault()
+}
+
+// GetApplicationName returns the effective application_name:
+// transaction-local override if set, else session override, else default.
+func (m *MultiGatewayConnectionState) GetApplicationName() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.applicationName.GetEffective()
+}
+
+// ShowApplicationName returns the effective application_name for SHOW output.
+// PostgreSQL's SHOW returns the raw string value; no formatting is applied.
+func (m *MultiGatewayConnectionState) ShowApplicationName() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.applicationName.GetEffective()
+}
+
+// InitApplicationName sets the default for the application_name variable.
+// Called once during connection initialization with the value from the
+// application_name startup parameter (if present) or "" (PostgreSQL default).
+func (m *MultiGatewayConnectionState) InitApplicationName(defaultValue string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.applicationName = NewGatewayManagedVariable(defaultValue)
 }
 
 // TargetReplica returns true if this connection targets a replica.

--- a/go/services/multigateway/handler/gateway_managed_variable.go
+++ b/go/services/multigateway/handler/gateway_managed_variable.go
@@ -14,6 +14,25 @@
 
 package handler
 
+// gmvLifecycle is the non-generic subset of GatewayManagedVariable[T] needed by
+// MultiGatewayConnectionState to drive savepoint / transaction lifecycle in a
+// type-agnostic way. Every GatewayManagedVariable[T] satisfies this interface
+// via pointer receiver, so the connection-state registry can iterate a single
+// []gmvLifecycle instead of naming each typed field explicitly.
+//
+// Adding a new gateway-managed variable requires only:
+//  1. Declaring a `GatewayManagedVariable[T]` field on MultiGatewayConnectionState.
+//  2. Registering &field in the gmvs slice in NewMultiGatewayConnectionState.
+//
+// All snapshot/restore/reset behavior is then inherited automatically.
+type gmvLifecycle interface {
+	Snapshot()
+	RestoreFromDepth(int)
+	PopFrom(int)
+	ClearSnapshots()
+	ResetLocal()
+}
+
 // GatewayManagedVariable holds a variable with three priority layers matching
 // PostgreSQL's GUC semantics:
 //

--- a/go/services/multigateway/handler/handler.go
+++ b/go/services/multigateway/handler/handler.go
@@ -341,6 +341,21 @@ func (h *MultiGatewayHandler) getConnectionState(conn *server.Conn) *MultiGatewa
 			delete(newState.StartupParams, "statement_timeout")
 		}
 		newState.InitStatementTimeout(stDefault)
+
+		// application_name is gateway-managed: the multipooler stamps
+		// `multigres_vpid:<id>` on the backend's application_name for lock
+		// detection, so the gateway owns the client-visible value (SHOW,
+		// SET, RESET). Default comes from the startup parameter if present;
+		// otherwise the PostgreSQL default (empty string). Remove from
+		// StartupParams so it is not forwarded to PostgreSQL — the multipooler
+		// stamping is authoritative on the wire.
+		appNameDefault := ""
+		if v, ok := newState.StartupParams["application_name"]; ok {
+			appNameDefault = v
+			delete(newState.StartupParams, "application_name")
+		}
+		newState.InitApplicationName(appNameDefault)
+
 		newState.targetReplica = h.targetReplica
 
 		newState.SubSync = &handlerSubSync{

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -108,7 +108,7 @@ func (p *Planner) planVariableSetStmt(
 // them to PostgreSQL would be redundant or counterproductive for connection pooling.
 func isGatewayManagedVariable(name string) bool {
 	switch strings.ToLower(name) {
-	case "statement_timeout":
+	case "statement_timeout", "application_name":
 		return true
 	default:
 		return false
@@ -136,6 +136,13 @@ func (p *Planner) planGatewayManagedVariable(
 			p.logger.Debug("planning SET statement_timeout (gateway-managed)",
 				"value", value, "parsed", d, "is_local", stmt.IsLocal)
 			return engine.NewStatementTimeoutSet(sql, d, stmt.IsLocal), nil
+		case "application_name":
+			// application_name has no parser-level validation in PostgreSQL —
+			// any string is accepted (length is implicitly bounded by GUC
+			// buffer sizes). Pass the extracted value through verbatim.
+			p.logger.Debug("planning SET application_name (gateway-managed)",
+				"value", value, "is_local", stmt.IsLocal)
+			return engine.NewApplicationNameSet(sql, value, stmt.IsLocal), nil
 		default:
 			return nil, mterrors.NewUnrecognizedParameter(name)
 		}

--- a/go/test/endtoend/queryserving/application_name_test.go
+++ b/go/test/endtoend/queryserving/application_name_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMultiGateway_ApplicationName covers the gateway-managed
+// `application_name` GUC: SET/SHOW/RESET resolve at the gateway without a PG
+// round-trip, the client-visible value tracks SET, and the multipooler-side
+// `multigres_vpid:<id>` stamping on the backend application_name is
+// preserved (visible only through pg_stat_activity, not SHOW).
+func TestMultiGateway_ApplicationName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping application_name test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping application_name tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	ctx := utils.WithTimeout(t, 150*time.Second)
+
+	t.Run("SET and SHOW", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'myapp'")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "myapp", result, "SHOW must return the client-set value")
+	})
+
+	t.Run("SET to empty string is honoured", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = ''")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "", result, "explicit SET to empty string overrides default")
+	})
+
+	t.Run("RESET reverts to PG default (empty string)", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'myapp'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "RESET application_name")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "", result, "RESET reverts to empty default when no startup param given")
+	})
+
+	t.Run("SET TO DEFAULT reverts to default", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'myapp'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SET application_name TO DEFAULT")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "", result, "SET TO DEFAULT reverts to empty default")
+	})
+
+	t.Run("RESET ALL also resets application_name", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'myapp'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "RESET ALL")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "", result, "RESET ALL must revert application_name to default")
+	})
+
+	t.Run("SET LOCAL is reverted at COMMIT", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'session'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "BEGIN")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SET LOCAL application_name = 'local'")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "local", result, "SET LOCAL effective during txn")
+
+		_, err = conn.Exec(ctx, "COMMIT")
+		require.NoError(t, err)
+
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "session", result, "after COMMIT, session value restored")
+	})
+
+	t.Run("ROLLBACK reverts non-LOCAL SET", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'pre-txn'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "BEGIN")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SET application_name = 'in-txn'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "ROLLBACK")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "pre-txn", result, "ROLLBACK reverts non-LOCAL SET")
+	})
+
+	t.Run("savepoint rollback reverts application_name", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "BEGIN")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SET application_name = 'outer'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SAVEPOINT sp")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "SET application_name = 'inner'")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "inner", result)
+
+		_, err = conn.Exec(ctx, "ROLLBACK TO SAVEPOINT sp")
+		require.NoError(t, err)
+
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "outer", result, "ROLLBACK TO sp reverts to pre-savepoint value")
+
+		_, err = conn.Exec(ctx, "COMMIT")
+		require.NoError(t, err)
+	})
+
+	t.Run("client value never reaches PostgreSQL backend", func(t *testing.T) {
+		// Documented limitation (and proof that the gateway intercepts SET):
+		// `SHOW application_name` returns the client-set value, but
+		// `current_setting('application_name')` is evaluated by PostgreSQL and
+		// therefore reflects whatever the multipooler set on the backend — never
+		// the client-supplied value. Asserting the divergence guards against a
+		// regression that would accidentally forward SET to PostgreSQL.
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET application_name = 'myapp-client-only'")
+		require.NoError(t, err)
+
+		var showResult string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&showResult)
+		require.NoError(t, err)
+		assert.Equal(t, "myapp-client-only", showResult)
+
+		var setting string
+		err = conn.QueryRow(ctx, "SELECT current_setting('application_name')").Scan(&setting)
+		require.NoError(t, err)
+		assert.NotEqual(t, "myapp-client-only", setting,
+			"current_setting must never see the client-supplied value — "+
+				"if this fires, SET application_name is leaking through to PostgreSQL")
+	})
+}
+
+// TestMultiGateway_ApplicationNameStartupParam confirms the startup parameter
+// path: pgx passes application_name through the StartupMessage, the gateway
+// captures it as the default, and removes it from the params forwarded to PG
+// so the multipooler stamp remains authoritative on the wire.
+func TestMultiGateway_ApplicationNameStartupParam(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping application_name startup param test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping application_name startup param tests")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	ctx := utils.WithTimeout(t, 150*time.Second)
+
+	t.Run("startup param sets default", func(t *testing.T) {
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
+		require.NoError(t, err)
+		connCfg.RuntimeParams["application_name"] = "startup-app"
+
+		conn, err := pgx.ConnectConfig(ctx, connCfg)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "startup-app", result, "startup param sets the default for SHOW")
+	})
+
+	t.Run("SET overrides startup param", func(t *testing.T) {
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
+		require.NoError(t, err)
+		connCfg.RuntimeParams["application_name"] = "startup-app"
+
+		conn, err := pgx.ConnectConfig(ctx, connCfg)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		_, err = conn.Exec(ctx, "SET application_name = 'override'")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "override", result, "SET overrides startup param")
+	})
+
+	t.Run("RESET reverts to startup param default", func(t *testing.T) {
+		connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+		connCfg, err := pgx.ParseConfig(connStr)
+		require.NoError(t, err)
+		connCfg.RuntimeParams["application_name"] = "startup-app"
+
+		conn, err := pgx.ConnectConfig(ctx, connCfg)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		_, err = conn.Exec(ctx, "SET application_name = 'override'")
+		require.NoError(t, err)
+
+		_, err = conn.Exec(ctx, "RESET application_name")
+		require.NoError(t, err)
+
+		var result string
+		err = conn.QueryRow(ctx, "SHOW application_name").Scan(&result)
+		require.NoError(t, err)
+		assert.Equal(t, "startup-app", result,
+			"RESET reverts to startup param default, not empty")
+	})
+}


### PR DESCRIPTION
## Summary

- `SET` / `SHOW` / `RESET application_name` now resolve at the gateway, so `SHOW application_name` returns the client value instead of the multipooler stamp.
- Multipooler-PG path unchanged: it still stamps `multigres_vpid:<id>` on the backend `application_name` for lock detection.
- Refactored gateway-managed variable scaffolding onto a `gmvLifecycle` interface + registry, per the maintenance contract in `connection_state.go`.

## Description

Closes [MUL-415](https://linear.app/supabase/issue/MUL-415/multigateway-make-application-name-a-gateway-managed-guc).

The startup parameter `application_name` is captured as the per-connection default and removed from the params forwarded to PostgreSQL — multipooler stamping is authoritative on the wire.

Known limitation (documented in code and the Linear issue): `current_setting('application_name')` inside arbitrary SQL still returns the multipooler stamp. Full transparency would require AST-level rewriting and is out of scope.

## Test plan

- [x] Unit tests for the new GMV (`application_name_test.go`) covering SET / SET LOCAL / RESET / SET TO DEFAULT, savepoint snapshot/restore, BEGIN/COMMIT/ROLLBACK, and cross-GMV lockstep with `statement_timeout`.
- [x] End-to-end queryserving tests covering startup-param init, SET/SHOW/RESET, `SET LOCAL` revert on COMMIT, savepoint rollback, and the divergence between `SHOW` and `current_setting`.
- [x] `TestMultiGateway_StatementTimeout*` and the session/transaction integration suites still pass after the `gmvLifecycle` refactor.
- [x] `golangci-lint run` clean on touched packages.