### PR TITLE
feat(multigateway): COPY TO STDOUT, notice forwarding, un-wrapped PG errors

### DIFF
--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 )
 
@@ -398,40 +399,48 @@ func (c *Conn) WriteCopyFail(errorMsg string) error {
 	return c.flush()
 }
 
-// ReadCopyDoneResponse reads the CommandComplete response after WriteCopyDone()
-// Returns the command tag (e.g., "COPY 100") and rows affected
-// Note: In simple query protocol, PostgreSQL sends CommandComplete followed by ReadyForQuery
-// We need to consume both messages to clear the buffer
-func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, error) {
+// ReadCopyDoneResponse reads the CommandComplete response after WriteCopyDone().
+// Returns the command tag (e.g., "COPY 100"), rows affected, and any
+// NoticeResponse / InfoResponse diagnostics received between CopyDone and
+// ReadyForQuery. Notices come from BEFORE/AFTER row triggers that fire during
+// COPY FROM STDIN (e.g. RAISE NOTICE) and from COPY progress reporting; the
+// gateway forwards them to the client as NoticeResponse frames before the
+// final CommandComplete so client-side test fixtures see the expected
+// NOTICE / INFO lines.
+//
+// Note: In simple query protocol, PostgreSQL sends CommandComplete followed
+// by ReadyForQuery — both messages must be consumed to clear the buffer.
+func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, []*mterrors.PgDiagnostic, error) {
 	c.bufMu.Lock()
 	defer c.bufMu.Unlock()
 
 	var commandTag string
 	var rowsAffected uint64
+	var notices []*mterrors.PgDiagnostic
 	gotCommandComplete := false
 
 	// Read messages until we get both CommandComplete and ReadyForQuery
 	for {
 		msgType, err := c.readMessageType()
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to read message type: %w", err)
+			return "", 0, notices, fmt.Errorf("failed to read message type: %w", err)
 		}
 
 		length, err := c.readMessageLength()
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to read message length: %w", err)
+			return "", 0, notices, fmt.Errorf("failed to read message length: %w", err)
 		}
 
 		body, err := c.readMessageBody(length)
 		if err != nil {
-			return "", 0, fmt.Errorf("failed to read message body: %w", err)
+			return "", 0, notices, fmt.Errorf("failed to read message body: %w", err)
 		}
 
 		switch msgType {
 		case protocol.MsgCommandComplete:
 			// Parse command tag
 			if len(body) == 0 {
-				return "", 0, errors.New("empty CommandComplete body")
+				return "", 0, notices, errors.New("empty CommandComplete body")
 			}
 			// Command tag is null-terminated string
 			tag := string(body)
@@ -460,23 +469,25 @@ func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, error)
 			// finalization fails inside a transaction.
 			pgErr := c.parseError(body)
 			_ = c.waitForReadyForQuery(ctx)
-			return "", 0, pgErr
+			return "", 0, notices, pgErr
 
 		case protocol.MsgNoticeResponse:
-			// Ignore notices
-			continue
+			// Collect notices for forwarding. Trigger RAISE NOTICE output and
+			// INFO progress events arrive here between CopyDone and the final
+			// CommandComplete.
+			notices = append(notices, c.parseNotice(body))
 
 		case protocol.MsgReadyForQuery:
 			// End of response - if we got CommandComplete, return success
 			if gotCommandComplete {
 				c.txnStatus = protocol.TransactionStatus(body[0])
-				return commandTag, rowsAffected, nil
+				return commandTag, rowsAffected, notices, nil
 			}
 			// Otherwise, we got ReadyForQuery without CommandComplete (error case)
-			return "", 0, errors.New("received ReadyForQuery without CommandComplete")
+			return "", 0, notices, errors.New("received ReadyForQuery without CommandComplete")
 
 		default:
-			return "", 0, fmt.Errorf("unexpected message type after CopyDone: '%c'", msgType)
+			return "", 0, notices, fmt.Errorf("unexpected message type after CopyDone: '%c'", msgType)
 		}
 	}
 }
@@ -484,27 +495,30 @@ func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, error)
 // ReadCopyFailResponse reads the expected ErrorResponse + ReadyForQuery sequence
 // after sending CopyFail. Unlike ReadCopyDoneResponse, this treats ErrorResponse
 // as the expected (normal) response and continues reading until ReadyForQuery,
-// leaving the connection in a clean protocol state.
-func (c *Conn) ReadCopyFailResponse(ctx context.Context) error {
+// leaving the connection in a clean protocol state. Notices received in this
+// window are collected and returned so callers can forward trigger output
+// that fired before the abort.
+func (c *Conn) ReadCopyFailResponse(ctx context.Context) ([]*mterrors.PgDiagnostic, error) {
 	c.bufMu.Lock()
 	defer c.bufMu.Unlock()
 
+	var notices []*mterrors.PgDiagnostic
 	gotError := false
 
 	for {
 		msgType, err := c.readMessageType()
 		if err != nil {
-			return fmt.Errorf("failed to read message type: %w", err)
+			return notices, fmt.Errorf("failed to read message type: %w", err)
 		}
 
 		length, err := c.readMessageLength()
 		if err != nil {
-			return fmt.Errorf("failed to read message length: %w", err)
+			return notices, fmt.Errorf("failed to read message length: %w", err)
 		}
 
 		body, err := c.readMessageBody(length)
 		if err != nil {
-			return fmt.Errorf("failed to read message body: %w", err)
+			return notices, fmt.Errorf("failed to read message body: %w", err)
 		}
 
 		switch msgType {
@@ -514,16 +528,17 @@ func (c *Conn) ReadCopyFailResponse(ctx context.Context) error {
 			gotError = true
 
 		case protocol.MsgNoticeResponse:
-			continue
+			notices = append(notices, c.parseNotice(body))
 
 		case protocol.MsgReadyForQuery:
+			c.txnStatus = protocol.TransactionStatus(body[0])
 			if gotError {
-				return nil // clean abort: ErrorResponse + ReadyForQuery consumed
+				return notices, nil // clean abort: ErrorResponse + ReadyForQuery consumed
 			}
-			return errors.New("received ReadyForQuery without ErrorResponse after CopyFail")
+			return notices, errors.New("received ReadyForQuery without ErrorResponse after CopyFail")
 
 		default:
-			return fmt.Errorf("unexpected message type after CopyFail: '%c'", msgType)
+			return notices, fmt.Errorf("unexpected message type after CopyFail: '%c'", msgType)
 		}
 	}
 }
@@ -579,33 +594,34 @@ func (c *Conn) ReadCopyInResponse() (format int16, columnFormats []int16, err er
 
 // InitiateCopyFromStdin sends a COPY FROM STDIN query and reads the CopyInResponse.
 // This is a special operation that doesn't follow the normal query flow.
-// Returns the COPY format and column formats from the CopyInResponse.
-func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, err error) {
+// Returns the COPY format, column formats from the CopyInResponse, and any
+// NoticeResponse diagnostics received before the CopyInResponse (e.g. notices
+// from BEFORE STATEMENT triggers that fire at COPY initiation).
+func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, err error) {
 	c.bufMu.Lock()
 	defer c.bufMu.Unlock()
 
 	// Send the COPY query (simple-protocol Q message + flush).
 	if err := c.writeQueryMessage(copyQuery); err != nil {
-		return 0, nil, fmt.Errorf("failed to send COPY query: %w", err)
+		return 0, nil, notices, fmt.Errorf("failed to send COPY query: %w", err)
 	}
 
-	// Loop through messages until we get CopyInResponse or an error
-	// We need to skip NoticeResponse and ParameterStatus messages
-	// This is similar to processQueryResponses but simplified for COPY initiation
+	// Loop through messages until we get CopyInResponse or an error.
+	// Notices and ParameterStatus updates may interleave.
 	for {
 		msgType, err := c.readMessageType()
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to read message type: %w", err)
+			return 0, nil, notices, fmt.Errorf("failed to read message type: %w", err)
 		}
 
 		bodyLen, err := c.readMessageLength()
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to read message length: %w", err)
+			return 0, nil, notices, fmt.Errorf("failed to read message length: %w", err)
 		}
 
 		body, err := c.readMessageBody(bodyLen)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to read message body: %w", err)
+			return 0, nil, notices, fmt.Errorf("failed to read message body: %w", err)
 		}
 
 		switch msgType {
@@ -613,7 +629,7 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 			// Parse CopyInResponse body using manual byte array indexing
 			// Format: Int8 (format) + Int16 (numCols) + Int16[numCols] (column formats)
 			if len(body) < 3 {
-				return 0, nil, fmt.Errorf("CopyInResponse body too short: %d bytes", len(body))
+				return 0, nil, notices, fmt.Errorf("CopyInResponse body too short: %d bytes", len(body))
 			}
 
 			// Read format (Int8, 1 byte) - 0=text, 1=binary
@@ -627,13 +643,13 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 			offset := 3
 			for i := 0; i < int(numCols); i++ {
 				if offset+2 > len(body) {
-					return 0, nil, errors.New("CopyInResponse body too short for column formats")
+					return 0, nil, notices, errors.New("CopyInResponse body too short for column formats")
 				}
 				columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
 				offset += 2
 			}
 
-			return format, columnFormats, nil
+			return format, columnFormats, notices, nil
 
 		case protocol.MsgErrorResponse:
 			// Parse the error, then drain the trailing ReadyForQuery so
@@ -645,11 +661,10 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 			// payload, which we want even on the error path.
 			pgErr := c.parseError(body)
 			_ = c.waitForReadyForQuery(ctx)
-			return 0, nil, pgErr
+			return 0, nil, notices, pgErr
 
 		case protocol.MsgNoticeResponse:
-			// Skip notices (PostgreSQL might send notices before CopyInResponse)
-			continue
+			notices = append(notices, c.parseNotice(body))
 
 		case protocol.MsgParameterStatus:
 			// Handle parameter status updates, ignore errors
@@ -659,10 +674,226 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 		case protocol.MsgReadyForQuery:
 			// If we get ReadyForQuery before CopyInResponse, the query failed
 			// but we didn't get an ErrorResponse (which shouldn't happen)
-			return 0, nil, errors.New("received ReadyForQuery before CopyInResponse - query may have failed without error")
+			return 0, nil, notices, errors.New("received ReadyForQuery before CopyInResponse - query may have failed without error")
 
 		default:
-			return 0, nil, fmt.Errorf("unexpected message type during COPY initiation: '%c' (0x%02x)", msgType, msgType)
+			return 0, nil, notices, fmt.Errorf("unexpected message type during COPY initiation: '%c' (0x%02x)", msgType, msgType)
+		}
+	}
+}
+
+// InitiateCopyToStdout sends a COPY ... TO STDOUT query and reads the
+// CopyOutResponse. The caller is then expected to drive the response stream
+// with ReadCopyOutMessage until io.EOF (CopyDone), followed by
+// FinishCopyToStdout to consume the trailing CommandComplete + ReadyForQuery.
+// Returns the COPY format, per-column formats from the CopyOutResponse, and
+// any NoticeResponse diagnostics seen before the CopyOutResponse arrived.
+//
+// Modeled after InitiateCopyFromStdin — same Q-then-flush, same notice /
+// ParameterStatus / ErrorResponse handling.
+func (c *Conn) InitiateCopyToStdout(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, err error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	if err := c.writeQueryMessage(copyQuery); err != nil {
+		return 0, nil, notices, fmt.Errorf("failed to send COPY query: %w", err)
+	}
+
+	for {
+		msgType, err := c.readMessageType()
+		if err != nil {
+			return 0, nil, notices, fmt.Errorf("failed to read message type: %w", err)
+		}
+
+		bodyLen, err := c.readMessageLength()
+		if err != nil {
+			return 0, nil, notices, fmt.Errorf("failed to read message length: %w", err)
+		}
+
+		body, err := c.readMessageBody(bodyLen)
+		if err != nil {
+			return 0, nil, notices, fmt.Errorf("failed to read message body: %w", err)
+		}
+
+		switch msgType {
+		case protocol.MsgCopyOutResponse:
+			// CopyOutResponse body: Int8(format) + Int16(numCols) + Int16[numCols]
+			if len(body) < 3 {
+				return 0, nil, notices, fmt.Errorf("CopyOutResponse body too short: %d bytes", len(body))
+			}
+			format = int16(body[0])
+			numCols := int16(uint16(body[1])<<8 | uint16(body[2]))
+			columnFormats = make([]int16, numCols)
+			offset := 3
+			for i := 0; i < int(numCols); i++ {
+				if offset+2 > len(body) {
+					return 0, nil, notices, errors.New("CopyOutResponse body too short for column formats")
+				}
+				columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
+				offset += 2
+			}
+			return format, columnFormats, notices, nil
+
+		case protocol.MsgErrorResponse:
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			return 0, nil, notices, pgErr
+
+		case protocol.MsgNoticeResponse:
+			notices = append(notices, c.parseNotice(body))
+
+		case protocol.MsgParameterStatus:
+			_ = c.handleParameterStatus(body)
+
+		case protocol.MsgReadyForQuery:
+			return 0, nil, notices, errors.New("received ReadyForQuery before CopyOutResponse - query may have failed without error")
+
+		default:
+			return 0, nil, notices, fmt.Errorf("unexpected message type during COPY TO initiation: '%c' (0x%02x)", msgType, msgType)
+		}
+	}
+}
+
+// CopyOutMessage represents a single message read from the COPY TO STDOUT
+// response stream. Exactly one of Data or Notice is set; Done is true when
+// PG sent CopyDone (Data and Notice will both be nil in that case).
+type CopyOutMessage struct {
+	Data   []byte
+	Notice *mterrors.PgDiagnostic
+	Done   bool
+}
+
+// ReadCopyOutMessage reads the next message in the COPY TO STDOUT stream.
+// Returns a CopyOutMessage containing a CopyData chunk, a NoticeResponse
+// diagnostic, or Done=true on CopyDone. CommandComplete/ReadyForQuery are
+// not consumed here — call FinishCopyToStdout once Done is observed.
+//
+// Distinct from ReadCopyData (which only reads CopyData / CopyDone) because
+// trigger output and INFO progress messages can be interleaved with data
+// rows during a COPY ... TO STDOUT.
+//
+// ctx is used only on the ErrorResponse path to drain the trailing
+// ReadyForQuery; reads themselves are framed at the wire layer and don't
+// take a context.
+func (c *Conn) ReadCopyOutMessage(ctx context.Context) (CopyOutMessage, error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	for {
+		msgType, err := c.readMessageType()
+		if err != nil {
+			return CopyOutMessage{}, fmt.Errorf("failed to read message type: %w", err)
+		}
+
+		length, err := c.readMessageLength()
+		if err != nil {
+			return CopyOutMessage{}, fmt.Errorf("failed to read message length: %w", err)
+		}
+
+		switch msgType {
+		case protocol.MsgCopyData:
+			data, err := c.readMessageBody(length)
+			if err != nil {
+				return CopyOutMessage{}, fmt.Errorf("failed to read CopyData body: %w", err)
+			}
+			return CopyOutMessage{Data: data}, nil
+
+		case protocol.MsgCopyDone:
+			if length != 0 {
+				return CopyOutMessage{}, fmt.Errorf("invalid CopyDone length: %d (expected 0)", length)
+			}
+			return CopyOutMessage{Done: true}, nil
+
+		case protocol.MsgNoticeResponse:
+			body, err := c.readMessageBody(length)
+			if err != nil {
+				return CopyOutMessage{}, fmt.Errorf("failed to read NoticeResponse body: %w", err)
+			}
+			return CopyOutMessage{Notice: c.parseNotice(body)}, nil
+
+		case protocol.MsgErrorResponse:
+			body, err := c.readMessageBody(length)
+			if err != nil {
+				return CopyOutMessage{}, fmt.Errorf("failed to read ErrorResponse body: %w", err)
+			}
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			return CopyOutMessage{}, pgErr
+
+		default:
+			// Drain unexpected body bytes before returning the error to keep
+			// the protocol position valid for callers that recover.
+			_, _ = c.readMessageBody(length)
+			return CopyOutMessage{}, fmt.Errorf("unexpected message type during COPY TO stream: '%c' (0x%02x)", msgType, msgType)
+		}
+	}
+}
+
+// FinishCopyToStdout reads the trailing CommandComplete + ReadyForQuery that
+// PG sends after CopyDone in the COPY TO STDOUT flow. Returns the command
+// tag (e.g. "COPY 5"), rows affected, and any NoticeResponse diagnostics
+// that arrived between CopyDone and the final ReadyForQuery — same flow as
+// ReadCopyDoneResponse, but the COPY-out caller has already consumed
+// CopyDone via ReadCopyOutMessage.
+func (c *Conn) FinishCopyToStdout(ctx context.Context) (string, uint64, []*mterrors.PgDiagnostic, error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	var commandTag string
+	var rowsAffected uint64
+	var notices []*mterrors.PgDiagnostic
+	gotCommandComplete := false
+
+	for {
+		msgType, err := c.readMessageType()
+		if err != nil {
+			return "", 0, notices, fmt.Errorf("failed to read message type: %w", err)
+		}
+
+		length, err := c.readMessageLength()
+		if err != nil {
+			return "", 0, notices, fmt.Errorf("failed to read message length: %w", err)
+		}
+
+		body, err := c.readMessageBody(length)
+		if err != nil {
+			return "", 0, notices, fmt.Errorf("failed to read message body: %w", err)
+		}
+
+		switch msgType {
+		case protocol.MsgCommandComplete:
+			if len(body) == 0 {
+				return "", 0, notices, errors.New("empty CommandComplete body")
+			}
+			tag := string(body)
+			if len(tag) > 0 && tag[len(tag)-1] == 0 {
+				tag = tag[:len(tag)-1]
+			}
+			var rows uint64
+			if len(tag) > 5 && tag[:4] == "COPY" {
+				_, _ = fmt.Sscanf(tag[5:], "%d", &rows)
+			}
+			commandTag = tag
+			rowsAffected = rows
+			gotCommandComplete = true
+
+		case protocol.MsgErrorResponse:
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			return "", 0, notices, pgErr
+
+		case protocol.MsgNoticeResponse:
+			notices = append(notices, c.parseNotice(body))
+
+		case protocol.MsgReadyForQuery:
+			c.txnStatus = protocol.TransactionStatus(body[0])
+			if gotCommandComplete {
+				return commandTag, rowsAffected, notices, nil
+			}
+			return "", 0, notices, errors.New("received ReadyForQuery without CommandComplete")
+
+		default:
+			return "", 0, notices, fmt.Errorf("unexpected message type after CopyDone in COPY TO STDOUT: '%c'", msgType)
 		}
 	}
 }

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -568,22 +568,23 @@ func (c *Conn) ReadCopyInResponse() (format int16, columnFormats []int16, err er
 		return 0, nil, fmt.Errorf("failed to read message body: %w", err)
 	}
 
+	return parseCopyResponseBody("CopyInResponse", body)
+}
+
+func parseCopyResponseBody(responseType string, body []byte) (format int16, columnFormats []int16, err error) {
 	if len(body) < 3 {
-		return 0, nil, fmt.Errorf("CopyInResponse body too short: %d bytes", len(body))
+		return 0, nil, fmt.Errorf("%s body too short: %d bytes", responseType, len(body))
 	}
 
-	// Read format (Int8, 1 byte) - 0=text, 1=binary
+	// Body layout: Int8(format) + Int16(numCols) + Int16[numCols].
 	format = int16(body[0])
-
-	// Read number of columns (Int16, 2 bytes, big-endian)
 	numCols := int16(uint16(body[1])<<8 | uint16(body[2]))
 
-	// Read format codes for each column (Int16 each)
 	columnFormats = make([]int16, numCols)
 	offset := 3
 	for i := 0; i < int(numCols); i++ {
 		if offset+2 > len(body) {
-			return 0, nil, errors.New("CopyInResponse body too short for column formats")
+			return 0, nil, fmt.Errorf("%s body too short for column formats", responseType)
 		}
 		columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
 		offset += 2
@@ -626,29 +627,10 @@ func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (for
 
 		switch msgType {
 		case protocol.MsgCopyInResponse:
-			// Parse CopyInResponse body using manual byte array indexing
-			// Format: Int8 (format) + Int16 (numCols) + Int16[numCols] (column formats)
-			if len(body) < 3 {
-				return 0, nil, notices, fmt.Errorf("CopyInResponse body too short: %d bytes", len(body))
+			format, columnFormats, err = parseCopyResponseBody("CopyInResponse", body)
+			if err != nil {
+				return 0, nil, notices, err
 			}
-
-			// Read format (Int8, 1 byte) - 0=text, 1=binary
-			format = int16(body[0])
-
-			// Read number of columns (Int16, 2 bytes, big-endian)
-			numCols := int16(uint16(body[1])<<8 | uint16(body[2]))
-
-			// Read format codes for each column (Int16 each)
-			columnFormats = make([]int16, numCols)
-			offset := 3
-			for i := 0; i < int(numCols); i++ {
-				if offset+2 > len(body) {
-					return 0, nil, notices, errors.New("CopyInResponse body too short for column formats")
-				}
-				columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
-				offset += 2
-			}
-
 			return format, columnFormats, notices, nil
 
 		case protocol.MsgErrorResponse:
@@ -717,20 +699,9 @@ func (c *Conn) InitiateCopyToStdout(ctx context.Context, copyQuery string) (form
 
 		switch msgType {
 		case protocol.MsgCopyOutResponse:
-			// CopyOutResponse body: Int8(format) + Int16(numCols) + Int16[numCols]
-			if len(body) < 3 {
-				return 0, nil, notices, fmt.Errorf("CopyOutResponse body too short: %d bytes", len(body))
-			}
-			format = int16(body[0])
-			numCols := int16(uint16(body[1])<<8 | uint16(body[2]))
-			columnFormats = make([]int16, numCols)
-			offset := 3
-			for i := 0; i < int(numCols); i++ {
-				if offset+2 > len(body) {
-					return 0, nil, notices, errors.New("CopyOutResponse body too short for column formats")
-				}
-				columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
-				offset += 2
+			format, columnFormats, err = parseCopyResponseBody("CopyOutResponse", body)
+			if err != nil {
+				return 0, nil, notices, err
 			}
 			return format, columnFormats, notices, nil
 
@@ -923,28 +894,7 @@ func (c *Conn) ReadCopyOutResponse() (format int16, columnFormats []int16, err e
 		return 0, nil, fmt.Errorf("failed to read message body: %w", err)
 	}
 
-	if len(body) < 3 {
-		return 0, nil, fmt.Errorf("CopyOutResponse body too short: %d bytes", len(body))
-	}
-
-	// Read format (Int8, 1 byte) - 0=text, 1=binary
-	format = int16(body[0])
-
-	// Read number of columns (Int16, 2 bytes, big-endian)
-	numCols := int16(uint16(body[1])<<8 | uint16(body[2]))
-
-	// Read format codes for each column (Int16 each)
-	columnFormats = make([]int16, numCols)
-	offset := 3
-	for i := 0; i < int(numCols); i++ {
-		if offset+2 > len(body) {
-			return 0, nil, errors.New("CopyOutResponse body too short for column formats")
-		}
-		columnFormats[i] = int16(uint16(body[offset])<<8 | uint16(body[offset+1]))
-		offset += 2
-	}
-
-	return format, columnFormats, nil
+	return parseCopyResponseBody("CopyOutResponse", body)
 }
 
 // ReadCopyData reads a CopyData ('d') message from PostgreSQL.

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -324,6 +324,124 @@ func TestFinishCopyToStdout(t *testing.T) {
 	})
 }
 
+// buildCopyOutResponse returns a serialized CopyOutResponse ('H') message
+// with the given overall format and column formats (text=0/binary=1 each).
+func buildCopyOutResponse(format int16, columnFormats []int16) []byte {
+	body := make([]byte, 0, 3+2*len(columnFormats))
+	body = append(body, byte(format))
+	body = append(body, byte(len(columnFormats)>>8), byte(len(columnFormats)))
+	for _, f := range columnFormats {
+		body = append(body, byte(f>>8), byte(f))
+	}
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgCopyOutResponse, body)
+	return out.Bytes()
+}
+
+// newTestReadWriteConn builds a Conn where writes go to a discard buffer
+// and reads pull from the supplied response bytes. Suitable for testing
+// methods that send a query then read the response (InitiateCopyToStdout,
+// InitiateCopyFromStdin, etc.).
+func newTestReadWriteConn(response []byte) *Conn {
+	return &Conn{
+		conn:           &mockNetConn{buf: bytes.NewBuffer(nil)},
+		bufferedReader: bufio.NewReader(bytes.NewReader(response)),
+		bufferedWriter: bufio.NewWriter(bytes.NewBuffer(nil)),
+	}
+}
+
+// TestInitiateCopyToStdout covers the request/response flow of the
+// COPY TO STDOUT initiator: send a query, read CopyOutResponse, capture
+// any pre-CopyOutResponse notices, and surface PG ErrorResponse
+// un-wrapped on the error path.
+func TestInitiateCopyToStdout(t *testing.T) {
+	t.Run("success returns format, columns, notices", func(t *testing.T) {
+		var input bytes.Buffer
+		input.Write(buildNoticeResponse("NOTICE", "before-statement trigger"))
+		input.Write(buildCopyOutResponse(0, []int16{0, 0, 0}))
+
+		c := newTestReadWriteConn(input.Bytes())
+		format, columnFormats, notices, err := c.InitiateCopyToStdout(context.Background(), "COPY t TO STDOUT")
+		require.NoError(t, err)
+		assert.Equal(t, int16(0), format, "text format")
+		assert.Equal(t, []int16{0, 0, 0}, columnFormats)
+		require.Len(t, notices, 1)
+		assert.Equal(t, "before-statement trigger", notices[0].Message)
+	})
+
+	t.Run("ErrorResponse drains RFQ and returns PgDiagnostic", func(t *testing.T) {
+		// PG rejects the COPY (e.g. relation does not exist) before sending
+		// CopyOutResponse. The helper must parse the error, drain RFQ so the
+		// conn is reusable, and surface *PgDiagnostic via errors.As.
+		var input bytes.Buffer
+		input.Write(buildErrorResponse("42P01", "relation \"t\" does not exist"))
+		input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+		c := newTestReadWriteConn(input.Bytes())
+		_, _, _, err := c.InitiateCopyToStdout(context.Background(), "COPY t TO STDOUT")
+		require.Error(t, err)
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag))
+		assert.Equal(t, "42P01", diag.Code)
+		leftover, _ := c.bufferedReader.Peek(1)
+		assert.Empty(t, leftover, "trailing RFQ drained")
+	})
+
+	t.Run("ReadyForQuery before CopyOutResponse is an error", func(t *testing.T) {
+		// Defensive: server returned RFQ before CopyOutResponse / ErrorResponse.
+		c := newTestReadWriteConn(buildReadyForQuery(protocol.TxnStatusIdle))
+		_, _, _, err := c.InitiateCopyToStdout(context.Background(), "COPY t TO STDOUT")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ReadyForQuery before CopyOutResponse")
+	})
+}
+
+// buildCopyInResponse returns a serialized CopyInResponse ('G') message.
+func buildCopyInResponse(format int16, columnFormats []int16) []byte {
+	body := make([]byte, 0, 3+2*len(columnFormats))
+	body = append(body, byte(format))
+	body = append(body, byte(len(columnFormats)>>8), byte(len(columnFormats)))
+	for _, f := range columnFormats {
+		body = append(body, byte(f>>8), byte(f))
+	}
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgCopyInResponse, body)
+	return out.Bytes()
+}
+
+// TestInitiateCopyFromStdin mirrors TestInitiateCopyToStdout for the
+// FROM STDIN direction. The PR adapted this method's return signature to
+// expose pre-CopyInResponse notices; this test pins both the success and
+// PG-error paths to that contract.
+func TestInitiateCopyFromStdin(t *testing.T) {
+	t.Run("success returns format, columns, notices", func(t *testing.T) {
+		var input bytes.Buffer
+		input.Write(buildNoticeResponse("NOTICE", "before-statement"))
+		input.Write(buildCopyInResponse(0, []int16{0}))
+
+		c := newTestReadWriteConn(input.Bytes())
+		format, columnFormats, notices, err := c.InitiateCopyFromStdin(context.Background(), "COPY t FROM STDIN")
+		require.NoError(t, err)
+		assert.Equal(t, int16(0), format)
+		assert.Equal(t, []int16{0}, columnFormats)
+		require.Len(t, notices, 1)
+		assert.Equal(t, "before-statement", notices[0].Message)
+	})
+
+	t.Run("ErrorResponse surfaces PgDiagnostic and drains RFQ", func(t *testing.T) {
+		var input bytes.Buffer
+		input.Write(buildErrorResponse("42703", "column \"xyz\" of relation \"t\" does not exist"))
+		input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+		c := newTestReadWriteConn(input.Bytes())
+		_, _, _, err := c.InitiateCopyFromStdin(context.Background(), "COPY t (xyz) FROM STDIN")
+		require.Error(t, err)
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag))
+		assert.Equal(t, "42703", diag.Code)
+	})
+}
+
 // TestReadCopyFailResponse_CapturesNotices verifies that NoticeResponse
 // diagnostics arriving between CopyFail and ReadyForQuery are returned to
 // the caller (rather than silently dropped) — symmetric with the notice

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -180,3 +180,167 @@ func TestReadCopyDoneResponse_ReadyForQueryWithoutCommandComplete(t *testing.T) 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ReadyForQuery without CommandComplete")
 }
