### PR TITLE
feat(pgctld): add --pg-initdb-sql-dir flag for directory-based SQL init

### DIFF
--- a/go/cmd/pgctld/command/flags_test.go
+++ b/go/cmd/pgctld/command/flags_test.go
@@ -147,6 +147,43 @@ func TestPgInitdbExtraConfFlag(t *testing.T) {
 	})
 }
 
+func TestPgInitdbSQLDirsFlag(t *testing.T) {
+	t.Run("defaults to empty slice", func(t *testing.T) {
+		_, pc := GetRootCommand()
+		assert.Empty(t, pc.pgInitdbSQLDirs.Get())
+	})
+
+	t.Run("accepts repeated flag", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--pg-initdb-sql-dirs", "postgres:/tmp/init-scripts",
+			"--pg-initdb-sql-dirs", "multigres:/tmp/migrations",
+		}))
+		assert.Equal(t, []string{"postgres:/tmp/init-scripts", "multigres:/tmp/migrations"}, pc.pgInitdbSQLDirs.Get())
+	})
+
+	t.Run("accepts comma-separated values", func(t *testing.T) {
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{
+			"--pg-initdb-sql-dirs", "postgres:/tmp/init-scripts,multigres:/tmp/migrations",
+		}))
+		assert.Equal(t, []string{"postgres:/tmp/init-scripts", "multigres:/tmp/migrations"}, pc.pgInitdbSQLDirs.Get())
+	})
+
+	t.Run("POSTGRES_INITDB_SQL_DIRS env var is used when flag not set", func(t *testing.T) {
+		t.Setenv(constants.PgInitdbSQLDirsEnvVar, "postgres:/tmp/init-scripts")
+		_, pc := GetRootCommand()
+		assert.Equal(t, []string{"postgres:/tmp/init-scripts"}, pc.pgInitdbSQLDirs.Get())
+	})
+
+	t.Run("flag overrides POSTGRES_INITDB_SQL_DIRS env var", func(t *testing.T) {
+		t.Setenv(constants.PgInitdbSQLDirsEnvVar, "postgres:/tmp/env-dir")
+		root, pc := GetRootCommand()
+		require.NoError(t, root.ParseFlags([]string{"--pg-initdb-sql-dirs", "postgres:/tmp/flag-dir"}))
+		assert.Equal(t, []string{"postgres:/tmp/flag-dir"}, pc.pgInitdbSQLDirs.Get())
+	})
+}
+
 func TestPgBackRestFlags(t *testing.T) {
 	// Test default values
 	rootCmd, _ := GetRootCommand()

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/multigres/multigres/go/common/constants"
@@ -113,7 +114,7 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 
 	// Post-initdb steps that need a running server (custom DB creation, init
 	// SQL files) share a single transient PostgreSQL instance.
-	if cfg.Database != constants.DefaultPostgresDatabase || len(cfg.InitdbSQLFiles) > 0 {
+	if cfg.Database != constants.DefaultPostgresDatabase || len(cfg.InitdbSQLFiles) > 0 || len(cfg.InitdbSQLDirs) > 0 {
 		if err := postInitdbSetup(logger, cfg); err != nil {
 			return nil, err
 		}
@@ -127,12 +128,21 @@ func InitDataDirWithResult(logger *slog.Logger, poolerDir string, cfg PgCtldServ
 
 // postInitdbSetup starts a transient PostgreSQL instance and performs any
 // post-initdb setup steps: creating a custom target database (if requested)
-// and running user-provided init SQL files against the target database.
+// and running user-provided init SQL against the target database.
+//
+// Execution order:
+//  1. Create target database (if non-default).
+//  2. Run --pg-initdb-sql-dirs: bulk schema/migration directories, each under
+//     SET SESSION AUTHORIZATION <role>. Directories establish the base schema.
+//  3. Run --pg-initdb-sql-files: individual files applied on top as targeted
+//     overrides or patches.
 func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	createDB := cfg.Database != constants.DefaultPostgresDatabase
 
 	logger.Info("Starting PostgreSQL transiently for post-initdb setup",
-		"create_database", createDB, "init_sql_files", len(cfg.InitdbSQLFiles))
+		"create_database", createDB,
+		"init_sql_files", len(cfg.InitdbSQLFiles),
+		"init_sql_dirs", len(cfg.InitdbSQLDirs))
 	pg, err := newPgInstance(logger, pgctld.PostgresDataDir(), pgctld.PostgresConfigFile(), cfg)
 	if err != nil {
 		return err
@@ -145,6 +155,12 @@ func postInitdbSetup(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 		}
 	}
 
+	// Dirs first: establish bulk schema/migrations under the specified roles.
+	if err := runInitdbSQLDirs(logger, pg, cfg.Database, cfg.InitdbSQLDirs); err != nil {
+		return err
+	}
+
+	// Files second: apply targeted overrides or patches on top of the base schema.
 	if err := runInitdbSQLFiles(logger, pg, cfg.Database, cfg.InitdbSQLFiles); err != nil {
 		return err
 	}
@@ -169,6 +185,69 @@ func runInitdbSQLFiles(logger *slog.Logger, pg *pgInstance, database string, fil
 	return nil
 }
 
+// runInitdbSQLDirs processes each role:path entry: reads all .sql files from the
+// directory in lexicographic order and runs them in a single psql session under
+// SET SESSION AUTHORIZATION "<role>" / RESET SESSION AUTHORIZATION.
+func runInitdbSQLDirs(logger *slog.Logger, pg *pgInstance, database string, entries []string) error {
+	for _, entry := range entries {
+		role, dir, err := parseSQLDirEntry(entry)
+		if err != nil {
+			return err
+		}
+
+		files, err := sqlFilesInDir(dir)
+		if err != nil {
+			return err
+		}
+		if len(files) == 0 {
+			logger.Info("Init SQL dir is empty, skipping", "dir", dir, "role", role)
+			continue
+		}
+
+		logger.Info("Running init SQL dir", "dir", dir, "role", role, "files", len(files), "database", database)
+		args := []string{
+			"-v", "ON_ERROR_STOP=1",
+			"-c", "SET SESSION AUTHORIZATION " + quoteIdentifier(role),
+		}
+		for _, f := range files {
+			args = append(args, "-f", f)
+		}
+		args = append(args, "-c", "RESET SESSION AUTHORIZATION")
+
+		if out, err := pg.psql(database, args...); err != nil {
+			return fmt.Errorf("init SQL dir failed (%s as %s): %w\nOutput: %s", dir, role, err, out)
+		}
+		logger.Info("Init SQL dir applied", "dir", dir, "role", role)
+	}
+	return nil
+}
+
+// parseSQLDirEntry splits a "role:path" entry on the first colon.
+func parseSQLDirEntry(entry string) (role, dir string, err error) {
+	idx := strings.IndexByte(entry, ':')
+	if idx <= 0 {
+		return "", "", fmt.Errorf("invalid --pg-initdb-sql-dir entry %q: expected role:path format", entry)
+	}
+	return entry[:idx], entry[idx+1:], nil
+}
+
+// sqlFilesInDir returns .sql file paths from dir in lexicographic order,
+// skipping subdirectories and non-.sql files.
+// os.ReadDir already returns entries sorted by name.
+func sqlFilesInDir(dir string) ([]string, error) {
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read init SQL dir %q: %w", dir, err)
+	}
+	var files []string
+	for _, e := range dirEntries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			files = append(files, filepath.Join(dir, e.Name()))
+		}
+	}
+	return files, nil
+}
+
 func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 	poolerDir := i.pgCtlCmd.GetPoolerDir()
 	cfg := PgCtldServiceConfig{
@@ -177,6 +256,7 @@ func (i *PgCtldInitCmd) runInit(cmd *cobra.Command, args []string) error {
 		Database:             i.pgCtlCmd.pgDatabase.Get(),
 		Password:             i.pgCtlCmd.pgPassword.Get(),
 		InitdbSQLFiles:       i.pgCtlCmd.pgInitdbSQLFiles.Get(),
+		InitdbSQLDirs:        i.pgCtlCmd.pgInitdbSQLDirs.Get(),
 		InitdbExtraConfFiles: i.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
 	result, err := InitDataDirWithResult(i.pgCtlCmd.lg.GetLogger(), poolerDir, cfg)
@@ -214,11 +294,9 @@ func createDatabaseOnInstance(logger *slog.Logger, pg *pgInstance, database stri
 		return nil
 	}
 
-	// CREATE DATABASE with a double-quoted identifier; double quotes in the name
-	// are escaped as "" per the SQL standard.
 	logger.Info("Creating database", "database", database)
 	if out, err := pg.psql(constants.DefaultPostgresDatabase,
-		"-c", fmt.Sprintf(`CREATE DATABASE "%s"`, strings.ReplaceAll(database, `"`, `""`)),
+		"-c", "CREATE DATABASE "+quoteIdentifier(database),
 	); err != nil {
 		return fmt.Errorf("failed to create database %q: %w\nOutput: %s", database, err, out)
 	}
@@ -286,4 +364,14 @@ func initializeDataDir(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	logger.Info("User password set successfully", "user", cfg.User, "password_source", "POSTGRES_PASSWORD environment variable")
 
 	return nil
+}
+
+// quoteIdentifier wraps name in double quotes and escapes any embedded double
+// quotes as "" per the SQL standard, producing a safe PostgreSQL identifier.
+// The value comes from operator config, not from untrusted user input, so a
+// simple ReplaceAll is sufficient here. If that assumption ever changes, replace
+// this with pq.QuoteIdentifier from github.com/lib/pq, which applies the same
+// escaping but is a well-tested, purpose-built function.
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/go/cmd/pgctld/command/root.go
+++ b/go/cmd/pgctld/command/root.go
@@ -50,6 +50,7 @@ type PgCtlCommand struct {
 	postgresConfigTmpl viperutil.Value[string]
 	pgInitdbArgs       viperutil.Value[string]
 	pgInitdbSQLFiles   viperutil.Value[[]string]
+	pgInitdbSQLDirs    viperutil.Value[[]string]
 	pgInitdbExtraConf  viperutil.Value[[]string]
 
 	vc        *viperutil.ViperConfig
@@ -123,6 +124,12 @@ func GetRootCommand() (*cobra.Command, *PgCtlCommand) {
 			EnvVars:  []string{constants.PgInitdbSQLFilesEnvVar},
 			Dynamic:  false,
 		}),
+		pgInitdbSQLDirs: viperutil.Configure(reg, "pg-initdb-sql-dirs", viperutil.Options[[]string]{
+			Default:  []string{},
+			FlagName: "pg-initdb-sql-dirs",
+			EnvVars:  []string{constants.PgInitdbSQLDirsEnvVar},
+			Dynamic:  false,
+		}),
 		pgInitdbExtraConf: viperutil.Configure(reg, "pg-initdb-extra-conf", viperutil.Options[[]string]{
 			Default:  []string{},
 			FlagName: "pg-initdb-extra-conf",
@@ -180,6 +187,7 @@ management for PostgreSQL servers.`,
 	root.PersistentFlags().String("postgres-config-template", pc.postgresConfigTmpl.Default(), "Path to custom postgresql.conf template file")
 	root.PersistentFlags().String("pg-initdb-args", pc.pgInitdbArgs.Default(), "Extra arguments passed to initdb (overrides "+constants.PgInitdbArgsEnvVar+" env var)")
 	root.PersistentFlags().StringSlice("pg-initdb-sql-files", pc.pgInitdbSQLFiles.Default(), "Path to an .sql file to run against the target database after data directory initialization. Repeat the flag to run multiple files in order (overrides "+constants.PgInitdbSQLFilesEnvVar+" env var).")
+	root.PersistentFlags().StringSlice("pg-initdb-sql-dirs", pc.pgInitdbSQLDirs.Default(), "Directory of .sql files to run after initdb, in role:path format. Files run in lexicographic order under SET SESSION AUTHORIZATION <role>. Repeat for multiple directories (overrides "+constants.PgInitdbSQLDirsEnvVar+" env var).")
 	root.PersistentFlags().StringSlice("pg-initdb-extra-conf", pc.pgInitdbExtraConf.Default(), "Path to a postgresql.conf snippet appended verbatim onto the generated config at init time. Repeat the flag to append multiple files in order; postgres applies last-write-wins (overrides "+constants.PgInitdbExtraConfEnvVar+" env var).")
 
 	// Backwards-compat alias: --init-db-sql-file → --pg-initdb-sql-files.
@@ -206,6 +214,7 @@ management for PostgreSQL servers.`,
 		pc.postgresConfigTmpl,
 		pc.pgInitdbArgs,
 		pc.pgInitdbSQLFiles,
+		pc.pgInitdbSQLDirs,
 		pc.pgInitdbExtraConf,
 	)
 

--- a/go/cmd/pgctld/command/server.go
+++ b/go/cmd/pgctld/command/server.go
@@ -149,6 +149,7 @@ func (s *PgCtldServerCmd) runServer(cmd *cobra.Command, args []string) error {
 		Database:             s.pgCtlCmd.pgDatabase.Get(),
 		Password:             s.pgCtlCmd.pgPassword.Get(),
 		InitdbSQLFiles:       s.pgCtlCmd.pgInitdbSQLFiles.Get(),
+		InitdbSQLDirs:        s.pgCtlCmd.pgInitdbSQLDirs.Get(),
 		InitdbExtraConfFiles: s.pgCtlCmd.pgInitdbExtraConf.Get(),
 	}
 
@@ -247,6 +248,7 @@ type PgCtldServiceConfig struct {
 	Password             string
 	InitdbArgs           string
 	InitdbSQLFiles       []string
+	InitdbSQLDirs        []string
 	InitdbExtraConfFiles []string
 }
 

--- a/go/cmd/pgctld/command/start_test.go
+++ b/go/cmd/pgctld/command/start_test.go
@@ -387,6 +387,175 @@ fi
 	})
 }
 
