### PR TITLE
fix(multipooler): retry pool ops on transient close instead of generation bump

### DIFF
--- a/go/services/multipooler/connpoolmanager/config.go
+++ b/go/services/multipooler/connpoolmanager/config.go
@@ -606,6 +606,6 @@ func (c *Config) NewManager(logger *slog.Logger) *Manager {
 		logger:  logger,
 		metrics: metrics,
 	}
-	mgr.closed.Store(true) // Manager is closed until Open() is called
+	mgr.lifecycle.Store(uint32(managerLifecycleClosed)) // Manager is closed until Open() is called
 	return mgr
 }

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -79,15 +79,10 @@ type Manager struct {
 	// This mutex is only acquired when a new user pool needs to be created.
 	createMu sync.Mutex
 
-	// closed indicates whether the manager has been closed.
+	// closed indicates whether the manager has been closed. withReopenRetry
+	// reads this on ErrPoolClosed to distinguish a transient pool swap
+	// (reopen/eviction) from a genuine terminal shutdown.
 	closed atomic.Bool
-
-	// generation is incremented on every Open(). Callers that get
-	// ErrPoolClosed from an in-flight pool operation can compare the
-	// pre-call generation against the current one: if it advanced, a
-	// reopen swapped the pools underneath them and the call is safe to
-	// retry against the fresh snapshot.
-	generation atomic.Uint64
 
 	// Rebalancer goroutine management
 	rebalancerCtx    context.Context
@@ -137,7 +132,6 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.zeroCh = zeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
 	m.closed.Store(false)
-	m.generation.Add(1)
 
 	// Build admin client config. pwSourceNone signals that ResolvePgPassword
 	// was never called — production startup in services/multipooler/init.go
@@ -551,10 +545,17 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 // withReopenRetry runs op against the current user pool with two single-shot
 // retry paths for transient, self-healable failures:
 //
-//  1. ErrPoolClosed after a generation bump: reopenConnections() swapped the
-//     pools mid-flight (PostgreSQL auto-restart recovery). Retry against the
-//     fresh pool. A closed-pool error with no generation bump means the
-//     manager is genuinely shutting down — surface it unchanged.
+//  1. ErrPoolClosed while the manager is still operational: either
+//     reopenConnections() swapped the pools mid-flight (PostgreSQL auto-restart
+//     recovery) or evictUserPool() replaced a stale-credentials pool. Either
+//     way the manager itself has not shut down, so getOrCreateUserPool will
+//     return the freshly installed (or freshly created) pool on retry.
+//     We use m.closed instead of comparing a per-Open generation counter
+//     because reopenConnections does Close→Open under pm.mu, and Open()
+//     bumps its generation only after clearing the snapshot. A query whose
+//     op() resolves to ErrPoolClosed in the Close-but-not-yet-Open window
+//     would otherwise observe an unchanged generation and surface the
+//     transient error to the client.
 //
 //  2. Class-28 SQLSTATE from PostgreSQL: the cached user pool's ClientConfig
 //     carries stale SCRAM keys (password rotated in pg_authid). Evict the
@@ -571,7 +572,6 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 // keys.
 func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
-	startGen := m.generation.Load()
 	pool, err := m.getOrCreateUserPool(user, clientKey, serverKey)
 	if err != nil {
 		return zero, err
@@ -581,9 +581,11 @@ func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte
 		return result, nil
 	}
 
-	// Manager-restart race: reopenConnections swapped pools mid-flight.
+	// Pool was closed mid-flight (reopen swap or stale-credentials eviction).
+	// Retry against the current snapshot unless the manager itself is shutting
+	// down — in which case getOrCreateUserPool returns "manager is closed".
 	if errors.Is(err, connpool.ErrPoolClosed) {
-		if m.generation.Load() == startGen {
+		if m.closed.Load() {
 			return zero, err
 		}
 		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -37,6 +37,18 @@ const (
 	// initialUserPoolCapacity is the initial capacity for new user pools.
 	// The rebalancer will adjust this based on demand.
 	initialUserPoolCapacity int64 = 10
+
+	// maxPoolClosedRetries bounds retries for transient ErrPoolClosed failures.
+	// This protects callers from unbounded loops during repeated reopen/evict races.
+	maxPoolClosedRetries = 4
+)
+
+type managerLifecycleState uint32
+
+const (
+	managerLifecycleRunning managerLifecycleState = iota
+	managerLifecycleReopening
+	managerLifecycleClosed
 )
 
 // Manager orchestrates per-user connection pools with a shared admin pool.
@@ -79,10 +91,18 @@ type Manager struct {
 	// This mutex is only acquired when a new user pool needs to be created.
 	createMu sync.Mutex
 
-	// closed indicates whether the manager has been closed. withReopenRetry
-	// reads this on ErrPoolClosed to distinguish a transient pool swap
-	// (reopen/eviction) from a genuine terminal shutdown.
-	closed atomic.Bool
+	// lifecycle captures manager shutdown/reopen state for retry decisions:
+	// running, reopening, or closed.
+	lifecycle atomic.Uint32
+
+	// Reopen signaling for withReopenRetry.
+	//
+	// BeginReopen/EndReopen bracket MultiPoolerManager.reopenConnections'
+	// Close->Open sequence. withReopenRetry waits on reopenDone when lifecycle
+	// is reopening so callers do not leak transient ErrPoolClosed from the
+	// close/open window.
+	reopenMu   sync.Mutex
+	reopenDone chan struct{}
 
 	// Rebalancer goroutine management
 	rebalancerCtx    context.Context
@@ -131,7 +151,9 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	close(zeroCh)
 	m.zeroCh = zeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
-	m.closed.Store(false)
+	if m.lifecycleState() != managerLifecycleReopening {
+		m.lifecycle.Store(uint32(managerLifecycleRunning))
+	}
 
 	// Build admin client config. pwSourceNone signals that ResolvePgPassword
 	// was never called — production startup in services/multipooler/init.go
@@ -275,7 +297,7 @@ func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) 
 	}
 
 	// Check if closed before attempting to create
-	if m.closed.Load() {
+	if m.isClosedLifecycle() {
 		return nil, errors.New("manager is closed")
 	}
 
@@ -300,7 +322,7 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 	}
 
 	// Check if closed (with lock held)
-	if m.closed.Load() {
+	if m.isClosedLifecycle() {
 		return nil, errors.New("manager is closed")
 	}
 
@@ -376,10 +398,14 @@ func (m *Manager) Close() {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
 
-	if m.closed.Load() {
+	state := m.lifecycleState()
+	if state == managerLifecycleClosed {
 		return
 	}
-	m.closed.Store(true)
+	// Reopen intentionally runs Close->Open while lifecycle stays in reopening.
+	if state != managerLifecycleReopening {
+		m.lifecycle.Store(uint32(managerLifecycleClosed))
+	}
 
 	// Stop the rebalancer goroutine first
 	if m.rebalancerCancel != nil {
@@ -461,7 +487,7 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 // pool regardless of the keys they pass. The caller must call Recycle() on
 // the returned connection to return it to the pool.
 func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConn(ctx)
 	})
 }
@@ -471,7 +497,7 @@ func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, se
 // for consistent bucket assignment.
 func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConnWithSettings(ctx, s)
 	})
 }
