### PR TITLE
fix(parser): deparser drops OVERRIDING, mangles SHOW ALL, doubles space

### DIFF
--- a/go/common/parser/ast/ddl_creation_statements.go
+++ b/go/common/parser/ast/ddl_creation_statements.go
@@ -757,8 +757,13 @@ func (oci *CreateOpClassItem) SqlString() string {
 			nameStr = strings.ReplaceAll(nameStr, "SMALLINT", "int2")
 			nameStr = strings.ReplaceAll(nameStr, "BIGINT", "int8")
 			nameStr = strings.ReplaceAll(nameStr, "INT", "int4")
-			// Add space before opening parenthesis
-			nameStr = strings.ReplaceAll(nameStr, "(", " (")
+			// Add a space between the operator name and the argument list,
+			// e.g. "=(int4, int4)" -> "= (int4, int4)". If there is no operator
+			// name (DROP OPERATOR), nameStr starts with "(" and we must not
+			// emit a leading space — that produces a double space when joined.
+			if !strings.HasPrefix(nameStr, "(") {
+				nameStr = strings.ReplaceAll(nameStr, "(", " (")
+			}
 		case OPCLASS_ITEM_FUNCTION:
 			// Fix type normalization in function arguments (order matters!)
 			nameStr = strings.ReplaceAll(nameStr, "SMALLINT", "int2")

--- a/go/common/parser/ast/statements.go
+++ b/go/common/parser/ast/statements.go
@@ -861,6 +861,13 @@ func (i *InsertStmt) SqlString() string {
 		}
 		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(cols, ", ")))
 	}
