### PR TITLE
ci(coverage): only upload coverage on successful runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -216,13 +216,11 @@ jobs:
           path: coverage-merged.txt
           retention-days: 7
       - name: Upload coverage to Codecov
-        if: success() || failure()
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-merged.txt
       - name: Upload coverage to Coveralls
-        if: success() || failure()
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           file: ./coverage-merged.txt
@@ -233,7 +231,6 @@ jobs:
     name: Finish Coveralls upload
     runs-on: ubuntu-24.04
     needs: [coverage-direct, coverage-subprocess, merge-and-upload]
-    if: always()
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Coverage was previously uploaded even when the coverage jobs failed, which could surface misleading partial numbers in Codecov and Coveralls. Test reliability has improved enough that gating uploads on success is the better default. Also drops the now-redundant `if: always()` on coveralls-finish so it no longer finalizes builds that were never uploaded.