@@ -487,7 +513,7 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // connection.
 func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewReservedConn(ctx, s, opts...)
 	})
 }
@@ -497,7 +523,7 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 // ReasonLogicalReplication, on the specified user's reserved pool. SCRAM
 // passthrough key semantics match NewReservedConn.
 func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewLogicalReplicationConn(ctx)
 	})
 }
@@ -542,20 +568,18 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 	return true
 }
 
-// withReopenRetry runs op against the current user pool with two single-shot
-// retry paths for transient, self-healable failures:
+// withReopenRetry runs op against the current user pool with bounded retries for
+// transient, self-healable failures:
 //
 //  1. ErrPoolClosed while the manager is still operational: either
 //     reopenConnections() swapped the pools mid-flight (PostgreSQL auto-restart
 //     recovery) or evictUserPool() replaced a stale-credentials pool. Either
 //     way the manager itself has not shut down, so getOrCreateUserPool will
 //     return the freshly installed (or freshly created) pool on retry.
-//     We use m.closed instead of comparing a per-Open generation counter
-//     because reopenConnections does Close→Open under pm.mu, and Open()
-//     bumps its generation only after clearing the snapshot. A query whose
-//     op() resolves to ErrPoolClosed in the Close-but-not-yet-Open window
-//     would otherwise observe an unchanged generation and surface the
-//     transient error to the client.
+//
+//     During reopenConnections' Close->Open window, lifecycle is "reopening".
+//     On that path we wait for EndReopen (or ctx cancellation), then retry.
+//     This retry path is bounded by maxPoolClosedRetries to avoid unbounded loops.
 //
 //  2. Class-28 SQLSTATE from PostgreSQL: the cached user pool's ClientConfig
 //     carries stale SCRAM keys (password rotated in pg_authid). Evict the
