### PR TITLE
fix(multipooler): WAL receiver disconnect handling, backup-restore term, skip_outgoing_quorum proto

### DIFF
--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -81,21 +81,21 @@ type discoverer func(
 type quorumMode int
 
 const (
-	// requireTransitionQuorum requires that enough members of the
+	// requireOutgoingQuorum requires that enough members of the
 	// current/outgoing cohort (identified from the highest recorded rule
 	// across the recruited nodes) have accepted the term revocation. This is
 	// the standard safety check for normal failover: the existing cohort must
 	// consent to the leadership transition. validateProposal additionally
 	// verifies the proposed (incoming) cohort has sufficient recruited members.
-	requireTransitionQuorum quorumMode = iota
+	requireOutgoingQuorum quorumMode = iota
 
-	// onlyRequireIncomingQuorum skips the outgoing-cohort transition check and
+	// skipOutgoingQuorum skips the outgoing-cohort transition check and
 	// relies solely on validateProposal to verify that enough members of the
 	// PROPOSED (incoming) cohort have been recruited. Used for bootstrap and
 	// externally certified recovery where the outgoing cohort cannot be
 	// consulted (so transition consent comes from a cert or is unnecessary
 	// because there is no prior cohort).
-	onlyRequireIncomingQuorum
+	skipOutgoingQuorum
 )
 
 // BuildSafeProposal validates that the recruited nodes allow a safe
@@ -127,7 +127,7 @@ func BuildSafeProposal(
 	if len(recruited) == 0 {
 		return nil, errors.New("no nodes accepted the requested term revocation")
 	}
-	return buildProposalCore(revocation, recruited, requireTransitionQuorum, discoverMostAdvancedTimeline, buildProposal)
+	return buildProposalCore(revocation, recruited, requireOutgoingQuorum, discoverMostAdvancedTimeline, buildProposal)
 }
 
 // CheckProposalPossible checks whether a safe leadership proposal is possible
@@ -149,14 +149,14 @@ func CheckProposalPossible(
 	if len(candidates) == 0 {
 		return errors.New("no nodes could accept the proposed revocation")
 	}
-	_, err := buildProposalCore(revocation, candidates, requireTransitionQuorum, discoverMostAdvancedTimeline, buildProposal)
+	_, err := buildProposalCore(revocation, candidates, requireOutgoingQuorum, discoverMostAdvancedTimeline, buildProposal)
 	return err
 }
 
 // CheckExternallyCertifiedProposalPossible checks whether an externally certified
 // proposal is possible given the current observed statuses, without requiring
 // nodes to have already accepted the revocation. It is the externally-certified
-// counterpart of CheckProposalPossible: it uses onlyRequireIncomingQuorum so that
+// counterpart of CheckProposalPossible: it uses skipOutgoingQuorum so that
 // bootstrap scenarios with no recorded rule (no OutgoingRule) are handled correctly.
 //
 // Returns an error if no viable proposal exists; the proposal itself is not
@@ -178,7 +178,7 @@ func CheckExternallyCertifiedProposalPossible(
 	if err != nil {
 		return err
 	}
-	_, err = buildProposalCore(revocation, candidates, onlyRequireIncomingQuorum, discover, buildProposal)
+	_, err = buildProposalCore(revocation, candidates, skipOutgoingQuorum, discover, buildProposal)
 	return err
 }
 
@@ -217,7 +217,7 @@ func BuildExternallyCertifiedProposal(
 	if err != nil {
 		return nil, err
 	}
-	return buildProposalCore(revocation, recruited, onlyRequireIncomingQuorum, discover, buildProposal)
+	return buildProposalCore(revocation, recruited, skipOutgoingQuorum, discover, buildProposal)
 }
 
 // newExternallyCertifiedDiscoverer validates cert against the given nodes and returns a
@@ -236,7 +236,7 @@ func BuildExternallyCertifiedProposal(
 // occurred beyond frozen_lsn under term_revocation.outgoing_rule. Any node
 // whose LSN ≥ frozen_lsn therefore holds every committed transaction up to
 // that frozen point — which is why buildProposalCore is safe to skip the
-// outgoing-cohort quorum check for this discoverer (onlyRequireIncomingQuorum).
+// outgoing-cohort quorum check for this discoverer (skipOutgoingQuorum).
 func newExternallyCertifiedDiscoverer(
 	cert *clustermetadatapb.ExternallyCertifiedRevocation,
 	nodes []*clustermetadatapb.ConsensusStatus,
@@ -274,9 +274,9 @@ func newExternallyCertifiedDiscoverer(
 // CheckProposalPossible, and BuildExternallyCertifiedProposal. Callers are responsible
 // for pre-filtering and deduplicating statuses before calling this.
 //
-// With requireTransitionQuorum: validates that the current/outgoing cohort has
+// With requireOutgoingQuorum: validates that the current/outgoing cohort has
 // sufficient recruited members before building the proposal.
-// With onlyRequireIncomingQuorum: skips that check and relies on validateProposal to
+// With skipOutgoingQuorum: skips that check and relies on validateProposal to
 // verify the proposed (incoming) cohort has sufficient recruited members.
 func buildProposalCore(
 	revocation *clustermetadatapb.TermRevocation,
@@ -325,7 +325,7 @@ func buildProposalCore(
 	}
 
 	switch mode {
-	case requireTransitionQuorum:
+	case requireOutgoingQuorum:
 		// Validate revocation of the outgoing cohort: no parallel quorum can still
 		// form among the non-recruited nodes. outgoingRule must be known to identify
 		// the cohort. A nil here means no recruit reported a rule matching the
@@ -345,7 +345,7 @@ func buildProposalCore(
 		if err := outgoingPolicy.CheckSufficientRecruitment(cohort, statusesToIDs(filterCohortStatuses(cohort, recruitedStatuses))); err != nil {
 			return nil, fmt.Errorf("insufficient outgoing cohort recruitment: %w", err)
 		}
-	case onlyRequireIncomingQuorum:
+	case skipOutgoingQuorum:
 		// Outgoing-cohort quorum is not required. The incoming cohort is checked
 		// below after the proposal is built.
 	}
@@ -385,9 +385,9 @@ func buildProposalCore(
 // rule number if one is known, otherwise across all recruits (fresh bootstrap).
 //
 // Safety contract: buildProposalCore's outgoing-cohort quorum check (run with
-// requireTransitionQuorum) guarantees recruits intersect every committing
+// requireOutgoingQuorum) guarantees recruits intersect every committing
 // N-subset of the outgoing cohort, so the most-advanced recruit holds every
-// committed transaction. With onlyRequireIncomingQuorum (no outgoing quorum
+// committed transaction. With skipOutgoingQuorum (no outgoing quorum
 // guarantee), this discoverer is unsafe — use newExternallyCertifiedDiscoverer instead.
 //
 // Callers are expected to pre-filter via filterByValidPosition; nodes with
@@ -426,7 +426,7 @@ func discoverMostAdvancedTimeline(
 // validateProposal checks structural validity and cohort quorum for the proposal.
 // The proposed leader must be among the eligible leaders, the proposed rule and
 // durability policy must be valid, and the cohort must satisfy achievability and
-// (in onlyRequireIncomingQuorum) sufficient-recruitment constraints.
+// (in skipOutgoingQuorum) sufficient-recruitment constraints.
 func validateProposal(
 	proposal *consensusdatapb.CoordinatorProposal,
 	result RecruitmentResult,
@@ -439,7 +439,7 @@ func validateProposal(
 
 	// skip_outgoing_quorum may only be set by the externally-certified path:
 	// regular safe proposals always have a known outgoing cohort to drain.
-	if proposal.GetSkipOutgoingQuorum() && mode != onlyRequireIncomingQuorum {
+	if proposal.GetSkipOutgoingQuorum() && mode != skipOutgoingQuorum {
 		return errors.New("skip_outgoing_quorum is only valid for externally-certified proposals")
 	}
 
@@ -484,7 +484,7 @@ func validateProposal(
 	if err := p.CheckAchievable(recruitedInProposedCohort); err != nil {
 		return fmt.Errorf("recruited proposed cohort cannot achieve durability: %w", err)
 	}
-	if mode == onlyRequireIncomingQuorum {
+	if mode == skipOutgoingQuorum {
 		// Coordinator-retry safety: multiple coordinators may attempt externally
 		// certified proposals (e.g. repeated bootstrap attempts with different proposed
 		// leaders). Sufficient recruitment (majority overlap) ensures any two

--- a/go/common/consensus/proposals.go
+++ b/go/common/consensus/proposals.go
@@ -437,6 +437,12 @@ func validateProposal(
 		return errors.New("proposal term revocation does not match the recruitment revocation")
 	}
 
+	// skip_outgoing_quorum may only be set by the externally-certified path:
+	// regular safe proposals always have a known outgoing cohort to drain.
+	if proposal.GetSkipOutgoingQuorum() && mode != onlyRequireIncomingQuorum {
+		return errors.New("skip_outgoing_quorum is only valid for externally-certified proposals")
+	}
+
 	leaderID := proposal.GetProposalLeader().GetId()
 	if leaderID == nil {
 		return errors.New("proposal has no leader ID")

--- a/go/common/consensus/proposals_test.go
+++ b/go/common/consensus/proposals_test.go
@@ -194,7 +194,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "all 3 recruited: success, pooler-a is first eligible leader",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -210,7 +210,7 @@ func TestBuildProposalCore(t *testing.T) {
 			cohort := zone1.all[:3]
 			return tc{
 				name:       "no current_position: filtered by filterByValidPosition",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					{Id: zone1.a, TermRevocation: revocation(5, ruleNum(3, 0))}, // no current_position → no LSN
@@ -225,7 +225,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "1 of 3 recruited: insufficient outgoing cohort",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -240,7 +240,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "callback proposes outsider: not among eligible leaders",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -264,7 +264,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "proposed cohort has unrecruited member but passes (outsider not recruited, a+b satisfy AT_LEAST_2)",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -288,7 +288,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "2 of 3 recruited, dead leader stays in proposed cohort",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
@@ -310,7 +310,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "proposed cohort has new members not recruited",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -335,7 +335,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "callback returns error",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -354,7 +354,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "callback returns nil proposal",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -375,7 +375,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "mixed rule numbers: higher rule is outgoing, lagging node excluded from eligibles",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -403,7 +403,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "proposed cohort too small for AT_LEAST_2",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -426,7 +426,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "extra non-cohort node does not inflate outgoing quorum count",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -442,7 +442,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "LSN tiebreaker: highest LSN is sole eligible leader",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"), // highest
@@ -469,7 +469,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "LSN tie at max: two nodes tied at highest LSN both eligible",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -498,7 +498,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "rule takes priority: node at old rule excluded despite higher LSN",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/5000000"),
@@ -525,7 +525,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "duplicate status: same pooler twice counts once toward quorum",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -543,7 +543,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "duplicate: rule number wins over LSN when deduplicating",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, makeRule(ruleNum(2, 0), atLeast(2), cohort...), revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -565,7 +565,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "all accepted nodes have empty LSN: invalid WAL position",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), ""),
@@ -582,7 +582,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "all accepted nodes have unparsable LSN: invalid WAL position",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "not-an-lsn"),
@@ -599,7 +599,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "node with invalid LSN excluded: remaining 2 satisfy AT_LEAST_2",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -616,7 +616,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "invalid LSN causes quorum failure: 1 valid of 3",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -633,7 +633,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "node with invalid LSN cannot be proposed as leader",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, rule, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -658,7 +658,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(4, 0), atLeast(2), newCohort...)
 			return tc{
 				name:       "cohort expansion: only 2 of 5 new-cohort members respond",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(4, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.d, rule, revocation(5, ruleNum(4, 0)), "0/4000000"),
@@ -684,7 +684,7 @@ func TestBuildProposalCore(t *testing.T) {
 			}
 			return tc{
 				name:       "outgoing rule has unknown quorum type: failed to parse",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, unknownRule, revocation(5, ruleNum(3, 0))),
@@ -700,7 +700,7 @@ func TestBuildProposalCore(t *testing.T) {
 			cohort := zone1.all[:3]
 			return tc{
 				name:       "outgoing mode, no recorded rule among recruited nodes",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/2000000"),
@@ -716,7 +716,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "validate proposal: mismatched term revocation",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -739,7 +739,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "validate proposal: nil leader ID",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -762,7 +762,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "validate proposal: nil proposed rule",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -785,7 +785,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "validate proposal: nil durability policy",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -812,7 +812,7 @@ func TestBuildProposalCore(t *testing.T) {
 			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "validate proposal: proposed rule term above recruitment revocation term",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
@@ -829,13 +829,61 @@ func TestBuildProposalCore(t *testing.T) {
 				wantErr: "proposal validation: proposed rule term 99 is above the recruitment revocation term 5",
 			}
 		}(),
+		func() tc {
+			zone1 := poolerIDs.zone1
+			cohort := zone1.all[:3]
+			rule := makeRule(ruleNum(3, 0), atLeast(2), cohort...)
+			return tc{
+				name:       "skip_outgoing_quorum on transition-quorum path is rejected",
+				mode:       requireOutgoingQuorum,
+				revocation: revocation(5, ruleNum(3, 0)),
+				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
+					makeStatus(zone1.a, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.b, rule, revocation(5, ruleNum(3, 0))),
+					makeStatus(zone1.c, rule, revocation(5, ruleNum(3, 0))),
+				},
+				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+					return &consensusdatapb.CoordinatorProposal{
+						TermRevocation:     r.TermRevocation,
+						ProposalLeader:     &clustermetadatapb.PoolerAddress{Id: zone1.a},
+						ProposedRule:       makeRule(ruleNum(5, 0), atLeast(2), cohort...),
+						SkipOutgoingQuorum: true,
+					}, nil
+				},
+				wantErr: "proposal validation: skip_outgoing_quorum is only valid for externally-certified proposals",
+			}
+		}(),
 		// ── incoming cohort mode (bootstrap) ─────────────────────────────────────
 		func() tc {
 			zone1 := poolerIDs.zone1
 			cohort := zone1.all[:3]
 			return tc{
+				name:       "bootstrap: skip_outgoing_quorum is accepted on externally-certified proposal",
+				mode:       skipOutgoingQuorum,
+				revocation: revocation(5, ruleNum(3, 0)),
+				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
+					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/3000000"),
+					makeStatusWithLSN(zone1.b, nil, revocation(5, ruleNum(3, 0)), "0/2000000"),
+					makeStatusWithLSN(zone1.c, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
+				},
+				buildProposal: func(r RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+					leader := r.EligibleLeaders[0]
+					return &consensusdatapb.CoordinatorProposal{
+						TermRevocation:     r.TermRevocation,
+						ProposalLeader:     &clustermetadatapb.PoolerAddress{Id: leader.GetId()},
+						ProposedRule:       makeRule(ruleNum(5, 0), atLeast(2), cohort...),
+						SkipOutgoingQuorum: true,
+					}, nil
+				},
+				wantLeader: "pooler-a",
+			}
+		}(),
+		func() tc {
+			zone1 := poolerIDs.zone1
+			cohort := zone1.all[:3]
+			return tc{
 				name:       "bootstrap: nil outgoing rule allowed, highest LSN leads",
-				mode:       onlyRequireIncomingQuorum,
+				mode:       skipOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -858,7 +906,7 @@ func TestBuildProposalCore(t *testing.T) {
 			cohort := zone1.all[:3]
 			return tc{
 				name:       "bootstrap: 1 of 3 recruited — cannot achieve durability",
-				mode:       onlyRequireIncomingQuorum,
+				mode:       skipOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
@@ -879,7 +927,7 @@ func TestBuildProposalCore(t *testing.T) {
 			cohort := zone1.all[:3]
 			return tc{
 				name:       "bootstrap: unknown quorum type in proposed rule",
-				mode:       onlyRequireIncomingQuorum,
+				mode:       skipOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/1000000"),
@@ -909,7 +957,7 @@ func TestBuildProposalCore(t *testing.T) {
 			bigCohort := []*clustermetadatapb.ID{zone1.a, zone1.b, zone1.d, zone1.e, zone1.f}
 			return tc{
 				name:       "bootstrap: proposed cohort achievable but insufficient majority",
-				mode:       onlyRequireIncomingQuorum,
+				mode:       skipOutgoingQuorum,
 				revocation: revocation(5, ruleNum(3, 0)),
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatusWithLSN(zone1.a, nil, revocation(5, ruleNum(3, 0)), "0/3000000"),
@@ -938,7 +986,7 @@ func TestBuildProposalCore(t *testing.T) {
 			atLeastNRule := makeRule(ruleNum(5, 0), atLeast(2), cohort...)
 			return tc{
 				name:       "stuck rule change: coordinator re-proposes outgoing rule below revocation term",
-				mode:       requireTransitionQuorum,
+				mode:       requireOutgoingQuorum,
 				revocation: rev,
 				recruitedStatuses: []*clustermetadatapb.ConsensusStatus{
 					makeStatus(poolerIDs.zone1.a, multiCellRule, rev),
@@ -961,7 +1009,7 @@ func TestBuildProposalCore(t *testing.T) {
 		// through to the misleading "invalid or missing WAL position" branch.
 		{
 			name:              "empty recruited statuses",
-			mode:              requireTransitionQuorum,
+			mode:              requireOutgoingQuorum,
 			revocation:        revocation(5, ruleNum(3, 0)),
 			recruitedStatuses: nil,
 			buildProposal:     proposeFirstEligible(makeRule(ruleNum(5, 0), atLeast(2), poolerIDs.zone1.all[:3]...)),
@@ -1005,7 +1053,7 @@ func TestBuildProposalCore(t *testing.T) {
 		statuses := []*clustermetadatapb.ConsensusStatus{
 			makeStatus(zone1.a, rule, rev),
 		}
-		_, err := buildProposalCore(rev, statuses, requireTransitionQuorum, discoverMostAdvancedTimeline,
+		_, err := buildProposalCore(rev, statuses, requireOutgoingQuorum, discoverMostAdvancedTimeline,
 			func(RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) { return nil, nil })
 		require.ErrorContains(t, err, "revocation.outgoing_rule is required")
 	})

--- a/go/pb/consensusdata/consensusdata.pb.go
+++ b/go/pb/consensusdata/consensusdata.pb.go
@@ -507,9 +507,13 @@ type CoordinatorProposal struct {
 	ProposalLeader *clustermetadata.PoolerAddress `protobuf:"bytes,2,opt,name=proposal_leader,json=proposalLeader,proto3" json:"proposal_leader,omitempty"`
 	// The full proposed rule. This can either be an entirely new rule or an
 	// existing rule that hasn't yet finished propagating to durability.
-	ProposedRule  *clustermetadata.ShardRule `protobuf:"bytes,3,opt,name=proposed_rule,json=proposedRule,proto3" json:"proposed_rule,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ProposedRule *clustermetadata.ShardRule `protobuf:"bytes,3,opt,name=proposed_rule,json=proposedRule,proto3" json:"proposed_rule,omitempty"`
+	// When true, the leader must apply the incoming cohort GUC directly without
+	// first satisfying the outgoing cohort quorum. Only valid for externally-
+	// certified proposals (bootstrap, etc.).
+	SkipOutgoingQuorum bool `protobuf:"varint,4,opt,name=skip_outgoing_quorum,json=skipOutgoingQuorum,proto3" json:"skip_outgoing_quorum,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CoordinatorProposal) Reset() {
@@ -561,6 +565,13 @@ func (x *CoordinatorProposal) GetProposedRule() *clustermetadata.ShardRule {
 		return x.ProposedRule
 	}
 	return nil
+}
+
+func (x *CoordinatorProposal) GetSkipOutgoingQuorum() bool {
+	if x != nil {
+		return x.SkipOutgoingQuorum
+	}
+	return false
 }
 
 // RecruitRequest asks a pooler to revoke all terms below the one in the
@@ -917,11 +928,12 @@ const file_consensusdata_proto_rawDesc = "" +
 	"\x0eStatusResponse\x12#\n" +
 	"\x02id\x18\x04 \x01(\v2\x13.clustermetadata.IDR\x02id\x12K\n" +
 	"\x10consensus_status\x18\v \x01(\v2 .clustermetadata.ConsensusStatusR\x0fconsensusStatus\x12T\n" +
-	"\x13availability_status\x18\f \x01(\v2#.clustermetadata.AvailabilityStatusR\x12availabilityStatus\"\xe9\x01\n" +
+	"\x13availability_status\x18\f \x01(\v2#.clustermetadata.AvailabilityStatusR\x12availabilityStatus\"\x9b\x02\n" +
 	"\x13CoordinatorProposal\x12H\n" +
 	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\x12G\n" +
 	"\x0fproposal_leader\x18\x02 \x01(\v2\x1e.clustermetadata.PoolerAddressR\x0eproposalLeader\x12?\n" +
-	"\rproposed_rule\x18\x03 \x01(\v2\x1a.clustermetadata.ShardRuleR\fproposedRule\"Z\n" +
+	"\rproposed_rule\x18\x03 \x01(\v2\x1a.clustermetadata.ShardRuleR\fproposedRule\x120\n" +
+	"\x14skip_outgoing_quorum\x18\x04 \x01(\bR\x12skipOutgoingQuorum\"Z\n" +
 	"\x0eRecruitRequest\x12H\n" +
 	"\x0fterm_revocation\x18\x01 \x01(\v2\x1f.clustermetadata.TermRevocationR\x0etermRevocation\"^\n" +
 	"\x0fRecruitResponse\x12K\n" +

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -365,6 +365,7 @@ func buildBootstrapProposal(
 			DurabilityPolicy: policy,
 			LeaderId:         leader.GetId(),
 		},
+		SkipOutgoingQuorum: true,
 	}, nil
 }
 

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -201,6 +201,76 @@ func TestBuildFailoverProposal(t *testing.T) {
 	})
 }
 
+// ---- TestBuildBootstrapProposal ----
+
+func TestBuildBootstrapProposal(t *testing.T) {
+	makeID := func(name string) *clustermetadatapb.ID {
+		return &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Name:      name,
+		}
+	}
+	makeMP := func(name string) *clustermetadatapb.MultiPooler {
+		return &clustermetadatapb.MultiPooler{
+			Id:       makeID(name),
+			Hostname: "localhost",
+			PortMap:  map[string]int32{"postgres": 5432},
+		}
+	}
+	makeCS := func(name string) *clustermetadatapb.ConsensusStatus {
+		return &clustermetadatapb.ConsensusStatus{Id: makeID(name)}
+	}
+
+	cohortIDs := []*clustermetadatapb.ID{makeID("mp1"), makeID("mp2"), makeID("mp3")}
+	policy := &clustermetadatapb.DurabilityPolicy{
+		QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+		RequiredCount: 2,
+	}
+	rev := &clustermetadatapb.TermRevocation{RevokedBelowTerm: 5}
+	poolerByID := map[string]*clustermetadatapb.MultiPooler{
+		"zone1_mp1": makeMP("mp1"),
+		"zone1_mp2": makeMP("mp2"),
+		"zone1_mp3": makeMP("mp3"),
+	}
+
+	t.Run("sets skip_outgoing_quorum and picks first eligible leader", func(t *testing.T) {
+		result := commonconsensus.RecruitmentResult{
+			TermRevocation:  rev,
+			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("mp1"), makeCS("mp2")},
+		}
+
+		proposal, err := buildBootstrapProposal(result, cohortIDs, policy, poolerByID)
+		require.NoError(t, err)
+		assert.Equal(t, "mp1", proposal.GetProposalLeader().GetId().GetName())
+		assert.True(t, proposal.GetSkipOutgoingQuorum(),
+			"bootstrap proposals must set skip_outgoing_quorum so multipoolers apply the GUC without an outgoing-cohort quorum")
+		assert.Equal(t, int64(5), proposal.GetProposedRule().GetRuleNumber().GetCoordinatorTerm())
+	})
+
+	t.Run("no EligibleLeaders returns error", func(t *testing.T) {
+		result := commonconsensus.RecruitmentResult{
+			TermRevocation:  rev,
+			EligibleLeaders: nil,
+		}
+
+		_, err := buildBootstrapProposal(result, cohortIDs, policy, poolerByID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no eligible leaders")
+	})
+
+	t.Run("leader missing from poolerByID returns error", func(t *testing.T) {
+		result := commonconsensus.RecruitmentResult{
+			TermRevocation:  rev,
+			EligibleLeaders: []*clustermetadatapb.ConsensusStatus{makeCS("ghost")},
+		}
+
+		_, err := buildBootstrapProposal(result, cohortIDs, policy, poolerByID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in cohort")
+	})
+}
+
 // ---- TestRun ----
 
 func TestRun_Success(t *testing.T) {

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -550,32 +550,57 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
+	// Track the latest poll snapshot so a timeout has diagnostic detail without
+	// needing another query after the ctx has already expired.
+	var (
+		lastCount    int64 = -1 // -1 = not yet polled
+		lastStatus   string
+		lastConnInfo string
+	)
+
+	timedOut := func(cause error) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
+		pm.logger.ErrorContext(ctx, "WAL receiver did not disconnect",
+			"cause", cause,
+			"last_receiver_count", lastCount,
+			"last_walreceiver_status", lastStatus,
+			"last_primary_conninfo", lastConnInfo)
+		if errors.Is(cause, context.DeadlineExceeded) {
+			return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL receiver to disconnect")
+		}
+		return nil, mterrors.Wrap(cause, "context cancelled while waiting for WAL receiver to disconnect")
+	}
+
 	for {
 		select {
 		case <-waitCtx.Done():
-			if waitCtx.Err() == context.DeadlineExceeded {
-				pm.logger.ErrorContext(ctx, "Timeout waiting for WAL receiver to disconnect")
-				return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL receiver to disconnect")
-			}
-			pm.logger.ErrorContext(ctx, "Context cancelled while waiting for WAL receiver to disconnect")
-			return nil, mterrors.Wrap(waitCtx.Err(), "context cancelled while waiting for WAL receiver to disconnect")
+			return timedOut(waitCtx.Err())
 
 		case <-ticker.C:
-			// Check if WAL receiver has disconnected by counting rows in pg_stat_wal_receiver
-			result, err := pm.query(waitCtx, "SELECT COUNT(*) FROM pg_stat_wal_receiver")
+			// Re-check waitCtx before issuing a query: when waitCtx expires at the
+			// same tick boundary, select may pick this branch and the subsequent
+			// pm.query would surface an opaque "pool ctx expired" instead of the
+			// real timeout cause.
+			if err := waitCtx.Err(); err != nil {
+				return timedOut(err)
+			}
+
+			// Pull the count, the walreceiver status, and the live primary_conninfo
+			// in a single query so each poll is also a diagnostic snapshot.
+			result, err := pm.query(waitCtx, `SELECT
+				(SELECT COUNT(*) FROM pg_stat_wal_receiver),
+				coalesce((SELECT status FROM pg_stat_wal_receiver), ''),
+				current_setting('primary_conninfo')`)
 			if err != nil {
 				pm.logger.ErrorContext(ctx, "Failed to query pg_stat_wal_receiver", "error", err)
 				return nil, mterrors.Wrap(err, "failed to query pg_stat_wal_receiver")
 			}
-
-			var receiverCount int64
-			if err := executor.ScanSingleRow(result, &receiverCount); err != nil {
-				pm.logger.ErrorContext(ctx, "Failed to scan receiver count", "error", err)
-				return nil, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver count")
+			if err := executor.ScanSingleRow(result, &lastCount, &lastStatus, &lastConnInfo); err != nil {
+				pm.logger.ErrorContext(ctx, "Failed to scan pg_stat_wal_receiver row", "error", err)
+				return nil, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver row")
 			}
 
 			// Once receiver is disconnected, query final replication status
-			if receiverCount == 0 {
+			if lastCount == 0 {
 				pm.logger.InfoContext(ctx, "WAL receiver has disconnected")
 
 				// Get the final replication status

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -605,9 +605,27 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 				return nil, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver row")
 			}
 
-			// Once receiver is disconnected, query final replication status
-			if lastCount == 0 {
-				pm.logger.InfoContext(ctx, "WAL receiver has disconnected")
+			// Done when either the walreceiver slot is gone, OR it's sitting
+			// in WALRCV_WAITING with primary_conninfo empty. The latter is
+			// safe because:
+			//
+			//   - We hold the action lock, so no other in-process path can
+			//     write primary_conninfo during this wait.
+			//   - WAITING → STREAMING requires the startup process to call
+			//     RequestXLogStreaming, which only fires when primary_conninfo
+			//     is non-empty.
+			//   - We can't actively terminate a walreceiver from SQL —
+			//     pg_terminate_backend only works on regular backends, not
+			//     auxiliary processes like the walreceiver. The walreceiver
+			//     only exits when its in-flight libpq call returns, which is
+			//     bounded by connect_timeout (potentially tens of seconds).
+			//     Treating WAITING+empty as done lets us proceed without
+			//     waiting out that timeout.
+			done := lastCount == 0 || (lastStatus == "waiting" && lastConnInfo == "")
+			if done {
+				pm.logger.InfoContext(ctx, "WAL receiver has disconnected",
+					"last_receiver_count", lastCount,
+					"last_walreceiver_status", lastStatus)
 
 				// Get the final replication status
 				status, err := pm.queryReplicationStatus(waitCtx)

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -591,6 +591,12 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 				coalesce((SELECT status FROM pg_stat_wal_receiver), ''),
 				current_setting('primary_conninfo')`)
 			if err != nil {
+				// If waitCtx expired between the pre-check and the Pool.Get
+				// ctx.Err() check, surface the cleaner timeout cause instead of
+				// an opaque "pool ctx expired" wrapper.
+				if waitErr := waitCtx.Err(); waitErr != nil {
+					return timedOut(waitErr)
+				}
 				pm.logger.ErrorContext(ctx, "Failed to query pg_stat_wal_receiver", "error", err)
 				return nil, mterrors.Wrap(err, "failed to query pg_stat_wal_receiver")
 			}

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -1572,6 +1572,57 @@ func TestPauseReplication(t *testing.T) {
 	}
 }
 
+// TestWaitForReceiverDisconnect_Timeout covers the diagnostic timeout branch
+// added with the better-diagnostics fix: when the wait budget expires, the
+// function should return the canonical DEADLINE_EXCEEDED error rather than
+// leaking a pool-context-expired wrapper. The 10s budget is hardcoded, but
+// shrinking the parent context shortens the effective deadline via the
+// min-deadline semantics of context.WithTimeout.
+func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
+	t.Run("deadline expires before first poll", func(t *testing.T) {
+		pm, _ := newTestManagerWithMock("default", "0-inf")
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		defer cancel()
+
+		status, err := pm.waitForReceiverDisconnect(ctx)
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.Contains(t, err.Error(), "timeout waiting for WAL receiver to disconnect")
+		assert.Equal(t, mtrpcpb.Code_DEADLINE_EXCEEDED, mterrors.Code(err))
+	})
+
+	t.Run("deadline expires after one poll returns still-streaming", func(t *testing.T) {
+		pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
+		// Persistent (non-consumeOnce) pattern: the function may poll once or
+		// more before the deadline trips, depending on scheduling.
+		mockQueryService.AddQueryPattern("SELECT COUNT", mock.MakeQueryResult(
+			[]string{"count", "status", "primary_conninfo"},
+			[][]any{{int64(1), "streaming", "host=primary port=5432"}}))
+
+		// 600ms leaves room for at least one 500ms tick before the deadline trips.
+		ctx, cancel := context.WithTimeout(t.Context(), 600*time.Millisecond)
+		defer cancel()
+
+		status, err := pm.waitForReceiverDisconnect(ctx)
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.Contains(t, err.Error(), "timeout waiting for WAL receiver to disconnect")
+		assert.Equal(t, mtrpcpb.Code_DEADLINE_EXCEEDED, mterrors.Code(err))
+	})
+
+	t.Run("parent context cancelled surfaces cancellation, not timeout", func(t *testing.T) {
+		pm, _ := newTestManagerWithMock("default", "0-inf")
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // cancel immediately
+
+		status, err := pm.waitForReceiverDisconnect(ctx)
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.Contains(t, err.Error(), "context cancelled while waiting for WAL receiver to disconnect")
+		assert.NotEqual(t, mtrpcpb.Code_DEADLINE_EXCEEDED, mterrors.Code(err))
+	})
+}
+
 func TestResetPrimaryConnInfo(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -1500,6 +1500,30 @@ func TestPauseReplication(t *testing.T) {
 			errorContains: "failed to query pg_stat_wal_receiver",
 		},
 		{
+			// count > 0 but status=waiting with empty primary_conninfo should be
+			// treated as effectively disconnected: the walreceiver can't transition
+			// out of WAITING without a non-empty primary_conninfo, and we hold the
+			// action lock so nothing else can repopulate it.
+			name: "PauseReceiverOnly accepts WALRCV_WAITING+empty primary_conninfo as disconnected",
+			mode: multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_RECEIVER_ONLY,
+			wait: true,
+			setupMock: func(m *mock.QueryService) {
+				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
+				expectReloadConfig(m)
+				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult(
+					[]string{"count", "status", "primary_conninfo"},
+					[][]any{{int64(1), "waiting", ""}}))
+				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
+					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
+					[][]any{{"0/6000000", "", "f", "not paused", "2025-01-15 13:00:00+00", "", "waiting", nil, nil, nil}}))
+			},
+			expectError:  false,
+			expectStatus: true,
+			validateResult: func(t *testing.T, status *multipoolermanagerdatapb.StandbyReplicationStatus) {
+				assert.Equal(t, "0/6000000", status.LastReplayLsn)
+			},
+		},
+		{
 			name: "PauseReplayAndReceiver fails on pause",
 			mode: multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_AND_RECEIVER,
 			wait: false,

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -1391,7 +1391,7 @@ func TestPauseReplication(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 				expectReloadConfig(m)
-				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
+				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
 					[][]any{{"0/4000000", "", "f", "not paused", "2025-01-15 11:00:00+00", "", "", nil, nil, nil}}))
@@ -1443,7 +1443,7 @@ func TestPauseReplication(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 				expectReloadConfig(m)
-				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
+				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 				// First query for waitForReceiverDisconnect - consumed after first match
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
@@ -1468,7 +1468,7 @@ func TestPauseReplication(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 				expectReloadConfig(m)
-				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
+				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
 					[][]any{{"0/5000000", "", "f", "not paused", "2025-01-15 12:00:00+00", "", "", nil, nil, nil}}))
@@ -1506,7 +1506,7 @@ func TestPauseReplication(t *testing.T) {
 			setupMock: func(m *mock.QueryService) {
 				m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 				expectReloadConfig(m)
-				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count"}, [][]any{{"0"}}))
+				m.AddQueryPatternOnce("SELECT COUNT", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 				m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(
 					[]string{"replay_lsn", "receive_lsn", "is_paused", "pause_state", "xact_time", "conninfo", "wal_receiver_status", "last_msg_receive_time", "wal_receiver_status_interval", "wal_receiver_timeout"},
 					[][]any{{"0/5000000", "", "f", "not paused", "2025-01-15 12:00:00+00", "", "", nil, nil, nil}}))

--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -348,25 +348,13 @@ func (pm *MultiPoolerManager) restoreFromBackupLocked(ctx context.Context, backu
 		return err
 	}
 
-	// Delete the consensus term file after restore.
-	//
-	// The term file lives outside PGDATA and is not included in the backup, so
-	// its on-disk value may be ahead of what the restored PGDATA participated in.
-	// Deleting it resets the node to term 0; multiorch will advance the term to
-	// the current cluster value on first contact via BeginTerm.
-	//
-	// TODO: Revisit this when we restore backups for other reasons than to
-	// bootstrap a new node, e.g. point-in-time recovery for an existing node.
-	if err := telemetry.WithSpan(ctx, "restore/reset-consensus-term", func(ctx context.Context) error {
-		pm.logger.InfoContext(ctx, "Deleting consensus term file after restore; node will re-join consensus from term 0")
-		if err := pm.consensusState.DeleteTermFile(); err != nil {
-			return mterrors.Wrap(err, "failed to delete consensus term file after restore")
-		}
-		pm.healthStreamer.UpdateLeaderObservation(nil)
-		return nil
-	}); err != nil {
-		return err
-	}
+	// Clear the in-memory leader observation. The restored PGDATA may have been
+	// from a different point in time, so the previously observed leader may no
+	// longer be accurate. The term revocation is intentionally preserved: it is
+	// monotonically increasing and the restore does not change who is allowed to
+	// lead — only a coordinator with a term >= the revocation term may configure
+	// this node, which is exactly the right safety property.
+	pm.healthStreamer.UpdateLeaderObservation(nil)
 
 	if err := telemetry.WithSpan(ctx, "restore/reopen-pooler", func(ctx context.Context) error {
 		return pm.reopenPoolerManager(ctx)

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -107,7 +107,7 @@ func expectStandbyRevokeMocks(m *mock.QueryService, lsn string) {
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 	expectReloadConfig(m)
 	// waitForReceiverDisconnect
-	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count"}, [][]any{{int64(0)}}))
+	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 	// queryReplicationStatus (from waitForReceiverDisconnect)
 	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
 	// waitForReplayStabilize: three consecutive polls with same replay_lsn = stable
@@ -1233,7 +1233,7 @@ func expectStandbyRecruitMocks(m *mock.QueryService, lsn string, savedConnInfo s
 	m.AddQueryPatternOnce("ALTER SYSTEM RESET primary_conninfo", mock.MakeQueryResult(nil, nil))
 	expectReloadConfig(m)
 	// waitForReceiverDisconnect
-	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count"}, [][]any{{int64(0)}}))
+	m.AddQueryPatternOnce("SELECT COUNT.*pg_stat_wal_receiver", mock.MakeQueryResult([]string{"count", "status", "primary_conninfo"}, [][]any{{int64(0), "", ""}}))
 	// queryReplicationStatus (from waitForReceiverDisconnect)
 	m.AddQueryPatternOnce("pg_last_wal_replay_lsn", mock.MakeQueryResult(replStatusCols, replStatusRow))
 	// waitForReplayStabilize: three consecutive polls with same replay_lsn = stable

--- a/go/test/endtoend/multipooler/backup_test.go
+++ b/go/test/endtoend/multipooler/backup_test.go
@@ -232,8 +232,8 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 						restoredTerm = statusResp.ConsensusStatus.GetTermRevocation().GetRevokedBelowTerm()
 						return statusResp.Status.PostgresReady
 					}, 10*time.Second, 100*time.Millisecond, "PostgreSQL should be running after restore")
-					t.Logf("Term after restore: %d (expected: 0)", restoredTerm)
-					assert.Equal(t, int64(0), restoredTerm, "Term should be reset to 0 after restore (stale term file is deleted)")
+					t.Logf("Term after restore: %d (expected: %d)", restoredTerm, higherTerm)
+					assert.Equal(t, higherTerm, restoredTerm, "Term revocation should be preserved after restore")
 
 					// Verify primary_term is 0 after restore (never been primary)
 					statusCtx = utils.WithShortDeadline(t)
@@ -247,8 +247,8 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 						Primary:               primary,
 						StartReplicationAfter: true,
 						StopReplicationBefore: false,
-						CurrentTerm:           restoredTerm, // Term is 0 after restore; Force allows multiorch to advance it
-						Force:                 true,         // Force reconfiguration after restore
+						CurrentTerm:           restoredTerm,
+						Force:                 true, // Force reconfiguration after restore
 					}
 					setPrimaryCtx := utils.WithTimeout(t, 30*time.Second)
 					_, err = standbyConsensusClient.SetPrimaryConnInfo(setPrimaryCtx, setPrimaryReq)

--- a/proto/consensusdata.proto
+++ b/proto/consensusdata.proto
@@ -150,6 +150,11 @@ message CoordinatorProposal {
   // The full proposed rule. This can either be an entirely new rule or an
   // existing rule that hasn't yet finished propagating to durability.
   clustermetadata.ShardRule proposed_rule = 3;
+
+  // When true, the leader must apply the incoming cohort GUC directly without
+  // first satisfying the outgoing cohort quorum. Only valid for externally-
+  // certified proposals (bootstrap, etc.).
+  bool skip_outgoing_quorum = 4;
 }
 
 // RecruitRequest asks a pooler to revoke all terms below the one in the


### PR DESCRIPTION
Four small, independent changes split out of the rule store PR for easier review.

### 1. Better diagnostics on WAL receiver disconnect timeout
`waitForReceiverDisconnect`'s 10s budget expiring at a tick boundary was surfacing as
`connection pool context already expired` (an opaque pool error) rather than the real
"timeout waiting for WAL receiver to disconnect". Short-circuits on `waitCtx.Err()`
before issuing the next query, and folds `primary_conninfo` + `pg_stat_wal_receiver.status`
into the polling query so the timeout log shows the last-observed state — next failure
self-diagnoses whether the receiver was stuck or `primary_conninfo` was never cleared.

### 2. Accept WALRCV_WAITING + empty primary_conninfo as disconnected
Diagnostics from #1 revealed a bimodal pattern: walreceiver exits within 500ms (count=0)
or stays "waiting" for the full 10s budget. The stuck case happens when the walreceiver
is mid-`PQconnectdb` when SIGHUP arrives — the cooperative shutdown signal isn't
processed until libpq returns or `connect_timeout` expires (tens of seconds under load).
`pg_terminate_backend` can't help: it doesn't work on auxiliary processes like the
walreceiver. Treat WALRCV_WAITING with empty `primary_conninfo` as effectively-
disconnected; safe because we hold the action lock and WAITING→STREAMING requires
non-empty `primary_conninfo`.

### 3. Preserve term revocation across backup restores
The term revocation file lives outside PGDATA intentionally so restores don't affect it.
A prior change was deleting it on restore, probably left over from the previous bootstrap
design where orch needed to begin terms before `initdb` ran.

### 4. `skip_outgoing_quorum` proto field on `CoordinatorProposal`
Adds the field, validation (`validateProposal` restricts it to externally-certified
proposals), and the coordinator-side setter (`buildBootstrapProposal`). The multipooler-side
reader lands separately with the rule store work. Until then, multipoolers ignore the
flag — which matches today's behavior since `Propose()` already operates under
incoming-cohort-quorum semantics.