### PR TITLE
feat(pgregresstest): add pgbouncer session and transaction comparison targets

### DIFF
--- a/.github/scripts/detect-regressions.sh
+++ b/.github/scripts/detect-regressions.sh
@@ -51,18 +51,27 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 
+# Regression detection only compares the multigateway target. The pgbouncer
+# comparison targets exist as a control baseline and are out of scope for
+# pass/fail regression tracking.
+#
 # Build a map of baseline test statuses: { "suite/test": "status" }
 # Then compare against current results to find regressions.
 regressions=$(jq -n \
   --slurpfile baseline "$BASELINE" \
   --slurpfile current "$CURRENT" \
   '
-  # Build lookup: "SuiteName/TestName" -> status
-  ($baseline[0] | [.[] | .name as $suite | .tests[] | {key: ($suite + "/" + .name), value: .status}] | from_entries) as $base_map |
+  # Build lookup: "SuiteName/TestName" -> status (multigateway target only)
+  ($baseline[0] | [
+     .[] | .name as $suite |
+     (.targets.multigateway.tests // [])[] |
+     {key: ($suite + "/" + .name), value: .status}
+   ] | from_entries) as $base_map |
 
-  # Find tests that passed in baseline but fail now
+  # Find tests that passed in baseline but fail now (multigateway target only)
   [
-    $current[0][] | .name as $suite | .tests[] |
+    $current[0][] | .name as $suite |
+    (.targets.multigateway.tests // [])[] |
     select(.status == "fail") |
     ($suite + "/" + .name) as $key |
     select($base_map[$key] == "pass") |

--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -20,7 +20,18 @@ on:
     - cron: "0 9 * * 1" # Weekly summary: Monday 9:00 AM UTC
   pull_request:
     types: [labeled]
+  # checkov:skip=CKV_GHA_7: dispatch input is a closed-set choice (see options below) used only to route an env var inside the test harness — it does not influence the build output, only which targets run. Dispatching the workflow is restricted to repository collaborators by GitHub, so the input source is trusted.
   workflow_dispatch:
+    inputs:
+      targets:
+        description: "PGREGRESS_TARGETS — frontends to run the suites against"
+        required: false
+        default: "multigateway"
+        type: choice
+        options:
+          - multigateway
+          - "multigateway,pgbouncer-session,pgbouncer-tx"
+          - "pgbouncer-session,pgbouncer-tx"
 
 permissions: {}
 
@@ -52,6 +63,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential bison flex libreadline-dev zlib1g-dev
 
+      # Pgbouncer is only required for comparison-target runs (the
+      # workflow_dispatch path with pgbouncer-* in PGREGRESS_TARGETS). The
+      # nightly cron, weekly cron, and "Run Extended Query Serving Tests"
+      # PR label all run multigateway-only and skip this step.
+      #
+      # The GitHub-hosted Ubuntu runner has the PGDG apt source preconfigured
+      # (signed-by /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg),
+      # so we just install — adding a second pgdg.list with a different
+      # Signed-By path triggers "Conflicting values set for option Signed-By".
+      # The runtime version check in RequirePgbouncer (pgbouncer.go)
+      # hard-fails if PGDG ships a version that diverges from
+      # PinnedPgbouncerVersion, surfacing it as a clean test failure rather
+      # than silently changing baseline output.
+      - name: Install pgbouncer (PGDG)
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(inputs.targets, 'pgbouncer') }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y pgbouncer
+          pgbouncer --version
+
       - name: Build
         run: make build
 
@@ -69,9 +101,14 @@ jobs:
           echo "PORT_POOL_PID=$!" >> "$GITHUB_ENV"
           echo "MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock" >> "$GITHUB_ENV"
 
+      # PGREGRESS_TARGETS: workflow_dispatch supplies the dropdown selection;
+      # all other triggers (schedule, PR label) leave it unset so the harness
+      # defaults to multigateway-only — matching pre-comparison-mode CI.
+      # The Go-side ParseTargets accepts an empty string as "multigateway".
       - name: Run PostgreSQL compatibility tests
         env:
           RUN_EXTENDED_QUERY_SERVING_TESTS: "1"
+          PGREGRESS_TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.targets || '' }}
           TEST_PRINT_LOGS: "1"
         run: go test -json -v -run TestPostgreSQLRegression ./go/test/endtoend/pgregresstest/... -timeout 60m | tee pgregress-test-results.jsonl | go tool tparse -follow
 
@@ -138,7 +175,8 @@ jobs:
         if: >-
           !cancelled() &&
           steps.regressions.outputs.found == 'true' &&
-          github.event_name == 'schedule'
+          github.event_name == 'schedule' &&
+          github.repository == 'multigres/multigres'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}
         run: |
@@ -169,7 +207,8 @@ jobs:
         if: >-
           !cancelled() &&
           (github.event.schedule == '0 9 * * 1' || github.event_name == 'workflow_dispatch') &&
-          steps.results.outputs.path != ''
+          steps.results.outputs.path != '' &&
+          github.repository == 'multigres/multigres'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}
           RESULTS_PATH: ${{ steps.results.outputs.path }}
@@ -180,10 +219,12 @@ jobs:
           baseline_file="/tmp/pgregress-baseline/results.json"
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # Compute previous pass count from baseline (if it exists)
+          # Compute previous pass count from baseline (if it exists). The
+          # weekly summary tracks the multigateway target only — pgbouncer
+          # comparison targets are out of scope for this rollup.
           prev_passed="null"
           if [[ -f "$baseline_file" ]]; then
-            prev_passed=$(jq '[.[].tests[] | select(.status == "pass")] | length' "$baseline_file")
+            prev_passed=$(jq '[.[].targets.multigateway.tests[]? | select(.status == "pass")] | length' "$baseline_file")
           fi
 
           # Build per-suite sections and compute overall totals
@@ -192,13 +233,16 @@ jobs:
             --argjson prev_passed "$prev_passed" \
             --arg url "$run_url" \
             '
-            ($results[0] | map({
-              name: .name,
-              total: (.tests | length),
-              passed: ([.tests[] | select(.status == "pass")] | length),
-              failed: ([.tests[] | select(.status == "fail")] | length),
-              failing_names: ([.tests[] | select(.status == "fail") | .name] | join(", ") | if length > 300 then .[:300] + "..." else . end)
-            })) as $suites |
+            ($results[0] | map(
+              (.targets.multigateway.tests // []) as $tests |
+              {
+                name: .name,
+                total: ($tests | length),
+                passed: ([$tests[] | select(.status == "pass")] | length),
+                failed: ([$tests[] | select(.status == "fail")] | length),
+                failing_names: ([$tests[] | select(.status == "fail") | .name] | join(", ") | if length > 300 then .[:300] + "..." else . end)
+              }
+            )) as $suites |
 
             ($suites | map(.total) | add) as $total |
             ($suites | map(.passed) | add) as $passed |
@@ -237,7 +281,8 @@ jobs:
         if: >-
           !cancelled() &&
           steps.results.outputs.path == '' &&
-          github.event_name == 'schedule'
+          github.event_name == 'schedule' &&
+          github.repository == 'multigres/multigres'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}
         run: |

--- a/go/test/endtoend/pgbuilder/standalone.go
+++ b/go/test/endtoend/pgbuilder/standalone.go
@@ -53,17 +53,29 @@ type Standalone struct {
 	cmd    *executil.Cmd
 }
 
-// StartStandalone runs initdb into a fresh data directory under builder.OutputDir
-// and launches a postgres server on a free port. The returned Standalone
-// exposes connection parameters and a Stop method.
+// StartStandalone runs initdb into a fresh data directory under
+// builder.OutputDir/standalone and launches a postgres server on a free port.
+// Equivalent to StartStandaloneIn with subdir = "standalone".
+func StartStandalone(t *testing.T, ctx context.Context, builder *Builder, password string) (*Standalone, error) {
+	return StartStandaloneIn(t, ctx, builder, "standalone", password)
+}
+
+// StartStandaloneIn runs initdb into a fresh data directory under
+// builder.OutputDir/<subdir> and launches a postgres server on a free port.
+// The returned Standalone exposes connection parameters and a Stop method.
 //
 // Callers should defer Stop. The server logs are written to LogPath and left