@@ -564,51 +588,69 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 //     SCRAM handshake at MultiGateway against whatever verifier pg_authid
 //     holds right now. If the retry also auth-fails (retrier itself used the
 //     old password at the gateway), we surface the clean 28xxx error and the
-//     client reconnects to re-derive keys against the new verifier.
+//     client reconnects to re-derive keys against the new verifier. This path
+//     performs at most one eviction+retry.
 //
 // clientKey and serverKey forward the SCRAM passthrough material to
 // getOrCreateUserPool so that a first-time pool creation triggered during
 // this call (including after an eviction or reopen swap) gets the session's
 // keys.
-func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
+func withReopenRetry[T any](ctx context.Context, m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
-	pool, err := m.getOrCreateUserPool(user, clientKey, serverKey)
-	if err != nil {
-		return zero, err
-	}
-	result, err := op(pool)
-	if err == nil {
-		return result, nil
-	}
+	authRetried := false
 
-	// Pool was closed mid-flight (reopen swap or stale-credentials eviction).
-	// Retry against the current snapshot unless the manager itself is shutting
-	// down — in which case getOrCreateUserPool returns "manager is closed".
-	if errors.Is(err, connpool.ErrPoolClosed) {
-		if m.closed.Load() {
+	for closedRetries := 0; ; {
+		pool, err := m.getOrCreateUserPool(user, clientKey, serverKey)
+		if err != nil {
 			return zero, err
 		}
-		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
-		if err2 != nil {
-			return zero, err2
-		}
-		return op(pool2)
-	}
 
-	// Stale-key self-heal. evictUserPool is best-effort; even if it returns
-	// false (racing eviction), getOrCreateUserPool returns whatever is in the
-	// snapshot now, which is either a freshly-created pool with fresh keys
-	// or absent (and we create one).
-	if mterrors.IsAuthenticationError(err) {
-		m.evictUserPool(user, pool)
-		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
-		if err2 != nil {
-			return zero, err2
+		result, err := op(pool)
+		if err == nil {
+			return result, nil
 		}
-		return op(pool2)
-	}
 
-	return zero, err
+		// Pool was closed mid-flight (reopen swap or stale-credentials eviction).
+		// Retry against the current snapshot unless the manager is terminally closed.
+		if errors.Is(err, connpool.ErrPoolClosed) {
+			state := m.lifecycleState()
+			switch state {
+			case managerLifecycleClosed:
+				return zero, err
+			case managerLifecycleReopening:
+				wait := m.reopenWaitCh()
+				if wait == nil {
+					return zero, err
+				}
+				select {
+				case <-wait:
+				case <-ctx.Done():
+					return zero, ctx.Err()
+				}
+			}
+
+			closedRetries++
+			if closedRetries > maxPoolClosedRetries {
+				return zero, err
+			}
+			continue
+		}
+
+		// Stale-key self-heal. evictUserPool is best-effort; even if it returns
+		// false (racing eviction), getOrCreateUserPool returns whatever is in the
+		// snapshot now, which is either a freshly-created pool with fresh keys
+		// or absent (and we create one).
+		if mterrors.IsAuthenticationError(err) {
+			if authRetried {
+				return zero, err
+			}
+			authRetried = true
+			m.evictUserPool(user, pool)
+			continue
+		}
+
+		return zero, err
+	}
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.
@@ -733,9 +775,57 @@ func (m *Manager) CloseReservedConnections(ctx context.Context) int {
 	return total
 }
 
+func (m *Manager) lifecycleState() managerLifecycleState {
+	return managerLifecycleState(m.lifecycle.Load())
+}
+
+func (m *Manager) isClosedLifecycle() bool {
+	return m.lifecycleState() == managerLifecycleClosed
+}
+
+// BeginReopen marks a close->open manager refresh window as in progress.
+// Callers must pair this with EndReopen, usually via defer.
+func (m *Manager) BeginReopen() {
+	m.reopenMu.Lock()
+	defer m.reopenMu.Unlock()
+	if m.lifecycleState() == managerLifecycleReopening {
+		return
+	}
+	m.reopenDone = make(chan struct{})
+	m.lifecycle.Store(uint32(managerLifecycleReopening))
+}
+
+// EndReopen marks a close->open refresh window as complete and unblocks any
+// withReopenRetry callers that were waiting for reopen completion.
+func (m *Manager) EndReopen() {
+	m.reopenMu.Lock()
+	if m.lifecycleState() != managerLifecycleReopening {
+		m.reopenMu.Unlock()
+		return
+	}
+	done := m.reopenDone
+	m.reopenDone = nil
+	m.lifecycle.Store(uint32(managerLifecycleRunning))
+	m.reopenMu.Unlock()
+	if done != nil {
+		close(done)
+	}
+}
+
+// reopenWaitCh returns a completion channel iff a reopen window is in
+// progress. Otherwise it returns nil.
+func (m *Manager) reopenWaitCh() <-chan struct{} {
+	m.reopenMu.Lock()
+	defer m.reopenMu.Unlock()
+	if m.lifecycleState() != managerLifecycleReopening || m.reopenDone == nil {
+		return nil
+	}
+	return m.reopenDone
+}
+
 // IsClosed returns whether the manager has been closed.
 func (m *Manager) IsClosed() bool {
-	return m.closed.Load()
+	return m.isClosedLifecycle()
 }
 
 // UserPoolCount returns the number of user pools currently managed.

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -279,9 +280,8 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 // reopenConnections (triggered by MonitorPostgres after a postgres restart)
 // closes the user pool while a connection acquisition is already in-flight.
 // The helper must retry against the fresh snapshot rather than surfacing the
-// transient ErrPoolClosed to the caller. The retry is gated on m.closed
-// rather than a generation counter so it also catches the Close-but-not-yet
-// -Open window during reopenConnections.
+// transient ErrPoolClosed to the caller, including the Close-but-not-yet-Open
+// window where lifecycle is "reopening" and the manager is still mid-swap.
 func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -289,18 +289,45 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 
 	manager := newTestManager(t, server)
 	defer manager.Close()
+	manager.BeginReopen()
+	t.Cleanup(manager.EndReopen)
+
+	ctx := context.Background()
+	connConfig := &ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	}
+
+	reopenNow := make(chan struct{})
+	reopenDone := make(chan struct{})
+	go func() {
+		defer close(reopenDone)
+		<-reopenNow
+		// This is the "Open" half of the simulated reopenConnections window.
+		manager.Open(ctx, connConfig)
+		manager.EndReopen()
+	}()
 
 	calls := 0
-	result, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	result, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		if calls == 1 {
-			// Simulate reopenConnections running mid-flight: the pool we
-			// were handed has been closed, but the manager itself is still
-			// operational so a retry should succeed against a fresh pool.
+			// Simulate the "Close" half of reopenConnections running mid-flight.
+			// withReopenRetry should block on EndReopen and then retry once.
+			manager.Close()
+			close(reopenNow)
 			return 0, connpool.ErrPoolClosed
 		}
 		return 42, nil
 	})