+
+// buildCopyData returns a serialized CopyData ('d') message carrying the
+// given payload.
+func buildCopyData(payload []byte) []byte {
+	var b bytes.Buffer
+	writeRawMessage(&b, protocol.MsgCopyData, payload)
+	return b.Bytes()
+}
+
+// buildCopyDone returns a serialized CopyDone ('c') message (zero-length body).
+func buildCopyDone() []byte {
+	var b bytes.Buffer
+	writeRawMessage(&b, protocol.MsgCopyDone, nil)
+	return b.Bytes()
+}
+
+// buildNoticeResponse returns a serialized NoticeResponse message with the
+// minimum field set parseNotice cares about.
+func buildNoticeResponse(severity, message string) []byte {
+	var body bytes.Buffer
+	body.WriteByte('S')
+	body.WriteString(severity)
+	body.WriteByte(0)
+	body.WriteByte('M')
+	body.WriteString(message)
+	body.WriteByte(0)
+	body.WriteByte(0)
+
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgNoticeResponse, body.Bytes())
+	return out.Bytes()
+}
+
+// TestReadCopyOutMessage covers the three terminal frame kinds the COPY TO
+// STDOUT response stream can deliver: CopyData (row payload), CopyDone
+// (end-of-stream), and NoticeResponse (interleaved diagnostic). Each is
+// returned via a distinct field on CopyOutMessage so the caller's
+// dispatch table can be exhaustive.
+func TestReadCopyOutMessage(t *testing.T) {
+	t.Run("CopyData returns payload", func(t *testing.T) {
+		c := newTestReadOnlyConn(buildCopyData([]byte("1\tAlice\n")))
+
+		msg, err := c.ReadCopyOutMessage(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []byte("1\tAlice\n"), msg.Data)
+		assert.Nil(t, msg.Notice)
+		assert.False(t, msg.Done)
+	})
+
+	t.Run("CopyDone returns Done=true", func(t *testing.T) {
+		c := newTestReadOnlyConn(buildCopyDone())
+
+		msg, err := c.ReadCopyOutMessage(context.Background())
+		require.NoError(t, err)
+		assert.True(t, msg.Done)
+		assert.Nil(t, msg.Data)
+		assert.Nil(t, msg.Notice)
+	})
+
+	t.Run("NoticeResponse returns Notice", func(t *testing.T) {
+		c := newTestReadOnlyConn(buildNoticeResponse("NOTICE", "trigger fired"))
+
+		msg, err := c.ReadCopyOutMessage(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, msg.Notice)
+		assert.Equal(t, "NOTICE", msg.Notice.Severity)
+		assert.Equal(t, "trigger fired", msg.Notice.Message)
+		assert.Nil(t, msg.Data)
+		assert.False(t, msg.Done)
+	})
+
+	t.Run("ErrorResponse parses to PgDiagnostic and drains RFQ", func(t *testing.T) {
+		// PG ErrorResponse mid-stream — the helper must parse the error,
+		// drain the trailing ReadyForQuery so the conn is left clean, and
+		// surface a *PgDiagnostic to the caller (via errors.As).
+		var input bytes.Buffer
+		input.Write(buildErrorResponse("57014", "canceling statement due to user request"))
+		input.Write(buildReadyForQuery(protocol.TxnStatusFailed))
+
+		c := newTestReadOnlyConn(input.Bytes())
+
+		_, err := c.ReadCopyOutMessage(context.Background())
+		require.Error(t, err)
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag))
+		assert.Equal(t, "57014", diag.Code)
+
+		// RFQ drained — buffered reader has no leftover bytes.
+		leftover, _ := c.bufferedReader.Peek(1)
+		assert.Empty(t, leftover)
+	})
+}
+
+// TestFinishCopyToStdout exercises the trailing CommandComplete +
+// ReadyForQuery drain after CopyDone. Notices arriving in this window
+// (AFTER STATEMENT triggers, COPY progress finalization) must be
+// returned alongside the command tag so the gateway can re-emit them
+// to the client before CommandComplete.
+func TestFinishCopyToStdout(t *testing.T) {
+	t.Run("Success returns tag, rows, and trailing notices", func(t *testing.T) {
+		var input bytes.Buffer
+		input.Write(buildNoticeResponse("NOTICE", "after-statement"))
+		input.Write(buildCommandComplete("COPY 5"))
+		input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+		c := newTestReadOnlyConn(input.Bytes())
+
+		tag, rows, notices, err := c.FinishCopyToStdout(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "COPY 5", tag)
+		assert.Equal(t, uint64(5), rows)
+		require.Len(t, notices, 1)
+		assert.Equal(t, "after-statement", notices[0].Message)
+		assert.Equal(t, protocol.TxnStatusIdle, c.txnStatus)
+	})
+
+	t.Run("ErrorResponse drains RFQ and returns PgDiagnostic", func(t *testing.T) {
+		// Server-side abort mid-COPY (e.g. statement_timeout). FinishCopyToStdout
+		// must drain RFQ so the conn is reusable.
+		var input bytes.Buffer
+		input.Write(buildErrorResponse("57014", "canceling statement"))
+		input.Write(buildReadyForQuery(protocol.TxnStatusFailed))
+
+		c := newTestReadOnlyConn(input.Bytes())
+
+		_, _, _, err := c.FinishCopyToStdout(context.Background())
+		require.Error(t, err)
+		var diag *mterrors.PgDiagnostic
+		require.True(t, errors.As(err, &diag))
+		assert.Equal(t, "57014", diag.Code)
+		leftover, _ := c.bufferedReader.Peek(1)
+		assert.Empty(t, leftover)
+	})
+
+	t.Run("ReadyForQuery without CommandComplete is an error", func(t *testing.T) {
+		// Defensive: server returned RFQ without CommandComplete or ErrorResponse.
+		c := newTestReadOnlyConn(buildReadyForQuery(protocol.TxnStatusIdle))
+
+		_, _, _, err := c.FinishCopyToStdout(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ReadyForQuery without CommandComplete")
+	})
+}
+
+// TestReadCopyFailResponse_CapturesNotices verifies that NoticeResponse
+// diagnostics arriving between CopyFail and ReadyForQuery are returned to
+// the caller (rather than silently dropped) — symmetric with the notice
+// capture in ReadCopyDoneResponse.
+func TestReadCopyFailResponse_CapturesNotices(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildNoticeResponse("WARNING", "trigger ran before abort"))
+	input.Write(buildErrorResponse("57014", "COPY from stdin failed: aborted"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusFailed))
+
+	c := newTestReadOnlyConn(input.Bytes())
+
+	notices, err := c.ReadCopyFailResponse(context.Background())
+	require.NoError(t, err)
+	require.Len(t, notices, 1)
+	assert.Equal(t, "WARNING", notices[0].Severity)
+	assert.Equal(t, "trigger ran before abort", notices[0].Message)
+	// RFQ payload updates txnStatus on the failed-transaction abort.
+	assert.Equal(t, protocol.TxnStatusFailed, c.txnStatus)
+}

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -442,6 +442,44 @@ func TestInitiateCopyFromStdin(t *testing.T) {
 	})
 }
 
+func TestReadCopyResponse(t *testing.T) {
+	t.Run("ReadCopyInResponse success", func(t *testing.T) {
+		c := newTestReadOnlyConn(buildCopyInResponse(1, []int16{0, 1}))
+		format, columnFormats, err := c.ReadCopyInResponse()
+		require.NoError(t, err)
+		assert.Equal(t, int16(1), format)
+		assert.Equal(t, []int16{0, 1}, columnFormats)
+	})
+
+	t.Run("ReadCopyOutResponse success", func(t *testing.T) {
+		c := newTestReadOnlyConn(buildCopyOutResponse(0, []int16{1}))
+		format, columnFormats, err := c.ReadCopyOutResponse()
+		require.NoError(t, err)
+		assert.Equal(t, int16(0), format)
+		assert.Equal(t, []int16{1}, columnFormats)
+	})
+
+	t.Run("ReadCopyInResponse short column formats", func(t *testing.T) {
+		var input bytes.Buffer
+		writeRawMessage(&input, protocol.MsgCopyInResponse, []byte{0, 0, 1, 0})
+
+		c := newTestReadOnlyConn(input.Bytes())
+		_, _, err := c.ReadCopyInResponse()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CopyInResponse body too short for column formats")
+	})
+
+	t.Run("ReadCopyOutResponse short body", func(t *testing.T) {
+		var input bytes.Buffer
+		writeRawMessage(&input, protocol.MsgCopyOutResponse, []byte{0, 0})
+
+		c := newTestReadOnlyConn(input.Bytes())
+		_, _, err := c.ReadCopyOutResponse()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CopyOutResponse body too short: 2 bytes")
+	})
+}
+
 // TestReadCopyFailResponse_CapturesNotices verifies that NoticeResponse
 // diagnostics arriving between CopyFail and ReadyForQuery are returned to
 // the caller (rather than silently dropped) — symmetric with the notice

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -97,10 +97,11 @@ func TestReadCopyDoneResponse_Success(t *testing.T) {
 
 	c := newTestReadOnlyConn(input.Bytes())
 
-	tag, rows, err := c.ReadCopyDoneResponse(context.Background())
+	tag, rows, notices, err := c.ReadCopyDoneResponse(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "COPY 7", tag)
 	assert.Equal(t, uint64(7), rows)
+	assert.Empty(t, notices, "no notices on the success path")
 	assert.Equal(t, protocol.TxnStatusIdle, c.txnStatus,
 		"txnStatus must be updated from the trailing ReadyForQuery on the success path")
 }
@@ -118,10 +119,11 @@ func TestReadCopyDoneResponse_ErrorResponseDrainsReadyForQuery(t *testing.T) {
 
 	c := newTestReadOnlyConn(input.Bytes())
 
-	tag, rows, err := c.ReadCopyDoneResponse(context.Background())
+	tag, rows, notices, err := c.ReadCopyDoneResponse(context.Background())
 	require.Error(t, err)
 	assert.Empty(t, tag)
 	assert.Equal(t, uint64(0), rows)
+	assert.Empty(t, notices, "no preceding notices in this fixture")
 
 	// Underlying error should be the PgDiagnostic from the ErrorResponse.
 	var diag *mterrors.PgDiagnostic
@@ -138,10 +140,12 @@ func TestReadCopyDoneResponse_ErrorResponseDrainsReadyForQuery(t *testing.T) {
 		"txnStatus must be updated from the drained ReadyForQuery on the error path")
 }
 
