### PR TITLE
feat(release): add GoReleaser release workflow

### DIFF
--- a/.github/workflows/docker-build-multiadmin-web.yml
+++ b/.github/workflows/docker-build-multiadmin-web.yml
@@ -15,11 +15,10 @@
 name: Docker Build and Publish (multiadmin-web)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - "v*"
     paths:
       - "web/multiadmin/Dockerfile"
       - "web/multiadmin/**"

--- a/.github/workflows/docker-build-pgctld.yml
+++ b/.github/workflows/docker-build-pgctld.yml
@@ -15,11 +15,10 @@
 name: Docker Build and Publish (pgctld)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - "v*"
     paths:
       - "Dockerfile.pgctld"
       - "go/**"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,11 +15,10 @@
 name: Docker Build and Publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - "v*"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,183 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  verify-tag:
+    name: Verify Tag
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release tag
+        env:
+          TAG_NAME: ${{ github.event_name == 'push' && github.ref_name || 'v0.0.0' }}
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag '$TAG_NAME' must look like vX.Y.Z or vX.Y.Z-rc.1"
+            exit 1
+          fi
+
+      - name: Verify tag is on main
+        if: github.event_name == 'push'
+        run: |
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on main."
+            exit 1
+          fi
+
+  test-go:
+    name: Test Go
+    needs: verify-tag
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: make build
+
+      - name: Run short tests
+        run: go test -short -timeout=20m ./...
+
+  build-release-images:
+    name: Build Release Images
+    needs: test-go
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: multigres
+            context: .
+            file: ./Dockerfile
+          - image: pgctld
+            context: .
+            file: ./Dockerfile.pgctld
+          - image: multiadmin-web
+            context: web/multiadmin/
+            file: web/multiadmin/Dockerfile
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set release image tags
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_TAG=snapshot-${{ github.sha }}" >> "$GITHUB_ENV"
+            echo "PUSH_IMAGE=false" >> "$GITHUB_ENV"
+          fi
+          echo "IMAGE_REF=ghcr.io/${{ github.repository_owner }}/${IMAGE}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build release image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: ${{ env.PUSH_IMAGE }}
+          tags: ${{ env.IMAGE_REF }}:${{ env.RELEASE_TAG }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.RELEASE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Verify published image
+        if: github.event_name == 'push'
+        run: docker buildx imagetools inspect "${IMAGE_REF}:${RELEASE_TAG}"
+
+  goreleaser:
+    name: Publish GitHub Release
+    needs: build-release-images
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          version: v2.16.0
+          args: check
+
+      - name: Run GoReleaser dry run
+        if: github.event_name == 'workflow_dispatch'
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          version: v2.16.0
+          args: release --snapshot --clean --skip=publish
+
+      - name: Run GoReleaser release
+        if: github.event_name == 'push'
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          version: v2.16.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   verify-tag:
@@ -47,9 +46,12 @@ jobs:
 
       - name: Verify tag is on main
         if: github.event_name == 'push'
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
-            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on main."
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag $TAG_NAME does not point to a commit on main."
             exit 1
           fi
 
@@ -68,6 +70,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build
         run: make build
@@ -79,6 +82,9 @@ jobs:
     name: Build Release Images
     needs: test-go
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
 
     strategy:
       fail-fast: false
@@ -102,16 +108,20 @@ jobs:
 
       - name: Set release image tags
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA: ${{ github.sha }}
           IMAGE: ${{ matrix.image }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            echo "RELEASE_TAG=$TAG_NAME" >> "$GITHUB_ENV"
             echo "PUSH_IMAGE=true" >> "$GITHUB_ENV"
           else
-            echo "RELEASE_TAG=snapshot-${{ github.sha }}" >> "$GITHUB_ENV"
+            echo "RELEASE_TAG=snapshot-$GITHUB_SHA" >> "$GITHUB_ENV"
             echo "PUSH_IMAGE=false" >> "$GITHUB_ENV"
           fi
-          echo "IMAGE_REF=ghcr.io/${{ github.repository_owner }}/${IMAGE}" >> "$GITHUB_ENV"
+          echo "IMAGE_REF=ghcr.io/${REPOSITORY_OWNER}/${IMAGE}" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -147,6 +157,8 @@ jobs:
     name: Publish GitHub Release
     needs: build-release-images
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
       - name: Check out code
@@ -159,6 +171,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+version: 2
+
+builds:
+  - skip: true
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: "🚀 Features"
+      regexp: '^feat(\(.+\))?:'
+    - title: "🐛 Bug Fixes"
+      regexp: '^fix(\(.+\))?:'
+    - title: "⚡ Performance"
+      regexp: '^perf(\(.+\))?:'
+    - title: "♻️ Refactoring"
+      regexp: '^refactor(\(.+\))?:'
+    - title: "📚 Documentation"
+      regexp: '^docs(\(.+\))?:'
+    - title: "🔧 Other"
+      order: 999
+  filters:
+    exclude:
+      - '^test(\(.+\))?:'
+      - '^chore(\(.+\))?:'
+      - '^ci(\(.+\))?:'
+      - '^build(\(.+\))?:'
+
+release:
+  github:
+    owner: multigres
+    name: multigres
+  prerelease: auto
+  footer: |
+    ---
+
+    Container images for this release:
+
+    - `ghcr.io/multigres/multigres:{{ .Tag }}`
+    - `ghcr.io/multigres/pgctld:{{ .Tag }}`
+    - `ghcr.io/multigres/multiadmin-web:{{ .Tag }}`
+
+    Source archives are available on this GitHub release.


### PR DESCRIPTION
## Description

This PR adds the first GoReleaser-based release path for Multigres core, giving tagged OSS releases a repeatable publish flow with tag validation, release notes generation, GitHub Release creation, and versioned GHCR image publishing handled from a single release workflow.

## Main Changes

- Adds `.goreleaser.yaml` to generate categorised release notes and create GitHub Releases for Multigres tags.
- Adds `.github/workflows/release.yml` to validate semver tags, verify tags are cut from `main`, run the short test suite, build release images, verify published image manifests, and run GoReleaser.
- Publishes versioned GHCR images for `multigres`, `pgctld`, and `multiadmin-web` as part of the release flow.
- Updates the standalone Docker workflows so release tag image publishing is centralised in the release workflow, while keeping manual image builds available for maintainers.