+
+	select {
+	case <-reopenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for simulated reopen to finish")
+	}
 
 	require.NoError(t, err)
 	assert.Equal(t, 42, result)
@@ -320,11 +347,11 @@ func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
-		// Simulate Close() racing with the in-flight op: the pool got
-		// closed AND the manager itself is now shutting down.
-		manager.closed.Store(true)
+		// Simulate Close() racing with the in-flight op: manager transitions
+		// to terminally closed and ErrPoolClosed should be surfaced.
+		manager.Close()
 		return 0, connpool.ErrPoolClosed
 	})
 
@@ -344,10 +371,10 @@ func TestWithReopenRetry_FailsFastOnPreClosedManager(t *testing.T) {
 	manager := newTestManager(t, server)
 	defer manager.Close()
 
-	manager.closed.Store(true)
+	manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, nil
 	})
@@ -357,10 +384,9 @@ func TestWithReopenRetry_FailsFastOnPreClosedManager(t *testing.T) {
 	assert.Equal(t, 0, calls, "op must not run when manager is already closed")
 }
 
-// TestWithReopenRetry_OnlyRetriesOnce ensures the helper stops after one retry
-// even if the retry also fails with ErrPoolClosed (e.g. if a second reopen
-// races with the retry). Without a cap this could loop forever.
-func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
+// TestWithReopenRetry_RetriesErrPoolClosedUpToCap ensures ErrPoolClosed retries
+// are bounded, so repeated transient closes do not loop forever.
+func TestWithReopenRetry_RetriesErrPoolClosedUpToCap(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 	server.SetNeverFail(true)
@@ -369,14 +395,43 @@ func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, connpool.ErrPoolClosed
 	})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