-// on disk after Stop to aid debugging.
-func StartStandalone(t *testing.T, ctx context.Context, builder *Builder, password string) (*Standalone, error) {
+// on disk after Stop to aid debugging. Use subdir to host multiple
+// independent standalone instances under the same builder (e.g. one per
+// pgregress comparison target).
+func StartStandaloneIn(t *testing.T, ctx context.Context, builder *Builder, subdir, password string) (*Standalone, error) {
 	t.Helper()
 
 	if password == "" {
 		password = "pgbuilder"
+	}
+	if subdir == "" {
+		subdir = "standalone"
 	}
 
 	port, err := pickFreePort()
@@ -71,7 +83,7 @@ func StartStandalone(t *testing.T, ctx context.Context, builder *Builder, passwo
 		return nil, fmt.Errorf("pick free port: %w", err)
 	}
 
-	rootDir := filepath.Join(builder.OutputDir, "standalone")
+	rootDir := filepath.Join(builder.OutputDir, subdir)
 	dataDir := filepath.Join(rootDir, "data")
 	logPath := filepath.Join(rootDir, "postgres.log")
 	pwFile := filepath.Join(rootDir, "pwfile")

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Compatibility Tests
 
-This test package validates multigres compatibility by running PostgreSQL's official regression and isolation test suites against a multigres cluster.
+This test package validates multigres compatibility by running PostgreSQL's official regression and isolation test suites against one or more frontends.
 
 ## Overview
 
@@ -10,12 +10,37 @@ The test performs the following steps:
 2. **Build with make**: Compiles PostgreSQL using traditional ./configure and make
 3. **Build isolation tools** (if enabled): Builds `isolationtester` and `pg_isolation_regress`
 4. **Configure PATH**: Prepends the built PostgreSQL bin directory to PATH
-5. **Spin up multigres cluster**: Creates a 2-node cluster with multigateway using the built PostgreSQL
-6. **Run regression tests** (if enabled): Executes PostgreSQL regression tests through multigateway
-7. **Run isolation tests** (if enabled): Executes multi-connection concurrency tests through multigateway
-8. **Report results**: Generates a unified compatibility report (failures are logged but don't fail the test)
+5. **Per target**: Spins up the target's cluster (multigateway, pgbouncer-session, or pgbouncer-tx) and runs the enabled suites against it
+6. **Report results**: Generates a unified compatibility report (failures are logged but don't fail the test)
 
 **Important**: The test builds PostgreSQL from source and uses those binaries for the test cluster. This ensures the PostgreSQL server and the regression test library (`regress.so`) are from the same version, avoiding symbol compatibility issues.
+
+## Targets
+
+`PGREGRESS_TARGETS` is a comma-separated list of frontends the suites run against. Each target spins up its own PostgreSQL cluster so failures cannot leak across targets.
+
+| Target | Frontend | Backend | Purpose |
+|--------|----------|---------|---------|
+| `multigateway` (default) | multigres multigateway → multipooler | shardsetup PostgreSQL | Primary target. Patch-based verification is enabled for known multigres-vs-vanilla output differences. |
+| `pgbouncer-session` | pgbouncer (pool_mode=session) | standalone PostgreSQL | Near-vanilla pooler baseline. Almost identical behaviour to a direct PostgreSQL connection. |
+| `pgbouncer-tx` | pgbouncer (pool_mode=transaction) | standalone PostgreSQL | Strict pooler baseline. Session-scoped state (SET, LISTEN/NOTIFY, advisory locks, temp tables, etc.) is expected to break; the resulting failures are the signal. |
+
+The pgbouncer targets are a **control baseline**: they answer "is this failure unique to multigres, or does any pooler in this mode show it?" The patch directory under `testdata/pg17/patches` is intentionally not consulted for pgbouncer targets — every test runs raw against the rendered config.
+
+Regression detection and the Slack weekly summary read the **multigateway** target only. Pgbouncer columns exist in the report and the JSON results, but they are not part of the regression baseline.
+
+**Isolation tests are multigateway-only.** The harness patches `isolationtester` to route lock-wait probes through `public.multigres_test_session_is_blocked`, a shim that maps virtual PIDs to real backend PIDs via `application_name`. Pgbouncer does not propagate the `multigres_vpid:N` stamp that the shim looks for (session-scoped state), so most specs would hang waiting for lock-release detection that can never fire. Pgbouncer targets therefore skip the isolation suite entirely; their columns render blank in the isolation table.
+
+### Known pgbouncer-session limitations
+
+The session-mode target ships with `server_lifetime = 0` so every client connection forces a fresh PostgreSQL backend. That restores the test invariants the upstream regression suite relies on for temp tables, prepared statements, `LOAD`'ed extensions, and the `ON login` event trigger — and brings pgbouncer-session to **221/222 (99.5%)** against the upstream fixtures.
+
+The remaining fixed-cost failure is `event_trigger_login`:
+
+- The test counts how many times `ON login` fires after creating its trigger. Pgbouncer's own internal connections to the backend (`server_check_query` keepalives, pool setup, admin probes) each open a fresh backend with `server_lifetime = 0` and therefore each fire the user-defined login trigger, inflating the count by one or more before the test's `\c` even runs.
+- Avoiding this would require disabling pgbouncer's health-check machinery (`server_check_query = ''`), which trades a production-essential pooler reliability primitive for one test — not a trade we make.
+
+Treat `event_trigger_login` as the expected pgbouncer-session ceiling. Any pooler that probes its own backends will hit the same wall.
 
 ## Requirements
 
@@ -41,6 +66,27 @@ sudo apt-get install build-essential git
 # Xcode Command Line Tools (includes make, gcc, git)
 xcode-select --install
 ```
+
+### pgbouncer (only required for pgbouncer-* targets)
+
+The default `multigateway` target does not need pgbouncer. Install it only when running a comparison target locally. The harness pins a specific version (`PinnedPgbouncerVersion` in `pgbouncer.go`) and hard-fails if the installed binary differs — keeping fixture output reproducible across machines.
+
+```bash
+# macOS
+brew install pgbouncer
+pgbouncer --version   # must match PinnedPgbouncerVersion
+
+# Ubuntu / Debian (PGDG repo is the easiest way to get a current build)
+sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+  | sudo tee /etc/apt/sources.list.d/pgdg.list
+sudo apt-get update
+sudo apt-get install -y pgbouncer
+pgbouncer --version
+```
+
+If the installed version differs from `PinnedPgbouncerVersion`, either bump the constant (and call it out in the PR) or pin your install to the matching version.
 
 ## Running Tests
 
@@ -77,6 +123,46 @@ PGREGRESS_TESTS="boolean char" RUN_PGREGRESS=1 go test -v -timeout 60m ./go/test
 
 # Run specific isolation tests only
 PGISOLATION_TESTS="deadlock-simple tuplelock-update" RUN_PGISOLATION=1 go test -v -timeout 60m ./go/test/endtoend/pgregresstest/...
+```
+
+### Running the pooler comparison locally
+
+Pgbouncer comparison targets are opt-in via `PGREGRESS_TARGETS`. Install pgbouncer first (see the dependencies section above).
+
+```bash
+# All three targets (multigateway + both pgbouncer modes)
+PGREGRESS_TARGETS=multigateway,pgbouncer-session,pgbouncer-tx \
+RUN_PGREGRESS=1 RUN_PGISOLATION=1 \
+go test -v -timeout 180m ./go/test/endtoend/pgregresstest/...
+
+# Pgbouncer targets only (skip the multigres path for faster iteration)
+PGREGRESS_TARGETS=pgbouncer-session,pgbouncer-tx \
+RUN_PGREGRESS=1 \
+go test -v -timeout 120m ./go/test/endtoend/pgregresstest/...
+```
+
+Each target gets a separate 20-minute suite timeout, so a slow target cannot starve later ones. Bump `-timeout` on the outer `go test` invocation accordingly.
+
+### Triggering on GitHub
+
+`test-pgregress.yml` exposes the comparison-target run through `workflow_dispatch` only. The nightly cron, weekly cron, and the "Run Extended Query Serving Tests" PR label always run multigateway-only.
+
+To launch a comparison run from the GitHub UI:
+
+1. Navigate to **Actions → PostgreSQL Compatibility Tests**.
+2. Click **Run workflow**.
+3. Pick the branch and choose a value for **targets**:
+   - `multigateway` (default — same as cron)
+   - `multigateway,pgbouncer-session,pgbouncer-tx`
+   - `pgbouncer-session,pgbouncer-tx`
+4. Click the green **Run workflow** button.
+
+From the command line:
+
+```bash
+gh workflow run test-pgregress.yml \
+  -f targets="multigateway,pgbouncer-session,pgbouncer-tx" \
+  --ref <branch>
 ```
 
 ### First Run vs Cached Runs
@@ -227,13 +313,44 @@ RUN_EXTENDED_QUERY_SERVING_TESTS=1 go test -v -timeout 60m ./go/test/endtoend/pg
 
 ```text
 go/test/endtoend/pgregresstest/
-├── README.md              # This file
-├── main_test.go          # TestMain, shared setup management
-├── postgres_builder.go   # PostgreSQL build and test execution
-└── pgregress_test.go     # Regression + isolation test implementation
+├── README.md                  # This file
+├── main_test.go               # TestMain, shared multigateway setup
+├── postgres_builder.go        # PostgreSQL build, suite execution, report writers
+├── pgregress_test.go          # Top-level test: target loop, suite drivers
+├── target_cluster_test.go     # Per-target cluster lifecycle (multigateway, pgbouncer-*)
+├── targets.go                 # Target enum + PGREGRESS_TARGETS parser
+├── pgbouncer.go               # Pgbouncer process management + version pin
+└── testdata/
+    ├── pg17/patches/          # Multigateway-target output patches (no patches for pgb-*)
+    └── pgbouncer/             # session.ini.tmpl + tx.ini.tmpl rendered per instance
 ```
 
 <!-- markdownlint-enable MD013 -->
+
+### Reading the comparison report
+
+`compatibility-report.md` (also pasted into `GITHUB_STEP_SUMMARY` on CI) has the following shape when more than one target ran:
+
+```text
+## PostgreSQL Compatibility Report
+
+**PostgreSQL Version:** `REL_17_6`
+**Pgbouncer Version:** `1.24.1`
+
+[Regression — multigateway badge] [Regression — pgbouncer-session badge] [Regression — pgbouncer-tx badge]
+
+### Regression Tests
+
+| # | Test     | multigateway | pgbouncer-session | pgbouncer-tx |
+|---|----------|--------------|-------------------|--------------|
+| 1 | boolean  | ✅           | ✅                 | ✅           |
+| 2 | char     | ✅           | ✅                 | ❌           |
+| 3 | numeric  | ❌           | ❌                 | -            |
+```
+
+- `✅` / `❌` / `⏭️` mean the test passed / failed / was skipped on that target.
+- `-` means the test did not run on that target (e.g. pgbouncer-tx timed out before reaching it).
+- A failure that appears in **every** target column is almost certainly a pooler-generic limitation — useful when triaging multigres-only failures.
 
 ## Contributing
 

--- a/go/test/endtoend/pgregresstest/pgbouncer.go
+++ b/go/test/endtoend/pgregresstest/pgbouncer.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// PinnedPgbouncerVersion is the pgbouncer release the comparison targets run
+// against. Pinning ensures reproducible fixture output across CI runs and
+// developer machines: a pgbouncer minor bump can shift which regression tests
+// pass under transaction pooling, and the report would no longer be
+// comparable to previous runs.
+//
+// Bump deliberately when the project decides to track a newer pgbouncer; the
+// current value matches what PGDG ships for Ubuntu 24.04 (noble) as of the
+// install date.
+const PinnedPgbouncerVersion = "1.25.2"
+
+//go:embed testdata/pgbouncer/session.ini.tmpl testdata/pgbouncer/tx.ini.tmpl
+var pgbouncerTemplates embed.FS
+
+// PgbouncerMode selects the pool_mode pgbouncer is configured with.
+type PgbouncerMode string
+
+const (
+	// PgbouncerModeSession runs pgbouncer with pool_mode = session.
+	PgbouncerModeSession PgbouncerMode = "session"
+	// PgbouncerModeTransaction runs pgbouncer with pool_mode = transaction.
+	PgbouncerModeTransaction PgbouncerMode = "transaction"
+)
+
+// Pgbouncer represents a running pgbouncer process fronting a backend
+// PostgreSQL instance. Callers obtain one via StartPgbouncer and must invoke
+// Stop when done (typically via t.Cleanup).
+type Pgbouncer struct {
+	// Mode is the configured pool_mode.
+	Mode PgbouncerMode
+	// ListenAddr is the loopback address pgbouncer accepts connections on.
+	ListenAddr string
+	// ListenPort is the TCP port pgbouncer listens on. Clients should use this.
+	ListenPort int
+	// BackendPort is the PostgreSQL port pgbouncer forwards to.
+	BackendPort int
+	// Password is the password pgbouncer uses to authenticate to the backend.
+	Password string
+	// ConfigPath is the rendered pgbouncer.ini path.
+	ConfigPath string
+	// LogPath is the pgbouncer process log path.
+	LogPath string
+	// DataDir holds the config + log + auxiliary files.
+	DataDir string
+
+	binary string
+	cmd    *executil.Cmd
+}
+
+// RequirePgbouncer locates the pgbouncer binary in PATH and verifies it
+// matches PinnedPgbouncerVersion. Hard fails the test if the binary is
+// missing or the version differs. Returns the absolute path to the binary on
+// success.
+//
+// Hard-failing (rather than skipping the target) is intentional: a CI job
+// that asks for a pgbouncer target but silently runs only multigateway would
+// hide pooler-targeted regressions for weeks at a time.
+func RequirePgbouncer(t *testing.T) string {
+	t.Helper()
+	bin, err := exec.LookPath("pgbouncer")
+	if err != nil {
+		t.Fatalf("pgbouncer binary not found in PATH; install pinned version %s before running pgbouncer targets (see README): %v",
+			PinnedPgbouncerVersion, err)
+	}
+	out, vErr := exec.Command(bin, "--version").CombinedOutput()
+	if vErr != nil {
+		t.Fatalf("pgbouncer --version failed (binary=%s): %v\n%s", bin, vErr, out)
+	}
+	v := parsePgbouncerVersion(string(out))
+	if v == "" {
+		t.Fatalf("could not parse pgbouncer version from output: %q", strings.TrimSpace(string(out)))
+	}
+	if v != PinnedPgbouncerVersion {
+		t.Fatalf("pgbouncer version mismatch: have %s, want pinned %s (binary=%s)", v, PinnedPgbouncerVersion, bin)
+	}
+	return bin
+}
+
+// pgbouncerVersionRe captures the first SemVer-looking token in the
+// "pgbouncer --version" output (e.g. "PgBouncer 1.24.1").
+var pgbouncerVersionRe = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+
+func parsePgbouncerVersion(output string) string {
+	m := pgbouncerVersionRe.FindStringSubmatch(output)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// pgbouncerTemplateData is the substitution context exposed to the embedded
+// .ini.tmpl files. Field names are referenced directly in the templates.
+type pgbouncerTemplateData struct {
+	BackendPort int
+	ListenPort  int
+	Password    string
+	LogPath     string
+}
+
+// StartPgbouncer renders the per-mode template, launches pgbouncer against
+// the supplied backend, and waits for the listener to accept connections.
+//
+// dataDir is the per-target scratch directory the config and logs live in.
+// backendPort is the PostgreSQL port pgbouncer forwards to. password is the
+// superuser password configured on that backend.
+//
+// The caller owns lifecycle: defer p.Stop() or register a t.Cleanup. The data
+// directory is left on disk so a failing CI job can upload the log.
+func StartPgbouncer(t *testing.T, ctx context.Context, mode PgbouncerMode, dataDir string, backendPort int, password string) (*Pgbouncer, error) {
+	t.Helper()
+	bin := RequirePgbouncer(t)
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir pgbouncer data dir: %w", err)
+	}
+	port, err := pickFreePortPgbouncer()
+	if err != nil {
+		return nil, fmt.Errorf("pick pgbouncer listen port: %w", err)
+	}
+
+	p := &Pgbouncer{
+		Mode:        mode,
+		ListenAddr:  "127.0.0.1",
+		ListenPort:  port,
+		BackendPort: backendPort,
+		Password:    password,
+		DataDir:     dataDir,
+		ConfigPath:  filepath.Join(dataDir, "pgbouncer.ini"),
+		LogPath:     filepath.Join(dataDir, "pgbouncer.log"),
+		binary:      bin,
+	}
+	if err := p.renderConfig(); err != nil {
+		return nil, err
+	}
+	if err := p.launch(); err != nil {
+		return nil, err
+	}
+	if err := p.waitReady(ctx); err != nil {
+		_ = p.Stop()
+		return nil, fmt.Errorf("pgbouncer (%s) not ready: %w", p.Mode, err)
+	}
+	t.Logf("Pgbouncer (%s) listening on %s:%d -> backend :%d (config=%s, log=%s)",
+		p.Mode, p.ListenAddr, p.ListenPort, p.BackendPort, p.ConfigPath, p.LogPath)
+	return p, nil
+}
+
+// renderConfig writes the per-mode pgbouncer.ini into DataDir.
+func (p *Pgbouncer) renderConfig() error {
+	var tmplPath string
+	switch p.Mode {
+	case PgbouncerModeSession:
+		tmplPath = "testdata/pgbouncer/session.ini.tmpl"
+	case PgbouncerModeTransaction:
+		tmplPath = "testdata/pgbouncer/tx.ini.tmpl"
+	default:
+		return fmt.Errorf("unknown pgbouncer mode %q", p.Mode)
+	}
+	raw, err := pgbouncerTemplates.ReadFile(tmplPath)
+	if err != nil {
+		return fmt.Errorf("read embedded template %s: %w", tmplPath, err)
+	}
+	tmpl, err := template.New(filepath.Base(tmplPath)).Parse(string(raw))
+	if err != nil {
+		return fmt.Errorf("parse template %s: %w", tmplPath, err)
+	}
+	f, err := os.Create(p.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("create pgbouncer config: %w", err)
+	}
+	defer f.Close()
+	return tmpl.Execute(f, pgbouncerTemplateData{
+		BackendPort: p.BackendPort,
+		ListenPort:  p.ListenPort,
+		Password:    p.Password,
+		LogPath:     p.LogPath,
+	})
+}
+
+// launch starts pgbouncer in the background. pgbouncer writes its own
+// structured log to LogPath (see "logfile =" in the templates); we still
+// capture stdout/stderr to LogPath + ".stderr" in case it dies before
+// initialising the configured log.
+func (p *Pgbouncer) launch() error {
+	stderrLog, err := os.Create(p.LogPath + ".stderr")
+	if err != nil {
+		return fmt.Errorf("create pgbouncer stderr log: %w", err)
+	}
+	// Use context.Background so the pgbouncer process is not killed when the
+	// caller's setup ctx (typically time-boxed) expires. Stop() handles shutdown.
+	p.cmd = executil.Command(context.Background(), p.binary, p.ConfigPath).WithProcessGroup()
+	p.cmd.Stdout = stderrLog
+	p.cmd.Stderr = stderrLog
+	if err := p.cmd.Start(); err != nil {
+		_ = stderrLog.Close()
+		return fmt.Errorf("start pgbouncer: %w", err)
+	}
+	return nil
+}
+
+// waitReady polls the listen port until a TCP connection succeeds or the
+// caller's context deadline expires. A 15-second cap protects against
+// silently-broken configs without depending on the caller passing a tight
+// timeout.
+func (p *Pgbouncer) waitReady(ctx context.Context) error {
+	deadline := time.Now().Add(15 * time.Second)
+	addr := net.JoinHostPort(p.ListenAddr, strconv.Itoa(p.ListenPort))
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("deadline exceeded")
+	}
+	return fmt.Errorf("pgbouncer not accepting connections on %s: %w", addr, lastErr)
+}
+
+// Stop terminates the pgbouncer process. Safe to call multiple times and on
+// a half-initialised instance.
+func (p *Pgbouncer) Stop() error {
+	if p == nil || p.cmd == nil {
+		return nil
+	}
+	stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _ = p.cmd.Terminate(stopCtx)
+	p.cmd = nil
+	return nil
+}
+
+// pickFreePortPgbouncer asks the kernel for an unused TCP port. Mirrors the
+// helper in pgbuilder/standalone.go; duplicated to avoid widening that
+// package's exported API for a single test-only consumer.
+func pickFreePortPgbouncer() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/go/test/endtoend/pgregresstest/pgbouncer_test.go
+++ b/go/test/endtoend/pgregresstest/pgbouncer_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePgbouncerVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"PgBouncer 1.24.1\n", "1.24.1"},
+		{"pgbouncer version 1.21.0", "1.21.0"},
+		{"junk before 2.0.0 trailing", "2.0.0"},
+		{"no version here", ""},
+	}
+	for _, tc := range tests {
+		got := parsePgbouncerVersion(tc.in)
+		if got != tc.want {
+			t.Errorf("parsePgbouncerVersion(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestRenderPgbouncerConfig exercises the template rendering path end-to-end
+// without launching pgbouncer. Catches template syntax errors, missing
+// substitution fields, and accidental edits to the embedded .tmpl files.
+func TestRenderPgbouncerConfig(t *testing.T) {
+	for _, mode := range []PgbouncerMode{PgbouncerModeSession, PgbouncerModeTransaction} {
+		t.Run(string(mode), func(t *testing.T) {
+			dir := t.TempDir()
+			p := &Pgbouncer{
+				Mode:        mode,
+				ListenAddr:  "127.0.0.1",
+				ListenPort:  6432,
+				BackendPort: 5432,
+				Password:    "secret",
+				DataDir:     dir,
+				ConfigPath:  filepath.Join(dir, "pgbouncer.ini"),
+				LogPath:     filepath.Join(dir, "pgbouncer.log"),
+			}
+			if err := p.renderConfig(); err != nil {
+				t.Fatalf("renderConfig: %v", err)
+			}
+			data, err := os.ReadFile(p.ConfigPath)
+			if err != nil {
+				t.Fatalf("read rendered config: %v", err)
+			}
+			cfg := string(data)
+			if !strings.Contains(cfg, "listen_port = 6432") {
+				t.Errorf("listen_port not substituted into config:\n%s", cfg)
+			}
+			if !strings.Contains(cfg, "port=5432") {
+				t.Errorf("backend port not substituted:\n%s", cfg)
+			}
+			if !strings.Contains(cfg, "password=secret") {
+				t.Errorf("password not substituted:\n%s", cfg)
+			}
+			if !strings.Contains(cfg, "logfile = "+p.LogPath) {
+				t.Errorf("logfile not substituted:\n%s", cfg)
+			}
+			wantPoolMode := "pool_mode = " + string(mode)
+			if !strings.Contains(cfg, wantPoolMode) {
+				t.Errorf("expected %q in config:\n%s", wantPoolMode, cfg)
+			}
+			if mode == PgbouncerModeTransaction && !strings.Contains(cfg, "max_prepared_statements") {
+				t.Errorf("transaction-mode config missing max_prepared_statements:\n%s", cfg)
+			}
+		})
+	}
+}

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -16,28 +16,29 @@ package pgregresstest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/test/utils"
 )
 
 // TestPostgreSQLRegression tests PostgreSQL compatibility by running the official
-// PostgreSQL regression and isolation test suites against a multigres cluster.
+// PostgreSQL regression and isolation test suites against one or more frontends.
 //
-// This test performs the following steps:
-// 1. Checks out PostgreSQL source code (REL_17_6) from GitHub
-// 2. Builds PostgreSQL using ./configure and make
-// 3. Builds isolation test tools (only when the isolation suite will run)
-// 4. Prepends the built PostgreSQL bin directory to PATH
-// 5. Spins up a multigres cluster (2 nodes + multigateway) using the built PostgreSQL
-// 6. Runs regression tests through multigateway (if enabled)
-// 7. Runs isolation tests through multigateway (if enabled)
-// 8. Generates a unified compatibility report
+// Steps:
+//  1. Checks out PostgreSQL source code (REL_17_6) from GitHub.
+//  2. Builds PostgreSQL using ./configure and make.
+//  3. Builds isolation test tools (only when the isolation suite will run).
+//  4. Prepends the built PostgreSQL bin directory to PATH so pgctld + the
+//     standalone pgbouncer-target PostgreSQL instances share the same binary
+//     as the regression test library (regress.so).
+//  5. For each target in PGREGRESS_TARGETS (default: multigateway), spins up
+//     that target's backing cluster and runs the enabled suites against it.
+//  6. Generates a unified compatibility report covering every (suite, target).
 //
 // The test is skipped by default. Enable via one of:
 //   - RUN_EXTENDED_QUERY_SERVING_TESTS=1 — runs both suites (what CI uses)
@@ -50,6 +51,9 @@ import (
 //   - RUN_EXTENDED_QUERY_SERVING_TESTS=1 — enable both regression and isolation
 //   - RUN_PGREGRESS=1 — enable regression only
 //   - RUN_PGISOLATION=1 — enable isolation only
+//   - PGREGRESS_TARGETS="multigateway,pgbouncer-session,pgbouncer-tx" — target
+//     frontends to run against; defaults to multigateway only. Triggered by the
+//     workflow_dispatch input for ad-hoc comparison runs.
 //   - PGREGRESS_TESTS="boolean char" — run only specific regression tests
 //   - PGISOLATION_TESTS="deadlock-simple tuplelock-update" — run only specific isolation tests
 func TestPostgreSQLRegression(t *testing.T) {
@@ -61,18 +65,28 @@ func TestPostgreSQLRegression(t *testing.T) {
 			suiteutil.EnvRunExtendedQueryServingTests)
 	}
 
+	// PGREGRESS_TARGETS selects which frontends the suites run against. The
+	// extended-query-serving CI label and the nightly cron both unset this and
+	// therefore run only multigateway; the all-targets comparison run is
+	// triggered manually via the workflow_dispatch input.
+	targets, err := ParseTargets(os.Getenv("PGREGRESS_TARGETS"))
+	if err != nil {
+		t.Fatalf("PGREGRESS_TARGETS: %v", err)
+	}
+
 	// Check build dependencies first (before doing anything expensive)
 	if err := CheckBuildDependencies(t); err != nil {
 		t.Skipf("Build dependencies not available: %v", err)
 	}
 
-	// Each test suite gets its own sub-context so one suite hanging cannot
-	// starve the other. The build phase needs room for a cold clone + configure
-	// + make + install on slower developer machines (macOS); CI is faster so
-	// 20 minutes is overkill there but harmless.
+	// Each target gets its own suite-timeout budget so a slow target cannot
+	// starve later ones. The build phase needs room for a cold clone +
+	// configure + make + install on slower developer machines (macOS); CI is
+	// faster so 20 minutes is overkill there but harmless.
 	const (
 		buildTimeout = 20 * time.Minute
 		suiteTimeout = 20 * time.Minute
+		setupTimeout = 5 * time.Minute
 	)
 
 	buildCtx := utils.WithTimeout(t, buildTimeout)
@@ -101,8 +115,9 @@ func TestPostgreSQLRegression(t *testing.T) {
 		}
 	}
 
-	// Phase 3: Prepend built PostgreSQL bin directory to PATH so that pgctld uses
-	// the same PostgreSQL version as the regression test library (regress.so)
+	// Phase 3: Prepend built PostgreSQL bin directory to PATH so that pgctld
+	// and the per-target standalone PostgreSQL instances use the same
+	// PostgreSQL version as the regression test library (regress.so).
 	t.Logf("Phase 3: Configuring PATH to use built PostgreSQL...")
 	pgBinDir := filepath.Join(builder.InstallDir, "bin")
 	currentPath := os.Getenv("PATH")
@@ -112,114 +127,29 @@ func TestPostgreSQLRegression(t *testing.T) {
 	}
 	t.Logf("Using built PostgreSQL from %s", pgBinDir)
 
-	// Phase 4: Set up cluster using the built PostgreSQL
-	// This MUST happen after we modify PATH so pgctld uses the correct binaries
-	t.Logf("Phase 4: Setting up multigres cluster...")
-	setup := getSharedSetup(t)
-	setup.SetupTest(t)
+	// Phase 4: Loop over targets, spinning up each target's cluster and
+	// running the enabled suites against it.
+	t.Logf("Phase 4: Running suites against targets: %s", joinTargets(targets))
 
-	// Collect suite results for the unified report
-	var suites []SuiteResult
+	suitesByName := map[string]*SuiteResult{}
 
-	// Phase 5: Run regression tests
-	if runRegress {
-		t.Run("regression", func(t *testing.T) {
-			suiteCtx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
-			defer cancel()
-			results, err := builder.RunRegressionTests(t, suiteCtx, setup.MultigatewayPgPort, shardsetup.TestPostgresPassword)
-			if results == nil {
-				if err != nil {
-					t.Fatalf("Test harness failed to execute: %v", err)
-				}
-				t.Fatal("Test harness returned nil results")
-				return
-			}
-
-			// Replace pg_regress's strict diff verdict with patch-based
-			// verification. Operates on the regress build directory, where
-			// pg_regress wrote expected/ and results/ files.
-			regressDir := filepath.Join(builder.BuildDir, "src", "test", "regress")
-			if verr := builder.VerifyWithPatches(t, suiteCtx, results, regressDir, builder.OutputDir); verr != nil {
-				t.Logf("Warning: patch verification failed: %v", verr)
-			}
-
-			logSuiteResults(t, "Regression", results)
-
-			// Count expected tests from schedule (only for full suite runs)
-			var expectedRegress int
-			if os.Getenv("PGREGRESS_TESTS") == "" {
-				schedule := filepath.Join(builder.SourceDir, "src", "test", "regress", "parallel_schedule")
-				if n, err := CountScheduleTests(schedule); err == nil {
-					expectedRegress = n
-					t.Logf("Regression schedule has %d tests; %d executed", n, results.TotalTests)
-				}
-			}
-
-			suites = append(suites, SuiteResult{
-				Name:          "Regression Tests",
-				Results:       results,
-				ExpectedTests: expectedRegress,
+	for _, tgt := range targets {
+		t.Run(string(tgt), func(t *testing.T) {
+			runTargetSuites(t, runTargetSuitesArgs{
+				target:       tgt,
+				builder:      builder,
+				runRegress:   runRegress,
+				runIsolation: runIsolation,
+				setupTimeout: setupTimeout,
+				suiteTimeout: suiteTimeout,
+				suitesByName: suitesByName,
 			})
-
-			if err != nil && results.TotalTests == 0 {
-				t.Fatalf("Test harness failed to execute: %v", err)
-			}
 		})
 	}
 
-	// Between suites: fully reinitialize the cluster. The regression suite
-	// can leave PostgreSQL in a degraded state (crashed backends, stale
-	// connection pools, modified databases). A full teardown + re-bootstrap
-	// gives isolation a completely fresh cluster.
-	if runRegress && runIsolation {
-		t.Logf("Reinitializing cluster between suites...")
-		setup.ReinitializeCluster(t)
-	}
-
-	// Phase 6: Run isolation tests
-	if runIsolation {
-		t.Run("isolation", func(t *testing.T) {
-			suiteCtx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
-			defer cancel()
-			// The isolation harness installs a lock-detection shim on the
-			// primary's PostgreSQL directly, bypassing multigateway, so it
-			// needs the primary's direct PG port too.
-			directPgPort := setup.GetPrimary(t).Pgctld.PgPort
-			results, err := builder.RunIsolationTests(t, suiteCtx, setup.MultigatewayPgPort, directPgPort, shardsetup.TestPostgresPassword)
-			if results == nil {
-				if err != nil {
-					t.Fatalf("Isolation test harness failed to execute: %v", err)
-				}
-				t.Fatal("Isolation test harness returned nil results")
-				return
-			}
-
-			logSuiteResults(t, "Isolation", results)
-
-			// Count expected tests from schedule (only for full suite runs)
-			var expectedIsolation int
-			if os.Getenv("PGISOLATION_TESTS") == "" {
-				schedule := filepath.Join(builder.SourceDir, "src", "test", "isolation", "isolation_schedule")
-				if n, err := CountScheduleTests(schedule); err == nil {
-					expectedIsolation = n
-					t.Logf("Isolation schedule has %d tests; %d executed", n, results.TotalTests)
-				}
-			}
-
-			suites = append(suites, SuiteResult{
-				Name:          "Isolation Tests",
-				Results:       results,
-				ExpectedTests: expectedIsolation,
-			})
-
-			if err != nil && results.TotalTests == 0 {
-				t.Fatalf("Isolation test harness failed to execute: %v", err)
-			}
-		})
-	}
-
-	// Phase 7: Generate unified report
-	if len(suites) > 0 {
+	// Phase 5: Generate unified report covering every (suite, target).
+	if len(suitesByName) > 0 {
+		suites := orderedSuites(suitesByName)
 		if _, err := builder.WriteMarkdownSummary(t, suites); err != nil {
 			t.Logf("Warning: Failed to write markdown summary: %v", err)
 		}
@@ -227,6 +157,190 @@ func TestPostgreSQLRegression(t *testing.T) {
 			t.Logf("Warning: Failed to write JSON results: %v", err)
 		}
 	}
+}
+
+// runTargetSuitesArgs groups arguments for runTargetSuites — easier to grow
+// than a long positional signature when later commits add per-target options.
+type runTargetSuitesArgs struct {
+	target       Target
+	builder      *PostgresBuilder
+	runRegress   bool
+	runIsolation bool
+	setupTimeout time.Duration
+	suiteTimeout time.Duration
+	suitesByName map[string]*SuiteResult
+}
+
+// runTargetSuites brings up the cluster for a single target, runs the enabled
+// suites against it, and aggregates the per-(suite, target) results into
+// args.suitesByName. The cluster is torn down via t.Cleanup so it dies even
+// if a sub-suite t.Fatal's.
+//
+// Isolation is skipped for pgbouncer targets even when args.runIsolation is
+// set. The isolation harness uses a multigres-specific shim that maps
+// virtual PIDs to real backend PIDs via application_name; pgbouncer does not
+// propagate session-scoped state, so the shim has nothing to map against and
+// most specs hang waiting for lock-release detection that can never fire.
+// Surfacing "(timed out)" rows for every pgbouncer isolation run would be
+// noise without signal — we skip the run cleanly and leave the pgbouncer
+// columns blank in the isolation table.
+func runTargetSuites(t *testing.T, args runTargetSuitesArgs) {
+	t.Helper()
+
+	cluster, err := newTargetCluster(t, args.target, args.builder)
+	if err != nil {
+		t.Fatalf("construct cluster for %s: %v", args.target, err)
+	}
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), args.setupTimeout)
+	defer setupCancel()
+	if err := cluster.Setup(t, setupCtx); err != nil {
+		t.Fatalf("setup cluster for %s: %v", args.target, err)
+	}
+	t.Cleanup(cluster.Teardown)
+
+	runIsolationForTarget := args.runIsolation && args.target == TargetMultigateway
+	if args.runIsolation && !runIsolationForTarget {
+		t.Logf("Skipping isolation suite for %s: harness shim is multigres-specific and pgbouncer does not propagate the vpid stamp the shim looks for.", args.target)
+	}
+
+	if args.runRegress {
+		t.Run("regression", func(t *testing.T) {
+			runRegressionSuite(t, args.suiteTimeout, args.builder, cluster, args.suitesByName)
+		})
+	}
+
+	// Between suites: full cluster reinit. The regression suite can leave
+	// PostgreSQL in a degraded state (crashed backends, stale pools,
+	// modified databases). A clean cluster gives isolation a fair shake.
+	if args.runRegress && runIsolationForTarget {
+		t.Logf("Reinitializing %s cluster between suites...", args.target)
+		reinitCtx, reinitCancel := context.WithTimeout(context.Background(), args.setupTimeout)
+		if err := cluster.ReinitializeBetweenSuites(t, reinitCtx); err != nil {
+			reinitCancel()
+			t.Fatalf("reinit cluster for %s: %v", args.target, err)
+		}
+		reinitCancel()
+	}
+
+	if runIsolationForTarget {
+		t.Run("isolation", func(t *testing.T) {
+			runIsolationSuite(t, args.suiteTimeout, args.builder, cluster, args.suitesByName)
+		})
+	}
+}
+
+// runRegressionSuite executes pg_regress against cluster and records its
+// per-target results into suitesByName under the "Regression Tests" key.
+// Patch-based verification runs only on the multigateway target — pgbouncer
+// targets are a control baseline and explicitly skip patches.
+func runRegressionSuite(t *testing.T, suiteTimeout time.Duration, builder *PostgresBuilder, cluster targetCluster, suitesByName map[string]*SuiteResult) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
+	defer cancel()
+
+	// Multigateway cannot run pg_regress's default CREATE-then-DROP DATABASE
+	// flow (it rejects DROP DATABASE), so it pins the suite to the
+	// pre-existing "postgres" DB. The pgbouncer comparison targets sit on a
+	// standalone PG that accepts the full lifecycle — let pg_regress own
+	// "regression" so tests that hard-code that DB name run cleanly.
+	useExistingDB := cluster.Target() == TargetMultigateway
+	results, err := builder.RunRegressionTests(t, ctx, cluster.FrontendPort(), cluster.Password(), useExistingDB)
+	if results == nil {
+		if err != nil {
+			t.Fatalf("Regression harness failed for %s: %v", cluster.Target(), err)
+		}
+		t.Fatalf("Regression harness returned nil results for %s", cluster.Target())
+	}
+
+	if cluster.Target() == TargetMultigateway {
+		regressDir := filepath.Join(builder.BuildDir, "src", "test", "regress")
+		if verr := builder.VerifyWithPatches(t, ctx, results, regressDir, builder.OutputDir); verr != nil {
+			t.Logf("Warning: patch verification failed: %v", verr)
+		}
+	}
+
+	logSuiteResults(t, fmt.Sprintf("Regression (%s)", cluster.Target()), results)
+
+	expectedRegress := 0
+	if os.Getenv("PGREGRESS_TESTS") == "" {
+		schedule := filepath.Join(builder.SourceDir, "src", "test", "regress", "parallel_schedule")
+		if n, e := CountScheduleTests(schedule); e == nil {
+			expectedRegress = n
+			t.Logf("Regression schedule has %d tests; %d executed (%s)", n, results.TotalTests, cluster.Target())
+		}
+	}
+
+	appendTargetResults(suitesByName, "Regression Tests", cluster.Target(), results, expectedRegress)
+
+	if err != nil && results.TotalTests == 0 {
+		t.Fatalf("Regression harness failed for %s: %v", cluster.Target(), err)
+	}
+}
+
+// runIsolationSuite executes pg_isolation_regress against cluster and records
+// its per-target results into suitesByName under the "Isolation Tests" key.
+// The lock-detection shim is installed via the cluster's DirectPgPort so it
+// bypasses the frontend pooler — this is the same trick the multigateway
+// path uses, repurposed for pgbouncer comparison targets.
+func runIsolationSuite(t *testing.T, suiteTimeout time.Duration, builder *PostgresBuilder, cluster targetCluster, suitesByName map[string]*SuiteResult) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
+	defer cancel()
+
+	directPgPort := cluster.DirectPgPort(t)
+	results, err := builder.RunIsolationTests(t, ctx, cluster.FrontendPort(), directPgPort, cluster.Password())
+	if results == nil {
+		if err != nil {
+			t.Fatalf("Isolation harness failed for %s: %v", cluster.Target(), err)
+		}
+		t.Fatalf("Isolation harness returned nil results for %s", cluster.Target())
+	}
+
+	logSuiteResults(t, fmt.Sprintf("Isolation (%s)", cluster.Target()), results)
+
+	expectedIsolation := 0
+	if os.Getenv("PGISOLATION_TESTS") == "" {
+		schedule := filepath.Join(builder.SourceDir, "src", "test", "isolation", "isolation_schedule")
+		if n, e := CountScheduleTests(schedule); e == nil {
+			expectedIsolation = n
+			t.Logf("Isolation schedule has %d tests; %d executed (%s)", n, results.TotalTests, cluster.Target())
+		}
+	}
+
+	appendTargetResults(suitesByName, "Isolation Tests", cluster.Target(), results, expectedIsolation)
+
+	if err != nil && results.TotalTests == 0 {
+		t.Fatalf("Isolation harness failed for %s: %v", cluster.Target(), err)
+	}
+}
+
+// appendTargetResults stores per-target results for a suite, creating the
+// SuiteResult on first write. ExpectedTests is the per-suite schedule count
+// and is target-independent; the larger of the existing and incoming values
+// wins so timeouts on one target do not undercount the schedule.
+func appendTargetResults(m map[string]*SuiteResult, name string, tgt Target, r *TestResults, expected int) {
+	s, ok := m[name]
+	if !ok {
+		s = &SuiteResult{Name: name, PerTarget: map[Target]*TestResults{}}
+		m[name] = s
+	}
+	s.PerTarget[tgt] = r
+	if expected > s.ExpectedTests {
+		s.ExpectedTests = expected
+	}
+}
+
+// orderedSuites returns the suites in a stable order (regression first,
+// isolation second) so reports look identical across runs that include the
+// same set of suites.
+func orderedSuites(m map[string]*SuiteResult) []SuiteResult {
+	var out []SuiteResult
+	for _, name := range []string{"Regression Tests", "Isolation Tests"} {
+		if s, ok := m[name]; ok {
+			out = append(out, *s)
+		}
+	}
+	return out
 }
 
 // logSuiteResults logs structured results for a test suite to the test output.

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -233,13 +233,28 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 	return results, nil
 }
 
-// RunRegressionTests runs PostgreSQL regression tests against multigateway.
+// RunRegressionTests runs PostgreSQL regression tests against the supplied
+// frontend port.
 //
 // Uses make installcheck-tests with TESTS variable to run specific regression tests
-// against the existing PostgreSQL server (multigateway).
+// against the existing PostgreSQL server. The installcheck-tests target runs
+// specific tests against an already-running PostgreSQL server, unlike
+// installcheck which runs the entire parallel_schedule.
 //
-// The installcheck-tests target runs specific tests against an already-running
-// PostgreSQL server, unlike installcheck which runs the entire parallel_schedule.
+// useExistingDB controls pg_regress's database-lifecycle mode:
+//
+//   - true  → pass --use-existing --dbname=postgres so pg_regress runs every
+//     test inside the pre-existing "postgres" DB. Used by the multigateway
+//     target because multigateway rejects DROP DATABASE (see
+//     go/services/multigateway/planner/unsafe_stmt.go) and pg_regress's
+//     default CREATE-then-DROP flow would fail. Cost: every test shares one
+//     DB, so many upstream tests that hard-code the "regression" DB name or
+//     assume a fresh schema fail with name/state collisions.
+//   - false → let pg_regress own the lifecycle: it connects to PGDATABASE,
+//     issues CREATE DATABASE regression, then runs tests inside that fresh
+//     DB. Used by the pgbouncer targets where the backend tolerates
+//     CREATE/DROP DATABASE; recovers ~11 of the tests that the shared-DB
+//     mode loses.
 //
 // From PostgreSQL's src/test/regress/GNUmakefile:
 //
@@ -251,24 +266,17 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 //	PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE - connection params
 //
 // Reference: https://github.com/postgres/postgres/blob/master/src/test/regress/GNUmakefile
-func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context, multigatewayPort int, password string) (*TestResults, error) {
+func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context, frontendPort int, password string, useExistingDB bool) (*TestResults, error) {
 	t.Helper()
 
-	t.Logf("Running PostgreSQL regression tests against multigateway on port %d...", multigatewayPort)
+	t.Logf("Running PostgreSQL regression tests against port %d (useExistingDB=%t)...", frontendPort, useExistingDB)
 
 	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
 	makeArgs := []string{"-C", regressDir}
 
-	// --use-existing: skip pg_regress's automatic DROP + CREATE of the
-	// "regression" database. Multigateway rejects DROP DATABASE (see the
-	// unsafe-statement list in go/services/multigateway/planner/unsafe_stmt.go),
-	// so we can't let pg_regress manage the database. Instead we run against
-	// the existing "postgres" database for the whole suite.
-	//
-	// --dbname=postgres: point pg_regress at that existing database. pg_regress
-	// will create/drop the expected schema objects per test; cross-test state
-	// leakage is still possible but has not surfaced in practice.
-	makeArgs = append(makeArgs, "EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres")
+	if useExistingDB {
+		makeArgs = append(makeArgs, "EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres")
+	}
 
 	if testsEnv := os.Getenv("PGREGRESS_TESTS"); testsEnv != "" {
 		makeArgs = append(makeArgs, "installcheck-tests", "TESTS="+testsEnv)
@@ -284,7 +292,7 @@ func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context,
 		suiteName: "Regression",
 		outputDir: pb.OutputDir,
 		srcOutDir: regressDir,
-	}, multigatewayPort, password)
+	}, frontendPort, password)
 }
 
 // ParseTestResults parses pg_regress TAP output to extract test results.
