### PR TITLE
feat(security): support POSTGRES_PASSWORD_FILE

### DIFF
--- a/demo/k8s/README.md
+++ b/demo/k8s/README.md
@@ -39,6 +39,8 @@ Step 4: Launch the multigres cluster
 
 This deploys multipooler, multiorch, and multigateway, waits for them to be ready, then starts port-forwards for the cluster.
 
+The script also applies `k8s-postgres-password-secret.yaml`, which holds the plaintext PostgreSQL superuser password each multipooler/pgctld container reads via `POSTGRES_PASSWORD_FILE`. The committed value (`postgres`) is for the demo only — replace it before reusing this manifest anywhere real.
+
 Step 5 (optional): Load demo data with supafirehose
 
 # First build the supafirehose image (in the supafirehose directory):

--- a/demo/k8s/k8s-multipooler-statefulset.yaml
+++ b/demo/k8s/k8s-multipooler-statefulset.yaml
@@ -155,6 +155,9 @@ spec:
             - name: sampling-config
               mountPath: /etc/otel
               readOnly: true
+            - name: postgres-password
+              mountPath: /var/run/secrets/multigres
+              readOnly: true
           env:
             - name: POD_NAME
               valueFrom:
@@ -170,8 +173,11 @@ spec:
                   fieldPath: metadata.labels['cell']
             - name: OTEL_SERVICE_NAME
               value: "multipooler"
-            - name: POSTGRES_PASSWORD
-              value: postgres
+            # Read the postgres password from the file mounted from the
+            # multigres-postgres-password Secret. Swap to
+            # /var/run/secrets/multigres/$(POD_NAME) for per-pod passwords.
+            - name: POSTGRES_PASSWORD_FILE
+              value: /var/run/secrets/multigres/password
             - name: PGDATA
               value: /data/pg_data
           envFrom:
@@ -210,6 +216,9 @@ spec:
             - name: pg-hba-template
               mountPath: /etc/pgctld
               readOnly: true
+            - name: postgres-password
+              mountPath: /var/run/secrets/multigres
+              readOnly: true
           env:
             - name: POD_NAME
               valueFrom:
@@ -217,8 +226,11 @@ spec:
                   fieldPath: metadata.name
             - name: PGDATA
               value: /data/pg_data
-            - name: POSTGRES_PASSWORD
-              value: postgres
+            # initdb / start / stop all read the postgres password from this
+            # file. Swap to /var/run/secrets/multigres/$(POD_NAME) for per-pod
+            # passwords (POD_NAME is already in scope above).
+            - name: POSTGRES_PASSWORD_FILE
+              value: /var/run/secrets/multigres/password
 
       volumes:
         # We have to give different mount points.
@@ -246,3 +258,12 @@ spec:
         - name: sampling-config
           configMap:
             name: sampling-config
+        # The postgres password is mounted from a Secret. The mode is set to
+        # 0444 to ensure the file is readable by the non-root user in the
+        # container. This is just for the demo. In production, you may want to
+        # use a more secure mode and ensure the Secret is only readable by the
+        # appropriate users.
+        - name: postgres-password
+          secret:
+            secretName: multigres-postgres-password
+            defaultMode: 0444

--- a/demo/k8s/k8s-postgres-password-secret.yaml
+++ b/demo/k8s/k8s-postgres-password-secret.yaml
@@ -1,0 +1,27 @@
+# Example Secret holding the PostgreSQL superuser password. Each multipooler
+# pod mounts this Secret read-only and reads the password from the file
+# pointed at by POSTGRES_PASSWORD_FILE.
+#
+# Conventions:
+#   - the value is the *plaintext* password (matches docker-library/postgres);
+#     initdb hashes it into a SCRAM-SHA-256 verifier on first launch.
+#   - the env var POSTGRES_PASSWORD_FILE in the StatefulSet points at the
+#     mounted file path. Replace the value below before deploying; the demo
+#     value is published in version control and must not be used in any real
+#     environment.
+#
+# Per-pod unique passwords:
+#   Add one key per pod (multipooler-zone1-0, multipooler-zone1-1, …) and
+#   change the StatefulSet env to
+#     POSTGRES_PASSWORD_FILE=/var/run/secrets/multigres/$(POD_NAME)
+#   Kubernetes substitutes $(POD_NAME) at pod start and each pod opens its own
+#   file. All pods still mount the full key set, so this isolates secrets at
+#   the file level only, not at the API level.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: multigres-postgres-password
+type: Opaque
+stringData:
+  # Shared-password form: every replica reads /var/run/secrets/multigres/password.
+  password: postgres

--- a/demo/k8s/launch-multigres-cluster.sh
+++ b/demo/k8s/launch-multigres-cluster.sh
@@ -27,6 +27,9 @@ fi
 # Deploy core multigres components
 # Once the multipoolers come up, multiorch will bootstrap the cluster
 # and elect a primary.