-func TestReadCopyDoneResponse_IgnoresNotices(t *testing.T) {
+func TestReadCopyDoneResponse_CapturesNotices(t *testing.T) {
 	var input bytes.Buffer
-	// NoticeResponse uses the same wire shape as ErrorResponse and must be
-	// skipped silently before the CommandComplete.
+	// NoticeResponse uses the same wire shape as ErrorResponse and arrives
+	// between CopyDone and CommandComplete when triggers fire during the COPY.
+	// Trigger / progress notices must be captured and surfaced to the
+	// gateway so the client sees the expected NOTICE / INFO lines.
 	var notice bytes.Buffer
 	notice.WriteByte('S')
 	notice.WriteString("NOTICE")
@@ -156,10 +160,13 @@ func TestReadCopyDoneResponse_IgnoresNotices(t *testing.T) {
 
 	c := newTestReadOnlyConn(input.Bytes())
 
-	tag, rows, err := c.ReadCopyDoneResponse(context.Background())
+	tag, rows, notices, err := c.ReadCopyDoneResponse(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "COPY 3", tag)
 	assert.Equal(t, uint64(3), rows)
+	require.Len(t, notices, 1, "trigger NOTICE between CopyDone and CommandComplete must be captured")
+	assert.Equal(t, "NOTICE", notices[0].Severity)
+	assert.Equal(t, "hello", notices[0].Message)
 	assert.Equal(t, protocol.TxnStatusInBlock, c.txnStatus)
 }
 
@@ -169,7 +176,7 @@ func TestReadCopyDoneResponse_ReadyForQueryWithoutCommandComplete(t *testing.T) 
 	// than silently returning empty success.
 	c := newTestReadOnlyConn(buildReadyForQuery(protocol.TxnStatusIdle))
 
-	_, _, err := c.ReadCopyDoneResponse(context.Background())
+	_, _, _, err := c.ReadCopyDoneResponse(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ReadyForQuery without CommandComplete")
 }

--- a/go/common/pgprotocol/server/query.go
+++ b/go/common/pgprotocol/server/query.go
@@ -302,6 +302,37 @@ func (c *Conn) WriteCopyInResponse(format int16, columnFormats []int16) error {
 	return c.writePacket(buf, pos)
 }
 
+// WriteCopyOutResponse writes a CopyOutResponse ('H') message to the client.
+// Sent at the start of a COPY ... TO STDOUT response, before any CopyData
+// frames. Body layout matches CopyInResponse: Int8(format) +
+// Int16(numCols) + Int16[numCols] per-column formats.
+func (c *Conn) WriteCopyOutResponse(format int16, columnFormats []int16) error {
+	bodyLen := 1 + 2 + 2*len(columnFormats)
+	buf, pos := c.startPacket(protocol.MsgCopyOutResponse, bodyLen)
+	pos = writeByteAt(buf, pos, byte(format))
+	pos = writeInt16At(buf, pos, int16(len(columnFormats)))
+	for _, fmt := range columnFormats {
+		pos = writeInt16At(buf, pos, fmt)
+	}
+	return c.writePacket(buf, pos)
+}
+
+// WriteCopyData writes a CopyData ('d') message body to the client.
+// Used during COPY ... TO STDOUT to forward each row chunk PG returned.
+func (c *Conn) WriteCopyData(data []byte) error {
+	buf, pos := c.startPacket(protocol.MsgCopyData, len(data))
+	pos = writeBytesAt(buf, pos, data)
+	return c.writePacket(buf, pos)
+}
+
+// WriteCopyDone writes a CopyDone ('c') message (zero-length body) to the
+// client. Sent after the last CopyData frame in a COPY ... TO STDOUT response,
+// just before CommandComplete.
+func (c *Conn) WriteCopyDone() error {
+	buf, pos := c.startPacket(protocol.MsgCopyDone, 0)
+	return c.writePacket(buf, pos)
+}
+
 // ReadCopyDataMessage reads a CopyData ('d') message body
 // The message type byte has already been read
 // length is the body length (already has 4 subtracted by ReadMessageLength)

--- a/go/common/queryservice/queryservice.go
+++ b/go/common/queryservice/queryservice.go
@@ -24,6 +24,8 @@ package queryservice
 import (
 	"context"
 
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
@@ -186,6 +188,29 @@ type QueryService interface {
 		errorMsg string,
 		options *query.ExecuteOptions,
 	) (*query.ReservedState, error)
+
+	// CopyOutReady initiates a COPY ... TO STDOUT operation and returns
+	// format information plus any NoticeResponse diagnostics that arrived
+	// before the CopyOutResponse. Reserves the underlying connection for
+	// the duration of the COPY just like CopyReady (FROM STDIN).
+	CopyOutReady(
+		ctx context.Context,
+		target *query.Target,
+		copyQuery string,
+		options *query.ExecuteOptions,
+		reservationOptions *query.ReservationOptions,
+	) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, reservedState *query.ReservedState, err error)
+
+	// CopyOutStream pumps CopyData / NoticeResponse messages back through
+	// the supplied callback until PG sends CopyDone, then drains
+	// CommandComplete + ReadyForQuery and returns the final Result (with
+	// any notices that arrived between CopyDone and CommandComplete).
+	CopyOutStream(
+		ctx context.Context,
+		target *query.Target,
+		options *query.ExecuteOptions,
+		onMessage func(client.CopyOutMessage) error,
+	) (*sqltypes.Result, *query.ReservedState, error)
 
 	// ConcludeTransaction concludes a transaction on a reserved connection.
 	// Executes COMMIT or ROLLBACK based on the conclusion parameter.

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -219,6 +219,54 @@ func (CopyBidiExecuteRequest_Phase) EnumDescriptor() ([]byte, []int) {
 	return file_multipoolerservice_proto_rawDescGZIP(), []int{11, 0}
 }
 
+// Direction indicates whether the COPY operation streams data into the
+// server (FROM STDIN) or out from the server (TO STDOUT). Set on INITIATE.
+type CopyBidiExecuteRequest_Direction int32
+
+const (
+	CopyBidiExecuteRequest_FROM_STDIN CopyBidiExecuteRequest_Direction = 0 // Default for back-compat: clients without this field set get FROM STDIN.
+	CopyBidiExecuteRequest_TO_STDOUT  CopyBidiExecuteRequest_Direction = 1
+)
+
+// Enum value maps for CopyBidiExecuteRequest_Direction.
+var (
+	CopyBidiExecuteRequest_Direction_name = map[int32]string{
+		0: "FROM_STDIN",
+		1: "TO_STDOUT",
+	}
+	CopyBidiExecuteRequest_Direction_value = map[string]int32{
+		"FROM_STDIN": 0,
+		"TO_STDOUT":  1,
+	}
+)
+
+func (x CopyBidiExecuteRequest_Direction) Enum() *CopyBidiExecuteRequest_Direction {
+	p := new(CopyBidiExecuteRequest_Direction)
+	*p = x
+	return p
+}
+
+func (x CopyBidiExecuteRequest_Direction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CopyBidiExecuteRequest_Direction) Descriptor() protoreflect.EnumDescriptor {
+	return file_multipoolerservice_proto_enumTypes[3].Descriptor()
+}
+
+func (CopyBidiExecuteRequest_Direction) Type() protoreflect.EnumType {
+	return &file_multipoolerservice_proto_enumTypes[3]
+}
+
+func (x CopyBidiExecuteRequest_Direction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CopyBidiExecuteRequest_Direction.Descriptor instead.
+func (CopyBidiExecuteRequest_Direction) EnumDescriptor() ([]byte, []int) {
+	return file_multipoolerservice_proto_rawDescGZIP(), []int{11, 1}
+}
+
 // Phase indicates which phase of the response this represents
 type CopyBidiExecuteResponse_Phase int32
 
@@ -258,11 +306,11 @@ func (x CopyBidiExecuteResponse_Phase) String() string {
 }
 
 func (CopyBidiExecuteResponse_Phase) Descriptor() protoreflect.EnumDescriptor {
-	return file_multipoolerservice_proto_enumTypes[3].Descriptor()
+	return file_multipoolerservice_proto_enumTypes[4].Descriptor()
 }
 
 func (CopyBidiExecuteResponse_Phase) Type() protoreflect.EnumType {
-	return &file_multipoolerservice_proto_enumTypes[3]
+	return &file_multipoolerservice_proto_enumTypes[4]
 }
 
 func (x CopyBidiExecuteResponse_Phase) Number() protoreflect.EnumNumber {
@@ -1001,6 +1049,8 @@ type CopyBidiExecuteRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// phase indicates the current phase
 	Phase CopyBidiExecuteRequest_Phase `protobuf:"varint,1,opt,name=phase,proto3,enum=multipoolerservice.CopyBidiExecuteRequest_Phase" json:"phase,omitempty"`
+	// direction indicates COPY ... FROM STDIN vs COPY ... TO STDOUT (INITIATE only).
+	Direction CopyBidiExecuteRequest_Direction `protobuf:"varint,9,opt,name=direction,proto3,enum=multipoolerservice.CopyBidiExecuteRequest_Direction" json:"direction,omitempty"`
 	// query is the SQL command to execute (only for INITIATE phase)
 	Query string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
 	// target specifies the routing destination (only for INITIATE phase)
@@ -1056,6 +1106,13 @@ func (x *CopyBidiExecuteRequest) GetPhase() CopyBidiExecuteRequest_Phase {
 		return x.Phase
 	}
 	return CopyBidiExecuteRequest_INITIATE
+}
+
+func (x *CopyBidiExecuteRequest) GetDirection() CopyBidiExecuteRequest_Direction {
+	if x != nil {
+		return x.Direction
+	}
+	return CopyBidiExecuteRequest_FROM_STDIN
 }
 
 func (x *CopyBidiExecuteRequest) GetQuery() string {
@@ -1127,9 +1184,25 @@ type CopyBidiExecuteResponse struct {
 	// result contains the final query result (for RESULT phase)
 	Result *query.QueryResult `protobuf:"bytes,6,opt,name=result,proto3" json:"result,omitempty"`
 	// error contains the error message (for ERROR phase)
-	Error         string `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Error string `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`
+	// notices carries PostgreSQL NoticeResponse/InfoResponse diagnostics
+	// collected during this phase. Trigger RAISE NOTICE output, INFO progress
+	// messages, and other backend notices appear here so the gateway can
+	// forward them to the client as NoticeResponse frames between CopyData and
+	// CommandComplete. Populated on READY (notices seen before CopyInResponse /
+	// CopyOutResponse), DATA (notices interleaved with CopyData on COPY TO
+	// STDOUT), and RESULT (notices read between CopyDone and CommandComplete).
+	Notices []*query.PgDiagnostic `protobuf:"bytes,11,rep,name=notices,proto3" json:"notices,omitempty"`
+	// error_diagnostic carries the structured PostgreSQL ErrorResponse for
+	// ERROR phase responses. When the error originates from PG (e.g.
+	// constraint violation, "column does not exist"), this preserves SQLSTATE,
+	// severity, DETAIL, HINT, position, etc., so the gateway can re-emit a
+	// verbatim ErrorResponse instead of a wrapped Go-formatted string.
+	// The `error` field above remains populated as a fallback for callers /
+	// log paths that only need the message text.
+	ErrorDiagnostic *query.PgDiagnostic `protobuf:"bytes,12,opt,name=error_diagnostic,json=errorDiagnostic,proto3" json:"error_diagnostic,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CopyBidiExecuteResponse) Reset() {
@@ -1209,6 +1282,20 @@ func (x *CopyBidiExecuteResponse) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *CopyBidiExecuteResponse) GetNotices() []*query.PgDiagnostic {
+	if x != nil {
+		return x.Notices
+	}
+	return nil
+}
+
+func (x *CopyBidiExecuteResponse) GetErrorDiagnostic() *query.PgDiagnostic {
+	if x != nil {
+		return x.ErrorDiagnostic
+	}
+	return nil
 }
 
 // ConcludeTransactionRequest represents a request to conclude a transaction on a reserved connection.
@@ -1941,9 +2028,10 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x1aGetAuthCredentialsResponse\x12\x1d\n" +
 	"\n" +
 	"scram_hash\x18\x01 \x01(\tR\tscramHash\x12.\n" +
-	"\x13is_replication_role\x18\x02 \x01(\bR\x11isReplicationRole\"\xb6\x03\n" +
+	"\x13is_replication_role\x18\x02 \x01(\bR\x11isReplicationRole\"\xb6\x04\n" +
 	"\x16CopyBidiExecuteRequest\x12F\n" +
-	"\x05phase\x18\x01 \x01(\x0e20.multipoolerservice.CopyBidiExecuteRequest.PhaseR\x05phase\x12\x14\n" +
+	"\x05phase\x18\x01 \x01(\x0e20.multipoolerservice.CopyBidiExecuteRequest.PhaseR\x05phase\x12R\n" +
+	"\tdirection\x18\t \x01(\x0e24.multipoolerservice.CopyBidiExecuteRequest.DirectionR\tdirection\x12\x14\n" +
 	"\x05query\x18\x02 \x01(\tR\x05query\x12%\n" +
 	"\x06target\x18\x03 \x01(\v2\r.query.TargetR\x06target\x12,\n" +
 	"\tcaller_id\x18\x04 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
@@ -1955,7 +2043,11 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\bINITIATE\x10\x00\x12\b\n" +
 	"\x04DATA\x10\x01\x12\b\n" +
 	"\x04DONE\x10\x02\x12\b\n" +
-	"\x04FAIL\x10\x03\"\xe9\x02\n" +
+	"\x04FAIL\x10\x03\"*\n" +
+	"\tDirection\x12\x0e\n" +
+	"\n" +
+	"FROM_STDIN\x10\x00\x12\r\n" +
+	"\tTO_STDOUT\x10\x01\"\xd8\x03\n" +
 	"\x17CopyBidiExecuteResponse\x12G\n" +
 	"\x05phase\x18\x01 \x01(\x0e21.multipoolerservice.CopyBidiExecuteResponse.PhaseR\x05phase\x12;\n" +
 	"\x0ereserved_state\x18\n" +
@@ -1964,7 +2056,9 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x0ecolumn_formats\x18\b \x03(\x05R\rcolumnFormats\x12\x12\n" +
 	"\x04data\x18\x05 \x01(\fR\x04data\x12*\n" +
 	"\x06result\x18\x06 \x01(\v2\x12.query.QueryResultR\x06result\x12\x14\n" +
-	"\x05error\x18\a \x01(\tR\x05error\"3\n" +
+	"\x05error\x18\a \x01(\tR\x05error\x12-\n" +
+	"\anotices\x18\v \x03(\v2\x13.query.PgDiagnosticR\anotices\x12>\n" +
+	"\x10error_diagnostic\x18\f \x01(\v2\x13.query.PgDiagnosticR\x0ferrorDiagnostic\"3\n" +
 	"\x05Phase\x12\t\n" +
 	"\x05READY\x10\x00\x12\b\n" +
 	"\x04DATA\x10\x01\x12\n" +
@@ -2049,135 +2143,140 @@ func file_multipoolerservice_proto_rawDescGZIP() []byte {
 	return file_multipoolerservice_proto_rawDescData
 }
 
-var file_multipoolerservice_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_multipoolerservice_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_multipoolerservice_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_multipoolerservice_proto_goTypes = []any{
 	(ReservationReason)(0),                    // 0: multipoolerservice.ReservationReason
 	(TransactionConclusion)(0),                // 1: multipoolerservice.TransactionConclusion
 	(CopyBidiExecuteRequest_Phase)(0),         // 2: multipoolerservice.CopyBidiExecuteRequest.Phase
-	(CopyBidiExecuteResponse_Phase)(0),        // 3: multipoolerservice.CopyBidiExecuteResponse.Phase
-	(*ExecuteQueryRequest)(nil),               // 4: multipoolerservice.ExecuteQueryRequest
-	(*ExecuteQueryResponse)(nil),              // 5: multipoolerservice.ExecuteQueryResponse
-	(*StreamExecuteRequest)(nil),              // 6: multipoolerservice.StreamExecuteRequest
-	(*StreamExecuteResponse)(nil),             // 7: multipoolerservice.StreamExecuteResponse
-	(*PortalStreamExecuteRequest)(nil),        // 8: multipoolerservice.PortalStreamExecuteRequest
-	(*PortalExecuteOptions)(nil),              // 9: multipoolerservice.PortalExecuteOptions
-	(*PortalStreamExecuteResponse)(nil),       // 10: multipoolerservice.PortalStreamExecuteResponse
-	(*DescribeRequest)(nil),                   // 11: multipoolerservice.DescribeRequest
-	(*DescribeResponse)(nil),                  // 12: multipoolerservice.DescribeResponse
-	(*GetAuthCredentialsRequest)(nil),         // 13: multipoolerservice.GetAuthCredentialsRequest
-	(*GetAuthCredentialsResponse)(nil),        // 14: multipoolerservice.GetAuthCredentialsResponse
-	(*CopyBidiExecuteRequest)(nil),            // 15: multipoolerservice.CopyBidiExecuteRequest
-	(*CopyBidiExecuteResponse)(nil),           // 16: multipoolerservice.CopyBidiExecuteResponse
-	(*ConcludeTransactionRequest)(nil),        // 17: multipoolerservice.ConcludeTransactionRequest
-	(*ConcludeTransactionResponse)(nil),       // 18: multipoolerservice.ConcludeTransactionResponse
-	(*DiscardTempTablesRequest)(nil),          // 19: multipoolerservice.DiscardTempTablesRequest
-	(*DiscardTempTablesResponse)(nil),         // 20: multipoolerservice.DiscardTempTablesResponse
-	(*ReleaseReservedConnectionRequest)(nil),  // 21: multipoolerservice.ReleaseReservedConnectionRequest
-	(*ReleaseReservedConnectionResponse)(nil), // 22: multipoolerservice.ReleaseReservedConnectionResponse
-	(*StreamPoolerHealthRequest)(nil),         // 23: multipoolerservice.StreamPoolerHealthRequest
-	(*StreamPoolerHealthResponse)(nil),        // 24: multipoolerservice.StreamPoolerHealthResponse
-	(*LeaderObservation)(nil),                 // 25: multipoolerservice.LeaderObservation
-	(*StreamNotificationsRequest)(nil),        // 26: multipoolerservice.StreamNotificationsRequest
-	(*StreamNotificationsResponse)(nil),       // 27: multipoolerservice.StreamNotificationsResponse
-	(*query.Target)(nil),                      // 28: query.Target
-	(*mtrpc.CallerID)(nil),                    // 29: mtrpc.CallerID
-	(*query.ExecuteOptions)(nil),              // 30: query.ExecuteOptions
-	(*query.QueryResult)(nil),                 // 31: query.QueryResult
-	(*query.ReservedState)(nil),               // 32: query.ReservedState
-	(*query.ReservationOptions)(nil),          // 33: query.ReservationOptions
-	(*query.QueryResultPayload)(nil),          // 34: query.QueryResultPayload
-	(*query.PreparedStatement)(nil),           // 35: query.PreparedStatement
-	(*query.Portal)(nil),                      // 36: query.Portal
-	(*query.StatementDescription)(nil),        // 37: query.StatementDescription
-	(*clustermetadata.ID)(nil),                // 38: clustermetadata.ID
-	(clustermetadata.PoolerServingStatus)(0),  // 39: clustermetadata.PoolerServingStatus
-	(*durationpb.Duration)(nil),               // 40: google.protobuf.Duration
-	(*query.PgNotification)(nil),              // 41: query.PgNotification
+	(CopyBidiExecuteRequest_Direction)(0),     // 3: multipoolerservice.CopyBidiExecuteRequest.Direction
+	(CopyBidiExecuteResponse_Phase)(0),        // 4: multipoolerservice.CopyBidiExecuteResponse.Phase
+	(*ExecuteQueryRequest)(nil),               // 5: multipoolerservice.ExecuteQueryRequest
+	(*ExecuteQueryResponse)(nil),              // 6: multipoolerservice.ExecuteQueryResponse
+	(*StreamExecuteRequest)(nil),              // 7: multipoolerservice.StreamExecuteRequest
+	(*StreamExecuteResponse)(nil),             // 8: multipoolerservice.StreamExecuteResponse
+	(*PortalStreamExecuteRequest)(nil),        // 9: multipoolerservice.PortalStreamExecuteRequest
+	(*PortalExecuteOptions)(nil),              // 10: multipoolerservice.PortalExecuteOptions
+	(*PortalStreamExecuteResponse)(nil),       // 11: multipoolerservice.PortalStreamExecuteResponse
+	(*DescribeRequest)(nil),                   // 12: multipoolerservice.DescribeRequest
+	(*DescribeResponse)(nil),                  // 13: multipoolerservice.DescribeResponse
+	(*GetAuthCredentialsRequest)(nil),         // 14: multipoolerservice.GetAuthCredentialsRequest
+	(*GetAuthCredentialsResponse)(nil),        // 15: multipoolerservice.GetAuthCredentialsResponse
+	(*CopyBidiExecuteRequest)(nil),            // 16: multipoolerservice.CopyBidiExecuteRequest
+	(*CopyBidiExecuteResponse)(nil),           // 17: multipoolerservice.CopyBidiExecuteResponse
+	(*ConcludeTransactionRequest)(nil),        // 18: multipoolerservice.ConcludeTransactionRequest
+	(*ConcludeTransactionResponse)(nil),       // 19: multipoolerservice.ConcludeTransactionResponse
+	(*DiscardTempTablesRequest)(nil),          // 20: multipoolerservice.DiscardTempTablesRequest
+	(*DiscardTempTablesResponse)(nil),         // 21: multipoolerservice.DiscardTempTablesResponse
+	(*ReleaseReservedConnectionRequest)(nil),  // 22: multipoolerservice.ReleaseReservedConnectionRequest
+	(*ReleaseReservedConnectionResponse)(nil), // 23: multipoolerservice.ReleaseReservedConnectionResponse
+	(*StreamPoolerHealthRequest)(nil),         // 24: multipoolerservice.StreamPoolerHealthRequest
+	(*StreamPoolerHealthResponse)(nil),        // 25: multipoolerservice.StreamPoolerHealthResponse
+	(*LeaderObservation)(nil),                 // 26: multipoolerservice.LeaderObservation
+	(*StreamNotificationsRequest)(nil),        // 27: multipoolerservice.StreamNotificationsRequest
+	(*StreamNotificationsResponse)(nil),       // 28: multipoolerservice.StreamNotificationsResponse
+	(*query.Target)(nil),                      // 29: query.Target
+	(*mtrpc.CallerID)(nil),                    // 30: mtrpc.CallerID
+	(*query.ExecuteOptions)(nil),              // 31: query.ExecuteOptions
+	(*query.QueryResult)(nil),                 // 32: query.QueryResult
+	(*query.ReservedState)(nil),               // 33: query.ReservedState
+	(*query.ReservationOptions)(nil),          // 34: query.ReservationOptions
+	(*query.QueryResultPayload)(nil),          // 35: query.QueryResultPayload
+	(*query.PreparedStatement)(nil),           // 36: query.PreparedStatement
+	(*query.Portal)(nil),                      // 37: query.Portal
+	(*query.StatementDescription)(nil),        // 38: query.StatementDescription
+	(*query.PgDiagnostic)(nil),                // 39: query.PgDiagnostic
+	(*clustermetadata.ID)(nil),                // 40: clustermetadata.ID
+	(clustermetadata.PoolerServingStatus)(0),  // 41: clustermetadata.PoolerServingStatus
+	(*durationpb.Duration)(nil),               // 42: google.protobuf.Duration
+	(*query.PgNotification)(nil),              // 43: query.PgNotification
 }
 var file_multipoolerservice_proto_depIdxs = []int32{
-	28, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
-	29, // 1: multipoolerservice.ExecuteQueryRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 2: multipoolerservice.ExecuteQueryRequest.options:type_name -> query.ExecuteOptions
-	31, // 3: multipoolerservice.ExecuteQueryResponse.result:type_name -> query.QueryResult
-	32, // 4: multipoolerservice.ExecuteQueryResponse.reserved_state:type_name -> query.ReservedState
-	28, // 5: multipoolerservice.StreamExecuteRequest.target:type_name -> query.Target
-	29, // 6: multipoolerservice.StreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 7: multipoolerservice.StreamExecuteRequest.options:type_name -> query.ExecuteOptions
-	33, // 8: multipoolerservice.StreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
-	34, // 9: multipoolerservice.StreamExecuteResponse.result:type_name -> query.QueryResultPayload
-	32, // 10: multipoolerservice.StreamExecuteResponse.reserved_state:type_name -> query.ReservedState
-	28, // 11: multipoolerservice.PortalStreamExecuteRequest.target:type_name -> query.Target
-	35, // 12: multipoolerservice.PortalStreamExecuteRequest.prepared_statement:type_name -> query.PreparedStatement
-	36, // 13: multipoolerservice.PortalStreamExecuteRequest.portal:type_name -> query.Portal
-	29, // 14: multipoolerservice.PortalStreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 15: multipoolerservice.PortalStreamExecuteRequest.options:type_name -> query.ExecuteOptions
-	9,  // 16: multipoolerservice.PortalStreamExecuteRequest.portal_options:type_name -> multipoolerservice.PortalExecuteOptions
-	34, // 17: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResultPayload
-	32, // 18: multipoolerservice.PortalStreamExecuteResponse.reserved_state:type_name -> query.ReservedState
-	28, // 19: multipoolerservice.DescribeRequest.target:type_name -> query.Target
-	35, // 20: multipoolerservice.DescribeRequest.prepared_statement:type_name -> query.PreparedStatement
-	36, // 21: multipoolerservice.DescribeRequest.portal:type_name -> query.Portal
-	29, // 22: multipoolerservice.DescribeRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 23: multipoolerservice.DescribeRequest.options:type_name -> query.ExecuteOptions
-	37, // 24: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
+	29, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
+	30, // 1: multipoolerservice.ExecuteQueryRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 2: multipoolerservice.ExecuteQueryRequest.options:type_name -> query.ExecuteOptions
+	32, // 3: multipoolerservice.ExecuteQueryResponse.result:type_name -> query.QueryResult
+	33, // 4: multipoolerservice.ExecuteQueryResponse.reserved_state:type_name -> query.ReservedState
+	29, // 5: multipoolerservice.StreamExecuteRequest.target:type_name -> query.Target
+	30, // 6: multipoolerservice.StreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 7: multipoolerservice.StreamExecuteRequest.options:type_name -> query.ExecuteOptions
+	34, // 8: multipoolerservice.StreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
+	35, // 9: multipoolerservice.StreamExecuteResponse.result:type_name -> query.QueryResultPayload
+	33, // 10: multipoolerservice.StreamExecuteResponse.reserved_state:type_name -> query.ReservedState
+	29, // 11: multipoolerservice.PortalStreamExecuteRequest.target:type_name -> query.Target
+	36, // 12: multipoolerservice.PortalStreamExecuteRequest.prepared_statement:type_name -> query.PreparedStatement
+	37, // 13: multipoolerservice.PortalStreamExecuteRequest.portal:type_name -> query.Portal
+	30, // 14: multipoolerservice.PortalStreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 15: multipoolerservice.PortalStreamExecuteRequest.options:type_name -> query.ExecuteOptions
+	10, // 16: multipoolerservice.PortalStreamExecuteRequest.portal_options:type_name -> multipoolerservice.PortalExecuteOptions
+	35, // 17: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResultPayload
+	33, // 18: multipoolerservice.PortalStreamExecuteResponse.reserved_state:type_name -> query.ReservedState
+	29, // 19: multipoolerservice.DescribeRequest.target:type_name -> query.Target
+	36, // 20: multipoolerservice.DescribeRequest.prepared_statement:type_name -> query.PreparedStatement
+	37, // 21: multipoolerservice.DescribeRequest.portal:type_name -> query.Portal
+	30, // 22: multipoolerservice.DescribeRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 23: multipoolerservice.DescribeRequest.options:type_name -> query.ExecuteOptions
+	38, // 24: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
 	2,  // 25: multipoolerservice.CopyBidiExecuteRequest.phase:type_name -> multipoolerservice.CopyBidiExecuteRequest.Phase
-	28, // 26: multipoolerservice.CopyBidiExecuteRequest.target:type_name -> query.Target
-	29, // 27: multipoolerservice.CopyBidiExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 28: multipoolerservice.CopyBidiExecuteRequest.options:type_name -> query.ExecuteOptions
-	33, // 29: multipoolerservice.CopyBidiExecuteRequest.reservation_options:type_name -> query.ReservationOptions
-	3,  // 30: multipoolerservice.CopyBidiExecuteResponse.phase:type_name -> multipoolerservice.CopyBidiExecuteResponse.Phase
-	32, // 31: multipoolerservice.CopyBidiExecuteResponse.reserved_state:type_name -> query.ReservedState
-	31, // 32: multipoolerservice.CopyBidiExecuteResponse.result:type_name -> query.QueryResult
-	28, // 33: multipoolerservice.ConcludeTransactionRequest.target:type_name -> query.Target
-	29, // 34: multipoolerservice.ConcludeTransactionRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 35: multipoolerservice.ConcludeTransactionRequest.options:type_name -> query.ExecuteOptions
-	1,  // 36: multipoolerservice.ConcludeTransactionRequest.conclusion:type_name -> multipoolerservice.TransactionConclusion
-	31, // 37: multipoolerservice.ConcludeTransactionResponse.result:type_name -> query.QueryResult
-	32, // 38: multipoolerservice.ConcludeTransactionResponse.reserved_state:type_name -> query.ReservedState
-	28, // 39: multipoolerservice.DiscardTempTablesRequest.target:type_name -> query.Target
-	29, // 40: multipoolerservice.DiscardTempTablesRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 41: multipoolerservice.DiscardTempTablesRequest.options:type_name -> query.ExecuteOptions
-	31, // 42: multipoolerservice.DiscardTempTablesResponse.result:type_name -> query.QueryResult
-	32, // 43: multipoolerservice.DiscardTempTablesResponse.reserved_state:type_name -> query.ReservedState
-	28, // 44: multipoolerservice.ReleaseReservedConnectionRequest.target:type_name -> query.Target
-	29, // 45: multipoolerservice.ReleaseReservedConnectionRequest.caller_id:type_name -> mtrpc.CallerID
-	30, // 46: multipoolerservice.ReleaseReservedConnectionRequest.options:type_name -> query.ExecuteOptions
-	28, // 47: multipoolerservice.StreamPoolerHealthResponse.target:type_name -> query.Target
-	38, // 48: multipoolerservice.StreamPoolerHealthResponse.pooler_id:type_name -> clustermetadata.ID
-	39, // 49: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	25, // 50: multipoolerservice.StreamPoolerHealthResponse.leader_observation:type_name -> multipoolerservice.LeaderObservation
-	40, // 51: multipoolerservice.StreamPoolerHealthResponse.recommended_staleness_timeout:type_name -> google.protobuf.Duration
-	38, // 52: multipoolerservice.LeaderObservation.leader_id:type_name -> clustermetadata.ID
-	28, // 53: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
-	41, // 54: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
-	4,  // 55: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
-	6,  // 56: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
-	8,  // 57: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
-	11, // 58: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
-	13, // 59: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
-	15, // 60: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
-	17, // 61: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
-	19, // 62: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
-	21, // 63: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
-	23, // 64: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
-	26, // 65: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
-	5,  // 66: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
-	7,  // 67: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
-	10, // 68: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
-	12, // 69: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
-	14, // 70: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
-	16, // 71: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
-	18, // 72: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
-	20, // 73: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
-	22, // 74: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
-	24, // 75: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
-	27, // 76: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
-	66, // [66:77] is the sub-list for method output_type
-	55, // [55:66] is the sub-list for method input_type
-	55, // [55:55] is the sub-list for extension type_name
-	55, // [55:55] is the sub-list for extension extendee
-	0,  // [0:55] is the sub-list for field type_name
+	3,  // 26: multipoolerservice.CopyBidiExecuteRequest.direction:type_name -> multipoolerservice.CopyBidiExecuteRequest.Direction
+	29, // 27: multipoolerservice.CopyBidiExecuteRequest.target:type_name -> query.Target
+	30, // 28: multipoolerservice.CopyBidiExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 29: multipoolerservice.CopyBidiExecuteRequest.options:type_name -> query.ExecuteOptions
+	34, // 30: multipoolerservice.CopyBidiExecuteRequest.reservation_options:type_name -> query.ReservationOptions
+	4,  // 31: multipoolerservice.CopyBidiExecuteResponse.phase:type_name -> multipoolerservice.CopyBidiExecuteResponse.Phase
+	33, // 32: multipoolerservice.CopyBidiExecuteResponse.reserved_state:type_name -> query.ReservedState
+	32, // 33: multipoolerservice.CopyBidiExecuteResponse.result:type_name -> query.QueryResult
+	39, // 34: multipoolerservice.CopyBidiExecuteResponse.notices:type_name -> query.PgDiagnostic
+	39, // 35: multipoolerservice.CopyBidiExecuteResponse.error_diagnostic:type_name -> query.PgDiagnostic
+	29, // 36: multipoolerservice.ConcludeTransactionRequest.target:type_name -> query.Target
+	30, // 37: multipoolerservice.ConcludeTransactionRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 38: multipoolerservice.ConcludeTransactionRequest.options:type_name -> query.ExecuteOptions
+	1,  // 39: multipoolerservice.ConcludeTransactionRequest.conclusion:type_name -> multipoolerservice.TransactionConclusion
+	32, // 40: multipoolerservice.ConcludeTransactionResponse.result:type_name -> query.QueryResult
+	33, // 41: multipoolerservice.ConcludeTransactionResponse.reserved_state:type_name -> query.ReservedState
+	29, // 42: multipoolerservice.DiscardTempTablesRequest.target:type_name -> query.Target
+	30, // 43: multipoolerservice.DiscardTempTablesRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 44: multipoolerservice.DiscardTempTablesRequest.options:type_name -> query.ExecuteOptions
+	32, // 45: multipoolerservice.DiscardTempTablesResponse.result:type_name -> query.QueryResult
+	33, // 46: multipoolerservice.DiscardTempTablesResponse.reserved_state:type_name -> query.ReservedState
+	29, // 47: multipoolerservice.ReleaseReservedConnectionRequest.target:type_name -> query.Target
+	30, // 48: multipoolerservice.ReleaseReservedConnectionRequest.caller_id:type_name -> mtrpc.CallerID
+	31, // 49: multipoolerservice.ReleaseReservedConnectionRequest.options:type_name -> query.ExecuteOptions
+	29, // 50: multipoolerservice.StreamPoolerHealthResponse.target:type_name -> query.Target
+	40, // 51: multipoolerservice.StreamPoolerHealthResponse.pooler_id:type_name -> clustermetadata.ID
+	41, // 52: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
+	26, // 53: multipoolerservice.StreamPoolerHealthResponse.leader_observation:type_name -> multipoolerservice.LeaderObservation
+	42, // 54: multipoolerservice.StreamPoolerHealthResponse.recommended_staleness_timeout:type_name -> google.protobuf.Duration
+	40, // 55: multipoolerservice.LeaderObservation.leader_id:type_name -> clustermetadata.ID
+	29, // 56: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
+	43, // 57: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
+	5,  // 58: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
+	7,  // 59: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
+	9,  // 60: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
+	12, // 61: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
+	14, // 62: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
+	16, // 63: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
+	18, // 64: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
+	20, // 65: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
+	22, // 66: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
+	24, // 67: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
+	27, // 68: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
+	6,  // 69: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
+	8,  // 70: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
+	11, // 71: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
+	13, // 72: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
+	15, // 73: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
+	17, // 74: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
+	19, // 75: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
+	21, // 76: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
+	23, // 77: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
+	25, // 78: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
+	28, // 79: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
+	69, // [69:80] is the sub-list for method output_type
+	58, // [58:69] is the sub-list for method input_type
+	58, // [58:58] is the sub-list for extension type_name
+	58, // [58:58] is the sub-list for extension extendee
+	0,  // [0:58] is the sub-list for field type_name
 }
 
 func init() { file_multipoolerservice_proto_init() }
@@ -2190,7 +2289,7 @@ func file_multipoolerservice_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolerservice_proto_rawDesc), len(file_multipoolerservice_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/go/services/multigateway/engine/copy_statement.go
+++ b/go/services/multigateway/engine/copy_statement.go
@@ -295,17 +295,24 @@ func (c *CopyStatement) streamCopyOut(
 	// released (or kept-state) the conn. No deferred abort needed.
 	streamCompleted = true
 
-	// Trailing notices (between CopyDone and CommandComplete) — write them
-	// before CopyDone so the client sees NoticeResponse → CopyDone →
-	// CommandComplete in order, matching upstream PG.
+	// Wire ordering matches upstream PG for COPY ... TO STDOUT:
+	//   CopyData* → CopyDone → NoticeResponse* → CommandComplete → ReadyForQuery
+	//
+	// result.Notices holds diagnostics PG sent between CopyDone and
+	// CommandComplete (AFTER STATEMENT trigger output, COPY progress
+	// finalization, etc.), so they go AFTER WriteCopyDone but BEFORE the
+	// callback that emits CommandComplete. NoticeResponse is technically
+	// valid at any point on the wire, so any client (libpq, pgx) will
+	// accept it either way — but matching PG ordering avoids surprising
+	// protocol-level diff tools / wire fuzzers.
+	if err := conn.WriteCopyDone(); err != nil {
+		return fmt.Errorf("failed to write CopyDone: %w", err)
+	}
+
 	if len(result.Notices) > 0 {
 		if cbErr := callback(ctx, &sqltypes.Result{Notices: result.Notices}); cbErr != nil {
 			return cbErr
 		}
-	}
-
-	if err := conn.WriteCopyDone(); err != nil {
-		return fmt.Errorf("failed to write CopyDone: %w", err)
 	}
 
 	// Hand the Result (with CommandTag) to the higher-level callback which

--- a/go/services/multigateway/engine/copy_statement.go
+++ b/go/services/multigateway/engine/copy_statement.go
@@ -21,6 +21,7 @@ import (
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -46,7 +47,9 @@ func NewCopyStatement(tableGroup, query string, copyStmt *ast.CopyStmt) *CopySta
 }
 
 // StreamExecute implements the Primitive interface.
-// Orchestrates COPY operations (currently COPY FROM STDIN).
+// Orchestrates COPY operations: COPY FROM STDIN (client → server data)
+// and COPY TO STDOUT (server → client data) are both streamed through this
+// primitive. The branch is taken on c.CopyStmt.IsFrom.
 func (c *CopyStatement) StreamExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -59,13 +62,21 @@ func (c *CopyStatement) StreamExecute(
 	// this will need to be determined from the COPY target table.
 	shard := constants.DefaultShard
 
+	if !c.CopyStmt.IsFrom {
+		return c.streamCopyOut(ctx, exec, conn, shard, state, callback)
+	}
+
 	// Phase 1: INITIATE - Send COPY command to pooler
-	// CopyInitiate stores reserved connection info in state.ShardStates internally
+	// CopyInitiate stores reserved connection info in state.ShardStates internally.
+	// PG errors (e.g. "column does not exist") are surfaced un-wrapped so the
+	// gateway re-emits a verbatim ErrorResponse to the client — wrapping with
+	// "failed to initiate COPY:" here would corrupt regression-test fixtures
+	// that match against bare upstream PG ERROR text.
 	format, columnFormats, err := exec.CopyInitiate(ctx, conn, c.TableGroup, shard, c.Query, state, func(ctx context.Context, result *sqltypes.Result) error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to initiate COPY: %w", err)
+		return err
 	}
 
 	// Ensure cleanup on any exit path after successful initiate
@@ -103,7 +114,9 @@ func (c *CopyStatement) StreamExecute(
 				return err
 			}
 			if err := exec.CopySendData(ctx, conn, c.TableGroup, shard, state, data); err != nil {
-				return fmt.Errorf("failed to send COPY data: %w", err)
+				// PG errors are returned un-wrapped — see comment in
+				// StreamExecute's CopyInitiate error path.
+				return err
 			}
 
 		case protocol.MsgCopyDone:
@@ -177,7 +190,103 @@ func (c *CopyStatement) String() string {
 	if !c.CopyStmt.IsFrom {
 		direction = "TO STDOUT"
 	}
-	return fmt.Sprintf("CopyStatement(%s %s)", c.CopyStmt.Relation.RelName, direction)
+	// COPY (SELECT ...) TO STDOUT has Relation == nil and Query set
+	// instead; keep this nil-safe so debug logging / planner traces don't
+	// crash on subquery COPYs.
+	target := "(query)"
+	if c.CopyStmt.Relation != nil {
+		target = c.CopyStmt.Relation.RelName
+	}
+	return fmt.Sprintf("CopyStatement(%s %s)", target, direction)
+}
+
+// streamCopyOut drives a COPY ... TO STDOUT.
+//
+// Flow:
+//  1. CopyOutInitiate → reserves a backend conn and returns the
+//     CopyOutResponse format/columnFormats plus any pre-CopyOutResponse
+//     notices (BEFORE STATEMENT triggers, etc.).
+//  2. Write CopyOutResponse to the client; flush any initiation notices.
+//  3. CopyOutStream pumps each CopyData / Notice frame from the
+//     multipooler via callback: data is written as CopyData('d') to the
+//     client; notices are written as NoticeResponse('N').
+//  4. Final RESULT carries the CommandTag + post-data Notices. Notices
+//     are written first (between the last CopyData and CopyDone), then
+//     CopyDone('c') is sent, then the higher-level callback consumes
+//     the Result (which writes CommandComplete).
+func (c *CopyStatement) streamCopyOut(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	shard string,
+	state *handler.MultiGatewayConnectionState,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	format, columnFormats, initNotices, err := exec.CopyOutInitiate(ctx, conn, c.TableGroup, shard, c.Query, state)
+	if err != nil {
+		// Surface PG errors un-wrapped so the gateway re-emits a verbatim
+		// ErrorResponse — see StreamExecute's FROM-STDIN path comment.
+		return err
+	}
+
+	// Forward any pre-CopyOutResponse notices to the client as standalone
+	// NoticeResponse frames via the callback (the per-result Conn writer
+	// emits NoticeResponse for every entry in result.Notices).
+	if len(initNotices) > 0 {
+		if err := callback(ctx, &sqltypes.Result{Notices: initNotices}); err != nil {
+			return err
+		}
+	}
+
+	if err := conn.WriteCopyOutResponse(format, columnFormats); err != nil {
+		return fmt.Errorf("failed to write CopyOutResponse: %w", err)
+	}
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush CopyOutResponse: %w", err)
+	}
+
+	// Pump data + interleaved notices to the client.
+	result, err := exec.CopyOutStream(ctx, conn, c.TableGroup, shard, state, func(msg pgClient.CopyOutMessage) error {
+		if msg.Notice != nil {
+			if cbErr := callback(ctx, &sqltypes.Result{Notices: []*mterrors.PgDiagnostic{msg.Notice}}); cbErr != nil {
+				return cbErr
+			}
+			return nil
+		}
+		if err := conn.WriteCopyData(msg.Data); err != nil {
+			return fmt.Errorf("failed to write CopyData: %w", err)
+		}
+		// Don't flush per chunk — bufferedWriter will flush in
+		// reasonably large batches, which is the usual server behavior.
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Trailing notices (between CopyDone and CommandComplete) — write them
+	// before CopyDone so the client sees NoticeResponse → CopyDone →
+	// CommandComplete in order, matching upstream PG.
+	if len(result.Notices) > 0 {
+		if cbErr := callback(ctx, &sqltypes.Result{Notices: result.Notices}); cbErr != nil {
+			return cbErr
+		}
+	}
+
+	if err := conn.WriteCopyDone(); err != nil {
+		return fmt.Errorf("failed to write CopyDone: %w", err)
+	}
+
+	// Hand the Result (with CommandTag) to the higher-level callback which
+	// will write CommandComplete and update transaction bookkeeping.
+	resultForCallback := &sqltypes.Result{
+		CommandTag:   result.CommandTag,
+		RowsAffected: result.RowsAffected,
+	}
+	if err := callback(ctx, resultForCallback); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Ensure CopyStatement implements Primitive interface.

--- a/go/services/multigateway/engine/copy_statement.go
+++ b/go/services/multigateway/engine/copy_statement.go
@@ -229,6 +229,28 @@ func (c *CopyStatement) streamCopyOut(
 		return err
 	}
 
+	// CopyOutInitiate succeeded — the multipooler has reserved a backend
+	// conn and added the ReasonCopy reservation reason. If anything below
+	// returns before CopyOutStream removes it (notice callback,
+	// WriteCopyOutResponse, Flush, or a ReadCopyOutMessage error that
+	// the stream pump turns into a connection-level fail), we must run
+	// CopyAbort so the reservation is released and the backend isn't left
+	// stuck in COPY OUT pushing CopyData with no reader. CopyAbort sends
+	// CopyFail which isn't a legal frontend message during COPY OUT, but
+	// the resulting protocol error makes the multipooler release the
+	// reserved conn with ReleaseError — which is the cleanup we want.
+	//
+	// Mirrors the FROM-STDIN guard in StreamExecute. The flag is cleared
+	// once CopyOutStream returns successfully (at which point ReasonCopy
+	// is already removed inside the executor); anything failing after that
+	// is gateway-to-client write failure and the reservation is gone.
+	streamCompleted := false
+	defer func() {
+		if !streamCompleted {
+			_ = exec.CopyAbort(ctx, conn, c.TableGroup, shard, state)
+		}
+	}()
+
 	// Forward any pre-CopyOutResponse notices to the client as standalone
 	// NoticeResponse frames via the callback (the per-result Conn writer
 	// emits NoticeResponse for every entry in result.Notices).
@@ -261,8 +283,17 @@ func (c *CopyStatement) streamCopyOut(
 		return nil
 	})
 	if err != nil {
+		// CopyOutStream's own error paths already drop ReasonCopy and
+		// release the conn (PG error → ReleasePortalComplete or kept-state;
+		// connection error → ReleaseError). Mark the stream complete so
+		// the deferred CopyAbort above doesn't run a second cleanup on
+		// top of an already-released conn.
+		streamCompleted = true
 		return err
 	}
+	// Success path — executor's CopyOutStream removed ReasonCopy and
+	// released (or kept-state) the conn. No deferred abort needed.
+	streamCompleted = true
 
 	// Trailing notices (between CopyDone and CommandComplete) — write them
 	// before CopyDone so the client sees NoticeResponse → CopyDone →

--- a/go/services/multigateway/engine/copy_statement_test.go
+++ b/go/services/multigateway/engine/copy_statement_test.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -53,6 +54,19 @@ type mockIExecute struct {
 	// Track calls
 	copyAbortCalled atomic.Int32
 	copyAbortErr    error
+
+	// CopyOutInitiate behavior (TO STDOUT direction)
+	copyOutInitiateErr     error
+	copyOutInitiateFormat  int16
+	copyOutInitiateFormats []int16
+	copyOutInitiateNotices []*mterrors.PgDiagnostic
+
+	// CopyOutStream behavior — controls what frames the executor
+	// "pumps" back via the onMessage callback before returning the
+	// final Result.
+	copyOutStreamMessages []pgClient.CopyOutMessage
+	copyOutStreamResult   *sqltypes.Result
+	copyOutStreamErr      error
 }
 
 func (m *mockIExecute) StreamExecute(
@@ -151,18 +165,29 @@ func (m *mockIExecute) CopyOutInitiate(
 	string,
 	*handler.MultiGatewayConnectionState,
 ) (int16, []int16, []*mterrors.PgDiagnostic, error) {
-	return 0, nil, nil, nil
+	if m.copyOutInitiateErr != nil {
+		return 0, nil, m.copyOutInitiateNotices, m.copyOutInitiateErr
+	}
+	return m.copyOutInitiateFormat, m.copyOutInitiateFormats, m.copyOutInitiateNotices, nil
 }
 
 func (m *mockIExecute) CopyOutStream(
-	context.Context,
-	*server.Conn,
-	string,
-	string,
-	*handler.MultiGatewayConnectionState,
-	func(pgClient.CopyOutMessage) error,
+	ctx context.Context,
+	conn *server.Conn,
+	tableGroup string,
+	shard string,
+	state *handler.MultiGatewayConnectionState,
+	onMessage func(pgClient.CopyOutMessage) error,
 ) (*sqltypes.Result, error) {
-	return nil, nil
+	for _, msg := range m.copyOutStreamMessages {
+		if err := onMessage(msg); err != nil {
+			return nil, err
+		}
+	}
+	if m.copyOutStreamErr != nil {
+		return nil, m.copyOutStreamErr
+	}
+	return m.copyOutStreamResult, nil
 }
 
 func (m *mockIExecute) ConcludeTransaction(
@@ -465,4 +490,175 @@ func TestCopyStatement_GetQuery(t *testing.T) {
 		Relation: &ast.RangeVar{RelName: "users"},
 	})
 	require.Equal(t, "COPY users FROM STDIN", copyStmt.GetQuery())
+}
+
+// newTestCopyToStdoutStatement builds a TO-STDOUT CopyStatement for tests.
+func newTestCopyToStdoutStatement() *CopyStatement {
+	return NewCopyStatement("test_tablegroup", "COPY t TO STDOUT", &ast.CopyStmt{
+		IsFrom:   false,
+		Relation: &ast.RangeVar{RelName: "t"},
+	})
+}
+
+// recordingCallback records every Result the engine emits to the
+// higher-level callback so tests can assert ordering / payload.
+type recordedResult struct {
+	rows         int
+	commandTag   string
+	noticeCount  int
+	rowsAffected uint64
+}
+
+func recordingCallback(out *[]recordedResult) func(context.Context, *sqltypes.Result) error {
+	return func(_ context.Context, r *sqltypes.Result) error {
+		*out = append(*out, recordedResult{
+			rows:         len(r.Rows),
+			commandTag:   r.CommandTag,
+			noticeCount:  len(r.Notices),
+			rowsAffected: r.RowsAffected,
+		})
+		return nil
+	}
+}
+
+// TestStreamCopyOut_Success exercises the happy path:
+//   - CopyOutInitiate returns format + columnFormats + zero initiation notices
+//   - CopyOutStream pumps two CopyData chunks and an interleaved Notice
+//   - The final Result carries a CommandTag + trailing notices
+//
+// Verifies that the engine writes CopyOutResponse, forwards each chunk,
+// orders the trailing notices AFTER CopyDone (matching upstream PG), and
+// hands the CommandTag-bearing Result to the higher-level callback.
+func TestStreamCopyOut_Success(t *testing.T) {
+	mockExec := &mockIExecute{
+		copyOutInitiateFormat:  0,
+		copyOutInitiateFormats: []int16{0, 0},
+		copyOutStreamMessages: []pgClient.CopyOutMessage{
+			{Data: []byte("1\tAlice\n")},
+			{Notice: &mterrors.PgDiagnostic{Severity: "NOTICE", Code: "00000", Message: "mid-stream"}},
+			{Data: []byte("2\tBob\n")},
+		},
+		copyOutStreamResult: &sqltypes.Result{
+			CommandTag:   "COPY 2",
+			RowsAffected: 2,
+			Notices: []*mterrors.PgDiagnostic{
+				{Severity: "NOTICE", Code: "00000", Message: "after-statement trigger"},
+			},
+		},
+	}
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	var got []recordedResult
+
+	err := newTestCopyToStdoutStatement().StreamExecute(
+		context.Background(),
+		mockExec,
+		testConn.Conn,
+		&handler.MultiGatewayConnectionState{},
+		nil,
+		recordingCallback(&got),
+	)
+	require.NoError(t, err)
+
+	// Defer abort must NOT have fired on the success path.
+	require.Equal(t, int32(0), mockExec.copyAbortCalled.Load())
+
+	// Two callback invocations: one mid-stream notice forward, one for
+	// the trailing-notices result. Plus the CommandTag-bearing result at
+	// the end → 3 callbacks total. (CopyData chunks are written directly
+	// to conn, not through the callback.)
+	require.Len(t, got, 3, "expected mid-stream notice + trailing notices + CommandComplete result")
+	assert.Equal(t, 1, got[0].noticeCount, "first callback is the mid-stream NoticeResponse")
+	assert.Equal(t, "", got[0].commandTag)
+
+	assert.Equal(t, 1, got[1].noticeCount, "second callback is the trailing notice batch")
+	assert.Equal(t, "", got[1].commandTag, "trailing notices come BEFORE the CommandTag callback")
+
+	assert.Equal(t, "COPY 2", got[2].commandTag, "final callback carries CommandTag")
+	assert.Equal(t, uint64(2), got[2].rowsAffected)
+}
+
+// TestStreamCopyOut_InitiateError surfaces the PG error un-wrapped and
+// skips the deferred CopyAbort — CopyOutInitiate failed before any
+// reservation was held.
+func TestStreamCopyOut_InitiateError(t *testing.T) {
+	mockExec := &mockIExecute{
+		copyOutInitiateErr: errors.New("column \"foo\" does not exist"),
+	}
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	err := newTestCopyToStdoutStatement().StreamExecute(
+		context.Background(),
+		mockExec,
+		testConn.Conn,
+		&handler.MultiGatewayConnectionState{},
+		nil,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil },
+	)
+	require.Error(t, err)
+	assert.Equal(t, "column \"foo\" does not exist", err.Error(),
+		"PG errors flow back un-wrapped so the gateway re-emits a verbatim ErrorResponse")
+	// No reservation was created → no deferred abort to run.
+	assert.Equal(t, int32(0), mockExec.copyAbortCalled.Load())
+}
+
+// TestStreamCopyOut_DeferredAbortFiresOnPreStreamFailure verifies the
+// deferred guard: when the pre-CopyOutResponse notice callback fails
+// AFTER CopyOutInitiate succeeded (so the multipooler holds ReasonCopy
+// on the reserved conn), the deferred CopyAbort must run so the
+// reservation isn't leaked.
+func TestStreamCopyOut_DeferredAbortFiresOnPreStreamFailure(t *testing.T) {
+	mockExec := &mockIExecute{
+		copyOutInitiateFormat:  0,
+		copyOutInitiateFormats: []int16{0, 0},
+		copyOutInitiateNotices: []*mterrors.PgDiagnostic{
+			{Severity: "NOTICE", Code: "00000", Message: "before-statement"},
+		},
+	}
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	cbErr := errors.New("client write failed")
+	err := newTestCopyToStdoutStatement().StreamExecute(
+		context.Background(),
+		mockExec,
+		testConn.Conn,
+		&handler.MultiGatewayConnectionState{},
+		nil,
+		func(_ context.Context, _ *sqltypes.Result) error {
+			// First (and only) callback is the pre-stream initiation
+			// notice — make it fail so the engine bails before
+			// CopyOutStream is reached.
+			return cbErr
+		},
+	)
+	require.ErrorIs(t, err, cbErr)
+	assert.Equal(t, int32(1), mockExec.copyAbortCalled.Load(),
+		"deferred abort must run when failure happens in the pre-stream window")
+}
+
+// TestStreamCopyOut_StreamErrorSkipsDeferredAbort verifies that when
+// CopyOutStream returns an error, the engine clears streamCompleted so
+// the deferred CopyAbort does NOT fire on top of the executor's own
+// cleanup (the executor already released or kept-state the conn via
+// abortCopyOut / RemoveReservationReason).
+func TestStreamCopyOut_StreamErrorSkipsDeferredAbort(t *testing.T) {
+	streamErr := errors.New("PG mid-stream error")
+	mockExec := &mockIExecute{
+		copyOutInitiateFormat:  0,
+		copyOutInitiateFormats: []int16{0, 0},
+		copyOutStreamErr:       streamErr,
+	}
+
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	err := newTestCopyToStdoutStatement().StreamExecute(
+		context.Background(),
+		mockExec,
+		testConn.Conn,
+		&handler.MultiGatewayConnectionState{},
+		nil,
+		func(_ context.Context, _ *sqltypes.Result) error { return nil },
+	)
+	require.ErrorIs(t, err, streamErr)
+	assert.Equal(t, int32(0), mockExec.copyAbortCalled.Load(),
+		"deferred abort must NOT run on top of executor's own CopyOutStream cleanup")
 }

--- a/go/services/multigateway/engine/copy_statement_test.go
+++ b/go/services/multigateway/engine/copy_statement_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -142,6 +143,28 @@ func (m *mockIExecute) CopyAbort(
 	return m.copyAbortErr
 }
 
+func (m *mockIExecute) CopyOutInitiate(
+	context.Context,
+	*server.Conn,
+	string,
+	string,
+	string,
+	*handler.MultiGatewayConnectionState,
+) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	return 0, nil, nil, nil
+}
+
+func (m *mockIExecute) CopyOutStream(
+	context.Context,
+	*server.Conn,
+	string,
+	string,
+	*handler.MultiGatewayConnectionState,
+	func(pgClient.CopyOutMessage) error,
+) (*sqltypes.Result, error) {
+	return nil, nil
+}
+
 func (m *mockIExecute) ConcludeTransaction(
 	context.Context,
 	*server.Conn,
@@ -189,7 +212,9 @@ func TestCopyStatement_CopyInitiateError(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to initiate COPY")
+	// CopyStatement now surfaces the underlying error un-wrapped so the
+	// gateway re-emits a verbatim ErrorResponse to the client.
+	require.Equal(t, "initiate failed", err.Error())
 	// CopyAbort should NOT be called since CopyInitiate failed before defer is set up
 	require.Equal(t, int32(0), mockExec.copyAbortCalled.Load())
 }
@@ -251,7 +276,9 @@ func TestCopyStatement_CopySendDataError(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to send COPY data")
+	// CopySendData errors surface un-wrapped — gateway re-emits the
+	// verbatim PG ErrorResponse.
+	require.Equal(t, "send data failed", err.Error())
 	// CopyAbort should be called via defer
 	require.Equal(t, int32(1), mockExec.copyAbortCalled.Load())
 }

--- a/go/services/multigateway/engine/engine.go
+++ b/go/services/multigateway/engine/engine.go
@@ -20,7 +20,9 @@ package engine
 import (
 	"context"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -222,6 +224,32 @@ type IExecute interface {
 		shard string,
 		state *handler.MultiGatewayConnectionState,
 	) error
+
+	// CopyOutInitiate initiates a COPY ... TO STDOUT operation. Returns
+	// format and column formats from CopyOutResponse plus any NoticeResponse
+	// diagnostics received before CopyOutResponse. Stores the reserved
+	// connection state in state.ShardStates so CopyOutStream can find it.
+	CopyOutInitiate(
+		ctx context.Context,
+		conn *server.Conn,
+		tableGroup string,
+		shard string,
+		queryStr string,
+		state *handler.MultiGatewayConnectionState,
+	) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, err error)
+
+	// CopyOutStream drives the COPY ... TO STDOUT data stream, invoking
+	// onMessage for each CopyData chunk / NoticeResponse pumped by the
+	// multipooler. Returns the final Result with CommandTag, RowsAffected,
+	// and any trailing notices in result.Notices.
+	CopyOutStream(
+		ctx context.Context,
+		conn *server.Conn,
+		tableGroup string,
+		shard string,
+		state *handler.MultiGatewayConnectionState,
+		onMessage func(pgClient.CopyOutMessage) error,
+	) (*sqltypes.Result, error)
 }
 
 // Primitive is the building block of the query execution plan.

--- a/go/services/multigateway/engine/transaction_primitive_test.go
+++ b/go/services/multigateway/engine/transaction_primitive_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -94,6 +96,14 @@ func (m *txMockIExecute) CopyFinalize(context.Context, *server.Conn, string, str
 
 func (m *txMockIExecute) CopyAbort(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState) error {
 	return nil
+}
+
+func (m *txMockIExecute) CopyOutInitiate(context.Context, *server.Conn, string, string, string, *handler.MultiGatewayConnectionState) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	return 0, nil, nil, nil
+}
+
+func (m *txMockIExecute) CopyOutStream(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState, func(pgClient.CopyOutMessage) error) (*sqltypes.Result, error) {
+	return nil, nil
 }
 
 func (m *txMockIExecute) ConcludeTransaction(

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -98,6 +100,14 @@ func (m *mockExec) CopyFinalize(context.Context, *server.Conn, string, string, *
 
 func (m *mockExec) CopyAbort(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState) error {
 	return nil
+}
+
+func (m *mockExec) CopyOutInitiate(context.Context, *server.Conn, string, string, string, *handler.MultiGatewayConnectionState) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	return 0, nil, nil, nil
+}
+
+func (m *mockExec) CopyOutStream(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState, func(pgClient.CopyOutMessage) error) (*sqltypes.Result, error) {
+	return nil, nil
 }
 
 func newTestExecutor(mock *mockExec) *Executor {

--- a/go/services/multigateway/planner/copy_stmt.go
+++ b/go/services/multigateway/planner/copy_stmt.go
@@ -22,8 +22,8 @@ import (
 )
 
 // planCopyStmt plans COPY commands.
-// Supports COPY FROM STDIN (streaming), COPY FROM/TO file (pass-through).
-// Rejects COPY FROM/TO PROGRAM for security. COPY TO STDOUT not yet supported.
+// Supports COPY FROM STDIN and COPY TO STDOUT (streaming),
+// COPY FROM/TO file (pass-through). Rejects COPY FROM/TO PROGRAM for security.
 func (p *Planner) planCopyStmt(
 	sql string,
 	stmt *ast.CopyStmt,
@@ -62,26 +62,33 @@ func (p *Planner) planCopyStmt(
 			p.logger.Debug("created COPY FROM file plan (pass-through)", "plan", plan.String())
 			return plan, nil
 		}
-	} else {
-		// COPY TO ...
-		if stmt.Filename == "" {
-			// COPY TO STDOUT - not yet supported
-			return nil, mterrors.NewPgError("ERROR", mterrors.PgSSFeatureNotSupported,
-				"COPY TO STDOUT not yet supported", "")
-		} else {
-			// COPY TO file - simple Route (PostgreSQL writes server-side file)
-			// TODO(multigateway): Future enhancement - similar to FROM file,
-			// multigateway could intercept to support client downloads or
-			// distributed writes across shards.
-			p.logger.Debug("planning COPY TO file command (pass-through)",
-				"query", sql,
-				"file", stmt.Filename,
-				"tablegroup", p.defaultTableGroup)
-
-			route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, nil)
-			plan := engine.NewPlan(sql, route)
-			p.logger.Debug("created COPY TO file plan (pass-through)", "plan", plan.String())
-			return plan, nil
-		}
 	}
+
+	// COPY TO ...
+	if stmt.Filename == "" {
+		// COPY TO STDOUT — streams CopyData frames back to the client. Uses
+		// the same CopyStatement primitive as FROM STDIN; the primitive
+		// dispatches on stmt.IsFrom internally.
+		p.logger.Debug("planning COPY TO STDOUT command",
+			"query", sql,
+			"tablegroup", p.defaultTableGroup)
+
+		copyPrimitive := engine.NewCopyStatement(p.defaultTableGroup, sql, stmt)
+		plan := engine.NewPlan(sql, copyPrimitive)
+		p.logger.Debug("created COPY TO STDOUT plan", "plan", plan.String())
+		return plan, nil
+	}
+	// COPY TO file - simple Route (PostgreSQL writes server-side file)
+	// TODO(multigateway): Future enhancement - similar to FROM file,
+	// multigateway could intercept to support client downloads or
+	// distributed writes across shards.
+	p.logger.Debug("planning COPY TO file command (pass-through)",
+		"query", sql,
+		"file", stmt.Filename,
+		"tablegroup", p.defaultTableGroup)
+
+	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, nil)
+	plan := engine.NewPlan(sql, route)
+	p.logger.Debug("created COPY TO file plan (pass-through)", "plan", plan.String())
+	return plan, nil
 }

--- a/go/services/multigateway/planner/prepared_stmt_test.go
+++ b/go/services/multigateway/planner/prepared_stmt_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -86,6 +87,14 @@ func (m *mockIExecute) CopyFinalize(context.Context, *server.Conn, string, strin
 
 func (m *mockIExecute) CopyAbort(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState) error {
 	return nil
+}
+
+func (m *mockIExecute) CopyOutInitiate(context.Context, *server.Conn, string, string, string, *handler.MultiGatewayConnectionState) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	return 0, nil, nil, nil
+}
+
+func (m *mockIExecute) CopyOutStream(context.Context, *server.Conn, string, string, *handler.MultiGatewayConnectionState, func(pgClient.CopyOutMessage) error) (*sqltypes.Result, error) {
+	return nil, nil
 }
 
 func (m *mockIExecute) DiscardTempTables(context.Context, *server.Conn, *handler.MultiGatewayConnectionState, func(context.Context, *sqltypes.Result) error) error {

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -882,6 +882,11 @@ func (g *grpcQueryService) CopyOutStream(
 						g.copyStreamsMu.Lock()
 						delete(g.copyStreams, options.ReservedConnectionId)
 						g.copyStreamsMu.Unlock()
+						// Close the send half so the multipooler's
+						// stream ctx cancels and its CopyOutStream
+						// pump exits via the abortCopyOut path. Mirrors
+						// the RESULT / ERROR terminal branches below.
+						_ = stream.CloseSend()
 						return nil, nil, err
 					}
 				}
@@ -891,6 +896,7 @@ func (g *grpcQueryService) CopyOutStream(
 					g.copyStreamsMu.Lock()
 					delete(g.copyStreams, options.ReservedConnectionId)
 					g.copyStreamsMu.Unlock()
+					_ = stream.CloseSend()
 					return nil, nil, err
 				}
 			}

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -882,10 +882,10 @@ func (g *grpcQueryService) CopyOutStream(
 						g.copyStreamsMu.Lock()
 						delete(g.copyStreams, options.ReservedConnectionId)
 						g.copyStreamsMu.Unlock()
-						// Close the send half so the multipooler's
-						// stream ctx cancels and its CopyOutStream
-						// pump exits via the abortCopyOut path. Mirrors
-						// the RESULT / ERROR terminal branches below.
+						// CloseSend half-closes the client send direction only.
+						// Server cleanup is driven by the caller returning this
+						// error up-stack (which cancels the query context) and by
+						// send failures in the pooler's data pump.
 						_ = stream.CloseSend()
 						return nil, nil, err
 					}

--- a/go/services/multigateway/poolergateway/grpc_query_service.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -375,7 +376,7 @@ func (g *grpcQueryService) CopyReady(
 	// reserved connection; if no state was attached, the connection is gone
 	// and the gateway should clear its tracking.
 	if resp.Phase == multipoolerservice.CopyBidiExecuteResponse_ERROR {
-		return 0, nil, resp.GetReservedState(), fmt.Errorf("COPY initiation failed: %s", resp.Error)
+		return 0, nil, resp.GetReservedState(), copyErrorFromResp(resp)
 	}
 
 	// Validate READY response
@@ -499,7 +500,7 @@ func (g *grpcQueryService) CopyFinalize(
 	// because of another reason such as a transaction. Forward that state
 	// so the gateway keeps tracking the connection instead of clearing it.
 	if resp.Phase == multipoolerservice.CopyBidiExecuteResponse_ERROR {
-		return nil, resp.GetReservedState(), fmt.Errorf("COPY finalization failed: %s", resp.Error)
+		return nil, resp.GetReservedState(), copyErrorFromResp(resp)
 	}
 
 	// Validate RESULT response
@@ -508,6 +509,21 @@ func (g *grpcQueryService) CopyFinalize(
 	}
 
 	result := sqltypes.ResultFromProto(resp.Result)
+	if result == nil {
+		result = &sqltypes.Result{}
+	}
+	// Forward NoticeResponse diagnostics that arrived between CopyDone and
+	// CommandComplete (e.g. trigger RAISE NOTICE during COPY FROM STDIN).
+	// The bidi proto carries them in resp.Notices alongside the Result; the
+	// proto Result message itself has no Notices field by design — notices
+	// are streamed as separate frames in the StreamExecute path. For COPY
+	// we batch them onto the final Result so the gateway can re-emit them
+	// in order before CommandComplete via the per-result callback chain.
+	if len(resp.Notices) > 0 {
+		for _, pd := range resp.Notices {
+			result.Notices = append(result.Notices, mterrors.PgDiagnosticFromProto(pd))
+		}
+	}
 
 	// Build reserved state from response
 	reservedState := resp.GetReservedState()
@@ -729,6 +745,185 @@ func (g *grpcQueryService) ReleaseReservedConnection(
 		"reserved_conn_id", options.ReservedConnectionId)
 
 	return nil
+}
+
+// copyErrorFromResp builds an error from a CopyBidiExecuteResponse_ERROR
+// frame. When the multipooler attached a structured PgDiagnostic (the common
+// case — PG ErrorResponse with full severity/SQLSTATE/DETAIL/HINT), return
+// the *mterrors.PgDiagnostic directly so the gateway re-emits a verbatim
+// ErrorResponse to the client. Otherwise fall back to the legacy text
+// message — used for infrastructure errors that never had a PG diagnostic
+// to begin with.
+func copyErrorFromResp(resp *multipoolerservice.CopyBidiExecuteResponse) error {
+	if diagProto := resp.GetErrorDiagnostic(); diagProto != nil {
+		return mterrors.PgDiagnosticFromProto(diagProto)
+	}
+	return errors.New(resp.GetError())
+}
+
+// CopyOutReady opens a bidi stream, sends INITIATE with direction=TO_STDOUT,
+// and reads the READY response. The stream is kept open for CopyOutStream
+// to pump DATA frames; ownership of the stream lives in copyStreams keyed
+// by the multipooler-assigned reserved connection ID, mirroring CopyReady.
+func (g *grpcQueryService) CopyOutReady(
+	ctx context.Context,
+	target *querypb.Target,
+	copyQuery string,
+	options *querypb.ExecuteOptions,
+	reservationOptions *querypb.ReservationOptions,
+) (int16, []int16, []*mterrors.PgDiagnostic, *querypb.ReservedState, error) {
+	g.logger.DebugContext(ctx, "initiating COPY TO STDOUT",
+		"pooler_id", g.poolerID,
+		"tablegroup", target.TableGroup,
+		"shard", target.Shard,
+		"query", copyQuery)
+
+	stream, err := g.client.CopyBidiExecute(ctx)
+	if err != nil {
+		return 0, nil, nil, nil, mterrors.Wrapf(mterrors.FromGRPC(err), "failed to start bidirectional execute stream")
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			_ = stream.CloseSend()
+			_, _ = stream.Recv()
+		}
+	}()
+
+	initiateReq := &multipoolerservice.CopyBidiExecuteRequest{
+		Phase:              multipoolerservice.CopyBidiExecuteRequest_INITIATE,
+		Direction:          multipoolerservice.CopyBidiExecuteRequest_TO_STDOUT,
+		Query:              copyQuery,
+		Target:             target,
+		Options:            options,
+		ReservationOptions: reservationOptions,
+	}
+	if err := stream.Send(initiateReq); err != nil {
+		return 0, nil, nil, nil, mterrors.Wrapf(mterrors.FromGRPC(err), "failed to send INITIATE")
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return 0, nil, nil, nil, mterrors.Wrapf(mterrors.FromGRPC(err), "failed to receive READY response")
+	}
+
+	if resp.Phase == multipoolerservice.CopyBidiExecuteResponse_ERROR {
+		return 0, nil, nil, resp.GetReservedState(), copyErrorFromResp(resp)
+	}
+	if resp.Phase != multipoolerservice.CopyBidiExecuteResponse_READY {
+		return 0, nil, nil, nil, fmt.Errorf("expected READY, got %v", resp.Phase)
+	}
+
+	columnFormats := make([]int16, len(resp.ColumnFormats))
+	for i, f := range resp.ColumnFormats {
+		columnFormats[i] = int16(f)
+	}
+
+	notices := make([]*mterrors.PgDiagnostic, 0, len(resp.Notices))
+	for _, pd := range resp.Notices {
+		notices = append(notices, mterrors.PgDiagnosticFromProto(pd))
+	}
+
+	reservedState := resp.GetReservedState()
+
+	g.copyStreamsMu.Lock()
+	g.copyStreams[reservedState.GetReservedConnectionId()] = stream
+	success = true
+	g.copyStreamsMu.Unlock()
+
+	return int16(resp.Format), columnFormats, notices, reservedState, nil
+}
+
+// CopyOutStream pumps DATA / RESULT frames from the multipooler. For each
+// DATA frame the callback is invoked with either a CopyData chunk or a
+// NoticeResponse diagnostic — exactly one of the two is set. On RESULT,
+// the final *sqltypes.Result (CommandTag + RowsAffected + post-data
+// Notices) and authoritative ReservedState are returned. Caller is
+// responsible for handling the result.Notices (re-emit to the client
+// before CommandComplete).
+//
+// The bidi stream is removed from copyStreams on terminal frames (RESULT
+// or ERROR), so a stray CopyAbort after a clean completion is a safe
+// no-op.
+func (g *grpcQueryService) CopyOutStream(
+	ctx context.Context,
+	target *querypb.Target,
+	options *querypb.ExecuteOptions,
+	onMessage func(client.CopyOutMessage) error,
+) (*sqltypes.Result, *querypb.ReservedState, error) {
+	if options == nil || options.ReservedConnectionId == 0 {
+		return nil, nil, errors.New("options.ReservedConnectionId is required for CopyOutStream")
+	}
+
+	g.copyStreamsMu.Lock()
+	stream, ok := g.copyStreams[options.ReservedConnectionId]
+	g.copyStreamsMu.Unlock()
+	if !ok {
+		return nil, nil, fmt.Errorf("no active COPY stream for reserved connection %d", options.ReservedConnectionId)
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			g.copyStreamsMu.Lock()
+			delete(g.copyStreams, options.ReservedConnectionId)
+			g.copyStreamsMu.Unlock()
+			return nil, nil, mterrors.Wrapf(mterrors.FromGRPC(err), "failed to receive COPY frame")
+		}
+
+		switch resp.Phase {
+		case multipoolerservice.CopyBidiExecuteResponse_DATA:
+			// DATA frame: either a CopyData chunk or a Notice diagnostic
+			// (or both — in practice exactly one will be populated).
+			if len(resp.Notices) > 0 {
+				for _, pd := range resp.Notices {
+					if err := onMessage(client.CopyOutMessage{Notice: mterrors.PgDiagnosticFromProto(pd)}); err != nil {
+						g.copyStreamsMu.Lock()
+						delete(g.copyStreams, options.ReservedConnectionId)
+						g.copyStreamsMu.Unlock()
+						return nil, nil, err
+					}
+				}
+			}
+			if len(resp.Data) > 0 {
+				if err := onMessage(client.CopyOutMessage{Data: resp.Data}); err != nil {
+					g.copyStreamsMu.Lock()
+					delete(g.copyStreams, options.ReservedConnectionId)
+					g.copyStreamsMu.Unlock()
+					return nil, nil, err
+				}
+			}
+
+		case multipoolerservice.CopyBidiExecuteResponse_RESULT:
+			g.copyStreamsMu.Lock()
+			delete(g.copyStreams, options.ReservedConnectionId)
+			g.copyStreamsMu.Unlock()
+			_ = stream.CloseSend()
+
+			result := sqltypes.ResultFromProto(resp.Result)
+			if result == nil {
+				result = &sqltypes.Result{}
+			}
+			for _, pd := range resp.Notices {
+				result.Notices = append(result.Notices, mterrors.PgDiagnosticFromProto(pd))
+			}
+			return result, resp.GetReservedState(), nil
+
+		case multipoolerservice.CopyBidiExecuteResponse_ERROR:
+			g.copyStreamsMu.Lock()
+			delete(g.copyStreams, options.ReservedConnectionId)
+			g.copyStreamsMu.Unlock()
+			_ = stream.CloseSend()
+			return nil, resp.GetReservedState(), copyErrorFromResp(resp)
+
+		default:
+			g.copyStreamsMu.Lock()
+			delete(g.copyStreams, options.ReservedConnectionId)
+			g.copyStreamsMu.Unlock()
+			return nil, nil, fmt.Errorf("unexpected phase in COPY TO STDOUT stream: %v", resp.Phase)
+		}
+	}
 }
 
 // Ensure grpcQueryService implements queryservice.QueryService

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -254,7 +254,9 @@ func TestCopyReady_ErrorPhaseResponse(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "COPY initiation failed")
+	// CopyReady now surfaces the underlying PG error un-wrapped so the gateway
+	// re-emits a verbatim ErrorResponse. Without a PgDiagnostic attached the
+	// fallback path returns the bare resp.Error text.
 	require.Contains(t, err.Error(), "some backend error")
 	require.Nil(t, rs, "ReservedState should be nil when multipooler did not attach one")
 	// Verify cleanup was called

--- a/go/services/multigateway/poolergateway/grpc_query_service_test.go
+++ b/go/services/multigateway/poolergateway/grpc_query_service_test.go
@@ -17,6 +17,7 @@ package poolergateway
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"sync/atomic"
 	"testing"
@@ -25,6 +26,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -35,23 +38,38 @@ import (
 // mockBidiStream is a mock implementation of grpc.BidiStreamingClient for testing.
 type mockBidiStream struct {
 	// Configurable behavior
-	sendErr      error
-	recvErr      error
-	recvResponse *multipoolerservice.CopyBidiExecuteResponse
+	sendErr       error
+	recvErr       error
+	recvResponse  *multipoolerservice.CopyBidiExecuteResponse
+	recvErrors    []error
+	recvResponses []*multipoolerservice.CopyBidiExecuteResponse
 
 	// Track calls for verification
 	closeSendCalled atomic.Bool
 	recvCalled      atomic.Bool
 	sendCalled      atomic.Bool
+	sentRequests    []*multipoolerservice.CopyBidiExecuteRequest
+	recvIdx         int
 }
 
 func (m *mockBidiStream) Send(req *multipoolerservice.CopyBidiExecuteRequest) error {
 	m.sendCalled.Store(true)
+	m.sentRequests = append(m.sentRequests, req)
 	return m.sendErr
 }
 
 func (m *mockBidiStream) Recv() (*multipoolerservice.CopyBidiExecuteResponse, error) {
 	m.recvCalled.Store(true)
+	if m.recvIdx < len(m.recvErrors) && m.recvErrors[m.recvIdx] != nil {
+		err := m.recvErrors[m.recvIdx]
+		m.recvIdx++
+		return nil, err
+	}
+	if m.recvIdx < len(m.recvResponses) {
+		resp := m.recvResponses[m.recvIdx]
+		m.recvIdx++
+		return resp, nil
+	}
 	if m.recvErr != nil {
 		return nil, m.recvErr
 	}
@@ -375,6 +393,253 @@ func TestCopyReady_Success(t *testing.T) {
 	require.Len(t, svc.copyStreams, 1)
 	_, exists := svc.copyStreams[12345]
 	require.True(t, exists, "Stream should be stored in copyStreams with reserved connection ID")
+}
+
+func TestCopyOutReady_Success(t *testing.T) {
+	mockStream := &mockBidiStream{
+		recvResponse: &multipoolerservice.CopyBidiExecuteResponse{
+			Phase: multipoolerservice.CopyBidiExecuteResponse_READY,
+			ReservedState: &query.ReservedState{
+				ReservedConnectionId: 54321,
+			},
+			Format:        1,
+			ColumnFormats: []int32{0, 1},
+			Notices: []*query.PgDiagnostic{
+				mterrors.PgDiagnosticToProto(&mterrors.PgDiagnostic{MessageType: 'N', Severity: "NOTICE", Message: "before-copy"}),
+			},
+		},
+	}
+	mockClient := &mockMultiPoolerServiceClient{bidiStream: mockStream}
+	svc := newTestGRPCQueryService(mockClient)
+
+	format, columnFormats, notices, reservedState, err := svc.CopyOutReady(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		"COPY t TO STDOUT",
+		&query.ExecuteOptions{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int16(1), format)
+	require.Equal(t, []int16{0, 1}, columnFormats)
+	require.Equal(t, uint64(54321), reservedState.GetReservedConnectionId())
+	require.Len(t, notices, 1)
+	require.Equal(t, "before-copy", notices[0].Message)
+	require.False(t, mockStream.closeSendCalled.Load(), "CloseSend should NOT be called on success")
+	_, exists := svc.copyStreams[54321]
+	require.True(t, exists, "stream should be stored for subsequent CopyOutStream")
+	require.Len(t, mockStream.sentRequests, 1)
+	require.Equal(t, multipoolerservice.CopyBidiExecuteRequest_TO_STDOUT, mockStream.sentRequests[0].GetDirection())
+}
+
+func TestCopyOutReady_ErrorPhasePropagatesReservedState(t *testing.T) {
+	survivingState := &query.ReservedState{
+		ReservedConnectionId: 123,
+		ReservationReasons:   protoutil.ReasonTransaction,
+	}
+	mockStream := &mockBidiStream{
+		recvResponse: &multipoolerservice.CopyBidiExecuteResponse{
+			Phase:         multipoolerservice.CopyBidiExecuteResponse_ERROR,
+			Error:         "copy rejected",
+			ReservedState: survivingState,
+		},
+	}
+	mockClient := &mockMultiPoolerServiceClient{bidiStream: mockStream}
+	svc := newTestGRPCQueryService(mockClient)
+
+	_, _, _, rs, err := svc.CopyOutReady(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		"COPY t TO STDOUT",
+		&query.ExecuteOptions{ReservedConnectionId: 123},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "copy rejected")
+	require.NotNil(t, rs)
+	require.Equal(t, uint64(123), rs.GetReservedConnectionId())
+	require.True(t, mockStream.closeSendCalled.Load(), "error path should close the stream")
+	require.Len(t, svc.copyStreams, 0, "error path should not keep the stream")
+}
+
+func TestCopyOutStream_SuccessWithDataNoticesAndResult(t *testing.T) {
+	const connID = uint64(777)
+	mockStream := &mockBidiStream{
+		recvResponses: []*multipoolerservice.CopyBidiExecuteResponse{
+			{
+				Phase: multipoolerservice.CopyBidiExecuteResponse_DATA,
+				Notices: []*query.PgDiagnostic{
+					mterrors.PgDiagnosticToProto(&mterrors.PgDiagnostic{MessageType: 'N', Severity: "NOTICE", Message: "row notice"}),
+				},
+			},
+			{
+				Phase: multipoolerservice.CopyBidiExecuteResponse_DATA,
+				Data:  []byte("payload"),
+			},
+			{
+				Phase: multipoolerservice.CopyBidiExecuteResponse_RESULT,
+				Result: (&sqltypes.Result{
+					CommandTag:   "COPY 1",
+					RowsAffected: 1,
+				}).ToProto(),
+				Notices: []*query.PgDiagnostic{
+					mterrors.PgDiagnosticToProto(&mterrors.PgDiagnostic{MessageType: 'N', Severity: "NOTICE", Message: "final notice"}),
+				},
+				ReservedState: &query.ReservedState{ReservedConnectionId: connID},
+			},
+		},
+	}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	var messages []client.CopyOutMessage
+	result, rs, err := svc.CopyOutStream(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+		func(msg client.CopyOutMessage) error {
+			messages = append(messages, msg)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "COPY 1", result.CommandTag)
+	require.Equal(t, uint64(1), result.RowsAffected)
+	require.Len(t, result.Notices, 1)
+	require.Equal(t, "final notice", result.Notices[0].Message)
+	require.NotNil(t, rs)
+	require.Equal(t, connID, rs.GetReservedConnectionId())
+	require.Len(t, messages, 2)
+	require.Equal(t, "row notice", messages[0].Notice.Message)
+	require.Equal(t, []byte("payload"), messages[1].Data)
+	require.True(t, mockStream.closeSendCalled.Load(), "result path should close send")
+	_, exists := svc.copyStreams[connID]
+	require.False(t, exists, "stream should be removed after terminal RESULT")
+}
+
+func TestCopyOutStream_CallbackErrorClosesAndRemovesStream(t *testing.T) {
+	const connID = uint64(888)
+	mockStream := &mockBidiStream{
+		recvResponse: &multipoolerservice.CopyBidiExecuteResponse{
+			Phase: multipoolerservice.CopyBidiExecuteResponse_DATA,
+			Data:  []byte("payload"),
+		},
+	}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	_, _, err := svc.CopyOutStream(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+		func(client.CopyOutMessage) error {
+			return errors.New("client write failed")
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client write failed")
+	require.True(t, mockStream.closeSendCalled.Load())
+	_, exists := svc.copyStreams[connID]
+	require.False(t, exists)
+}
+
+func TestCopyOutStream_ErrorPhasePropagatesState(t *testing.T) {
+	const connID = uint64(999)
+	mockStream := &mockBidiStream{
+		recvResponse: &multipoolerservice.CopyBidiExecuteResponse{
+			Phase: multipoolerservice.CopyBidiExecuteResponse_ERROR,
+			Error: "backend copy error",
+			ReservedState: &query.ReservedState{
+				ReservedConnectionId: connID,
+			},
+		},
+	}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	_, rs, err := svc.CopyOutStream(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+		func(client.CopyOutMessage) error { return nil },
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "backend copy error")
+	require.NotNil(t, rs)
+	require.Equal(t, connID, rs.GetReservedConnectionId())
+	_, exists := svc.copyStreams[connID]
+	require.False(t, exists)
+}
+
+func TestCopyOutStream_RecvErrorRemovesStream(t *testing.T) {
+	const connID = uint64(1001)
+	mockStream := &mockBidiStream{recvErr: errors.New("recv failed")}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	_, _, err := svc.CopyOutStream(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+		func(client.CopyOutMessage) error { return nil },
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to receive COPY frame")
+	_, exists := svc.copyStreams[connID]
+	require.False(t, exists)
+}
+
+func TestCopyAbort_HandlesStreamLifecycle(t *testing.T) {
+	const connID = uint64(2024)
+	mockStream := &mockBidiStream{
+		recvResponse: &multipoolerservice.CopyBidiExecuteResponse{
+			Phase: multipoolerservice.CopyBidiExecuteResponse_ERROR,
+			ReservedState: &query.ReservedState{
+				ReservedConnectionId: connID,
+			},
+		},
+	}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	rs, err := svc.CopyAbort(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		"abort requested",
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, connID, rs.GetReservedConnectionId())
+	require.True(t, mockStream.sendCalled.Load())
+	require.True(t, mockStream.closeSendCalled.Load())
+	require.True(t, mockStream.recvCalled.Load())
+	require.Len(t, mockStream.sentRequests, 1)
+	require.Equal(t, multipoolerservice.CopyBidiExecuteRequest_FAIL, mockStream.sentRequests[0].GetPhase())
+	require.Equal(t, "abort requested", mockStream.sentRequests[0].GetErrorMessage())
+	_, exists := svc.copyStreams[connID]
+	require.False(t, exists, "abort should remove stream from map")
+}
+
+func TestCopyAbort_RecvEOFStillSucceeds(t *testing.T) {
+	const connID = uint64(3030)
+	mockStream := &mockBidiStream{
+		recvErr: io.EOF,
+	}
+	svc := newTestGRPCQueryService(&mockMultiPoolerServiceClient{bidiStream: mockStream})
+	svc.copyStreams[connID] = mockStream
+
+	rs, err := svc.CopyAbort(
+		context.Background(),
+		&query.Target{TableGroup: "test"},
+		"abort requested",
+		&query.ExecuteOptions{ReservedConnectionId: connID},
+	)
+	require.NoError(t, err)
+	require.Nil(t, rs)
+	require.True(t, mockStream.sendCalled.Load())
+	require.True(t, mockStream.closeSendCalled.Load())
 }
 
 // TestCopyFinalize_ErrorPhasePropagatesReservedState verifies CopyFinalize

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -287,6 +288,51 @@ func (pg *PoolerGateway) CopyReady(
 		return err
 	})
 	return format, colFormats, state, err
+}
+
+// CopyOutReady implements queryservice.QueryService.
+// It initiates a COPY ... TO STDOUT operation and returns format information
+// plus any pre-CopyOutResponse notices.
+func (pg *PoolerGateway) CopyOutReady(
+	ctx context.Context,
+	target *query.Target,
+	copyQuery string,
+	options *query.ExecuteOptions,
+	reservationOptions *query.ReservationOptions,
+) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+	var (
+		format     int16
+		colFormats []int16
+		notices    []*mterrors.PgDiagnostic
+		state      *query.ReservedState
+	)
+	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+		var err error
+		format, colFormats, notices, state, err = conn.QueryService().CopyOutReady(ctx, target, copyQuery, options, reservationOptions)
+		return err
+	})
+	return format, colFormats, notices, state, err
+}
+
+// CopyOutStream implements queryservice.QueryService.
+// Pumps CopyData / NoticeResponse frames from the multipooler back through
+// the supplied callback until RESULT/ERROR.
+func (pg *PoolerGateway) CopyOutStream(
+	ctx context.Context,
+	target *query.Target,
+	options *query.ExecuteOptions,
+	onMessage func(client.CopyOutMessage) error,
+) (*sqltypes.Result, *query.ReservedState, error) {
+	var (
+		result *sqltypes.Result
+		state  *query.ReservedState
+	)
+	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+		var err error
+		result, state, err = conn.QueryService().CopyOutStream(ctx, target, options, onMessage)
+		return err
+	})
+	return result, state, err
 }
 
 // Close implements queryservice.QueryService.

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -317,22 +317,36 @@ func (pg *PoolerGateway) CopyOutReady(
 // CopyOutStream implements queryservice.QueryService.
 // Pumps CopyData / NoticeResponse frames from the multipooler back through
 // the supplied callback until RESULT/ERROR.
+//
+// Uses loadBalancer.GetConnection directly rather than withBuffering — same
+// as CopySendData / CopyFinalize for the FROM-STDIN data phase. The stream
+// has already been established by CopyOutReady and lives on a specific
+// PoolerConnection's grpcQueryService.copyStreams map keyed by the
+// reserved connection ID; routing this call through withBuffering's
+// proactive failover check (which may stall, retry, and land on a
+// different PoolerConnection) would only surface a confusing
+// "no active COPY stream for reserved connection X" error in place of
+// the real failure. Failover during a live COPY stream is a connection-level
+// failure that the executor's CopyOutStream handles via
+// IsConnectionError → Release(ReleaseError).
 func (pg *PoolerGateway) CopyOutStream(
 	ctx context.Context,
 	target *query.Target,
 	options *query.ExecuteOptions,
 	onMessage func(client.CopyOutMessage) error,
 ) (*sqltypes.Result, *query.ReservedState, error) {
-	var (
-		result *sqltypes.Result
-		state  *query.ReservedState
-	)
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
-		var err error
-		result, state, err = conn.QueryService().CopyOutStream(ctx, target, options, onMessage)
-		return err
-	})
-	return result, state, err
+	conn, err := pg.loadBalancer.GetConnection(target)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pg.logger.DebugContext(ctx, "selected pooler for target",
+		"tablegroup", target.TableGroup,
+		"shard", target.Shard,
+		"pooler_type", target.PoolerType.String(),
+		"pooler_id", conn.ID())
+
+	return conn.QueryService().CopyOutStream(ctx, target, options, onMessage)
 }
 
 // Close implements queryservice.QueryService.

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -767,6 +768,124 @@ func (sc *ScatterConn) DiscardTempTables(
 
 // --- COPY FROM STDIN methods ---
 
+// CopyOutInitiate initiates a COPY ... TO STDOUT operation using
+// bidirectional streaming. Stores reserved connection info in
+// state.ShardStates for the given tableGroup/shard. Returns format,
+// columnFormats, and any NoticeResponse diagnostics that arrived before
+// the CopyOutResponse (e.g. BEFORE STATEMENT trigger output). The caller
+// then drives the data stream with CopyOutStream.
+func (sc *ScatterConn) CopyOutInitiate(
+	ctx context.Context,
+	conn *server.Conn,
+	tableGroup string,
+	shard string,
+	queryStr string,
+	state *handler.MultiGatewayConnectionState,
+) (int16, []int16, []*mterrors.PgDiagnostic, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "shard.copy_out_initiate",
+		trace.WithAttributes(
+			attribute.String("tablegroup", tableGroup),
+			attribute.String("shard", shard),
+			attribute.String("db.namespace", conn.Database()),
+		),
+	)
+	defer span.End()
+
+	target := &querypb.Target{
+		TableGroup: tableGroup,
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		Shard:      shard,
+	}
+
+	execOptions := &querypb.ExecuteOptions{
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		ClientConnectionId: conn.ConnectionID(),
+		SessionSettings:    state.GetSessionSettings(),
+	}
+
+	// Reuse an existing reserved connection (e.g. one already held by a
+	// transaction or temp-table reservation) so the COPY runs on the same
+	// backend that owns the in-flight session state. Otherwise pass deferred
+	// BEGIN options so the new connection enters the transaction before
+	// starting COPY. Mirrors CopyInitiate (FROM STDIN).
+	var reservationOpts *querypb.ReservationOptions
+	ss := state.GetMatchingShardState(target)
+	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
+		execOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
+	} else if conn.IsInTransaction() {
+		reservationOpts = protoutil.NewTransactionReservationOptions()
+		if state.HasTempTableReservation() {
+			reservationOpts.Reasons |= protoutil.ReasonTempTable
+		}
+		if state.PendingBeginQuery != "" {
+			reservationOpts.BeginQuery = state.PendingBeginQuery
+			state.PendingBeginQuery = ""
+		}
+	}
+
+	format, columnFormats, notices, reservedState, err := sc.gateway.CopyOutReady(ctx, target, queryStr, execOptions, reservationOpts)
+	if err != nil {
+		sc.applyReservedState(conn, state, target, reservedState)
+		// Surface the PG error un-wrapped — see the comment on CopyInitiate
+		// below for the rationale.
+		return 0, nil, notices, err
+	}
+
+	sc.applyReservedState(conn, state, target, reservedState)
+	return format, columnFormats, notices, nil
+}
+
+// CopyOutStream drives the COPY ... TO STDOUT data stream, invoking
+// onMessage for each CopyData chunk / NoticeResponse pumped by the
+// multipooler. Returns the final Result (CommandTag, RowsAffected, plus any
+// trailing notices in result.Notices) and applies the authoritative
+// ReservedState to shard tracking on completion. PG ErrorResponse mid-stream
+// surfaces un-wrapped so the gateway re-emits a verbatim ErrorResponse.
+func (sc *ScatterConn) CopyOutStream(
+	ctx context.Context,
+	conn *server.Conn,
+	tableGroup string,
+	shard string,
+	state *handler.MultiGatewayConnectionState,
+	onMessage func(pgClient.CopyOutMessage) error,
+) (*sqltypes.Result, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "shard.copy_out_stream",
+		trace.WithAttributes(
+			attribute.String("tablegroup", tableGroup),
+			attribute.String("shard", shard),
+			attribute.String("db.namespace", conn.Database()),
+		),
+	)
+	defer span.End()
+
+	target := &querypb.Target{
+		TableGroup: tableGroup,
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+		Shard:      shard,
+	}
+
+	ss := state.GetMatchingShardState(target)
+	if ss == nil || ss.ReservedState.GetReservedConnectionId() == 0 {
+		return nil, errors.New("no active COPY connection")
+	}
+
+	copyOptions := &querypb.ExecuteOptions{
+		UserAuth:             userAuthFrom(conn),
+		User:                 conn.User(),
+		ClientConnectionId:   conn.ConnectionID(),
+		SessionSettings:      state.GetSessionSettings(),
+		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
+	}
+
+	result, reservedState, err := sc.gateway.CopyOutStream(ctx, target, copyOptions, onMessage)
+	sc.applyReservedState(conn, state, target, reservedState)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // CopyInitiate initiates a COPY FROM STDIN operation using bidirectional streaming.
 // Stores reserved connection info in state.ShardStates for the given tableGroup/shard.
 // Returns: format, columnFormats, error
@@ -842,7 +961,11 @@ func (sc *ScatterConn) CopyInitiate(
 		// so we don't end up sending future statements to a connection that
 		// no longer exists.
 		sc.applyReservedState(conn, state, target, reservedState)
-		return 0, nil, fmt.Errorf("failed to initiate COPY: %w", err)
+		// Surface the PG error un-wrapped: the gateway re-emits a verbatim
+		// ErrorResponse to the client. Wrapping here with
+		// "failed to initiate COPY:" would diverge from upstream PG output
+		// that regression-test fixtures match against.
+		return 0, nil, err
 	}
 
 	// Use authoritative state from multipooler (reasons already include copy + transaction if applicable)
@@ -895,7 +1018,8 @@ func (sc *ScatterConn) CopySendData(
 
 	// Send data via gateway
 	if err := sc.gateway.CopySendData(ctx, target, data, copyOptions); err != nil {
-		return fmt.Errorf("failed to send COPY data: %w", err)
+		// Surface PG errors un-wrapped — see CopyInitiate comment above.
+		return err
 	}
 
 	sc.logger.DebugContext(ctx, "sent COPY data", "size", len(data))
@@ -961,7 +1085,8 @@ func (sc *ScatterConn) CopyFinalize(
 		// state has a non-zero conn ID, clear it and mark the transaction
 		// failed if not.
 		sc.applyReservedState(conn, state, target, reservedState)
-		return fmt.Errorf("failed to finalize COPY: %w", err)
+		// Surface PG errors un-wrapped — see CopyInitiate comment above.
+		return err
 	}
 
 	sc.logger.DebugContext(ctx, "COPY finalized successfully",

--- a/go/services/multigateway/scatterconn/scatter_conn_test.go
+++ b/go/services/multigateway/scatterconn/scatter_conn_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/mterrors"
+	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/protoutil"
@@ -127,6 +129,14 @@ func (m *mockGateway) CopyFinalize(_ context.Context, _ *querypb.Target, _ []byt
 
 func (m *mockGateway) CopyAbort(_ context.Context, _ *querypb.Target, _ string, _ *querypb.ExecuteOptions) (*querypb.ReservedState, error) {
 	return m.copyAbortReturnState, m.copyAbortErr
+}
+
+func (m *mockGateway) CopyOutReady(context.Context, *querypb.Target, string, *querypb.ExecuteOptions, *querypb.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *querypb.ReservedState, error) {
+	return 0, nil, nil, nil, nil
+}
+
+func (m *mockGateway) CopyOutStream(_ context.Context, _ *querypb.Target, _ *querypb.ExecuteOptions, _ func(pgClient.CopyOutMessage) error) (*sqltypes.Result, *querypb.ReservedState, error) {
+	return nil, nil, nil
 }
 
 func (m *mockGateway) ReleaseReservedConnection(context.Context, *querypb.Target, *querypb.ExecuteOptions) error {

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
@@ -961,7 +962,12 @@ func (e *Executor) CopyReady(
 		// CopyDone/CopyFail, so this is the only window to tag the
 		// backend for lock-detection during long-running COPYs.
 		e.stampVpidOnReserved(ctx, reservedConn, options)
-		format, columnFormats, err = reservedConn.Conn().InitiateCopyFromStdin(ctx, copyQuery)
+		// InitiateCopyFromStdin may return NoticeResponse diagnostics that
+		// arrive before CopyInResponse (e.g. BEFORE STATEMENT triggers).
+		// They are uncommon and harmless to drop here; the gateway's main
+		// regression-test concern is trigger NOTICE output during the data
+		// phase, which surfaces via ReadCopyDoneResponse in CopyFinalize.
+		format, columnFormats, _, err = reservedConn.Conn().InitiateCopyFromStdin(ctx, copyQuery)
 		if err != nil {
 			// InitiateCopyFromStdin distinguishes two failure modes:
 			//   - Connection-level error (broken socket): conn is dead, release it.
@@ -973,11 +979,14 @@ func (e *Executor) CopyReady(
 			//     subsequent statement to fail with "reserved connection not
 			//     found". Return the current state alongside the error so the
 			//     gateway can keep tracking the conn.
+			// Surface PG errors un-wrapped so the gateway can re-emit a
+			// verbatim ErrorResponse — see ReadCopyDoneResponse error path
+			// in CopyFinalize for the same rationale.
 			if mterrors.IsConnectionError(err) {
 				reservedConn.Release(reserved.ReleaseError)
-				return 0, nil, nil, fmt.Errorf("failed to initiate COPY FROM STDIN: %w", err)
+				return 0, nil, nil, err
 			}
-			return 0, nil, e.buildReservedState(reservedConn), fmt.Errorf("failed to initiate COPY FROM STDIN: %w", err)
+			return 0, nil, e.buildReservedState(reservedConn), err
 		}
 	} else {
 		// New reserved conn — wire BEGIN-if-needed and InitiateCopyFromStdin
@@ -1003,11 +1012,9 @@ func (e *Executor) CopyReady(
 			// promote to a *reserved.Conn, so the tag carries through.
 			e.stampVpidOnRegular(ctx, conn, options)
 			var initErr error
-			format, columnFormats, initErr = conn.InitiateCopyFromStdin(ctx, copyQuery)
-			if initErr != nil {
-				return fmt.Errorf("failed to initiate COPY FROM STDIN: %w", initErr)
-			}
-			return nil
+			format, columnFormats, _, initErr = conn.InitiateCopyFromStdin(ctx, copyQuery)
+			// Surface PG errors un-wrapped — see comment above.
+			return initErr
 		}
 
 		clientKey, serverKey := scramKeysFromOptions(options)
@@ -1125,8 +1132,11 @@ func (e *Executor) CopyFinalize(
 		return nil, nil, fmt.Errorf("failed to write CopyDone: %w", err)
 	}
 
-	// Read CommandComplete response from PostgreSQL
-	commandTag, rowsAffected, err := conn.ReadCopyDoneResponse(ctx)
+	// Read CommandComplete response from PostgreSQL. Notices from triggers /
+	// progress reporting that fired during the data phase arrive between
+	// CopyDone and CommandComplete; capture them so the gateway can forward
+	// them to the client as NoticeResponse frames.
+	commandTag, rowsAffected, notices, err := conn.ReadCopyDoneResponse(ctx)
 	if err != nil {
 		e.logger.ErrorContext(ctx, "COPY operation failed", "error", err)
 		// For a PG ErrorResponse (e.g., constraint violation, type mismatch,
@@ -1136,25 +1146,36 @@ func (e *Executor) CopyFinalize(
 		// so we mirror CopyAbort here: remove the COPY reason and release
 		// only if no other reasons remain. A connection-level failure (broken
 		// socket) still falls through to Release(ReleaseError).
+		//
+		// We deliberately do NOT wrap the PG error with "COPY operation
+		// failed:" — the gateway round-trips a structured PgDiagnostic over
+		// the bidi stream's error_diagnostic field and re-emits a verbatim
+		// ErrorResponse to the client. Adding a Go-style prefix here would
+		// cause regression-test fixtures comparing ERROR / CONTEXT lines to
+		// diverge from upstream PostgreSQL output.
 		if !mterrors.IsConnectionError(err) {
 			if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
 				reservedConn.Release(reserved.ReleasePortalComplete)
-				return nil, nil, fmt.Errorf("COPY operation failed: %w", err)
+				return nil, nil, err
 			}
-			return nil, e.buildReservedState(reservedConn), fmt.Errorf("COPY operation failed: %w", err)
+			return nil, e.buildReservedState(reservedConn), err
 		}
 		reservedConn.Release(reserved.ReleaseError)
-		return nil, nil, fmt.Errorf("COPY operation failed: %w", err)
+		return nil, nil, err
 	}
 
 	e.logger.DebugContext(ctx, "COPY DONE successful",
 		"rows_affected", rowsAffected,
 		"command_tag", commandTag)
 
-	// Build result
+	// Build result. Attach any NoticeResponse diagnostics captured during
+	// CopyDone → CommandComplete; the gateway serializes them into the
+	// CopyBidiExecuteResponse.notices proto field and re-emits them as
+	// NoticeResponse frames to the client before CommandComplete.
 	result := &sqltypes.Result{
 		CommandTag:   commandTag,
 		RowsAffected: rowsAffected,
+		Notices:      notices,
 	}
 
 	// Remove the COPY reason. If other reasons remain (e.g., transaction),
@@ -1220,7 +1241,10 @@ func (e *Executor) CopyAbort(
 	// Read ErrorResponse + ReadyForQuery from PostgreSQL.
 	// After CopyFail, PostgreSQL responds with ErrorResponse then ReadyForQuery.
 	// ReadCopyFailResponse drains both, leaving the connection in a clean state.
-	readErr := conn.ReadCopyFailResponse(ctx)
+	// Any notices that arrived between CopyFail and ReadyForQuery are
+	// discarded here — the client has already initiated an abort, so the
+	// abort outcome is what matters, not pre-abort trigger output.
+	_, readErr := conn.ReadCopyFailResponse(ctx)
 	if readErr != nil {
 		e.logger.ErrorContext(ctx, "failed to read response after CopyFail", "error", readErr)
 	}
@@ -1243,6 +1267,198 @@ func (e *Executor) CopyAbort(
 	}
 
 	return e.buildReservedState(reservedConn), nil
+}
+
+// CopyOutReady initiates a COPY ... TO STDOUT operation and returns format
+// information plus any pre-CopyOutResponse notices. The caller (the
+// multipooler bidi gRPC handler) then calls CopyOutStream to pump CopyData
+// chunks back to the gateway, ending with the trailing CommandComplete +
+// ReadyForQuery.
+//
+// Structure mirrors CopyReady (FROM STDIN) so the reservation lifecycle is
+// identical: reuse an existing reserved conn when ReservedConnectionId is
+// set, or create a new one (with optional BEGIN-if-needed). The reservation
+// reason ReasonCopy is added on success; it must be removed by
+// CopyOutStream / CopyAbort.
+func (e *Executor) CopyOutReady(
+	ctx context.Context,
+	target *query.Target,
+	copyQuery string,
+	options *query.ExecuteOptions,
+	reservationOptions *query.ReservationOptions,
+) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+	user := e.getUserFromOptions(options)
+	var settings map[string]string
+	if options != nil {
+		settings = e.sessionSettingsForPool(options.SessionSettings)
+	}
+
+	e.logger.DebugContext(ctx, "initiating COPY TO STDOUT",
+		"query", copyQuery,
+		"user", user)
+
+	var (
+		reservedConn  *reserved.Conn
+		err           error
+		format        int16
+		columnFormats []int16
+		notices       []*mterrors.PgDiagnostic
+	)
+
+	if options != nil && options.ReservedConnectionId > 0 {
+		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		if reservedConn == nil {
+			return 0, nil, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+		}
+		e.stampVpidOnReserved(ctx, reservedConn, options)
+		format, columnFormats, notices, err = reservedConn.Conn().InitiateCopyToStdout(ctx, copyQuery)
+		if err != nil {
+			// Same dual failure handling as CopyReady (FROM STDIN): a PG
+			// ErrorResponse leaves the conn at RFQ and reusable if other
+			// reservation reasons remain; a connection-level error means
+			// the socket is dead. Surface the PG error un-wrapped so the
+			// gateway can re-emit the verbatim ErrorResponse.
+			if mterrors.IsConnectionError(err) {
+				reservedConn.Release(reserved.ReleaseError)
+				return 0, nil, notices, nil, err
+			}
+			return 0, nil, notices, e.buildReservedState(reservedConn), err
+		}
+	} else {
+		requiresBegin := protoutil.RequiresBegin(protoutil.GetReasons(reservationOptions))
+		beginQuery := "BEGIN"
+		if reservationOptions != nil && reservationOptions.BeginQuery != "" {
+			beginQuery = reservationOptions.BeginQuery
+		}
+
+		validate := func(ctx context.Context, conn *regular.Conn) error {
+			if requiresBegin {
+				if _, err := conn.Query(ctx, beginQuery); err != nil {
+					return fmt.Errorf("failed to begin transaction for COPY: %w", err)
+				}
+			}
+			e.stampVpidOnRegular(ctx, conn, options)
+			var initErr error
+			format, columnFormats, notices, initErr = conn.InitiateCopyToStdout(ctx, copyQuery)
+			// Surface PG errors un-wrapped — see CopyOutReady comment above.
+			return initErr
+		}
+
+		clientKey, serverKey := scramKeysFromOptions(options)
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
+		if err != nil {
+			return 0, nil, notices, nil, err
+		}
+
+		if requiresBegin {
+			reservedConn.AddReservationReason(protoutil.ReasonTransaction)
+		}
+	}
+
+	reservedConn.AddReservationReason(protoutil.ReasonCopy)
+
+	e.logger.DebugContext(ctx, "COPY OUT INITIATE successful",
+		"conn_id", reservedConn.ConnID(),
+		"format", format,
+		"num_columns", len(columnFormats))
+
+	return format, columnFormats, notices, e.buildReservedState(reservedConn), nil
+}
+
+// CopyOutStream pumps the COPY ... TO STDOUT response stream back to the
+// caller via onMessage callbacks. PG drives the stream: a series of
+// CopyData chunks interleaved with NoticeResponse diagnostics, terminated
+// by CopyDone followed by CommandComplete + ReadyForQuery. The callback
+// receives one CopyOutMessage per CopyData / NoticeResponse seen; a
+// CopyData chunk has Data set, a notice has Notice set. CopyDone is
+// consumed internally and signals end-of-stream.
+//
+// After the stream ends, the trailing CommandComplete + ReadyForQuery is
+// drained via FinishCopyToStdout and the resulting (*sqltypes.Result with
+// CommandTag + RowsAffected + post-data Notices) is returned. On a PG
+// ErrorResponse anywhere in the stream, the connection is left in a clean
+// state by the underlying client helpers and the ReasonCopy reservation
+// reason is dropped; the surviving ReservedState (or nil) is returned for
+// the gateway to apply.
+func (e *Executor) CopyOutStream(
+	ctx context.Context,
+	target *query.Target,
+	options *query.ExecuteOptions,
+	onMessage func(client.CopyOutMessage) error,
+) (*sqltypes.Result, *query.ReservedState, error) {
+	if options == nil || options.ReservedConnectionId == 0 {
+		return nil, nil, errors.New("options.ReservedConnectionId is required for CopyOutStream")
+	}
+
+	user := e.getUserFromOptions(options)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	if !ok || reservedConn == nil {
+		return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+	}
+
+	conn := reservedConn.Conn()
+
+	// Pump CopyData / NoticeResponse to the gateway until CopyDone.
+	for {
+		if err := ctx.Err(); err != nil {
+			// Caller canceled — abort the COPY so the backend doesn't
+			// keep streaming into a dead stream. Use the same shared
+			// CopyAbort cleanup as the FROM-STDIN path.
+			_, _ = e.CopyAbort(ctx, target, "stream canceled", options)
+			return nil, nil, err
+		}
+
+		msg, err := conn.ReadCopyOutMessage(ctx)
+		if err != nil {
+			// PG ErrorResponse path: the helper already drained RFQ.
+			// Mirror CopyFinalize's release semantics.
+			if !mterrors.IsConnectionError(err) {
+				if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
+					reservedConn.Release(reserved.ReleasePortalComplete)
+					return nil, nil, err
+				}
+				return nil, e.buildReservedState(reservedConn), err
+			}
+			reservedConn.Release(reserved.ReleaseError)
+			return nil, nil, err
+		}
+
+		if msg.Done {
+			break
+		}
+
+		if cbErr := onMessage(msg); cbErr != nil {
+			// Caller (gateway grpc handler) couldn't forward — abort to
+			// keep the backend protocol position valid.
+			_, _ = e.CopyAbort(ctx, target, "callback failed: "+cbErr.Error(), options)
+			return nil, nil, cbErr
+		}
+	}
+
+	commandTag, rowsAffected, notices, err := conn.FinishCopyToStdout(ctx)
+	if err != nil {
+		if !mterrors.IsConnectionError(err) {
+			if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
+				reservedConn.Release(reserved.ReleasePortalComplete)
+				return nil, nil, err
+			}
+			return nil, e.buildReservedState(reservedConn), err
+		}
+		reservedConn.Release(reserved.ReleaseError)
+		return nil, nil, err
+	}
+
+	result := &sqltypes.Result{
+		CommandTag:   commandTag,
+		RowsAffected: rowsAffected,
+		Notices:      notices,
+	}
+
+	if reservedConn.RemoveReservationReason(protoutil.ReasonCopy) {
+		reservedConn.Release(reserved.ReleasePortalComplete)
+		return result, nil, nil
+	}
+	return result, e.buildReservedState(reservedConn), nil
 }
 
 // getUserFromOptions extracts the user from ExecuteOptions.
@@ -1490,7 +1706,7 @@ func (e *Executor) ReleaseReservedConnection(
 			e.logger.ErrorContext(ctx, "CopyFail write failed during release",
 				"reserved_conn_id", options.ReservedConnectionId, "error", err)
 			cleanupFailed = true
-		} else if _, _, err := conn.ReadCopyDoneResponse(ctx); err != nil {
+		} else if _, _, _, err := conn.ReadCopyDoneResponse(ctx); err != nil {
 			e.logger.DebugContext(ctx, "error reading response after CopyFail (expected)",
 				"reserved_conn_id", options.ReservedConnectionId, "error", err)
 			cleanupFailed = true

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -1714,14 +1714,20 @@ func (e *Executor) ReleaseReservedConnection(
 	}
 
 	// Step 2: If there's a COPY reason, send CopyFail and read the response.
+	// After CopyFail PG sends ErrorResponse + ReadyForQuery (not
+	// CommandComplete), so use ReadCopyFailResponse — it expects that
+	// shape, leaves the conn in a clean RFQ state, and reports cleanup
+	// success without flipping cleanupFailed. ReadCopyDoneResponse would
+	// happen to drain the same bytes but treat the ErrorResponse as a
+	// failure, falsely marking the conn unrecyclable.
 	if !cleanupFailed && protoutil.HasCopyReason(reservedConn.RemainingReasons()) {
 		conn := reservedConn.Conn()
 		if err := conn.WriteCopyFail("connection closing"); err != nil {
 			e.logger.ErrorContext(ctx, "CopyFail write failed during release",
 				"reserved_conn_id", options.ReservedConnectionId, "error", err)
 			cleanupFailed = true
-		} else if _, _, _, err := conn.ReadCopyDoneResponse(ctx); err != nil {
-			e.logger.DebugContext(ctx, "error reading response after CopyFail (expected)",
+		} else if _, err := conn.ReadCopyFailResponse(ctx); err != nil {
+			e.logger.DebugContext(ctx, "error reading response after CopyFail",
 				"reserved_conn_id", options.ReservedConnectionId, "error", err)
 			cleanupFailed = true
 		}

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -1398,13 +1398,29 @@ func (e *Executor) CopyOutStream(
 
 	conn := reservedConn.Conn()
 
+	// abortCopyOut releases the reserved conn with ReleaseError, which
+	// destroys the backend socket. This is the correct cleanup during a
+	// COPY ... TO STDOUT abort because PG is in copy-out mode and is NOT
+	// reading from the frontend — writing CopyFail (the FROM STDIN abort
+	// message) would only buffer in the kernel and a subsequent
+	// ReadCopyFailResponse would receive CopyData where ErrorResponse is
+	// expected, fail, and fall through to the same ReleaseError. Skipping
+	// the wasted round-trip avoids that I/O. Destroying the socket makes
+	// PG see EOF and abort the COPY on its own — the protocol-correct
+	// way for a frontend to cancel an in-progress COPY OUT (there is no
+	// in-band cancel; pg_cancel_backend on a separate session is the only
+	// other PG-blessed option).
+	abortCopyOut := func(reason string) {
+		e.logger.DebugContext(ctx, "aborting COPY TO STDOUT via socket destroy",
+			"conn_id", options.ReservedConnectionId,
+			"reason", reason)
+		reservedConn.Release(reserved.ReleaseError)
+	}
+
 	// Pump CopyData / NoticeResponse to the gateway until CopyDone.
 	for {
 		if err := ctx.Err(); err != nil {
-			// Caller canceled — abort the COPY so the backend doesn't
-			// keep streaming into a dead stream. Use the same shared
-			// CopyAbort cleanup as the FROM-STDIN path.
-			_, _ = e.CopyAbort(ctx, target, "stream canceled", options)
+			abortCopyOut("stream canceled: " + err.Error())
 			return nil, nil, err
 		}
 
@@ -1428,9 +1444,7 @@ func (e *Executor) CopyOutStream(
 		}
 
 		if cbErr := onMessage(msg); cbErr != nil {
-			// Caller (gateway grpc handler) couldn't forward — abort to
-			// keep the backend protocol position valid.
-			_, _ = e.CopyAbort(ctx, target, "callback failed: "+cbErr.Error(), options)
+			abortCopyOut("callback failed: " + cbErr.Error())
 			return nil, nil, cbErr
 		}
 	}

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/multigres/multigres/go/common/sqltypes"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multipooler/connpoolmanager"
+	"github.com/multigres/multigres/go/services/multipooler/pools/admin"
 	"github.com/multigres/multigres/go/services/multipooler/pools/connpool"
 	"github.com/multigres/multigres/go/services/multipooler/pools/regular"
 	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
@@ -119,6 +121,44 @@ func (m *mockReservedConn) Release(reason reserved.ReleaseReason) {
 
 // Compile-time check.
 var _ reservedConnAPI = (*mockReservedConn)(nil)
+
+type stubPoolManager struct {
+	reservedConn   *reserved.Conn
+	reservedConnOK bool
+}
+
+func (m *stubPoolManager) Open(context.Context, *connpoolmanager.ConnectionConfig) {}
+func (m *stubPoolManager) Close()                                                  {}
+func (m *stubPoolManager) PgUser() string                                          { return "postgres" }
+func (m *stubPoolManager) PgPassword() (string, bool)                              { return "", true }
+func (m *stubPoolManager) GetAdminConn(context.Context) (admin.PooledConn, error)  { return nil, nil }
+func (m *stubPoolManager) GetRegularConn(context.Context, string, []byte, []byte) (regular.PooledConn, error) {
+	return nil, nil
+}
+
+func (m *stubPoolManager) GetRegularConnWithSettings(context.Context, map[string]string, string, []byte, []byte) (regular.PooledConn, error) {
+	return nil, nil
+}
+
+func (m *stubPoolManager) NewReservedConn(context.Context, map[string]string, string, []byte, []byte, ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+	return nil, errors.New("not implemented in test stub")
+}
+
+func (m *stubPoolManager) GetReservedConn(int64, string) (*reserved.Conn, bool) {
+	return m.reservedConn, m.reservedConnOK
+}
+
+func (m *stubPoolManager) ApplySettingsToConn(context.Context, *regular.Conn, map[string]string) error {
+	return nil
+}
+func (m *stubPoolManager) WaitForDrain(context.Context) error           { return nil }
+func (m *stubPoolManager) CloseReservedConnections(context.Context) int { return 0 }
+func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats          { return connpoolmanager.ManagerStats{} }
+func (m *stubPoolManager) CredentialQueryRecorder() connpoolmanager.CredentialQueryRecorder {
+	return nil
+}
+
+var _ connpoolmanager.PoolManager = (*stubPoolManager)(nil)
 
 // newTestExecutor returns an Executor that has just enough wiring to exercise
 // streamExecuteOnReservedConn. The pool manager is left nil because the helper
@@ -634,5 +674,70 @@ func TestNewExecutor(t *testing.T) {
 		e := NewExecutor(logger, nil, poolerID, false)
 		require.NotNil(t, e)
 		assert.False(t, e.vpidStampEnabled)
+	})
+}
+
+func TestCopyOutReady_ReservedConnectionNotFound(t *testing.T) {
+	e := newTestExecutor()
+	e.poolManager = &stubPoolManager{}
+
+	_, _, _, _, err := e.CopyOutReady(
+		context.Background(),
+		&query.Target{TableGroup: "tg"},
+		"COPY t TO STDOUT",
+		&query.ExecuteOptions{User: "alice", ReservedConnectionId: 42},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved connection 42 not found for user alice")
+}
+
+func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
+	e := newTestExecutor()
+
+	t.Run("missing reserved connection id", func(t *testing.T) {
+		_, _, err := e.CopyOutStream(
+			context.Background(),
+			&query.Target{TableGroup: "tg"},
+			&query.ExecuteOptions{},
+			func(client.CopyOutMessage) error { return nil },
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "options.ReservedConnectionId is required for CopyOutStream")
+	})
+
+	t.Run("reserved connection not found", func(t *testing.T) {
+		e.poolManager = &stubPoolManager{}
+		_, _, err := e.CopyOutStream(
+			context.Background(),
+			&query.Target{TableGroup: "tg"},
+			&query.ExecuteOptions{User: "alice", ReservedConnectionId: 99},
+			func(client.CopyOutMessage) error { return nil },
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reserved connection 99 not found for user alice")
+	})
+}
+
+func TestCopyAbort_NilOptionsAndNoCopyReason(t *testing.T) {
+	e := newTestExecutor()
+
+	t.Run("nil options is best-effort no-op", func(t *testing.T) {
+		state, err := e.CopyAbort(context.Background(), &query.Target{TableGroup: "tg"}, "abort", nil)
+		require.NoError(t, err)
+		require.Nil(t, state)
+	})
+
+	t.Run("missing reserved conn is best-effort no-op", func(t *testing.T) {
+		e.poolManager = &stubPoolManager{}
+
+		state, err := e.CopyAbort(
+			context.Background(),
+			&query.Target{TableGroup: "tg"},
+			"abort",
+			&query.ExecuteOptions{User: "postgres", ReservedConnectionId: 777},
+		)
+		require.NoError(t, err)
+		require.Nil(t, state)
 	})
 }

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -353,7 +353,7 @@ func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecu
 
 // CopyBidiExecute handles bidirectional streaming operations (e.g., COPY commands).
 // The gateway sends: INITIATE → DATA (repeated) → DONE/FAIL  (for COPY FROM STDIN)
-// The gateway sends: INITIATE → FAIL?                        (for COPY TO STDOUT)
+// The gateway sends: INITIATE                                (for COPY TO STDOUT)
 // The pooler responds: READY → DATA (for COPY TO STDOUT) → RESULT/ERROR
 func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_CopyBidiExecuteServer) error {
 	ctx := stream.Context()
@@ -589,9 +589,9 @@ func noticesToProto(notices []*mterrors.PgDiagnostic) []*query.PgDiagnostic {
 // CopyDone, then CommandComplete + ReadyForQuery. We translate that into
 // the bidi protocol as READY → DATA* → RESULT.
 //
-// A FAIL message from the gateway during the data phase still aborts the
-// COPY (e.g. client disconnect mid-stream), but we don't expect DATA from
-// the gateway — receiving one is a protocol violation.
+// During this phase we do not call stream.Recv(); cleanup happens when
+// stream.Send starts failing (client gone) or the RPC context is canceled
+// by the caller returning up-stack.
 func (s *poolerService) copyBidiExecuteToStdout(
 	ctx context.Context,
 	stream multipoolerpb.MultiPoolerService_CopyBidiExecuteServer,

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -26,7 +26,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
@@ -350,8 +352,9 @@ func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecu
 }
 
 // CopyBidiExecute handles bidirectional streaming operations (e.g., COPY commands).
-// The gateway sends: INITIATE → DATA (repeated) → DONE/FAIL
-// The pooler responds: READY → DATA (for COPY TO) → RESULT/ERROR
+// The gateway sends: INITIATE → DATA (repeated) → DONE/FAIL  (for COPY FROM STDIN)
+// The gateway sends: INITIATE → FAIL?                        (for COPY TO STDOUT)
+// The pooler responds: READY → DATA (for COPY TO STDOUT) → RESULT/ERROR
 func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_CopyBidiExecuteServer) error {
 	ctx := stream.Context()
 
@@ -375,6 +378,13 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 		return mterrors.ToGRPC(err)
 	}
 
+	// Dispatch on direction: COPY TO STDOUT has a server-push data phase
+	// and does not consume client DATA messages, so it goes through a
+	// dedicated handler. COPY FROM STDIN falls through to the existing flow.
+	if req.Direction == multipoolerpb.CopyBidiExecuteRequest_TO_STDOUT {
+		return s.copyBidiExecuteToStdout(ctx, stream, exec, req)
+	}
+
 	// Phase 1: INITIATE - Send COPY command and get reserved connection
 	format, columnFormats, reservedState, err := exec.CopyReady(ctx, req.Target, req.Query, req.Options, req.ReservationOptions)
 	if err != nil {
@@ -385,14 +395,19 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 		// response so the gateway keeps tracking the reserved conn; without
 		// this, the gateway would see only the gRPC status error and the next
 		// statement would fail with "reserved connection not found".
-		if reservedState != nil {
-			_ = stream.Send(&multipoolerpb.CopyBidiExecuteResponse{
-				Phase:         multipoolerpb.CopyBidiExecuteResponse_ERROR,
-				Error:         err.Error(),
-				ReservedState: reservedState,
-			})
+		//
+		// Carry the structured PG diagnostic in error_diagnostic so the
+		// gateway can re-emit a verbatim ErrorResponse to the client
+		// (severity/SQLSTATE/DETAIL/HINT preserved). The text-only `error`
+		// field is kept populated for legacy callers / log lines.
+		errResp := &multipoolerpb.CopyBidiExecuteResponse{
+			Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
+			Error:           err.Error(),
+			ErrorDiagnostic: pgDiagnosticFromError(err),
+			ReservedState:   reservedState,
 		}
-		return status.Errorf(codes.Internal, "failed to initiate COPY: %v", err)
+		_ = stream.Send(errResp)
+		return mterrors.ToGRPC(err)
 	}
 
 	// Convert columnFormats from []int16 to []int32 for protobuf
@@ -458,14 +473,16 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 			// Phase 2a: DATA - Write data chunk to PostgreSQL
 			if err := exec.CopySendData(ctx, req.Target, req.Data, copyOptions); err != nil {
 				abortState, _ := exec.CopyAbort(ctx, req.Target, "failed to write data", copyOptions)
-				// Send ERROR response with reserved state so gateway can update shard state
+				// Send ERROR response with reserved state so gateway can update shard state.
+				// Attach PgDiagnostic if the error carries one — keeps SQLSTATE/severity intact.
 				errorResp := &multipoolerpb.CopyBidiExecuteResponse{
-					Phase:         multipoolerpb.CopyBidiExecuteResponse_ERROR,
-					Error:         err.Error(),
-					ReservedState: abortState,
+					Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
+					Error:           err.Error(),
+					ErrorDiagnostic: pgDiagnosticFromError(err),
+					ReservedState:   abortState,
 				}
 				_ = stream.Send(errorResp)
-				return status.Errorf(codes.Internal, "failed to handle COPY data: %v", err)
+				return mterrors.ToGRPC(err)
 			}
 
 		case multipoolerpb.CopyBidiExecuteRequest_DONE:
@@ -480,21 +497,24 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 				// Either way, calling CopyAbort here would either be a no-op
 				// (conn already released) or actively poison a clean conn by
 				// writing CopyFail on a backend already back in RFQ. Forward
-				// the state CopyFinalize returned.
+				// the state CopyFinalize returned. Carry the structured PG
+				// diagnostic so the gateway re-emits a verbatim ErrorResponse.
 				errorResp := &multipoolerpb.CopyBidiExecuteResponse{
-					Phase:         multipoolerpb.CopyBidiExecuteResponse_ERROR,
-					Error:         err.Error(),
-					ReservedState: reservedState,
+					Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
+					Error:           err.Error(),
+					ErrorDiagnostic: pgDiagnosticFromError(err),
+					ReservedState:   reservedState,
 				}
 				_ = stream.Send(errorResp)
-				return status.Errorf(codes.Internal, "COPY operation failed: %v", err)
+				return mterrors.ToGRPC(err)
 			}
 
-			// Send RESULT response with final result and reserved state
+			// Send RESULT response with final result, notices, and reserved state
 			resultResp := &multipoolerpb.CopyBidiExecuteResponse{
 				Phase:         multipoolerpb.CopyBidiExecuteResponse_RESULT,
 				Result:        result.ToProto(),
 				ReservedState: reservedState,
+				Notices:       noticesToProto(result.Notices),
 			}
 			if err := stream.Send(resultResp); err != nil {
 				return status.Errorf(codes.Internal, "failed to send RESULT: %v", err)
@@ -535,6 +555,129 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 			return status.Errorf(codes.InvalidArgument, "unexpected phase: %v", req.Phase)
 		}
 	}
+}
+
+// pgDiagnosticFromError returns the proto representation of a PG diagnostic
+// extracted from err, or nil when err is not a *mterrors.PgDiagnostic (e.g.
+// an infrastructure error). Callers attach the result to
+// CopyBidiExecuteResponse.error_diagnostic so the gateway can re-emit a
+// verbatim ErrorResponse rather than wrapping the message text.
+func pgDiagnosticFromError(err error) *query.PgDiagnostic {
+	var diag *mterrors.PgDiagnostic
+	if errors.As(err, &diag) {
+		return mterrors.PgDiagnosticToProto(diag)
+	}
+	return nil
+}
+
+// noticesToProto converts a slice of mterrors notices to their proto form
+// for forwarding through CopyBidiExecuteResponse.notices.
+func noticesToProto(notices []*mterrors.PgDiagnostic) []*query.PgDiagnostic {
+	if len(notices) == 0 {
+		return nil
+	}
+	out := make([]*query.PgDiagnostic, 0, len(notices))
+	for _, n := range notices {
+		out = append(out, mterrors.PgDiagnosticToProto(n))
+	}
+	return out
+}
+
+// copyBidiExecuteToStdout drives the COPY ... TO STDOUT half of the bidi
+// stream. Unlike COPY FROM STDIN, the client doesn't send DATA messages;
+// PG pushes CopyData frames (interleaved with NoticeResponse) until
+// CopyDone, then CommandComplete + ReadyForQuery. We translate that into
+// the bidi protocol as READY → DATA* → RESULT.
+//
+// A FAIL message from the gateway during the data phase still aborts the
+// COPY (e.g. client disconnect mid-stream), but we don't expect DATA from
+// the gateway — receiving one is a protocol violation.
+func (s *poolerService) copyBidiExecuteToStdout(
+	ctx context.Context,
+	stream multipoolerpb.MultiPoolerService_CopyBidiExecuteServer,
+	exec queryservice.QueryService,
+	req *multipoolerpb.CopyBidiExecuteRequest,
+) error {
+	format, columnFormats, initNotices, reservedState, err := exec.CopyOutReady(ctx, req.Target, req.Query, req.Options, req.ReservationOptions)
+	if err != nil {
+		errResp := &multipoolerpb.CopyBidiExecuteResponse{
+			Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
+			Error:           err.Error(),
+			ErrorDiagnostic: pgDiagnosticFromError(err),
+			ReservedState:   reservedState,
+			Notices:         noticesToProto(initNotices),
+		}
+		_ = stream.Send(errResp)
+		return mterrors.ToGRPC(err)
+	}
+
+	columnFormats32 := make([]int32, len(columnFormats))
+	for i, f := range columnFormats {
+		columnFormats32[i] = int32(f)
+	}
+
+	readyResp := &multipoolerpb.CopyBidiExecuteResponse{
+		Phase:         multipoolerpb.CopyBidiExecuteResponse_READY,
+		ReservedState: reservedState,
+		Format:        int32(format),
+		ColumnFormats: columnFormats32,
+		Notices:       noticesToProto(initNotices),
+	}
+	if err := stream.Send(readyResp); err != nil {
+		copyOptions := &query.ExecuteOptions{
+			User:                 req.Options.GetUser(),
+			SessionSettings:      req.Options.GetSessionSettings(),
+			ReservedConnectionId: reservedState.GetReservedConnectionId(),
+		}
+		_, _ = exec.CopyAbort(ctx, req.Target, "failed to send READY response", copyOptions)
+		return status.Errorf(codes.Internal, "failed to send READY response: %v", err)
+	}
+
+	copyOptions := &query.ExecuteOptions{
+		User:                 req.Options.GetUser(),
+		SessionSettings:      req.Options.GetSessionSettings(),
+		ReservedConnectionId: reservedState.GetReservedConnectionId(),
+	}
+
+	// Stream CopyData / NoticeResponse to the gateway. The executor reads
+	// from the backend and invokes the callback for each message until
+	// CopyDone, at which point FinishCopyToStdout drains
+	// CommandComplete + ReadyForQuery.
+	result, finalState, err := exec.CopyOutStream(ctx, req.Target, copyOptions, func(msg client.CopyOutMessage) error {
+		if msg.Notice != nil {
+			noticeResp := &multipoolerpb.CopyBidiExecuteResponse{
+				Phase:   multipoolerpb.CopyBidiExecuteResponse_DATA,
+				Notices: []*query.PgDiagnostic{mterrors.PgDiagnosticToProto(msg.Notice)},
+			}
+			return stream.Send(noticeResp)
+		}
+		dataResp := &multipoolerpb.CopyBidiExecuteResponse{
+			Phase: multipoolerpb.CopyBidiExecuteResponse_DATA,
+			Data:  msg.Data,
+		}
+		return stream.Send(dataResp)
+	})
+	if err != nil {
+		errResp := &multipoolerpb.CopyBidiExecuteResponse{
+			Phase:           multipoolerpb.CopyBidiExecuteResponse_ERROR,
+			Error:           err.Error(),
+			ErrorDiagnostic: pgDiagnosticFromError(err),
+			ReservedState:   finalState,
+		}
+		_ = stream.Send(errResp)
+		return mterrors.ToGRPC(err)
+	}
+
+	resultResp := &multipoolerpb.CopyBidiExecuteResponse{
+		Phase:         multipoolerpb.CopyBidiExecuteResponse_RESULT,
+		Result:        result.ToProto(),
+		ReservedState: finalState,
+		Notices:       noticesToProto(result.Notices),
+	}
+	if err := stream.Send(resultResp); err != nil {
+		return status.Errorf(codes.Internal, "failed to send RESULT: %v", err)
+	}
+	return nil
 }
 
 // ConcludeTransaction concludes a transaction on a reserved connection.

--- a/go/services/multipooler/grpcpoolerservice/service_test.go
+++ b/go/services/multipooler/grpcpoolerservice/service_test.go
@@ -16,14 +16,20 @@ package grpcpoolerservice
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/sqltypes"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
+	"github.com/multigres/multigres/go/pb/query"
 )
 
 func TestGetAuthCredentials_Validation(t *testing.T) {
@@ -101,4 +107,213 @@ func (m *mockHealthStream) Context() context.Context {
 
 func (m *mockHealthStream) Send(*multipoolerpb.StreamPoolerHealthResponse) error {
 	return nil
+}
+
+type mockCopyBidiStream struct {
+	ctx           context.Context
+	sendErrAtCall int
+	sendCalls     int
+	sent          []*multipoolerpb.CopyBidiExecuteResponse
+}
+
+func (m *mockCopyBidiStream) SetHeader(metadata.MD) error  { return nil }
+func (m *mockCopyBidiStream) SendHeader(metadata.MD) error { return nil }
+func (m *mockCopyBidiStream) SetTrailer(metadata.MD)       {}
+func (m *mockCopyBidiStream) Context() context.Context {
+	if m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+func (m *mockCopyBidiStream) SendMsg(any) error { return nil }
+func (m *mockCopyBidiStream) RecvMsg(any) error { return nil }
+
+func (m *mockCopyBidiStream) Send(resp *multipoolerpb.CopyBidiExecuteResponse) error {
+	m.sendCalls++
+	if m.sendErrAtCall > 0 && m.sendCalls == m.sendErrAtCall {
+		return errors.New("send failed")
+	}
+	m.sent = append(m.sent, resp)
+	return nil
+}
+
+func (m *mockCopyBidiStream) Recv() (*multipoolerpb.CopyBidiExecuteRequest, error) {
+	return nil, errors.New("not used by copyBidiExecuteToStdout")
+}
+
+var _ multipoolerpb.MultiPoolerService_CopyBidiExecuteServer = (*mockCopyBidiStream)(nil)
+
+type mockCopyQueryService struct {
+	copyOutReadyFn  func(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error)
+	copyOutStreamFn func(context.Context, *query.Target, *query.ExecuteOptions, func(client.CopyOutMessage) error) (*sqltypes.Result, *query.ReservedState, error)
+	copyAbortFn     func(context.Context, *query.Target, string, *query.ExecuteOptions) (*query.ReservedState, error)
+}
+
+func (m *mockCopyQueryService) ExecuteQuery(context.Context, *query.Target, string, *query.ExecuteOptions) (*sqltypes.Result, *query.ReservedState, error) {
+	return nil, nil, nil
+}
+
+func (m *mockCopyQueryService) StreamExecute(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions, func(context.Context, *sqltypes.Result) error) (*query.ReservedState, error) {
+	return nil, nil
+}
+
+func (m *mockCopyQueryService) PortalStreamExecute(context.Context, *query.Target, *query.PreparedStatement, *query.Portal, *query.ExecuteOptions, *multipoolerpb.PortalExecuteOptions, func(context.Context, *sqltypes.Result) error) (*query.ReservedState, error) {
+	return nil, nil
+}
+
+func (m *mockCopyQueryService) Describe(context.Context, *query.Target, *query.PreparedStatement, *query.Portal, *query.ExecuteOptions) (*query.StatementDescription, error) {
+	return nil, nil
+}
+
+func (m *mockCopyQueryService) Close() error { return nil }
+
+func (m *mockCopyQueryService) CopyReady(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions) (int16, []int16, *query.ReservedState, error) {
+	return 0, nil, nil, nil
+}
+
+func (m *mockCopyQueryService) CopySendData(context.Context, *query.Target, []byte, *query.ExecuteOptions) error {
+	return nil
+}
+
+func (m *mockCopyQueryService) CopyFinalize(context.Context, *query.Target, []byte, *query.ExecuteOptions) (*sqltypes.Result, *query.ReservedState, error) {
+	return nil, nil, nil
+}
+
+func (m *mockCopyQueryService) CopyAbort(ctx context.Context, target *query.Target, errorMsg string, options *query.ExecuteOptions) (*query.ReservedState, error) {
+	if m.copyAbortFn != nil {
+		return m.copyAbortFn(ctx, target, errorMsg, options)
+	}
+	return nil, nil
+}
+
+func (m *mockCopyQueryService) CopyOutReady(ctx context.Context, target *query.Target, copyQuery string, options *query.ExecuteOptions, reservationOptions *query.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+	if m.copyOutReadyFn == nil {
+		return 0, nil, nil, nil, nil
+	}
+	return m.copyOutReadyFn(ctx, target, copyQuery, options, reservationOptions)
+}
+
+func (m *mockCopyQueryService) CopyOutStream(ctx context.Context, target *query.Target, options *query.ExecuteOptions, onMessage func(client.CopyOutMessage) error) (*sqltypes.Result, *query.ReservedState, error) {
+	if m.copyOutStreamFn == nil {
+		return nil, nil, nil
+	}
+	return m.copyOutStreamFn(ctx, target, options, onMessage)
+}
+
+func (m *mockCopyQueryService) ConcludeTransaction(context.Context, *query.Target, *query.ExecuteOptions, multipoolerpb.TransactionConclusion, []string, bool) (*sqltypes.Result, *query.ReservedState, error) {
+	return nil, nil, nil
+}
+
+func (m *mockCopyQueryService) DiscardTempTables(context.Context, *query.Target, *query.ExecuteOptions) (*sqltypes.Result, *query.ReservedState, error) {
+	return nil, nil, nil
+}
+
+func (m *mockCopyQueryService) ReleaseReservedConnection(context.Context, *query.Target, *query.ExecuteOptions) error {
+	return nil
+}
+
+func TestCopyBidiExecuteToStdout_Success(t *testing.T) {
+	stream := &mockCopyBidiStream{}
+	svc := &poolerService{}
+
+	exec := &mockCopyQueryService{
+		copyOutReadyFn: func(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+			return 1, []int16{0, 1}, []*mterrors.PgDiagnostic{
+				{MessageType: 'N', Severity: "NOTICE", Message: "init-notice"},
+			}, &query.ReservedState{ReservedConnectionId: 42}, nil
+		},
+		copyOutStreamFn: func(_ context.Context, _ *query.Target, _ *query.ExecuteOptions, onMessage func(client.CopyOutMessage) error) (*sqltypes.Result, *query.ReservedState, error) {
+			if err := onMessage(client.CopyOutMessage{Notice: &mterrors.PgDiagnostic{MessageType: 'N', Severity: "NOTICE", Message: "mid-notice"}}); err != nil {
+				return nil, nil, err
+			}
+			if err := onMessage(client.CopyOutMessage{Data: []byte("row")}); err != nil {
+				return nil, nil, err
+			}
+			return &sqltypes.Result{
+				CommandTag: "COPY 1",
+				Notices: []*mterrors.PgDiagnostic{
+					{MessageType: 'N', Severity: "NOTICE", Message: "final-notice"},
+				},
+			}, &query.ReservedState{ReservedConnectionId: 42}, nil
+		},
+	}
+
+	req := &multipoolerpb.CopyBidiExecuteRequest{
+		Target:  &query.Target{TableGroup: "tg"},
+		Query:   "COPY t TO STDOUT",
+		Options: &query.ExecuteOptions{User: "postgres"},
+	}
+
+	err := svc.copyBidiExecuteToStdout(context.Background(), stream, exec, req)
+	require.NoError(t, err)
+	require.Len(t, stream.sent, 4)
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_READY, stream.sent[0].GetPhase())
+	require.Equal(t, int32(1), stream.sent[0].GetFormat())
+	require.Len(t, stream.sent[0].GetNotices(), 1)
+	require.Equal(t, "init-notice", stream.sent[0].GetNotices()[0].GetMessage())
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_DATA, stream.sent[1].GetPhase())
+	require.Equal(t, "mid-notice", stream.sent[1].GetNotices()[0].GetMessage())
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_DATA, stream.sent[2].GetPhase())
+	require.Equal(t, []byte("row"), stream.sent[2].GetData())
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_RESULT, stream.sent[3].GetPhase())
+	require.Equal(t, "COPY 1", stream.sent[3].GetResult().GetCommandTag())
+	require.Len(t, stream.sent[3].GetNotices(), 1)
+	require.Equal(t, "final-notice", stream.sent[3].GetNotices()[0].GetMessage())
+}
+
+func TestCopyBidiExecuteToStdout_ReadySendFailureCallsCopyAbort(t *testing.T) {
+	stream := &mockCopyBidiStream{sendErrAtCall: 1}
+	svc := &poolerService{}
+	abortCalled := false
+
+	exec := &mockCopyQueryService{
+		copyOutReadyFn: func(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+			return 0, []int16{0}, nil, &query.ReservedState{ReservedConnectionId: 55}, nil
+		},
+		copyAbortFn: func(_ context.Context, _ *query.Target, _ string, options *query.ExecuteOptions) (*query.ReservedState, error) {
+			abortCalled = true
+			require.Equal(t, uint64(55), options.GetReservedConnectionId())
+			return nil, nil
+		},
+	}
+
+	req := &multipoolerpb.CopyBidiExecuteRequest{
+		Target:  &query.Target{TableGroup: "tg"},
+		Query:   "COPY t TO STDOUT",
+		Options: &query.ExecuteOptions{User: "postgres"},
+	}
+
+	err := svc.copyBidiExecuteToStdout(context.Background(), stream, exec, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
+	require.True(t, abortCalled, "CopyAbort should run when sending READY fails")
+}
+
+func TestCopyBidiExecuteToStdout_StreamErrorSendsErrorPhase(t *testing.T) {
+	stream := &mockCopyBidiStream{}
+	svc := &poolerService{}
+
+	exec := &mockCopyQueryService{
+		copyOutReadyFn: func(context.Context, *query.Target, string, *query.ExecuteOptions, *query.ReservationOptions) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
+			return 0, []int16{0}, nil, &query.ReservedState{ReservedConnectionId: 91}, nil
+		},
+		copyOutStreamFn: func(context.Context, *query.Target, *query.ExecuteOptions, func(client.CopyOutMessage) error) (*sqltypes.Result, *query.ReservedState, error) {
+			return nil, &query.ReservedState{ReservedConnectionId: 91}, errors.New("copy stream failed")
+		},
+	}
+
+	req := &multipoolerpb.CopyBidiExecuteRequest{
+		Target:  &query.Target{TableGroup: "tg"},
+		Query:   "COPY t TO STDOUT",
+		Options: &query.ExecuteOptions{User: "postgres"},
+	}
+
+	err := svc.copyBidiExecuteToStdout(context.Background(), stream, exec, req)
+	require.Error(t, err)
+	require.Len(t, stream.sent, 2)
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_READY, stream.sent[0].GetPhase())
+	require.Equal(t, multipoolerpb.CopyBidiExecuteResponse_ERROR, stream.sent[1].GetPhase())
+	require.Contains(t, stream.sent[1].GetError(), "copy stream failed")
 }

--- a/go/services/multipooler/pools/regular/regular_conn.go
+++ b/go/services/multipooler/pools/regular/regular_conn.go
@@ -630,9 +630,17 @@ func execWithContextCancel[T any](c *Conn, ctx context.Context, op func() (T, er
 // --- COPY FROM STDIN operations ---
 
 // InitiateCopyFromStdin sends a COPY FROM STDIN command and reads the CopyInResponse.
-// Returns the COPY format and column formats.
-func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, err error) {
+// Returns the COPY format, column formats, and any NoticeResponse diagnostics
+// received before the CopyInResponse.
+func (c *Conn) InitiateCopyFromStdin(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, err error) {
 	return c.conn.InitiateCopyFromStdin(ctx, copyQuery)
+}
+
+// InitiateCopyToStdout sends a COPY TO STDOUT command and reads the CopyOutResponse.
+// Returns the COPY format, column formats, and any NoticeResponse diagnostics
+// received before the CopyOutResponse.
+func (c *Conn) InitiateCopyToStdout(ctx context.Context, copyQuery string) (format int16, columnFormats []int16, notices []*mterrors.PgDiagnostic, err error) {
+	return c.conn.InitiateCopyToStdout(ctx, copyQuery)
 }
 
 // WriteCopyData writes a CopyData message to PostgreSQL.
@@ -646,14 +654,28 @@ func (c *Conn) WriteCopyDone() error {
 }
 
 // ReadCopyDoneResponse reads the CommandComplete and ReadyForQuery after CopyDone.
-// Returns the command tag and rows affected.
-func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, error) {
+// Returns the command tag, rows affected, and any NoticeResponse diagnostics
+// received between CopyDone and ReadyForQuery (e.g. trigger output).
+func (c *Conn) ReadCopyDoneResponse(ctx context.Context) (string, uint64, []*mterrors.PgDiagnostic, error) {
 	return c.conn.ReadCopyDoneResponse(ctx)
+}
+
+// ReadCopyOutMessage reads the next message in a COPY TO STDOUT response
+// stream: a CopyData chunk, a NoticeResponse diagnostic, or CopyDone.
+func (c *Conn) ReadCopyOutMessage(ctx context.Context) (client.CopyOutMessage, error) {
+	return c.conn.ReadCopyOutMessage(ctx)
+}
+
+// FinishCopyToStdout consumes the trailing CommandComplete + ReadyForQuery
+// that PG sends after CopyDone in a COPY TO STDOUT flow.
+func (c *Conn) FinishCopyToStdout(ctx context.Context) (string, uint64, []*mterrors.PgDiagnostic, error) {
+	return c.conn.FinishCopyToStdout(ctx)
 }
 
 // ReadCopyFailResponse reads the expected ErrorResponse + ReadyForQuery
 // sequence after sending CopyFail, leaving the connection in a clean state.
-func (c *Conn) ReadCopyFailResponse(ctx context.Context) error {
+// Returns any NoticeResponse diagnostics seen before the trailing RFQ.
+func (c *Conn) ReadCopyFailResponse(ctx context.Context) ([]*mterrors.PgDiagnostic, error) {
 	return c.conn.ReadCopyFailResponse(ctx)
 }
 

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/merge.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/merge.patch
@@ -91,23 +91,3 @@
  -- source and target names the same
  MERGE INTO target
  USING target
-@@ -155,7 +137,7 @@
- MERGE INTO target USING source ON (true)
- WHEN MATCHED THEN DELETE
- ) TO stdout;
--ERROR: COPY query must have a RETURNING clause
-+ERROR: COPY TO STDOUT not yet supported
- -- unsupported relation types
- -- materialized view
- CREATE MATERIALIZED VIEW mv AS SELECT * FROM target;
-@@ -1520,9 +1502,7 @@
- DELETE
- RETURNING merge_action(), t.*
- ) TO stdout;
--DELETE 1 100
--UPDATE 2 220
--INSERT 4 40
-+ERROR: COPY TO STDOUT not yet supported
- ROLLBACK;
- -- SQL function with MERGE ... RETURNING
- BEGIN;

--- a/go/test/endtoend/queryserving/copy_test.go
+++ b/go/test/endtoend/queryserving/copy_test.go
@@ -15,6 +15,7 @@
 package queryserving
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -277,13 +278,24 @@ func TestMultiGateway_CopyCommands(t *testing.T) {
 				tableName := "copy_unsupported"
 				createCopyTestTable(t, conn, ctx, tableName, "id INT, name TEXT")
 
-				t.Run("COPY TO STDOUT fails", func(t *testing.T) {
-					if target.Name != "multigateway" {
-						t.Skip("COPY TO STDOUT rejection is multigateway-specific")
+				t.Run("COPY TO STDOUT streams rows", func(t *testing.T) {
+					// COPY TO STDOUT is now implemented in multigateway (CopyOutReady /
+					// CopyOutStream). Seed the table and assert the streamed text
+					// representation comes back row-for-row.
+					seed := [][]any{{1, "Alice"}, {2, "Bob"}, {3, "Carol"}}
+					executeCopyAndVerify(t, conn, ctx, tableName, []string{"id", "name"}, seed)
+
+					var buf bytes.Buffer
+					_, err := conn.PgConn().CopyTo(ctx, &buf, fmt.Sprintf("COPY %s TO STDOUT", tableName))
+					require.NoError(t, err, "COPY TO STDOUT should succeed")
+
+					// Default text format: one row per line, tab-separated columns.
+					gotLines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+					require.Len(t, gotLines, len(seed), "should stream one line per row")
+					for i, row := range seed {
+						want := fmt.Sprintf("%d\t%s", row[0], row[1])
+						assert.Equal(t, want, gotLines[i], "row %d mismatch", i)
 					}
-					_, err := conn.Exec(ctx, fmt.Sprintf("COPY %s TO STDOUT", tableName))
-					require.Error(t, err, "COPY TO STDOUT should fail")
-					assert.Contains(t, err.Error(), "not yet supported", "should mention not supported")
 				})
 
 				t.Run("COPY FROM file pass-through", func(t *testing.T) {

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -256,8 +256,18 @@ message CopyBidiExecuteRequest {
     FAIL = 3;      // Abort operation
   }
 
+  // Direction indicates whether the COPY operation streams data into the
+  // server (FROM STDIN) or out from the server (TO STDOUT). Set on INITIATE.
+  enum Direction {
+    FROM_STDIN = 0; // Default for back-compat: clients without this field set get FROM STDIN.
+    TO_STDOUT = 1;
+  }
+
   // phase indicates the current phase
   Phase phase = 1;
+
+  // direction indicates COPY ... FROM STDIN vs COPY ... TO STDOUT (INITIATE only).
+  Direction direction = 9;
 
   // query is the SQL command to execute (only for INITIATE phase)
   string query = 2;
@@ -319,6 +329,24 @@ message CopyBidiExecuteResponse {
 
   // error contains the error message (for ERROR phase)
   string error = 7;
+
+  // notices carries PostgreSQL NoticeResponse/InfoResponse diagnostics
+  // collected during this phase. Trigger RAISE NOTICE output, INFO progress
+  // messages, and other backend notices appear here so the gateway can
+  // forward them to the client as NoticeResponse frames between CopyData and
+  // CommandComplete. Populated on READY (notices seen before CopyInResponse /
+  // CopyOutResponse), DATA (notices interleaved with CopyData on COPY TO
+  // STDOUT), and RESULT (notices read between CopyDone and CommandComplete).
+  repeated query.PgDiagnostic notices = 11;
+
+  // error_diagnostic carries the structured PostgreSQL ErrorResponse for
+  // ERROR phase responses. When the error originates from PG (e.g.
+  // constraint violation, "column does not exist"), this preserves SQLSTATE,
+  // severity, DETAIL, HINT, position, etc., so the gateway can re-emit a
+  // verbatim ErrorResponse instead of a wrapped Go-formatted string.
+  // The `error` field above remains populated as a fallback for callers /
+  // log paths that only need the message text.
+  query.PgDiagnostic error_diagnostic = 12;
 }
 
 // ReservationReason indicates why a connection needs to be reserved.


### PR DESCRIPTION
## Summary

Three coupled fixes that unblock five failing pgregress tests (`copy`, `copyselect`, `copydml`, `insert`, `generated`) and clean up COPY error reporting end-to-end.

### 1. COPY ... TO STDOUT streaming

- `planCopyStmt` now plans `CopyStatement` for the TO STDOUT direction (previously rejected with `PgSSFeatureNotSupported`).
- New pgprotocol/client helpers: `InitiateCopyToStdout`, `ReadCopyOutMessage`, `FinishCopyToStdout` — read `CopyOutResponse` + interleaved `CopyData` / `NoticeResponse` + trailing `CommandComplete` / `ReadyForQuery`.
- New pgprotocol/server helpers: `WriteCopyOutResponse`, `WriteCopyData`, `WriteCopyDone`.
- Multipooler executor: `CopyOutReady` reserves a backend conn (reusing existing reservations / deferred BEGIN like `CopyReady` FROM STDIN); `CopyOutStream` pumps each PG frame back via callback.
- `CopyBidiExecuteRequest` grows a `Direction` field; the multipooler bidi handler routes `TO_STDOUT` requests through `copyBidiExecuteToStdout` while `FROM_STDIN` keeps the existing flow.
- Multigateway `grpcQueryService` / `PoolerGateway` / `ScatterConn` / `IExecute` all gain `CopyOutReady` + `CopyOutStream` symmetric with the FROM STDIN plumbing. `CopyStatement.streamCopyOut` writes `CopyOutResponse` → forwards each pumped chunk as `CopyData` → writes `CopyDone` → hands the final Result to the per-statement callback (which writes `CommandComplete`).

### 2. NoticeResponse forwarding during COPY

Previously dropped by `ReadCopyDoneResponse` / `ReadCopyFailResponse` (`// Ignore notices`). Now:

- Capture `NoticeResponse` diagnostics that PG emits between `CopyDone` and `ReadyForQuery` (trigger `RAISE NOTICE`, COPY progress reporting, etc.) and return them alongside the command tag.
- `InitiateCopyFromStdin` / `InitiateCopyToStdout` also capture pre-response notices.
- `executor.CopyFinalize` stores the captured slice on `sqltypes.Result.Notices`; the multipooler grpc service serializes them onto `CopyBidiExecuteResponse.notices`; the gateway decodes them back and the existing per-result Conn writer emits `NoticeResponse` frames to the client in order before `CommandComplete`.

### 3. Un-wrapped PG errors from the COPY path

`CopyBidiExecuteResponse` grows an `error_diagnostic` field. The multipooler attaches the full `PgDiagnostic` (severity/SQLSTATE/DETAIL/HINT/position) for every ERROR phase; the gateway's `copyErrorFromResp` prefers it over the legacy text-only `error` field. PG `ErrorResponse` text now round-trips verbatim.

Error wraps that previously produced

```
ERROR: failed to initiate COPY: failed to initiate COPY: COPY initiation failed:
       failed to initiate COPY FROM STDIN: ERROR: column "xyz" of relation "x" does not exist
```

are gone; the underlying `PgError` is returned as-is to the client.

## Stack

Standalone fix branched off `upstream/main`.

## Test plan

- [x] `go test ./...` (multigateway / multipooler / pgprotocol packages all green; new unit tests cover notice capture + un-wrapped error path).
- [x] Full pgregress run in verify mode against upstream/main baseline:
  - **4 fewer failures** than baseline (`copy`, `copydml`, `insert`, `generated`).
  - **No new regressions.**
  - `merge.patch` updated to drop now-stale "COPY TO STDOUT not yet supported" hunks; `merge` continues to pass.
  - Residual `copyselect` / `insert_conflict` failures left for follow-up (parser syntax-error format + `MultiAssignRef` deparser — separate issues, not in scope).