### PR TITLE
feat(multiadmin-web): show pooler replication status and link multiorch dashboards

### DIFF
--- a/web/multiadmin/app/dashboard/multiorch/components/multiorch-table.tsx
+++ b/web/multiadmin/app/dashboard/multiorch/components/multiorch-table.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
-import { Loader2 } from "lucide-react";
+import { Loader2, ExternalLink } from "lucide-react";
 import { useApi } from "@/lib/api/context";
 import type { MultiOrch } from "@/lib/api/types";
 
@@ -120,26 +120,42 @@ export function MultiOrchTable() {
                 <TableHead className="pl-6">Cell</TableHead>
                 <TableHead>Name</TableHead>
                 <TableHead>Hostname</TableHead>
-                <TableHead className="text-right pr-6">gRPC Port</TableHead>
+                <TableHead className="text-right">gRPC Port</TableHead>
+                <TableHead className="pr-6">Dashboard</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredOrchs.map((orch, idx) => (
-                <TableRow key={orch.id?.name || idx}>
-                  <TableCell className="pl-6 font-mono text-xs py-3">
-                    {orch.id?.cell || "-"}
-                  </TableCell>
-                  <TableCell className="font-mono text-xs py-3">
-                    {orch.id?.name || "-"}
-                  </TableCell>
-                  <TableCell className="font-mono text-xs py-3">
-                    {orch.hostname || "-"}
-                  </TableCell>
-                  <TableCell className="text-right pr-6 font-mono text-xs py-3">
-                    {orch.port_map?.grpc || "-"}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {filteredOrchs.map((orch, idx) => {
+                const dashboardUrl = `/proxy/orch/${orch.id?.cell}/${orch.id?.name}`;
+
+                return (
+                  <TableRow key={orch.id?.name || idx}>
+                    <TableCell className="pl-6 font-mono text-xs py-3">
+                      {orch.id?.cell || "-"}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs py-3">
+                      {orch.id?.name || "-"}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs py-3">
+                      {orch.hostname || "-"}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs py-3">
+                      {orch.port_map?.grpc || "-"}
+                    </TableCell>
+                    <TableCell className="pr-6 py-3">
+                      <a
+                        href={dashboardUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                        View
+                      </a>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </div>

--- a/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
+++ b/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ChevronLeft, Loader2 } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useApi } from "@/lib/api/context";
+import { cn } from "@/lib/utils";
+import type {
+  PoolerStatus,
+  PrimaryStatus,
+  StandbyReplicationStatus,
+  SyncReplicationConfig,
+  ID,
+} from "@/lib/api/types";
+
+const REFRESH_INTERVAL_MS = 10_000;
+
+interface PageProps {
+  params: Promise<{ cell: string; name: string }>;
+}
+
+export default function PoolerReplicationPage({ params }: PageProps) {
+  const { cell, name } = use(params);
+  const cellName = decodeURIComponent(cell);
+  const poolerName = decodeURIComponent(name);
+
+  const api = useApi();
+  const [status, setStatus] = useState<PoolerStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const resp = await api.getPoolerStatus({
+          component: "MULTIPOOLER",
+          cell: cellName,
+          name: poolerName,
+        });
+        if (cancelled) return;
+        setStatus(resp.status);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error ? err.message : "Failed to load pooler status",
+        );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [api, cellName, poolerName]);
+
+  return (
+    <div className="flex flex-col gap-4 py-4 lg:py-6">
+      <div className="px-4 lg:px-6 flex flex-col gap-1">
+        <Link
+          href="/dashboard/multipoolers"
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-3 w-3" />
+          Back to poolers
+        </Link>
+        <h1 className="text-2xl font-semibold tracking-tight">Replication</h1>
+        <p className="text-sm text-muted-foreground">
+          <span className="font-mono">{cellName}</span> /
+          <span className="font-mono"> {poolerName}</span> · refreshes every{" "}
+          {REFRESH_INTERVAL_MS / 1000}s
+        </p>
+      </div>
+
+      {loading && !status ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          <span className="ml-2 text-muted-foreground">Loading…</span>
+        </div>
+      ) : error ? (
+        <div className="px-4 lg:px-6">
+          <p className="text-destructive">{error}</p>
+        </div>
+      ) : !status ? null : (
+        <ReplicationView status={status} />
+      )}
+    </div>
+  );
+}
+
+function ReplicationView({ status }: { status: PoolerStatus }) {
+  const role = status.pooler_type ?? "—";
+  const postgresStatus = formatEnum(status.postgres_status, "POSTGRES_STATUS_");
+
+  return (
+    <>
+      <div className="px-4 lg:px-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <SummaryCard label="Pooler type" value={role} mono />
+        <SummaryCard
+          label="Postgres status"
+          value={postgresStatus || "—"}
+          mono
+        />
+        <SummaryCard
+          label="Postgres ready"
+          value={boolText(status.postgres_ready)}
+          mono
+        />
+        <SummaryCard
+          label="WAL position"
+          value={status.wal_position || "—"}
+          mono
+        />
+      </div>
+
+      {status.primary_status ? (
+        <PrimarySection primary={status.primary_status} />
+      ) : null}
+
+      {status.replication_status ? (
+        <ReplicaSection replication={status.replication_status} />
+      ) : null}
+
+      {!status.primary_status && !status.replication_status ? (
+        <div className="px-4 lg:px-6">
+          <p className="text-muted-foreground">
+            No replication status available (PostgreSQL may not be connected).
+          </p>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function PrimarySection({ primary }: { primary: PrimaryStatus }) {
+  const sync = primary.sync_replication_config;
+  const followerSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const f of primary.connected_followers ?? []) {
+      s.add(idKey(f));
+    }
+    return s;
+  }, [primary.connected_followers]);
+
+  const standbyRows = useMemo(() => {
+    const ids = sync?.standby_ids ?? [];
+    const names = sync?.standby_application_names ?? [];
+    return ids.map((id, i) => ({
+      id,
+      applicationName: names[i],
+      connected: followerSet.has(idKey(id)),
+    }));
+  }, [sync, followerSet]);
+
+  return (
+    <>
+      <SectionHeading>Primary</SectionHeading>
+
+      <div className="px-4 lg:px-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <SummaryCard
+          label="synchronous_commit"
+          value={
+            formatEnum(sync?.synchronous_commit, "SYNCHRONOUS_COMMIT_") || "—"
+          }
+          mono
+        />
+        <SummaryCard
+          label="Sync method"
+          value={
+            formatEnum(sync?.synchronous_method, "SYNCHRONOUS_METHOD_") || "—"
+          }
+          mono
+        />
+        <SummaryCard label="num_sync" value={sync?.num_sync ?? "—"} mono />
+        <SummaryCard
+          label="Connected followers"
+          value={primary.connected_followers?.length ?? 0}
+          mono
+        />
+      </div>
+
+      <div className="px-4 lg:px-6">
+        <h3 className="text-sm font-medium mb-2">Standbys</h3>
+        {standbyRows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No standbys configured in synchronous_standby_names.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="pl-6">Cell</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>application_name</TableHead>
+                <TableHead className="pr-6 text-right">Streaming</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {standbyRows.map((row) => (
+                <TableRow key={idKey(row.id)}>
+                  <TableCell className="pl-6 font-mono text-xs py-3">
+                    {row.id.cell}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs py-3">
+                    {row.id.name}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs py-3">
+                    {row.applicationName || "—"}
+                  </TableCell>
+                  <TableCell className="pr-6 text-right py-3">
+                    <ConnectedBadge connected={row.connected} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </>
+  );
+}
+
+function ReplicaSection({
+  replication,
+}: {
+  replication: StandbyReplicationStatus;
+}) {
+  const conn = replication.primary_conn_info;
+  const waiting = replication.wal_receiver_status || "—";
+  const lastMsgAgo = formatAgo(replication.last_msg_receive_time);
+
+  return (
+    <>
+      <SectionHeading>Replica</SectionHeading>
+
+      <div className="px-4 lg:px-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <SummaryCard
+          label="WAL receiver"
+          value={waiting}
+          mono
+          tone={walReceiverTone(replication.wal_receiver_status)}
+        />
+        <SummaryCard label="Last msg from primary" value={lastMsgAgo} mono />
+        <SummaryCard
+          label="status_interval"
+          value={formatDuration(replication.wal_receiver_status_interval)}
+          mono
+        />
+        <SummaryCard
+          label="receiver_timeout"
+          value={formatDuration(replication.wal_receiver_timeout)}
+          mono
+        />
+      </div>
+
+      <SectionHeading subtle>Replay state</SectionHeading>
+      <div className="px-4 lg:px-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <SummaryCard
+          label="last_receive_lsn"
+          value={replication.last_receive_lsn || "—"}
+          mono
+        />
+        <SummaryCard
+          label="last_replay_lsn"
+          value={replication.last_replay_lsn || "—"}
+          mono
+        />
+        <SummaryCard
+          label="Replay paused"
+          value={
+            replication.is_wal_replay_paused === undefined
+              ? "—"
+              : replication.is_wal_replay_paused
+                ? replication.wal_replay_pause_state || "paused"
+                : "not paused"
+          }
+          mono
+        />
+        <SummaryCard label="Lag" value={formatDuration(replication.lag)} mono />
+      </div>
+
+      <SectionHeading subtle>primary_conninfo</SectionHeading>
+      {conn ? (
+        <div className="px-4 lg:px-6 flex flex-col gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <SummaryCard label="host" value={conn.host || "—"} mono />
+            <SummaryCard label="port" value={conn.port ?? "—"} mono />
+            <SummaryCard label="user" value={conn.user || "—"} mono />
+            <SummaryCard
+              label="application_name"
+              value={conn.application_name || "—"}
+              mono
+            />
+          </div>
+          {conn.raw ? (
+            <div className="rounded border bg-card p-3">
+              <p className="text-xs uppercase text-muted-foreground tracking-wide mb-1">
+                raw (password redacted)
+              </p>
+              <code className="text-xs whitespace-pre-wrap break-words block font-mono">
+                {conn.raw}
+              </code>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div className="px-4 lg:px-6">
+          <p className="text-muted-foreground text-sm">
+            primary_conninfo is empty (no streaming source configured).
+          </p>
+        </div>
+      )}
+
+      {replication.last_xact_replay_timestamp ? (
+        <div className="px-4 lg:px-6">
+          <p className="text-xs text-muted-foreground">
+            Last replayed commit at{" "}
+            <span className="font-mono">
+              {replication.last_xact_replay_timestamp}
+            </span>
+          </p>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function SectionHeading({
+  children,
+  subtle,
+}: {
+  children: React.ReactNode;
+  subtle?: boolean;
+}) {
+  return (
+    <div className="px-4 lg:px-6 mt-2">
+      <h2
+        className={cn(
+          subtle ? "text-sm font-medium" : "text-lg font-semibold",
+          "tracking-tight",
+        )}
+      >
+        {children}
+      </h2>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  mono,
+  tone,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+  tone?: "success" | "warn" | "neutral";
+}) {
+  return (
+    <div className="rounded border bg-card p-3">
+      <p className="text-xs uppercase text-muted-foreground tracking-wide">
+        {label}
+      </p>
+      <p
+        className={cn(
+          "text-xl font-semibold",
+          mono && "font-mono",
+          tone === "success" && "text-emerald-400",
+          tone === "warn" && "text-amber-400",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function ConnectedBadge({ connected }: { connected: boolean }) {
+  return (
+    <span
+      className={cn(
+        "font-mono text-xs px-1.5 py-0.5 rounded",
+        connected
+          ? "bg-emerald-500/20 text-emerald-400"
+          : "bg-muted text-muted-foreground",
+      )}
+    >
+      {connected ? "yes" : "no"}
+    </span>
+  );
+}
+
+function idKey(id: ID): string {
+  return `${id.cell}/${id.name}`;
+}
+
+function formatEnum(value: string | undefined, prefix: string): string {
+  if (!value) return "";
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+function boolText(v: boolean | undefined): string {
+  if (v === undefined) return "—";
+  return v ? "yes" : "no";
+}
+
+function formatDuration(d: string | undefined): string {
+  if (!d) return "—";
+  return d;
+}
+
+function formatAgo(ts: string | undefined): string {
+  if (!ts) return "—";
+  const then = Date.parse(ts);
+  if (Number.isNaN(then)) return ts;
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  return `${Math.round(seconds / 3600)}h ago`;
+}
+
+function walReceiverTone(
+  status: string | undefined,
+): "success" | "warn" | "neutral" | undefined {
+  if (!status) return "warn";
+  if (status === "streaming") return "success";
+  if (status === "stopping" || status === "waiting") return "warn";
+  return undefined;
+}

--- a/web/multiadmin/app/dashboard/multipoolers/components/multipoolers-table.tsx
+++ b/web/multiadmin/app/dashboard/multipoolers/components/multipoolers-table.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, ExternalLink } from "lucide-react";
+import Link from "next/link";
 import { useApi } from "@/lib/api/context";
 import type { MultiPooler } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -165,6 +166,7 @@ export function MultiPoolersTable() {
                 <TableHead className="text-center">Status</TableHead>
                 <TableHead>Hostname</TableHead>
                 <TableHead className="text-right">gRPC Port</TableHead>
+                <TableHead>Diagnostics</TableHead>
                 <TableHead className="pr-6">Dashboard</TableHead>
               </TableRow>
             </TableHeader>
@@ -200,6 +202,18 @@ export function MultiPoolersTable() {
                     </TableCell>
                     <TableCell className="text-right font-mono text-xs py-3">
                       {pooler.port_map?.grpc || "-"}
+                    </TableCell>
+                    <TableCell className="py-3">
+                      {pooler.id ? (
+                        <Link
+                          href={`/dashboard/multipoolers/${encodeURIComponent(pooler.id.cell)}/${encodeURIComponent(pooler.id.name)}/replication`}
+                          className="text-primary hover:underline text-xs"
+                        >
+                          Replication
+                        </Link>
+                      ) : (
+                        "-"
+                      )}
                     </TableCell>
                     <TableCell className="pr-6 py-3">
                       <a

--- a/web/multiadmin/lib/api/types.ts
+++ b/web/multiadmin/lib/api/types.ts
@@ -195,7 +195,9 @@ export interface PoolerStatus {
   is_initialized?: boolean;
   has_data_directory?: boolean;
   postgres_running?: boolean;
+  postgres_ready?: boolean;
   postgres_role?: string;
+  postgres_status?: string;
   wal_position?: string;
   consensus_term?: string;
   shard_id?: string;
@@ -213,6 +215,15 @@ export interface SyncReplicationConfig {
   synchronous_method?: string;
   num_sync?: number;
   standby_ids?: ID[];
+  standby_application_names?: string[];
+}
+
+export interface PrimaryConnInfo {
+  host?: string;
+  port?: number;
+  user?: string;
+  application_name?: string;
+  raw?: string;
 }
 
 export interface StandbyReplicationStatus {
@@ -222,6 +233,11 @@ export interface StandbyReplicationStatus {
   wal_replay_pause_state?: string;
   lag?: string; // Duration as string (e.g., "5s")
   last_xact_replay_timestamp?: string;
+  primary_conn_info?: PrimaryConnInfo;
+  wal_receiver_status?: string;
+  last_msg_receive_time?: string;
+  wal_receiver_status_interval?: string;
+  wal_receiver_timeout?: string;
 }
 
 // Gateway diagnostics types — match proto/multigatewaymanagerdata.proto.


### PR DESCRIPTION
Add a per-pooler Replication page (under /dashboard/multipoolers/[cell]/[name]/replication) that surfaces what was previously only reachable via the gRPC GetPoolerStatus API: synchronous_commit / sync method / num_sync and the standby ⨯ connected-followers join on primaries, and WAL receiver status, replay LSNs, lag, and parsed (password-redacted) primary_conninfo on replicas. Wire a Diagnostics → Replication link from the poolers table. Also add a Dashboard column to the multiorch table that opens the /proxy/orch/{cell}/{name} status page, mirroring the multipooler and multigateway tables.

It's not fancy, but could be useful

Pooler list:
<img width="914" height="350" alt="image" src="https://github.com/user-attachments/assets/d027dae8-4fc5-4778-b5a3-436cd6f3ed40" />

Primary pooler view:
<img width="956" height="571" alt="image" src="https://github.com/user-attachments/assets/3ae85300-387b-4efc-b40b-769329f7b9d5" />

Replica view:
<img width="949" height="653" alt="image" src="https://github.com/user-attachments/assets/fbbcd10b-1724-400a-8ad3-f064dc5b8d1e" />
