### PR TITLE
fix(multipooler): surface bufio.Scanner errors in safeCombinedOutput

### DIFF
--- a/go/services/multipooler/manager/rpc_backup.go
+++ b/go/services/multipooler/manager/rpc_backup.go
@@ -713,12 +713,22 @@ func safeCombinedOutput(cmd *executil.Cmd) (string, error) {
 	stdoutDone := make(chan struct{})
 	stderrDone := make(chan struct{})
 
+	// scanErr captures a scanner error (e.g. bufio.ErrTooLong for lines
+	// exceeding the default 64 KiB buffer) so silent truncation surfaces
+	// to the caller instead of looking like clean EOF. Writes happen
+	// before the corresponding Done channel closes; the close()-then-
+	// channel-receive ordering through stdoutDone/stderrDone → lines →
+	// the consumer loop establishes the happens-before edge that lets
+	// the caller read these without a separate lock.
+	var stdoutScanErr, stderrScanErr error
+
 	go func() {
 		defer close(stdoutDone)
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
 			lines <- scanner.Text() + "\n"
 		}
+		stdoutScanErr = scanner.Err()
 	}()
 
 	go func() {
@@ -727,6 +737,7 @@ func safeCombinedOutput(cmd *executil.Cmd) (string, error) {
 		for scanner.Scan() {
 			lines <- scanner.Text() + "\n"
 		}
+		stderrScanErr = scanner.Err()
 	}()
 
 	go func() {
@@ -740,7 +751,20 @@ func safeCombinedOutput(cmd *executil.Cmd) (string, error) {
 		combinedBuf.WriteString(line)
 	}
 
-	return combinedBuf.String(), cmd.Wait()
+	// cmd.Wait's exit code is the operational signal, so it takes
+	// precedence. If the process exited cleanly but a scanner failed
+	// (e.g. ErrTooLong), surface that so a silently-truncated output
+	// doesn't look successful.
+	if waitErr := cmd.Wait(); waitErr != nil {
+		return combinedBuf.String(), waitErr
+	}
+	if stdoutScanErr != nil {
+		return combinedBuf.String(), fmt.Errorf("stdout scan: %w", stdoutScanErr)
+	}
+	if stderrScanErr != nil {
+		return combinedBuf.String(), fmt.Errorf("stderr scan: %w", stderrScanErr)
+	}
+	return combinedBuf.String(), nil
 }
 
 // findBackupByJobID finds a backup by matching the job_id annotation

--- a/go/services/multipooler/manager/rpc_backup_test.go
+++ b/go/services/multipooler/manager/rpc_backup_test.go
@@ -15,7 +15,9 @@
 package manager
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -622,6 +624,25 @@ func TestSafeCombinedOutput_LongLines(t *testing.T) {
 			assert.Greater(t, len(line), 4000, "Each line should be at least 4KB")
 		}
 	})
+}
+
+// TestSafeCombinedOutput_LineExceedsScannerLimit verifies that a line
+// longer than bufio.Scanner's default buffer (64 KiB) does not silently
+// truncate the output: safeCombinedOutput surfaces the underlying
+// bufio.ErrTooLong as a wrapped error instead of returning a clean nil.
+// Without the scanner.Err() check inside the reader goroutine, this case
+// previously looked like a successful command with truncated output.
+func TestSafeCombinedOutput_LineExceedsScannerLimit(t *testing.T) {
+	// printf with no newline emits a single token larger than the
+	// default 64 KiB scanner buffer.
+	overlong := strings.Repeat("a", bufio.MaxScanTokenSize+1024)
+	script := "printf %s '" + overlong + "'"
+	cmd := executil.Command(t.Context(), "bash", "-c", script)
+
+	_, err := safeCombinedOutput(cmd)
+	require.Error(t, err, "scanner error on overlong line must be surfaced")
+	assert.True(t, errors.Is(err, bufio.ErrTooLong),
+		"expected wrapped bufio.ErrTooLong, got %v", err)
 }
 
 func TestSafeCombinedOutput_RapidOutput(t *testing.T) {


### PR DESCRIPTION
Both reader goroutines in safeCombinedOutput drove `bufio.Scanner.Scan` to completion and dropped `Scanner.Err()` on the floor. That made silent truncation indistinguishable from a clean EOF — a line longer than the default 64 KiB buffer (or any other Scan-side I/O failure) would stop the read mid-stream, the goroutine would exit, the `lines` channel would close on schedule, and the caller would receive whatever had been read so far paired with a nil error from cmd.Wait when the process itself succeeded.

Capture the scanner error in a function-level variable inside each goroutine before the deferred close of the corresponding Done channel. The existing close(stdoutDone)/close(stderrDone) → close(lines) → consumer-loop-exits chain establishes the happens-before edge that lets the caller read the captured errors after the loop terminates. cmd.Wait's exit code takes precedence (it's the operational signal); a scanner error is surfaced only when the process otherwise exited cleanly.

Test: TestSafeCombinedOutput_LineExceedsScannerLimit emits a single token of bufio.MaxScanTokenSize+1024 bytes and asserts the returned error wraps bufio.ErrTooLong.