### PR TITLE
fix(multigateway): discard extended-query messages until Sync after error

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -1394,17 +1394,15 @@ func (c *Conn) maybeDispatchDrain(msgType byte) (handled bool, err error) {
 // message body while the connection is in error-drain mode. The bytes
 // must still be consumed off the wire so the next ReadMessageType aligns
 // to the next message header — only the handler call and the reply
-// frame are suppressed.
+// frame are suppressed. readMessageBody handles zero-length bodies as a
+// no-op, so no special case is needed here.
 func (c *Conn) drainExtendedQueryMessage() error {
 	bodyLen, err := c.ReadMessageLength()
 	if err != nil {
-		return fmt.Errorf("failed to read message length while draining: %w", err)
-	}
-	if bodyLen == 0 {
-		return nil
+		return fmt.Errorf("read length while draining: %w", err)
 	}
 	if _, err := c.readMessageBody(bodyLen); err != nil {
-		return fmt.Errorf("failed to read message body while draining: %w", err)
+		return fmt.Errorf("read body while draining: %w", err)
 	}
 	c.returnReadBuffer()
 	return nil

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -763,34 +763,16 @@ func (c *Conn) serve() error {
 // waiting on). This matches PostgreSQL's documented behavior and prevents
 // the post-error frames (notably CloseComplete) that crash strict drivers.
 func (c *Conn) handleMessage(msgType byte) error {
-	if c.discardingUntilSync {
-		switch msgType {
-		case protocol.MsgSync, protocol.MsgQuery:
-			// Flush boundaries — clear the flag and fall through to
-			// normal dispatch so handleSync emits ReadyForQuery (or
-			// handleQuery runs a fresh simple-query exchange).
-			c.discardingUntilSync = false
-		case protocol.MsgTerminate:
-			// Connection teardown — fall through to normal dispatch.
-		case protocol.MsgFlush:
-			// Flush still pushes any buffered ErrorResponse to the
-			// client, but writes no reply of its own. Mirror the
-			// length-consume + flush dance that handleMessage's
-			// MsgFlush branch does below.
-			if _, err := c.ReadMessageLength(); err != nil {
-				return fmt.Errorf("failed to read Flush message length: %w", err)
-			}
-			return c.flush()
-		case protocol.MsgParse, protocol.MsgBind, protocol.MsgDescribe,
-			protocol.MsgExecute, protocol.MsgClose:
-			return c.drainExtendedQueryMessage()
-		}
+	if handled, err := c.maybeDispatchDrain(msgType); handled {
+		return err
 	}
 
 	switch msgType {
 	case protocol.MsgExecute:
 		// handleExecute consumes the deferred describe directly (it folds
 		// it into the backend call rather than flushing it separately).
+		// handleExecute itself re-checks the drain flag after the
+		// fallback resolveDeferredPortalDescribe path.
 		return c.handleExecute()
 
 	case protocol.MsgTerminate:
@@ -801,6 +783,14 @@ func (c *Conn) handleMessage(msgType byte) error {
 	// Every other message must run after any pending portal describe is
 	// flushed so the wire stays well-formed.
 	if err := c.resolveDeferredPortalDescribe(); err != nil {
+		return err
+	}
+	// resolveDeferredPortalDescribe may have flushed via HandleDescribe
+	// and entered drain mode by emitting an ErrorResponse. In that case
+	// the inbound message that triggered the flush (Parse/Bind/Close/…)
+	// must also be discarded — otherwise its reply frame would land
+	// between ErrorResponse and ReadyForQuery and crash strict drivers.
+	if handled, err := c.maybeDispatchDrain(msgType); handled {
 		return err
 	}
 
@@ -1142,6 +1132,13 @@ func (c *Conn) handleExecute() error {
 			if err := c.resolveDeferredPortalDescribe(); err != nil {
 				return err
 			}
+			// If the deferred Describe flush errored, we're now in
+			// drain mode. Don't run HandleExecute — its
+			// RowDescription / DataRow / CommandComplete frames
+			// would leak between ErrorResponse and ReadyForQuery.
+			if c.discardingUntilSync {
+				return nil
+			}
 		}
 	}
 
@@ -1346,6 +1343,51 @@ func (c *Conn) handleClose() error {
 
 	// Send CloseComplete. Stays buffered for the rest of the batch.
 	return c.writeMessage(protocol.MsgCloseComplete, nil)
+}
+
+// maybeDispatchDrain is the extended-query error-drain gate. When
+// c.discardingUntilSync is set it routes the current inbound message
+// without dispatching to its normal handler — Sync/Query clear the
+// flag and signal the caller to fall through, Flush flushes buffered
+// bytes without writing a reply, Parse/Bind/Describe/Execute/Close get
+// their bodies drained off the wire, and Terminate falls through to
+// the normal teardown.
+//
+// Returns (handled=true, err) when the message was absorbed here and
+// the caller should return immediately; (handled=false, nil) when the
+// caller should continue to its normal dispatch.
+//
+// Called twice from handleMessage — once at the top for messages that
+// arrive while drain mode is already set, and once again after
+// resolveDeferredPortalDescribe runs (which can itself enter drain
+// mode by flushing a failing deferred Describe).
+func (c *Conn) maybeDispatchDrain(msgType byte) (handled bool, err error) {
+	if !c.discardingUntilSync {
+		return false, nil
+	}
+	switch msgType {
+	case protocol.MsgSync, protocol.MsgQuery:
+		// Flush boundaries — clear the flag and signal the caller to
+		// fall through so handleSync emits ReadyForQuery (or
+		// handleQuery runs a fresh simple-query exchange).
+		c.discardingUntilSync = false
+		return false, nil
+	case protocol.MsgTerminate:
+		// Connection teardown — fall through to normal dispatch.
+		return false, nil
+	case protocol.MsgFlush:
+		// Flush still pushes any buffered ErrorResponse to the client
+		// but writes no reply of its own. Mirror the length-consume +
+		// flush dance that handleMessage's MsgFlush branch does.
+		if _, err := c.ReadMessageLength(); err != nil {
+			return true, fmt.Errorf("failed to read Flush message length: %w", err)
+		}
+		return true, c.flush()
+	case protocol.MsgParse, protocol.MsgBind, protocol.MsgDescribe,
+		protocol.MsgExecute, protocol.MsgClose:
+		return true, c.drainExtendedQueryMessage()
+	}
+	return false, nil
 }
 
 // drainExtendedQueryMessage reads and discards a single extended-query

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -216,6 +216,18 @@ type Conn struct {
 	deferredPortalDescribe     bool
 	deferredPortalDescribeName string
 
+	// discardingUntilSync is the extended-query error-recovery flag. Set
+	// when an ErrorResponse is emitted from any extended-query handler
+	// (Parse, Bind, Describe, Execute, Close); cleared when handleMessage
+	// observes Sync or Query (both flush boundaries). While set, every
+	// Parse/Bind/Describe/Execute/Close inbound message is read off the
+	// wire and silently discarded — no handler runs, no reply frame is
+	// emitted — matching PostgreSQL's "reads and discards messages until
+	// a Sync message is reached" rule. Without this gate, a CloseComplete
+	// (or ParseComplete, BindComplete, etc.) emitted after ErrorResponse
+	// in the same pipelined batch crashes strict drivers like Postgrex.
+	discardingUntilSync bool
+
 	// flushTimer is used for auto-flushing buffered writes.
 	flushTimer *time.Timer
 
@@ -742,7 +754,39 @@ func (c *Conn) serve() error {
 // other message (including a follow-up Describe of either type) flushes the
 // held state here first so the wire reply order matches what an unfused
 // Describe(P)+Execute would produce.
+//
+// Extended-query error recovery: once an ErrorResponse has been emitted in
+// the current batch, c.discardingUntilSync is set and every subsequent
+// Parse / Bind / Describe / Execute / Close is read off the wire and
+// discarded here without dispatching to a handler. Sync clears the flag
+// and proceeds to handleSync (which emits the ReadyForQuery the client is
+// waiting on). This matches PostgreSQL's documented behavior and prevents
+// the post-error frames (notably CloseComplete) that crash strict drivers.
 func (c *Conn) handleMessage(msgType byte) error {
+	if c.discardingUntilSync {
+		switch msgType {
+		case protocol.MsgSync, protocol.MsgQuery:
+			// Flush boundaries — clear the flag and fall through to
+			// normal dispatch so handleSync emits ReadyForQuery (or
+			// handleQuery runs a fresh simple-query exchange).
+			c.discardingUntilSync = false
+		case protocol.MsgTerminate:
+			// Connection teardown — fall through to normal dispatch.
+		case protocol.MsgFlush:
+			// Flush still pushes any buffered ErrorResponse to the
+			// client, but writes no reply of its own. Mirror the
+			// length-consume + flush dance that handleMessage's
+			// MsgFlush branch does below.
+			if _, err := c.ReadMessageLength(); err != nil {
+				return fmt.Errorf("failed to read Flush message length: %w", err)
+			}
+			return c.flush()
+		case protocol.MsgParse, protocol.MsgBind, protocol.MsgDescribe,
+			protocol.MsgExecute, protocol.MsgClose:
+			return c.drainExtendedQueryMessage()
+		}
+	}
+
 	switch msgType {
 	case protocol.MsgExecute:
 		// handleExecute consumes the deferred describe directly (it folds
@@ -953,7 +997,7 @@ func (c *Conn) handleParse() error {
 		// (Describe, Sync) would corrupt the next query's response stream.
 		// The error packet stays buffered until Sync flushes the batch — same shape
 		// as upstream PostgreSQL, which also defers error delivery to Sync/Flush.
-		return c.writeError(mterrors.MTD04.NewWithDetail(err.Error()))
+		return c.writeExtendedQueryError(mterrors.MTD04.NewWithDetail(err.Error()))
 	}
 
 	// Send ParseComplete message. Stays buffered for the rest of the batch.
@@ -1039,7 +1083,7 @@ func (c *Conn) handleBind() error {
 		// Do NOT send ReadyForQuery here — same reasoning as handleParse.
 		// ReadyForQuery is sent only in response to Sync. The error packet
 		// stays buffered until Sync flushes the batch.
-		return c.writeError(mterrors.MTD05.NewWithDetail(err.Error()))
+		return c.writeExtendedQueryError(mterrors.MTD05.NewWithDetail(err.Error()))
 	}
 
 	// Send BindComplete message. Stays buffered for the rest of the batch.
@@ -1155,7 +1199,7 @@ func (c *Conn) handleExecute() error {
 	})
 	if err != nil {
 		err = queryContextError(queryCtx, err)
-		return c.writeError(err)
+		return c.writeExtendedQueryError(err)
 	}
 
 	return nil
@@ -1215,7 +1259,7 @@ func (c *Conn) handleDescribe() error {
 	// Describe('P') was already flushed by handleMessage before this call.
 	desc, err := c.handler.HandleDescribe(c.ctx, c, typ, name)
 	if err != nil {
-		return c.writeError(mterrors.MTD06.NewWithDetail(err.Error()))
+		return c.writeExtendedQueryError(mterrors.MTD06.NewWithDetail(err.Error()))
 	}
 
 	// Send ParameterDescription only for statement describes ('S').
@@ -1256,7 +1300,7 @@ func (c *Conn) resolveDeferredPortalDescribe() error {
 	c.deferredPortalDescribeName = ""
 	desc, err := c.handler.HandleDescribe(c.ctx, c, 'P', name)
 	if err != nil {
-		return c.writeError(mterrors.MTD06.NewWithDetail(err.Error()))
+		return c.writeExtendedQueryError(mterrors.MTD06.NewWithDetail(err.Error()))
 	}
 	if desc != nil && desc.Fields != nil {
 		return c.writeRowDescription(desc.Fields)
@@ -1297,11 +1341,49 @@ func (c *Conn) handleClose() error {
 
 	// Call the handler.
 	if err := c.handler.HandleClose(c.ctx, c, typ, name); err != nil {
-		return c.writeError(mterrors.MTD07.NewWithDetail(err.Error()))
+		return c.writeExtendedQueryError(mterrors.MTD07.NewWithDetail(err.Error()))
 	}
 
 	// Send CloseComplete. Stays buffered for the rest of the batch.
 	return c.writeMessage(protocol.MsgCloseComplete, nil)
+}
+
+// drainExtendedQueryMessage reads and discards a single extended-query
+// message body while the connection is in error-drain mode. The bytes
+// must still be consumed off the wire so the next ReadMessageType aligns
+// to the next message header — only the handler call and the reply
+// frame are suppressed.
+func (c *Conn) drainExtendedQueryMessage() error {
+	bodyLen, err := c.ReadMessageLength()
+	if err != nil {
+		return fmt.Errorf("failed to read message length while draining: %w", err)
+	}
+	if bodyLen == 0 {
+		return nil
+	}
+	if _, err := c.readMessageBody(bodyLen); err != nil {
+		return fmt.Errorf("failed to read message body while draining: %w", err)
+	}
+	c.returnReadBuffer()
+	return nil
+}
+
+// writeExtendedQueryError writes an ErrorResponse and enters error-drain
+// mode. PostgreSQL's protocol spec requires that after an extended-query
+// message errors, the backend discards every subsequent message until
+// Sync and only then emits ReadyForQuery. Strict drivers (Postgrex, JDBC)
+// treat any frame between ErrorResponse and ReadyForQuery as protocol
+// corruption and drop the connection.
+//
+// Use this from any handler that processes an extended-query inbound
+// message (Parse, Bind, Describe, Execute, Close) when reporting an
+// error to the client. Do NOT use it from handleQuery (simple Query is
+// its own self-contained ErrorResponse + ReadyForQuery flow) or from
+// handleSync (Sync itself emits ReadyForQuery and is the boundary the
+// drain ends at).
+func (c *Conn) writeExtendedQueryError(err error) error {
+	c.discardingUntilSync = true
+	return c.writeError(err)
 }
 
 // handleSync handles an 'S' (Sync) message - extended query protocol.

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -1250,3 +1250,120 @@ func TestExtendedQueryErrorDiscardsUntilSync(t *testing.T) {
 			"and emit only ReadyForQuery — any frame between Error and RFQ "+
 			"(notably CloseComplete) breaks strict clients like Postgrex/JDBC")
 }
+
+// TestDeferredDescribeErrorDiscardsTriggeringMessage covers a subtle
+// second path into drain mode: handleDescribe('P') defers; the next
+// inbound message (here, Bind) calls handleMessage → resolveDeferredPortalDescribe
+// → HandleDescribe fails → writeExtendedQueryError sets the drain flag
+// and returns nil. handleMessage's flag check at the top has already
+// run, so without a second check the triggering Bind still dispatches
+// to handleBind, which emits BindComplete after the just-buffered
+// ErrorResponse — the exact protocol violation the PR is fixing.
+//
+// Wire must be: ErrorResponse (from the deferred Describe), ReadyForQuery.
+// No BindComplete.
+func TestDeferredDescribeErrorDiscardsTriggeringMessage(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		describeFunc: func(ctx context.Context, conn *Conn, typ byte, name string) (*query.StatementDescription, error) {
+			return nil, errors.New("portal does not exist")
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Describe('P', "missing") — deferred until the next non-Execute msg.
+	readBuf.WriteByte(protocol.MsgDescribe)
+	writeTestInt32(&readBuf, int32(4+1+len("missing")+1))
+	readBuf.WriteByte('P')
+	writeTestString(&readBuf, "missing")
+
+	// Bind — triggers resolveDeferredPortalDescribe, which fails.
+	readBuf.WriteByte(protocol.MsgBind)
+	writeTestInt32(&readBuf, int32(4+1+1+2+2+2)) // empty portal + empty stmt + 0/0/0 counts
+	writeTestString(&readBuf, "")
+	writeTestString(&readBuf, "")
+	writeTestInt16(&readBuf, 0)
+	writeTestInt16(&readBuf, 0)
+	writeTestInt16(&readBuf, 0)
+
+	// Sync
+	readBuf.WriteByte(protocol.MsgSync)
+	writeTestInt32(&readBuf, 4)
+
+	conn.startWriterBuffering()
+	for i := range 3 {
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err, "ReadMessageType iter %d", i)
+		require.NoError(t, conn.handleMessage(msgType), "handleMessage iter %d", i)
+	}
+	require.NoError(t, conn.endWriterBuffering())
+
+	var got []byte
+	for writeBuf.Len() > 0 {
+		msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+		got = append(got, msgType)
+	}
+
+	want := []byte{protocol.MsgErrorResponse, protocol.MsgReadyForQuery}
+	assert.Equal(t, want, got,
+		"when the deferred Describe flush emits ErrorResponse, the message "+
+			"that triggered the flush (Bind) must not also emit its own "+
+			"BindComplete — that frame would land between Error and RFQ")
+}
+
+// TestDeferredDescribeErrorDiscardsTriggeringExecute covers the same
+// gap inside handleExecute: Execute with a portal name that doesn't
+// match the deferred describe forces resolveDeferredPortalDescribe to
+// flush via HandleDescribe; if that fails and enters drain mode, the
+// subsequent HandleExecute call must not run — otherwise its
+// CommandComplete (or DataRow / RowDescription) frames leak after
+// ErrorResponse.
+func TestDeferredDescribeErrorDiscardsTriggeringExecute(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		describeFunc: func(ctx context.Context, conn *Conn, typ byte, name string) (*query.StatementDescription, error) {
+			return nil, errors.New("portal does not exist")
+		},
+		// HandleExecute default in testHandler emits a row — if the gate
+		// fails to suppress it, RowDescription/DataRow/CommandComplete
+		// will appear in the wire output.
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Describe('P', "deferred-name") — sets the deferred-describe state.
+	readBuf.WriteByte(protocol.MsgDescribe)
+	writeTestInt32(&readBuf, int32(4+1+len("deferred-name")+1))
+	readBuf.WriteByte('P')
+	writeTestString(&readBuf, "deferred-name")
+
+	// Execute("other-portal") — mismatched name, so the deferred describe
+	// flushes via the handler, which errors out.
+	readBuf.WriteByte(protocol.MsgExecute)
+	writeTestInt32(&readBuf, int32(4+len("other-portal")+1+4))
+	writeTestString(&readBuf, "other-portal")
+	writeTestInt32(&readBuf, 0)
+
+	// Sync
+	readBuf.WriteByte(protocol.MsgSync)
+	writeTestInt32(&readBuf, 4)
+
+	conn.startWriterBuffering()
+	for i := range 3 {
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err, "ReadMessageType iter %d", i)
+		require.NoError(t, conn.handleMessage(msgType), "handleMessage iter %d", i)
+	}
+	require.NoError(t, conn.endWriterBuffering())
+
+	var got []byte
+	for writeBuf.Len() > 0 {
+		msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+		got = append(got, msgType)
+	}
+
+	want := []byte{protocol.MsgErrorResponse, protocol.MsgReadyForQuery}
+	assert.Equal(t, want, got,
+		"deferred Describe flush erroring inside handleExecute must abort "+
+			"the HandleExecute call — no RowDescription/DataRow/CommandComplete "+
+			"may appear between ErrorResponse and ReadyForQuery")
+}

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -1182,3 +1182,71 @@ func TestPipelinedParseErrorRecovery(t *testing.T) {
 	// Buffer should be empty — no extra messages.
 	assert.Equal(t, 0, writeBuf.Len(), "no extra messages should be in the buffer")
 }
+
+// TestExtendedQueryErrorDiscardsUntilSync pins the PostgreSQL extended-query
+// error-recovery rule:
+//
+//	"When an error is detected while processing any extended-query message,
+//	 the backend issues ErrorResponse, then reads and discards messages until
+//	 a Sync message is reached, then issues ReadyForQuery."
+//	 — https://www.postgresql.org/docs/current/protocol-flow.html
+//
+// Minimum reproducer: one extended-query message that errors (Parse),
+// then any extended-query follow-up (Close) that would otherwise emit a
+// *Complete reply, then Sync. The follow-up's reply frame must be
+// suppressed; only ErrorResponse and ReadyForQuery may appear on the
+// wire. Strict drivers (Postgrex, JDBC) crash on any frame between
+// ErrorResponse and ReadyForQuery; the original wire trace came from a
+// Parse / Bind / Execute / Close / Sync flight, but the gate applies to
+// every Parse/Bind/Describe/Execute/Close after an error.
+// See ~/dev/multigres-plans/investigations/2026-05-20-multigateway-extended-query-close-after-error.md.
+func TestExtendedQueryErrorDiscardsUntilSync(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		parseFunc: func(ctx context.Context, conn *Conn, name, queryStr string, paramTypes []uint32) error {
+			return errors.New("parse failed")
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Drive the serve()-loop's ReadMessageType + handleMessage path —
+	// that's where the discard-until-Sync gate lives. (Calling handlers
+	// individually bypasses the gate by design.)
+
+	// Parse 'P' — parseFunc above makes this fail.
+	readBuf.WriteByte(protocol.MsgParse)
+	writeTestInt32(&readBuf, int32(4+1+1+2)) // empty stmt name + empty query + 0 param types
+	writeTestString(&readBuf, "")
+	writeTestString(&readBuf, "")
+	writeTestInt16(&readBuf, 0)
+
+	// Close 'C' — the frame whose CloseComplete must NOT be emitted.
+	readBuf.WriteByte(protocol.MsgClose)
+	writeTestInt32(&readBuf, int32(4+1+1)) // type byte + empty name + null
+	readBuf.WriteByte('S')
+	writeTestString(&readBuf, "")
+
+	// Sync 'S'
+	readBuf.WriteByte(protocol.MsgSync)
+	writeTestInt32(&readBuf, 4)
+
+	conn.startWriterBuffering()
+	for i := range 3 {
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err, "ReadMessageType iter %d", i)
+		require.NoError(t, conn.handleMessage(msgType), "handleMessage iter %d", i)
+	}
+	require.NoError(t, conn.endWriterBuffering())
+
+	var got []byte
+	for writeBuf.Len() > 0 {
+		msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+		got = append(got, msgType)
+	}
+
+	want := []byte{protocol.MsgErrorResponse, protocol.MsgReadyForQuery}
+	assert.Equal(t, want, got,
+		"after ErrorResponse the gateway must discard the pipelined Close "+
+			"and emit only ReadyForQuery — any frame between Error and RFQ "+
+			"(notably CloseComplete) breaks strict clients like Postgrex/JDBC")
+}

--- a/go/common/pgprotocol/server/extended_query_test.go
+++ b/go/common/pgprotocol/server/extended_query_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"sync"
@@ -1366,4 +1367,174 @@ func TestDeferredDescribeErrorDiscardsTriggeringExecute(t *testing.T) {
 		"deferred Describe flush erroring inside handleExecute must abort "+
 			"the HandleExecute call — no RowDescription/DataRow/CommandComplete "+
 			"may appear between ErrorResponse and ReadyForQuery")
+}
+
+// TestDrainModeFlushPushesErrorWithoutReply covers the Flush branch of
+// maybeDispatchDrain. A client that issues `Parse(err) + Flush` (the
+// shape libpq uses to surface a Parse error without committing to a
+// Sync yet) must see the ErrorResponse on the wire after the Flush,
+// but no further reply frame from the Flush itself. The drain flag
+// stays set; the next Parse is still drained; Sync clears the flag.
+func TestDrainModeFlushPushesErrorWithoutReply(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		parseFunc: func(ctx context.Context, conn *Conn, name, queryStr string, paramTypes []uint32) error {
+			return errors.New("parse failed")
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Parse (errors).
+	readBuf.WriteByte(protocol.MsgParse)
+	writeTestInt32(&readBuf, int32(4+1+1+2))
+	writeTestString(&readBuf, "")
+	writeTestString(&readBuf, "")
+	writeTestInt16(&readBuf, 0)
+
+	// Flush — should push the buffered ErrorResponse without adding a frame.
+	readBuf.WriteByte(protocol.MsgFlush)
+	writeTestInt32(&readBuf, 4)
+
+	// Another Parse — must be drained, no reply.
+	readBuf.WriteByte(protocol.MsgParse)
+	writeTestInt32(&readBuf, int32(4+1+1+2))
+	writeTestString(&readBuf, "")
+	writeTestString(&readBuf, "")
+	writeTestInt16(&readBuf, 0)
+
+	// Sync — clears drain mode and emits RFQ.
+	readBuf.WriteByte(protocol.MsgSync)
+	writeTestInt32(&readBuf, 4)
+
+	conn.startWriterBuffering()
+	for i := range 4 {
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err, "ReadMessageType iter %d", i)
+		require.NoError(t, conn.handleMessage(msgType), "handleMessage iter %d", i)
+	}
+	require.NoError(t, conn.endWriterBuffering())
+
+	var got []byte
+	for writeBuf.Len() > 0 {
+		msgType, _, _ := readMessageTypeAndLength(t, &writeBuf)
+		got = append(got, msgType)
+	}
+
+	want := []byte{protocol.MsgErrorResponse, protocol.MsgReadyForQuery}
+	assert.Equal(t, want, got,
+		"Flush in drain mode must push buffered ErrorResponse but emit "+
+			"no reply of its own; subsequent Parse must drain; Sync ends "+
+			"drain mode with ReadyForQuery")
+	assert.False(t, conn.discardingUntilSync,
+		"drain flag must be cleared by Sync")
+}
+
+// TestDrainModeTruncatedStreamSurfacesError pins the I/O error paths
+// in maybeDispatchDrain (Flush) and drainExtendedQueryMessage (Bind):
+// if the wire is truncated mid-header, both must return a wrapped error
+// rather than crashing or silently advancing.
+func TestDrainModeTruncatedStreamSurfacesError(t *testing.T) {
+	t.Run("drained_message_missing_length", func(t *testing.T) {
+		var readBuf, writeBuf bytes.Buffer
+		handler := &testHandler{
+			parseFunc: func(ctx context.Context, conn *Conn, name, queryStr string, paramTypes []uint32) error {
+				return errors.New("parse failed")
+			},
+		}
+		conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+		// Parse (errors) — enters drain mode.
+		readBuf.WriteByte(protocol.MsgParse)
+		writeTestInt32(&readBuf, int32(4+1+1+2))
+		writeTestString(&readBuf, "")
+		writeTestString(&readBuf, "")
+		writeTestInt16(&readBuf, 0)
+
+		// Bind type byte with no length — truncated header.
+		readBuf.WriteByte(protocol.MsgBind)
+
+		conn.startWriterBuffering()
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err)
+		require.NoError(t, conn.handleMessage(msgType))
+		assert.True(t, conn.discardingUntilSync)
+
+		msgType, err = conn.ReadMessageType()
+		require.NoError(t, err)
+		err = conn.handleMessage(msgType)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read length while draining")
+	})
+
+	t.Run("drain_flush_missing_length", func(t *testing.T) {
+		var readBuf, writeBuf bytes.Buffer
+		handler := &testHandler{
+			parseFunc: func(ctx context.Context, conn *Conn, name, queryStr string, paramTypes []uint32) error {
+				return errors.New("parse failed")
+			},
+		}
+		conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+		// Parse (errors) — enters drain mode.
+		readBuf.WriteByte(protocol.MsgParse)
+		writeTestInt32(&readBuf, int32(4+1+1+2))
+		writeTestString(&readBuf, "")
+		writeTestString(&readBuf, "")
+		writeTestInt16(&readBuf, 0)
+
+		// Flush type byte with no length — truncated header.
+		readBuf.WriteByte(protocol.MsgFlush)
+
+		conn.startWriterBuffering()
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err)
+		require.NoError(t, conn.handleMessage(msgType))
+
+		msgType, err = conn.ReadMessageType()
+		require.NoError(t, err)
+		err = conn.handleMessage(msgType)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read Flush message length")
+	})
+}
+
+// TestDrainModeTerminateExits covers the Terminate branch of
+// maybeDispatchDrain. A client that errors during an extended-query
+// batch and then closes the connection (Parse(err) + Terminate) must
+// still see Terminate handled as connection teardown — the gate falls
+// through to handleMessage's normal Terminate dispatch (return io.EOF).
+func TestDrainModeTerminateExits(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		parseFunc: func(ctx context.Context, conn *Conn, name, queryStr string, paramTypes []uint32) error {
+			return errors.New("parse failed")
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Parse (errors).
+	readBuf.WriteByte(protocol.MsgParse)
+	writeTestInt32(&readBuf, int32(4+1+1+2))
+	writeTestString(&readBuf, "")
+	writeTestString(&readBuf, "")
+	writeTestInt16(&readBuf, 0)
+
+	// Terminate (no body).
+	readBuf.WriteByte(protocol.MsgTerminate)
+
+	conn.startWriterBuffering()
+
+	// Parse: writes ErrorResponse, enters drain mode.
+	msgType, err := conn.ReadMessageType()
+	require.NoError(t, err)
+	require.NoError(t, conn.handleMessage(msgType))
+	assert.True(t, conn.discardingUntilSync, "Parse error must enter drain mode")
+
+	// Terminate: must surface io.EOF so the serve() loop tears the
+	// connection down cleanly even from drain mode.
+	msgType, err = conn.ReadMessageType()
+	require.NoError(t, err)
+	require.Equal(t, byte(protocol.MsgTerminate), msgType)
+	require.ErrorIs(t, conn.handleMessage(msgType), io.EOF,
+		"Terminate in drain mode must return io.EOF, not silently drain")
 }


### PR DESCRIPTION
## Summary

Realtime tests are failing against Multigres because of this bug.

Multigateway emitted a `CloseComplete` frame between `ErrorResponse` and `ReadyForQuery` in pipelined extended-query batches, violating the PostgreSQL protocol's "read and discard messages until Sync" rule. Strict drivers (Postgrex, JDBC `PgPreparedStatement`) treat any frame between `ErrorResponse` and `ReadyForQuery` as protocol corruption and drop the connection.

## Problem

For `Parse, Bind, Execute, Close, Sync` where `Execute` errors, the protocol requires `ParseComplete, BindComplete, ErrorResponse, ReadyForQuery`. Multigateway instead emitted `ParseComplete, BindComplete, ErrorResponse, CloseComplete, ReadyForQuery` — every extended-query handler ran its reply unconditionally, even after a prior message in the same batch had emitted `ErrorResponse`. Wire-level analysis: `multigres-plans/investigations/2026-05-20-multigateway-extended-query-close-after-error.md`.

## Solution

- New `discardingUntilSync` flag on `Conn`, set by a `writeExtendedQueryError` wrapper used by every extended-query error path. While set, `handleMessage` drains Parse/Bind/Describe/Execute/Close off the wire without dispatching to a handler; `Flush` still pushes the buffered `ErrorResponse`; `Sync` (and simple `Query`) clear the flag.
- The gate is re-checked after `resolveDeferredPortalDescribe` in both `handleMessage` and `handleExecute`, so a failing deferred `Describe('P')` can't leak `BindComplete` / `RowDescription` / `CommandComplete` from the message that triggered the flush.
- Regression tests pin the wire output for the three paths above. Full `./go/test/endtoend/queryserving/...` suite passes.