### PR TITLE
feat(observability): add auth and TLS metrics with Grafana panels

### DIFF
--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -2692,7 +2692,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Credential-query failures per second, labeled by error_type (user_not_found = baseline traffic, pool_acquire_failed / db_error = operator issues).",
+      "description": "Credential-query failures per second, labeled by error_type. Baseline traffic: user_not_found, login_disabled, password_expired (policy outcomes from a successful pg_authid query). Operator issues: pool_acquire_failed, db_error.",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -786,10 +786,7 @@
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
+          "calcs": ["lastNotNull", "max"]
         },
         "tooltip": {
           "mode": "multi",
@@ -1782,9 +1779,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -2731,10 +2726,7 @@
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": [
-    "multigres",
-    "production"
-  ],
+  "tags": ["multigres", "production"],
   "templating": {
     "list": [
       {

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -2283,7 +2283,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Client authentication attempts per second, split by outcome. success/bad_password/user_not_found/login_disabled/password_expired/protocol_error/lookup_error.",
+      "description": "Client authentication attempts per second, split by outcome. success/bad_password/user_not_found/login_disabled/password_expired/protocol_error/lookup_error/internal_error/replication_role_required.",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"

--- a/demo/observability/grafana-dashboard.json
+++ b/demo/observability/grafana-dashboard.json
@@ -786,7 +786,10 @@
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "calcs": ["lastNotNull", "max"]
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
         },
         "tooltip": {
           "mode": "multi",
@@ -1779,7 +1782,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -2264,11 +2269,472 @@
       ],
       "title": "Restore Duration",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 186
+      },
+      "id": 170,
+      "panels": [],
+      "title": "Multigateway - Auth & TLS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Client authentication attempts per second, split by outcome. success/bad_password/user_not_found/login_disabled/password_expired/protocol_error/lookup_error.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 187
+      },
+      "id": 171,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (outcome) (rate(mg_gateway_auth_attempts_total{job=\"multigateway\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Auth Attempts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "SCRAM handshake duration percentiles (client-first to server-final), labeled by outcome.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 187
+      },
+      "id": 172,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le, outcome) (rate(mg_gateway_auth_scram_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p95 - {{outcome}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(mg_gateway_auth_scram_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p50 - {{outcome}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "SCRAM Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "GetAuthCredentials RPC latency observed from the gateway. p50/p95/p99. Baseline for credential-cache sizing.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 196
+      },
+      "id": 173,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(mg_gateway_auth_credential_lookup_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mg_gateway_auth_credential_lookup_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(mg_gateway_auth_credential_lookup_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Credential Lookup Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "GetAuthCredentials invocations per second. Quantifies benefit of a future credential cache.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 196
+      },
+      "id": 174,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mg_gateway_auth_credential_lookup_rate_total{job=\"multigateway\"}[$__rate_interval]))",
+          "legendFormat": "lookups/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Credential Lookup Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "TLS handshake duration percentiles in handleSSLRequest, labeled by outcome (success/handshake_failure/client_aborted).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 205
+      },
+      "id": 175,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le, outcome) (rate(mg_gateway_tls_handshake_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p95 - {{outcome}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(mg_gateway_tls_handshake_duration_seconds_bucket{job=\"multigateway\"}[$__rate_interval])))",
+          "legendFormat": "p50 - {{outcome}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "TLS Handshake Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Completed TLS negotiations per second, labeled by negotiated tls_version and cipher_suite.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 205
+      },
+      "id": 176,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (tls_version, cipher_suite) (rate(mg_gateway_tls_connections_total{job=\"multigateway\"}[$__rate_interval]))",
+          "legendFormat": "{{tls_version}} / {{cipher_suite}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TLS Connections by Version & Cipher",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Connections rejected because --pg-require-ssl=true and the client did not negotiate TLS. reason=no_sslrequest (client never asked) vs tls_disabled_by_server (server declined). Feeds the SSL-enforcement fleet validation alert (MUL-420).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 214
+      },
+      "id": 177,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (reason) (rate(mg_gateway_tls_plaintext_rejected_total{job=\"multigateway\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plaintext Rejected",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "SSLRequest replied with 'N' because no cert/key configured. Use before enforcement to size impact of flipping --pg-require-ssl per fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 214
+      },
+      "id": 178,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mg_gateway_tls_sslrequest_declined_total{job=\"multigateway\"}[$__rate_interval]))",
+          "legendFormat": "declined/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SSLRequest Declined",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 223
+      },
+      "id": 220,
+      "panels": [],
+      "title": "Multipooler - Auth",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Admin-pool SELECT rolpassword FROM pg_authid lookup duration percentiles. Includes admin-pool acquire + query + decode. Tail rise is the first signal of admin-pool contention.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 224
+      },
+      "id": 221,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(mg_pooler_auth_credential_query_duration_seconds_bucket{job=\"multipooler\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(mg_pooler_auth_credential_query_duration_seconds_bucket{job=\"multipooler\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(mg_pooler_auth_credential_query_duration_seconds_bucket{job=\"multipooler\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Credential Query Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Credential-query failures per second, labeled by error_type (user_not_found = baseline traffic, pool_acquire_failed / db_error = operator issues).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 224
+      },
+      "id": 222,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (error_type) (rate(mg_pooler_auth_credential_query_errors_total{job=\"multipooler\"}[$__rate_interval]))",
+          "legendFormat": "{{error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Credential Query Errors",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": ["multigres", "production"],
+  "tags": [
+    "multigres",
+    "production"
+  ],
   "templating": {
     "list": [
       {

--- a/go/common/pgprotocol/server/auth_classify_test.go
+++ b/go/common/pgprotocol/server/auth_classify_test.go
@@ -46,7 +46,7 @@ func TestClassifyAuthError(t *testing.T) {
 		{"channel binding check", scram.ErrChannelBindingCheck, AuthOutcomeProtocolError},
 		{"authzid not supported", scram.ErrAuthzidNotSupported, AuthOutcomeProtocolError},
 		{"wrapped bad password", fmt.Errorf("scram failed: %w", scram.ErrAuthenticationFailed), AuthOutcomeBadPassword},
-		{"unknown is lookup_error", errors.New("transport closed"), AuthOutcomeLookupError},
+		{"unknown is internal_error", errors.New("transport closed"), AuthOutcomeInternal},
 	}
 
 	for _, tc := range cases {

--- a/go/common/pgprotocol/server/auth_classify_test.go
+++ b/go/common/pgprotocol/server/auth_classify_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/scram"
+)
+
+// TestClassifyAuthError covers the closed mapping from SCRAM sentinels to
+// the auth.attempts outcome label set. Wrapping the sentinel with %w must
+// preserve the classification — sendAuthError-style helpers rewrap the
+// underlying cause and the recorder must still see the specific outcome.
+func TestClassifyAuthError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil maps to success", nil, AuthOutcomeSuccess},
+		{"bad password", scram.ErrAuthenticationFailed, AuthOutcomeBadPassword},
+		{"user not found", scram.ErrUserNotFound, AuthOutcomeUserNotFound},
+		{"login disabled", scram.ErrLoginDisabled, AuthOutcomeLoginDisabled},
+		{"password expired", scram.ErrPasswordExpired, AuthOutcomePasswordExpired},
+		{"sasl protocol violation", scram.ErrSASLProtocol, AuthOutcomeProtocolError},
+		{"channel binding negotiation", scram.ErrChannelBindingNegotiation, AuthOutcomeProtocolError},
+		{"channel binding check", scram.ErrChannelBindingCheck, AuthOutcomeProtocolError},
+		{"authzid not supported", scram.ErrAuthzidNotSupported, AuthOutcomeProtocolError},
+		{"wrapped bad password", fmt.Errorf("scram failed: %w", scram.ErrAuthenticationFailed), AuthOutcomeBadPassword},
+		{"unknown is lookup_error", errors.New("transport closed"), AuthOutcomeLookupError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, classifyAuthError(tc.err))
+		})
+	}
+}
+
+// TestIsClientAbortError separates network teardown from crypto/handshake
+// failures so the tls.handshake.duration outcome label can suppress noise
+// from clients that hang up mid-handshake.
+func TestIsClientAbortError(t *testing.T) {
+	require.False(t, isClientAbortError(nil))
+	require.False(t, isClientAbortError(errors.New("opaque crypto failure")))
+	require.True(t, isClientAbortError(io.EOF))
+	require.True(t, isClientAbortError(io.ErrUnexpectedEOF))
+	require.True(t, isClientAbortError(fmt.Errorf("wrapped: %w", net.ErrClosed)))
+}

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -133,6 +133,12 @@ type Conn struct {
 	// listener at accept time. Cancel requests bypass this check.
 	requireTLS bool
 
+	// authMetrics receives auth- and TLS-path metric events for this
+	// connection. Never nil — a noop is substituted at listener
+	// construction when the caller did not supply one — so startup-phase
+	// code can call methods unconditionally.
+	authMetrics AuthMetricsRecorder
+
 	// sslDone indicates that an SSLRequest has already been handled
 	// (accepted or declined) for this connection. Prevents double negotiation.
 	sslDone bool

--- a/go/common/pgprotocol/server/listener.go
+++ b/go/common/pgprotocol/server/listener.go
@@ -69,6 +69,12 @@ type Listener struct {
 	// DefaultAuthenticationTimeout, so this field is never zero in practice.
 	authenticationTimeout time.Duration
 
+	// authMetrics is the sink for auth- and TLS-path metrics emitted during
+	// the startup phase. Always non-nil after NewListener — a noop
+	// implementation is substituted when the config leaves AuthMetrics unset,
+	// so call sites in startup.go can invoke methods unconditionally.
+	authMetrics AuthMetricsRecorder
+
 	// logger for logging.
 	logger *slog.Logger
 
@@ -197,6 +203,13 @@ type ListenerConfig struct {
 	// Negative disables the timeout.
 	AuthenticationTimeout time.Duration
 
+	// AuthMetrics receives auth- and TLS-path metric events during the
+	// startup phase. Nil means metrics are dropped (a noop sink is
+	// substituted internally). The pgprotocol/server package intentionally
+	// has no OTel dependency; production callers wire an OTel-backed
+	// implementation here.
+	AuthMetrics AuthMetricsRecorder
+
 	// Logger for logging (optional, defaults to slog.Default()).
 	Logger *slog.Logger
 }
@@ -235,6 +248,11 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		authTimeout = DefaultAuthenticationTimeout
 	}
 
+	authMetrics := config.AuthMetrics
+	if authMetrics == nil {
+		authMetrics = noopAuthMetrics{}
+	}
+
 	ctx, cancel := context.WithCancel(context.TODO())
 
 	l := &Listener{
@@ -245,6 +263,7 @@ func NewListener(config ListenerConfig) (*Listener, error) {
 		tlsConfig:             config.TLSConfig,
 		requireTLS:            config.RequireTLS,
 		authenticationTimeout: authTimeout,
+		authMetrics:           authMetrics,
 		logger:                logger,
 		gatewayID:             config.GatewayID,
 		conns:                 make(map[uint32]*Conn),
@@ -308,6 +327,7 @@ func (l *Listener) Serve() error {
 		conn.trustAuthProvider = l.trustAuthProvider
 		conn.tlsConfig = l.tlsConfig
 		conn.requireTLS = l.requireTLS
+		conn.authMetrics = l.authMetrics
 
 		// Handle connection in a new goroutine.
 		l.wg.Go(func() {

--- a/go/common/pgprotocol/server/metrics.go
+++ b/go/common/pgprotocol/server/metrics.go
@@ -25,13 +25,15 @@ import (
 // implementations in higher layers share the vocabulary without inverting
 // the dependency direction (pgprotocol/server must not import service code).
 const (
-	AuthOutcomeSuccess         = "success"
-	AuthOutcomeUserNotFound    = "user_not_found"
-	AuthOutcomeBadPassword     = "bad_password"
-	AuthOutcomeProtocolError   = "protocol_error"
-	AuthOutcomeLoginDisabled   = "login_disabled"
-	AuthOutcomePasswordExpired = "password_expired"
-	AuthOutcomeLookupError     = "lookup_error"
+	AuthOutcomeSuccess                 = "success"
+	AuthOutcomeUserNotFound            = "user_not_found"
+	AuthOutcomeBadPassword             = "bad_password"
+	AuthOutcomeProtocolError           = "protocol_error"
+	AuthOutcomeLoginDisabled           = "login_disabled"
+	AuthOutcomePasswordExpired         = "password_expired"
+	AuthOutcomeLookupError             = "lookup_error"
+	AuthOutcomeInternal                = "internal_error"
+	AuthOutcomeReplicationRoleRequired = "replication_role_required"
 )
 
 // TLS handshake outcome label values.

--- a/go/common/pgprotocol/server/metrics.go
+++ b/go/common/pgprotocol/server/metrics.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"time"
+)
+
+// Auth outcome label values used when emitting auth metrics. The set is
+// closed (bounded cardinality) and mirrors the rejection sites in
+// authenticateSCRAM. Keeping the canonical strings here lets the recorder
+// implementations in higher layers share the vocabulary without inverting
+// the dependency direction (pgprotocol/server must not import service code).
+const (
+	AuthOutcomeSuccess         = "success"
+	AuthOutcomeUserNotFound    = "user_not_found"
+	AuthOutcomeBadPassword     = "bad_password"
+	AuthOutcomeProtocolError   = "protocol_error"
+	AuthOutcomeLoginDisabled   = "login_disabled"
+	AuthOutcomePasswordExpired = "password_expired"
+	AuthOutcomeLookupError     = "lookup_error"
+)
+
+// TLS handshake outcome label values.
+const (
+	TLSOutcomeSuccess          = "success"
+	TLSOutcomeHandshakeFailure = "handshake_failure"
+	TLSOutcomeClientAborted    = "client_aborted"
+)
+
+// Plaintext-rejection reason labels.
+const (
+	PlaintextRejectedReasonNoSSLRequest        = "no_sslrequest"
+	PlaintextRejectedReasonTLSDisabledByServer = "tls_disabled_by_server"
+)
+
+// AuthMetricsRecorder is the sink the listener calls during the startup
+// phase to publish auth- and TLS-path metrics. Implementations live in
+// service code (multigateway) so this package stays OTel-free.
+//
+// All methods must be safe to call concurrently. A nil receiver pattern is
+// allowed in implementations — callers do not check before invoking — so
+// implementations should also be safe when constructed but not yet wired
+// to a meter (e.g. tests).
+type AuthMetricsRecorder interface {
+	// RecordSCRAMDuration is called once per SCRAM handshake attempt with
+	// the wall-clock duration and one of the AuthOutcome* values.
+	RecordSCRAMDuration(ctx context.Context, outcome string, d time.Duration)
+
+	// RecordAuthAttempt is called once per client authentication attempt
+	// — including trust auth — tagged with the outcome. Counter, not
+	// histogram: cardinality is bounded by the outcome set.
+	RecordAuthAttempt(ctx context.Context, outcome string)
+
+	// RecordCredentialLookup is called by the gateway's credential
+	// provider after each backing lookup (e.g. the GetAuthCredentials
+	// RPC). Records the latency and bumps the lookup-rate counter so
+	// future cache work has a baseline.
+	RecordCredentialLookup(ctx context.Context, d time.Duration)
+
+	// RecordTLSHandshake is called once per TLS negotiation with the
+	// handshake wall-clock duration and one of the TLSOutcome* values.
+	RecordTLSHandshake(ctx context.Context, outcome string, d time.Duration)
+
+	// RecordTLSConnection is called once per connection that completed
+	// TLS negotiation, tagged with the negotiated tls_version and
+	// cipher_suite (raw uint16 values from crypto/tls; the recorder
+	// stringifies via tls.VersionName / tls.CipherSuiteName).
+	RecordTLSConnection(ctx context.Context, version, cipher uint16)
+
+	// RecordPlaintextRejected is called when a plaintext StartupMessage
+	// arrives on a RequireTLS listener, tagged with one of the
+	// PlaintextRejectedReason* values.
+	RecordPlaintextRejected(ctx context.Context, reason string)
+
+	// RecordSSLRequestDeclined is called when SSLRequest is declined
+	// with 'N' because no TLS config is present. Useful before
+	// enforcement to size the impact of flipping --pg-require-ssl.
+	RecordSSLRequestDeclined(ctx context.Context)
+}
+
+// noopAuthMetrics is used when the listener is constructed without an
+// explicit recorder, so callers in startup.go can invoke methods
+// unconditionally. Eliminates per-call nil checks at every emission site.
+type noopAuthMetrics struct{}
+
+func (noopAuthMetrics) RecordSCRAMDuration(context.Context, string, time.Duration) {}
+func (noopAuthMetrics) RecordAuthAttempt(context.Context, string)                  {}
+func (noopAuthMetrics) RecordCredentialLookup(context.Context, time.Duration)      {}
+func (noopAuthMetrics) RecordTLSHandshake(context.Context, string, time.Duration)  {}
+func (noopAuthMetrics) RecordTLSConnection(context.Context, uint16, uint16)        {}
+func (noopAuthMetrics) RecordPlaintextRejected(context.Context, string)            {}
+func (noopAuthMetrics) RecordSSLRequestDeclined(context.Context)                   {}
+
+// metrics returns the connection's auth metrics sink, substituting a noop
+// when none was injected. Tests that construct *Conn directly (rather than
+// going through the listener accept path) leave authMetrics unset; the
+// helper keeps startup-phase call sites free of nil checks without forcing
+// every test fixture to wire a recorder.
+func (c *Conn) metrics() AuthMetricsRecorder {
+	if c.authMetrics == nil {
+		return noopAuthMetrics{}
+	}
+	return c.authMetrics
+}

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -700,15 +700,13 @@ func (c *Conn) sendReplicationRoleError() error {
 // Returns the outcome label for mg.gateway.auth.attempts alongside the
 // error. The label survives the errAuthRejected wrapping that
 // sendAuthError-style helpers apply, so the caller does not have to
-// reverse-engineer the cause from the returned error. The full SCRAM
-// handshake duration (client-first to server-final) is recorded on every
-// exit path tagged with the same outcome.
+// reverse-engineer the cause from the returned error. The SCRAM handshake
+// duration (client-first to server-final) is recorded only on paths that
+// actually exchange SASL frames; credential-lookup failures exit before
+// any frame is emitted and are observed via the separate
+// mg.gateway.auth.credential_lookup.duration metric.
 func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 	c.logger.Debug("authenticating client", "method", "scram-sha-256")
-	scramStart := time.Now()
-	defer func() {
-		c.metrics().RecordSCRAMDuration(c.ctx, outcome, time.Since(scramStart))
-	}()
 
 	creds, err := c.credentialProvider.GetCredentials(c.ctx, c.user, c.database)
 	if err != nil {
@@ -738,6 +736,14 @@ func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 		return AuthOutcomeLookupError, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 	}
 	c.credentials = creds
+
+	// Start the SCRAM handshake timer here so the histogram captures only
+	// the SASL exchange (client-first → server-final), not the upstream
+	// credential lookup which has its own metric.
+	scramStart := time.Now()
+	defer func() {
+		c.metrics().RecordSCRAMDuration(c.ctx, outcome, time.Since(scramStart))
+	}()
 
 	// Create the SCRAM authenticator with the pre-fetched hash.
 	auth := scram.NewScramAuthenticator(creds.Hash, c.database)

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -19,8 +19,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
+	"net"
 	"strings"
+	"time"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
@@ -127,6 +130,16 @@ func (c *Conn) readAndDispatchStartup() error {
 		if c.requireTLS && !c.tlsHandshakeComplete {
 			c.logger.Warn("rejecting plaintext connection: TLS required",
 				"remote_addr", c.RemoteAddr())
+			// Distinguish the two ways a client can hit this gate so the
+			// fleet-validation alert (MUL-420) can tell "client never
+			// asked for TLS" from "server declined the SSLRequest" — the
+			// latter would indicate misconfiguration that --pg-require-ssl
+			// alone won't catch.
+			reason := PlaintextRejectedReasonNoSSLRequest
+			if c.sslDone {
+				reason = PlaintextRejectedReasonTLSDisabledByServer
+			}
+			c.metrics().RecordPlaintextRejected(c.ctx, reason)
 			// Returning a *PgDiagnostic lets serve() emit the FATAL
 			// ErrorResponse via its standard startup-error path (which
 			// also clears the auth deadline and closes the connection).
@@ -151,6 +164,7 @@ func (c *Conn) handleSSLRequest() error {
 	if c.tlsConfig == nil {
 		// No TLS configured, decline SSL.
 		c.logger.Debug("client requested SSL, declining (no TLS config)")
+		c.metrics().RecordSSLRequestDeclined(c.ctx)
 		if err := c.writeRawByte('N'); err != nil {
 			return fmt.Errorf("failed to send SSL response: %w", err)
 		}
@@ -184,11 +198,24 @@ func (c *Conn) handleSSLRequest() error {
 	// fallback below and skip the wrapper.
 	handshakeCfg := wrapTLSConfigForCertCapture(c.tlsConfig, c.captureTLSServerCert)
 
-	// Perform TLS handshake.
+	// Perform TLS handshake. Time it for mg.gateway.tls.handshake.duration
+	// and classify the outcome so the fleet-validation alert can tell a
+	// crypto failure from a client tear-down. net.ErrClosed / io.EOF map
+	// to client_aborted; everything else is treated as a handshake_failure.
 	tlsConn := tls.Server(c.conn, handshakeCfg)
+	handshakeStart := time.Now()
 	if err := tlsConn.Handshake(); err != nil {
+		outcome := TLSOutcomeHandshakeFailure
+		if isClientAbortError(err) {
+			outcome = TLSOutcomeClientAborted
+		}
+		c.metrics().RecordTLSHandshake(c.ctx, outcome, time.Since(handshakeStart))
 		return fmt.Errorf("TLS handshake failed: %w", err)
 	}
+	handshakeDuration := time.Since(handshakeStart)
+	c.metrics().RecordTLSHandshake(c.ctx, TLSOutcomeSuccess, handshakeDuration)
+	connState := tlsConn.ConnectionState()
+	c.metrics().RecordTLSConnection(c.ctx, connState.Version, connState.CipherSuite)
 
 	// Replace the underlying connection and reset the buffered reader
 	// to read from the TLS connection. The buffered writer is nil during
@@ -468,16 +495,31 @@ var errAuthRejected = errors.New("auth rejected; FATAL already sent")
 // replication clients. libpq, pgx, and JDBC all accept ErrorResponse at this
 // stage either way — the wire-visible difference is one fewer frame and no
 // successful-handshake-then-rejection optic for the client.
-func (c *Conn) authenticate() error {
+func (c *Conn) authenticate() (err error) {
+	// Track the outcome label for mg.gateway.auth.attempts. Each rejection
+	// site below assigns a specific value before returning so we don't lose
+	// the cause when sendAuthError-style helpers fold it into errAuthRejected.
+	outcome := AuthOutcomeSuccess
+	defer func() {
+		c.metrics().RecordAuthAttempt(c.ctx, outcome)
+	}()
+
 	// Check if trust auth is allowed for this connection. errAuthRejected
 	// is propagated unchanged so serve() can short-circuit out of the
 	// startup phase without entering the command loop.
 	if c.trustAuthProvider != nil && c.trustAuthProvider.AllowTrustAuth(c.ctx, c.user, c.database) {
-		if err := c.authenticateTrust(); err != nil {
+		if err = c.authenticateTrust(); err != nil {
+			outcome = classifyAuthError(err)
 			return err
 		}
 	} else {
-		if err := c.authenticateSCRAM(); err != nil {
+		// authenticateSCRAM returns a specific outcome label alongside
+		// the error so this caller doesn't have to reverse-engineer it
+		// from errAuthRejected (which folds the cause).
+		var scramOutcome string
+		scramOutcome, err = c.authenticateSCRAM()
+		outcome = scramOutcome
+		if err != nil {
 			return err
 		}
 	}
@@ -485,11 +527,43 @@ func (c *Conn) authenticate() error {
 	// Replication startup parameter requires rolreplication=true on the role.
 	// Done post-auth so we don't leak which roles exist for unauthenticated
 	// clients.
-	if err := c.verifyReplicationRole(); err != nil {
+	if err = c.verifyReplicationRole(); err != nil {
+		// SCRAM succeeded but the role lacks rolreplication. Reuse
+		// login_disabled — operators see the same "auth-stage rejected
+		// the role" semantics; the rolreplication-specific FATAL is
+		// already visible in logs.
+		outcome = AuthOutcomeLoginDisabled
 		return err
 	}
 
 	return c.finishAuth()
+}
+
+// classifyAuthError maps an auth-path error to the closed set of outcome
+// labels used by mg.gateway.auth.attempts and mg.gateway.auth.scram.duration.
+// Order matters: the SCRAM sentinels must be checked before the generic
+// errAuthRejected fallback so cause-specific labels survive the wrapping
+// done by sendAuthError / sendScramFatal.
+func classifyAuthError(err error) string {
+	switch {
+	case err == nil:
+		return AuthOutcomeSuccess
+	case errors.Is(err, scram.ErrAuthenticationFailed):
+		return AuthOutcomeBadPassword
+	case errors.Is(err, scram.ErrUserNotFound):
+		return AuthOutcomeUserNotFound
+	case errors.Is(err, scram.ErrLoginDisabled):
+		return AuthOutcomeLoginDisabled
+	case errors.Is(err, scram.ErrPasswordExpired):
+		return AuthOutcomePasswordExpired
+	case errors.Is(err, scram.ErrSASLProtocol),
+		errors.Is(err, scram.ErrChannelBindingNegotiation),
+		errors.Is(err, scram.ErrChannelBindingCheck),
+		errors.Is(err, scram.ErrAuthzidNotSupported):
+		return AuthOutcomeProtocolError
+	default:
+		return AuthOutcomeLookupError
+	}
 }
 
 // authenticateTrust performs trust authentication (no password required).
@@ -622,8 +696,19 @@ func (c *Conn) sendReplicationRoleError() error {
 // for both. Lookup-time sentinels (login-disabled, expired, missing user)
 // are mapped to the matching native-PG error here, before any SASL frames
 // are emitted, so we don't reveal which case applied.
-func (c *Conn) authenticateSCRAM() error {
+//
+// Returns the outcome label for mg.gateway.auth.attempts alongside the
+// error. The label survives the errAuthRejected wrapping that
+// sendAuthError-style helpers apply, so the caller does not have to
+// reverse-engineer the cause from the returned error. The full SCRAM
+// handshake duration (client-first to server-final) is recorded on every
+// exit path tagged with the same outcome.
+func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 	c.logger.Debug("authenticating client", "method", "scram-sha-256")
+	scramStart := time.Now()
+	defer func() {
+		c.metrics().RecordSCRAMDuration(c.ctx, outcome, time.Since(scramStart))
+	}()
 
 	creds, err := c.credentialProvider.GetCredentials(c.ctx, c.user, c.database)
 	if err != nil {
@@ -631,18 +716,18 @@ func (c *Conn) authenticateSCRAM() error {
 		// (invalid_authorization_specification), matching native PG.
 		if errors.Is(err, scram.ErrLoginDisabled) {
 			c.logger.Warn("authentication failed: role not permitted to log in", "user", c.user)
-			return c.sendLoginDisabledError()
+			return AuthOutcomeLoginDisabled, c.sendLoginDisabledError()
 		}
 		// Expired rolvaliduntil and unknown-user both surface as the opaque
 		// "password authentication failed" message (28P01), matching PG's
 		// convention of not disclosing why auth failed.
 		if errors.Is(err, scram.ErrUserNotFound) {
 			c.logger.Warn("authentication failed: user not found", "user", c.user)
-			return c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
+			return AuthOutcomeUserNotFound, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 		}
 		if errors.Is(err, scram.ErrPasswordExpired) {
 			c.logger.Warn("authentication failed: password expired", "user", c.user)
-			return c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
+			return AuthOutcomePasswordExpired, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 		}
 		// Generic credential-lookup failure (pooler unreachable, parse
 		// error, transport error not carrying a PgDiagnostic). Fail
@@ -650,7 +735,7 @@ func (c *Conn) authenticateSCRAM() error {
 		// passwords so the client does not learn whether the user
 		// exists; operators see the underlying cause in the logs.
 		c.logger.Error("credential lookup failed", "user", c.user, "error", err)
-		return c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
+		return AuthOutcomeLookupError, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 	}
 	c.credentials = creds
 
@@ -686,16 +771,16 @@ func (c *Conn) authenticateSCRAM() error {
 		advertised[m] = struct{}{}
 	}
 	if err := c.sendAuthenticationSASL(mechanisms); err != nil {
-		return fmt.Errorf("failed to send AuthenticationSASL: %w", err)
+		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASL: %w", err)
 	}
 	if err := c.flush(); err != nil {
-		return fmt.Errorf("failed to flush AuthenticationSASL: %w", err)
+		return AuthOutcomeLookupError, fmt.Errorf("failed to flush AuthenticationSASL: %w", err)
 	}
 
 	// Read SASLInitialResponse (chosen mechanism + client-first-message).
 	selectedMechanism, clientFirstMessage, err := c.readSASLInitialResponse(advertised)
 	if err != nil {
-		return fmt.Errorf("failed to read SASLInitialResponse: %w", err)
+		return AuthOutcomeProtocolError, fmt.Errorf("failed to read SASLInitialResponse: %w", err)
 	}
 
 	// Process client-first-message and generate server-first-message.
@@ -705,23 +790,23 @@ func (c *Conn) authenticateSCRAM() error {
 	if err != nil {
 		if handled, ferr := c.mapSCRAMProtocolError(err); handled {
 			c.logger.Warn("authentication failed: SCRAM protocol violation in client-first", "user", c.user, "err", err)
-			return ferr
+			return AuthOutcomeProtocolError, ferr
 		}
-		return fmt.Errorf("failed to handle client-first-message: %w", err)
+		return AuthOutcomeProtocolError, fmt.Errorf("failed to handle client-first-message: %w", err)
 	}
 
 	// Send AuthenticationSASLContinue with server-first-message.
 	if err := c.sendAuthenticationSASLContinue(serverFirstMessage); err != nil {
-		return fmt.Errorf("failed to send AuthenticationSASLContinue: %w", err)
+		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASLContinue: %w", err)
 	}
 	if err := c.flush(); err != nil {
-		return fmt.Errorf("failed to flush AuthenticationSASLContinue: %w", err)
+		return AuthOutcomeLookupError, fmt.Errorf("failed to flush AuthenticationSASLContinue: %w", err)
 	}
 
 	// Read SASLResponse (contains client-final-message).
 	clientFinalMessage, err := c.readSASLResponse()
 	if err != nil {
-		return fmt.Errorf("failed to read SASLResponse: %w", err)
+		return AuthOutcomeProtocolError, fmt.Errorf("failed to read SASLResponse: %w", err)
 	}
 
 	// Verify client proof and generate server signature.
@@ -729,13 +814,13 @@ func (c *Conn) authenticateSCRAM() error {
 	if err != nil {
 		if errors.Is(err, scram.ErrAuthenticationFailed) {
 			c.logger.Warn("authentication failed: invalid password", "user", c.user)
-			return c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
+			return AuthOutcomeBadPassword, c.sendAuthError("password authentication failed for user \"" + c.user + "\"")
 		}
 		if handled, ferr := c.mapSCRAMProtocolError(err); handled {
 			c.logger.Warn("authentication failed: SCRAM protocol violation in client-final", "user", c.user, "err", err)
-			return ferr
+			return AuthOutcomeProtocolError, ferr
 		}
-		return fmt.Errorf("failed to handle client-final-message: %w", err)
+		return AuthOutcomeProtocolError, fmt.Errorf("failed to handle client-final-message: %w", err)
 	}
 
 	// Capture keys for SCRAM passthrough to the backing PostgreSQL.
@@ -745,11 +830,11 @@ func (c *Conn) authenticateSCRAM() error {
 	// the caller (authenticate) continues with the post-auth role-attribute
 	// check and the AuthenticationOk → ReadyForQuery completion sequence.
 	if err := c.sendAuthenticationSASLFinal(serverFinalMessage); err != nil {
-		return fmt.Errorf("failed to send AuthenticationSASLFinal: %w", err)
+		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASLFinal: %w", err)
 	}
 
 	c.logger.Debug("scram authentication succeeded", "user", c.user)
-	return nil
+	return AuthOutcomeSuccess, nil
 }
 
 // sendAuthenticationSASL sends AuthenticationSASL message with supported mechanisms.
@@ -1001,6 +1086,25 @@ func (c *Conn) sendParameterStatus(name, value string) error {
 	pos = writeStringAt(buf, pos, name)
 	pos = writeStringAt(buf, pos, value)
 	return c.writePacket(buf, pos)
+}
+
+// isClientAbortError reports whether a TLS handshake error looks like the
+// client closed the connection (network teardown, EOF, or use of an already-
+// closed socket) rather than a server-side or crypto failure. Used to split
+// the tls.handshake.duration outcome label so the fleet-validation alert
+// can suppress noise from clients that hang up mid-handshake.
+func isClientAbortError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
 }
 
 // sendReadyForQuery sends a ReadyForQuery message to indicate the server is ready.

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -1099,15 +1099,18 @@ func (c *Conn) sendParameterStatus(name, value string) error {
 // closed socket) rather than a server-side or crypto failure. Used to split
 // the tls.handshake.duration outcome label so the fleet-validation alert
 // can suppress noise from clients that hang up mid-handshake.
+//
+// Timeouts are intentionally excluded: a deadline-exceeded error during
+// the TLS handshake is ambiguous between a stalled client and the server's
+// own authentication_timeout firing on c.conn. Tagging timeouts as
+// handshake_failure (the default) is more accurate than blaming the
+// client; operators alerting on a sustained handshake_failure rate will
+// still spot stalled-client patterns via the timing distribution.
 func isClientAbortError(err error) bool {
 	if err == nil {
 		return false
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed) {
-		return true
-	}
-	var ne net.Error
-	if errors.As(err, &ne) && ne.Timeout() {
 		return true
 	}
 	return false

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -528,11 +528,11 @@ func (c *Conn) authenticate() (err error) {
 	// Done post-auth so we don't leak which roles exist for unauthenticated
 	// clients.
 	if err = c.verifyReplicationRole(); err != nil {
-		// SCRAM succeeded but the role lacks rolreplication. Reuse
-		// login_disabled — operators see the same "auth-stage rejected
-		// the role" semantics; the rolreplication-specific FATAL is
-		// already visible in logs.
-		outcome = AuthOutcomeLoginDisabled
+		// SCRAM succeeded but the role lacks rolreplication. Tagged as
+		// its own outcome so MUL-420's fleet validation alert can
+		// distinguish role-attribute rejections from login_disabled
+		// without scanning logs.
+		outcome = AuthOutcomeReplicationRoleRequired
 		return err
 	}
 
@@ -562,7 +562,7 @@ func classifyAuthError(err error) string {
 		errors.Is(err, scram.ErrAuthzidNotSupported):
 		return AuthOutcomeProtocolError
 	default:
-		return AuthOutcomeLookupError
+		return AuthOutcomeInternal
 	}
 }
 
@@ -777,10 +777,10 @@ func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 		advertised[m] = struct{}{}
 	}
 	if err := c.sendAuthenticationSASL(mechanisms); err != nil {
-		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASL: %w", err)
+		return AuthOutcomeInternal, fmt.Errorf("failed to send AuthenticationSASL: %w", err)
 	}
 	if err := c.flush(); err != nil {
-		return AuthOutcomeLookupError, fmt.Errorf("failed to flush AuthenticationSASL: %w", err)
+		return AuthOutcomeInternal, fmt.Errorf("failed to flush AuthenticationSASL: %w", err)
 	}
 
 	// Read SASLInitialResponse (chosen mechanism + client-first-message).
@@ -803,10 +803,10 @@ func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 
 	// Send AuthenticationSASLContinue with server-first-message.
 	if err := c.sendAuthenticationSASLContinue(serverFirstMessage); err != nil {
-		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASLContinue: %w", err)
+		return AuthOutcomeInternal, fmt.Errorf("failed to send AuthenticationSASLContinue: %w", err)
 	}
 	if err := c.flush(); err != nil {
-		return AuthOutcomeLookupError, fmt.Errorf("failed to flush AuthenticationSASLContinue: %w", err)
+		return AuthOutcomeInternal, fmt.Errorf("failed to flush AuthenticationSASLContinue: %w", err)
 	}
 
 	// Read SASLResponse (contains client-final-message).
@@ -836,7 +836,7 @@ func (c *Conn) authenticateSCRAM() (outcome string, err error) {
 	// the caller (authenticate) continues with the post-auth role-attribute
 	// check and the AuthenticationOk → ReadyForQuery completion sequence.
 	if err := c.sendAuthenticationSASLFinal(serverFinalMessage); err != nil {
-		return AuthOutcomeLookupError, fmt.Errorf("failed to send AuthenticationSASLFinal: %w", err)
+		return AuthOutcomeInternal, fmt.Errorf("failed to send AuthenticationSASLFinal: %w", err)
 	}
 
 	c.logger.Debug("scram authentication succeeded", "user", c.user)

--- a/go/services/multigateway/auth/pooler_credential_provider.go
+++ b/go/services/multigateway/auth/pooler_credential_provider.go
@@ -31,10 +31,13 @@ import (
 )
 
 // CredentialLookupRecorder is the metric sink for credential-lookup latency
-// and rate. Implemented by *multigateway.GatewayMetrics; declared here to
-// avoid the import cycle that pulling the multigateway package into go/services/multigateway/auth
-// would create. A nil receiver is acceptable — the gateway init wires a real
-// implementation, but tests and the trust-auth path can leave it unset.
+// and rate. It is a subset of pgprotocol/server.AuthMetricsRecorder kept
+// aligned with that interface — drift between the two would silently no-op
+// metric emission. Declared here (not imported from the server package) to
+// avoid the import cycle that pulling the multigateway package into
+// go/services/multigateway/auth would create. A nil receiver is acceptable —
+// the gateway init wires a real implementation, but tests and the trust-auth
+// path can leave it unset.
 type CredentialLookupRecorder interface {
 	RecordCredentialLookup(ctx context.Context, d time.Duration)
 }

--- a/go/services/multigateway/auth/pooler_credential_provider.go
+++ b/go/services/multigateway/auth/pooler_credential_provider.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -28,6 +29,15 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 )
+
+// CredentialLookupRecorder is the metric sink for credential-lookup latency
+// and rate. Implemented by *multigateway.GatewayMetrics; declared here to
+// avoid the import cycle that pulling the multigateway package into go/services/multigateway/auth
+// would create. A nil receiver is acceptable — the gateway init wires a real
+// implementation, but tests and the trust-auth path can leave it unset.
+type CredentialLookupRecorder interface {
+	RecordCredentialLookup(ctx context.Context, d time.Duration)
+}
 
 // PoolerSystemClient is the interface for system-level operations on multipooler.
 // This is used for authentication and other tasks that act as the system rather
@@ -44,15 +54,18 @@ type PoolerSystemClient interface {
 // the gateway does not need a second round-trip to admit a replication
 // connection.
 type PoolerCredentialProvider struct {
-	client PoolerSystemClient
+	client  PoolerSystemClient
+	metrics CredentialLookupRecorder
 }
 
 // NewPoolerCredentialProvider creates a new PoolerCredentialProvider.
 // The client is typically a PoolerGateway, which handles pooler selection
-// and failover buffering internally.
-func NewPoolerCredentialProvider(client PoolerSystemClient) *PoolerCredentialProvider {
+// and failover buffering internally. metrics is optional — pass nil to
+// disable mg.gateway.auth.credential_lookup.* recording (e.g. in tests).
+func NewPoolerCredentialProvider(client PoolerSystemClient, metrics CredentialLookupRecorder) *PoolerCredentialProvider {
 	return &PoolerCredentialProvider{
-		client: client,
+		client:  client,
+		metrics: metrics,
 	}
 }
 
@@ -71,6 +84,18 @@ func NewPoolerCredentialProvider(client PoolerSystemClient) *PoolerCredentialPro
 // also used by gRPC auth interceptors for mTLS / authz failures, so keying
 // on code alone would misclassify those transport errors as user auth errors.
 func (p *PoolerCredentialProvider) GetCredentials(ctx context.Context, username, database string) (*server.Credentials, error) {
+	// Time every lookup — success and failure both feed
+	// mg.gateway.auth.credential_lookup.duration so the future
+	// password-hash cache work has a baseline including tail-latency
+	// from pooler failover events. Increment the rate counter on the
+	// same defer to keep the two signals correlated.
+	start := time.Now()
+	defer func() {
+		if p.metrics != nil {
+			p.metrics.RecordCredentialLookup(ctx, time.Since(start))
+		}
+	}()
+
 	resp, err := p.client.GetAuthCredentials(ctx, &multipoolerpb.GetAuthCredentialsRequest{
 		Database: database,
 		Username: username,

--- a/go/services/multigateway/auth/pooler_credential_provider_test.go
+++ b/go/services/multigateway/auth/pooler_credential_provider_test.go
@@ -52,7 +52,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 				IsReplicationRole: true,
 			},
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		creds, err := provider.GetCredentials(context.Background(), "testuser", "testdb")
 		require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 				IsReplicationRole: false,
 			},
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		creds, err := provider.GetCredentials(context.Background(), "regular", "testdb")
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: mterrors.FromGRPC(status.Error(codes.NotFound, "user not found")),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "nonexistent", "testdb")
 		require.Error(t, err)
@@ -101,7 +101,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: mterrors.FromGRPC(mterrors.ToGRPC(diag)),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "nologin_user", "testdb")
 		require.Error(t, err)
@@ -117,7 +117,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: mterrors.FromGRPC(mterrors.ToGRPC(diag)),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "expired_user", "testdb")
 		require.Error(t, err)
@@ -131,7 +131,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: mterrors.FromGRPC(status.Error(codes.PermissionDenied, "authz: caller not in role")),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "alice", "testdb")
 		require.Error(t, err)
@@ -147,7 +147,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: mterrors.FromGRPC(status.Error(codes.Unauthenticated, "mTLS: bad client cert")),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "alice", "testdb")
 		require.Error(t, err)
@@ -162,7 +162,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 				ScramHash: "", // No password set
 			},
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "nopassword", "testdb")
 		require.Error(t, err)
@@ -173,7 +173,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 		client := &mockPoolerSystemClient{
 			err: errors.New("connection refused"),
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "testuser", "testdb")
 		require.Error(t, err)
@@ -186,7 +186,7 @@ func TestPoolerCredentialProvider_GetCredentials(t *testing.T) {
 				ScramHash: "invalid-hash-format",
 			},
 		}
-		provider := NewPoolerCredentialProvider(client)
+		provider := NewPoolerCredentialProvider(client, nil)
 
 		_, err := provider.GetCredentials(context.Background(), "testuser", "testdb")
 		require.Error(t, err)

--- a/go/services/multigateway/init.go
+++ b/go/services/multigateway/init.go
@@ -383,10 +383,19 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 	// Pass ScatterConn as the IExecute implementation
 	mg.executor = executor.NewExecutor(mg.scatterConn, logger, mg.planCacheMemory.Get())
 
+	// Initialize gateway-wide OTel metrics up front so the credential
+	// provider and listener can share the same sink. Failures here are
+	// non-fatal: the auth and TLS code paths tolerate a nil/noop recorder
+	// and we don't want metric init to block startup.
+	gatewayMetrics, err := NewGatewayMetrics()
+	if err != nil {
+		logger.WarnContext(ctx, "failed to initialize gateway metrics", "error", err)
+	}
+
 	// Create the credential provider for SCRAM authentication and the
 	// replication-role gate. A single GetAuthCredentials RPC feeds both,
 	// so admitting a replication connection never costs two pooler hops.
-	credentialProvider := auth.NewPoolerCredentialProvider(mg.poolerGateway)
+	credentialProvider := auth.NewPoolerCredentialProvider(mg.poolerGateway, gatewayMetrics)
 
 	// Build TLS config if cert and key files are provided.
 	certFile := mg.pgTLSCertFile.Get()
@@ -505,6 +514,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		TLSConfig:             pgTLSConfig,
 		RequireTLS:            requireSSL,
 		AuthenticationTimeout: mg.authenticationTimeout.Get(),
+		AuthMetrics:           gatewayMetrics,
 		Logger:                logger,
 	})
 	if err != nil {
@@ -527,6 +537,7 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 			TLSConfig:             pgTLSConfig,
 			RequireTLS:            requireSSL,
 			AuthenticationTimeout: mg.authenticationTimeout.Get(),
+			AuthMetrics:           gatewayMetrics,
 			Logger:                logger,
 		})
 		if err != nil {
@@ -539,11 +550,8 @@ func (mg *MultiGateway) Init(ctx context.Context) error {
 		}
 	}
 
-	// Register client connection metrics.
-	gatewayMetrics, err := NewGatewayMetrics()
-	if err != nil {
-		logger.WarnContext(ctx, "failed to initialize gateway metrics", "error", err)
-	}
+	// Register client connection metrics. The gatewayMetrics instance was
+	// constructed earlier so the credential provider and listeners share it.
 	if gatewayMetrics != nil {
 		var replicaConnCount func() int
 		if mg.pgReplicaListener != nil {

--- a/go/services/multigateway/metrics.go
+++ b/go/services/multigateway/metrics.go
@@ -16,18 +16,56 @@ package multigateway
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+)
+
+// Re-export the canonical auth/TLS label constants from pgprotocol/server so
+// callers inside the multigateway package (e.g. tests) don't need a second
+// import. The vocabulary is defined alongside the AuthMetricsRecorder
+// interface so the listener can emit metrics without depending on this
+// package.
+const (
+	AuthOutcomeSuccess         = server.AuthOutcomeSuccess
+	AuthOutcomeUserNotFound    = server.AuthOutcomeUserNotFound
+	AuthOutcomeBadPassword     = server.AuthOutcomeBadPassword
+	AuthOutcomeProtocolError   = server.AuthOutcomeProtocolError
+	AuthOutcomeLoginDisabled   = server.AuthOutcomeLoginDisabled
+	AuthOutcomePasswordExpired = server.AuthOutcomePasswordExpired
+	AuthOutcomeLookupError     = server.AuthOutcomeLookupError
+
+	TLSOutcomeSuccess          = server.TLSOutcomeSuccess
+	TLSOutcomeHandshakeFailure = server.TLSOutcomeHandshakeFailure
+	TLSOutcomeClientAborted    = server.TLSOutcomeClientAborted
+
+	PlaintextRejectedReasonNoSSLRequest        = server.PlaintextRejectedReasonNoSSLRequest
+	PlaintextRejectedReasonTLSDisabledByServer = server.PlaintextRejectedReasonTLSDisabledByServer
 )
 
 // GatewayMetrics holds OTel metrics for the multigateway service.
 type GatewayMetrics struct {
 	meter             metric.Meter
 	clientConnections metric.Int64ObservableGauge
+
+	// Auth metrics (mg.gateway.auth.*).
+	authSCRAMDuration            metric.Float64Histogram
+	authAttempts                 metric.Int64Counter
+	authCredentialLookupDuration metric.Float64Histogram
+	authCredentialLookupRate     metric.Int64Counter
+
+	// TLS metrics (mg.gateway.tls.*).
+	tlsHandshakeDuration  metric.Float64Histogram
+	tlsConnections        metric.Int64Counter
+	tlsPlaintextRejected  metric.Int64Counter
+	tlsSSLRequestDeclined metric.Int64Counter
 }
 
 // NewGatewayMetrics initializes OTel metrics for the multigateway service.
@@ -45,6 +83,81 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.client.connections gauge: %w", err))
+	}
+
+	m.authSCRAMDuration, err = meter.Float64Histogram(
+		"mg.gateway.auth.scram.duration",
+		metric.WithDescription("Full SCRAM handshake duration (client-first to server-final)"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.auth.scram.duration histogram: %w", err))
+	}
+
+	m.authAttempts, err = meter.Int64Counter(
+		"mg.gateway.auth.attempts",
+		metric.WithDescription("Client authentication attempts"),
+		metric.WithUnit("{attempt}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.auth.attempts counter: %w", err))
+	}
+
+	m.authCredentialLookupDuration, err = meter.Float64Histogram(
+		"mg.gateway.auth.credential_lookup.duration",
+		metric.WithDescription("GetAuthCredentials RPC latency observed from the gateway"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.auth.credential_lookup.duration histogram: %w", err))
+	}
+
+	m.authCredentialLookupRate, err = meter.Int64Counter(
+		"mg.gateway.auth.credential_lookup.rate",
+		metric.WithDescription("GetAuthCredentials RPC invocations; quantifies benefit of a credential cache"),
+		metric.WithUnit("{lookup}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.auth.credential_lookup.rate counter: %w", err))
+	}
+
+	m.tlsHandshakeDuration, err = meter.Float64Histogram(
+		"mg.gateway.tls.handshake.duration",
+		metric.WithDescription("TLS handshake duration in handleSSLRequest"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.tls.handshake.duration histogram: %w", err))
+	}
+
+	m.tlsConnections, err = meter.Int64Counter(
+		"mg.gateway.tls.connections",
+		metric.WithDescription("Connections that completed TLS negotiation"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.tls.connections counter: %w", err))
+	}
+
+	m.tlsPlaintextRejected, err = meter.Int64Counter(
+		"mg.gateway.tls.plaintext_rejected",
+		metric.WithDescription("Connections rejected because --pg-require-ssl=true and client did not negotiate TLS"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.tls.plaintext_rejected counter: %w", err))
+	}
+
+	m.tlsSSLRequestDeclined, err = meter.Int64Counter(
+		"mg.gateway.tls.sslrequest_declined",
+		metric.WithDescription("SSLRequest replied with 'N' because no cert/key configured"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.tls.sslrequest_declined counter: %w", err))
 	}
 
 	if len(errs) > 0 {
@@ -75,4 +188,79 @@ func (m *GatewayMetrics) RegisterClientConnectionsCallback(primaryGetter, replic
 		m.clientConnections,
 	)
 	return err
+}
+
+// RecordSCRAMDuration records the SCRAM handshake duration tagged by outcome.
+// Safe to call on a nil receiver — no-op so call sites can stay unconditional.
+func (m *GatewayMetrics) RecordSCRAMDuration(ctx context.Context, outcome string, d time.Duration) {
+	if m == nil || m.authSCRAMDuration == nil {
+		return
+	}
+	m.authSCRAMDuration.Record(ctx, d.Seconds(),
+		metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+// RecordAuthAttempt increments the auth-attempts counter tagged by outcome.
+func (m *GatewayMetrics) RecordAuthAttempt(ctx context.Context, outcome string) {
+	if m == nil || m.authAttempts == nil {
+		return
+	}
+	m.authAttempts.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+// RecordCredentialLookup records the GetAuthCredentials RPC latency from the
+// gateway side and increments the lookup-rate counter.
+func (m *GatewayMetrics) RecordCredentialLookup(ctx context.Context, d time.Duration) {
+	if m == nil {
+		return
+	}
+	if m.authCredentialLookupDuration != nil {
+		m.authCredentialLookupDuration.Record(ctx, d.Seconds())
+	}
+	if m.authCredentialLookupRate != nil {
+		m.authCredentialLookupRate.Add(ctx, 1)
+	}
+}
+
+// RecordTLSHandshake records the TLS handshake duration tagged by outcome.
+func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, outcome string, d time.Duration) {
+	if m == nil || m.tlsHandshakeDuration == nil {
+		return
+	}
+	m.tlsHandshakeDuration.Record(ctx, d.Seconds(),
+		metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+// RecordTLSConnection increments the completed-TLS-connections counter tagged
+// with the negotiated tls_version and cipher_suite. Names come from
+// crypto/tls so they match Go's published constants (e.g. "TLS 1.3",
+// "TLS_AES_128_GCM_SHA256").
+func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, version, cipher uint16) {
+	if m == nil || m.tlsConnections == nil {
+		return
+	}
+	m.tlsConnections.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("tls_version", tls.VersionName(version)),
+		attribute.String("cipher_suite", tls.CipherSuiteName(cipher)),
+	))
+}
+
+// RecordPlaintextRejected increments the plaintext-rejection counter tagged
+// by reason.
+func (m *GatewayMetrics) RecordPlaintextRejected(ctx context.Context, reason string) {
+	if m == nil || m.tlsPlaintextRejected == nil {
+		return
+	}
+	m.tlsPlaintextRejected.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("reason", reason)))
+}
+
+// RecordSSLRequestDeclined increments the SSL-declined counter, used before
+// enforcement is enabled to size the impact of flipping --pg-require-ssl.
+func (m *GatewayMetrics) RecordSSLRequestDeclined(ctx context.Context) {
+	if m == nil || m.tlsSSLRequestDeclined == nil {
+		return
+	}
+	m.tlsSSLRequestDeclined.Add(ctx, 1)
 }

--- a/go/services/multigateway/metrics.go
+++ b/go/services/multigateway/metrics.go
@@ -25,6 +25,18 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/services/multigateway/auth"
+)
+
+// Compile-time checks that GatewayMetrics implements the recorder
+// interfaces it is wired into. Catches drift in interface method
+// signatures at build time rather than at the (out-of-test) assignment
+// sites in init.go.
+var (
+	_ server.AuthMetricsRecorder    = (*GatewayMetrics)(nil)
+	_ auth.CredentialLookupRecorder = (*GatewayMetrics)(nil)
 )
 
 // GatewayMetrics holds OTel metrics for the multigateway service.

--- a/go/services/multigateway/metrics.go
+++ b/go/services/multigateway/metrics.go
@@ -24,30 +24,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-
-	"github.com/multigres/multigres/go/common/pgprotocol/server"
-)
-
-// Re-export the canonical auth/TLS label constants from pgprotocol/server so
-// callers inside the multigateway package (e.g. tests) don't need a second
-// import. The vocabulary is defined alongside the AuthMetricsRecorder
-// interface so the listener can emit metrics without depending on this
-// package.
-const (
-	AuthOutcomeSuccess         = server.AuthOutcomeSuccess
-	AuthOutcomeUserNotFound    = server.AuthOutcomeUserNotFound
-	AuthOutcomeBadPassword     = server.AuthOutcomeBadPassword
-	AuthOutcomeProtocolError   = server.AuthOutcomeProtocolError
-	AuthOutcomeLoginDisabled   = server.AuthOutcomeLoginDisabled
-	AuthOutcomePasswordExpired = server.AuthOutcomePasswordExpired
-	AuthOutcomeLookupError     = server.AuthOutcomeLookupError
-
-	TLSOutcomeSuccess          = server.TLSOutcomeSuccess
-	TLSOutcomeHandshakeFailure = server.TLSOutcomeHandshakeFailure
-	TLSOutcomeClientAborted    = server.TLSOutcomeClientAborted
-
-	PlaintextRejectedReasonNoSSLRequest        = server.PlaintextRejectedReasonNoSSLRequest
-	PlaintextRejectedReasonTLSDisabledByServer = server.PlaintextRejectedReasonTLSDisabledByServer
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // GatewayMetrics holds OTel metrics for the multigateway service.
@@ -69,6 +46,8 @@ type GatewayMetrics struct {
 }
 
 // NewGatewayMetrics initializes OTel metrics for the multigateway service.
+// Individual metrics that fail to initialize use noop implementations and are
+// included in the returned error. The returned instance is always usable.
 func NewGatewayMetrics() (*GatewayMetrics, error) {
 	meter := otel.Meter("github.com/multigres/multigres/go/services/multigateway")
 
@@ -87,12 +66,13 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 
 	m.authSCRAMDuration, err = meter.Float64Histogram(
 		"mg.gateway.auth.scram.duration",
-		metric.WithDescription("Full SCRAM handshake duration (client-first to server-final)"),
+		metric.WithDescription("SCRAM handshake duration (client-first to server-final)"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10),
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.auth.scram.duration histogram: %w", err))
+		m.authSCRAMDuration = noop.Float64Histogram{}
 	}
 
 	m.authAttempts, err = meter.Int64Counter(
@@ -102,6 +82,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.auth.attempts counter: %w", err))
+		m.authAttempts = noop.Int64Counter{}
 	}
 
 	m.authCredentialLookupDuration, err = meter.Float64Histogram(
@@ -112,6 +93,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.auth.credential_lookup.duration histogram: %w", err))
+		m.authCredentialLookupDuration = noop.Float64Histogram{}
 	}
 
 	m.authCredentialLookupRate, err = meter.Int64Counter(
@@ -121,6 +103,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.auth.credential_lookup.rate counter: %w", err))
+		m.authCredentialLookupRate = noop.Int64Counter{}
 	}
 
 	m.tlsHandshakeDuration, err = meter.Float64Histogram(
@@ -131,6 +114,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.tls.handshake.duration histogram: %w", err))
+		m.tlsHandshakeDuration = noop.Float64Histogram{}
 	}
 
 	m.tlsConnections, err = meter.Int64Counter(
@@ -140,6 +124,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.tls.connections counter: %w", err))
+		m.tlsConnections = noop.Int64Counter{}
 	}
 
 	m.tlsPlaintextRejected, err = meter.Int64Counter(
@@ -149,6 +134,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.tls.plaintext_rejected counter: %w", err))
+		m.tlsPlaintextRejected = noop.Int64Counter{}
 	}
 
 	m.tlsSSLRequestDeclined, err = meter.Int64Counter(
@@ -158,6 +144,7 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.gateway.tls.sslrequest_declined counter: %w", err))
+		m.tlsSSLRequestDeclined = noop.Int64Counter{}
 	}
 
 	if len(errs) > 0 {
@@ -191,9 +178,9 @@ func (m *GatewayMetrics) RegisterClientConnectionsCallback(primaryGetter, replic
 }
 
 // RecordSCRAMDuration records the SCRAM handshake duration tagged by outcome.
-// Safe to call on a nil receiver — no-op so call sites can stay unconditional.
+// Safe to call on a nil receiver so call sites can stay unconditional.
 func (m *GatewayMetrics) RecordSCRAMDuration(ctx context.Context, outcome string, d time.Duration) {
-	if m == nil || m.authSCRAMDuration == nil {
+	if m == nil {
 		return
 	}
 	m.authSCRAMDuration.Record(ctx, d.Seconds(),
@@ -202,7 +189,7 @@ func (m *GatewayMetrics) RecordSCRAMDuration(ctx context.Context, outcome string
 
 // RecordAuthAttempt increments the auth-attempts counter tagged by outcome.
 func (m *GatewayMetrics) RecordAuthAttempt(ctx context.Context, outcome string) {
-	if m == nil || m.authAttempts == nil {
+	if m == nil {
 		return
 	}
 	m.authAttempts.Add(ctx, 1,
@@ -215,17 +202,13 @@ func (m *GatewayMetrics) RecordCredentialLookup(ctx context.Context, d time.Dura
 	if m == nil {
 		return
 	}
-	if m.authCredentialLookupDuration != nil {
-		m.authCredentialLookupDuration.Record(ctx, d.Seconds())
-	}
-	if m.authCredentialLookupRate != nil {
-		m.authCredentialLookupRate.Add(ctx, 1)
-	}
+	m.authCredentialLookupDuration.Record(ctx, d.Seconds())
+	m.authCredentialLookupRate.Add(ctx, 1)
 }
 
 // RecordTLSHandshake records the TLS handshake duration tagged by outcome.
 func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, outcome string, d time.Duration) {
-	if m == nil || m.tlsHandshakeDuration == nil {
+	if m == nil {
 		return
 	}
 	m.tlsHandshakeDuration.Record(ctx, d.Seconds(),
@@ -237,7 +220,7 @@ func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, outcome string,
 // crypto/tls so they match Go's published constants (e.g. "TLS 1.3",
 // "TLS_AES_128_GCM_SHA256").
 func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, version, cipher uint16) {
-	if m == nil || m.tlsConnections == nil {
+	if m == nil {
 		return
 	}
 	m.tlsConnections.Add(ctx, 1, metric.WithAttributes(
@@ -249,7 +232,7 @@ func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, version, ciphe
 // RecordPlaintextRejected increments the plaintext-rejection counter tagged
 // by reason.
 func (m *GatewayMetrics) RecordPlaintextRejected(ctx context.Context, reason string) {
-	if m == nil || m.tlsPlaintextRejected == nil {
+	if m == nil {
 		return
 	}
 	m.tlsPlaintextRejected.Add(ctx, 1,
@@ -259,7 +242,7 @@ func (m *GatewayMetrics) RecordPlaintextRejected(ctx context.Context, reason str
 // RecordSSLRequestDeclined increments the SSL-declined counter, used before
 // enforcement is enabled to size the impact of flipping --pg-require-ssl.
 func (m *GatewayMetrics) RecordSSLRequestDeclined(ctx context.Context) {
-	if m == nil || m.tlsSSLRequestDeclined == nil {
+	if m == nil {
 		return
 	}
 	m.tlsSSLRequestDeclined.Add(ctx, 1)

--- a/go/services/multigateway/metrics_test.go
+++ b/go/services/multigateway/metrics_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multigateway
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// setupGatewayMetrics installs a ManualReader-backed MeterProvider and
+// constructs a fresh GatewayMetrics. The provider is restored on cleanup
+// so other tests are not affected. Returns the metrics handle and the
+// reader so the caller can collect snapshots.
+func setupGatewayMetrics(t *testing.T) (*GatewayMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		_ = mp.Shutdown(context.Background())
+	})
+
+	m, err := NewGatewayMetrics()
+	require.NoError(t, err)
+	return m, reader
+}
+
+// findMetric returns the named metric's data from the most-recent collect,
+// or nil when the metric has not been emitted yet.
+func findMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Aggregation {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+	return nil
+}
+
+// attrLookup returns the string-valued attribute on the data point matching
+// key, or "" if absent. Used to assert outcome / reason label values.
+func attrLookup(t *testing.T, attrs attribute.Set, key string) string {
+	t.Helper()
+	v, ok := attrs.Value(attribute.Key(key))
+	if !ok {
+		return ""
+	}
+	return v.AsString()
+}
+
+func TestGatewayMetrics_RecordSCRAMDuration_TagsOutcome(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordSCRAMDuration(ctx, AuthOutcomeSuccess, 5*time.Millisecond)
+	m.RecordSCRAMDuration(ctx, AuthOutcomeBadPassword, 7*time.Millisecond)
+	m.RecordSCRAMDuration(ctx, AuthOutcomeBadPassword, 9*time.Millisecond)
+
+	agg := findMetric(t, reader, "mg.gateway.auth.scram.duration")
+	require.NotNil(t, agg, "scram duration histogram not emitted")
+
+	hist, ok := agg.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+	require.Len(t, hist.DataPoints, 2, "expected one bucket per outcome")
+
+	counts := map[string]uint64{}
+	for _, dp := range hist.DataPoints {
+		counts[attrLookup(t, dp.Attributes, "outcome")] = dp.Count
+	}
+	require.Equal(t, uint64(1), counts[AuthOutcomeSuccess])
+	require.Equal(t, uint64(2), counts[AuthOutcomeBadPassword])
+}
+
+func TestGatewayMetrics_RecordAuthAttempt_Increments(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
+	m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
+	m.RecordAuthAttempt(ctx, AuthOutcomeUserNotFound)
+
+	agg := findMetric(t, reader, "mg.gateway.auth.attempts")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64]")
+
+	values := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		values[attrLookup(t, dp.Attributes, "outcome")] = dp.Value
+	}
+	require.Equal(t, int64(2), values[AuthOutcomeSuccess])
+	require.Equal(t, int64(1), values[AuthOutcomeUserNotFound])
+}
+
+func TestGatewayMetrics_RecordCredentialLookup_RateAndDuration(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordCredentialLookup(ctx, 3*time.Millisecond)
+	m.RecordCredentialLookup(ctx, 4*time.Millisecond)
+
+	durAgg := findMetric(t, reader, "mg.gateway.auth.credential_lookup.duration")
+	require.NotNil(t, durAgg)
+	hist, ok := durAgg.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, hist.DataPoints, 1)
+	require.Equal(t, uint64(2), hist.DataPoints[0].Count)
+
+	rateAgg := findMetric(t, reader, "mg.gateway.auth.credential_lookup.rate")
+	require.NotNil(t, rateAgg)
+	sum, ok := rateAgg.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(2), sum.DataPoints[0].Value)
+}
+
+func TestGatewayMetrics_RecordTLSConnection_TagsVersionAndCipher(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordTLSConnection(ctx, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
+
+	agg := findMetric(t, reader, "mg.gateway.tls.connections")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	dp := sum.DataPoints[0]
+	require.Equal(t, "TLS 1.3", attrLookup(t, dp.Attributes, "tls_version"))
+	require.Equal(t, tls.CipherSuiteName(tls.TLS_AES_128_GCM_SHA256),
+		attrLookup(t, dp.Attributes, "cipher_suite"))
+	require.Equal(t, int64(1), dp.Value)
+}
+
+func TestGatewayMetrics_RecordPlaintextRejected_TagsReason(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
+	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
+	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonTLSDisabledByServer)
+
+	agg := findMetric(t, reader, "mg.gateway.tls.plaintext_rejected")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	values := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		values[attrLookup(t, dp.Attributes, "reason")] = dp.Value
+	}
+	require.Equal(t, int64(2), values[PlaintextRejectedReasonNoSSLRequest])
+	require.Equal(t, int64(1), values[PlaintextRejectedReasonTLSDisabledByServer])
+}
+
+func TestGatewayMetrics_RecordSSLRequestDeclined_Increments(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordSSLRequestDeclined(ctx)
+	m.RecordSSLRequestDeclined(ctx)
+	m.RecordSSLRequestDeclined(ctx)
+
+	agg := findMetric(t, reader, "mg.gateway.tls.sslrequest_declined")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(3), sum.DataPoints[0].Value)
+}
+
+func TestGatewayMetrics_NilReceiverIsNoop(t *testing.T) {
+	// All recorders must tolerate a nil receiver so call sites can stay
+	// unconditional even when metric init failed. Panic here would
+	// surface as a crash at the auth-rejection hot path.
+	var m *GatewayMetrics
+	ctx := context.Background()
+
+	require.NotPanics(t, func() {
+		m.RecordSCRAMDuration(ctx, AuthOutcomeSuccess, time.Second)
+		m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
+		m.RecordCredentialLookup(ctx, time.Second)
+		m.RecordTLSHandshake(ctx, TLSOutcomeSuccess, time.Second)
+		m.RecordTLSConnection(ctx, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
+		m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
+		m.RecordSSLRequestDeclined(ctx)
+	})
+}

--- a/go/services/multigateway/metrics_test.go
+++ b/go/services/multigateway/metrics_test.go
@@ -21,32 +21,25 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
-// setupGatewayMetrics installs a ManualReader-backed MeterProvider and
-// constructs a fresh GatewayMetrics. The provider is restored on cleanup
-// so other tests are not affected. Returns the metrics handle and the
-// reader so the caller can collect snapshots.
+// setupGatewayMetrics installs the shared test telemetry stack and returns
+// a fresh GatewayMetrics wired to its ManualReader.
 func setupGatewayMetrics(t *testing.T) (*GatewayMetrics, *sdkmetric.ManualReader) {
 	t.Helper()
 
-	reader := sdkmetric.NewManualReader()
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-
-	prev := otel.GetMeterProvider()
-	otel.SetMeterProvider(mp)
-	t.Cleanup(func() {
-		otel.SetMeterProvider(prev)
-		_ = mp.Shutdown(context.Background())
-	})
+	setup := telemetry.SetupTestTelemetry(t)
+	require.NoError(t, setup.Telemetry.InitTelemetry(t.Context(), "test-multigateway"))
 
 	m, err := NewGatewayMetrics()
 	require.NoError(t, err)
-	return m, reader
+	return m, setup.MetricReader
 }
 
 // findMetric returns the named metric's data from the most-recent collect,
@@ -80,9 +73,9 @@ func TestGatewayMetrics_RecordSCRAMDuration_TagsOutcome(t *testing.T) {
 	m, reader := setupGatewayMetrics(t)
 	ctx := context.Background()
 
-	m.RecordSCRAMDuration(ctx, AuthOutcomeSuccess, 5*time.Millisecond)
-	m.RecordSCRAMDuration(ctx, AuthOutcomeBadPassword, 7*time.Millisecond)
-	m.RecordSCRAMDuration(ctx, AuthOutcomeBadPassword, 9*time.Millisecond)
+	m.RecordSCRAMDuration(ctx, server.AuthOutcomeSuccess, 5*time.Millisecond)
+	m.RecordSCRAMDuration(ctx, server.AuthOutcomeBadPassword, 7*time.Millisecond)
+	m.RecordSCRAMDuration(ctx, server.AuthOutcomeBadPassword, 9*time.Millisecond)
 
 	agg := findMetric(t, reader, "mg.gateway.auth.scram.duration")
 	require.NotNil(t, agg, "scram duration histogram not emitted")
@@ -95,17 +88,17 @@ func TestGatewayMetrics_RecordSCRAMDuration_TagsOutcome(t *testing.T) {
 	for _, dp := range hist.DataPoints {
 		counts[attrLookup(t, dp.Attributes, "outcome")] = dp.Count
 	}
-	require.Equal(t, uint64(1), counts[AuthOutcomeSuccess])
-	require.Equal(t, uint64(2), counts[AuthOutcomeBadPassword])
+	require.Equal(t, uint64(1), counts[server.AuthOutcomeSuccess])
+	require.Equal(t, uint64(2), counts[server.AuthOutcomeBadPassword])
 }
 
 func TestGatewayMetrics_RecordAuthAttempt_Increments(t *testing.T) {
 	m, reader := setupGatewayMetrics(t)
 	ctx := context.Background()
 
-	m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
-	m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
-	m.RecordAuthAttempt(ctx, AuthOutcomeUserNotFound)
+	m.RecordAuthAttempt(ctx, server.AuthOutcomeSuccess)
+	m.RecordAuthAttempt(ctx, server.AuthOutcomeSuccess)
+	m.RecordAuthAttempt(ctx, server.AuthOutcomeUserNotFound)
 
 	agg := findMetric(t, reader, "mg.gateway.auth.attempts")
 	require.NotNil(t, agg)
@@ -116,8 +109,8 @@ func TestGatewayMetrics_RecordAuthAttempt_Increments(t *testing.T) {
 	for _, dp := range sum.DataPoints {
 		values[attrLookup(t, dp.Attributes, "outcome")] = dp.Value
 	}
-	require.Equal(t, int64(2), values[AuthOutcomeSuccess])
-	require.Equal(t, int64(1), values[AuthOutcomeUserNotFound])
+	require.Equal(t, int64(2), values[server.AuthOutcomeSuccess])
+	require.Equal(t, int64(1), values[server.AuthOutcomeUserNotFound])
 }
 
 func TestGatewayMetrics_RecordCredentialLookup_RateAndDuration(t *testing.T) {
@@ -164,9 +157,9 @@ func TestGatewayMetrics_RecordPlaintextRejected_TagsReason(t *testing.T) {
 	m, reader := setupGatewayMetrics(t)
 	ctx := context.Background()
 
-	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
-	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
-	m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonTLSDisabledByServer)
+	m.RecordPlaintextRejected(ctx, server.PlaintextRejectedReasonNoSSLRequest)
+	m.RecordPlaintextRejected(ctx, server.PlaintextRejectedReasonNoSSLRequest)
+	m.RecordPlaintextRejected(ctx, server.PlaintextRejectedReasonTLSDisabledByServer)
 
 	agg := findMetric(t, reader, "mg.gateway.tls.plaintext_rejected")
 	require.NotNil(t, agg)
@@ -177,8 +170,8 @@ func TestGatewayMetrics_RecordPlaintextRejected_TagsReason(t *testing.T) {
 	for _, dp := range sum.DataPoints {
 		values[attrLookup(t, dp.Attributes, "reason")] = dp.Value
 	}
-	require.Equal(t, int64(2), values[PlaintextRejectedReasonNoSSLRequest])
-	require.Equal(t, int64(1), values[PlaintextRejectedReasonTLSDisabledByServer])
+	require.Equal(t, int64(2), values[server.PlaintextRejectedReasonNoSSLRequest])
+	require.Equal(t, int64(1), values[server.PlaintextRejectedReasonTLSDisabledByServer])
 }
 
 func TestGatewayMetrics_RecordSSLRequestDeclined_Increments(t *testing.T) {
@@ -205,12 +198,12 @@ func TestGatewayMetrics_NilReceiverIsNoop(t *testing.T) {
 	ctx := context.Background()
 
 	require.NotPanics(t, func() {
-		m.RecordSCRAMDuration(ctx, AuthOutcomeSuccess, time.Second)
-		m.RecordAuthAttempt(ctx, AuthOutcomeSuccess)
+		m.RecordSCRAMDuration(ctx, server.AuthOutcomeSuccess, time.Second)
+		m.RecordAuthAttempt(ctx, server.AuthOutcomeSuccess)
 		m.RecordCredentialLookup(ctx, time.Second)
-		m.RecordTLSHandshake(ctx, TLSOutcomeSuccess, time.Second)
+		m.RecordTLSHandshake(ctx, server.TLSOutcomeSuccess, time.Second)
 		m.RecordTLSConnection(ctx, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
-		m.RecordPlaintextRejected(ctx, PlaintextRejectedReasonNoSSLRequest)
+		m.RecordPlaintextRejected(ctx, server.PlaintextRejectedReasonNoSSLRequest)
 		m.RecordSSLRequestDeclined(ctx)
 	})
 }

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -16,6 +16,7 @@ package connpoolmanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
@@ -106,12 +107,19 @@ type PoolManager interface {
 	// Stats returns statistics for all pools.
 	Stats() ManagerStats
 
-	// Metrics returns the manager's OTel metrics handle for ad-hoc
-	// recording (e.g. auth-path observations in the gRPC service).
-	// May return nil when the manager is unopened or metric init failed;
-	// callers should treat nil as the noop sink — the *Metrics methods
-	// are nil-safe.
-	Metrics() *Metrics
+	// CredentialQueryRecorder returns a narrow recorder for auth-path
+	// observations made by the gRPC service. May return nil when the
+	// manager is unopened or metric init failed; the underlying *Metrics
+	// receiver is nil-safe, so callers can treat nil as the noop sink.
+	CredentialQueryRecorder() CredentialQueryRecorder
+}
+
+// CredentialQueryRecorder records credential-query latency and error-type
+// labels. Implemented by *Metrics; declared as an interface so callers
+// (e.g. grpcpoolerservice) do not couple to the full pool-manager metrics
+// surface.
+type CredentialQueryRecorder interface {
+	RecordCredentialQuery(ctx context.Context, d time.Duration, errorType string)
 }
 
 // Compile-time check that Manager implements PoolManager.

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -105,6 +105,13 @@ type PoolManager interface {
 
 	// Stats returns statistics for all pools.
 	Stats() ManagerStats
+
+	// Metrics returns the manager's OTel metrics handle for ad-hoc
+	// recording (e.g. auth-path observations in the gRPC service).
+	// May return nil when the manager is unopened or metric init failed;
+	// callers should treat nil as the noop sink — the *Metrics methods
+	// are nil-safe.
+	Metrics() *Metrics
 }
 
 // Compile-time check that Manager implements PoolManager.

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -105,6 +105,18 @@ type Manager struct {
 	zeroCh    chan struct{}
 }
 
+// Metrics returns the manager's OTel metrics handle. Safe to call when the
+// manager is unopened or metric init failed — the caller treats a nil
+// return as the noop sink. Used by the gRPC service to record auth-path
+// observations without taking a hard dependency on the manager's
+// initialization order.
+func (m *Manager) Metrics() *Metrics {
+	if m == nil {
+		return nil
+	}
+	return m.metrics
+}
+
 // Open initializes the manager and creates the shared admin pool.
 // User pools are created lazily on first connection request.
 //

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -105,12 +105,11 @@ type Manager struct {
 	zeroCh    chan struct{}
 }
 
-// Metrics returns the manager's OTel metrics handle. Safe to call when the
-// manager is unopened or metric init failed — the caller treats a nil
-// return as the noop sink. Used by the gRPC service to record auth-path
-// observations without taking a hard dependency on the manager's
-// initialization order.
-func (m *Manager) Metrics() *Metrics {
+// CredentialQueryRecorder returns a narrow recorder for the gRPC service's
+// credential-query observations. Returns nil when the manager is unopened
+// or metric init failed; the *Metrics receiver is nil-safe, so callers
+// can treat a nil return as the noop sink.
+func (m *Manager) CredentialQueryRecorder() CredentialQueryRecorder {
 	if m == nil {
 		return nil
 	}

--- a/go/services/multipooler/connpoolmanager/metrics.go
+++ b/go/services/multipooler/connpoolmanager/metrics.go
@@ -30,9 +30,15 @@ import (
 
 // Error type labels for mg.pooler.auth.credential_query.errors. Closed set,
 // driven by the failure modes in grpcpoolerservice.GetAuthCredentials so
-// the cardinality stays bounded.
+// the cardinality stays bounded. user_not_found / login_disabled /
+// password_expired are policy outcomes of a successful pg_authid query
+// (baseline traffic); pool_acquire_failed / db_error indicate operator
+// issues. All five are tagged on the counter so the success rate equals
+// duration_count - errors_total.
 const (
 	CredentialQueryErrorUserNotFound      = "user_not_found"
+	CredentialQueryErrorLoginDisabled     = "login_disabled"
+	CredentialQueryErrorPasswordExpired   = "password_expired"
 	CredentialQueryErrorPoolAcquireFailed = "pool_acquire_failed"
 	CredentialQueryErrorDB                = "db_error"
 )

--- a/go/services/multipooler/connpoolmanager/metrics.go
+++ b/go/services/multipooler/connpoolmanager/metrics.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 )
@@ -263,6 +264,7 @@ func NewMetrics() (*Metrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.pooler.auth.credential_query.duration histogram: %w", err))
+		m.authCredQueryDuration = noop.Float64Histogram{}
 	}
 
 	// Auth credential-query error counter.
@@ -273,6 +275,7 @@ func NewMetrics() (*Metrics, error) {
 	)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("mg.pooler.auth.credential_query.errors counter: %w", err))
+		m.authCredQueryErrors = noop.Int64Counter{}
 	}
 
 	if len(errs) > 0 {
@@ -285,16 +288,14 @@ func NewMetrics() (*Metrics, error) {
 // RecordCredentialQuery records a credential-query latency observation and,
 // when errorType is non-empty, bumps the corresponding error counter. Use
 // the CredentialQueryError* constants for errorType so the label set stays
-// closed. Safe to call on a nil receiver — no-op so the gRPC handler can
-// stay unconditional even when metric init failed.
+// closed. Safe to call on a nil receiver so the gRPC handler can stay
+// unconditional even when metric init failed.
 func (m *Metrics) RecordCredentialQuery(ctx context.Context, d time.Duration, errorType string) {
 	if m == nil {
 		return
 	}
-	if m.authCredQueryDuration != nil {
-		m.authCredQueryDuration.Record(ctx, d.Seconds())
-	}
-	if errorType != "" && m.authCredQueryErrors != nil {
+	m.authCredQueryDuration.Record(ctx, d.Seconds())
+	if errorType != "" {
 		m.authCredQueryErrors.Add(ctx, 1,
 			metric.WithAttributes(attribute.String("error_type", errorType)))
 	}

--- a/go/services/multipooler/connpoolmanager/metrics.go
+++ b/go/services/multipooler/connpoolmanager/metrics.go
@@ -18,12 +18,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
+)
+
+// Error type labels for mg.pooler.auth.credential_query.errors. Closed set,
+// driven by the failure modes in grpcpoolerservice.GetAuthCredentials so
+// the cardinality stays bounded.
+const (
+	CredentialQueryErrorUserNotFound      = "user_not_found"
+	CredentialQueryErrorPoolAcquireFailed = "pool_acquire_failed"
+	CredentialQueryErrorDB                = "db_error"
 )
 
 // Metrics holds OpenTelemetry metrics for connection pool management.
@@ -79,6 +89,21 @@ type Metrics struct {
 
 	// queriesPooledTotal is the total number of connections borrowed (Get() calls).
 	queriesPooledTotal metric.Int64ObservableCounter
+
+	// --- Auth-path metrics (mg.pooler.auth.*) ---
+
+	// authCredQueryDuration histograms the wall-clock duration of the
+	// admin-pool `SELECT rolpassword FROM pg_authid` lookup the gateway
+	// triggers via GetAuthCredentials. Covers admin-pool acquire +
+	// query + result decode end-to-end, so a tail rise here is the
+	// first signal that the admin pool is contended.
+	authCredQueryDuration metric.Float64Histogram
+
+	// authCredQueryErrors counts the failure modes of the credential
+	// query, labeled by error type (user_not_found / pool_acquire_failed
+	// / db_error). user_not_found is the legitimate-traffic baseline;
+	// the other two indicate operator issues.
+	authCredQueryErrors metric.Int64Counter
 }
 
 // NewMetrics initializes OpenTelemetry metrics for connection pool management.
@@ -229,11 +254,50 @@ func NewMetrics() (*Metrics, error) {
 		errs = append(errs, fmt.Errorf("mg.pooler.queries_pooled_total counter: %w", err))
 	}
 
+	// Auth credential-query latency histogram.
+	m.authCredQueryDuration, err = meter.Float64Histogram(
+		"mg.pooler.auth.credential_query.duration",
+		metric.WithDescription("Admin-pool SELECT rolpassword FROM pg_authid lookup duration"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.auth.credential_query.duration histogram: %w", err))
+	}
+
+	// Auth credential-query error counter.
+	m.authCredQueryErrors, err = meter.Int64Counter(
+		"mg.pooler.auth.credential_query.errors",
+		metric.WithDescription("Credential-query failures labeled by error type"),
+		metric.WithUnit("{error}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.pooler.auth.credential_query.errors counter: %w", err))
+	}
+
 	if len(errs) > 0 {
 		return m, errors.Join(errs...)
 	}
 
 	return m, nil
+}
+
+// RecordCredentialQuery records a credential-query latency observation and,
+// when errorType is non-empty, bumps the corresponding error counter. Use
+// the CredentialQueryError* constants for errorType so the label set stays
+// closed. Safe to call on a nil receiver — no-op so the gRPC handler can
+// stay unconditional even when metric init failed.
+func (m *Metrics) RecordCredentialQuery(ctx context.Context, d time.Duration, errorType string) {
+	if m == nil {
+		return
+	}
+	if m.authCredQueryDuration != nil {
+		m.authCredQueryDuration.Record(ctx, d.Seconds())
+	}
+	if errorType != "" && m.authCredQueryErrors != nil {
+		m.authCredQueryErrors.Add(ctx, 1,
+			metric.WithAttributes(attribute.String("error_type", errorType)))
+	}
 }
 
 // RegisterManagerCallbacks registers OTel observable callbacks that read pool statistics.

--- a/go/services/multipooler/connpoolmanager/metrics_test.go
+++ b/go/services/multipooler/connpoolmanager/metrics_test.go
@@ -20,28 +20,22 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
 func setupPoolerMetrics(t *testing.T) (*Metrics, *sdkmetric.ManualReader) {
 	t.Helper()
 
-	reader := sdkmetric.NewManualReader()
-	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-
-	prev := otel.GetMeterProvider()
-	otel.SetMeterProvider(mp)
-	t.Cleanup(func() {
-		otel.SetMeterProvider(prev)
-		_ = mp.Shutdown(context.Background())
-	})
+	setup := telemetry.SetupTestTelemetry(t)
+	require.NoError(t, setup.Telemetry.InitTelemetry(t.Context(), "test-multipooler"))
 
 	m, err := NewMetrics()
 	require.NoError(t, err)
-	return m, reader
+	return m, setup.MetricReader
 }
 
 func collectAggregation(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Aggregation {

--- a/go/services/multipooler/connpoolmanager/metrics_test.go
+++ b/go/services/multipooler/connpoolmanager/metrics_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connpoolmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func setupPoolerMetrics(t *testing.T) (*Metrics, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		_ = mp.Shutdown(context.Background())
+	})
+
+	m, err := NewMetrics()
+	require.NoError(t, err)
+	return m, reader
+}
+
+func collectAggregation(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Aggregation {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+	return nil
+}
+
+// TestMetrics_RecordCredentialQuery_DurationAlwaysRecorded ensures the
+// histogram fires on every call (success and error) so success-path
+// latency is also visible — operators triaging the admin pool need to see
+// the full distribution, not only failures.
+func TestMetrics_RecordCredentialQuery_DurationAlwaysRecorded(t *testing.T) {
+	m, reader := setupPoolerMetrics(t)
+	ctx := context.Background()
+
+	m.RecordCredentialQuery(ctx, 5*time.Millisecond, "")
+	m.RecordCredentialQuery(ctx, 7*time.Millisecond, CredentialQueryErrorUserNotFound)
+	m.RecordCredentialQuery(ctx, 8*time.Millisecond, CredentialQueryErrorPoolAcquireFailed)
+
+	agg := collectAggregation(t, reader, "mg.pooler.auth.credential_query.duration")
+	require.NotNil(t, agg, "duration histogram not emitted")
+	hist, ok := agg.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+	require.Len(t, hist.DataPoints, 1)
+	require.Equal(t, uint64(3), hist.DataPoints[0].Count,
+		"all three calls should land in the unlabeled histogram bucket")
+}
+
+// TestMetrics_RecordCredentialQuery_ErrorCounter checks that the error
+// counter only fires when an error_type is supplied and that each label
+// is its own bucket.
+func TestMetrics_RecordCredentialQuery_ErrorCounter(t *testing.T) {
+	m, reader := setupPoolerMetrics(t)
+	ctx := context.Background()
+
+	m.RecordCredentialQuery(ctx, time.Millisecond, "")
+	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorUserNotFound)
+	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorUserNotFound)
+	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorDB)
+
+	agg := collectAggregation(t, reader, "mg.pooler.auth.credential_query.errors")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	counts := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		v, _ := dp.Attributes.Value(attribute.Key("error_type"))
+		counts[v.AsString()] = dp.Value
+	}
+	require.Equal(t, int64(2), counts[CredentialQueryErrorUserNotFound])
+	require.Equal(t, int64(1), counts[CredentialQueryErrorDB])
+	require.NotContains(t, counts, "", "empty error_type should not produce a counter point")
+}
+
+// TestMetrics_RecordCredentialQuery_NilReceiver ensures the gRPC handler
+// can call through a nil *Metrics without crashing — metric init may
+// have failed at startup, and the auth path must keep working.
+func TestMetrics_RecordCredentialQuery_NilReceiver(t *testing.T) {
+	var m *Metrics
+	require.NotPanics(t, func() {
+		m.RecordCredentialQuery(context.Background(), time.Millisecond, CredentialQueryErrorDB)
+	})
+}

--- a/go/services/multipooler/connpoolmanager/metrics_test.go
+++ b/go/services/multipooler/connpoolmanager/metrics_test.go
@@ -83,6 +83,8 @@ func TestMetrics_RecordCredentialQuery_ErrorCounter(t *testing.T) {
 	m.RecordCredentialQuery(ctx, time.Millisecond, "")
 	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorUserNotFound)
 	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorUserNotFound)
+	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorLoginDisabled)
+	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorPasswordExpired)
 	m.RecordCredentialQuery(ctx, time.Millisecond, CredentialQueryErrorDB)
 
 	agg := collectAggregation(t, reader, "mg.pooler.auth.credential_query.errors")
@@ -96,6 +98,8 @@ func TestMetrics_RecordCredentialQuery_ErrorCounter(t *testing.T) {
 		counts[v.AsString()] = dp.Value
 	}
 	require.Equal(t, int64(2), counts[CredentialQueryErrorUserNotFound])
+	require.Equal(t, int64(1), counts[CredentialQueryErrorLoginDisabled])
+	require.Equal(t, int64(1), counts[CredentialQueryErrorPasswordExpired])
 	require.Equal(t, int64(1), counts[CredentialQueryErrorDB])
 	require.NotContains(t, counts, "", "empty error_type should not produce a counter point")
 }

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -187,11 +187,13 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 	// gateway-visible auth latency. The duration is recorded on every
 	// exit, error or not; the error counter only fires on failures so
 	// the success rate is implicit.
-	metrics := poolManager.Metrics()
+	recorder := poolManager.CredentialQueryRecorder()
 	start := time.Now()
 	var errorType string
 	defer func() {
-		metrics.RecordCredentialQuery(ctx, time.Since(start), errorType)
+		if recorder != nil {
+			recorder.RecordCredentialQuery(ctx, time.Since(start), errorType)
+		}
 	}()
 
 	// An admin connection:

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -222,6 +222,7 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 			// codes.Unauthenticated for transport failures; keying on code
 			// alone would misclassify an mTLS or authz error as an app-level
 			// "role not permitted to log in" rejection to the end user.
+			errorType = connpoolmanager.CredentialQueryErrorLoginDisabled
 			return nil, mterrors.ToGRPC(mterrors.NewPgError(
 				"FATAL", mterrors.PgSSInvalidAuthSpec,
 				fmt.Sprintf("role %q is not permitted to log in", req.Username),
@@ -231,6 +232,7 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 			// SQLSTATE 28P01 matches PG's opaque "password authentication
 			// failed" error for expired passwords. PgDiagnostic detail
 			// survives the gRPC round trip and the gateway matches on it.
+			errorType = connpoolmanager.CredentialQueryErrorPasswordExpired
 			return nil, mterrors.ToGRPC(mterrors.NewPgError(
 				"FATAL", mterrors.PgSSAuthFailed,
 				fmt.Sprintf("password authentication failed for user %q", req.Username),

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,6 +31,7 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multipooler/connpoolmanager"
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
 	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
 	"github.com/multigres/multigres/go/services/multipooler/pubsub"
@@ -179,12 +181,26 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 		return nil, status.Error(codes.Unavailable, "pool manager not initialized")
 	}
 
+	// Time the full credential-query path (admin acquire + pg_authid
+	// lookup + decode) for mg.pooler.auth.credential_query.duration so
+	// admin-pool contention shows up before it cascades into
+	// gateway-visible auth latency. The duration is recorded on every
+	// exit, error or not; the error counter only fires on failures so
+	// the success rate is implicit.
+	metrics := poolManager.Metrics()
+	start := time.Now()
+	var errorType string
+	defer func() {
+		metrics.RecordCredentialQuery(ctx, time.Since(start), errorType)
+	}()
+
 	// An admin connection:
 	// - has permission to read password hashes
 	// - also avoids a chicken-egg scenario of needing to create and use a role-specific connection
 	//   to figure out if the caller should have access to that role-specific connection.
 	conn, err := poolManager.GetAdminConn(ctx)
 	if err != nil {
+		errorType = connpoolmanager.CredentialQueryErrorPoolAcquireFailed
 		return nil, status.Errorf(codes.Unavailable, "failed to get admin connection: %v", err)
 	}
 	defer conn.Recycle()
@@ -195,6 +211,7 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 	if err != nil {
 		switch {
 		case errors.Is(err, admin.ErrUserNotFound):
+			errorType = connpoolmanager.CredentialQueryErrorUserNotFound
 			return nil, status.Errorf(codes.NotFound, "user %q not found", req.Username)
 		case errors.Is(err, admin.ErrLoginDisabled):
 			// Emit as a PgDiagnostic so the SQLSTATE (28000) is the

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -235,6 +235,11 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 				"",
 			))
 		default:
+			// Genuine DB-level failure (SQL error, unexpected result shape,
+			// connection drop mid-query). Tagged db_error so operators can
+			// alert on it without false positives from the user_not_found
+			// baseline.
+			errorType = connpoolmanager.CredentialQueryErrorDB
 			return nil, status.Errorf(codes.Internal, "failed to get role password: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Closes MUL-372.

Instrument the MultiGateway auth path and the MultiPooler credential query so login slowdowns are diagnosable and SSL enforcement is observable. Pre-existing TLS startup paths had no signal, leaving "is plaintext actually rejected fleet-wide?" unanswerable.

### Metrics added

**Gateway** (`mg.gateway.auth.*`, `mg.gateway.tls.*`):
- `auth.attempts` (counter, `outcome`)
- `auth.scram.duration` (histogram, `outcome`)
- `auth.credential_lookup.duration` / `.rate`
- `tls.handshake.duration` (`outcome`)
- `tls.connections` (`tls_version`, `cipher_suite`)
- `tls.plaintext_rejected` (`reason`)
- `tls.sslrequest_declined`

**Pooler** (`mg.pooler.auth.*`):
- `credential_query.duration`
- `credential_query.errors` (`error_type`)

### Architecture

- `pgprotocol/server` defines `AuthMetricsRecorder` + canonical outcome / reason label constants so the listener emits metrics without importing service code, keeping the protocol package OTel-free.
- `multigateway.GatewayMetrics` implements the recorder. A `CredentialLookupRecorder` interface in `auth/` avoids an import cycle.
- `connpoolmanager.Manager` exposes `Metrics()` so `grpcpoolerservice` can record auth-path observations without ordering coupling.

All `Record*` methods are nil-safe so init failures degrade to noop emission rather than crashing the auth hot path. Histograms use explicit bucket boundaries (`0.5ms` to `10s`) matching the existing query / scatter convention; default OTel buckets start at 5s and would collapse all auth latencies into a single bucket.

### Dashboard

Panels added under **Multigateway - Auth & TLS** and **Multipooler - Auth** in `demo/observability/grafana-dashboard.json`, matching the precedent set by #800 (backup/restore) and #874 (per-query): new metric, new panel, same PR.

<img width="1418" height="714" alt="Screenshot 2026-05-20 at 15 03 44" src="https://github.com/user-attachments/assets/49ced415-979d-4bc3-a0b2-2ba5383c7a6c" />

<img width="1415" height="483" alt="Screenshot 2026-05-20 at 15 03 57" src="https://github.com/user-attachments/assets/9e22b275-18e2-4b32-abda-4f90137eba12" />



## Test plan

- [x] Unit tests pass: `pgprotocol/server`, `multigateway` (+ subpackages), `multipooler/connpoolmanager`, `multipooler/grpcpoolerservice`
- [x] Race detector clean on touched packages
- [x] Manually verified end-to-end in local cluster (`demo/local/multigres-with-otel.sh`):
  - Drove auth via `pgbench -C` + targeted bad-password / unknown-user loops
  - Verified all `outcome` / `reason` / `error_type` labels render distinct lines on dashboard
  - Verified TLS panels populate under `pg-require-ssl=true` with self-signed cert: `tls.handshake.duration{outcome=success}`, `tls.connections{tls_version=TLS 1.3, cipher_suite=TLS_AES_128_GCM_SHA256}`, `tls.plaintext_rejected{reason=no_sslrequest}`, `tls.sslrequest_declined`