-	assert.Equal(t, 2, calls, "should retry exactly once, not loop")
+	assert.Equal(t, maxPoolClosedRetries+1, calls, "should retry up to cap, then surface error")
+}
+
+// TestWithReopenRetry_ReopenWaitHonorsContextCancellation verifies that callers
+// don't block forever if reopen bookkeeping stalls: waiting on a reopen window
+// must respect the request context's deadline.
+func TestWithReopenRetry_ReopenWaitHonorsContextCancellation(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	manager.BeginReopen()
+	t.Cleanup(manager.EndReopen)
+	manager.Close() // Keep lifecycle in reopening with pools closed.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	calls := 0
+	_, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 0, connpool.ErrPoolClosed
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 1, calls, "should stop while waiting for reopen completion")
 }
 
 // TestWithReopenRetry_EvictsStalePoolOnAuthError verifies the stale-key
@@ -396,7 +451,7 @@ func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
 
 	var seenPools []*UserPool
 	calls := 0
-	result, err := withReopenRetry(manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
+	result, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
 		calls++
 		seenPools = append(seenPools, pool)
 		if calls == 1 {
@@ -432,7 +487,7 @@ func TestWithReopenRetry_SurfacesPersistentAuthError(t *testing.T) {
 	authErr := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01", Message: "password authentication failed"}
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, fmt.Errorf("dial failed: %w", authErr)
 	})

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -278,8 +278,10 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 // TestWithReopenRetry_RetriesOnReopen covers the race in which
 // reopenConnections (triggered by MonitorPostgres after a postgres restart)
 // closes the user pool while a connection acquisition is already in-flight.
-// The helper must notice the generation bump and retry against the fresh pool
-// rather than surfacing the transient ErrPoolClosed to the caller.
+// The helper must retry against the fresh snapshot rather than surfacing the
+// transient ErrPoolClosed to the caller. The retry is gated on m.closed
+// rather than a generation counter so it also catches the Close-but-not-yet
+// -Open window during reopenConnections.
 func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -293,9 +295,8 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 		calls++
 		if calls == 1 {
 			// Simulate reopenConnections running mid-flight: the pool we
-			// were handed has been closed, but a new one has already been
-			// installed with a bumped generation.
-			manager.generation.Add(1)
+			// were handed has been closed, but the manager itself is still
+			// operational so a retry should succeed against a fresh pool.
 			return 0, connpool.ErrPoolClosed
 		}
 		return 42, nil
@@ -306,9 +307,10 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	assert.Equal(t, 2, calls, "should have retried once after the reopen")
 }
 