+
+	// OVERRIDING { SYSTEM | USER } VALUE clause — semantically significant
+	// when inserting into GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY columns.
+	if s := i.Override.SqlString(); s != "" {
+		parts = append(parts, s)
+	}
+
 	// SelectStmt/VALUES clause
 	if i.SelectStmt != nil {
 		selectStr := i.SelectStmt.SqlString()

--- a/go/common/parser/ast/utility_statements.go
+++ b/go/common/parser/ast/utility_statements.go
@@ -1772,6 +1772,14 @@ func (vss *VariableShowStmt) StatementType() string {
 
 // SqlString returns the SQL representation of the SHOW statement
 func (vss *VariableShowStmt) SqlString() string {
+	// "all" is a sentinel set by the grammar for `SHOW ALL` — it must be
+	// rendered as the bare keyword, not a quoted identifier. The other
+	// grammar-set sentinels ("timezone", "transaction_isolation",
+	// "session_authorization") are valid bare identifiers that round-trip
+	// without quoting.
+	if vss.Name == "all" {
+		return "SHOW ALL"
+	}
 	return "SHOW " + QuoteQualifiedIdentifier(vss.Name)
 }
 

--- a/go/common/parser/testdata/ddl_cases.json
+++ b/go/common/parser/testdata/ddl_cases.json
@@ -2751,8 +2751,7 @@
   },
   {
     "comment": "ALTER OPERATOR FAMILY DROP",
-    "query": "ALTER OPERATOR FAMILY test_family USING btree DROP OPERATOR 1 (int4, int4)",
-    "expected": "ALTER OPERATOR FAMILY test_family USING btree DROP OPERATOR 1  (int4, int4)"
+    "query": "ALTER OPERATOR FAMILY test_family USING btree DROP OPERATOR 1 (int4, int4)"
   },
   {
     "comment": "CREATE TRANSFORM basic",

--- a/go/common/parser/testdata/dml_cases.json
+++ b/go/common/parser/testdata/dml_cases.json
@@ -533,23 +533,19 @@
   },
   {
     "comment": "INSERT with OVERRIDING USER VALUE",
-    "query": "INSERT INTO users OVERRIDING USER VALUE SELECT * FROM temp_users",
-    "expected": "INSERT INTO users SELECT * FROM temp_users"
+    "query": "INSERT INTO users OVERRIDING USER VALUE SELECT * FROM temp_users"
   },
   {
     "comment": "INSERT with OVERRIDING SYSTEM VALUE",
-    "query": "INSERT INTO users OVERRIDING SYSTEM VALUE SELECT * FROM temp_users",
-    "expected": "INSERT INTO users SELECT * FROM temp_users"
+    "query": "INSERT INTO users OVERRIDING SYSTEM VALUE SELECT * FROM temp_users"
   },
   {
     "comment": "INSERT with column list and OVERRIDING USER VALUE",
-    "query": "INSERT INTO users (id, name) OVERRIDING USER VALUE SELECT * FROM temp_users",
-    "expected": "INSERT INTO users (id, name) SELECT * FROM temp_users"
+    "query": "INSERT INTO users (id, name) OVERRIDING USER VALUE SELECT * FROM temp_users"
   },
   {
     "comment": "INSERT with column list and OVERRIDING SYSTEM VALUE",
-    "query": "INSERT INTO users (id, name) OVERRIDING SYSTEM VALUE SELECT * FROM temp_users",
-    "expected": "INSERT INTO users (id, name) SELECT * FROM temp_users"
+    "query": "INSERT INTO users (id, name) OVERRIDING SYSTEM VALUE SELECT * FROM temp_users"
   },
   {
     "comment": "INSERT with complex expressions in VALUES",

--- a/go/common/parser/testdata/misc_cases.json
+++ b/go/common/parser/testdata/misc_cases.json
@@ -209,8 +209,7 @@
   },
   {
     "comment": "SHOW ALL",
-    "query": "SHOW ALL",
-    "expected": "SHOW \"all\""
+    "query": "SHOW ALL"
   },
   {
     "comment": "SHOW timezone",

--- a/go/common/parser/testdata/postgres/alter_generic.json
+++ b/go/common/parser/testdata/postgres/alter_generic.json
@@ -543,7 +543,7 @@
   {
     "comment": "alter_generic - Statement 123",
     "query": "ALTER OPERATOR FAMILY alt_opf4 USING btree DROP OPERATOR 1 (int4, int2) , OPERATOR 2 (int4, int2) , OPERATOR 3 (int4, int2) , OPERATOR 4 (int4, int2) , OPERATOR 5 (int4, int2) , FUNCTION 1 (int4, int2)",
-    "expected": "ALTER OPERATOR FAMILY alt_opf4 USING btree DROP OPERATOR 1  (int4, int2), OPERATOR 2  (int4, int2), OPERATOR 3  (int4, int2), OPERATOR 4  (int4, int2), OPERATOR 5  (int4, int2), FUNCTION 1 (int4, int2)"
+    "expected": "ALTER OPERATOR FAMILY alt_opf4 USING btree DROP OPERATOR 1 (int4, int2), OPERATOR 2 (int4, int2), OPERATOR 3 (int4, int2), OPERATOR 4 (int4, int2), OPERATOR 5 (int4, int2), FUNCTION 1 (int4, int2)"
   },
   {
     "comment": "alter_generic - Statement 124",
@@ -645,8 +645,7 @@
   },
   {
     "comment": "alter_generic - Statement 147",
-    "query": "ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8)",
-    "expected": "ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1  (int4, int2, int8)"
+    "query": "ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8)"
   },
   {
     "comment": "alter_generic - Statement 148",
@@ -702,8 +701,7 @@
   },
   {
     "comment": "alter_generic - Statement 160",
-    "query": "ALTER OPERATOR FAMILY alt_opf11 USING gist DROP OPERATOR 1 (int4, int4)",
-    "expected": "ALTER OPERATOR FAMILY alt_opf11 USING gist DROP OPERATOR 1  (int4, int4)"
+    "query": "ALTER OPERATOR FAMILY alt_opf11 USING gist DROP OPERATOR 1 (int4, int4)"
   },
   {
     "comment": "alter_generic - Statement 161",
@@ -828,8 +826,7 @@
   },
   {
     "comment": "alter_generic - Statement 188",
-    "query": "ALTER OPERATOR FAMILY alt_opf18 USING btree DROP OPERATOR 1 (int4, int4)",
-    "expected": "ALTER OPERATOR FAMILY alt_opf18 USING btree DROP OPERATOR 1  (int4, int4)"
+    "query": "ALTER OPERATOR FAMILY alt_opf18 USING btree DROP OPERATOR 1 (int4, int4)"
   },
   {
     "comment": "alter_generic - Statement 189",

--- a/go/common/parser/testdata/postgres/identity.json
+++ b/go/common/parser/testdata/postgres/identity.json
@@ -137,53 +137,43 @@
   },
   {
     "comment": "identity - Statement 33",
-    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-1, 'aa')",
-    "expected": "INSERT INTO itest5 VALUES (-1, 'aa')"
+    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-1, 'aa')"
   },
   {
     "comment": "identity - Statement 34",
-    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-2, 'bb'), (-3, 'cc')",
-    "expected": "INSERT INTO itest5 VALUES (-2, 'bb'), (-3, 'cc')"
+    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-2, 'bb'), (-3, 'cc')"
   },
   {
     "comment": "identity - Statement 35",
-    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (DEFAULT, 'dd'), (-4, 'ee')",
-    "expected": "INSERT INTO itest5 VALUES (DEFAULT, 'dd'), (-4, 'ee')"
+    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (DEFAULT, 'dd'), (-4, 'ee')"
   },
   {
     "comment": "identity - Statement 36",
-    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-5, 'ff'), (DEFAULT, 'gg')",
-    "expected": "INSERT INTO itest5 VALUES (-5, 'ff'), (DEFAULT, 'gg')"
+    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (-5, 'ff'), (DEFAULT, 'gg')"
   },
   {
     "comment": "identity - Statement 37",
-    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (DEFAULT, 'hh'), (DEFAULT, 'ii')",
-    "expected": "INSERT INTO itest5 VALUES (DEFAULT, 'hh'), (DEFAULT, 'ii')"
+    "query": "INSERT INTO itest5 OVERRIDING SYSTEM VALUE VALUES (DEFAULT, 'hh'), (DEFAULT, 'ii')"
   },
   {
     "comment": "identity - Statement 38",
-    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-1, 'aaa')",
-    "expected": "INSERT INTO itest5 VALUES (-1, 'aaa')"
+    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-1, 'aaa')"
   },
   {
     "comment": "identity - Statement 39",
-    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-2, 'bbb'), (-3, 'ccc')",
-    "expected": "INSERT INTO itest5 VALUES (-2, 'bbb'), (-3, 'ccc')"
+    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-2, 'bbb'), (-3, 'ccc')"
   },
   {
     "comment": "identity - Statement 40",
-    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (DEFAULT, 'ddd'), (-4, 'eee')",
-    "expected": "INSERT INTO itest5 VALUES (DEFAULT, 'ddd'), (-4, 'eee')"
+    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (DEFAULT, 'ddd'), (-4, 'eee')"
   },
   {
     "comment": "identity - Statement 41",
-    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-5, 'fff'), (DEFAULT, 'ggg')",
-    "expected": "INSERT INTO itest5 VALUES (-5, 'fff'), (DEFAULT, 'ggg')"
+    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (-5, 'fff'), (DEFAULT, 'ggg')"
   },
   {
     "comment": "identity - Statement 42",
-    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (DEFAULT, 'hhh'), (DEFAULT, 'iii')",
-    "expected": "INSERT INTO itest5 VALUES (DEFAULT, 'hhh'), (DEFAULT, 'iii')"
+    "query": "INSERT INTO itest5 OVERRIDING USER VALUE VALUES (DEFAULT, 'hhh'), (DEFAULT, 'iii')"
   },
   {
     "comment": "identity - Statement 43",
@@ -207,13 +197,11 @@
   },
   {
     "comment": "identity - Statement 48",
-    "query": "INSERT INTO itest1 OVERRIDING SYSTEM VALUE VALUES (20, 'xyz')",
-    "expected": "INSERT INTO itest1 VALUES (20, 'xyz')"
+    "query": "INSERT INTO itest1 OVERRIDING SYSTEM VALUE VALUES (20, 'xyz')"
   },
   {
     "comment": "identity - Statement 49",
-    "query": "INSERT INTO itest1 OVERRIDING USER VALUE VALUES (30, 'xyz')",
-    "expected": "INSERT INTO itest1 VALUES (30, 'xyz')"
+    "query": "INSERT INTO itest1 OVERRIDING USER VALUE VALUES (30, 'xyz')"
   },
   {
     "comment": "identity - Statement 50",
@@ -221,13 +209,11 @@
   },
   {
     "comment": "identity - Statement 51",
-    "query": "INSERT INTO itest2 OVERRIDING SYSTEM VALUE VALUES (20, 'xyz')",
-    "expected": "INSERT INTO itest2 VALUES (20, 'xyz')"
+    "query": "INSERT INTO itest2 OVERRIDING SYSTEM VALUE VALUES (20, 'xyz')"
   },
   {
     "comment": "identity - Statement 52",
-    "query": "INSERT INTO itest2 OVERRIDING USER VALUE VALUES (30, 'xyz')",
-    "expected": "INSERT INTO itest2 VALUES (30, 'xyz')"
+    "query": "INSERT INTO itest2 OVERRIDING USER VALUE VALUES (30, 'xyz')"
   },
   {
     "comment": "identity - Statement 53",
@@ -317,8 +303,7 @@
   },
   {
     "comment": "identity - Statement 73",
-    "query": "INSERT INTO itestv10 OVERRIDING USER VALUE VALUES (11, 'xyz')",
-    "expected": "INSERT INTO itestv10 VALUES (11, 'xyz')"
+    "query": "INSERT INTO itestv10 OVERRIDING USER VALUE VALUES (11, 'xyz')"
   },
   {
     "comment": "identity - Statement 74",
@@ -326,8 +311,7 @@
   },
   {
     "comment": "identity - Statement 75",
-    "query": "INSERT INTO itestv11 OVERRIDING SYSTEM VALUE VALUES (11, 'xyz')",
-    "expected": "INSERT INTO itestv11 VALUES (11, 'xyz')"
+    "query": "INSERT INTO itestv11 OVERRIDING SYSTEM VALUE VALUES (11, 'xyz')"
   },
   {
     "comment": "identity - Statement 76",


### PR DESCRIPTION
InsertStmt.SqlString dropped the OVERRIDING { SYSTEM | USER } VALUE
clause, which is required to insert into GENERATED AS IDENTITY columns
and would cause the deparsed SQL to fail at runtime.

VariableShowStmt.SqlString ran the grammar's "all" sentinel through
QuoteQualifiedIdentifier, producing SHOW "all" (a lookup of a parameter
named "all", which doesn't exist) instead of the SHOW ALL keyword form.

CreateOpClassItem.SqlString unconditionally inserted a space before "("
for operator items, producing a double space in the DROP form where the
operator name is absent (e.g. DROP OPERATOR 1  (int4, int4)).