+// TestInitdbSQLExecutionOrder verifies that --pg-initdb-sql-dirs runs before
+// --pg-initdb-sql-files: directories establish the base schema; files apply
+// targeted overrides on top. This matches the documented ordering in postInitdbSetup.
+func TestInitdbSQLExecutionOrder(t *testing.T) {
+	baseDir, cleanup := testutil.TempDir(t, "pgctld_sql_order_test")
+	defer cleanup()
+
+	argsLog := filepath.Join(baseDir, "psql-args.log")
+
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.MockBinary(t, binDir, "psql", `echo "$@" >> `+argsLog)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	sqlDir := filepath.Join(baseDir, "migrations")
+	require.NoError(t, os.MkdirAll(sqlDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "schema.sql"), []byte("CREATE TABLE t();"), 0o644))
+
+	patchFile := filepath.Join(baseDir, "patch.sql")
+	require.NoError(t, os.WriteFile(patchFile, []byte("ALTER TABLE t ADD COLUMN x int;"), 0o644))
+
+	logger := slog.New(slog.DiscardHandler)
+	pg := &pgInstance{
+		socketDir: "/tmp",
+		port:      5432,
+		user:      "postgres",
+		logger:    logger,
+	}
+
+	// Simulate the postInitdbSetup call order: dirs then files.
+	require.NoError(t, runInitdbSQLDirs(logger, pg, "mydb", []string{"myrole:" + sqlDir}))
+	require.NoError(t, runInitdbSQLFiles(logger, pg, "mydb", []string{patchFile}))
+
+	logBytes, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	require.Len(t, lines, 2, "expected one psql invocation for the dir and one for the file")
+
+	assert.Contains(t, lines[0], "schema.sql", "dir invocation must come first")
+	assert.Contains(t, lines[1], "patch.sql", "file invocation must come second")
+}
+
+func TestRunInitdbSQLDirs(t *testing.T) {
+	t.Run("runs sql files in lexicographic order under the specified role", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_sql_dirs_test")
+		defer cleanup()
+
+		argsLog := filepath.Join(baseDir, "psql-args.log")
+
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		testutil.MockBinary(t, binDir, "psql", `echo "$@" >> `+argsLog)
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		sqlDir := filepath.Join(baseDir, "scripts")
+		require.NoError(t, os.MkdirAll(sqlDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "02-b.sql"), []byte("SELECT 2;"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "01-a.sql"), []byte("SELECT 1;"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "README.md"), []byte("ignore me"), 0o644))
+
+		logger := slog.New(slog.DiscardHandler)
+		pg := &pgInstance{
+			socketDir: "/tmp",
+			port:      5432,
+			user:      "postgres",
+			logger:    logger,
+		}
+		err := runInitdbSQLDirs(logger, pg, "mydb", []string{"myrole:" + sqlDir})
+		require.NoError(t, err)
+
+		logBytes, err := os.ReadFile(argsLog)
+		require.NoError(t, err)
+		line := strings.TrimSpace(string(logBytes))
+		// Single psql invocation for the directory
+		require.NotContains(t, line, "\n", "expected a single psql invocation for the directory")
+		assert.Contains(t, line, `SET SESSION AUTHORIZATION "myrole"`)
+		assert.Contains(t, line, "01-a.sql")
+		assert.Contains(t, line, "02-b.sql")
+		assert.NotContains(t, line, "README.md")
+		assert.Contains(t, line, "RESET SESSION AUTHORIZATION")
+		// 01-a.sql must appear before 02-b.sql
+		assert.Less(t, strings.Index(line, "01-a.sql"), strings.Index(line, "02-b.sql"))
+	})
+
+	t.Run("empty directory is a no-op", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_sql_dirs_empty_test")
+		defer cleanup()
+
+		argsLog := filepath.Join(baseDir, "psql-args.log")
+
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		testutil.MockBinary(t, binDir, "psql", `echo "$@" >> `+argsLog)
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		emptyDir := filepath.Join(baseDir, "empty")
+		require.NoError(t, os.MkdirAll(emptyDir, 0o755))
+
+		logger := slog.New(slog.DiscardHandler)
+		err := runInitdbSQLDirs(logger, nil, "mydb", []string{"myrole:" + emptyDir})
+		require.NoError(t, err)
+		_, statErr := os.Stat(argsLog)
+		assert.True(t, os.IsNotExist(statErr), "psql must not be called for an empty directory")
+	})
+
+	t.Run("invalid entry without colon returns error", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		err := runInitdbSQLDirs(logger, nil, "mydb", []string{"nodirformat"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "role:path")
+	})
+
+	t.Run("invalid entry with empty role returns error", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		err := runInitdbSQLDirs(logger, nil, "mydb", []string{":/tmp/somedir"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "role:path")
+	})
+
+	t.Run("unreadable directory returns error", func(t *testing.T) {
+		logger := slog.New(slog.DiscardHandler)
+		err := runInitdbSQLDirs(logger, nil, "mydb", []string{"myrole:/nonexistent/path"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot read init SQL dir")
+	})
+
+	t.Run("psql failure propagates and skips remaining dirs", func(t *testing.T) {
+		baseDir, cleanup := testutil.TempDir(t, "pgctld_sql_dirs_fail_test")
+		defer cleanup()
+
+		runLog := filepath.Join(baseDir, "psql-runs.log")
+
+		binDir := filepath.Join(baseDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0o755))
+		testutil.MockBinary(t, binDir, "psql", `
+echo "$@" >> `+runLog+`
+if [[ "$*" == *"fail-dir"* ]]; then
+    echo "mock psql: simulated failure" >&2
+    exit 1
+fi
+`)
+		t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+		failDir := filepath.Join(baseDir, "fail-dir")
+		nextDir := filepath.Join(baseDir, "next-dir")
+		require.NoError(t, os.MkdirAll(failDir, 0o755))
+		require.NoError(t, os.MkdirAll(nextDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(failDir, "a.sql"), []byte("BAD"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(nextDir, "b.sql"), []byte("OK"), 0o644))
+
+		logger := slog.New(slog.DiscardHandler)
+		pg := &pgInstance{
+			socketDir: "/tmp",
+			port:      5432,
+			user:      "postgres",
+			logger:    logger,
+		}
+		err := runInitdbSQLDirs(logger, pg, "mydb", []string{"myrole:" + failDir, "myrole:" + nextDir})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "init SQL dir failed")
+
+		logBytes, err := os.ReadFile(runLog)
+		require.NoError(t, err)
+		got := string(logBytes)
+		assert.Contains(t, got, "fail-dir", "first dir should have been invoked")
+		assert.NotContains(t, got, "next-dir", "second dir must not be invoked after failure")
+	})
+}
+
 func TestReadLogTail(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -44,6 +44,10 @@ const (
 	// Multiple files are comma-separated.
 	PgInitdbSQLFilesEnvVar = "POSTGRES_INITDB_SQL_FILES"
 
+	// PgInitdbSQLDirsEnvVar is the environment variable for init SQL dirs to run after initdb.
+	// Multiple entries are comma-separated, each in role:path format.
+	PgInitdbSQLDirsEnvVar = "POSTGRES_INITDB_SQL_DIRS"
+
 	// PgInitdbExtraConfEnvVar is the environment variable for extra postgresql.conf
 	// files appended verbatim onto the generated config at init time.
 	// Multiple files are comma-separated. Postgres applies last-write-wins, so

--- a/go/services/multipooler/connpoolmanager/config_test.go
+++ b/go/services/multipooler/connpoolmanager/config_test.go
@@ -254,7 +254,7 @@ func TestConfig_PgPassword_EnvVar(t *testing.T) {
 }
 
 func TestConfig_PgUser_EnvVar(t *testing.T) {
-	t.Setenv(constants.PgUserEnvVar, "supabase_admin")
+	t.Setenv(constants.PgUserEnvVar, "multigres")
 
 	reg := viperutil.NewRegistry()
 	config := NewConfig(reg)
@@ -262,5 +262,5 @@ func TestConfig_PgUser_EnvVar(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	config.RegisterFlags(fs)
 
-	assert.Equal(t, "supabase_admin", config.PgUser())
+	assert.Equal(t, "multigres", config.PgUser())
 }

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -87,6 +87,10 @@ type ProcessInstance struct {
 	// target database when InitDataDir runs on this pgctld instance.
 	InitdbSQLFiles []string
 
+	// InitdbSQLDirs is a list of role:path entries; each dir's .sql files run
+	// under SET SESSION AUTHORIZATION <role> after initdb (pgctld --pg-initdb-sql-dirs).
+	InitdbSQLDirs []string
+
 	// PgInitdbExtraConfFiles is a list of postgresql.conf snippets appended to
 	// the generated config at init time (pgctld --pg-initdb-extra-conf).
 	// Populated by WithMultipoolerPGTLS to enable ssl on the postgres side.
@@ -234,6 +238,10 @@ func (p *ProcessInstance) startPgctld(ctx context.Context, t *testing.T) error {
 
 	for _, file := range p.InitdbSQLFiles {
 		args = append(args, "--pg-initdb-sql-files", file)
+	}
+
+	for _, dir := range p.InitdbSQLDirs {
+		args = append(args, "--pg-initdb-sql-dirs", dir)
 	}
 
 	for _, file := range p.PgInitdbExtraConfFiles {

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -79,6 +79,7 @@ type SetupConfig struct {
 	EnableMetricsExport                bool     // Enable Prometheus metrics export on all services
 	LogLevel                           string   // --log-level for multipooler/multiorch/multigateway (empty = "debug")
 	InitdbSQLFiles                     []string // Paths to .sql files executed on each pgctld after initdb against the target database
+	InitdbSQLDirs                      []string // role:path entries; each dir's .sql files run under SET SESSION AUTHORIZATION <role> after initdb
 	EnableVpidStamping                 bool     // Pass --vpid-stamp-enabled=true to every multipooler (needed by the pgregress isolation harness shim)
 }
 
@@ -293,6 +294,15 @@ func WithVpidStamping() SetupOption {
 func WithInitdbSQLFiles(files ...string) SetupOption {
 	return func(c *SetupConfig) {
 		c.InitdbSQLFiles = files
+	}
+}
+
+// WithInitdbSQLDirs forwards role:path entries to every pgctld via --pg-initdb-sql-dirs.
+// pgctld runs all .sql files in each directory (lexicographic order) under
+// SET SESSION AUTHORIZATION <role> after initdb completes.
+func WithInitdbSQLDirs(dirs ...string) SetupOption {
+	return func(c *SetupConfig) {
+		c.InitdbSQLDirs = dirs
 	}
 }
 
@@ -568,6 +578,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 		inst.Multipooler.LogLevel = config.LogLevel
 		inst.Pgctld.InitdbSQLFiles = config.InitdbSQLFiles
+		inst.Pgctld.InitdbSQLDirs = config.InitdbSQLDirs
 		inst.Multipooler.VpidStampEnabled = config.EnableVpidStamping
 		multipoolerInstances = append(multipoolerInstances, inst)
 

--- a/go/test/endtoend/shardsetup/shardsetup_test.go
+++ b/go/test/endtoend/shardsetup/shardsetup_test.go
@@ -384,3 +384,50 @@ CREATE ROLE init_db_sql_role NOLOGIN;
 	require.NoError(t, err)
 	assert.Equal(t, "1", roleFound, "role created by init SQL must exist")
 }
+
+// TestShardSetup_InitdbSQLDirsExecuted validates the --pg-initdb-sql-dirs flag
+// end-to-end: pgctld reads all .sql files from the given directory (in
+// lexicographic order, skipping non-.sql files) and runs them under
+// SET SESSION AUTHORIZATION <role>. We assert that the artifacts exist on
+// the elected primary and that the non-.sql file did not cause an error.
+func TestShardSetup_InitdbSQLDirsExecuted(t *testing.T) {
+	skipIfShort(t)
+
+	sqlDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "01-table.sql"), []byte(`
+CREATE TABLE IF NOT EXISTS init_sql_dir_test (
+    id   int PRIMARY KEY,
+    note text NOT NULL
+);
+INSERT INTO init_sql_dir_test (id, note) VALUES (1, 'from-init-sql-dir');
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "02-role.sql"), []byte(`
+CREATE ROLE init_sql_dir_role NOLOGIN;
+`), 0o644))
+
+	// This file must be silently skipped (not a .sql file).
+	require.NoError(t, os.WriteFile(filepath.Join(sqlDir, "README.md"), []byte("should be ignored"), 0o644))
+
+	setup, cleanup := NewIsolated(t,
+		WithMultipoolerCount(2),
+		WithInitdbSQLDirs("postgres:"+sqlDir),
+	)
+	defer cleanup()
+
+	ctx := t.Context()
+
+	primaryClient := setup.NewPrimaryClient(t)
+	defer primaryClient.Close()
+
+	note, err := QueryStringValue(ctx, primaryClient.Pooler,
+		"SELECT note FROM init_sql_dir_test WHERE id = 1")
+	require.NoError(t, err, "primary should be queryable for init-sql-dir table")
+	assert.Equal(t, "from-init-sql-dir", note, "row inserted by init SQL dir must be present on primary")
+
+	roleFound, err := QueryStringValue(ctx, primaryClient.Pooler,
+		"SELECT 1 FROM pg_roles WHERE rolname = 'init_sql_dir_role'")
+	require.NoError(t, err)
+	assert.Equal(t, "1", roleFound, "role created by init SQL dir must exist")
+}


### PR DESCRIPTION
Adds --pg-initdb-sql-dirs (repeatable StringSlice, env var POSTGRES_INITDB_SQL_DIRS) accepting role:path entries. pgctld reads all .sql files from the directory in lexicographic order (os.ReadDir sort), skips non-.sql files, and runs them in a single psql session wrapped in SET SESSION AUTHORIZATION "<role>" / RESET SESSION AUTHORIZATION.

Execution order within postInitdbSetup:
  1. Create target database (if non-default)
  2. --pg-initdb-sql-dirs: bulk schema/migration directories under role
  3. --pg-initdb-sql-files: targeted overrides applied on top

Implementation details:
- parseSQLDirEntry splits role:path on the first colon; rejects empty role
- sqlFilesInDir returns sorted .sql paths; os.ReadDir order is guaranteed
- quoteIdentifier wraps identifiers in double quotes (ReplaceAll approach, used for both SET SESSION AUTHORIZATION and CREATE DATABASE)
- postInitdbSetup condition extended to include InitdbSQLDirs

Tests:
- flags_test.go: TestPgInitdbSQLDirsFlag (repeated flag, comma-separated, env var, flag overrides env var)
- start_test.go: TestRunInitdbSQLDirs (happy path, empty dir, invalid entry, unreadable dir, psql failure) and TestInitdbSQLExecutionOrder (dirs run before files)
- shardsetup_test.go: TestShardSetup_InitdbSQLDirsExecuted (E2E)

Closes MUL-484