### PR TITLE
feat(multiorch, multipooler): retire shutting-down poolers

### DIFF
--- a/go/common/topoclient/multipooler.go
+++ b/go/common/topoclient/multipooler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 )
@@ -40,6 +41,18 @@ func NewMultiPooler(name string, cell, host, tableGroup string) *clustermetadata
 			TableGroup: tableGroup,
 		},
 		PortMap: make(map[string]int32),
+		// The pooler process is up but postgres readiness has not yet been
+		// confirmed; the manager transitions this to ACTIVE once the
+		// pgMonitor observes postgres responding. The timestamp is set at
+		// construction time rather than at write time — the caller
+		// (registerFunc) invokes RegisterMultiPooler within microseconds
+		// of the factory call, so the difference is negligible and avoids
+		// plumbing a clock through the factory's call sites.
+		LifecycleStatus: &clustermetadatapb.PoolerLifecycle{
+			Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+			Reason:  "process starting",
+			Updated: timestamppb.Now(),
+		},
 	}
 }
 

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -94,6 +94,82 @@ func (PoolerType) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{0}
 }
 
+// PoolerLifecycleStatus represents where a pooler is in its process lifecycle.
+// Orthogonal to PoolerType (role) and PoolerServingStatus (query-serving
+// readiness). The pooler advances through these states as it boots, serves,
+// and exits. The value is operator-visible via the MultiPooler topology
+// entry; the orchestrator's pooler watcher observes the
+// LIFECYCLE_SHUTDOWN transition and tears down the per-pooler health
+// stream.
+type PoolerLifecycleStatus int32
+
+const (
+	// LIFECYCLE_UNKNOWN is the default for older recordings that predate
+	// this field.
+	PoolerLifecycleStatus_LIFECYCLE_UNKNOWN PoolerLifecycleStatus = 0
+	// LIFECYCLE_STARTING is set while the pooler is initialising (loading
+	// topology, opening pools) and has not yet begun serving.
+	PoolerLifecycleStatus_LIFECYCLE_STARTING PoolerLifecycleStatus = 1
+	// LIFECYCLE_ACTIVE is the normal steady-state — postgres is responding.
+	PoolerLifecycleStatus_LIFECYCLE_ACTIVE PoolerLifecycleStatus = 2
+	// LIFECYCLE_STOPPING announces that the pooler has been told to shut
+	// down. Written at the top of GracefulShutdown so operators see the
+	// state immediately, before the shutdown sequence runs (~5–15 s).
+	PoolerLifecycleStatus_LIFECYCLE_STOPPING PoolerLifecycleStatus = 3
+	// LIFECYCLE_SHUTDOWN is set after the OnClose chain has run: the pooler
+	// is durably down (not just announcing it via STOPPING). Written from
+	// unregisterFunc alongside Type=DRAINED. The topology entry is left in
+	// place so the orchestrator's 4 h unseen-instance bookkeeping handles
+	// eventual eviction, but the orchestrator's pooler watcher observes
+	// the transition and stops the per-pooler health stream immediately.
+	PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN PoolerLifecycleStatus = 4
+)
+
+// Enum value maps for PoolerLifecycleStatus.
+var (
+	PoolerLifecycleStatus_name = map[int32]string{
+		0: "LIFECYCLE_UNKNOWN",
+		1: "LIFECYCLE_STARTING",
+		2: "LIFECYCLE_ACTIVE",
+		3: "LIFECYCLE_STOPPING",
+		4: "LIFECYCLE_SHUTDOWN",
+	}
+	PoolerLifecycleStatus_value = map[string]int32{
+		"LIFECYCLE_UNKNOWN":  0,
+		"LIFECYCLE_STARTING": 1,
+		"LIFECYCLE_ACTIVE":   2,
+		"LIFECYCLE_STOPPING": 3,
+		"LIFECYCLE_SHUTDOWN": 4,
+	}
+)
+
+func (x PoolerLifecycleStatus) Enum() *PoolerLifecycleStatus {
+	p := new(PoolerLifecycleStatus)
+	*p = x
+	return p
+}
+
+func (x PoolerLifecycleStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PoolerLifecycleStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[1].Descriptor()
+}
+
+func (PoolerLifecycleStatus) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[1]
+}
+
+func (x PoolerLifecycleStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PoolerLifecycleStatus.Descriptor instead.
+func (PoolerLifecycleStatus) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{1}
+}
+
 // PoolerServingStatus represents the serving status of the given MultiPooler.
 type PoolerServingStatus int32
 
@@ -139,11 +215,11 @@ func (x PoolerServingStatus) String() string {
 }
 
 func (PoolerServingStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[1].Descriptor()
+	return file_clustermetadata_proto_enumTypes[2].Descriptor()
 }
 
 func (PoolerServingStatus) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[1]
+	return &file_clustermetadata_proto_enumTypes[2]
 }
 
 func (x PoolerServingStatus) Number() protoreflect.EnumNumber {
@@ -152,7 +228,7 @@ func (x PoolerServingStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PoolerServingStatus.Descriptor instead.
 func (PoolerServingStatus) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{1}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{2}
 }
 
 // QuorumType enumerates supported quorum algorithms
@@ -193,11 +269,11 @@ func (x QuorumType) String() string {
 }
 
 func (QuorumType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[2].Descriptor()
+	return file_clustermetadata_proto_enumTypes[3].Descriptor()
 }
 
 func (QuorumType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[2]
+	return &file_clustermetadata_proto_enumTypes[3]
 }
 
 func (x QuorumType) Number() protoreflect.EnumNumber {
@@ -206,7 +282,7 @@ func (x QuorumType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use QuorumType.Descriptor instead.
 func (QuorumType) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{2}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{3}
 }
 
 // LeadershipSignal describes a leader's self-reported status for its current term.
@@ -255,11 +331,11 @@ func (x LeadershipSignal) String() string {
 }
 
 func (LeadershipSignal) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[3].Descriptor()
+	return file_clustermetadata_proto_enumTypes[4].Descriptor()
 }
 
 func (LeadershipSignal) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[3]
+	return &file_clustermetadata_proto_enumTypes[4]
 }
 
 func (x LeadershipSignal) Number() protoreflect.EnumNumber {
@@ -268,7 +344,7 @@ func (x LeadershipSignal) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use LeadershipSignal.Descriptor instead.
 func (LeadershipSignal) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{3}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
 }
 
 // CohortEligibilitySignal describes a pooler's self-reported willingness to
@@ -312,11 +388,11 @@ func (x CohortEligibilitySignal) String() string {
 }
 
 func (CohortEligibilitySignal) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[4].Descriptor()
+	return file_clustermetadata_proto_enumTypes[5].Descriptor()
 }
 
 func (CohortEligibilitySignal) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[4]
+	return &file_clustermetadata_proto_enumTypes[5]
 }
 
 func (x CohortEligibilitySignal) Number() protoreflect.EnumNumber {
@@ -325,7 +401,7 @@ func (x CohortEligibilitySignal) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CohortEligibilitySignal.Descriptor instead.
 func (CohortEligibilitySignal) EnumDescriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{4}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{5}
 }
 
 // ComponentType represents the type of Multigres component
@@ -369,11 +445,11 @@ func (x ID_ComponentType) String() string {
 }
 
 func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[5].Descriptor()
+	return file_clustermetadata_proto_enumTypes[6].Descriptor()
 }
 
 func (ID_ComponentType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[5]
+	return &file_clustermetadata_proto_enumTypes[6]
 }
 
 func (x ID_ComponentType) Number() protoreflect.EnumNumber {
@@ -964,9 +1040,15 @@ type MultiPooler struct {
 	PoolerDir string `protobuf:"bytes,10,opt,name=pooler_dir,json=poolerDir,proto3" json:"pooler_dir,omitempty"`
 	// PgDataDir is the PostgreSQL data directory path (from the PGDATA environment variable).
 	// Used by multiadmin to compute the primary's data directory for pgBackRest.
-	PgDataDir     string `protobuf:"bytes,11,opt,name=pg_data_dir,json=pgDataDir,proto3" json:"pg_data_dir,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PgDataDir string `protobuf:"bytes,11,opt,name=pg_data_dir,json=pgDataDir,proto3" json:"pg_data_dir,omitempty"`
+	// LifecycleStatus is where the pooler is in its process lifecycle.
+	//
+	// Orthogonal to PoolerType (role) and PoolerServingStatus (query-serving
+	// readiness). Recorded in topology so the orchestrator can observe terminal
+	// lifecycle states even on cold start, not only over the health stream.
+	LifecycleStatus *PoolerLifecycle `protobuf:"bytes,12,opt,name=lifecycle_status,json=lifecycleStatus,proto3" json:"lifecycle_status,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *MultiPooler) Reset() {
@@ -1060,6 +1142,13 @@ func (x *MultiPooler) GetPgDataDir() string {
 		return x.PgDataDir
 	}
 	return ""
+}
+
+func (x *MultiPooler) GetLifecycleStatus() *PoolerLifecycle {
+	if x != nil {
+		return x.LifecycleStatus
+	}
+	return nil
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -1385,6 +1474,73 @@ func (x *KeyRange) GetEnd() []byte {
 	return nil
 }
 
+// PoolerLifecycle pairs a PoolerLifecycleStatus with operator-readable
+// context (reason) and a write timestamp (updated). Every caller that
+// produces a PoolerLifecycle value sets all three fields together;
+// readers use `updated` to compute "how long has this pooler been in
+// state X" for diagnostics.
+type PoolerLifecycle struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Status PoolerLifecycleStatus  `protobuf:"varint,1,opt,name=status,proto3,enum=clustermetadata.PoolerLifecycleStatus" json:"status,omitempty"`
+	// Optional reason for the current lifecycle stage.
+	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	// Wall-clock time at which this lifecycle entry was written.
+	Updated       *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=updated,proto3" json:"updated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PoolerLifecycle) Reset() {
+	*x = PoolerLifecycle{}
+	mi := &file_clustermetadata_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PoolerLifecycle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PoolerLifecycle) ProtoMessage() {}
+
+func (x *PoolerLifecycle) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PoolerLifecycle.ProtoReflect.Descriptor instead.
+func (*PoolerLifecycle) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *PoolerLifecycle) GetStatus() PoolerLifecycleStatus {
+	if x != nil {
+		return x.Status
+	}
+	return PoolerLifecycleStatus_LIFECYCLE_UNKNOWN
+}
+
+func (x *PoolerLifecycle) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *PoolerLifecycle) GetUpdated() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Updated
+	}
+	return nil
+}
+
 // DurabilityPolicy defines consensus quorum rules for a shard.
 // These policies are stored locally in each shard's postgres database
 // and replicated via postgres streaming replication.