@@ -553,34 +561,74 @@ func CountScheduleTests(scheduleFile string) (int, error) {
 	return count, nil
 }
 
-// SuiteResult holds results for one test suite.
+// SuiteResult holds results for one test suite across one or more targets.
+//
+// PerTarget is keyed by Target (e.g. TargetMultigateway, TargetPgbouncerSession,
+// TargetPgbouncerTx). When PGREGRESS_TARGETS is unset or selects a single
+// target the map has one entry.
+//
+// ExpectedTests is the number of tests in the upstream schedule file (parallel
+// or isolation). It applies to every target — schedules are target-independent
+// — and is captured once from the run that produced the largest suite.
 type SuiteResult struct {
-	Name          string       // e.g. "Regression Tests", "Isolation Tests"
-	Results       *TestResults // parsed TAP results
-	ExpectedTests int          // total tests from schedule file (0 = unknown)
+	Name          string                  // e.g. "Regression Tests", "Isolation Tests"
+	PerTarget     map[Target]*TestResults // target -> parsed TAP results
+	ExpectedTests int                     // total tests from schedule file (0 = unknown)
 }
 
-// githubBlobURLPrefix returns an absolute URL prefix of the form
-// "https://github.com/<owner>/<repo>/blob/<sha>/" when running inside a
-// GitHub Actions job, or an empty string otherwise. Repo-relative paths
-// concatenated onto this prefix resolve to the blob view of that file at
-// the exact commit the job is executing against.
-func githubBlobURLPrefix() string {
-	serverURL := os.Getenv("GITHUB_SERVER_URL")
-	repo := os.Getenv("GITHUB_REPOSITORY")
-	sha := os.Getenv("GITHUB_SHA")
-	if serverURL == "" || repo == "" || sha == "" {
-		return ""
+// orderedTargets returns the targets present in PerTarget, in canonical order.
+func (s *SuiteResult) orderedTargets() []Target {
+	var out []Target
+	for _, t := range allTargets {
+		if _, ok := s.PerTarget[t]; ok {
+			out = append(out, t)
+		}
 	}
-	return fmt.Sprintf("%s/%s/blob/%s/", serverURL, repo, sha)
+	return out
+}
+
+// reportUsesPgbouncer returns true if any suite in the report ran a pgbouncer
+// target. Drives whether the version header advertises a pgbouncer version
+// or "n/a" (the default multigateway-only run uses no pgbouncer).
+func reportUsesPgbouncer(suites []SuiteResult) bool {
+	for _, s := range suites {
+		for _, tgt := range s.orderedTargets() {
+			if tgt == TargetPgbouncerSession || tgt == TargetPgbouncerTx {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// statusCell maps a per-test status to the compact glyph rendered in the
+// wide compatibility table.
+func statusCell(status string) string {
+	switch status {
+	case "pass":
+		return "✅"
+	case "fail":
+		return "❌"
+	case "skip":
+		return "⏭️"
+	case "":
+		return "-"
+	default:
+		return status
+	}
 }
 
 // WriteMarkdownSummary generates a unified markdown report covering one or more
-// test suites. It writes the report to pb.OutputDir/compatibility-report.md and
-// appends it to GITHUB_STEP_SUMMARY when running in CI.
+// test suites and one or more targets. It writes the report to
+// pb.OutputDir/compatibility-report.md and appends it to GITHUB_STEP_SUMMARY
+// when running in CI.
 //
-// Each suite gets its own badge showing pass rate and timeout status. Full diffs
-// are available in the CI artifact (regression.diffs).
+// Layout: per-suite per-target badge row, then for each suite a single wide
+// table with one row per test and one column per target. The Patch and
+// Duration columns from the previous single-target report are intentionally
+// dropped — patch handling is scoped to multigateway anyway (pgbouncer
+// targets run no patches) and per-target durations carry no comparison
+// signal. Patch artifacts remain on disk under the CI uploads.
 func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResult) (string, error) {
 	t.Helper()
 
@@ -588,65 +636,103 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 
 	sb.WriteString("## PostgreSQL Compatibility Report\n\n")
 
-	for _, s := range suites {
-		label := strings.TrimSuffix(s.Name, " Tests")
-		sb.WriteString(suiteutil.BadgeMarkdown(
-			label,
-			s.Results.PassedTests,
-			s.Results.TotalTests,
-			s.ExpectedTests,
-			s.Results.TimedOut,
-		))
-		sb.WriteString(" ")
+	pgbouncerLabel := "n/a"
+	if reportUsesPgbouncer(suites) {
+		pgbouncerLabel = PinnedPgbouncerVersion
 	}
-	sb.WriteString("\n\n")
-
-	fmt.Fprintf(&sb, "**PostgreSQL Version:** `%s`\n", PostgresVersion)
+	fmt.Fprintf(&sb, "**PostgreSQL Version:** `%s`  \n", PostgresVersion)
+	fmt.Fprintf(&sb, "**Pgbouncer Version:** `%s`  \n", pgbouncerLabel)
 	fmt.Fprintf(&sb, "**Timestamp:** %s\n\n", time.Now().UTC().Format(time.RFC3339))
 
-	// Build an absolute URL prefix for patch links when running in CI.
-	// Without this, markdown like [patch](go/test/.../foo.patch) is resolved
-	// relative to the step-summary page (/actions/runs/<id>/) and produces a
-	// 404 URL like .../actions/runs/go/test/.../foo.patch. Falls back to a
-	// relative link when the GitHub Actions env vars aren't set (local runs).
-	patchURLPrefix := githubBlobURLPrefix()
+	// Per-suite badge rows: one badge per (suite, target) so a comparison
+	// run surfaces all six (or however many) pass rates at the top.
+	for _, s := range suites {
+		for _, tgt := range s.orderedTargets() {
+			r := s.PerTarget[tgt]
+			if r == nil {
+				continue
+			}
+			label := fmt.Sprintf("%s — %s", strings.TrimSuffix(s.Name, " Tests"), tgt)
+			sb.WriteString(suiteutil.BadgeMarkdown(
+				label,
+				r.PassedTests,
+				r.TotalTests,
+				s.ExpectedTests,
+				r.TimedOut,
+			))
+			sb.WriteString(" ")
+		}
+		sb.WriteString("\n\n")
+	}
 
 	for _, s := range suites {
 		fmt.Fprintf(&sb, "### %s\n\n", s.Name)
 
-		if s.Results.TimedOut {
-			ran := s.Results.TotalTests
+		targets := s.orderedTargets()
+		if len(targets) == 0 {
+			sb.WriteString("_No target results recorded for this suite._\n\n")
+			continue
+		}
+
+		// Per-target timeout notices. Targets time out independently so each
+		// gets its own callout, identified by name.
+		for _, tgt := range targets {
+			r := s.PerTarget[tgt]
+			if r == nil || !r.TimedOut {
+				continue
+			}
+			ran := r.TotalTests
 			if s.ExpectedTests > 0 {
-				fmt.Fprintf(&sb, "> **Timed out** — %d of %d scheduled tests executed before the deadline.\n\n", ran, s.ExpectedTests)
+				fmt.Fprintf(&sb, "> **%s timed out** — %d of %d scheduled tests executed before the deadline.\n\n", tgt, ran, s.ExpectedTests)
 			} else {
-				fmt.Fprintf(&sb, "> **Timed out** — %d tests executed before the deadline.\n\n", ran)
+				fmt.Fprintf(&sb, "> **%s timed out** — %d tests executed before the deadline.\n\n", tgt, ran)
 			}
 		}
 
-		sb.WriteString("| # | Test | Status | Patch | Duration |\n")
-		sb.WriteString("|---|------|--------|-------|----------|\n")
-
-		for i, test := range s.Results.Tests {
-			status := "✅ ok"
-			switch test.Status {
-			case "fail":
-				status = "❌ FAIL"
-			case "skip":
-				status = "⏭️ skip"
-			}
-			duration := test.Duration
-			if duration == "" {
-				duration = "-"
-			}
-			patchCell := "-"
-			if test.PatchApplied {
-				if test.PatchPath != "" {
-					patchCell = fmt.Sprintf("📎 [patch](%s%s)", patchURLPrefix, test.PatchPath)
-				} else {
-					patchCell = "📎 applied"
+		// Build the union ordered list of tests across all targets, plus a
+		// per-target lookup for status retrieval. The first target's order
+		// is canonical; tests appearing only in later targets are appended
+		// in the order they show up there.
+		var orderedNames []string
+		seen := make(map[string]bool)
+		lookups := make([]map[string]IndividualTestResult, len(targets))
+		for i, tgt := range targets {
+			r := s.PerTarget[tgt]
+			lookup := make(map[string]IndividualTestResult)
+			if r != nil {
+				for _, test := range r.Tests {
+					lookup[test.Name] = test
+					if !seen[test.Name] {
+						seen[test.Name] = true
+						orderedNames = append(orderedNames, test.Name)
+					}
 				}
 			}
-			fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s |\n", i+1, test.Name, status, patchCell, duration)
+			lookups[i] = lookup
+		}
+
+		// Render the wide header.
+		sb.WriteString("| # | Test |")
+		for _, tgt := range targets {
+			fmt.Fprintf(&sb, " %s |", tgt)
+		}
+		sb.WriteString("\n|---|------|")
+		for range targets {
+			sb.WriteString("---|")
+		}
+		sb.WriteString("\n")
+
+		for i, name := range orderedNames {
+			fmt.Fprintf(&sb, "| %d | %s |", i+1, name)
+			for k := range targets {
+				test, ok := lookups[k][name]
+				if !ok {
+					sb.WriteString(" - |")
+					continue
+				}
+				fmt.Fprintf(&sb, " %s |", statusCell(test.Status))
+			}
+			sb.WriteString("\n")
 		}
 		sb.WriteString("\n")
 	}
@@ -660,23 +746,54 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 	return summary, nil
 }
 
-// jsonSuiteResult is the JSON-serializable representation of a single test suite's results.
-type jsonSuiteResult struct {
-	Name  string                 `json:"name"`
+// jsonTargetResult is the JSON-serializable representation of one target's
+// pass/fail results within a suite.
+type jsonTargetResult struct {
 	Tests []IndividualTestResult `json:"tests"`
 }
 
+// jsonSuiteResult is the JSON-serializable representation of a single test
+// suite's results across every target it ran on.
+//
+// The schema is:
+//
+//	{
+//	  "name": "Regression Tests",
+//	  "targets": {
+//	    "multigateway":      {"tests": [...]},
+//	    "pgbouncer-session": {"tests": [...]},
+//	    "pgbouncer-tx":      {"tests": [...]}
+//	  }
+//	}
+//
+// Multigateway-only runs emit a single entry under "targets". Consumers must
+// reach through .targets.<name>.tests to access the per-test array; the
+// previous flat `.tests` shape no longer exists.
+type jsonSuiteResult struct {
+	Name    string                      `json:"name"`
+	Targets map[string]jsonTargetResult `json:"targets"`
+}
+
 // WriteJSONResults serializes suite results to pb.OutputDir/results.json.
-// This file is consumed by CI scripts that compare runs to detect regressions.
+// This file is consumed by CI scripts (detect-regressions.sh, the Slack weekly
+// summary jq pipeline) that compare runs to detect regressions.
 func (pb *PostgresBuilder) WriteJSONResults(t *testing.T, suites []SuiteResult) (string, error) {
 	t.Helper()
 
 	var out []jsonSuiteResult
 	for _, s := range suites {
-		out = append(out, jsonSuiteResult{
-			Name:  s.Name,
-			Tests: s.Results.Tests,
-		})
+		entry := jsonSuiteResult{
+			Name:    s.Name,
+			Targets: make(map[string]jsonTargetResult, len(s.PerTarget)),
+		}
+		for _, target := range s.orderedTargets() {
+			res := s.PerTarget[target]
+			if res == nil {
+				continue
+			}
+			entry.Targets[string(target)] = jsonTargetResult{Tests: res.Tests}
+		}
+		out = append(out, entry)
 	}
 
 	resultsPath, err := suiteutil.WriteJSON(pb.OutputDir, "results.json", out)

--- a/go/test/endtoend/pgregresstest/report_test.go
+++ b/go/test/endtoend/pgregresstest/report_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
+)
+
+// newReportBuilder constructs a PostgresBuilder pointed at a per-test temp
+// directory. The Builder is never asked to do real work in these tests — only
+// pb.OutputDir is read, so the cheaper New() path is sufficient.
+func newReportBuilder(t *testing.T) *PostgresBuilder {
+	t.Helper()
+	return &PostgresBuilder{Builder: pgbuilder.New(t)}
+}
+
+// TestMarkdownSummary_SingleTarget verifies the wide-table renderer still
+// produces the expected layout when only one target ran (the default
+// multigateway-only path). Patch and Duration columns must be absent, the
+// pgbouncer version must be "n/a", and the per-target column must be present.
+func TestMarkdownSummary_SingleTarget(t *testing.T) {
+	pb := newReportBuilder(t)
+	suites := []SuiteResult{{
+		Name:          "Regression Tests",
+		ExpectedTests: 3,
+		PerTarget: map[Target]*TestResults{
+			TargetMultigateway: {
+				TotalTests:  3,
+				PassedTests: 2,
+				FailedTests: 1,
+				Tests: []IndividualTestResult{
+					{Name: "boolean", Status: "pass"},
+					{Name: "char", Status: "pass"},
+					{Name: "numeric", Status: "fail"},
+				},
+			},
+		},
+	}}
+
+	out, err := pb.WriteMarkdownSummary(t, suites)
+	if err != nil {
+		t.Fatalf("WriteMarkdownSummary: %v", err)
+	}
+
+	mustContain(t, out, "**PostgreSQL Version:** `"+PostgresVersion+"`")
+	mustContain(t, out, "**Pgbouncer Version:** `n/a`")
+	mustContain(t, out, "| # | Test | multigateway |")
+	mustContain(t, out, "| 1 | boolean | ✅ |")
+	mustContain(t, out, "| 3 | numeric | ❌ |")
+	mustNotContain(t, out, "Duration")
+	mustNotContain(t, out, "Patch")
+}
+
+// TestMarkdownSummary_AllTargets verifies the wide-table renderer when all
+// three targets ran. Every target gets a badge per suite, the table header
+// lists all three columns, and tests missing from one target render "-".
+func TestMarkdownSummary_AllTargets(t *testing.T) {
+	pb := newReportBuilder(t)
+	suites := []SuiteResult{{
+		Name:          "Regression Tests",
+		ExpectedTests: 3,
+		PerTarget: map[Target]*TestResults{
+			TargetMultigateway: {
+				TotalTests: 3, PassedTests: 3,
+				Tests: []IndividualTestResult{
+					{Name: "boolean", Status: "pass"},
+					{Name: "char", Status: "pass"},
+					{Name: "numeric", Status: "pass"},
+				},
+			},
+			TargetPgbouncerSession: {
+				TotalTests: 3, PassedTests: 2, FailedTests: 1,
+				Tests: []IndividualTestResult{
+					{Name: "boolean", Status: "pass"},
+					{Name: "char", Status: "pass"},
+					{Name: "numeric", Status: "fail"},
+				},
+			},
+			TargetPgbouncerTx: {
+				TotalTests: 2, PassedTests: 1, FailedTests: 1,
+				// numeric absent on tx target to exercise the "-" path.
+				Tests: []IndividualTestResult{
+					{Name: "boolean", Status: "pass"},
+					{Name: "char", Status: "fail"},
+				},
+			},
+		},
+	}}
+
+	out, err := pb.WriteMarkdownSummary(t, suites)
+	if err != nil {
+		t.Fatalf("WriteMarkdownSummary: %v", err)
+	}
+
+	mustContain(t, out, "**Pgbouncer Version:** `"+PinnedPgbouncerVersion+"`")
+	mustContain(t, out, "Regression — multigateway")
+	mustContain(t, out, "Regression — pgbouncer-session")
+	mustContain(t, out, "Regression — pgbouncer-tx")
+	mustContain(t, out, "| # | Test | multigateway | pgbouncer-session | pgbouncer-tx |")
+	mustContain(t, out, "| 1 | boolean | ✅ | ✅ | ✅ |")
+	mustContain(t, out, "| 2 | char | ✅ | ✅ | ❌ |")
+	mustContain(t, out, "| 3 | numeric | ✅ | ❌ | - |")
+}
+
+// TestMarkdownSummary_PerTargetTimeout asserts each target gets its own
+// timeout callout so a comparison run does not lose which target died.
+func TestMarkdownSummary_PerTargetTimeout(t *testing.T) {
+	pb := newReportBuilder(t)
+	suites := []SuiteResult{{
+		Name:          "Isolation Tests",
+		ExpectedTests: 5,
+		PerTarget: map[Target]*TestResults{
+			TargetMultigateway: {
+				TotalTests:  5,
+				PassedTests: 5,
+				Tests: []IndividualTestResult{
+					{Name: "a", Status: "pass"},
+				},
+			},
+			TargetPgbouncerTx: {
+				TotalTests: 2,
+				TimedOut:   true,
+				Tests: []IndividualTestResult{
+					{Name: "a", Status: "pass"},
+				},
+			},
+		},
+	}}
+
+	out, err := pb.WriteMarkdownSummary(t, suites)
+	if err != nil {
+		t.Fatalf("WriteMarkdownSummary: %v", err)
+	}
+	mustContain(t, out, "**pgbouncer-tx timed out**")
+	mustNotContain(t, out, "**multigateway timed out**")
+}
+
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Fatalf("expected substring %q in output:\n%s", sub, s)
+	}
+}
+
+func mustNotContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if strings.Contains(s, sub) {
+		t.Fatalf("did not expect substring %q in output:\n%s", sub, s)
+	}
+}

--- a/go/test/endtoend/pgregresstest/target_cluster_test.go
+++ b/go/test/endtoend/pgregresstest/target_cluster_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// targetCluster owns the backing cluster (frontend + PostgreSQL) for one
+// Target. Construct via newTargetCluster; the caller drives Setup, the per-
+// suite runners, optional ReinitializeBetweenSuites, and Teardown.
+//
+// Implementations are intentionally not thread-safe: the test runs targets
+// sequentially so the shared PostgresBuilder, build dir, and (for the
+// multigateway target) the package-scoped setupManager are all single-owner
+// at any moment.
+type targetCluster interface {
+	// Target reports which Target this cluster serves.
+	Target() Target
+	// Setup brings the cluster up. ctx bounds the wall-clock time available
+	// for initdb + first listener readiness.
+	Setup(t *testing.T, ctx context.Context) error
+	// FrontendPort is the port pg_regress and pg_isolation_regress connect
+	// to (multigateway port or pgbouncer listen port depending on target).
+	FrontendPort() int
+	// DirectPgPort is the backend PostgreSQL port. Used to install the
+	// isolation lock-detection shim so it bypasses the pooler.
+	DirectPgPort(t *testing.T) int
+	// Password is the superuser password to authenticate with.
+	Password() string
+	// ReinitializeBetweenSuites resets cluster state between regression and
+	// isolation. The regression suite can leave PostgreSQL in a degraded
+	// state (crashed backends, stale pools, mutated catalog); a fresh
+	// cluster keeps isolation results meaningful.
+	ReinitializeBetweenSuites(t *testing.T, ctx context.Context) error
+	// Teardown stops every process this cluster started. Idempotent and
+	// safe to call on a partially-initialised cluster.
+	Teardown()
+}
+
+// newTargetCluster constructs the targetCluster appropriate for the requested
+// Target. The PostgresBuilder is required so pgbouncer targets can place
+// their per-target data directories under the builder's already-namespaced
+// OutputDir.
+func newTargetCluster(t *testing.T, target Target, builder *PostgresBuilder) (targetCluster, error) {
+	t.Helper()
+	switch target {
+	case TargetMultigateway:
+		return &multigatewayCluster{}, nil
+	case TargetPgbouncerSession:
+		return &pgbouncerCluster{
+			target:  TargetPgbouncerSession,
+			mode:    PgbouncerModeSession,
+			builder: builder,
+		}, nil
+	case TargetPgbouncerTx:
+		return &pgbouncerCluster{
+			target:  TargetPgbouncerTx,
+			mode:    PgbouncerModeTransaction,
+			builder: builder,
+		}, nil
+	default:
+		return nil, fmt.Errorf("no cluster implementation for target %q", target)
+	}
+}
+
+// multigatewayCluster reuses the package-scoped shared setup managed by
+// TestMain. Setup is essentially a stamp on that singleton, Teardown is a
+// no-op (TestMain owns the lifecycle), and ReinitializeBetweenSuites delegates
+// to shardsetup's full reinit.
+type multigatewayCluster struct {
+	setup *shardsetup.ShardSetup
+}
+
+func (c *multigatewayCluster) Target() Target { return TargetMultigateway }
+
+func (c *multigatewayCluster) Setup(t *testing.T, _ context.Context) error {
+	c.setup = getSharedSetup(t)
+	c.setup.SetupTest(t)
+	return nil
+}
+
+func (c *multigatewayCluster) FrontendPort() int { return c.setup.MultigatewayPgPort }
+
+func (c *multigatewayCluster) DirectPgPort(t *testing.T) int {
+	return c.setup.GetPrimary(t).Pgctld.PgPort
+}
+
+func (c *multigatewayCluster) Password() string { return shardsetup.TestPostgresPassword }
+
+func (c *multigatewayCluster) ReinitializeBetweenSuites(t *testing.T, _ context.Context) error {
+	c.setup.ReinitializeCluster(t)
+	return nil
+}
+
+func (c *multigatewayCluster) Teardown() {
+	// Shared setup is reused across tests in this package; TestMain handles
+	// teardown. Intentionally a no-op here.
+}
+
+// pgbouncerCluster owns a per-target standalone PostgreSQL + pgbouncer pair.
+// Each pgbouncer-* target spins up its own initdb'd cluster so regression
+// mutations from one target cannot leak into another. ReinitializeBetweenSuites
+// is implemented as a full stop + fresh initdb so isolation gets a clean
+// cluster, mirroring shardsetup.ReinitializeCluster semantics.
+type pgbouncerCluster struct {
+	target  Target
+	mode    PgbouncerMode
+	builder *PostgresBuilder
+
+	pg  *pgbuilder.Standalone
+	pgb *Pgbouncer
+
+	// reinitCount disambiguates data dir suffixes across reinit cycles, so
+	// each fresh standalone lives in a unique directory and initdb does
+	// not fail on an existing PGDATA.
+	reinitCount int
+}
+
+func (c *pgbouncerCluster) Target() Target { return c.target }
+
+func (c *pgbouncerCluster) Setup(t *testing.T, ctx context.Context) error {
+	return c.bringUp(t, ctx)
+}
+
+func (c *pgbouncerCluster) bringUp(t *testing.T, ctx context.Context) error {
+	t.Helper()
+	pgSubdir := fmt.Sprintf("standalone-%s", c.target)
+	pgbSubdir := fmt.Sprintf("pgbouncer-%s", c.target)
+	if c.reinitCount > 0 {
+		pgSubdir = fmt.Sprintf("%s-r%d", pgSubdir, c.reinitCount)
+		pgbSubdir = fmt.Sprintf("%s-r%d", pgbSubdir, c.reinitCount)
+	}
+
+	pg, err := pgbuilder.StartStandaloneIn(t, ctx, c.builder.Builder, pgSubdir, "pgregress-"+string(c.target))
+	if err != nil {
+		return fmt.Errorf("start standalone PostgreSQL for %s: %w", c.target, err)
+	}
+	if err := applyRegressionGUCs(t, pg); err != nil {
+		_ = pg.Stop()
+		return fmt.Errorf("apply regression GUCs for %s: %w", c.target, err)
+	}
+	pgbDataDir := filepath.Join(c.builder.OutputDir, pgbSubdir)
+	pgb, err := StartPgbouncer(t, ctx, c.mode, pgbDataDir, pg.Port, pg.Password)
+	if err != nil {
+		_ = pg.Stop()
+		return fmt.Errorf("start pgbouncer for %s: %w", c.target, err)
+	}
+	c.pg = pg
+	c.pgb = pgb
+	return nil
+}
+
+// applyRegressionGUCs sets the role-level defaults pg_regress relies on (set
+// via PGDATESTYLE / PGTZ env vars by pg_regress itself). For the multigateway
+// target these flow client → multigateway → backend correctly, but pgbouncer
+// drops at least DateStyle on the loopback path — leaving every date/time
+// test diffing ISO output against the upstream "Postgres, MDY" fixtures.
+//
+// ALTER ROLE attaches the settings to the postgres role, so every connection
+// by that role to any database picks them up — including the fresh
+// "regression" database pg_regress creates a moment later via CREATE DATABASE
+// (database-level ALTERs on template1 do not carry to the new DB; CREATE
+// DATABASE clones the data files but not pg_db_role_setting rows). Applied
+// directly to PG, bypassing the pooler.
+func applyRegressionGUCs(t *testing.T, pg *pgbuilder.Standalone) error {
+	t.Helper()
+	connStr := fmt.Sprintf("host=127.0.0.1 port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=5",
+		pg.Port, pg.User, pg.Password, pg.Database)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("open admin connection: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	// Values mirror pg_regress.c: PGDATESTYLE=Postgres, MDY and
+	// PGTZ=PST8PDT. IntervalStyle and extra_float_digits are not set by
+	// pg_regress but are pinned here for parity with the shipped fixtures.
+	stmts := []string{
+		fmt.Sprintf("ALTER ROLE %s SET DateStyle = 'Postgres, MDY'", pg.User),
+		fmt.Sprintf("ALTER ROLE %s SET TimeZone = 'PST8PDT'", pg.User),
+		fmt.Sprintf("ALTER ROLE %s SET IntervalStyle = 'postgres'", pg.User),
+		fmt.Sprintf("ALTER ROLE %s SET extra_float_digits = 1", pg.User),
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("exec %q: %w", stmt, err)
+		}
+	}
+	t.Logf("Applied regression GUC defaults to role %q on port %d", pg.User, pg.Port)
+	return nil
+}
+
+func (c *pgbouncerCluster) FrontendPort() int {
+	if c.pgb == nil {
+		return 0
+	}
+	return c.pgb.ListenPort
+}
+
+func (c *pgbouncerCluster) DirectPgPort(t *testing.T) int {
+	t.Helper()
+	if c.pg == nil {
+		return 0
+	}
+	return c.pg.Port
+}
+
+func (c *pgbouncerCluster) Password() string {
+	if c.pg == nil {
+		return ""
+	}
+	return c.pg.Password
+}
+
+func (c *pgbouncerCluster) ReinitializeBetweenSuites(t *testing.T, ctx context.Context) error {
+	t.Helper()
+	c.Teardown()
+	c.reinitCount++
+	return c.bringUp(t, ctx)
+}
+
+func (c *pgbouncerCluster) Teardown() {
+	if c.pgb != nil {
+		_ = c.pgb.Stop()
+		c.pgb = nil
+	}
+	if c.pg != nil {
+		_ = c.pg.Stop()
+		c.pg = nil
+	}
+}

--- a/go/test/endtoend/pgregresstest/targets.go
+++ b/go/test/endtoend/pgregresstest/targets.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Target identifies a frontend the regression and isolation suites can run
+// against. Each target stands up its own backend PostgreSQL instance so
+// failures observed on one target do not contaminate another. See README for
+// the comparison-mode rationale.
+type Target string
+
+const (
+	// TargetMultigateway routes through multigres: multigateway -> multipooler
+	// -> PostgreSQL. Patch-based verification is enabled.
+	TargetMultigateway Target = "multigateway"
+	// TargetPgbouncerSession routes through pgbouncer in session pooling mode
+	// against a standalone PostgreSQL. Used as a "near-vanilla" pooler
+	// baseline. No patch handling.
+	TargetPgbouncerSession Target = "pgbouncer-session"
+	// TargetPgbouncerTx routes through pgbouncer in transaction pooling mode
+	// against a standalone PostgreSQL. Used as the strictest pooler baseline.
+	// No patch handling.
+	TargetPgbouncerTx Target = "pgbouncer-tx"
+)
+
+// allTargets lists every recognised target value in canonical order.
+var allTargets = []Target{
+	TargetMultigateway,
+	TargetPgbouncerSession,
+	TargetPgbouncerTx,
+}
+
+// String returns the canonical name of the target. Implements fmt.Stringer.
+func (t Target) String() string { return string(t) }
+
+// ParseTargets reads a comma-separated PGREGRESS_TARGETS value and returns the
+// list of targets to run. Whitespace around each entry is ignored. Duplicates
+// are deduplicated while preserving first-seen order. An empty input returns
+// the default single-target list of TargetMultigateway. Unknown target names
+// return an error listing the valid choices.
+func ParseTargets(envVal string) ([]Target, error) {
+	envVal = strings.TrimSpace(envVal)
+	if envVal == "" {
+		return []Target{TargetMultigateway}, nil
+	}
+
+	seen := make(map[Target]struct{}, 3)
+	var out []Target
+	for raw := range strings.SplitSeq(envVal, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		t, ok := lookupTarget(name)
+		if !ok {
+			return nil, fmt.Errorf("unknown target %q (valid: %s)", name, joinTargets(allTargets))
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("PGREGRESS_TARGETS contained no usable target names")
+	}
+	return out, nil
+}
+
+func lookupTarget(name string) (Target, bool) {
+	for _, t := range allTargets {
+		if string(t) == name {
+			return t, true
+		}
+	}
+	return "", false
+}
+
+func joinTargets(ts []Target) string {
+	names := make([]string, len(ts))
+	for i, t := range ts {
+		names[i] = string(t)
+	}
+	return strings.Join(names, ", ")
+}

--- a/go/test/endtoend/pgregresstest/targets_test.go
+++ b/go/test/endtoend/pgregresstest/targets_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []Target
+		wantErr string
+	}{
+		{name: "empty defaults to multigateway", in: "", want: []Target{TargetMultigateway}},
+		{name: "whitespace only defaults to multigateway", in: "   ", want: []Target{TargetMultigateway}},
+		{name: "single multigateway", in: "multigateway", want: []Target{TargetMultigateway}},
+		{name: "all three in canonical order", in: "multigateway,pgbouncer-session,pgbouncer-tx", want: []Target{TargetMultigateway, TargetPgbouncerSession, TargetPgbouncerTx}},
+		{name: "preserves caller order", in: "pgbouncer-tx,multigateway", want: []Target{TargetPgbouncerTx, TargetMultigateway}},
+		{name: "dedups while preserving first-seen order", in: "multigateway,pgbouncer-tx,multigateway", want: []Target{TargetMultigateway, TargetPgbouncerTx}},
+		{name: "ignores surrounding whitespace", in: " multigateway , pgbouncer-session ", want: []Target{TargetMultigateway, TargetPgbouncerSession}},
+		{name: "unknown target rejected", in: "multigateway,bogus", wantErr: `unknown target "bogus"`},
+		{name: "trailing comma without name is ignored", in: "multigateway,", want: []Target{TargetMultigateway}},
+		{name: "only commas yields error", in: ",,", wantErr: "no usable target"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTargets(tc.in)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseTargets(%q) = %v, nil; want error containing %q", tc.in, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ParseTargets(%q) error = %q; want substring %q", tc.in, err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTargets(%q) returned unexpected error: %v", tc.in, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("ParseTargets(%q) length = %d (%v); want %d (%v)", tc.in, len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("ParseTargets(%q)[%d] = %q; want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/test/endtoend/pgregresstest/testdata/pgbouncer/session.ini.tmpl
+++ b/go/test/endtoend/pgregresstest/testdata/pgbouncer/session.ini.tmpl
@@ -1,0 +1,42 @@
+# pgbouncer config for the pgregress "pgbouncer-session" comparison target.
+#
+# Session pooling assigns one backend connection per client for the whole
+# session, so it behaves almost identically to a direct PostgreSQL connection.
+# Used as the "near-vanilla" pooler baseline.
+#
+# Authentication: auth_type = any accepts any client login on the loopback
+# listener without consulting an auth_file. The backend connection is
+# authenticated using the user + password baked into the [databases] entries
+# below (pgbouncer ignores the client-provided username when auth_type = any).
+# Safe for test-only loopback use; do not adopt this config in production.
+#
+# Note: auth_type = trust would also accept the login but requires the user
+# to be listed in an auth_file, which would be one more file to manage just
+# to make the harness work.
+
+[databases]
+# Wildcard with no dbname=: pgbouncer forwards to the database name the client
+# requested. pg_regress connects to "postgres" to issue CREATE DATABASE
+# regression, then reconnects to "regression" to run the suite — both paths
+# need to work transparently through the pooler.
+* = host=127.0.0.1 port={{.BackendPort}} user=postgres password={{.Password}}
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {{.ListenPort}}
+auth_type = any
+pool_mode = session
+max_client_conn = 500
+default_pool_size = 100
+# server_lifetime = 0 makes pgbouncer close a backend the moment it is
+# returned to the pool, so every new client connection gets a freshly
+# initialised PostgreSQL backend. Without this, the upstream regression
+# tests trip over backend reuse: temp tables, prepared statements, LOAD'ed
+# extensions, and the ON login event trigger all leak across what the test
+# assumes are independent sessions. The cost is a ~20-50ms backend
+# startup per client connection, paid in test runtime, not real-world ops.
+server_lifetime = 0
+server_reset_query = DISCARD ALL
+ignore_startup_parameters = extra_float_digits,options,application_name,search_path
+logfile = {{.LogPath}}
+unix_socket_dir =

--- a/go/test/endtoend/pgregresstest/testdata/pgbouncer/tx.ini.tmpl
+++ b/go/test/endtoend/pgregresstest/testdata/pgbouncer/tx.ini.tmpl
@@ -1,0 +1,41 @@
+# pgbouncer config for the pgregress "pgbouncer-tx" comparison target.
+#
+# Transaction pooling returns the backend connection to the pool after every
+# COMMIT/ROLLBACK, so any session-scoped feature (SET, LISTEN/NOTIFY, advisory
+# locks, temp tables, WITH HOLD cursors, prepared statements created via
+# PREPARE/EXECUTE rather than the extended-query protocol) is expected to
+# break or silently misbehave. The whole purpose of this target is to surface
+# how many regression tests fall over under those restrictions, providing a
+# strict pooler baseline to compare multigateway against.
+#
+# max_prepared_statements enables pgbouncer's protocol-level prepared-statement
+# tracking (1.21+); without it the extended-query path used by libpq breaks
+# under transaction pooling.
+
+[databases]
+# Wildcard with no dbname=: pgbouncer forwards to the database name the client
+# requested. pg_regress connects to "postgres" to issue CREATE DATABASE
+# regression, then reconnects to "regression" to run the suite — both paths
+# need to work transparently through the pooler.
+* = host=127.0.0.1 port={{.BackendPort}} user=postgres password={{.Password}}
+
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {{.ListenPort}}
+auth_type = any
+pool_mode = transaction
+max_client_conn = 500
+default_pool_size = 100
+max_prepared_statements = 200
+# Intentionally no server_lifetime = 0 here, unlike the session-mode
+# template. In transaction pooling the backend is already released per
+# COMMIT, so closing it on every release forces a full PostgreSQL
+# backend startup between every transaction. That tanked pgbouncer-tx
+# from 155/222 to 88/222 in a comparison run (multi-statement tests
+# could not maintain state across the rapid reconnects), so we keep
+# the default 3600s lifetime here and accept the backend reuse that
+# transaction pooling implies.
+server_reset_query = DISCARD ALL
+ignore_startup_parameters = extra_float_digits,options,application_name,search_path
+logfile = {{.LogPath}}
+unix_socket_dir =

--- a/go/test/endtoend/suiteutil/report.go
+++ b/go/test/endtoend/suiteutil/report.go
@@ -17,8 +17,10 @@ package suiteutil
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // WriteJSON marshals v with two-space indent and writes it to
@@ -89,6 +91,30 @@ func BadgeColor(passed, total int) string {
 	}
 }
 
+// shieldsEscape encodes a label or value for the shields.io static badge path.
+//
+// shields.io splits the path by hyphens (LABEL-VALUE-COLOR) and applies these
+// in-segment rules before rendering text:
+//
+//	_   → space
+//	__  → _
+//	-   → segment separator (consumed)
+//	--  → -
+//
+// To pass arbitrary text through unchanged we therefore have to:
+//   - replace every literal `_` with `__` (preserve underscores)
+//   - replace every literal `-` with `--` (preserve hyphens, e.g. pgbouncer-session)
+//   - URL-escape the result so spaces, em-dashes, and other non-ASCII bytes
+//     don't break the HTTP URL.
+//
+// Order matters: hyphens have to be doubled *before* URL-escaping so the
+// percent signs we generate don't themselves get rewritten.
+func shieldsEscape(s string) string {
+	s = strings.ReplaceAll(s, "_", "__")
+	s = strings.ReplaceAll(s, "-", "--")
+	return url.PathEscape(s)
+}
+
 // BadgeMarkdown renders a shields.io badge as an `![alt](url)` markdown image.
 //
 // When expected > total, the badge reads "P/T_passed_(of_E)" so timed-out or
@@ -96,6 +122,10 @@ func BadgeColor(passed, total int) string {
 // A timed-out run is flagged with a "_(timed_out)" suffix and downgraded one
 // colour level from brightgreen so 100% timed-out runs don't visually appear
 // identical to a clean pass.
+//
+// The label is escaped through shieldsEscape so callers can pass arbitrary
+// text — including hyphens (e.g. "pgbouncer-session"), spaces, and non-ASCII
+// separators — without breaking the URL or shields.io's path parser.
 func BadgeMarkdown(label string, passed, total, expected int, timedOut bool) string {
 	colour := BadgeColor(passed, total)
 	value := fmt.Sprintf("%d%%2F%d_passed", passed, total)
@@ -108,5 +138,5 @@ func BadgeMarkdown(label string, passed, total, expected int, timedOut bool) str
 			colour = "yellow"
 		}
 	}
-	return fmt.Sprintf("![%s](https://img.shields.io/badge/%s-%s-%s)", label, label, value, colour)
+	return fmt.Sprintf("![%s](https://img.shields.io/badge/%s-%s-%s)", label, shieldsEscape(label), value, colour)
 }


### PR DESCRIPTION
## Summary

Adds two new comparison targets to the pgregress harness so the regression suite can run against pgbouncer (session and transaction pool modes) alongside the existing multigateway path. Each target gets its own fresh PostgreSQL instance so failures cannot leak across targets, and the unified report renders one column per target.

The new targets are a **control baseline** — they answer "is this failure unique to multigres, or does any pooler in this mode show it?" Pgbouncer columns appear in the report and `results.json` but are explicitly out of scope for regression detection and the weekly Slack rollup, which continue to track the multigateway target only.

**Isolation suite is multigateway-only.** The isolation harness installs a multigres-specific shim that maps virtual PIDs through `application_name`; pgbouncer doesn't propagate session-scoped state, so most specs hang waiting for lock-release that can never fire. Skipping isolation for pgbouncer targets keeps the report clean (their columns are blank in the isolation table).

### Triggering

The default schedule (nightly + weekly cron), the "Run Extended Query Serving Tests" PR label, and every other existing trigger continue to run multigateway-only. The comparison run is opt-in via `workflow_dispatch`:

- GitHub UI: Actions → "PostgreSQL Compatibility Tests" → Run workflow → pick a branch + a value from the `targets` dropdown.
- CLI: `gh workflow run test-pgregress.yml -f targets="multigateway,pgbouncer-session,pgbouncer-tx" --ref <branch>`.

Pgbouncer install runs only when the selected targets include `pgbouncer`. Version is pinned (`PinnedPgbouncerVersion = 1.25.2` — matches PGDG noble); the runtime check hard-fails on mismatch so a PGDG bump shows up as a clean test failure, not silently changed baseline numbers.

### Headline numbers (latest dispatch run after rebase onto upstream/main)

| Target | Regression pass | Isolation pass | Notes |
|---|---|---|---|
| multigateway | 159/222 | 93/117 | unchanged baseline; numbers track upstream/main |
| pgbouncer-session | **221/222 (99.5%)** | (skipped) | `event_trigger_login` documented as ceiling |
| pgbouncer-tx | 155/222 | (skipped) | txn-mode baseline |

Comparison signal: pgb-session 221 vs multigateway 159 → 62 multigres-specific regression failures (the actionable number for follow-up work).

### Key pieces

- Target enum + PGREGRESS_TARGETS env parser (targets.go).
- targetCluster abstraction with multigateway (shared shardsetup) and pgbouncer (standalone PG + pgbouncer pair) implementations.
- pgbouncer.go: lifecycle, pinned version, config render from embedded `testdata/pgbouncer/{session,tx}.ini.tmpl`. `RequirePgbouncer` hard-fails on version mismatch.
- `pgbuilder.StartStandaloneIn` so multiple per-target standalones can coexist under one `Builder.OutputDir`.
- Wide-format markdown report: per-target columns + per-target badges + Pg/Pgbouncer version header. Patch + Duration columns dropped.
- JSON schema bumped to `[{name, targets: {<target>: {tests: [...]}}}]`; `detect-regressions.sh` + Slack weekly-summary jq follow `.targets.multigateway.tests` (regression detection and weekly rollup intentionally cover the multigateway target only — pgbouncer targets are a control baseline).
- `workflow_dispatch.inputs.targets` choice. PGDG pgbouncer install runs only when dispatch picks a pgbouncer target.

### Design decisions

- Isolation suite is multigateway-only (shim assumes multigres `vpid` stamping that pgbouncer cannot propagate).
- Pgbouncer targets bypass `--use-existing --dbname=postgres` (which multigateway needs because it rejects `DROP DATABASE`) and let `pg_regress` own the CREATE/DROP `regression` lifecycle.
- `ALTER ROLE postgres SET DateStyle/TimeZone/IntervalStyle/extra_float_digits` applied directly to the standalone PG so role-level defaults flow into `pg_regress`'s freshly created `regression` DB without relying on pgbouncer to forward startup parameters.
- pgbouncer-session template sets `server_lifetime = 0` so every client connection forces a fresh backend; restores upstream test invariants for temp tables, prepared statements, `LOAD`'ed extensions, and `ON login` triggers. Not applied to tx-mode (caused massive regression there).
- Slack notification steps gated on `github.repository == 'multigres/multigres'` so fork dispatches do not fail trying to POST to webhooks they cannot reach.
- shields.io badge label encoder (`suiteutil.shieldsEscape`) doubles `_` and `-` per shields.io's own escape rules then URL-encodes, so multi-target labels with em-dashes and embedded hyphens render correctly.

## Test plan

- [x] **Default schedule path (multigateway-only) runs unchanged on this branch.** Verified via `gh workflow run ... -f targets=multigateway`: regression + isolation numbers match what the same SHA on main would produce. No pgbouncer artifacts created. `Pgbouncer Version: n/a` in header.
- [x] **Dispatch with all three targets produces a three-column report.** Verified:
  - Pgbouncer version header reads `1.25.2` (matches `PinnedPgbouncerVersion`); `RequirePgbouncer` hard-fails clean on PGDG mismatch.
  - Per-target badges present for every (suite, target) combination.
  - Wide regression table renders as `| # | Test | multigateway | pgbouncer-session | pgbouncer-tx |`.
  - Isolation skipped for pgbouncer targets by design; their isolation columns are intentionally absent.
- [x] **`results.json` has the per-target keys.** `Regression Tests.targets` contains `multigateway, pgbouncer-session, pgbouncer-tx`; `Isolation Tests.targets` contains `multigateway` only.
- [x] **`detect-regressions.sh` flags only multigateway pass→fail transitions.** Verified against synthetic fixture: real multigateway `pass→fail` was flagged; a pgbouncer-tx `pass→fail` change in the same payload was correctly ignored.
- [x] **Unit tests pass locally:** `go test ./go/test/endtoend/pgregresstest/ -run "TestParseTargets|TestParsePgbouncer|TestRenderPgbouncer|TestMarkdownSummary|TestVerify"` — all green.