### PR TITLE
fix(parser): preserve quoting on "char" type deparse

### DIFF
--- a/go/common/parser/ast/ddl_statements.go
+++ b/go/common/parser/ast/ddl_statements.go
@@ -794,8 +794,12 @@ func normalizeSingleTypeName(typeName string) string {
 		return "DOUBLE PRECISION"
 	case "bool", "boolean":
 		return "BOOLEAN"
-	case "bpchar", "char":
+	case "bpchar":
 		return "CHAR"
+	case "char":
+		// pg_catalog."char" is a one-byte ad-hoc type distinct from bpchar/CHAR;
+		// preserve the quoting so it does not collapse to bpchar(1) on the wire.
+		return `"char"`
 	case "varchar":
 		return "VARCHAR"
 	case "text":


### PR DESCRIPTION
## Summary

- Stop collapsing `pg_catalog."char"` (one-byte ad-hoc type, OID 18) and `bpchar` onto the same unquoted `CHAR` keyword in `normalizeSingleTypeName`.
- Deparse `"char"` back as a quoted identifier so casts like `'a'::"char"` survive the gateway round-trip with the correct type and semantics.

## Problem

`SqlString()` rewrote `SELECT 'a'::"char"` to `SELECT CAST('a' AS CHAR)`. Postgres reads bare `CHAR` as `bpchar(1)`, so the wire type became `bpchar` instead of `"char"`, and bytea-style backslash escapes (`'\101'`, `'\377'`, `'\000'`) that only `charin()` decodes were left as literal text and then truncated to a single `\`. This surfaced as the `char` pg_regress diff against `expected/char_1.out`.

## Solution

Split the case in `normalizeSingleTypeName`: `bpchar` continues to emit `CHAR`, while `char` emits the quoted form `"char"`. The pg_query AST already distinguishes the two (`["char"]` vs. `["pg_catalog", "bpchar"]` with typmod=1), so the fix is local to the deparser. Verified by re-running `PGREGRESS_TESTS=char`: all the `bpchar` header / escape-decoding diff lines from the original report are gone.