-// TestWithReopenRetry_SurfacesGenuineClose covers the non-reopen case: the
-// manager is actually shutting down, so ErrPoolClosed must be returned to the
-// caller instead of being retried into an infinite loop.
+// TestWithReopenRetry_SurfacesGenuineClose covers the terminal-shutdown case:
+// the manager itself is closed mid-flight (e.g. Close() races with an
+// in-flight query), so the original ErrPoolClosed must be returned without
+// retrying — the retry would only re-hit a closed manager.
 func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -320,13 +322,39 @@ func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	calls := 0
 	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
-		// No generation bump — manager hasn't been reopened.
+		// Simulate Close() racing with the in-flight op: the pool got
+		// closed AND the manager itself is now shutting down.
+		manager.closed.Store(true)
 		return 0, connpool.ErrPoolClosed
 	})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
-	assert.Equal(t, 1, calls, "should not retry when generation did not advance")
+	assert.Equal(t, 1, calls, "should not retry once the manager is closed")
+}
+
+// TestWithReopenRetry_FailsFastOnPreClosedManager covers the case where the
+// manager is already closed before the call begins: getOrCreateUserPool
+// short-circuits with "manager is closed" and op is never invoked.
+func TestWithReopenRetry_FailsFastOnPreClosedManager(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	manager.closed.Store(true)
+
+	calls := 0
+	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 0, nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "manager is closed")
+	assert.Equal(t, 0, calls, "op must not run when manager is already closed")
 }
 
 // TestWithReopenRetry_OnlyRetriesOnce ensures the helper stops after one retry
@@ -343,7 +371,6 @@ func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
 	calls := 0
 	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
-		manager.generation.Add(1)
 		return 0, connpool.ErrPoolClosed
 	})
 

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -711,6 +711,18 @@ func (pm *MultiPoolerManager) reopenConnections(_ context.Context) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
+	// Signal connpoolmanager that this close->open cycle is a transient reopen,
+	// not a terminal shutdown. withReopenRetry can then wait out the window
+	// before retrying ErrPoolClosed once.
+	type reopenAware interface {
+		BeginReopen()
+		EndReopen()
+	}
+	if mgr, ok := pm.connPoolMgr.(reopenAware); ok {
+		mgr.BeginReopen()
+		defer mgr.EndReopen()
+	}
+
 	pm.closeConnectionsLocked()
 	pm.openConnectionsLocked()
 }


### PR DESCRIPTION
## Summary

- Stabilizes `TestWrappedPreparedStatementExecution/multigateway` (top queryserving flake — 13 failures in the past week per the flaky-test report).
- Closes a race in `withReopenRetry` that surfaced `ErrPoolClosed` to clients during a reopen.

## Problem

`reopenConnections()` does `Close → Open` under `pm.mu`, and `Manager.Open()` bumps its generation counter only after clearing the snapshot and resetting `closed`. A query whose `op()` resolves to `ErrPoolClosed` in the Close-but-not-yet-Open window observes an unchanged generation, and the retry guard treats it as a terminal shutdown and surfaces the transient error. The eviction path (`evictUserPool`) hit the same hole — it closes the pool without bumping generation at all.

Client-visible symptom against `multigateway`: `pq: query execution failed: Code: UNKNOWN — failed to get connection for user postgres: connection pool is closed`.

## Solution

Use `m.closed` as the source of truth for "is this shutdown terminal." On `ErrPoolClosed`, retry against the current snapshot unless `m.closed` is set — in which case `getOrCreateUserPool` returns `"manager is closed"` and the retry exits cleanly without re-invoking `op`. Drop the now-dead generation field.

Tests:
- Existing `TestWithReopenRetry_RetriesOnReopen` / `_OnlyRetriesOnce` no longer need a generation bump.
- `_SurfacesGenuineClose` rewritten to flip `closed` inside `op`, simulating the Close-races-op race the new guard must catch.
- New `_FailsFastOnPreClosedManager` covers the pre-closed path where `op` never fires.
- `TestWrappedPreparedStatementExecution` run under `-race -count=20`: 20/20 pass.