@@ -1409,7 +1565,7 @@ type DurabilityPolicy struct {
 
 func (x *DurabilityPolicy) Reset() {
 	*x = DurabilityPolicy{}
-	mi := &file_clustermetadata_proto_msgTypes[14]
+	mi := &file_clustermetadata_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1421,7 +1577,7 @@ func (x *DurabilityPolicy) String() string {
 func (*DurabilityPolicy) ProtoMessage() {}
 
 func (x *DurabilityPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[14]
+	mi := &file_clustermetadata_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1434,7 +1590,7 @@ func (x *DurabilityPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DurabilityPolicy.ProtoReflect.Descriptor instead.
 func (*DurabilityPolicy) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{14}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *DurabilityPolicy) GetPolicyName() string {
@@ -1490,7 +1646,7 @@ type RuleNumber struct {
 
 func (x *RuleNumber) Reset() {
 	*x = RuleNumber{}
-	mi := &file_clustermetadata_proto_msgTypes[15]
+	mi := &file_clustermetadata_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1502,7 +1658,7 @@ func (x *RuleNumber) String() string {
 func (*RuleNumber) ProtoMessage() {}
 
 func (x *RuleNumber) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[15]
+	mi := &file_clustermetadata_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1515,7 +1671,7 @@ func (x *RuleNumber) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuleNumber.ProtoReflect.Descriptor instead.
 func (*RuleNumber) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{15}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *RuleNumber) GetCoordinatorTerm() int64 {
@@ -1556,7 +1712,7 @@ type ShardRule struct {
 
 func (x *ShardRule) Reset() {
 	*x = ShardRule{}
-	mi := &file_clustermetadata_proto_msgTypes[16]
+	mi := &file_clustermetadata_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1568,7 +1724,7 @@ func (x *ShardRule) String() string {
 func (*ShardRule) ProtoMessage() {}
 
 func (x *ShardRule) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[16]
+	mi := &file_clustermetadata_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1581,7 +1737,7 @@ func (x *ShardRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardRule.ProtoReflect.Descriptor instead.
 func (*ShardRule) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{16}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ShardRule) GetRuleNumber() *RuleNumber {
@@ -1649,7 +1805,7 @@ type PoolerPosition struct {
 
 func (x *PoolerPosition) Reset() {
 	*x = PoolerPosition{}
-	mi := &file_clustermetadata_proto_msgTypes[17]
+	mi := &file_clustermetadata_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1661,7 +1817,7 @@ func (x *PoolerPosition) String() string {
 func (*PoolerPosition) ProtoMessage() {}
 
 func (x *PoolerPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[17]
+	mi := &file_clustermetadata_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1674,7 +1830,7 @@ func (x *PoolerPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PoolerPosition.ProtoReflect.Descriptor instead.
 func (*PoolerPosition) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{17}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *PoolerPosition) GetRule() *ShardRule {
@@ -1720,7 +1876,7 @@ type ReplicationPrimary struct {
 
 func (x *ReplicationPrimary) Reset() {
 	*x = ReplicationPrimary{}
-	mi := &file_clustermetadata_proto_msgTypes[18]
+	mi := &file_clustermetadata_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1732,7 +1888,7 @@ func (x *ReplicationPrimary) String() string {
 func (*ReplicationPrimary) ProtoMessage() {}
 
 func (x *ReplicationPrimary) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[18]
+	mi := &file_clustermetadata_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1745,7 +1901,7 @@ func (x *ReplicationPrimary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicationPrimary.ProtoReflect.Descriptor instead.
 func (*ReplicationPrimary) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{18}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ReplicationPrimary) GetRule() *ShardRule {
@@ -1806,7 +1962,7 @@ type TermRevocation struct {
 
 func (x *TermRevocation) Reset() {
 	*x = TermRevocation{}
-	mi := &file_clustermetadata_proto_msgTypes[19]
+	mi := &file_clustermetadata_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1818,7 +1974,7 @@ func (x *TermRevocation) String() string {
 func (*TermRevocation) ProtoMessage() {}
 
 func (x *TermRevocation) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[19]
+	mi := &file_clustermetadata_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1831,7 +1987,7 @@ func (x *TermRevocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TermRevocation.ProtoReflect.Descriptor instead.
 func (*TermRevocation) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{19}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TermRevocation) GetRevokedBelowTerm() int64 {
@@ -1894,7 +2050,7 @@ type ExternallyCertifiedRevocation struct {
 
 func (x *ExternallyCertifiedRevocation) Reset() {
 	*x = ExternallyCertifiedRevocation{}
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1906,7 +2062,7 @@ func (x *ExternallyCertifiedRevocation) String() string {
 func (*ExternallyCertifiedRevocation) ProtoMessage() {}
 
 func (x *ExternallyCertifiedRevocation) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[20]
+	mi := &file_clustermetadata_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1919,7 +2075,7 @@ func (x *ExternallyCertifiedRevocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternallyCertifiedRevocation.ProtoReflect.Descriptor instead.
 func (*ExternallyCertifiedRevocation) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{20}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ExternallyCertifiedRevocation) GetTermRevocation() *TermRevocation {
@@ -1972,7 +2128,7 @@ type ConsensusStatus struct {
 
 func (x *ConsensusStatus) Reset() {
 	*x = ConsensusStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[21]
+	mi := &file_clustermetadata_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1984,7 +2140,7 @@ func (x *ConsensusStatus) String() string {
 func (*ConsensusStatus) ProtoMessage() {}
 
 func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[21]
+	mi := &file_clustermetadata_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1997,7 +2153,7 @@ func (x *ConsensusStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsensusStatus.ProtoReflect.Descriptor instead.
 func (*ConsensusStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{21}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ConsensusStatus) GetTermRevocation() *TermRevocation {
@@ -2043,7 +2199,7 @@ type LeadershipStatus struct {
 
 func (x *LeadershipStatus) Reset() {
 	*x = LeadershipStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[22]
+	mi := &file_clustermetadata_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2055,7 +2211,7 @@ func (x *LeadershipStatus) String() string {
 func (*LeadershipStatus) ProtoMessage() {}
 
 func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[22]
+	mi := &file_clustermetadata_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2068,7 +2224,7 @@ func (x *LeadershipStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeadershipStatus.ProtoReflect.Descriptor instead.
 func (*LeadershipStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{22}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LeadershipStatus) GetLeaderTerm() int64 {
@@ -2116,7 +2272,7 @@ type AvailabilityStatus struct {
 
 func (x *AvailabilityStatus) Reset() {
 	*x = AvailabilityStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[23]
+	mi := &file_clustermetadata_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2128,7 +2284,7 @@ func (x *AvailabilityStatus) String() string {
 func (*AvailabilityStatus) ProtoMessage() {}
 
 func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[23]
+	mi := &file_clustermetadata_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2141,7 +2297,7 @@ func (x *AvailabilityStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AvailabilityStatus.ProtoReflect.Descriptor instead.
 func (*AvailabilityStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{23}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AvailabilityStatus) GetLeadershipStatus() *LeadershipStatus {
@@ -2171,7 +2327,7 @@ type CohortEligibilityStatus struct {
 
 func (x *CohortEligibilityStatus) Reset() {
 	*x = CohortEligibilityStatus{}
-	mi := &file_clustermetadata_proto_msgTypes[24]
+	mi := &file_clustermetadata_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2183,7 +2339,7 @@ func (x *CohortEligibilityStatus) String() string {
 func (*CohortEligibilityStatus) ProtoMessage() {}
 
 func (x *CohortEligibilityStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_clustermetadata_proto_msgTypes[24]
+	mi := &file_clustermetadata_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2196,7 +2352,7 @@ func (x *CohortEligibilityStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CohortEligibilityStatus.ProtoReflect.Descriptor instead.
 func (*CohortEligibilityStatus) Descriptor() ([]byte, []int) {
-	return file_clustermetadata_proto_rawDescGZIP(), []int{24}
+	return file_clustermetadata_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *CohortEligibilityStatus) GetSignal() CohortEligibilitySignal {
@@ -2247,7 +2403,7 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\rPoolerAddress\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x12\x12\n" +
 	"\x04host\x18\x02 \x01(\tR\x04host\x12#\n" +
-	"\rpostgres_port\x18\x03 \x01(\x05R\fpostgresPort\"\xfd\x03\n" +
+	"\rpostgres_port\x18\x03 \x01(\x05R\fpostgresPort\"\xca\x04\n" +
 	"\vMultiPooler\x12#\n" +
 	"\x02id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\x02id\x126\n" +
 	"\tshard_key\x18\x02 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x126\n" +
@@ -2259,7 +2415,8 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\n" +
 	"pooler_dir\x18\n" +
 	" \x01(\tR\tpoolerDir\x12\x1e\n" +
-	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x1a:\n" +
+	"\vpg_data_dir\x18\v \x01(\tR\tpgDataDir\x12K\n" +
+	"\x10lifecycle_status\x18\f \x01(\v2 .clustermetadata.PoolerLifecycleR\x0flifecycleStatus\x1a:\n" +
 	"\fPortMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\"\xf1\x01\n" +
@@ -2295,7 +2452,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\tMULTIORCH\x10\x03\"2\n" +
 	"\bKeyRange\x12\x14\n" +
 	"\x05start\x18\x01 \x01(\fR\x05start\x12\x10\n" +
-	"\x03end\x18\x02 \x01(\fR\x03end\"\xe1\x01\n" +
+	"\x03end\x18\x02 \x01(\fR\x03end\"\x9f\x01\n" +
+	"\x0fPoolerLifecycle\x12>\n" +
+	"\x06status\x18\x01 \x01(\x0e2&.clustermetadata.PoolerLifecycleStatusR\x06status\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x124\n" +
+	"\aupdated\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\"\xe1\x01\n" +
 	"\x10DurabilityPolicy\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12%\n" +
@@ -2350,7 +2511,13 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aPRIMARY\x10\x01\x12\v\n" +
 	"\aREPLICA\x10\x02\x12\v\n" +
-	"\aDRAINED\x10\x03*L\n" +
+	"\aDRAINED\x10\x03*\x8c\x01\n" +
+	"\x15PoolerLifecycleStatus\x12\x15\n" +
+	"\x11LIFECYCLE_UNKNOWN\x10\x00\x12\x16\n" +
+	"\x12LIFECYCLE_STARTING\x10\x01\x12\x14\n" +
+	"\x10LIFECYCLE_ACTIVE\x10\x02\x12\x16\n" +
+	"\x12LIFECYCLE_STOPPING\x10\x03\x12\x16\n" +
+	"\x12LIFECYCLE_SHUTDOWN\x10\x04*L\n" +
 	"\x13PoolerServingStatus\x12\v\n" +
 	"\aSERVING\x10\x00\x12\x0f\n" +
 	"\vNOT_SERVING\x10\x01\x12\n" +
@@ -2383,91 +2550,96 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                       // 0: clustermetadata.PoolerType
-	(PoolerServingStatus)(0),              // 1: clustermetadata.PoolerServingStatus
-	(QuorumType)(0),                       // 2: clustermetadata.QuorumType
-	(LeadershipSignal)(0),                 // 3: clustermetadata.LeadershipSignal
-	(CohortEligibilitySignal)(0),          // 4: clustermetadata.CohortEligibilitySignal
-	(ID_ComponentType)(0),                 // 5: clustermetadata.ID.ComponentType
-	(*GlobalTopoConfig)(nil),              // 6: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),                          // 7: clustermetadata.Cell
-	(*Database)(nil),                      // 8: clustermetadata.Database
-	(*ShardInitClaim)(nil),                // 9: clustermetadata.ShardInitClaim
-	(*BackupLocation)(nil),                // 10: clustermetadata.BackupLocation
-	(*FilesystemBackup)(nil),              // 11: clustermetadata.FilesystemBackup
-	(*S3Backup)(nil),                      // 12: clustermetadata.S3Backup
-	(*PoolerAddress)(nil),                 // 13: clustermetadata.PoolerAddress
-	(*MultiPooler)(nil),                   // 14: clustermetadata.MultiPooler
-	(*MultiGateway)(nil),                  // 15: clustermetadata.MultiGateway
-	(*ShardKey)(nil),                      // 16: clustermetadata.ShardKey
-	(*MultiOrch)(nil),                     // 17: clustermetadata.MultiOrch
-	(*ID)(nil),                            // 18: clustermetadata.ID
-	(*KeyRange)(nil),                      // 19: clustermetadata.KeyRange
-	(*DurabilityPolicy)(nil),              // 20: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),                    // 21: clustermetadata.RuleNumber
-	(*ShardRule)(nil),                     // 22: clustermetadata.ShardRule
-	(*PoolerPosition)(nil),                // 23: clustermetadata.PoolerPosition
-	(*ReplicationPrimary)(nil),            // 24: clustermetadata.ReplicationPrimary
-	(*TermRevocation)(nil),                // 25: clustermetadata.TermRevocation
-	(*ExternallyCertifiedRevocation)(nil), // 26: clustermetadata.ExternallyCertifiedRevocation
-	(*ConsensusStatus)(nil),               // 27: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),              // 28: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),            // 29: clustermetadata.AvailabilityStatus
-	(*CohortEligibilityStatus)(nil),       // 30: clustermetadata.CohortEligibilityStatus
-	nil,                                   // 31: clustermetadata.MultiPooler.PortMapEntry
-	nil,                                   // 32: clustermetadata.MultiGateway.PortMapEntry
-	nil,                                   // 33: clustermetadata.MultiOrch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),         // 34: google.protobuf.Timestamp
+	(PoolerLifecycleStatus)(0),            // 1: clustermetadata.PoolerLifecycleStatus
+	(PoolerServingStatus)(0),              // 2: clustermetadata.PoolerServingStatus
+	(QuorumType)(0),                       // 3: clustermetadata.QuorumType
+	(LeadershipSignal)(0),                 // 4: clustermetadata.LeadershipSignal
+	(CohortEligibilitySignal)(0),          // 5: clustermetadata.CohortEligibilitySignal
+	(ID_ComponentType)(0),                 // 6: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil),              // 7: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),                          // 8: clustermetadata.Cell
+	(*Database)(nil),                      // 9: clustermetadata.Database
+	(*ShardInitClaim)(nil),                // 10: clustermetadata.ShardInitClaim
+	(*BackupLocation)(nil),                // 11: clustermetadata.BackupLocation
+	(*FilesystemBackup)(nil),              // 12: clustermetadata.FilesystemBackup
+	(*S3Backup)(nil),                      // 13: clustermetadata.S3Backup
+	(*PoolerAddress)(nil),                 // 14: clustermetadata.PoolerAddress
+	(*MultiPooler)(nil),                   // 15: clustermetadata.MultiPooler
+	(*MultiGateway)(nil),                  // 16: clustermetadata.MultiGateway
+	(*ShardKey)(nil),                      // 17: clustermetadata.ShardKey
+	(*MultiOrch)(nil),                     // 18: clustermetadata.MultiOrch
+	(*ID)(nil),                            // 19: clustermetadata.ID
+	(*KeyRange)(nil),                      // 20: clustermetadata.KeyRange
+	(*PoolerLifecycle)(nil),               // 21: clustermetadata.PoolerLifecycle
+	(*DurabilityPolicy)(nil),              // 22: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),                    // 23: clustermetadata.RuleNumber
+	(*ShardRule)(nil),                     // 24: clustermetadata.ShardRule
+	(*PoolerPosition)(nil),                // 25: clustermetadata.PoolerPosition
+	(*ReplicationPrimary)(nil),            // 26: clustermetadata.ReplicationPrimary
+	(*TermRevocation)(nil),                // 27: clustermetadata.TermRevocation
+	(*ExternallyCertifiedRevocation)(nil), // 28: clustermetadata.ExternallyCertifiedRevocation
+	(*ConsensusStatus)(nil),               // 29: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),              // 30: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),            // 31: clustermetadata.AvailabilityStatus
+	(*CohortEligibilityStatus)(nil),       // 32: clustermetadata.CohortEligibilityStatus
+	nil,                                   // 33: clustermetadata.MultiPooler.PortMapEntry
+	nil,                                   // 34: clustermetadata.MultiGateway.PortMapEntry
+	nil,                                   // 35: clustermetadata.MultiOrch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),         // 36: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	10, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	20, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	18, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	18, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
-	11, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
-	12, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	18, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
-	18, // 7: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
-	16, // 8: clustermetadata.MultiPooler.shard_key:type_name -> clustermetadata.ShardKey
-	19, // 9: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
+	11, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
+	22, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	19, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	19, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	12, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
+	13, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
+	19, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
+	19, // 7: clustermetadata.MultiPooler.id:type_name -> clustermetadata.ID
+	17, // 8: clustermetadata.MultiPooler.shard_key:type_name -> clustermetadata.ShardKey
+	20, // 9: clustermetadata.MultiPooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 10: clustermetadata.MultiPooler.type:type_name -> clustermetadata.PoolerType
-	1,  // 11: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	31, // 12: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
-	18, // 13: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
-	32, // 14: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
-	18, // 15: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
-	33, // 16: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
-	5,  // 17: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
-	2,  // 18: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	21, // 19: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	18, // 20: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	18, // 21: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	20, // 22: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	18, // 23: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	34, // 24: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	22, // 25: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
-	22, // 26: clustermetadata.ReplicationPrimary.rule:type_name -> clustermetadata.ShardRule
-	13, // 27: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
-	18, // 28: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	34, // 29: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	21, // 30: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
-	25, // 31: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	25, // 32: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	23, // 33: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	24, // 34: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
-	18, // 35: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	3,  // 36: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	28, // 37: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	30, // 38: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
-	4,  // 39: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
-	40, // [40:40] is the sub-list for method output_type
-	40, // [40:40] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	2,  // 11: clustermetadata.MultiPooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
+	33, // 12: clustermetadata.MultiPooler.port_map:type_name -> clustermetadata.MultiPooler.PortMapEntry
+	21, // 13: clustermetadata.MultiPooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
+	19, // 14: clustermetadata.MultiGateway.id:type_name -> clustermetadata.ID
+	34, // 15: clustermetadata.MultiGateway.port_map:type_name -> clustermetadata.MultiGateway.PortMapEntry
+	19, // 16: clustermetadata.MultiOrch.id:type_name -> clustermetadata.ID
+	35, // 17: clustermetadata.MultiOrch.port_map:type_name -> clustermetadata.MultiOrch.PortMapEntry
+	6,  // 18: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	1,  // 19: clustermetadata.PoolerLifecycle.status:type_name -> clustermetadata.PoolerLifecycleStatus
+	36, // 20: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
+	3,  // 21: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
+	23, // 22: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	19, // 23: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	19, // 24: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	22, // 25: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	19, // 26: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	36, // 27: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	24, // 28: clustermetadata.PoolerPosition.rule:type_name -> clustermetadata.ShardRule
+	24, // 29: clustermetadata.ReplicationPrimary.rule:type_name -> clustermetadata.ShardRule
+	14, // 30: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
+	19, // 31: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	36, // 32: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	23, // 33: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
+	27, // 34: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	27, // 35: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	25, // 36: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	26, // 37: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	19, // 38: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	4,  // 39: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
+	30, // 40: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	32, // 41: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	5,  // 42: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
+	43, // [43:43] is the sub-list for method output_type
+	43, // [43:43] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }
@@ -2484,8 +2656,8 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   28,
+			NumEnums:      7,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/cohort_mismatch_analyzer.go
@@ -135,7 +135,7 @@ func (a *CohortMismatchAnalyzer) Analyze(sa *ShardAnalysis) ([]types.Problem, er
 // The IsLeader gate is also conceptually unnecessary — there's no correctness
 // problem an acting primary adding itself to the cohort. This may be useful
 // in some propagation scenarios.
-func (a *CohortMismatchAnalyzer) isAdditionCandidate(sa *ShardAnalysis, pa *PoolerAnalysis) bool {
+func (a *CohortMismatchAnalyzer) isAdditionCandidate(_ *ShardAnalysis, pa *PoolerAnalysis) bool {
 	if pa.IsLeader {
 		return false
 	}

--- a/go/services/multiorch/recovery/analysis/generator_test.go
+++ b/go/services/multiorch/recovery/analysis/generator_test.go
@@ -1890,7 +1890,7 @@ func setupMultiplePrimariesStore(t *testing.T, primaries []primaryConfig) *store
 	return setupMultiplePrimariesStoreWithReachability(t, configs)
 }
 
-func setupMultiplePrimariesStoreWithReachability(t *testing.T, primaries []primaryConfigWithReachability) *store.PoolerStore {
+func setupMultiplePrimariesStoreWithReachability(_ *testing.T, primaries []primaryConfigWithReachability) *store.PoolerStore {
 	ps := store.NewPoolerStore(nil, slog.Default())
 
 	for _, p := range primaries {

--- a/go/services/multiorch/recovery/discovery_test.go
+++ b/go/services/multiorch/recovery/discovery_test.go
@@ -136,14 +136,20 @@ func TestDiscovery_DatabaseLevelWatch(t *testing.T) {
 	_, ok = engine.poolerStore.Get(poolerKey("zone1", "pooler4"))
 	require.True(t, ok, "pooler4 in new shard should be discovered")
 
-	// Remove a pooler from topology
+	// Remove a pooler from topology. Under the new contract, NoNode is a
+	// log-only no-op on the orchestrator side: the cache entry survives
+	// (so the running pooler's stream isn't torn down by an accidental
+	// external deletion). The lifecycle-SHUTDOWN path, exercised in
+	// TestPoolerWatcher_PoolerEntersShutdownLifecycle, is what evicts the
+	// cache on a clean graceful shutdown.
 	require.NoError(t, ts.UnregisterMultiPooler(ctx, &clustermetadata.ID{
 		Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler2",
 	}))
 
-	// Fourth watch event - removed pooler still in store (bookkeeping removes it later)
 	require.NoError(t, engine.poolerWatcher.Sync(ctx))
-	require.Equal(t, 4, engine.poolerStore.Len(), "store should still contain all poolers, bookkeeping handles removal")
+	require.Equal(t, 4, engine.poolerStore.Len(), "NoNode is a no-op; the cache entry must survive")
+	_, ok = engine.poolerStore.Get(poolerKey("zone1", "pooler2"))
+	require.True(t, ok, "deleted pooler should remain cached")
 }
 
 func TestDiscovery_TablegroupLevelWatch(t *testing.T) {
@@ -575,7 +581,7 @@ func TestPoolerWatcher_DirectDiscovery(t *testing.T) {
 	onNewPooler := func(id *clustermetadata.ID) { discovered <- id }
 
 	watchTargets := []config.WatchTarget{{Database: "mydb", TableGroup: "tg1"}}
-	poolerWatcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return watchTargets }, poolerStore, onNewPooler, slog.Default())
+	poolerWatcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return watchTargets }, poolerStore, onNewPooler, nil /* onPoolerStopped */, nil /* onPoolerDeleted */, slog.Default())
 	startWatcher(t, poolerWatcher)
 
 	poolerStoreAtLeast := func(val int) func() bool {

--- a/go/services/multiorch/recovery/engine.go
+++ b/go/services/multiorch/recovery/engine.go
@@ -302,13 +302,21 @@ func NewEngine(
 		WithLogger(logger))
 
 	// Create the watcher-based topology discovery.
-	// When a new pooler is discovered, start a health stream for it.
+	// When a new pooler is discovered, start a health stream for it; when an
+	// existing pooler transitions to LIFECYCLE_SHUTDOWN, stop the per-pooler
+	// health-stream goroutine so the reconnect loop exits cleanly instead of
+	// dialling the dead address until bookkeeping eviction (~4 h). The
+	// onPoolerDeleted hook is reserved for future use — accidental external
+	// deletion of a still-running pooler's entry should not tear down its
+	// health stream, so we deliberately pass nil here.
 	engine.poolerWatcher = NewPoolerWatcher(
 		ctx,
 		ts,
 		engine.getWatchTargets,
 		poolerStore,
 		healthStream.Start,
+		healthStream.Stop, // onPoolerStopped
+		nil,               // onPoolerDeleted: reserved
 		logger,
 	)
 

--- a/go/services/multiorch/recovery/health_stream.go
+++ b/go/services/multiorch/recovery/health_stream.go
@@ -148,6 +148,12 @@ func (hs *HealthStream) Shutdown() {
 // If a stream is already running for this pooler the call is a no-op.
 // The pooler's MultiPooler metadata is read from the store on each
 // reconnect attempt so topology updates are automatically picked up.
+//
+// Dialing is unconditional: poolers whose lifecycle reads STOPPING in
+// topology are dialled the same as any other. If the pooler subsequently
+// goes away (its OnClose unregisterFunc deletes the topology entry),
+// the pooler watcher's onDeletedPooler callback invokes Stop, which
+// cancels the per-pooler context and unwinds the reconnect loop.
 func (hs *HealthStream) Start(id *clustermetadatapb.ID) {
 	poolerID := topoclient.MultiPoolerIDString(id)
 	hs.mu.Lock()

--- a/go/services/multiorch/recovery/health_stream_lifecycle_test.go
+++ b/go/services/multiorch/recovery/health_stream_lifecycle_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 // TestHealthStream_StreamEOFWithoutSpecialSignal_KeepsBackoff verifies that
-// an EOF on an ordinary stream goes through the existing
-// reconnect-with-backoff path. The graceful-shutdown trigger
-// (REQUESTING_DEMOTION on LeadershipStatus) is published by the pooler
-// directly and handled by the analyzer; this test guards the orthogonal
-// "no special signal → reconnect" default.
+// an EOF on an ordinary stream goes through the reconnect-with-backoff path.
+// Stream closure on graceful shutdown is driven by the topology deletion
+// performed by the pooler's OnClose unregisterFunc, not by anything on the
+// health stream itself — so a bare EOF (without an accompanying topology
+// delete) must continue to back off as today.
 func TestHealthStream_StreamEOFWithoutSpecialSignal_KeepsBackoff(t *testing.T) {
 	ctx := t.Context()
 
@@ -50,7 +50,7 @@ func TestHealthStream_StreamEOFWithoutSpecialSignal_KeepsBackoff(t *testing.T) {
 	stream := <-streamCh
 	completeHandshake(t, stream)
 
-	// Send a regular snapshot — no resignation signal.
+	// Send a regular snapshot.
 	stream.Ch <- makeSnapshot(&multipoolermanagerdatapb.Status{
 		PoolerType:    clustermetadata.PoolerType_PRIMARY,
 		PostgresReady: true,

--- a/go/services/multiorch/recovery/pooler_watcher.go
+++ b/go/services/multiorch/recovery/pooler_watcher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -44,11 +45,13 @@ import (
 // are reported via the onNewPooler callback so the caller can start monitoring
 // them (e.g. open a ManagerHealthStream stream).
 type PoolerWatcher struct {
-	topoStore   topoclient.Store
-	targets     func() []config.WatchTarget // live accessor, same as Engine.shardWatchTargets
-	store       *store.PoolerStore
-	onNewPooler func(id *clustermetadatapb.ID) // called when a new pooler is first discovered
-	logger      *slog.Logger
+	topoStore       topoclient.Store
+	targets         func() []config.WatchTarget // live accessor, same as Engine.shardWatchTargets
+	store           *store.PoolerStore
+	onNewPooler     func(id *clustermetadatapb.ID) // called when a new pooler is first discovered
+	onPoolerStopped func(id *clustermetadatapb.ID) // called on lifecycle transition into LIFECYCLE_SHUTDOWN
+	onPoolerDeleted func(id *clustermetadatapb.ID) // called when a tracked pooler's topology entry is removed (NoNode); reserved for future use
+	logger          *slog.Logger
 
 	// Control
 	ctx    context.Context
@@ -62,26 +65,35 @@ type PoolerWatcher struct {
 
 // NewPoolerWatcher creates a new PoolerWatcher.
 // targets is a function that returns the current WatchTargets (consulted on every event).
-// onNewPooler is called when a new pooler is discovered; the pooler is already present
-// in the store when the callback fires.
+// onNewPooler is called when a new pooler is discovered; the pooler is already
+// present in the store when the callback fires.
+// onPoolerStopped is called when a tracked pooler's lifecycle transitions to
+// LIFECYCLE_SHUTDOWN; the store entry has already been evicted when it fires.
+// onPoolerDeleted is called when a tracked pooler's topology entry is removed
+// (NoNode). Reserved for future use — pass nil to leave NoNode events as a
+// log-only no-op that does not evict the cache or stop per-pooler resources.
 func NewPoolerWatcher(
 	ctx context.Context,
 	topoStore topoclient.Store,
 	targets func() []config.WatchTarget,
 	poolerStore *store.PoolerStore,
 	onNewPooler func(id *clustermetadatapb.ID),
+	onPoolerStopped func(id *clustermetadatapb.ID),
+	onPoolerDeleted func(id *clustermetadatapb.ID),
 	logger *slog.Logger,
 ) *PoolerWatcher {
 	watchCtx, cancel := context.WithCancel(ctx)
 	return &PoolerWatcher{
-		topoStore:    topoStore,
-		targets:      targets,
-		store:        poolerStore,
-		onNewPooler:  onNewPooler,
-		logger:       logger,
-		ctx:          watchCtx,
-		cancel:       cancel,
-		cellWatchers: make(map[string]*cellPoolerWatcher),
+		topoStore:       topoStore,
+		targets:         targets,
+		store:           poolerStore,
+		onNewPooler:     onNewPooler,
+		onPoolerStopped: onPoolerStopped,
+		onPoolerDeleted: onPoolerDeleted,
+		logger:          logger,
+		ctx:             watchCtx,
+		cancel:          cancel,
+		cellWatchers:    make(map[string]*cellPoolerWatcher),
 	}
 }
 
@@ -227,7 +239,7 @@ func (pw *PoolerWatcher) processCellEvent(event *topoclient.WatchDataRecursive) 
 
 // startCellWatcher starts a per-cell pooler watcher. Caller must hold pw.mu.
 func (pw *PoolerWatcher) startCellWatcher(cell string) {
-	w := newCellPoolerWatcher(pw.ctx, pw.topoStore, cell, pw.targets, pw.store, pw.onNewPooler, pw.logger)
+	w := newCellPoolerWatcher(pw.ctx, pw.topoStore, cell, pw.targets, pw.store, pw.onNewPooler, pw.onPoolerStopped, pw.onPoolerDeleted, pw.logger)
 	pw.cellWatchers[cell] = w
 	w.start()
 }
@@ -249,12 +261,14 @@ func extractCellNameFromPath(watchPath string) string {
 // ---------------------------------------------------------------------------
 
 type cellPoolerWatcher struct {
-	topoStore   topoclient.Store
-	cell        string
-	targets     func() []config.WatchTarget
-	store       *store.PoolerStore
-	onNewPooler func(id *clustermetadatapb.ID)
-	logger      *slog.Logger
+	topoStore       topoclient.Store
+	cell            string
+	targets         func() []config.WatchTarget
+	store           *store.PoolerStore
+	onNewPooler     func(id *clustermetadatapb.ID)
+	onPoolerStopped func(id *clustermetadatapb.ID)
+	onPoolerDeleted func(id *clustermetadatapb.ID)
+	logger          *slog.Logger
 
 	ctx      context.Context
 	cancel   context.CancelFunc
@@ -269,19 +283,23 @@ func newCellPoolerWatcher(
 	targets func() []config.WatchTarget,
 	poolerStore *store.PoolerStore,
 	onNewPooler func(id *clustermetadatapb.ID),
+	onPoolerStopped func(id *clustermetadatapb.ID),
+	onPoolerDeleted func(id *clustermetadatapb.ID),
 	logger *slog.Logger,
 ) *cellPoolerWatcher {
 	watchCtx, cancel := context.WithCancel(ctx)
 	return &cellPoolerWatcher{
-		topoStore:   topoStore,
-		cell:        cell,
-		targets:     targets,
-		store:       poolerStore,
-		onNewPooler: onNewPooler,
-		logger:      logger.With("cell", cell),
-		ctx:         watchCtx,
-		cancel:      cancel,
-		syncChan:    make(chan chan struct{}, 1),
+		topoStore:       topoStore,
+		cell:            cell,
+		targets:         targets,
+		store:           poolerStore,
+		onNewPooler:     onNewPooler,
+		onPoolerStopped: onPoolerStopped,
+		onPoolerDeleted: onPoolerDeleted,
+		logger:          logger.With("cell", cell),
+		ctx:             watchCtx,
+		cancel:          cancel,
+		syncChan:        make(chan chan struct{}, 1),
 	}
 }
 
@@ -368,13 +386,28 @@ func (cw *cellPoolerWatcher) sync(ctx context.Context) error {
 // handlePoolerEvent processes a single watch event for a pooler file.
 func (cw *cellPoolerWatcher) handlePoolerEvent(wd *topoclient.WatchDataRecursive) {
 	if wd.Err != nil {
-		// Deletions (NoNode) are intentionally ignored here: the pooler store
-		// entry is left in place so that ongoing health checks can continue until
-		// bookkeeping removes it after the configured unseen threshold.
-		if !errors.Is(wd.Err, &topoclient.TopoError{Code: topoclient.NoNode}) {
+		// NoNode = the pooler's topology entry was removed outright. On the
+		// happy-path graceful-shutdown flow the pooler does NOT delete its
+		// entry; it writes LifecycleStatus=LIFECYCLE_SHUTDOWN and lets
+		// bookkeeping eviction clean up. So a NoNode here is unexpected —
+		// an operator typo, an automation bug, or a manual etcd delete.
+		// We log the event and invoke onPoolerDeleted if a caller wired
+		// it, but we deliberately do NOT evict the cache or stop per-pooler
+		// resources: the running pooler is unaffected, and tearing down
+		// the health stream over an accidental deletion would compound
+		// the operator mistake.
+		if errors.Is(wd.Err, &topoclient.TopoError{Code: topoclient.NoNode}) {
+			key := path.Base(path.Dir(wd.Path))
+			if entry, ok := cw.store.Get(key); ok {
+				cw.logger.Warn("pooler topology entry removed; cache and stream left intact",
+					"pooler_id", key)
+				if cw.onPoolerDeleted != nil {
+					cw.onPoolerDeleted(entry.MultiPooler.Id)
+				}
+			}
+		} else {
 			cw.logger.Warn("watch error on pooler path", "error", wd.Err, "path", wd.Path)
 		}
-		return
 	}
 
 	// Only handle files named "Pooler"
@@ -400,21 +433,66 @@ func (cw *cellPoolerWatcher) handlePoolerEvent(wd *topoclient.WatchDataRecursive
 	}
 
 	poolerID := topoclient.MultiPoolerIDString(pooler.Id)
+	newLifecycle := pooler.GetLifecycleStatus().GetStatus()
 
-	// Use DoUpdate to atomically update only the topology metadata, preserving all
-	// health-check fields (timestamps, IsUpToDate, IsLastCheckValid, etc.) that may
-	// be written concurrently by the health check worker. A closure variable tracks
-	// whether the key existed so we know whether to treat this as a new pooler.
-	existing := false
+	// Atomic read-modify-write: capture whether the entry already existed and
+	// what its previous lifecycle was, then refresh MultiPooler in place.
+	// Health-check fields written concurrently by the health worker are
+	// preserved.
+	var (
+		existing      bool
+		prevLifecycle clustermetadatapb.PoolerLifecycleStatus
+	)
 	cw.store.DoUpdate(poolerID, func(state *multiorchdatapb.PoolerHealthState) *multiorchdatapb.PoolerHealthState {
 		existing = true
+		prevLifecycle = state.MultiPooler.GetLifecycleStatus().GetStatus()
 		state.MultiPooler = pooler
 		return state
 	})
 
-	if existing {
+	switch {
+	case !existing && newLifecycle == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN:
+		// Cold-start discovery of an already-SHUTDOWN pooler. Cache the entry
+		// so that if the pooler restarts later (within the 4 h bookkeeping
+		// window) we'll detect the SHUTDOWN→non-SHUTDOWN transition and
+		// re-fire onNewPooler. Don't open a health stream now — there's
+		// nothing live to monitor.
+		cw.store.Set(poolerID, &multiorchdatapb.PoolerHealthState{
+			MultiPooler: pooler,
+			IsUpToDate:  false,
+		})
+		cw.logger.Debug("cached already-SHUTDOWN pooler without opening stream", "pooler_id", poolerID)
+
+	case existing && newLifecycle == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN && prevLifecycle != clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN:
+		// Transition into SHUTDOWN: notify the caller so per-pooler resources
+		// (health stream) can be torn down. We deliberately do NOT evict the
+		// in-memory PoolerStore entry — analyzers still need to see the entry
+		// to drive failover (e.g. LeaderIsDeadAnalyzer needs the cached
+		// PoolerHealthState to fire after stream EOF), and the topology
+		// record itself stays in place until the 4 h bookkeeping eviction
+		// window. The cached MultiPooler proto carries
+		// LifecycleStatus=LIFECYCLE_SHUTDOWN so analyzers and operator
+		// tooling can distinguish "just stopped" from "stalled".
+		if cw.onPoolerStopped != nil {
+			cw.onPoolerStopped(pooler.Id)
+		}
+		cw.logger.Info("pooler entered SHUTDOWN lifecycle", "pooler_id", poolerID)
+
+	case existing && prevLifecycle == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN && newLifecycle != clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN:
+		// Restart from SHUTDOWN: re-fire onNewPooler so per-pooler resources
+		// (health stream) get re-established. The cache entry was retained
+		// on the original SHUTDOWN transition so analyzers had consistent
+		// state; here we re-trigger the discovery callback.
+		cw.onNewPooler(pooler.Id)
+		cw.logger.Info("pooler restarted from SHUTDOWN lifecycle",
+			"pooler_id", poolerID,
+			"new_lifecycle", newLifecycle.String(),
+		)
+
+	case existing:
 		cw.logger.Debug("pooler metadata updated from topology", "pooler_id", poolerID)
-	} else {
+
+	default:
 		// New pooler — add to store and queue for immediate health check.
 		cw.store.Set(poolerID, &multiorchdatapb.PoolerHealthState{
 			MultiPooler: pooler,

--- a/go/services/multiorch/recovery/pooler_watcher_test.go
+++ b/go/services/multiorch/recovery/pooler_watcher_test.go
@@ -33,6 +33,9 @@ import (
 )
 
 // newTestPoolerWatcher creates a PoolerWatcher backed by memorytopo for testing.
+// onPoolerStopped and onPoolerDeleted default to nil; tests that need to
+// observe those events call NewPoolerWatcher directly (both branches in
+// handlePoolerEvent nil-check before invoking).
 func newTestPoolerWatcher(
 	ctx context.Context,
 	ts topoclient.Store,
@@ -47,6 +50,8 @@ func newTestPoolerWatcher(
 		func() []config.WatchTarget { return targets },
 		poolerStore,
 		onNewPooler,
+		nil, /* onPoolerStopped */
+		nil, /* onPoolerDeleted */
 		logger,
 	)
 }
@@ -356,46 +361,298 @@ func TestPoolerWatcher_NewCellDiscovered(t *testing.T) {
 	assert.True(t, exists)
 }
 
-// TestPoolerWatcher_PoolerDeletedFromTopology verifies that deleting a pooler from topology
-// does NOT immediately remove it from the store. Removal is deferred to bookkeeping so
-// that health-check state is preserved across transient topology blips (e.g. rolling
-// restarts). The store entry will be cleaned up by forgetLongUnseenInstances.
+// TestPoolerWatcher_PoolerDeletedFromTopology verifies that deleting a
+// pooler from topology evicts its store entry and fires the
+// onDeletedPooler callback with the right ID. This is the authoritative
+// signal that a pooler has gone away (typically because its OnClose
+// unregisterFunc ran during graceful shutdown); callers wire the callback
+// to per-pooler cleanup such as HealthStream.Stop.
+// TestPoolerWatcher_PoolerDeletedFromTopology pins the new NoNode contract:
+// the watcher logs the event and invokes onPoolerDeleted (the reserved hook)
+// if it was wired, but it does NOT evict the in-memory cache and does NOT
+// fire onPoolerStopped. The intent is that an accidental external deletion
+// of a still-running pooler's entry leaves the orchestrator's view of that
+// pooler — including its open health stream — intact.
 func TestPoolerWatcher_PoolerDeletedFromTopology(t *testing.T) {
 	ctx := t.Context()
 
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
 	defer ts.Close()
 
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
 	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id: &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"},
+		Id: poolerID,
 		ShardKey: &clustermetadata.ShardKey{
 			Database:   "mydb",
 			TableGroup: "tg1",
 			Shard:      "0",
+		},
+		LifecycleStatus: &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
 		},
 	}))
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	poolerStore := store.NewPoolerStore(nil, logger)
 
+	var stoppedIDs []*clustermetadata.ID
+	var stoppedMu sync.Mutex
+	onStopped := func(id *clustermetadata.ID) {
+		stoppedMu.Lock()
+		defer stoppedMu.Unlock()
+		stoppedIDs = append(stoppedIDs, id)
+	}
+
+	var deletedIDs []*clustermetadata.ID
+	var deletedMu sync.Mutex
+	onDeleted := func(id *clustermetadata.ID) {
+		deletedMu.Lock()
+		defer deletedMu.Unlock()
+		deletedIDs = append(deletedIDs, id)
+	}
+
 	targets := []config.WatchTarget{{Database: "mydb"}}
-	watcher := newTestPoolerWatcher(ctx, ts, targets, poolerStore, func(*clustermetadata.ID) {}, logger)
+	watcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return targets },
+		poolerStore, func(*clustermetadata.ID) {}, onStopped, onDeleted, logger)
 	watcher.Start()
 	defer watcher.Stop()
 
-	// Wait for discovery
-	ok := waitForCondition(t, 5*time.Second, func() bool {
+	require.True(t, waitForCondition(t, 5*time.Second, func() bool {
 		return poolerStore.Len() == 1
-	})
-	require.True(t, ok)
-
-	// Delete the pooler from topology
-	require.NoError(t, ts.UnregisterMultiPooler(ctx, &clustermetadata.ID{
-		Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1",
 	}))
 
-	// The pooler should remain in the store after the deletion event is processed;
-	// bookkeeping (forgetLongUnseenInstances) is responsible for eventual removal.
+	require.NoError(t, ts.UnregisterMultiPooler(ctx, poolerID))
 	require.NoError(t, watcher.Sync(ctx))
-	assert.Equal(t, 1, poolerStore.Len(), "deleted pooler should remain in store until bookkeeping removes it")
+
+	// Cache entry must survive: NoNode is a no-op on the orchestrator side.
+	assert.Equal(t, 1, poolerStore.Len(), "NoNode must not evict the cache")
+	_, ok := poolerStore.Get(poolerKey("zone1", "pooler1"))
+	assert.True(t, ok, "deleted pooler should still be cached")
+
+	// onPoolerDeleted fires; onPoolerStopped does not.
+	deletedMu.Lock()
+	defer deletedMu.Unlock()
+	require.Len(t, deletedIDs, 1, "onPoolerDeleted should fire exactly once for a single NoNode event")
+	assert.Equal(t, poolerID.Name, deletedIDs[0].Name)
+	assert.Equal(t, poolerID.Cell, deletedIDs[0].Cell)
+
+	stoppedMu.Lock()
+	defer stoppedMu.Unlock()
+	assert.Empty(t, stoppedIDs, "onPoolerStopped must not fire on a NoNode event")
+}
+
+// TestPoolerWatcher_PoolerEntersShutdownLifecycle pins the new lifecycle-
+// SHUTDOWN contract: when a tracked pooler's topology entry transitions to
+// LifecycleStatus=LIFECYCLE_SHUTDOWN, the watcher invokes onPoolerStopped
+// (so the caller can tear down per-pooler resources like the health stream)
+// but deliberately does NOT evict the cache. Analyzers need the cached
+// PoolerHealthState to fire failover (e.g. LeaderIsDeadAnalyzer); the 4 h
+// bookkeeping eviction handles eventual cleanup. onPoolerDeleted must not
+// fire — the topology entry is still present, just in its terminal state.
+func TestPoolerWatcher_PoolerEntersShutdownLifecycle(t *testing.T) {
+	ctx := t.Context()
+
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
+		Id: poolerID,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		LifecycleStatus: &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		},
+	}))
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	poolerStore := store.NewPoolerStore(nil, logger)
+
+	var stoppedIDs []*clustermetadata.ID
+	var stoppedMu sync.Mutex
+	onStopped := func(id *clustermetadata.ID) {
+		stoppedMu.Lock()
+		defer stoppedMu.Unlock()
+		stoppedIDs = append(stoppedIDs, id)
+	}
+
+	var deletedIDs []*clustermetadata.ID
+	var deletedMu sync.Mutex
+	onDeleted := func(id *clustermetadata.ID) {
+		deletedMu.Lock()
+		defer deletedMu.Unlock()
+		deletedIDs = append(deletedIDs, id)
+	}
+
+	targets := []config.WatchTarget{{Database: "mydb"}}
+	watcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return targets },
+		poolerStore, func(*clustermetadata.ID) {}, onStopped, onDeleted, logger)
+	watcher.Start()
+	defer watcher.Stop()
+
+	require.True(t, waitForCondition(t, 5*time.Second, func() bool {
+		return poolerStore.Len() == 1
+	}))
+
+	// Transition ACTIVE -> SHUTDOWN via read-modify-write.
+	_, err := ts.UpdateMultiPoolerFields(ctx, poolerID, func(mp *clustermetadata.MultiPooler) error {
+		mp.LifecycleStatus = &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+			Reason: "pooler shutdown",
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, watcher.Sync(ctx))
+
+	// Cache entry must survive: the SHUTDOWN transition is a signal, not a
+	// reason to evict. Analyzers still need to see the entry.
+	assert.Equal(t, 1, poolerStore.Len(), "SHUTDOWN transition must not evict the cache")
+	cached, ok := poolerStore.Get(poolerKey("zone1", "pooler1"))
+	require.True(t, ok, "cached entry should still be present")
+	assert.Equal(t,
+		clustermetadata.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+		cached.MultiPooler.GetLifecycleStatus().GetStatus(),
+		"cached MultiPooler should reflect the SHUTDOWN transition")
+
+	// onPoolerStopped fires; onPoolerDeleted does not.
+	stoppedMu.Lock()
+	defer stoppedMu.Unlock()
+	require.Len(t, stoppedIDs, 1, "onPoolerStopped should fire exactly once for a SHUTDOWN transition")
+	assert.Equal(t, poolerID.Name, stoppedIDs[0].Name)
+	assert.Equal(t, poolerID.Cell, stoppedIDs[0].Cell)
+
+	deletedMu.Lock()
+	defer deletedMu.Unlock()
+	assert.Empty(t, deletedIDs, "onPoolerDeleted must not fire on a lifecycle transition")
+}
+
+// TestPoolerWatcher_RestartAfterShutdownFiresOnNewPooler verifies the
+// re-entry path: a pooler that transitioned to SHUTDOWN and then comes back
+// up (writes STARTING/ACTIVE via RegisterMultiPooler(allowUpdate=true))
+// re-triggers onNewPooler so the orchestrator restarts its health stream.
+// The cache entry is retained across SHUTDOWN, so the watcher detects the
+// SHUTDOWN→non-SHUTDOWN lifecycle transition and explicitly re-fires the
+// discovery callback.
+func TestPoolerWatcher_RestartAfterShutdownFiresOnNewPooler(t *testing.T) {
+	ctx := t.Context()
+
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
+		Id: poolerID,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		LifecycleStatus: &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		},
+	}))
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	poolerStore := store.NewPoolerStore(nil, logger)
+	onNew, countNew := newCallbackTracker()
+
+	targets := []config.WatchTarget{{Database: "mydb"}}
+	watcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return targets },
+		poolerStore, onNew, func(*clustermetadata.ID) {} /* onPoolerStopped */, nil, logger)
+	watcher.Start()
+	defer watcher.Stop()
+
+	// Initial discovery fires onNewPooler once.
+	require.True(t, waitForCondition(t, 5*time.Second, func() bool { return countNew() == 1 }),
+		"new pooler should trigger onNewPooler on discovery")
+
+	// Transition ACTIVE -> SHUTDOWN (cache stays; onPoolerStopped fires).
+	_, err := ts.UpdateMultiPoolerFields(ctx, poolerID, func(mp *clustermetadata.MultiPooler) error {
+		mp.LifecycleStatus = &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, watcher.Sync(ctx))
+	require.Equal(t, 1, poolerStore.Len(), "cache must be retained across SHUTDOWN")
+
+	// Pooler comes back: lifecycle transitions back to ACTIVE.
+	_, err = ts.UpdateMultiPoolerFields(ctx, poolerID, func(mp *clustermetadata.MultiPooler) error {
+		mp.LifecycleStatus = &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.True(t, waitForCondition(t, 5*time.Second, func() bool { return countNew() == 2 }),
+		"restart after SHUTDOWN must re-fire onNewPooler so the health stream restarts")
+}
+
+// TestPoolerWatcher_ColdStartShutdownIgnored verifies that an already-SHUTDOWN
+// pooler discovered for the first time (e.g. orchestrator restart while the
+// entry is still in topology) is cached but triggers no callbacks. The cache
+// entry lets the watcher detect a future SHUTDOWN→non-SHUTDOWN transition
+// and fire onNewPooler then, but no health stream is opened immediately —
+// there's nothing live to monitor.
+func TestPoolerWatcher_ColdStartShutdownIgnored(t *testing.T) {
+	ctx := t.Context()
+
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	// Pre-existing SHUTDOWN entry.
+	poolerID := &clustermetadata.ID{Component: clustermetadata.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	require.NoError(t, ts.CreateMultiPooler(ctx, &clustermetadata.MultiPooler{
+		Id: poolerID,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "mydb",
+			TableGroup: "tg1",
+			Shard:      "0",
+		},
+		LifecycleStatus: &clustermetadata.PoolerLifecycle{
+			Status: clustermetadata.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+		},
+	}))
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	poolerStore := store.NewPoolerStore(nil, logger)
+	onNew, countNew := newCallbackTracker()
+
+	var stoppedCalls, deletedCalls int
+	var cbMu sync.Mutex
+	onStopped := func(*clustermetadata.ID) { cbMu.Lock(); stoppedCalls++; cbMu.Unlock() }
+	onDeleted := func(*clustermetadata.ID) { cbMu.Lock(); deletedCalls++; cbMu.Unlock() }
+
+	targets := []config.WatchTarget{{Database: "mydb"}}
+	watcher := NewPoolerWatcher(ctx, ts, func() []config.WatchTarget { return targets },
+		poolerStore, onNew, onStopped, onDeleted, logger)
+	watcher.Start()
+	defer watcher.Stop()
+
+	// Wait for the watcher to process the initial pooler event, then drain
+	// any remaining events.
+	require.True(t, waitForCondition(t, 5*time.Second, func() bool {
+		return poolerStore.Len() == 1
+	}), "watcher should cache the SHUTDOWN entry")
+	require.NoError(t, watcher.Sync(ctx))
+
+	cached, ok := poolerStore.Get(poolerKey("zone1", "pooler1"))
+	require.True(t, ok, "cached entry should be present")
+	assert.Equal(t,
+		clustermetadata.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+		cached.MultiPooler.GetLifecycleStatus().GetStatus(),
+		"cached MultiPooler lifecycle should reflect SHUTDOWN")
+	assert.Equal(t, 0, countNew(), "onNewPooler must not fire for an already-SHUTDOWN pooler")
+
+	cbMu.Lock()
+	defer cbMu.Unlock()
+	assert.Equal(t, 0, stoppedCalls, "onPoolerStopped must not fire for cold-start SHUTDOWN")
+	assert.Equal(t, 0, deletedCalls, "onPoolerDeleted must not fire for cold-start SHUTDOWN")
 }

--- a/go/services/multipooler/manager/graceful_shutdown.go
+++ b/go/services/multipooler/manager/graceful_shutdown.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
@@ -73,10 +74,36 @@ func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 	}
 	defer pm.actionLock.Release(lockCtx)
 
+	// Announce STOPPING in topology before any blocking work. Operators see
+	// the announcement immediately; the actual teardown happens in the rest
+	// of this function and in the StopTopoRegistration call that follows in
+	// OnClose. STOPPING is observability-only — the orchestrator does not
+	// react to this value behaviourally; the authoritative cleanup signal is
+	// LIFECYCLE_SHUTDOWN written by StopTopoRegistration. The Mutate
+	// schedules an async publish; a transient publish failure is recovered
+	// by the publisher's 30 s retry tick.
+	if err := pm.record.Mutate(lockCtx, func(s *MutablePoolerRecordState) {
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{
+			Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STOPPING,
+			Reason:  "shutting down",
+			Updated: timestamppb.Now(),
+		}
+	}); err != nil {
+		pm.logger.WarnContext(lockCtx, "failed to announce STOPPING lifecycle",
+			"error", err)
+	}
+
 	// Transition to NOT_SERVING so the gateway sees a clean rejection for new
 	// queries while in-flight transactions are allowed to complete (bounded by
-	// --connpool-drain-grace-period). Best-effort: a failure here is logged but
-	// doesn't block the rest of shutdown.
+	// --connpool-drain-grace-period). SetState fans out OnStateChange to the
+	// in-process components (query service, connection pool, heartbeat,
+	// health streamer) and routes the topology update through record.Mutate
+	// so the publisher reflects NOT_SERVING during the drain window —
+	// without it, the entry would still read SERVING in topology until the
+	// OnClose StopTopoRegistration runs at the very end of shutdown.
+	//
+	// Best-effort: a failure here is logged but doesn't block the rest of
+	// shutdown.
 	if pm.servingState != nil {
 		if err := pm.servingState.SetState(lockCtx, pm.record.Type(), clustermetadatapb.PoolerServingStatus_NOT_SERVING); err != nil {
 			pm.logger.WarnContext(lockCtx, "transition to NOT_SERVING returned error; proceeding with shutdown",

--- a/go/services/multipooler/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/manager/graceful_shutdown_test.go
@@ -21,14 +21,30 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
+
+// assertRecent fails the test if ts is nil or older than 5 seconds ago.
+// Used by lifecycle tests to verify that a write timestamp was set in the
+// recent past — a coarse sanity check rather than a precise comparison
+// (proto Timestamps round-trip through topology and can lose nanosecond
+// precision; we just want "this was written, not zero").
+func assertRecent(t *testing.T, ts *timestamppb.Timestamp, msg string) {
+	t.Helper()
+	require.NotNil(t, ts, msg+": timestamp is nil")
+	delta := time.Since(ts.AsTime())
+	assert.Less(t, delta, 5*time.Second, msg+": timestamp not recent (delta %s)", delta)
+}
 
 // recordingPgctldClient records each Stop call and returns whatever the
 // supplied stopFn dictates per mode. Other methods panic — keep usage scoped
@@ -82,6 +98,15 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		pgctldClient:   pgctldClient,
 		healthStreamer: newHealthStreamer(logger, id, "tg", "0"),
 		actionLock:     NewActionLock(),
+		// Match the production default set by topoclient.NewMultiPooler so
+		// the record's LifecycleStatus reads as STARTING from the start.
+		// (Real boot wires this in via NewMultiPoolerManager(multiPooler).)
+		record: newRecordFromProto(&clustermetadatapb.MultiPooler{
+			Id: id,
+			LifecycleStatus: &clustermetadatapb.PoolerLifecycle{
+				Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+			},
+		}),
 		// Fresh on-disk consensus state at a temp dir. announceLeaderResignationLocked
 		// reads primary term via primaryTermLocked -> getConsensusStatus -> ConsensusState;
 		// without this it nil-pointers. With no revocation file it reads as term 0,
@@ -147,6 +172,184 @@ func TestGracefulShutdown_NilPgctldClient(t *testing.T) {
 	})
 }
 
+// TestGracefulShutdown_AnnouncesStopping verifies the in-memory lifecycle
+// flips to STOPPING under the action lock at the top of GracefulShutdown,
+// before any blocking work.
+func TestGracefulShutdown_AnnouncesStopping(t *testing.T) {
+	pm := newGracefulShutdownTestManager(t, nil)
+	seedRecordLifecycleForTest(t, pm, clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE)
+
+	pm.GracefulShutdown(context.Background())
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STOPPING,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"GracefulShutdown must announce STOPPING in its in-memory state")
+}
+
+// seedRecordLifecycleForTest mutates the record's LifecycleStatus to the
+// given value, briefly holding the action lock. Tests that need to put the
+// manager into a specific lifecycle state before exercising shutdown call
+// this directly because record.Mutate requires an action-locked context.
+func seedRecordLifecycleForTest(t *testing.T, pm *MultiPoolerManager, status clustermetadatapb.PoolerLifecycleStatus) {
+	t.Helper()
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed-lifecycle")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	require.NoError(t, pm.record.Mutate(lockCtx, func(s *MutablePoolerRecordState) {
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{Status: status}
+	}))
+}
+
+// TestGracefulShutdown_AnnouncesStoppingInTopology verifies that GracefulShutdown
+// records STOPPING + reason + updated timestamp in topology, so operators see
+// the announcement immediately rather than only after shutdown completes. The
+// publisher is driven synchronously here via publishIfNeeded so the assertion
+// doesn't depend on the goroutine clock.
+func TestGracefulShutdown_AnnouncesStoppingInTopology(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	mp.LifecycleStatus.Status = clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+
+	pm.GracefulShutdown(ctx)
+
+	// Drain the scheduled publish synchronously.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STOPPING,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle must announce STOPPING")
+	assert.Equal(t, "shutting down", stored.GetLifecycleStatus().GetReason(),
+		"announcement should carry the canonical reason string")
+	assertRecent(t, stored.GetLifecycleStatus().GetUpdated(),
+		"STOPPING announcement should set the updated timestamp")
+}
+
+// TestMarkPoolerActive_TransitionsLifecycle verifies the STARTING → ACTIVE
+// transition: markPoolerActive flips the record's LifecycleStatus to ACTIVE
+// via record.Mutate and the publisher reflects it to topology. publishIfNeeded
+// is driven synchronously here so the assertion doesn't race the goroutine
+// clock.
+func TestMarkPoolerActive_TransitionsLifecycle(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	require.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+		mp.GetLifecycleStatus().GetStatus(),
+		"NewMultiPooler factory should default to STARTING")
+	require.Equal(t, "process starting", mp.GetLifecycleStatus().GetReason(),
+		"NewMultiPooler factory should annotate STARTING with a reason")
+	assertRecent(t, mp.GetLifecycleStatus().GetUpdated(),
+		"NewMultiPooler factory should set the updated timestamp")
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+	require.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"test manager should default to STARTING")
+
+	pm.markPoolerActive(ctx)
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"in-memory lifecycle must be ACTIVE after markPoolerActive")
+
+	// Drain the scheduled publish synchronously so we can assert against
+	// topology without racing the publisher goroutine.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle must be ACTIVE after markPoolerActive")
+	assert.Equal(t, "pooler active", stored.GetLifecycleStatus().GetReason(),
+		"markPoolerActive should annotate the topology write with a reason")
+	assertRecent(t, stored.GetLifecycleStatus().GetUpdated(),
+		"markPoolerActive should set the updated timestamp")
+}
+
+// TestMarkPoolerActive_Idempotent verifies that calling markPoolerActive
+// on an already-ACTIVE pooler is a no-op. The pgMonitor invokes this on
+// every tick once postgres is up; the cheap pre-check must short-circuit
+// before record.Mutate (and the action lock) is touched.
+func TestMarkPoolerActive_Idempotent(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	mp.LifecycleStatus.Status = clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+
+	pm.markPoolerActive(ctx)
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"in-memory lifecycle stays ACTIVE on idempotent call")
+
+	// The cheap pre-check must short-circuit before record.Mutate; the
+	// publisher's desired stays at the seeded ACTIVE so publishIfNeeded
+	// either no-ops or writes the same value back.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle stays ACTIVE on idempotent call")
+	assert.Equal(t, mp.GetLifecycleStatus().GetUpdated().GetSeconds(), stored.GetLifecycleStatus().GetUpdated().GetSeconds(),
+		"topology Updated seconds must not change on idempotent call")
+	assert.Equal(t, mp.GetLifecycleStatus().GetUpdated().GetNanos(), stored.GetLifecycleStatus().GetUpdated().GetNanos(),
+		"topology Updated nanos must not change on idempotent call")
+}
+
 // TestGracefulShutdown_AnnouncesBeforeStop is a regression test for the
 // ordering bug where primaryTermLocked was called after pgctld.Stop:
 // primaryTermLocked reads from postgres (via rules.observePosition), so it
@@ -199,6 +402,12 @@ func TestGracefulShutdown_AnnouncesBeforeStop(t *testing.T) {
 		actionLock:     NewActionLock(),
 		consensusState: NewConsensusState(t.TempDir(), id),
 		rules:          rules,
+		record: newRecordFromProto(&clustermetadatapb.MultiPooler{
+			Id: id,
+			LifecycleStatus: &clustermetadatapb.PoolerLifecycle{
+				Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+			},
+		}),
 	}
 
 	pm.GracefulShutdown(context.Background())

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -48,6 +48,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
@@ -439,6 +440,17 @@ func (pm *MultiPoolerManager) openLocked(ctx context.Context, targetServingStatu
 				pm.logger.InfoContext(ctx, "MonitorPostgres: postgres state changed, broadcasting health",
 					"postgres_running", newState.postgresRunning)
 				pm.broadcastHealth()
+			}
+			// Transition lifecycle STARTING → ACTIVE once postgres is up
+			// and responding. markPoolerActive is idempotent (short-circuits
+			// when already ACTIVE) so calling it every tick is cheap, and
+			// it retries the topology write on the next tick if it fails.
+			// The transition is monotonic per boot: once ACTIVE, postgres
+			// going down doesn't flip the lifecycle back to STARTING —
+			// runtime health is communicated via Status.PostgresReady /
+			// PostgresStatus, not via Lifecycle.
+			if newState.postgresRunning {
+				pm.markPoolerActive(ctx)
 			}
 			prevState = newState
 		}
@@ -1519,9 +1531,9 @@ func (pm *MultiPoolerManager) StartTopoRegistration(alarm func(string)) {
 }
 
 // StopTopoRegistration transitions the pooler to its shutdown topology
-// state (Type=DRAINED, ServingStatus=NOT_SERVING), stops the publisher with
-// a final publish, and cancels the toporeg retry goroutine. Safe to call
-// even if StartTopoRegistration was never invoked.
+// state (Type=DRAINED, ServingStatus=NOT_SERVING, LifecycleStatus=SHUTDOWN),
+// stops the publisher with a final publish, and cancels the toporeg retry
+// goroutine. Safe to call even if StartTopoRegistration was never invoked.
 //
 // Caller controls the deadline via ctx. ctx should NOT inherit from
 // pm.shutdownCtx, which GracefulShutdown cancels — by the time OnClose
@@ -1529,10 +1541,14 @@ func (pm *MultiPoolerManager) StartTopoRegistration(alarm func(string)) {
 //
 // Type=DRAINED is set so administrative views (e.g. `multigres getpoolers`)
 // reflect that this pooler has gone away rather than continuing to display
-// its last live role. This is purely cosmetic — failover keys off
-// LeadershipStatus.REQUESTING_DEMOTION on the health stream, not off
-// PoolerType. On restart the pooler re-registers with PoolerType_REPLICA
-// and the orchestrator promotes as usual.
+// its last live role. LifecycleStatus=LIFECYCLE_SHUTDOWN is the signal the
+// orchestrator's pooler watcher reacts to in order to close the per-pooler
+// health stream — without it, the orchestrator would dial the dead address
+// for ~4 h until forgetLongUnseenInstances tore down the cache entry. The
+// entry itself is left in place; the 4 h bookkeeping handles eventual
+// cleanup. On restart the pooler re-registers with PoolerType_REPLICA and
+// LifecycleStatus=LIFECYCLE_STARTING, and the orchestrator promotes as
+// usual.
 //
 // Does not require the manager's action lock — record.Unregister stops the
 // publisher before applying the finalize callback, so no other goroutine
@@ -1541,6 +1557,11 @@ func (pm *MultiPoolerManager) StopTopoRegistration(ctx context.Context) {
 	pm.record.Unregister(ctx, func(s *MutablePoolerRecordState) {
 		s.Type = clustermetadatapb.PoolerType_DRAINED
 		s.ServingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{
+			Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+			Reason:  "pooler shutdown",
+			Updated: timestamppb.Now(),
+		}
 	})
 }
 

--- a/go/services/multipooler/manager/pooler_record.go
+++ b/go/services/multipooler/manager/pooler_record.go
@@ -42,8 +42,9 @@ const (
 // immutable — exposing only this struct in the mutation API makes that
 // contract a property of the type system rather than a runtime check.
 type MutablePoolerRecordState struct {
-	Type          clustermetadatapb.PoolerType
-	ServingStatus clustermetadatapb.PoolerServingStatus
+	Type            clustermetadatapb.PoolerType
+	ServingStatus   clustermetadatapb.PoolerServingStatus
+	LifecycleStatus *clustermetadatapb.PoolerLifecycle
 }
 
 // poolerTopoStore is the subset of topoclient.Store used by poolerRecord.
@@ -172,18 +173,21 @@ func (r *poolerRecord) Mutate(ctx context.Context, fn func(*MutablePoolerRecordS
 
 // applyMutation clones the current desired proto, hands a
 // MutablePoolerRecordState view to fn, then writes back the (possibly
-// updated) Type and ServingStatus and atomically stores the result.
-// Caller is responsible for sequencing (action lock, publisher state).
+// updated) Type, ServingStatus, and LifecycleStatus and atomically stores
+// the result. Caller is responsible for sequencing (action lock, publisher
+// state).
 func (r *poolerRecord) applyMutation(fn func(*MutablePoolerRecordState)) {
 	current := r.desired.Load()
 	state := MutablePoolerRecordState{
-		Type:          current.Type,
-		ServingStatus: current.ServingStatus,
+		Type:            current.Type,
+		ServingStatus:   current.ServingStatus,
+		LifecycleStatus: current.LifecycleStatus,
 	}
 	fn(&state)
 	next := proto.Clone(current).(*clustermetadatapb.MultiPooler)
 	next.Type = state.Type
 	next.ServingStatus = state.ServingStatus
+	next.LifecycleStatus = state.LifecycleStatus
 	r.desired.Store(next)
 }
 

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/eventlog"
@@ -181,6 +182,52 @@ func (pm *MultiPoolerManager) setCohortEligibility(signal clustermetadatapb.Coho
 	pm.mu.Unlock()
 	if changed {
 		pm.broadcastHealth()
+	}
+}
+
+// markPoolerActive performs the STARTING → ACTIVE transition once postgres
+// has been observed running and responsive. The pgMonitor callback fires
+// every 5 s; the early-return below is the only thing preventing that tick
+// from issuing a topology publish every cycle. Removing it would turn
+// lifecycle into a per-tick heartbeat at the cost of N publishes per 5 s
+// across the cluster and would silently change the meaning of
+// LifecycleStatus.Updated from "first time ACTIVE" to "last seen ACTIVE".
+// Keep the guard.
+//
+// pm.multipooler is the single in-memory source of truth: the guard reads it,
+// the mutation writes it, and topoPublisher.Notify hands the same pointer to
+// the publisher goroutine which clones-then-writes. The action lock is held
+// across the mutate-then-Notify sequence so lifecycle writes serialise
+// against the consensus state machine (Promote/Demote/BeginTerm) the same
+// way every other Notify caller does.
+func (pm *MultiPoolerManager) markPoolerActive(ctx context.Context) {
+	// Cheap pre-check before acquiring the action lock: if the record
+	// already reads ACTIVE, skip the lock acquisition entirely. The guard
+	// inside record.Mutate's callback is the authoritative one.
+	if pm.record.Snapshot().GetLifecycleStatus().GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE {
+		return
+	}
+
+	lockCtx, err := pm.actionLock.Acquire(ctx, "markPoolerActive")
+	if err != nil {
+		pm.logger.WarnContext(ctx, "failed to acquire action lock for lifecycle ACTIVE; will retry next tick",
+			"error", err)
+		return
+	}
+	defer pm.actionLock.Release(lockCtx)
+
+	if err := pm.record.Mutate(lockCtx, func(s *MutablePoolerRecordState) {
+		if s.LifecycleStatus.GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE {
+			return
+		}
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{
+			Status:  clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+			Reason:  "pooler active",
+			Updated: timestamppb.Now(),
+		}
+	}); err != nil {
+		pm.logger.WarnContext(lockCtx, "record.Mutate for ACTIVE lifecycle failed",
+			"error", err)
 	}
 }
 

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -290,7 +290,7 @@ func waitForDivergenceRepaired(t *testing.T, setup *shardsetup.ShardSetup, oldPr
 }
 
 // verifyReplicaReplicating verifies the replica is actively streaming from the new primary
-func verifyReplicaReplicating(t *testing.T, setup *shardsetup.ShardSetup, replicaName, primaryName string) {
+func verifyReplicaReplicating(t *testing.T, setup *shardsetup.ShardSetup, replicaName, _ string) {
 	t.Helper()
 
 	replica := setup.GetMultipoolerInstance(replicaName)

--- a/go/test/endtoend/multiorch/graceful_shutdown_test.go
+++ b/go/test/endtoend/multiorch/graceful_shutdown_test.go
@@ -349,6 +349,95 @@ func TestMultiReplicaContinuityAfterStandbyShutdown(t *testing.T) {
 		primaryName, len(resp.Status.PrimaryStatus.ConnectedFollowers))
 }
 
+// TestStandbyGracefulShutdownLifecycleShutdown verifies the end-to-end
+// shutdown path of a standby:
+//
+//   - The standby's topology entry stays in place but its
+//     LifecycleStatus.Status transitions to LIFECYCLE_SHUTDOWN (with
+//     Type=DRAINED and ServingStatus=NOT_SERVING) once the OnClose
+//     unregisterFunc has run. This is the signal the orchestrator's
+//     pooler watcher reacts to in order to tear down the per-pooler
+//     health stream; the durable entry itself is left for the 4 h
+//     unseen-instance bookkeeping to evict.
+//
+//   - No spurious failover: the primary stays the same. A standby
+//     transitioning to LIFECYCLE_SHUTDOWN is not the same as resigning
+//     leadership; the existing LeaderResigned path remains the only
+//     trigger for failover.
+func TestStandbyGracefulShutdownLifecycleShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping integration test (no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+
+	primaryName := setup.PrimaryName
+	require.NotEmpty(t, primaryName)
+	t.Logf("Initial primary: %s", primaryName)
+
+	// Pick a standby to terminate.
+	var terminatedStandby string
+	for name := range setup.Multipoolers {
+		if name != primaryName {
+			terminatedStandby = name
+			break
+		}
+	}
+	require.NotEmpty(t, terminatedStandby)
+
+	standbyID := setup.GetMultipoolerID(terminatedStandby)
+	require.NotNil(t, standbyID, "expected to resolve standby ID")
+
+	// Sanity check: before SIGTERM, the standby's lifecycle should NOT be
+	// SHUTDOWN — the assertion below would be trivially vacuous otherwise.
+	pre, err := setup.TopoServer.GetMultiPooler(t.Context(), standbyID)
+	require.NoError(t, err)
+	require.NotEqual(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN,
+		pre.GetLifecycleStatus().GetStatus(),
+		"precondition: standby %s should not already be SHUTDOWN before SIGTERM (was %v)",
+		terminatedStandby, pre.GetLifecycleStatus().GetStatus())
+
+	t.Logf("Terminating standby %s", terminatedStandby)
+	terminateMultipoolerGracefully(t, setup.Multipoolers[terminatedStandby], 90*time.Second)
+
+	// The unregisterFunc runs after GracefulShutdown returns. Within a few
+	// seconds the topology entry must read LIFECYCLE_SHUTDOWN + DRAINED;
+	// 30 s is a generous bound that catches regressions in the unregister
+	// path while still leaving headroom for slower-responsive GitHub Actions
+	// runners.
+	require.Eventually(t, func() bool {
+		mp, err := setup.TopoServer.GetMultiPooler(t.Context(), standbyID)
+		if err != nil {
+			return false
+		}
+		return mp.GetLifecycleStatus().GetStatus() == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_SHUTDOWN &&
+			mp.Type == clustermetadatapb.PoolerType_DRAINED
+	}, 30*time.Second, 500*time.Millisecond,
+		"standby %s should have lifecycle=SHUTDOWN and type=DRAINED in topology after graceful shutdown",
+		terminatedStandby)
+	t.Logf("Standby %s lifecycle is SHUTDOWN + DRAINED in topology", terminatedStandby)
+
+	// No spurious failover.
+	current := setup.RefreshPrimary(t)
+	require.NotNil(t, current)
+	require.Equal(t, primaryName, current.Name,
+		"primary must remain unchanged after standby graceful shutdown")
+}
+
 // TestSequentialGracefulShutdowns verifies that the graceful-shutdown sequence
 // runs correctly across two back-to-back SIGTERMs:
 //

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -178,6 +178,13 @@ message MultiPooler {
   // PgDataDir is the PostgreSQL data directory path (from the PGDATA environment variable).
   // Used by multiadmin to compute the primary's data directory for pgBackRest.
   string pg_data_dir = 11;
+
+  // LifecycleStatus is where the pooler is in its process lifecycle.
+  //
+  // Orthogonal to PoolerType (role) and PoolerServingStatus (query-serving
+  // readiness). Recorded in topology so the orchestrator can observe terminal
+  // lifecycle states even on cold start, not only over the health stream.
+  PoolerLifecycle lifecycle_status = 12;
 }
 
 // MultiGateway represents metadata about a running multigateway component instance in the cluster.
@@ -276,6 +283,54 @@ enum PoolerType {
 
   // DRAINED is used for poolers that are temporarily removed from serving traffic
   DRAINED = 3;
+}
+
+// PoolerLifecycleStatus represents where a pooler is in its process lifecycle.
+// Orthogonal to PoolerType (role) and PoolerServingStatus (query-serving
+// readiness). The pooler advances through these states as it boots, serves,
+// and exits. The value is operator-visible via the MultiPooler topology
+// entry; the orchestrator's pooler watcher observes the
+// LIFECYCLE_SHUTDOWN transition and tears down the per-pooler health
+// stream.
+enum PoolerLifecycleStatus {
+  // LIFECYCLE_UNKNOWN is the default for older recordings that predate
+  // this field.
+  LIFECYCLE_UNKNOWN = 0;
+
+  // LIFECYCLE_STARTING is set while the pooler is initialising (loading
+  // topology, opening pools) and has not yet begun serving.
+  LIFECYCLE_STARTING = 1;
+
+  // LIFECYCLE_ACTIVE is the normal steady-state — postgres is responding.
+  LIFECYCLE_ACTIVE = 2;
+
+  // LIFECYCLE_STOPPING announces that the pooler has been told to shut
+  // down. Written at the top of GracefulShutdown so operators see the
+  // state immediately, before the shutdown sequence runs (~5–15 s).
+  LIFECYCLE_STOPPING = 3;
+
+  // LIFECYCLE_SHUTDOWN is set after the OnClose chain has run: the pooler
+  // is durably down (not just announcing it via STOPPING). Written from
+  // unregisterFunc alongside Type=DRAINED. The topology entry is left in
+  // place so the orchestrator's 4 h unseen-instance bookkeeping handles
+  // eventual eviction, but the orchestrator's pooler watcher observes
+  // the transition and stops the per-pooler health stream immediately.
+  LIFECYCLE_SHUTDOWN = 4;
+}
+
+// PoolerLifecycle pairs a PoolerLifecycleStatus with operator-readable
+// context (reason) and a write timestamp (updated). Every caller that
+// produces a PoolerLifecycle value sets all three fields together;
+// readers use `updated` to compute "how long has this pooler been in
+// state X" for diagnostics.
+message PoolerLifecycle {
+  PoolerLifecycleStatus status = 1;
+
+  // Optional reason for the current lifecycle stage.
+  string reason = 2;
+
+  // Wall-clock time at which this lifecycle entry was written.
+  google.protobuf.Timestamp updated = 3;
 }
 
 // PoolerServingStatus represents the serving status of the given MultiPooler.

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -212,7 +212,6 @@ message Status {
   // This is the combined check: process must exist AND respond to pg_isready.
   // Use postgres_running to check only if the process exists.
   bool postgres_ready = 14;
-
 }
 
 // PostgresStatus is the observed state of the PostgreSQL server process.


### PR DESCRIPTION
## Summary

Introduces a `PoolerLifecycle` field on the pooler topology entry that records where a pooler is in its process lifecycle, and wires it through `GracefulShutdown` and the orchestrator's pooler watcher so a gracefully-shutdown pooler is no longer dialled for ~4 hours until the bookkeeping eviction tears down the cache entry.

`PoolerLifecycle` is a deliberate replacement for an earlier (unmerged) attempt to overload `COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE` for the "I'm leaving" purpose. Cohort eligibility and lifecycle are now cleanly separated: `INELIGIBLE` keeps its current meaning ("don't put me in the cohort right now"); lifecycle answers the orthogonal question ("what phase of its life is this pooler in?").

## Problem

When a multipooler exits cleanly (rolling upgrade, ConfigMap rotation, node drain, manual restart), the orchestrator currently keeps dialling the dead address for ~4 hours until `forgetLongUnseenInstances` tears down the cache entry:

| What runs                                                     | For how long                  |
| ------------------------------------------------------------- | ----------------------------- |
| `runStream` reconnect loop (30 s backoff cap)                 | ~4 h until eviction           |
| Per-attempt: gRPC dial → connection refused → backoff → retry | ~120-180 attempts over 4 h    |
| Goroutines per dead pooler                                    | 1 reconnect loop + 1 watchdog |

For a _primary_, `REQUESTING_DEMOTION` on `LeadershipStatus` already drives the failover path and the cluster recovers in seconds — but the reconnect loop runs anyway. For a _standby_, no analyzer fires at all (correctly, given today's signals), so the dead-address dialling is pure waste plus log/metric noise that drowns out real connectivity problems. The pooler _knows_ it's leaving; discarding that information at the gRPC layer and forcing the orchestrator to re-derive it is fragile.

## Solution

### Proto

A new `PoolerLifecycle` message — `{status, reason, updated}` — and a `PoolerLifecycleStatus` enum with five values (`UNKNOWN`, `STARTING`, `ACTIVE`, `STOPPING`, `SHUTDOWN`):

- `MultiPooler.lifecycle_status` (field 12) — persisted in topology so the orchestrator observes lifecycle states even on cold start. Every writer sets all three sub-fields together: `status` for the state, `reason` for an operator-readable hint, and `updated` for "how long has this pooler been here" diagnostics.

### Pooler-side lifecycle state machine

| Transition              | Trigger                                                                                            | Write                                                                                                                                                                                                                                                                                  |
| ----------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `(none)` → `STARTING`   | Process boot. `topoclient.NewMultiPooler` initialises `LifecycleStatus` to `STARTING` + `"process starting"` + `timestamppb.Now()`. | Persisted on the first `RegisterMultiPooler` call.                                                                                                                                                                                                                                     |
| `STARTING` → `ACTIVE`   | `pgMonitor` observes `postgresRunning` (pgctld reports `RUNNING`).                                  | `markPoolerActive` writes `{ACTIVE, "pooler active", now}` to topology, then flips the in-memory record and publishes via `topoPublisher.Notify`. Idempotent — every subsequent tick short-circuits. Monotonic per boot: postgres bouncing afterwards is communicated via `Status.PostgresReady` / `PostgresStatus`, not by flipping lifecycle back. |
| `ACTIVE` → `STOPPING`   | Top of `GracefulShutdown`, before any blocking work.                                                 | Best-effort topology write of `{STOPPING, "shutting down", now}`. Operators see the state immediately, before pgctld stop runs (~5–15 s). Survives action-lock-acquire failures by design.                                                                                                                                |
| `STOPPING` → `SHUTDOWN` | `OnClose → tr.Unregister → unregisterFunc`, after `GracefulShutdown` returns.                       | Single `UpdateMultiPoolerFields` call writes `ServingStatus=NOT_SERVING`, `Type=DRAINED`, and `LifecycleStatus={SHUTDOWN, "pooler shutdown", now}` together. The topology entry is intentionally **not** deleted — the 4 h unseen-instance bookkeeping handles eventual eviction.                                                                          |

`PoolerType=DRAINED` is preserved as-is for the other consumers that observe it (e.g. `multigres getpoolers` display). SIGKILL-style exits skip `unregisterFunc` entirely and leave the entry in its last-known state — correct, because a crash is indistinguishable from a network partition.

### Orchestrator-side reaction

A single signal: the `PoolerWatcher` observes the lifecycle transition on the durable topology entry. `handlePoolerEvent` switches on `(existing, newLifecycle, prevLifecycle)`:

| Case                                          | Action                                                                                                                                                                                                                                                                                  |
| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Cold-start, already `SHUTDOWN`                | Ignore. The entry is not added to the in-memory `PoolerStore`; no callback fires. Nothing live to monitor.                                                                                                                                                                              |
| Transition into `SHUTDOWN`                    | Evict the in-memory `PoolerStore` entry (analyzers stop seeing a frozen-timestamp entry) and invoke `onPoolerStopped(id)`. The durable topology record is **not** touched.                                                                                                              |
| Metadata update on a tracked pooler            | Refresh `MultiPooler` in place via `DoUpdate`, preserving the health-worker-owned fields (`IsUpToDate`, `IsLastCheckValid`, timestamps).                                                                                                                                                |
| Fresh discovery (not in store, not `SHUTDOWN`) | `Set` the new state and invoke `onNewPooler(id)`, queuing the first health check.                                                                                                                                                                                                       |

The watcher exposes a second callback, `onPoolerDeleted`, that fires on `NoNode` topology events. It is **reserved**: today the watcher logs the event and invokes the callback if a caller wired one, but it does **not** evict the cache and does **not** stop per-pooler resources. The current engine deliberately passes `nil`. The intent is that an accidental external deletion (operator typo, automation bug, manual `etcdctl del`) of a still-running pooler's entry should not tear down its health stream — that would compound the operator mistake.

Engine wiring: `healthStream.Stop` is wired as `onPoolerStopped`, `nil` as `onPoolerDeleted`. `SHUTDOWN → ACTIVE` re-entry works for free: the in-memory cache is empty after the eviction, so the next watcher event for the same pooler falls into the fresh-discovery branch and `onNewPooler` fires, restarting the health stream.

Stream closure is driven **exclusively** by the lifecycle transition into `SHUTDOWN`. `INELIGIBLE` on `AvailabilityStatus.CohortEligibilityStatus` is a preference about consensus participation (e.g. the `StopReplication` admin path) and is **not** a terminal lifecycle signal — the two are deliberately decoupled.

## Operational consequences

| Scenario                                                | Behaviour                                                                                                                                                                                                                                                                            |
| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Standby graceful shutdown                                | `STOPPING` is announced first; on `OnClose` the entry transitions to `{SHUTDOWN, DRAINED, NOT_SERVING}`. The orchestrator's watcher evicts the cache and calls `healthStream.Stop`; the reconnect loop exits cleanly. No 4 h reconnect storm.                                       |
| Standby crash / SIGKILL                                  | `unregisterFunc` does not run; no `SHUTDOWN` written. The entry stays in its last-known state and the reconnect loop runs as today. Correct: a crash is indistinguishable from a network partition, and retrying is the right default.                                              |
| Primary graceful shutdown                                | `SHUTDOWN` published alongside the existing `REQUESTING_DEMOTION` path. Failover is unchanged (`LeaderResignedAnalyzer` drives it). The reconnect loop on the standby orchestrators exits the same way as for any other pooler.                                                       |
| Pooler restart within 4 h of `SHUTDOWN`                  | The new process boots with `STARTING` and `RegisterMultiPooler(allowUpdate=true)` overwrites the topology entry. The watcher sees a non-`SHUTDOWN` entry with no cache record and treats it as a fresh discovery → `onNewPooler` fires → `Start` resumes dialling.                  |
| Orchestrator restart while a pooler is `SHUTDOWN`        | The cold-start branch in `handlePoolerEvent` ignores the already-`SHUTDOWN` entry: it is not added to the cache and no callback fires. The orchestrator does not dial it.                                                                                                            |
| Topology write of `SHUTDOWN` fails                        | `unregisterFunc` returns the error and the entry stays in its previous state (`STOPPING` or earlier). The orchestrator's reconnect loop will continue until the 4 h bookkeeping eviction fires. Same recovery as a SIGKILL crash.                                                     |
| `StopReplication` admin path on a live standby            | Already publishes `INELIGIBLE` today via `walReceiverManuallyStopped`. Unchanged — the stream stays open, the orchestrator just removes the node from the cohort.                                                                                                                    |
| External `etcdctl del` of a live pooler's entry          | `NoNode` event fires. The watcher logs at WARN ("cache and stream left intact"); the cache and health stream are unaffected. Recovery story (a pooler self-watch that re-creates its own entry) is captured in `FOLLOWUPS.md`.                                                       |

## Test plan

- [x] **Pooler unit:**
  - `TestMarkPoolerActive_TransitionsLifecycle` — `STARTING → ACTIVE` writes in-memory and topology; the factory default of `STARTING` + reason/timestamp is pinned here.
  - `TestMarkPoolerActive_Idempotent` — second call on an already-`ACTIVE` pooler does not retrigger a topology write.
  - `TestGracefulShutdown_AnnouncesStopping` — in-memory `STOPPING` transition fires.
  - `TestGracefulShutdown_AnnouncesStoppingInTopology` — `STOPPING` persists to a real `memorytopo` backend with reason `"shutting down"` and a recent timestamp.
- [x] **Orchestrator unit:**
  - `TestPoolerWatcher_PoolerEntersShutdownLifecycle` — `ACTIVE → SHUTDOWN` transition evicts the cache, fires `onPoolerStopped` once, and does not fire `onPoolerDeleted`.
  - `TestPoolerWatcher_RestartAfterShutdownFiresOnNewPooler` — `SHUTDOWN → ACTIVE` re-fires `onNewPooler` so the health stream restarts.
  - `TestPoolerWatcher_ColdStartShutdownIgnored` — pre-existing `SHUTDOWN` entry on watcher boot is not cached and triggers no callbacks.
  - `TestPoolerWatcher_PoolerDeletedFromTopology` — `NoNode` fires `onPoolerDeleted` only; the cache is **not** evicted and `onPoolerStopped` does **not** fire.
  - `TestHealthStream_StreamEOFWithoutSpecialSignal_KeepsBackoff` — bare EOFs still enter the reconnect-with-backoff loop; the only thing that tears down the stream is the watcher's `onPoolerStopped`.
- [x] **Integration:**
  - `TestStandbyGracefulShutdownLifecycleShutdown` — SIGTERM a standby and assert the topology entry's `LifecycleStatus.Status == LIFECYCLE_SHUTDOWN` and `Type == DRAINED` within 30 s, with the entry still present (no `NoNode`) and no spurious failover. Passes locally in ~27 s.
- [x] **Regression:** all existing graceful-shutdown integration tests (`TestPrimaryGracefulShutdownTriggersFailover`, `TestStandbyGracefulShutdownDoesNotTriggerFailover`, `TestMultiReplicaContinuityAfterStandbyShutdown`, `TestSequentialGracefulShutdowns`) continue to pass.

## Out of scope

- **Removing `PoolerType=DRAINED`.** The `unregisterFunc` continues to write `Type=DRAINED` alongside `LifecycleStatus=LIFECYCLE_SHUTDOWN`. `DRAINED` is used for other purposes (e.g. `multigres getpoolers` display); whether to retire it later is a separate decision.
- **Aggressive cache eviction on `SHUTDOWN` in topology.** The `unregisterFunc` deliberately does **not** delete the topology record. The 4 h `forgetLongUnseenInstances` threshold handles eventual cleanup; the entry survives for that window so operators and post-mortem tooling can inspect the durable end-state. The in-memory `PoolerStore` is evicted immediately by the watcher.
- **Wiring `onPoolerDeleted` to behaviour.** The callback exists and is invoked on `NoNode`, but the engine passes `nil`. Hooking it up to anything (re-create the entry, page on-call, telemetry) is a follow-up.
- **Pooler self-watch for accidental deletions.** A pooler whose topology entry is externally removed does not currently notice or recover. Captured in `FOLLOWUPS.md`.
- **Lifecycle-driven cohort changes.** Cohort membership remains governed by `CohortEligibilityStatus`. A pooler going `SHUTDOWN` does not itself trigger cohort removal in this PR.
- **Wiring an `UNUSABLE` state.** The enum has `UNKNOWN`, `STARTING`, `ACTIVE`, `STOPPING`, `SHUTDOWN`. Adding an explicit non-recoverable state can be done later if needed.

Closing MUL-478