+# The postgres-password Secret must exist before the multipooler StatefulSet
+# starts, otherwise the pods will fail to mount the volume.
+kubectl apply -f k8s-postgres-password-secret.yaml
 kubectl apply -f k8s-multipooler-statefulset.yaml
 kubectl apply -f k8s-multiorch.yaml
 kubectl apply -f k8s-multigateway.yaml

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -15,7 +15,6 @@
 package command
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -171,11 +170,17 @@ func runInitdbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, fil
 
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
+	password, passwordSource, passwordFile, err := i.pgCtlCmd.GetPostgresPassword()
+	if err != nil {
+		return err
+	}
 	cfg := PgCtldServiceConfig{
 		Port:                 i.pgCtlCmd.pgPort.Get(),
 		User:                 i.pgCtlCmd.pgUser.Get(),
 		Database:             i.pgCtlCmd.pgDatabase.Get(),
-		Password:             i.pgCtlCmd.pgPassword.Get(),
+		Password:             password,
+		PasswordSource:       passwordSource,
+		PasswordFile:         passwordFile,
 		InitdbSQLFiles:       i.pgCtlCmd.pgInitdbSQLFiles.Get(),
 		InitdbExtraConfFiles: i.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
@@ -227,6 +232,55 @@ func createDatabaseOnInstance(logger *slog.Logger, pg *pgInstance, database stri
 	return nil
 }
 
+// resolveInitdbPwFile returns a filesystem path suitable for initdb's --pwfile
+// flag along with a cleanup function the caller must defer.
+//
+// The primary path is the operator-supplied password file (POSTGRES_PASSWORD_FILE
+// / --pg-password-file). In that case the returned path *is* that file
+// and no plaintext is ever copied — initdb reads it directly. The cleanup is a
+// no-op.
+//
+// The fallback path is the legacy POSTGRES_PASSWORD environment variable, which
+// is being phased out. There is no file on disk yet, so we have to stage the
+// password into a randomly named temp file long enough for initdb to read it.
+// The cleanup unlinks that temp file. This branch exists only to keep operators
+// who have not yet migrated to file-based secrets working; new deployments
+// should always hit the primary path.
+//
+// Note on first-line semantics: initdb --pwfile reads only the first line of
+// the file. pgsecret.ReadPasswordFile returns the whole content (minus
+// trailing CR/LF). The two parsers agree for any single-line password (with
+// or without a trailing newline) — which is every realistic Kubernetes Secret.
+// A multi-line file would silently diverge: the cluster would be initialized
+// with line 1, but the admin pool / replication would try to authenticate with
+// the whole content. Password files MUST be single-line.
+func resolveInitdbPwFile(cfg PgCtldServiceConfig) (path string, cleanup func(), err error) {
+	if cfg.PasswordSource == PasswordSourceFile {
+		return cfg.PasswordFile, func() {}, nil
+	}
+	// Fallback: POSTGRES_PASSWORD env. Stage the plaintext to a randomly named
+	// file in /tmp. Removed unconditionally on return so the plaintext window
+	// is bounded by the initdb exec. The filename has no prefix so its purpose
+	// isn't advertised in /tmp listings.
+	tmpFile, err := os.CreateTemp("", "*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("failed to create temporary password file: %w", err)
+	}
+	tempPwFile := tmpFile.Name()
+	cleanup = func() { _ = os.Remove(tempPwFile) }
+
+	if _, err := tmpFile.WriteString(cfg.Password); err != nil {
+		tmpFile.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("failed to write password to temporary file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("failed to close temporary password file: %w", err)
+	}
+	return tempPwFile, cleanup, nil
+}
+
 func initializeDataDir(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	// Derive dataDir from poolerDir using the standard convention
 	dataDir := pgctld.PostgresDataDir()
@@ -241,34 +295,28 @@ func initializeDataDir(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	// the backup.
 	args := []string{"-D", dataDir, "--data-checksums", "--auth-local=trust", "--auth-host=scram-sha-256", "-U", cfg.User}
 
-	// Password is required: pg_hba.conf uses scram-sha-256 for all connections,
-	// including the local socket, so initdb must set a password.
-	if cfg.Password == "" {
-		return errors.New("POSTGRES_PASSWORD must be set before initializing data directory")
+	// Invariant: production callers (runInit, the InitDataDir gRPC handler)
+	// populate Password, PasswordSource (and PasswordFile when source==File)
+	// via PgCtlCommand.GetPostgresPassword, which errors when no source is
+	// configured. Reaching here with a missing source means a caller — almost
+	// certainly a test — built PgCtldServiceConfig by hand without going
+	// through the resolver. Panic rather than guess a source that would
+	// mislabel the log line below.
+	if cfg.PasswordSource == "" || cfg.PasswordSource == PasswordSourceNone {
+		panic(fmt.Sprintf("initializeDataDir: PasswordSource=%q — callers must populate it via PgCtlCommand.GetPostgresPassword", cfg.PasswordSource))
+	}
+	if cfg.PasswordSource == PasswordSourceFile && cfg.PasswordFile == "" {
+		panic("initializeDataDir: PasswordSource=POSTGRES_PASSWORD_FILE but PasswordFile is empty — callers must populate PasswordFile (use PgCtlCommand.GetPostgresPassword)")
 	}
 
-	// Write the password to a temporary file for initdb --pwfile. The filename
-	// uses a random pattern with no prefix so the file's purpose isn't
-	// advertised in /tmp listings. This is the only way to set the password
-	// during initdb without exposing it in process arguments or environment
-	// variables, and the file is removed immediately after initdb completes.
-	tmpFile, err := os.CreateTemp("", "*")
+	pwFile, cleanup, err := resolveInitdbPwFile(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create temporary password file: %w", err)
+		return err
 	}
-	tempPwFile := tmpFile.Name()
-	defer os.Remove(tempPwFile)
+	defer cleanup()
 
-	if _, err := tmpFile.WriteString(cfg.Password); err != nil {
-		tmpFile.Close()
-		return fmt.Errorf("failed to write password to temporary file: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temporary password file: %w", err)
-	}
-
-	args = append(args, "--pwfile="+tempPwFile)
-	logger.Info("Setting password during initdb", "user", cfg.User, "password_source", "POSTGRES_PASSWORD environment variable")
+	args = append(args, "--pwfile="+pwFile)
+	logger.Info("Setting password during initdb", "user", cfg.User, "password_source", string(cfg.PasswordSource))
 
 	if cfg.InitdbArgs != "" {
 		args = append(args, strings.Fields(cfg.InitdbArgs)...)
@@ -283,7 +331,7 @@ func initializeDataDir(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 		return fmt.Errorf("initdb failed: %w\nOutput: %s", err, string(output))
 	}
 	logger.Info("initdb completed successfully", "output", string(output))
-	logger.Info("User password set successfully", "user", cfg.User, "password_source", "POSTGRES_PASSWORD environment variable")
+	logger.Info("User password set successfully", "user", cfg.User, "password_source", string(cfg.PasswordSource))
 
 	return nil
 }

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/multigres/multigres/config"
 	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/pgsecret"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/services/pgctld"
 	"github.com/multigres/multigres/go/tools/telemetry"
@@ -38,10 +39,15 @@ import (
 // PgCtlCommand holds the configuration for pgctld commands.
 // This contains all flags and information necessary to run any pgctld command.
 type PgCtlCommand struct {
-	reg                *viperutil.Registry
-	pgDatabase         viperutil.Value[string]
-	pgUser             viperutil.Value[string]
-	pgPassword         viperutil.Value[string]
+	reg            *viperutil.Registry
+	pgDatabase     viperutil.Value[string]
+	pgUser         viperutil.Value[string]
+	pgPassword     viperutil.Value[string]
+	pgPasswordFile viperutil.Value[string]
+	// flagSet is the persistent flag set, saved during GetRootCommand so
+	// GetPostgresPassword can use pflag.Flag.Changed to distinguish "flag
+	// explicitly set" from "flag at default value".
+	flagSet            *pflag.FlagSet
 	poolerDir          viperutil.Value[string]
 	timeout            viperutil.Value[int]
 	pgPort             viperutil.Value[int]
@@ -80,6 +86,12 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars: []string{constants.PgPasswordEnvVar},
 			Dynamic: false,
 			// No FlagName — env var only, no CLI flag
+		}),
+		pgPasswordFile: viperutil.Configure(reg, "pg-password-file", viperutil.Options[string]{
+			Default:  "",
+			FlagName: "pg-password-file",
+			EnvVars:  []string{constants.PgPasswordFileEnvVar},
+			Dynamic:  false,
 		}),
 		timeout: viperutil.Configure(reg, "timeout", viperutil.Options[int]{
 			Default:  30,
@@ -178,6 +190,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("pg-listen-addresses", pc.pgListenAddresses.Default(), "PostgreSQL listen addresses")
 	root.PersistentFlags().String("pg-hba-template", pc.pgHbaTemplate.Default(), "Path to custom pg_hba.conf template file")
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
+	root.PersistentFlags().String("pg-password-file", pc.pgPasswordFile.Default(), "Path to a file containing the PostgreSQL password (plaintext, docker-library/postgres convention). Takes precedence over "+constants.PgPasswordEnvVar+". Also reads "+constants.PgPasswordFileEnvVar+" env var.")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-files", pc.pgInitdbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitdbSQLFilesEnvVar+" env var).")
 	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
@@ -198,6 +211,7 @@ management for PostgreSQL servers.`,
 		pc.pgDatabase,
 		pc.pgUser,
 		pc.pgPassword,
+		pc.pgPasswordFile,
 		pc.timeout,
 		pc.poolerDir,
 		pc.pgPort,
@@ -208,6 +222,11 @@ management for PostgreSQL servers.`,
 		pc.pgInitdbSQLFiles,
 		pc.pgInitdbExtraConf,
 	)
+
+	// Save the persistent flag set so GetPostgresPassword can use
+	// pflag.Flag.Changed to distinguish "flag explicitly set" from
+	// "flag at default value".
+	pc.flagSet = root.PersistentFlags()
 
 	// Add all subcommands
 	AddServerCommand(root, pc)
@@ -262,6 +281,88 @@ func (pc *PgCtlCommand) validateGlobalFlags(cmd *cobra.Command, args []string) e
 // GetLogger returns the configured logger instance
 func (pc *PgCtlCommand) GetLogger() *slog.Logger {
 	return pc.lg.GetLogger()
+}
+
+// PasswordSource describes where GetPostgresPassword resolved the password
+// from. Used in log lines so tests and operators can confirm which input was
+// consumed without exposing the password itself.
+type PasswordSource string
+
+const (
+	PasswordSourceNone PasswordSource = "none"
+	PasswordSourceFile PasswordSource = "POSTGRES_PASSWORD_FILE" //nolint:gosec // env var name, not a credential
+	PasswordSourceEnv  PasswordSource = "POSTGRES_PASSWORD"      //nolint:gosec // env var name, not a credential
+)
+
+// GetPostgresPassword resolves the postgres superuser password and reports
+// which source it came from. Sources are tried in order:
+//
+//  1. --pg-password-file flag / POSTGRES_PASSWORD_FILE env, if the file exists
+//     and has non-empty content. Returns PasswordSourceFile and the file path
+//     so downstream code (initdb --pwfile) can read it directly.
+//  2. POSTGRES_PASSWORD env, if set to a non-empty value. Returns
+//     PasswordSourceEnv.
+//
+// Two independent inputs are considered, in strict precedence order — once
+// a higher-precedence input is "explicitly set" it is authoritative and
+// lower-precedence inputs are NOT consulted, even when the higher-precedence
+// value turns out to be empty (those empty cases become errors instead of
+// fallthroughs):
+//
+//  1. File path: --pg-password-file flag (Changed), or POSTGRES_PASSWORD_FILE
+//     env (LookupEnv).
+//     - Path explicitly empty                  → error.
+//     - Path set, file content empty           → error.
+//     - Path set, file content non-empty       → use it, source=File.
+//  2. Env var: POSTGRES_PASSWORD (LookupEnv).
+//     - Env set to empty                       → error.
+//     - Env set to non-empty                   → use it, source=Env.
+//
+// Reached the end with no input explicitly set: error "not configured".
+// pgctld does not expose a --pg-password flag, so the "option" row from the
+// multipooler resolver does not apply here. "Explicitly set" uses
+// os.LookupEnv and pflag.Flag.Changed to detect operator intent — viperutil
+// collapses unset and empty into the same "" via os.Getenv.
+func (pc *PgCtlCommand) GetPostgresPassword() (password string, source PasswordSource, file string, err error) {
+	// File path: flag or env.
+	if path, explicit, isEmpty := pc.passwordFileExplicit(); explicit {
+		if isEmpty {
+			return "", PasswordSourceNone, "", errors.New("postgres password file path is set to the empty string; unset it or provide a path")
+		}
+		pw, err := pgsecret.ReadPasswordFile(path)
+		if err != nil {
+			return "", PasswordSourceNone, "", err
+		}
+		if pw == "" {
+			return "", PasswordSourceNone, "", fmt.Errorf("postgres password file %q is empty", path)
+		}
+		return pw, PasswordSourceFile, path, nil
+	}
+	// Env var: POSTGRES_PASSWORD.
+	if v, ok := os.LookupEnv(constants.PgPasswordEnvVar); ok {
+		if v == "" {
+			return "", PasswordSourceNone, "", fmt.Errorf("env var %s is set to the empty string; unset it or provide a non-empty password", constants.PgPasswordEnvVar)
+		}
+		return v, PasswordSourceEnv, "", nil
+	}
+	return "", PasswordSourceNone, "", errors.New("postgres password must be set via POSTGRES_PASSWORD, POSTGRES_PASSWORD_FILE, or --pg-password-file")
+}
+
+// passwordFileExplicit reports whether the file-path input was explicitly
+// set (via --pg-password-file or POSTGRES_PASSWORD_FILE) and whether the
+// resulting path is the empty string. It does NOT consider viperutil
+// defaults — pflag.Flag.Changed and os.LookupEnv are the source of truth.
+func (pc *PgCtlCommand) passwordFileExplicit() (path string, explicit, isEmpty bool) {
+	if pc.flagSet != nil {
+		if flag := pc.flagSet.Lookup("pg-password-file"); flag != nil && flag.Changed {
+			v := flag.Value.String()
+			return v, true, v == ""
+		}
+	}
+	if v, ok := os.LookupEnv(constants.PgPasswordFileEnvVar); ok {
+		return v, true, v == ""
+	}
+	return "", false, false
 }
 
 // GetPoolerDir returns the configured pooler directory as an absolute path

--- a/go/cmd/pgctld/command/root_test.go
+++ b/go/cmd/pgctld/command/root_test.go
@@ -322,3 +322,68 @@ func TestSilenceUsage(t *testing.T) {
 		assert.NotContains(t, outBuf.String(), "Usage:", "usage should be suppressed for runtime errors")
 	})
 }
+
+// writePwFileForRoot creates a password file inside a fresh temp dir and
+// returns its path. Local helper to keep these tests independent of any
+// other file in the package.
+func writePwFileForRoot(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "postgres-password")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+// Row 2a (pgctld): file path set, file content empty. Resolver must error
+// and NOT fall through to env. Mirrors the multipooler behavior in
+// connpoolmanager.Config.ResolvePgPassword.
+func TestGetPostgresPassword_FileEmpty_Errors(t *testing.T) {
+	t.Setenv(constants.PgPasswordFileEnvVar, writePwFileForRoot(t, ""))
+	// Distinct env value so a regression would surface as a wrong source/value.
+	t.Setenv(constants.PgPasswordEnvVar, "from-env-should-be-ignored")
+
+	_, pc := GetRootCommand()
+	_, _, _, err := pc.GetPostgresPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+// Row 2b (pgctld): POSTGRES_PASSWORD_FILE explicitly set to "". That's
+// "operator wrote POSTGRES_PASSWORD_FILE= in a manifest" — distinct from
+// "unset" via os.LookupEnv.
+func TestGetPostgresPassword_FilePathEnvSetEmpty_Errors(t *testing.T) {
+	t.Setenv(constants.PgPasswordFileEnvVar, "")
+	t.Setenv(constants.PgPasswordEnvVar, "from-env-should-be-ignored")
+
+	_, pc := GetRootCommand()
+	_, _, _, err := pc.GetPostgresPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file path is set to the empty string")
+}
+
+// POSTGRES_PASSWORD set to the empty string (POSTGRES_PASSWORD= in an env
+// file or kubectl manifest) is a deliberate misconfiguration, not "unset".
+// Resolver must reject it explicitly rather than silently treat it as unset.
+func TestGetPostgresPassword_EnvSetToEmpty(t *testing.T) {
+	// Ensure no file path is configured so we exercise the env branch.
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	t.Setenv(constants.PgPasswordEnvVar, "")
+
+	_, pc := GetRootCommand()
+	_, _, _, err := pc.GetPostgresPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), constants.PgPasswordEnvVar)
+	assert.Contains(t, err.Error(), "empty string")
+}
+
+// No source configured at all: POSTGRES_PASSWORD_FILE unset, POSTGRES_PASSWORD
+// unset. Resolver returns the documented "must be set" error.
+func TestGetPostgresPassword_NoSourceConfigured(t *testing.T) {
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
+
+	_, pc := GetRootCommand()
+	_, _, _, err := pc.GetPostgresPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "postgres password must be set")
+}

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -143,11 +143,17 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 	pgbackrestPort := s.pgbackrestPort.Get()
 	pgbackrestCertDir := s.pgbackrestCertDir.Get()
 
+	password, passwordSource, passwordFile, err := s.pgCtlCmd.GetPostgresPassword()
+	if err != nil {
+		return err
+	}
 	pgctldConfig := PgCtldServiceConfig{
 		Port:                 s.pgCtlCmd.pgPort.Get(),
 		User:                 s.pgCtlCmd.pgUser.Get(),
 		Database:             s.pgCtlCmd.pgDatabase.Get(),
-		Password:             s.pgCtlCmd.pgPassword.Get(),
+		Password:             password,
+		PasswordSource:       passwordSource,
+		PasswordFile:         passwordFile,
 		InitdbSQLFiles:       s.pgCtlCmd.pgInitdbSQLFiles.Get(),
 		InitdbExtraConfFiles: s.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
@@ -241,10 +247,17 @@ func reapOrphanedChildren(logger *slog.Logger) {
 // parameters. These are the most commonly passed parameters and are grouped
 // here to reduce argument lists.
 type PgCtldServiceConfig struct {
-	Port                 int
-	User                 string
-	Database             string
-	Password             string
+	Port     int
+	User     string
+	Database string
+	Password string
+	// PasswordSource records where Password came from so log lines can report
+	// it without leaking the value itself. Optional; defaults to none.
+	PasswordSource PasswordSource
+	// PasswordFile is the absolute path to the operator-supplied password file
+	// when PasswordSource == PasswordSourceFile, otherwise "". initdb is handed
+	// this path directly via --pwfile so the plaintext never lands in /tmp.
+	PasswordFile         string
 	InitdbArgs           string
 	InitdbSQLFiles       []string
 	InitdbExtraConfFiles []string
@@ -306,9 +319,9 @@ func NewPgCtldService(
 	if listenAddresses == "" {
 		return nil, errors.New("listen-addresses needs to be set")
 	}
-	if cfg.Password == "" {
-		return nil, errors.New("POSTGRES_PASSWORD must be set")
-	}
+	// cfg.Password emptiness is not re-checked here: production callers
+	// (runServer) populate it via PgCtlCommand.GetPostgresPassword, which
+	// returns an error when no password source is configured.
 
 	// Write a pgpass file and set PGPASSFILE so pgbackrest (archive-push runs as a
 	// postgres subprocess and inherits this process's environment) can authenticate

--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -38,10 +38,11 @@ import (
 
 // testServiceConfig is the standard PgCtldServiceConfig used across service tests.
 var testServiceConfig = PgCtldServiceConfig{
-	Port:     5432,
-	User:     constants.DefaultPostgresUser,
-	Database: constants.DefaultPostgresDatabase,
-	Password: shardsetup.TestPostgresPassword,
+	Port:           5432,
+	User:           constants.DefaultPostgresUser,
+	Database:       constants.DefaultPostgresDatabase,
+	Password:       shardsetup.TestPostgresPassword,
+	PasswordSource: PasswordSourceEnv,
 }
 
 func TestIntToInt32(t *testing.T) {

--- a/go/cmd/pgctld/command/start.go
+++ b/go/cmd/pgctld/command/start.go
@@ -39,8 +39,13 @@ type StartResult struct {
 	Message        string
 }
 
-// NewPostgresCtlConfigFromDefaults creates a PostgresCtlConfig using command-line parameters
-// Port, listen_addresses, and unix_socket_directories come from CLI flags, not from the config file
+// NewPostgresCtlConfigFromDefaults creates a PostgresCtlConfig using
+// command-line parameters. Port, listen_addresses, and
+// unix_socket_directories come from CLI flags, not from the config file.
+//
+// Password is intentionally left unset — callers that need it (start, stop)
+// resolve it via PgCtlCommand.GetPostgresPassword so the file/env precedence
+// stays in one place.
 func NewPostgresCtlConfigFromDefaults(poolerDir string, pgPort int, pgListenAddresses string, pgUser string, pgDatabase string, timeout int) (*pgctld.PostgresCtlConfig, error) {
 	postgresConfigFile := pgctld.PostgresConfigFile()
 
@@ -52,7 +57,6 @@ func NewPostgresCtlConfigFromDefaults(poolerDir string, pgPort int, pgListenAddr
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
-	config.Password = os.Getenv("POSTGRES_PASSWORD")
 	return config, nil
 }
 
@@ -102,6 +106,11 @@ func (s *PgCtlStartCmd) runStart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	password, _, _, err := s.pgCtlCmd.GetPostgresPassword()
+	if err != nil {
+		return err
+	}
+	config.Password = password
 
 	result, err := StartPostgreSQLWithResult(s.pgCtlCmd.lg.GetLogger(), config)
 	if err != nil {

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -76,6 +76,12 @@ func TestRunStart(t *testing.T) {
 
 			tt.setupDataDir(baseDir)
 
+			// runStart now resolves the postgres password via
+			// GetPostgresPassword, which errors when no source is configured.
+			// Set POSTGRES_PASSWORD so the test exercises the start path
+			// rather than the missing-credential error.
+			t.Setenv(constants.PgPasswordEnvVar, "test-password")
+
 			// Setup mock binaries if needed
 			if tt.setupBinaries {
 				binDir := filepath.Join(baseDir, "bin")
@@ -216,8 +222,9 @@ func TestInitializeDataDir(t *testing.T) {
 
 		logger := slog.New(slog.DiscardHandler)
 		cfg := PgCtldServiceConfig{
-			User:     constants.DefaultPostgresUser,
-			Password: shardsetup.TestPostgresPassword,
+			User:           constants.DefaultPostgresUser,
+			Password:       shardsetup.TestPostgresPassword,
+			PasswordSource: PasswordSourceEnv,
 		}
 		err := initializeDataDir(logger, cfg)
 		require.NoError(t, err)
@@ -238,15 +245,20 @@ func TestInitializeDataDir(t *testing.T) {
 		t.Setenv(constants.PgDataDirEnvVar, "/root/impossible_dir")
 		logger := slog.New(slog.DiscardHandler)
 		cfg := PgCtldServiceConfig{
-			User:     constants.DefaultPostgresUser,
-			Password: shardsetup.TestPostgresPassword,
+			User:           constants.DefaultPostgresUser,
+			Password:       shardsetup.TestPostgresPassword,
+			PasswordSource: PasswordSourceEnv,
 		}
 		err := initializeDataDir(logger, cfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "initdb failed")
 	})
 
-	t.Run("fails when password is empty", func(t *testing.T) {
+	t.Run("panics when PasswordSource is unset", func(t *testing.T) {
+		// Validates the programmer-error guard in initializeDataDir. Production
+		// callers populate PasswordSource via PgCtlCommand.GetPostgresPassword,
+		// which errors out when no source is configured; reaching this code
+		// with an unset source means a caller bypassed the resolver.
 		baseDir, cleanup := testutil.TempDir(t, "pgctld_initdb_nopw_test")
 		defer cleanup()
 		t.Setenv(constants.PgDataDirEnvVar, filepath.Join(baseDir, "pg_data"))
@@ -254,11 +266,10 @@ func TestInitializeDataDir(t *testing.T) {
 		logger := slog.New(slog.DiscardHandler)
 		cfg := PgCtldServiceConfig{
 			User: constants.DefaultPostgresUser,
-			// Password intentionally left empty.
+			// PasswordSource intentionally unset.
 		}
-		err := initializeDataDir(logger, cfg)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "POSTGRES_PASSWORD must be set")
+		assert.Panics(t, func() { _ = initializeDataDir(logger, cfg) },
+			"unset PasswordSource should panic — production callers must go through GetPostgresPassword")
 	})
 
 	t.Run("extra initdb args are forwarded to initdb", func(t *testing.T) {
@@ -283,9 +294,10 @@ touch "$2/pg_hba.conf"
 
 		logger := slog.New(slog.DiscardHandler)
 		cfg := PgCtldServiceConfig{
-			User:       constants.DefaultPostgresUser,
-			Password:   "test-password",
-			InitdbArgs: "--locale-provider=icu --icu-locale=en_US.UTF-8",
+			User:           constants.DefaultPostgresUser,
+			Password:       "test-password",
+			PasswordSource: PasswordSourceEnv,
+			InitdbArgs:     "--locale-provider=icu --icu-locale=en_US.UTF-8",
 		}
 		err := initializeDataDir(logger, cfg)
 		require.NoError(t, err)

--- a/go/cmd/pgctld/command/stop.go
+++ b/go/cmd/pgctld/command/stop.go
@@ -96,7 +96,19 @@ func (s *PgCtlStopCmd) runStop(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	password, _, _, err := s.pgCtlCmd.GetPostgresPassword()
+	if err != nil {
+		return err
+	}
+	config.Password = password
 
+	// Stop PostgreSQL and get detailed result information. We are using a
+	// password here because the CHECKPOINT command requires authentication,
+	// even if the stop command itself does not.
+	//
+	// TODO: Consider removing the CHECKPOINT command in the stop flow since
+	// it's not strictly necessary and adds complexity (requires password, can
+	// fail if PostgreSQL is already in a bad state, etc.)
 	result, err := StopPostgreSQLWithResult(s.pgCtlCmd.lg.GetLogger(), config, s.mode.Get())
 	if err != nil {
 		return err

--- a/go/cmd/pgctld/command/stop_test.go
+++ b/go/cmd/pgctld/command/stop_test.go
@@ -204,6 +204,12 @@ func TestRunStop(t *testing.T) {
 
 			poolerDir := tt.setupPoolerDir(baseDir)
 
+			// runStop resolves the postgres password via GetPostgresPassword
+			// (used for the pre-shutdown CHECKPOINT psql call) and errors when
+			// no source is configured. Set POSTGRES_PASSWORD so the test
+			// exercises the stop path rather than the missing-credential error.
+			t.Setenv(constants.PgPasswordEnvVar, "test-password")
+
 			if tt.setupBinaries {
 				binDir := filepath.Join(baseDir, "bin")
 				require.NoError(t, os.MkdirAll(binDir, 0o755))

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -31,6 +31,12 @@ const (
 	// PgPasswordEnvVar is the environment variable for the PostgreSQL password.
 	PgPasswordEnvVar = "POSTGRES_PASSWORD" //nolint:gosec // This is an env var name, not a credential
 
+	// PgPasswordFileEnvVar names an environment variable that points at a file
+	// containing the PostgreSQL password. Takes precedence over PgPasswordEnvVar
+	// when set. Matches the docker-library/postgres convention: the file holds
+	// the plaintext password, not a pre-hashed SCRAM verifier.
+	PgPasswordFileEnvVar = "POSTGRES_PASSWORD_FILE" //nolint:gosec // env var name, not a credential
+
 	// PgDatabaseEnvVar is the environment variable for the PostgreSQL database name.
 	PgDatabaseEnvVar = "POSTGRES_DB"
 

--- a/go/common/pgsecret/postgres_password.go
+++ b/go/common/pgsecret/postgres_password.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pgsecret resolves the PostgreSQL superuser password from one of
+// several sources. It exists so every binary that needs the password (pgctld,
+// multipooler) applies the same precedence rules and so callers can avoid
+// embedding `os.Getenv("POSTGRES_PASSWORD")` directly.
+//
+// The file-based source matches the docker-library/postgres convention: the
+// file contains the plaintext password (initdb hashes it under the configured
+// auth method). Tooling that already targets PGDG images is therefore
+// byte-for-byte compatible.
+package pgsecret
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/constants"
+)
+
+// ReadPostgresPassword returns the plaintext PostgreSQL password, resolved in
+// this order, stopping at the first non-empty source:
+//
+//  1. file at filePath (typically the value of a --pg-password-file flag)
+//  2. file at $POSTGRES_PASSWORD_FILE (constants.PgPasswordFileEnvVar)
+//  3. $POSTGRES_PASSWORD (constants.PgPasswordEnvVar)
+//
+// Returns "" with no error when none of the sources are set; callers are
+// responsible for enforcing required-ness so they can produce a domain-specific
+// error message. Trailing CR/LF is trimmed from file contents so a Kubernetes
+// Secret written with `stringData` still yields the intended password.
+func ReadPostgresPassword(filePath string) (string, error) {
+	if filePath != "" {
+		return ReadPasswordFile(filePath)
+	}
+	if envFile := os.Getenv(constants.PgPasswordFileEnvVar); envFile != "" {
+		return ReadPasswordFile(envFile)
+	}
+	return os.Getenv(constants.PgPasswordEnvVar), nil
+}
+
+// ReadPasswordFile reads a postgres password from path and trims trailing
+// CR/LF. Exposed for callers that already resolve the file path via their own
+// configuration layer (e.g. viperutil) and only need the file-reading
+// primitive.
+func ReadPasswordFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read postgres password file %q: %w", path, err)
+	}
+	return strings.TrimRight(string(b), "\r\n"), nil
+}

--- a/go/common/pgsecret/postgres_password_test.go
+++ b/go/common/pgsecret/postgres_password_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgsecret
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+)
+
+func writePasswordFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "password")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestReadPostgresPassword_FlagWins(t *testing.T) {
+	flagFile := writePasswordFile(t, "from-flag")
+	envFile := writePasswordFile(t, "from-env-file")
+	t.Setenv(constants.PgPasswordFileEnvVar, envFile)
+	t.Setenv(constants.PgPasswordEnvVar, "from-env")
+
+	got, err := ReadPostgresPassword(flagFile)
+	require.NoError(t, err)
+	assert.Equal(t, "from-flag", got)
+}
+
+func TestReadPostgresPassword_EnvFileBeatsEnvVar(t *testing.T) {
+	envFile := writePasswordFile(t, "from-env-file")
+	t.Setenv(constants.PgPasswordFileEnvVar, envFile)
+	t.Setenv(constants.PgPasswordEnvVar, "from-env")
+
+	got, err := ReadPostgresPassword("")
+	require.NoError(t, err)
+	assert.Equal(t, "from-env-file", got)
+}
+
+func TestReadPostgresPassword_EnvVarFallback(t *testing.T) {
+	t.Setenv(constants.PgPasswordFileEnvVar, "")
+	t.Setenv(constants.PgPasswordEnvVar, "from-env")
+
+	got, err := ReadPostgresPassword("")
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", got)
+}
+
+func TestReadPostgresPassword_AllUnsetReturnsEmpty(t *testing.T) {
+	t.Setenv(constants.PgPasswordFileEnvVar, "")
+	t.Setenv(constants.PgPasswordEnvVar, "")
+
+	got, err := ReadPostgresPassword("")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestReadPostgresPassword_TrimsTrailingNewline(t *testing.T) {
+	cases := map[string]string{
+		"lf":    "secret\n",
+		"crlf":  "secret\r\n",
+		"none":  "secret",
+		"multi": "secret\n\n",
+	}
+	for name, contents := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writePasswordFile(t, contents)
+			got, err := ReadPostgresPassword(path)
+			require.NoError(t, err)
+			assert.Equal(t, "secret", got)
+		})
+	}
+}
+
+func TestReadPostgresPassword_MissingFileFromFlag(t *testing.T) {
+	_, err := ReadPostgresPassword("/definitely/does/not/exist/password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read postgres password file")
+}
+
+func TestReadPostgresPassword_MissingFileFromEnv(t *testing.T) {
+	t.Setenv(constants.PgPasswordFileEnvVar, "/definitely/does/not/exist/password")
+	t.Setenv(constants.PgPasswordEnvVar, "ignored-because-file-takes-precedence")
+
+	_, err := ReadPostgresPassword("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read postgres password file")
+}

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -810,16 +810,12 @@ func (p *localProvisioner) provisionMultipooler(ctx context.Context, req *provis
 	// Start multipooler process
 	multipoolerCmd := executil.Command(ctx, multipoolerBinary, args...)
 
-	// Pass POSTGRES_PASSWORD so multipooler can authenticate to the admin pool.
-	// Source it from the same pgctld config block pgctld itself uses, so both
-	// services agree on the credential. Required: multipooler refuses to start
+	// Point multipooler at the password file pgctld already wrote (and is
+	// using itself). Both services agree on the credential because they
+	// resolve it from the same file. Required: multipooler refuses to start
 	// without it (pg_hba.conf uses scram-sha-256 for every connection).
-	pgPassword, ok := pgctldConfig["password"].(string)
-	if !ok || pgPassword == "" {
-		return nil, fmt.Errorf("pgctld password not configured for cell %s: set pg-password in the local provisioner config", cell)
-	}
 	multipoolerCmd.Env = append(os.Environ(),
-		"POSTGRES_PASSWORD="+pgPassword,
+		constants.PgPasswordFileEnvVar+"="+pgctldResult.PasswordFile,
 		constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"),
 	)
 
@@ -879,6 +875,10 @@ type PgctldProvisionResult struct {
 	Address string
 	Port    int
 	LogFile string
+	// PasswordFile is the path to the postgres password file written under the
+	// pooler directory. Both pgctld (already running with POSTGRES_PASSWORD_FILE
+	// pointing here) and the multipooler in the same cell read from it.
+	PasswordFile string
 }
 
 // provisionMultiOrch provisions multi-orchestrator using local binary

--- a/go/provisioner/local/pgctld.go
+++ b/go/provisioner/local/pgctld.go
@@ -147,6 +147,27 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	// Create unique pgctld service ID using multipooler's service ID
 	pgctldServiceID := "pgctld-" + serviceID
 
+	// Resolve pgctld config up-front so we can materialize the postgres
+	// password file before either branch (already-running or fresh start)
+	// returns. The file is the wire format both pgctld and the multipooler
+	// in this cell consume via POSTGRES_PASSWORD_FILE.
+	pgctldConfig, err := p.getCellServiceConfig(cell, "pgctld")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pgctld config for cell %s: %w", cell, err)
+	}
+	poolerDir, ok := pgctldConfig["pooler_dir"].(string)
+	if !ok || poolerDir == "" {
+		return nil, errors.New("pooler_dir not found in config")
+	}
+	pgPassword, ok := pgctldConfig["password"].(string)
+	if !ok || pgPassword == "" {
+		return nil, fmt.Errorf("pgctld password not configured for cell %s: set pg-password in the local provisioner config", cell)
+	}
+	pgPasswordFile, err := writePostgresPasswordFile(poolerDir, pgPassword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to materialize postgres password file: %w", err)
+	}
+
 	// Check if pgctld is already running for this service combination
 	existingService, err := p.findRunningDbService("pgctld", dbName, cell)
 	if err != nil {
@@ -166,16 +187,11 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 
 		fmt.Printf(" ✓\n")
 		return &PgctldProvisionResult{
-			Address: fmt.Sprintf("localhost:%d", existingService.Ports["grpc_port"]),
-			Port:    existingService.Ports["grpc_port"],
-			LogFile: existingService.LogFile,
+			Address:      fmt.Sprintf("localhost:%d", existingService.Ports["grpc_port"]),
+			Port:         existingService.Ports["grpc_port"],
+			LogFile:      existingService.LogFile,
+			PasswordFile: pgPasswordFile,
 		}, nil
-	}
-
-	// Get cell-specific pgctld config
-	pgctldConfig, err := p.getCellServiceConfig(cell, "pgctld")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pgctld config for cell %s: %w", cell, err)
 	}
 
 	// Find pgctld binary
@@ -222,13 +238,6 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	if level, ok := pgctldConfig["log_level"].(string); ok && level != "" {
 		logLevel = level
 	}
-
-	poolerDir := ""
-	dir, ok := pgctldConfig["pooler_dir"].(string)
-	if !ok {
-		return nil, errors.New("pooler_dir not found in config")
-	}
-	poolerDir = dir
 
 	// Get gRPC socket file if configured
 	socketFile, err := getGRPCSocketFile(pgctldConfig)
@@ -297,11 +306,10 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	// Set PGDATA so pgctld knows where the PostgreSQL data directory is.
 	pgctldCmd.AddEnv(constants.PgDataDirEnvVar + "=" + filepath.Join(poolerDir, "pg_data"))
 
-	// Pass the PostgreSQL password so pgctld can use it during init (--pwfile)
-	// and pg_hba.conf setup.
-	if password, ok := pgctldConfig["password"].(string); ok && password != "" {
-		pgctldCmd.AddEnv(constants.PgPasswordEnvVar + "=" + password)
-	}
+	// Point pgctld at the password file written above. pgctld reads it during
+	// init (--pwfile) and at server startup; multipooler reads the same file
+	// for its admin pool.
+	pgctldCmd.AddEnv(constants.PgPasswordFileEnvVar + "=" + pgPasswordFile)
 
 	if err := pgctldCmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start pgctld server: %w", err)
@@ -348,9 +356,10 @@ func (p *localProvisioner) provisionPgctld(ctx context.Context, dbName, tableGro
 	}
 
 	return &PgctldProvisionResult{
-		Address: fmt.Sprintf("localhost:%d", grpcPort),
-		Port:    grpcPort,
-		LogFile: pgctldLogFile,
+		Address:      fmt.Sprintf("localhost:%d", grpcPort),
+		Port:         grpcPort,
+		LogFile:      pgctldLogFile,
+		PasswordFile: pgPasswordFile,
 	}, nil
 }
 
@@ -381,4 +390,21 @@ func (p *localProvisioner) deprovisionPgctld(ctx context.Context, service *Local
 
 	fmt.Printf(" pgctld stopped ✓\n")
 	return nil
+}
+
+// writePostgresPasswordFile materializes the postgres password into a 0600
+// file at <poolerDir>/postgres-password and returns its path. The file is the
+// wire format both pgctld and the multipooler in this cell consume via
+// POSTGRES_PASSWORD_FILE; writing it idempotently (overwriting on each
+// provision) keeps the file in sync with the YAML config when operators rotate
+// the value. Cleanup is handled by the provisioner tearing down poolerDir.
+func writePostgresPasswordFile(poolerDir, password string) (string, error) {
+	if err := os.MkdirAll(poolerDir, 0o700); err != nil {
+		return "", fmt.Errorf("create pooler dir: %w", err)
+	}
+	path := filepath.Join(poolerDir, "postgres-password")
+	if err := os.WriteFile(path, []byte(password), 0o600); err != nil {
+		return "", fmt.Errorf("write postgres password file: %w", err)
+	}
+	return path, nil
 }

--- a/go/services/multipooler/connpoolmanager/config.go
+++ b/go/services/multipooler/connpoolmanager/config.go
@@ -16,14 +16,17 @@ package connpoolmanager
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/spf13/pflag"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgsecret"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
 
@@ -55,6 +58,15 @@ type ConnectionConfig struct {
 	TLSConfig *tls.Config
 }
 
+type pgPasswordSource int
+
+const (
+	pwSourceNone   pgPasswordSource = iota
+	pwSourceEnv                     // CONNPOOL_ADMIN_PASSWORD / POSTGRES_PASSWORD env var
+	pwSourceOption                  // --connpool-admin-password flag
+	pwSourceFile                    // password file path (flag or env var)
+)
+
 // Config holds viper-backed configuration values for the connection pool manager.
 // Create with NewConfig(), register flags with RegisterFlags(), then create the
 // manager with NewManager() when ready.
@@ -66,8 +78,20 @@ type Config struct {
 	// Used by the admin pool for kill operations and internal system queries
 	// (heartbeat, replication tracking).
 	// Configured via POSTGRES_USER / POSTGRES_PASSWORD environment variables.
-	pgUser     viperutil.Value[string]
-	pgPassword viperutil.Value[string]
+	pgUser         viperutil.Value[string]
+	pgPassword     viperutil.Value[string]
+	pgPasswordFile viperutil.Value[string]
+	// pgPasswordCached caches the file-resolved password so the hot path
+	// (PgPassword()) does not touch disk. Populated by ResolvePgPassword at
+	// startup; "" until then.
+	pgPasswordCached string
+	pgPasswordSource pgPasswordSource // file / option / env / none
+	// flagSet is saved during RegisterFlags so ResolvePgPassword can use
+	// pflag.Flag.Changed to distinguish "flag explicitly set" from "flag
+	// at default value" — viperutil's Get() collapses both into the
+	// flag's resolved value. nil when RegisterFlags has not run (e.g. in
+	// tests that exercise only the env-var or file paths).
+	flagSet *pflag.FlagSet
 
 	// --- PostgreSQL TLS (multipooler → postgres leg) ---
 	// libpq-style server verification. Mode + optional CA bundle. Client cert
@@ -186,6 +210,11 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			FlagName: "connpool-admin-password",
 			EnvVars:  []string{"CONNPOOL_ADMIN_PASSWORD", constants.PgPasswordEnvVar},
 		}),
+		pgPasswordFile: viperutil.Configure(reg, "connpool.pg.password-file", viperutil.Options[string]{
+			Default:  "",
+			FlagName: "connpool-admin-password-file",
+			EnvVars:  []string{"CONNPOOL_ADMIN_PASSWORD_FILE", constants.PgPasswordFileEnvVar},
+		}),
 
 		// PostgreSQL TLS — libpq parity. Default "prefer" mirrors libpq.
 		pgSSLMode: viperutil.Configure(reg, "connpool.pg.sslmode", viperutil.Options[string]{
@@ -273,9 +302,13 @@ func NewConfig(reg *viperutil.Registry) *Config {
 
 // RegisterFlags registers all connection pool flags with the given FlagSet.
 func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
+	// Save the FlagSet so ResolvePgPassword can use pflag.Flag.Changed to
+	// distinguish "flag explicitly set" from "flag at default value".
+	c.flagSet = fs
 	// PostgreSQL superuser credentials
 	fs.String("connpool-admin-user", c.pgUser.Default(), "PostgreSQL superuser for admin and internal operations (env: CONNPOOL_ADMIN_USER or POSTGRES_USER)")
-	fs.String("connpool-admin-password", c.pgPassword.Default(), "PostgreSQL superuser password (env: CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD)")
+	fs.String("connpool-admin-password", c.pgPassword.Default(), "PostgreSQL superuser password (env: CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD). --connpool-admin-password-file takes precedence.")
+	fs.String("connpool-admin-password-file", c.pgPasswordFile.Default(), "Path to a file containing the PostgreSQL superuser password (plaintext, docker-library/postgres convention). Takes precedence over --connpool-admin-password (env: CONNPOOL_ADMIN_PASSWORD_FILE or POSTGRES_PASSWORD_FILE).")
 
 	// PostgreSQL TLS (multipooler → postgres). Mirrors libpq sslmode/sslrootcert.
 	fs.String("pg-client-sslmode", c.pgSSLMode.Default(), "TLS mode for connections to PostgreSQL: disable|prefer|require|verify-ca|verify-full (libpq parity; sslmode=allow is not supported)")
@@ -311,6 +344,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	viperutil.BindFlags(fs,
 		c.pgUser,
 		c.pgPassword,
+		c.pgPasswordFile,
 		c.pgSSLMode,
 		c.pgSSLRootCert,
 		c.adminCapacity,
@@ -339,10 +373,107 @@ func (c *Config) PgUser() string {
 	return c.pgUser.Get()
 }
 
-// PgPassword returns the configured PostgreSQL superuser password.
-// Set via POSTGRES_PASSWORD environment variable.
-func (c *Config) PgPassword() string {
-	return c.pgPassword.Get()
+// PgPassword returns the resolved PostgreSQL superuser password and the
+// source it was loaded from ("file" or "env"). Both are empty until
+// ResolvePgPassword has run successfully; the source string is the canonical
+// "is the password configured?" check — an empty source means no source
+// produced a value (or Resolve was never called). Production startup in
+// services/multipooler/init.go calls ResolvePgPassword first and surfaces
+// its error, so callers reaching this point can treat an empty source as a
+// programmer-error invariant violation.
+func (c *Config) PgPassword() (string, pgPasswordSource) {
+	return c.pgPasswordCached, c.pgPasswordSource
+}
+
+// ResolvePgPassword chooses the password source and caches the result so
+// subsequent PgPassword() calls return it. Three independent inputs are
+// considered, in strict precedence order — once a higher-precedence input is
+// "explicitly set" it is authoritative and lower-precedence inputs are NOT
+// consulted, even when the higher-precedence value turns out to be empty
+// (those empty cases become errors instead of fallthroughs):
+//
+//  1. File path: --connpool-admin-password-file flag, or
+//     CONNPOOL_ADMIN_PASSWORD_FILE / POSTGRES_PASSWORD_FILE env.
+//     - Path explicitly empty                  → error.
+//     - Path set, file content empty           → error.
+//     - Path set, file content non-empty       → use it, source=File.
+//  2. Flag option: --connpool-admin-password.
+//     - Flag set to empty                      → error.
+//     - Flag set to non-empty                  → use it, source=Option.
+//  3. Env var: CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD.
+//     - Env set to empty                       → error.
+//     - Env set to non-empty                   → use it, source=Env.
+//
+// Reached the end with no input explicitly set: error "not configured".
+// "Explicitly set" is distinct from "viperutil resolved to empty" — viperutil
+// collapses unset and empty into the same "" via os.Getenv, so we use
+// os.LookupEnv and pflag.Flag.Changed to detect operator intent.
+func (c *Config) ResolvePgPassword() error {
+	// Row 1, 2a, 2b: file path explicitly set.
+	if path, explicit, isEmpty := c.passwordFileExplicit(); explicit {
+		if isEmpty {
+			c.pgPasswordSource = pwSourceNone
+			return errors.New("password file path is set to the empty string; unset it or provide a path")
+		}
+		pw, err := pgsecret.ReadPasswordFile(path)
+		if err != nil {
+			return err
+		}
+		if pw == "" {
+			c.pgPasswordSource = pwSourceNone
+			return fmt.Errorf("password file %q is empty", path)
+		}
+		c.pgPasswordCached = pw
+		c.pgPasswordSource = pwSourceFile
+		return nil
+	}
+	// Row 3, 4: --connpool-admin-password flag explicitly set.
+	if c.flagSet != nil {
+		if flag := c.flagSet.Lookup("connpool-admin-password"); flag != nil && flag.Changed {
+			v := flag.Value.String()
+			if v == "" {
+				c.pgPasswordSource = pwSourceNone
+				return errors.New("--connpool-admin-password is set to the empty string; unset it or provide a non-empty password")
+			}
+			c.pgPasswordCached = v
+			c.pgPasswordSource = pwSourceOption
+			return nil
+		}
+	}
+	// Row 5, 6: env vars. CONNPOOL_ADMIN_PASSWORD checked before POSTGRES_PASSWORD.
+	for _, name := range []string{"CONNPOOL_ADMIN_PASSWORD", constants.PgPasswordEnvVar} {
+		if v, ok := os.LookupEnv(name); ok {
+			if v == "" {
+				c.pgPasswordSource = pwSourceNone
+				return fmt.Errorf("env var %s is set to the empty string; unset it or provide a non-empty password", name)
+			}
+			c.pgPasswordCached = v
+			c.pgPasswordSource = pwSourceEnv
+			return nil
+		}
+	}
+	// Row 7: no source configured.
+	c.pgPasswordSource = pwSourceNone
+	return errors.New("admin password not configured: set CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD env var, --connpool-admin-password flag, or --connpool-admin-password-file / CONNPOOL_ADMIN_PASSWORD_FILE / POSTGRES_PASSWORD_FILE to point at a password file")
+}
+
+// passwordFileExplicit reports whether the file-path input was explicitly
+// set (via flag or env var) and whether the resulting path is the empty
+// string. It does NOT consider viperutil defaults — the flag's
+// pflag.Flag.Changed bit and os.LookupEnv are the source of truth.
+func (c *Config) passwordFileExplicit() (path string, explicit, isEmpty bool) {
+	if c.flagSet != nil {
+		if flag := c.flagSet.Lookup("connpool-admin-password-file"); flag != nil && flag.Changed {
+			v := flag.Value.String()
+			return v, true, v == ""
+		}
+	}
+	for _, name := range []string{"CONNPOOL_ADMIN_PASSWORD_FILE", constants.PgPasswordFileEnvVar} {
+		if v, ok := os.LookupEnv(name); ok {
+			return v, true, v == ""
+		}
+	}
+	return "", false, false
 }
 
 // PgSSLMode parses and returns the configured libpq-style sslmode.

--- a/go/services/multipooler/connpoolmanager/config_test.go
+++ b/go/services/multipooler/connpoolmanager/config_test.go
@@ -16,6 +16,8 @@ package connpoolmanager
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -111,7 +113,11 @@ func TestConfig_Getters_ReturnDefaults(t *testing.T) {
 	// Verify getters return the default values (viperutil.Value returns defaults
 	// when no flags are parsed and no env vars are set).
 	assert.Equal(t, constants.DefaultPostgresUser, config.PgUser())
-	assert.Equal(t, "", config.PgPassword())
+	// Until ResolvePgPassword runs, PgPassword returns the zero value for
+	// both fields.
+	pw, source := config.PgPassword()
+	assert.Equal(t, "", pw)
+	assert.Equal(t, pwSourceNone, source)
 	assert.Equal(t, int64(5), config.AdminCapacity())
 
 	// Regular pool (capacity managed by rebalancer)
@@ -212,7 +218,10 @@ func TestConfig_ConnpoolAdminPassword_EnvVar(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	config.RegisterFlags(fs)
 
-	assert.Equal(t, "connpool_pass", config.PgPassword())
+	require.NoError(t, config.ResolvePgPassword())
+	pw, source := config.PgPassword()
+	assert.Equal(t, "connpool_pass", pw)
+	assert.Equal(t, pwSourceEnv, source)
 }
 
 func TestConfig_ConnpoolAdminUser_TakesPrecedence(t *testing.T) {
@@ -238,7 +247,10 @@ func TestConfig_ConnpoolAdminPassword_TakesPrecedence(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	config.RegisterFlags(fs)
 
-	assert.Equal(t, "connpool_pass", config.PgPassword())
+	require.NoError(t, config.ResolvePgPassword())
+	pw, source := config.PgPassword()
+	assert.Equal(t, "connpool_pass", pw)
+	assert.Equal(t, pwSourceEnv, source)
 }
 
 func TestConfig_PgPassword_EnvVar(t *testing.T) {
@@ -250,7 +262,155 @@ func TestConfig_PgPassword_EnvVar(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	config.RegisterFlags(fs)
 
-	assert.Equal(t, "test-password", config.PgPassword())
+	require.NoError(t, config.ResolvePgPassword())
+	pw, source := config.PgPassword()
+	assert.Equal(t, "test-password", pw)
+	assert.Equal(t, pwSourceEnv, source)
+}
+
+// --- ResolvePgPassword edge cases ---
+
+// writePwFile is a small helper that creates a password file inside a fresh
+// temp dir and returns its path. Used by the empty-file / non-empty-file
+// fallthrough tests below.
+func writePwFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "postgres-password")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+// Row 2a: file path set with non-empty path but the file's content is empty.
+// Resolver must surface a clear error and NOT silently fall through to env
+// even if env vars are set to something else.
+func TestResolvePgPassword_FileEmpty_Errors(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
+	t.Setenv(constants.PgPasswordFileEnvVar, writePwFile(t, ""))
+	// Distinct env value so a regression that falls through surfaces
+	// immediately as a wrong source/value.
+	t.Setenv(constants.PgPasswordEnvVar, "from-env-should-be-ignored")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+// Row 2b: file path env var is explicitly set to the empty string. That's
+// "operator wrote POSTGRES_PASSWORD_FILE= in a manifest" — a deliberate
+// misconfiguration, not "unset". os.LookupEnv distinguishes the two.
+func TestResolvePgPassword_FilePathEnvSetEmpty_Errors(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
+	t.Setenv(constants.PgPasswordFileEnvVar, "")
+	// Env value set to something so a regression would silently use it.
+	t.Setenv(constants.PgPasswordEnvVar, "from-env-should-be-ignored")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file path is set to the empty string")
+}
+
+// Row 3: --connpool-admin-password flag set to a non-empty value, no file
+// path configured. Flag wins over any env var; source must be Option.
+func TestResolvePgPassword_OptionFlagSet_UsesOption(t *testing.T) {
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
+	// Set env vars to a distinct value to prove the flag dominates.
+	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "from-env-should-be-ignored")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+	require.NoError(t, fs.Set("connpool-admin-password", "from-flag"))
+
+	require.NoError(t, config.ResolvePgPassword())
+	pw, source := config.PgPassword()
+	assert.Equal(t, "from-flag", pw)
+	assert.Equal(t, pwSourceOption, source)
+}
+
+// Row 4: --connpool-admin-password flag explicitly set to the empty string.
+// Resolver must error even when env vars are set to a non-empty value.
+func TestResolvePgPassword_OptionFlagSetEmpty_Errors(t *testing.T) {
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
+	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "from-env-should-be-ignored")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+	require.NoError(t, fs.Set("connpool-admin-password", ""))
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--connpool-admin-password")
+	assert.Contains(t, err.Error(), "empty string")
+}
+
+// No source configured at all: file path unset, neither env var set. Both
+// branches fall through; Resolve must surface a clear "not configured" error
+// rather than silently leave the resolver with an empty cached password.
+func TestResolvePgPassword_NoSourceConfigured(t *testing.T) {
+	require.NoError(t, os.Unsetenv(constants.PgPasswordFileEnvVar))
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD_FILE"))
+	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD"))
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "admin password not configured")
+}
+
+// POSTGRES_PASSWORD deliberately set to the empty string is a misconfiguration
+// (operator typed POSTGRES_PASSWORD= in a unit file or manifest). Distinct
+// from "unset" via os.LookupEnv; resolver must reject it explicitly.
+func TestResolvePgPassword_PostgresPasswordSetEmpty(t *testing.T) {
+	require.NoError(t, os.Unsetenv("CONNPOOL_ADMIN_PASSWORD"))
+	t.Setenv(constants.PgPasswordEnvVar, "")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "POSTGRES_PASSWORD")
+	assert.Contains(t, err.Error(), "empty string")
+}
+
+// CONNPOOL_ADMIN_PASSWORD deliberately set to empty — same misconfiguration,
+// different env-var name.
+func TestResolvePgPassword_ConnpoolAdminPasswordSetEmpty(t *testing.T) {
+	require.NoError(t, os.Unsetenv(constants.PgPasswordEnvVar))
+	t.Setenv("CONNPOOL_ADMIN_PASSWORD", "")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	config.RegisterFlags(fs)
+
+	err := config.ResolvePgPassword()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CONNPOOL_ADMIN_PASSWORD")
+	assert.Contains(t, err.Error(), "empty string")
 }
 
 func TestConfig_PgUser_EnvVar(t *testing.T) {

--- a/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
+++ b/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
@@ -70,6 +70,8 @@ func newTestManagerWithConfig(t *testing.T, server *fakepgserver.Server, testCfg
 		}
 	}
 
+	resolveTestPgPassword(t, config)
+
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{
 		SocketFile: server.ClientConfig().SocketFile,

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -48,8 +48,12 @@ type PoolManager interface {
 	// PgUser returns the configured PostgreSQL user for system queries.
 	PgUser() string
 
-	// PgPassword returns the configured PostgreSQL password for system queries.
-	PgPassword() string
+	// PgPassword returns the resolved PostgreSQL password and an "ok" flag
+	// indicating whether a password source was successfully resolved at
+	// startup. !ok means ResolvePgPassword has not run successfully and
+	// should be treated as an invariant violation by callers (production
+	// startup guarantees Resolve runs first).
+	PgPassword() (string, bool)
 
 	// --- Admin Pool Operations ---
 

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -128,8 +128,15 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.closed.Store(false)
 	m.generation.Add(1)
 
-	// Build admin client config
-	adminClientConfig := m.buildClientConfig(m.config.PgUser(), m.config.PgPassword())
+	// Build admin client config. pwSourceNone signals that ResolvePgPassword
+	// was never called — production startup in services/multipooler/init.go
+	// enforces it before reaching Open, so an unset source here is strictly
+	// a programmer error.
+	adminPassword, source := m.config.PgPassword()
+	if source == pwSourceNone {
+		panic("connpoolmanager: Open called before ResolvePgPassword; no password source configured")
+	}
+	adminClientConfig := m.buildClientConfig(m.config.PgUser(), adminPassword)
 
 	// Build admin pool config
 	connectTimeout := 2 * m.config.DialTimeout()
@@ -219,7 +226,14 @@ func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte
 	password := ""
 	if len(clientKey) == 0 || len(serverKey) == 0 {
 		if user == m.config.PgUser() {
-			password = m.config.PgPassword()
+			pw, source := m.config.PgPassword()
+			if source == pwSourceNone {
+				// Invariant violation: production startup in
+				// services/multipooler/init.go calls
+				// ResolvePgPassword before any user pool is created.
+				panic("connpoolmanager: buildUserClientConfig called before ResolvePgPassword; no password source configured")
+			}
+			password = pw
 		}
 	}
 	cfg := m.buildClientConfig(user, password)
@@ -399,9 +413,15 @@ func (m *Manager) PgUser() string {
 	return m.config.PgUser()
 }
 
-// PgPassword returns the configured PostgreSQL password for system queries.
-func (m *Manager) PgPassword() string {
-	return m.config.PgPassword()
+// PgPassword returns the resolved PostgreSQL superuser password and an "ok"
+// flag indicating whether ResolvePgPassword ran successfully and produced a
+// source. A false ok means no password source was configured (or Resolve was
+// never called); production startup in services/multipooler/init.go calls
+// Resolve first and surfaces its error, so callers reaching this point can
+// treat !ok as a programmer-error invariant violation.
+func (m *Manager) PgPassword() (string, bool) {
+	pw, source := m.config.PgPassword()
+	return pw, source != pwSourceNone
 }
 
 // --- Admin Pool Operations ---

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -31,6 +32,16 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 	"github.com/multigres/multigres/go/tools/viperutil"
 )
+
+// resolveTestPgPassword wires a benign password source into the Config so
+// Manager.Open does not panic on the missing-Resolve invariant. The fake
+// server uses trust authentication, so the value itself is never consulted —
+// only the source string matters to satisfy the invariant.
+func resolveTestPgPassword(t *testing.T, config *Config) {
+	t.Helper()
+	t.Setenv(constants.PgPasswordEnvVar, "test-password")
+	require.NoError(t, config.ResolvePgPassword())
+}
 
 // newTestManager creates a Manager configured for testing with the given fake server.
 // No password configuration is needed since fakepgserver uses trust authentication,
@@ -40,6 +51,7 @@ func newTestManager(t *testing.T, server *fakepgserver.Server) *Manager {
 
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
+	resolveTestPgPassword(t, config)
 
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{
@@ -904,6 +916,7 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 func TestBuildUserClientConfig_KeysApplied(t *testing.T) {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
+	resolveTestPgPassword(t, config)
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
 	defer manager.Close()
@@ -927,6 +940,7 @@ func TestBuildUserClientConfig_KeysApplied(t *testing.T) {
 func TestBuildUserClientConfig_NilKeys_FallsBack(t *testing.T) {
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
+	resolveTestPgPassword(t, config)
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
 	defer manager.Close()

--- a/go/services/multipooler/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/connpoolmanager/rebalancer_test.go
@@ -36,6 +36,7 @@ func newTestManagerForRebalancer(t *testing.T, server *fakepgserver.Server) *Man
 
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
+	resolveTestPgPassword(t, config)
 
 	manager := config.NewManager(slog.Default())
 	manager.Open(context.Background(), &ConnectionConfig{

--- a/go/services/multipooler/grpcconsensusservice/service_test.go
+++ b/go/services/multipooler/grpcconsensusservice/service_test.go
@@ -87,11 +87,17 @@ func TestConsensusService_BeginTerm(t *testing.T) {
 
 	multipooler.PoolerDir = tmpDir
 
+	// ConnPoolConfig now requires ResolvePgPassword to run before any pool is
+	// opened; seed POSTGRES_PASSWORD so the env path resolves cleanly. The
+	// value is irrelevant — fake postgres uses trust auth.
+	t.Setenv(constants.PgPasswordEnvVar, "test-password")
+	connPoolConfig := connpoolmanager.NewConfig(viperutil.NewRegistry())
+	require.NoError(t, connPoolConfig.ResolvePgPassword())
 	config := &manager.Config{
 		TopoClient:       ts,
 		PgctldAddr:       pgctldAddr,
 		ConsensusEnabled: true,
-		ConnPoolConfig:   connpoolmanager.NewConfig(viperutil.NewRegistry()),
+		ConnPoolConfig:   connPoolConfig,
 	}
 	pm, err := manager.NewMultiPoolerManager(logger, multipooler, config)
 	require.NoError(t, err)
@@ -182,11 +188,17 @@ func TestConsensusService_Status(t *testing.T) {
 
 	multipooler.PoolerDir = tmpDir
 
+	// ConnPoolConfig now requires ResolvePgPassword to run before any pool is
+	// opened; seed POSTGRES_PASSWORD so the env path resolves cleanly. The
+	// value is irrelevant — fake postgres uses trust auth.
+	t.Setenv(constants.PgPasswordEnvVar, "test-password")
+	connPoolConfig := connpoolmanager.NewConfig(viperutil.NewRegistry())
+	require.NoError(t, connPoolConfig.ResolvePgPassword())
 	config := &manager.Config{
 		TopoClient:       ts,
 		PgctldAddr:       pgctldAddr,
 		ConsensusEnabled: true,
-		ConnPoolConfig:   connpoolmanager.NewConfig(viperutil.NewRegistry()),
+		ConnPoolConfig:   connPoolConfig,
 	}
 	pm, err := manager.NewMultiPoolerManager(logger, multipooler, config)
 	require.NoError(t, err)
@@ -266,11 +278,17 @@ func TestConsensusService_AllMethods(t *testing.T) {
 
 	multipooler.PoolerDir = tmpDir
 
+	// ConnPoolConfig now requires ResolvePgPassword to run before any pool is
+	// opened; seed POSTGRES_PASSWORD so the env path resolves cleanly. The
+	// value is irrelevant — fake postgres uses trust auth.
+	t.Setenv(constants.PgPasswordEnvVar, "test-password")
+	connPoolConfig := connpoolmanager.NewConfig(viperutil.NewRegistry())
+	require.NoError(t, connPoolConfig.ResolvePgPassword())
 	config := &manager.Config{
 		TopoClient:       ts,
 		PgctldAddr:       pgctldAddr,
 		ConsensusEnabled: true,
-		ConnPoolConfig:   connpoolmanager.NewConfig(viperutil.NewRegistry()),
+		ConnPoolConfig:   connPoolConfig,
 	}
 	pm, err := manager.NewMultiPoolerManager(logger, multipooler, config)
 	require.NoError(t, err)

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -276,8 +276,8 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 		return errors.New("database is required")
 	}
 
-	if mp.connPoolConfig.PgPassword() == "" {
-		return errors.New("admin password not configured: set CONNPOOL_ADMIN_PASSWORD or POSTGRES_PASSWORD environment variable, or --connpool-admin-password flag")
+	if err := mp.connPoolConfig.ResolvePgPassword(); err != nil {
+		return fmt.Errorf("resolve admin password: %w", err)
 	}
 
 	if mp.tableGroup.Get() == "" {

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -899,8 +899,20 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 		pgPort := int(pm.multipooler.PortMap["postgres"])
 		socketDir := filepath.Join(pm.multipooler.PoolerDir, "pg_sockets")
 		pg1User := constants.DefaultPostgresUser
+		pg1Password := os.Getenv(constants.PgPasswordEnvVar)
 		if pm.connPoolMgr != nil {
 			pg1User = pm.connPoolMgr.PgUser()
+			// PgPassword() returns the password resolved at startup (file →
+			// env) and an ok flag. !ok means ResolvePgPassword never ran
+			// successfully — surface that via setStateError so the manager
+			// goroutine bails out cleanly instead of writing an empty pgpass
+			// file that fails auth later.
+			pw, ok := pm.connPoolMgr.PgPassword()
+			if !ok {
+				pm.setStateError(errors.New("pgbackrest pgpass: postgres password not resolved (ResolvePgPassword must run before pgbackrest setup)"))
+				return
+			}
+			pg1Password = pw
 		}
 		configPath, err := backup.WriteClientConfig(backup.ClientConfigOpts{
 			PoolerDir:     pm.multipooler.PoolerDir,
@@ -923,7 +935,7 @@ func (pm *MultiPoolerManager) loadMultiPoolerFromTopo() {
 		// temp directory because pgbackrest needs to be able to read it after
 		// we exec (and the temp file would be cleaned up when closed).
 		pgpassPath := filepath.Join(pm.multipooler.PoolerDir, "pgbackrest", "pgbackrest.pgpass")
-		pgpassContent := fmt.Sprintf("*:*:*:%s:%s\n", pg1User, os.Getenv("POSTGRES_PASSWORD"))
+		pgpassContent := fmt.Sprintf("*:*:*:%s:%s\n", pg1User, pg1Password)
 		if err := os.WriteFile(pgpassPath, []byte(pgpassContent), 0o600); err != nil {
 			pm.setStateError(fmt.Errorf("failed to write pgbackrest pgpass file: %w", err))
 			return

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -54,9 +54,9 @@ type fakeConnPoolMgr struct {
 	user string
 }
 
-func (f *fakeConnPoolMgr) PgUser() string     { return f.user }
-func (f *fakeConnPoolMgr) PgPassword() string { return "" }
-func (f *fakeConnPoolMgr) Close()             {} // called from MultiPoolerManager.Shutdown
+func (f *fakeConnPoolMgr) PgUser() string             { return f.user }
+func (f *fakeConnPoolMgr) PgPassword() (string, bool) { return "", false }
+func (f *fakeConnPoolMgr) Close()                     {} // called from MultiPoolerManager.Shutdown
 
 // setTermForTest writes the consensus term file directly for testing.
 func setTermForTest(t *testing.T, poolerDir string, term *clustermetadatapb.TermRevocation) {

--- a/go/test/endtoend/pgctld/pgctld_grpc_test.go
+++ b/go/test/endtoend/pgctld/pgctld_grpc_test.go
@@ -429,10 +429,11 @@ func TestGRPCPortableConfig(t *testing.T) {
 		service, err := command.NewPgCtldService(
 			slog.Default(),
 			command.PgCtldServiceConfig{
-				Port:     5432,
-				User:     constants.DefaultPostgresUser,
-				Database: constants.DefaultPostgresDatabase,
-				Password: shardsetup.TestPostgresPassword,
+				Port:           5432,
+				User:           constants.DefaultPostgresUser,
+				Database:       constants.DefaultPostgresDatabase,
+				Password:       shardsetup.TestPostgresPassword,
+				PasswordSource: command.PasswordSourceEnv,
 			},
 			30,
 			dataDir,
@@ -452,10 +453,11 @@ func TestGRPCPortableConfig(t *testing.T) {
 		service2, err := command.NewPgCtldService(
 			slog.Default(),
 			command.PgCtldServiceConfig{
-				Port:     5433,
-				User:     constants.DefaultPostgresUser,
-				Database: constants.DefaultPostgresDatabase,
-				Password: shardsetup.TestPostgresPassword,
+				Port:           5433,
+				User:           constants.DefaultPostgresUser,
+				Database:       constants.DefaultPostgresDatabase,
+				Password:       shardsetup.TestPostgresPassword,
+				PasswordSource: command.PasswordSourceEnv,
 			},
 			30,
 			dataDir,
@@ -486,10 +488,11 @@ func createTestGRPCServer(t *testing.T, dataDir, binDir string) (net.Listener, f
 
 	// Create the pgctld service with mock environment
 	cfg := command.PgCtldServiceConfig{
-		Port:     5432,
-		User:     constants.DefaultPostgresUser,
-		Database: constants.DefaultPostgresDatabase,
-		Password: shardsetup.TestPostgresPassword,
+		Port:           5432,
+		User:           constants.DefaultPostgresUser,
+		Database:       constants.DefaultPostgresDatabase,
+		Password:       shardsetup.TestPostgresPassword,
+		PasswordSource: command.PasswordSourceEnv,
 	}
 	service, err := command.NewPgCtldService(
 		slog.Default(),

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -558,7 +558,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 
 		output, err := initCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld init should succeed, output: %s", string(output))
-		assert.Contains(t, string(output), "\"password_source\":\"POSTGRES_PASSWORD environment variable\"", "Should use POSTGRES_PASSWORD")
+		assert.Contains(t, string(output), "\"password_source\":\"POSTGRES_PASSWORD\"", "Should record POSTGRES_PASSWORD env as the source")
 
 		// Start the PostgreSQL server
 		t.Logf("Starting PostgreSQL server")
@@ -688,6 +688,70 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		err = stopCmd.Run()
 		require.NoError(t, err, "pgctld stop should succeed")
 	})
+
+	// password_file_authentication exercises the Kubernetes-Secret-style path:
+	// POSTGRES_PASSWORD_FILE points at a file (with a trailing newline, mimicking
+	// `stringData`) and POSTGRES_PASSWORD is intentionally omitted. initdb,
+	// start, and stop must all resolve the password from the file.
+	t.Run("password_file_authentication", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_auth_file_test")
+		defer cleanup()
+
+		port := utils.GetFreePort(t)
+		testPassword := "secret_from_file_456"
+
+		pwFile := filepath.Join(baseDir, "postgres-password")
+		// Write with a trailing newline to match a kubectl-created Secret whose
+		// stringData value is line-terminated; the helper must strip it.
+		require.NoError(t, os.WriteFile(pwFile, []byte(testPassword+"\n"), 0o600))
+
+		envWithFile := func() []string {
+			env := filterEnv(os.Environ(), "POSTGRES_PASSWORD")
+			env = append(env,
+				"PGCONNECT_TIMEOUT=5",
+				"POSTGRES_PASSWORD_FILE="+pwFile,
+				constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
+			)
+			if runtime.GOOS == "darwin" {
+				env = append(env, "LC_ALL=en_US.UTF-8")
+			}
+			return env
+		}
+
+		t.Logf("Initializing PostgreSQL with POSTGRES_PASSWORD_FILE")
+		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
+		initCmd.Env = envWithFile()
+		output, err := initCmd.CombinedOutput()
+		require.NoError(t, err, "pgctld init should succeed with POSTGRES_PASSWORD_FILE, output: %s", string(output))
+		assert.Contains(t, string(output), "\"password_source\":\"POSTGRES_PASSWORD_FILE\"",
+			"Should record POSTGRES_PASSWORD_FILE as the source")
+
+		t.Logf("Starting PostgreSQL server")
+		startCmd := exec.Command("pgctld", "start", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
+		startCmd.Env = envWithFile()
+		output, err = startCmd.CombinedOutput()
+		require.NoError(t, err, "pgctld start should succeed, output: %s", string(output))
+
+		time.Sleep(2 * time.Second)
+
+		// TCP auth using the password that was sourced from the file.
+		tcpCmd := exec.Command("psql",
+			"-h", "localhost",
+			"-p", strconv.Itoa(port),
+			"-U", "postgres",
+			"-d", "postgres",
+			"-c", "SELECT current_user;",
+		)
+		tcpCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		output, err = tcpCmd.CombinedOutput()
+		require.NoError(t, err, "TCP connection should succeed, output: %s", string(output))
+		assert.Contains(t, string(output), "postgres")
+
+		t.Logf("Shutting down PostgreSQL")
+		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", baseDir)
+		stopCmd.Env = append(envWithFile(), "PGPASSWORD="+testPassword)
+		require.NoError(t, stopCmd.Run(), "pgctld stop should succeed")
+	})
 }
 
 // TestPgctldRequiresPassword verifies that pgctld init and pgctld server refuse
@@ -719,8 +783,8 @@ func TestPgctldRequiresPassword(t *testing.T) {
 
 		output, err := initCmd.CombinedOutput()
 		require.Error(t, err, "pgctld init should fail without POSTGRES_PASSWORD, output: %s", string(output))
-		assert.Contains(t, string(output), "POSTGRES_PASSWORD must be set",
-			"error message should explain the missing env var")
+		assert.Contains(t, string(output), "postgres password must be set",
+			"error message should explain how to supply the password")
 	})
 
 	t.Run("server fails without POSTGRES_PASSWORD", func(t *testing.T) {
@@ -744,8 +808,8 @@ func TestPgctldRequiresPassword(t *testing.T) {
 
 		output, err := serverCmd.CombinedOutput()
 		require.Error(t, err, "pgctld server should fail without POSTGRES_PASSWORD, output: %s", string(output))
-		assert.Contains(t, string(output), "POSTGRES_PASSWORD must be set",
-			"error message should explain the missing env var")
+		assert.Contains(t, string(output), "postgres password must be set",
+			"error message should explain how to supply the password")
 	})
 }
 

--- a/go/test/endtoend/pgctld/test_helpers.go
+++ b/go/test/endtoend/pgctld/test_helpers.go
@@ -216,10 +216,11 @@ func createTestGRPCServerWithPgBackRest(t *testing.T, setup *TestSetup) (net.Lis
 
 	// Create the pgctld service with pgBackRest configuration
 	cfg := command.PgCtldServiceConfig{
-		Port:     setup.PgPort,
-		User:     constants.DefaultPostgresUser,
-		Database: constants.DefaultPostgresDatabase,
-		Password: shardsetup.TestPostgresPassword,
+		Port:           setup.PgPort,
+		User:           constants.DefaultPostgresUser,
+		Database:       constants.DefaultPostgresDatabase,
+		Password:       shardsetup.TestPostgresPassword,
+		PasswordSource: command.PasswordSourceEnv,
 	}
 	service, err := command.NewPgCtldService(
 		slog.Default(),


### PR DESCRIPTION
Operators can now deliver the postgres superuser password via a mounted  Kubernetes Secret instead of the plaintext POSTGRES_PASSWORD env var. Using  POSTGRES_PASSWORD can potentially leak, for example when using commands like  "kubectl get pod -o yaml and /proc/PID/environ". The env path stays as a transitional fallback for the published images and the endtoend harness, but the local provisioner now uses the file-based path natively so it dogfoods what production should be doing.

Resolution order in pgctld and the multipooler admin pool:
  1. --pg-password-file / --connpool-admin-password-file flag
  2. POSTGRES_PASSWORD_FILE env (PGDG / docker-library convention)
  3. POSTGRES_PASSWORD env (fallback)

The new pgsecret helper centralizes the file-reading + trim logic so every consumer applies the same trim semantics. pgctld hands the operator's file directly to initdb --pwfile when available, falling back to staging a temp file only for the env-var path. The demo StatefulSet mounts the Secret at /var/run/secrets/multigres/ (tmpfs, FHS-appropriate for ephemeral runtime data) and per-pod passwords are supported via $(POD_NAME) substitution.

Local provisioner: writes <poolerDir>/postgres-password from the YAML pg-password value and passes POSTGRES_PASSWORD_FILE to both pgctld and multipooler instead of POSTGRES_PASSWORD. The file's path is threaded through PgctldProvisionResult so both children agree on the source. The write is idempotent so config rotation propagates on re-provision.

Fixes MUL-462