### PR TITLE
feat(multigateway): support bound params in set_config()

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -33,6 +33,20 @@ The system uses etcd for service discovery and topology storage. The topology is
 - **go/tools/**: Generic helpers (timers, retry, etc.) that aren't multigres-specific
 - **go/common/**: Shared multigres code (error codes, gRPC clients, protocol code, etc.)
 
+## Shared utilities
+
+Before defining new constants, helpers, or type wrappers for PG/SQL concepts, check whether they already exist in `go/common/`. Common spots worth grepping first:
+
+- **`go/common/parser/ast/oids.go`** — PostgreSQL type OIDs (`BOOLOID`, `TEXTOID`, `VARCHAROID`, `INT4OID`, etc.) and the `Oid` type alias. Don't redefine `uint32 = 25` for TEXT — use `ast.TEXTOID`.
+- **`go/common/parser/ast/`** — AST node types, clone helpers (`CloneRefOfSelectStmt`, etc.), tree walker (`Rewrite`), constructors (`NewA_Const`, `NewString`, `NewBoolean`, `NewParamRef`).
+- **`go/common/sqltypes/params.go`** — wire-format Bind param packing (`ParamsToProto` / `ParamsFromProto`).
+- **`go/common/preparedstatement/`** — `PortalInfo`, `PreparedStatementInfo`, `Consolidator`, bind value decoders (`DecodeBindAsText`, `DecodeBindAsBool`).
+- **`go/common/mterrors/`** — PostgreSQL SQLSTATE codes and `PgDiagnostic` builders (`NewFeatureNotSupported`, `NewPgError`, etc.). Don't construct error strings ad-hoc.
+- **`go/common/protoutil/`** — proto message constructors (`NewPreparedStatement`, `NewPortal`).
+- **`go/common/pgprotocol/`** — wire protocol (`server/`, `client/`, `scram/`, `protocol/` codes).
+
+When in doubt, `grep -r '<concept>' go/common/` before adding a new definition. Reuse keeps wire-protocol constants and PG semantics consistent across the codebase.
+
 ## Terminology: Leader vs. Primary
 
 "Primary" is overloaded in distributed databases. Use these terms consistently:

--- a/go/common/preparedstatement/binddecode.go
+++ b/go/common/preparedstatement/binddecode.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preparedstatement
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/sqltypes"
+)
+
+// DecodeBindAsText reads the wire-protocol bind value at pr.Number from
+// portalInfo and returns it as a text string. callSite is the user-facing
+// label (e.g. "set_config name") used in error messages so the
+// diagnostic matches the caller's terminology.
+//
+// Accepted OIDs: TEXT, VARCHAR, InvalidOid (unspecified — PG infers from
+// the function signature at execute time). For text-like OIDs the binary
+// wire format is byte-identical to the text format (raw UTF-8), so a
+// single branch covers both formats. Other OIDs are rejected — coercing
+// arbitrary types to text at the caller would diverge from PG's own
+// coercion and silently corrupt whatever state the caller is mirroring.
+// NULL binds are rejected too; PG's set_config (the current sole caller)
+// is STRICT and would no-op on NULL, leaving any gateway-side tracker out
+// of sync.
+//
+// callSite is included in the error message verbatim. Pass something like
+// "set_config name argument" so the error matches the planner's
+// literal-rejection diagnostics for the same slot.
+func DecodeBindAsText(portalInfo *PortalInfo, pr *ast.ParamRef, callSite string) (string, error) {
+	raw, oid, format, err := lookupBind(portalInfo, pr, callSite)
+	if err != nil {
+		return "", err
+	}
+	switch oid {
+	case ast.InvalidOid, ast.TEXTOID, ast.VARCHAROID:
+		return string(raw), nil
+	}
+	return "", mterrors.NewFeatureNotSupported(
+		fmt.Sprintf("%s bound parameter $%d has unsupported type oid=%d format=%d; declare the parameter as text",
+			callSite, pr.Number, oid, format))
+}
+
+// DecodeBindAsBool reads the wire-protocol bind value at pr.Number from
+// portalInfo and returns it as a bool. callSite is the user-facing label
+// used in error messages.
+//
+// Text format mirrors PG's boolin spellings (t/true/y/yes/on/1 and
+// f/false/n/no/off/0, case-insensitive, trimmed). Binary format is a
+// single byte where 0 means false and non-zero means true. Other OIDs are
+// rejected.
+func DecodeBindAsBool(portalInfo *PortalInfo, pr *ast.ParamRef, callSite string) (bool, error) {
+	raw, oid, format, err := lookupBind(portalInfo, pr, callSite)
+	if err != nil {
+		return false, err
+	}
+	switch oid {
+	case ast.InvalidOid, ast.BOOLOID:
+	default:
+		return false, mterrors.NewFeatureNotSupported(
+			fmt.Sprintf("%s bound parameter $%d has unsupported type oid=%d; declare the parameter as bool",
+				callSite, pr.Number, oid))
+	}
+
+	if format == 1 {
+		if len(raw) != 1 {
+			return false, mterrors.NewFeatureNotSupported(
+				fmt.Sprintf("%s bound parameter $%d has invalid binary bool length %d",
+					callSite, pr.Number, len(raw)))
+		}
+		return raw[0] != 0, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(string(raw))) {
+	case "t", "true", "y", "yes", "on", "1":
+		return true, nil
+	case "f", "false", "n", "no", "off", "0":
+		return false, nil
+	}
+	return false, mterrors.NewFeatureNotSupported(
+		fmt.Sprintf("%s bound parameter $%d has invalid boolean value", callSite, pr.Number))
+}
+
+// lookupBind resolves a ParamRef to its raw bytes, declared OID, and wire
+// format from the portal. Centralizes the per-slot bookkeeping so the text
+// and bool decoders share a single source of bind-level errors (out of
+// range, NULL, missing portal info).
+func lookupBind(portalInfo *PortalInfo, pr *ast.ParamRef, callSite string) (raw []byte, oid ast.Oid, format int32, err error) {
+	if portalInfo == nil || portalInfo.Portal == nil || portalInfo.PreparedStatementInfo == nil {
+		return nil, ast.InvalidOid, 0, mterrors.NewFeatureNotSupported(
+			fmt.Sprintf("%s bound parameter $%d cannot be resolved without a portal", callSite, pr.Number))
+	}
+	params := sqltypes.ParamsFromProto(portalInfo.Portal.ParamLengths, portalInfo.Portal.ParamValues)
+	slot := pr.Number - 1
+	if slot < 0 || slot >= len(params) {
+		return nil, ast.InvalidOid, 0, mterrors.NewFeatureNotSupported(
+			fmt.Sprintf("%s references bound parameter $%d, but the portal carries %d values",
+				callSite, pr.Number, len(params)))
+	}
+	raw = params[slot]
+	if raw == nil {
+		return nil, ast.InvalidOid, 0, mterrors.NewFeatureNotSupported(
+			fmt.Sprintf("%s bound parameter $%d cannot be NULL", callSite, pr.Number))
+	}
+	format = paramFormatFor(portalInfo.Portal.ParamFormats, slot)
+	oid = paramOidFor(portalInfo.PreparedStatementInfo.PreparedStatement.GetParamTypes(), slot)
+	return raw, oid, format, nil
+}
+
+// paramFormatFor returns the wire format code (0=text, 1=binary) for the
+// parameter at index i. The Bind message permits an empty format list (all
+// text), a single-element list (applies to all), or one per parameter.
+func paramFormatFor(formats []int32, i int) int32 {
+	switch len(formats) {
+	case 0:
+		return 0
+	case 1:
+		return formats[0]
+	}
+	if i < len(formats) {
+		return formats[i]
+	}
+	return 0
+}
+
+// paramOidFor returns the declared parameter OID at index i, or
+// ast.InvalidOid when the client did not declare it (Parse with an empty
+// ParameterTypes list, or fewer entries than $N).
+func paramOidFor(paramTypes []uint32, i int) ast.Oid {
+	if i < len(paramTypes) {
+		return ast.Oid(paramTypes[i])
+	}
+	return ast.InvalidOid
+}

--- a/go/common/preparedstatement/binddecode_test.go
+++ b/go/common/preparedstatement/binddecode_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preparedstatement
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/protoutil"
+)
+
+// buildTestPortalInfo wires a *PortalInfo for the given prepared SQL +
+// binds using the same factories the real Bind path uses, keeping the
+// test path byte-equivalent to a production portal.
+func buildTestPortalInfo(t *testing.T, sql string, paramTypes []uint32, params [][]byte, paramFormats []int16) *PortalInfo {
+	t.Helper()
+	psi, err := NewPreparedStatementInfo(protoutil.NewPreparedStatement("stmt", sql, paramTypes))
+	require.NoError(t, err)
+	portal := protoutil.NewPortal("", "stmt", params, paramFormats, nil)
+	return NewPortalInfo(psi, portal)
+}
+
+func paramRef(n int) *ast.ParamRef { return &ast.ParamRef{Number: n} }
+
+// TestDecodeBindAsText_AcceptedOIDs covers the byte-trivial path: TEXT,
+// VARCHAR, and InvalidOid (unspecified) all decode the raw bytes as
+// UTF-8 text. Binary wire format is identical to text format for these
+// type OIDs in PG, so a single branch covers both formats.
+func TestDecodeBindAsText_AcceptedOIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		oid    uint32
+		format int16
+	}{
+		{"text/text format", uint32(ast.TEXTOID), 0},
+		{"text/binary format", uint32(ast.TEXTOID), 1},
+		{"varchar/text format", uint32(ast.VARCHAROID), 0},
+		{"unspecified/text format", uint32(ast.InvalidOid), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pi := buildTestPortalInfo(t, "SELECT $1", []uint32{tc.oid}, [][]byte{[]byte("public,extensions")}, []int16{tc.format})
+			got, err := DecodeBindAsText(pi, paramRef(1), "test arg")
+			require.NoError(t, err)
+			assert.Equal(t, "public,extensions", got)
+		})
+	}
+}
+
+// TestDecodeBindAsText_RejectsUnsupportedOID — gateway must not invent
+// type coercion. Int4 bytes can't be safely interpreted as text without
+// PG-specific coercion semantics, so reject with a message that tells
+// the client how to fix it.
+func TestDecodeBindAsText_RejectsUnsupportedOID(t *testing.T) {
+	const oidInt4 uint32 = 23
+	pi := buildTestPortalInfo(t, "SELECT $1", []uint32{oidInt4}, [][]byte{[]byte("123")}, []int16{0})
+	_, err := DecodeBindAsText(pi, paramRef(1), "test arg")
+	require.Error(t, err)
+	assertFeatureErr(t, err, "unsupported type oid=23")
+	assertFeatureErr(t, err, "declare the parameter as text")
+}
+
+// TestDecodeBindAsBool_AcceptedSpellings — text-format bool mirrors PG's
+// boolin spellings exactly. Each accepted spelling must decode to the
+// right Go bool, case-insensitive, with leading/trailing whitespace
+// trimmed (PG behavior).
+func TestDecodeBindAsBool_AcceptedSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"t", true},
+		{"y", true},
+		{"yes", true},
+		{"on", true},
+		{"1", true},
+		{"  true  ", true},
+		{"false", false},
+		{"FALSE", false},
+		{"f", false},
+		{"n", false},
+		{"no", false},
+		{"off", false},
+		{"0", false},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.BOOLOID)}, [][]byte{[]byte(tc.raw)}, []int16{0})
+			got, err := DecodeBindAsBool(pi, paramRef(1), "test arg")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDecodeBindAsBool_Binary — binary wire format encodes bool as a
+// single byte, 0=false anything-else=true. Length must be exactly 1.
+func TestDecodeBindAsBool_Binary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+		want bool
+	}{
+		{"binary 0", []byte{0}, false},
+		{"binary 1", []byte{1}, true},
+		{"binary 255", []byte{255}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.BOOLOID)}, [][]byte{tc.raw}, []int16{1})
+			got, err := DecodeBindAsBool(pi, paramRef(1), "test arg")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDecodeBindAsBool_InvalidBinaryLength — binary bool must be exactly
+// 1 byte. Anything else is a protocol violation by the client; reject
+// rather than silently using the first byte.
+func TestDecodeBindAsBool_InvalidBinaryLength(t *testing.T) {
+	pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.BOOLOID)}, [][]byte{{1, 2}}, []int16{1})
+	_, err := DecodeBindAsBool(pi, paramRef(1), "test arg")
+	require.Error(t, err)
+	assertFeatureErr(t, err, "invalid binary bool length")
+}
+
+// TestDecodeBindAsBool_InvalidSpelling — text-format bool that isn't one
+// of PG's boolin spellings must error rather than guess.
+func TestDecodeBindAsBool_InvalidSpelling(t *testing.T) {
+	pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.BOOLOID)}, [][]byte{[]byte("maybe")}, []int16{0})
+	_, err := DecodeBindAsBool(pi, paramRef(1), "test arg")
+	require.Error(t, err)
+	assertFeatureErr(t, err, "invalid boolean value")
+}
+
+// TestDecodeBind_NullRejected covers both text and bool paths — NULL
+// binds are rejected uniformly because the caller (set_config) is STRICT
+// and the only safe gateway-side response is to refuse rather than
+// silently desync with PG.
+func TestDecodeBind_NullRejected(t *testing.T) {
+	t.Run("text", func(t *testing.T) {
+		pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.TEXTOID)}, [][]byte{nil}, []int16{0})
+		_, err := DecodeBindAsText(pi, paramRef(1), "test arg")
+		require.Error(t, err)
+		assertFeatureErr(t, err, "cannot be NULL")
+	})
+	t.Run("bool", func(t *testing.T) {
+		pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.BOOLOID)}, [][]byte{nil}, []int16{0})
+		_, err := DecodeBindAsBool(pi, paramRef(1), "test arg")
+		require.Error(t, err)
+		assertFeatureErr(t, err, "cannot be NULL")
+	})
+}
+
+// TestDecodeBind_OutOfRange — ParamRef.Number beyond the portal's bind
+// count is a malformed client request or a planner bug. Surface
+// explicitly rather than panicking on slice index.
+func TestDecodeBind_OutOfRange(t *testing.T) {
+	pi := buildTestPortalInfo(t, "SELECT $1", []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("only one")}, []int16{0})
+	_, err := DecodeBindAsText(pi, paramRef(2), "test arg")
+	require.Error(t, err)
+	assertFeatureErr(t, err, "but the portal carries 1 values")
+}
+
+// TestDecodeBind_NilPortal — defensive path for accidental nil portal.
+// Should never happen in production (planner always emits BindRefs only
+// when the executor has a portalInfo) but failing fast is safer than NPE.
+func TestDecodeBind_NilPortal(t *testing.T) {
+	_, err := DecodeBindAsText(nil, paramRef(1), "test arg")
+	require.Error(t, err)
+	assertFeatureErr(t, err, "cannot be resolved without a portal")
+}
+
+// TestParamFormatFor — the Bind message format-list shapes per PG spec:
+// empty = all text, single = applies to all, per-param = use index.
+func TestParamFormatFor(t *testing.T) {
+	assert.Equal(t, int32(0), paramFormatFor(nil, 0), "empty defaults to text")
+	assert.Equal(t, int32(0), paramFormatFor([]int32{}, 5), "empty defaults to text regardless of index")
+	assert.Equal(t, int32(1), paramFormatFor([]int32{1}, 0), "single applies to all")
+	assert.Equal(t, int32(1), paramFormatFor([]int32{1}, 99), "single applies to any index")
+	assert.Equal(t, int32(0), paramFormatFor([]int32{0, 1, 0}, 0))
+	assert.Equal(t, int32(1), paramFormatFor([]int32{0, 1, 0}, 1))
+	assert.Equal(t, int32(0), paramFormatFor([]int32{0, 1}, 5), "out-of-range falls back to text")
+}
+
+// TestParamOidFor — declared param types may have fewer entries than $N;
+// missing slots default to InvalidOid so unspecified-type clients still
+// work.
+func TestParamOidFor(t *testing.T) {
+	assert.Equal(t, ast.InvalidOid, paramOidFor(nil, 0))
+	assert.Equal(t, ast.InvalidOid, paramOidFor([]uint32{}, 0))
+	assert.Equal(t, ast.TEXTOID, paramOidFor([]uint32{uint32(ast.TEXTOID)}, 0))
+	assert.Equal(t, ast.InvalidOid, paramOidFor([]uint32{uint32(ast.TEXTOID)}, 1), "missing tail defaults to unspecified")
+}
+
+func assertFeatureErr(t *testing.T, err error, contains string) {
+	t.Helper()
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected *mterrors.PgDiagnostic, got %T", err)
+	assert.Equal(t, mterrors.PgSSFeatureNotSupported, diag.Code)
+	assert.Contains(t, diag.Message, contains)
+}

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -60,6 +60,35 @@ type ApplySessionState struct {
 	// the shape a `SELECT set_config(...)` plan takes: silent tracking step
 	// first, then a Route that sends the query to PG and streams the result.
 	SilentTracking bool
+
+	// BindRefs, when non-nil, marks this primitive as a deferred-resolution
+	// set_config(): name, value, and/or is_local are decoded from the
+	// portal's wire-protocol Bind values at execute time before
+	// SessionSettings is updated. Nil-valued fields use the literal already
+	// in VariableStmt.Name / Args[0] / LiteralIsLocal.
+	//
+	// Reachable only via PortalStreamExecute — StreamExecute is the simple
+	// protocol path, which has no binds and therefore never sets BindRefs.
+	// Set automatically by NewApplySessionStateFromBind for the
+	// extended-protocol `SELECT set_config($1, ...)` shape.
+	BindRefs *BoundSetConfigRefs
+}
+
+// BoundSetConfigRefs carries the ParamRef-to-portal-bind mapping for a
+// set_config(...) call whose name, value, or is_local was supplied as a
+// wire-protocol bound parameter. Each *ast.ParamRef field is the parser-
+// produced ParamRef for the corresponding set_config slot, or nil when
+// that slot was already a literal in the AST.
+//
+// is_local literals don't need to be carried here: the validator short-
+// circuits literal-true (no tracking, no setConfigCall produced), so any
+// setConfigCall that reaches the execute path with IsLocalParam == nil
+// implies is_local was literal false. executeSetWithBinds defaults to
+// false in that branch.
+type BoundSetConfigRefs struct {
+	NameParam    *ast.ParamRef
+	ValueParam   *ast.ParamRef
+	IsLocalParam *ast.ParamRef
 }
 
 // NewApplySessionState creates a new ApplySessionState primitive.
@@ -82,23 +111,105 @@ func NewApplySessionStateSilent(sql string, stmt *ast.VariableSetStmt) *ApplySes
 	}
 }
 
-// PortalStreamExecute handles SET/RESET on the extended-protocol path. The
-// primitive's effect is local to gateway state — it neither reads bind
-// values nor talks to a backend — so we delegate to StreamExecute and
-// ignore portalInfo entirely. This is the right shape for a silent
-// ApplySessionState sitting inside a Sequence whose trailing Route
-// reissues the actual portal.
+// NewApplySessionStateFromBind creates a silent ApplySessionState whose
+// name, value, or is_local will be resolved from the portal's Bind values
+// at execute time. The synthetic VariableStmt holds bind-placeholder
+// strings (e.g. "__bind_$1__") in the slots that refs marks as bound; the
+// placeholders are overwritten at execute time and exist only to keep
+// SqlString-based debug output structurally valid.
+//
+// Always silent: a bound set_config is only emitted as part of the
+// Sequence[ApplySessionState, Route] plan, where the trailing Route owns
+// the client-facing CommandComplete.
+func NewApplySessionStateFromBind(sql string, stmt *ast.VariableSetStmt, refs *BoundSetConfigRefs) *ApplySessionState {
+	return &ApplySessionState{
+		VariableStmt:   stmt,
+		Query:          sql,
+		SilentTracking: true,
+		BindRefs:       refs,
+	}
+}
+
+// PortalStreamExecute handles SET/RESET on the extended-protocol path.
+//
+// Two modes:
+//   - BindRefs == nil: the primitive carries literal arguments only, so the
+//     portal's binds are irrelevant; delegate to StreamExecute. This is the
+//     simple/literal SET/RESET shape and the
+//     `SELECT set_config('lit', 'lit', false)` Sequence step.
+//   - BindRefs != nil: name/value/is_local must be decoded from the
+//     portal's wire-protocol Bind values before SessionSettings is updated.
+//     Reached only via the `SELECT set_config($1, ...)` Sequence step.
 func (s *ApplySessionState) PortalStreamExecute(
 	ctx context.Context,
 	exec IExecute,
 	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
-	_ *preparedstatement.PortalInfo,
+	portalInfo *preparedstatement.PortalInfo,
 	_ int32,
 	_ bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
+	if s.BindRefs != nil {
+		return s.executeSetWithBinds(ctx, state, portalInfo, callback)
+	}
 	return s.StreamExecute(ctx, exec, conn, state, nil, callback)
+}
+
+// executeSetWithBinds resolves name/value/is_local from the portal's binds
+// and conditionally updates SessionSettings.
+//
+// is_local is resolved first because it decides whether tracking happens at
+// all: when it resolves true the call is transaction-scoped, PG owns it via
+// the Sequence's trailing Route, and the gateway must NOT write to
+// SessionSettings (otherwise the tracker would outlive the transaction PG
+// scoped the change to). Resolving it first also lets us skip the text
+// decodes for the bound name/value slots — they're only needed for the
+// tracker write.
+//
+// Errors (NULL bind, unsupported OID, out-of-range ParamRef) propagate up
+// through the Sequence, which aborts before the Route fires.
+func (s *ApplySessionState) executeSetWithBinds(
+	ctx context.Context,
+	state *handler.MultiGatewayConnectionState,
+	portalInfo *preparedstatement.PortalInfo,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	isLocal := false
+	if s.BindRefs.IsLocalParam != nil {
+		b, err := preparedstatement.DecodeBindAsBool(portalInfo, s.BindRefs.IsLocalParam, "set_config is_local argument")
+		if err != nil {
+			return err
+		}
+		isLocal = b
+	}
+	if isLocal {
+		// PG handles the SET LOCAL via the trailing Route; gateway stays out.
+		return nil
+	}
+
+	name := s.VariableStmt.Name
+	if s.BindRefs.NameParam != nil {
+		v, err := preparedstatement.DecodeBindAsText(portalInfo, s.BindRefs.NameParam, "set_config name argument")
+		if err != nil {
+			return err
+		}
+		name = v
+	}
+	value := extractVariableValue(s.VariableStmt.Args)
+	if s.BindRefs.ValueParam != nil {
+		v, err := preparedstatement.DecodeBindAsText(portalInfo, s.BindRefs.ValueParam, "set_config value argument")
+		if err != nil {
+			return err
+		}
+		value = v
+	}
+
+	state.SetSessionVariable(name, value)
+	if s.SilentTracking {
+		return nil
+	}
+	return callback(ctx, &sqltypes.Result{CommandTag: "SET"})
 }
 
 // StreamExecute handles the SET/RESET command.

--- a/go/services/multigateway/engine/apply_session_state_bind_test.go
+++ b/go/services/multigateway/engine/apply_session_state_bind_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// buildBoundPortalInfo wires a *preparedstatement.PortalInfo for the given
+// prepared SQL + binds via the same factories the real Bind path uses,
+// keeping the test path byte-equivalent to a production portal.
+func buildBoundPortalInfo(t *testing.T, sql string, paramTypes []uint32, params [][]byte, paramFormats []int16) *preparedstatement.PortalInfo {
+	t.Helper()
+	psi, err := preparedstatement.NewPreparedStatementInfo(protoutil.NewPreparedStatement("stmt", sql, paramTypes))
+	require.NoError(t, err)
+	portal := protoutil.NewPortal("", "stmt", params, paramFormats, nil)
+	return preparedstatement.NewPortalInfo(psi, portal)
+}
+
+// syntheticSetForTest builds a VariableSetStmt placeholder matching what
+// planner.syntheticSetStmt would emit when called with the given literal
+// fallbacks. Bind-placeholder slots are intentionally distinct strings so
+// a leaked placeholder is obvious if executeSetWithBinds forgot to
+// override the slot.
+func syntheticSetForTest(name, value string) *ast.VariableSetStmt {
+	return &ast.VariableSetStmt{
+		BaseNode: ast.BaseNode{Tag: ast.T_VariableSetStmt},
+		Kind:     ast.VAR_SET_VALUE,
+		Name:     name,
+		Args:     ast.NewNodeList(ast.NewA_Const(ast.NewString(value), 0)),
+	}
+}
+
+// runBindExecute executes the primitive's PortalStreamExecute against a
+// fresh connection state and reports the resulting tracker map and the
+// callback CommandTags it emitted. Returns (sessionSettings, tags, err).
+func runBindExecute(t *testing.T, prim *ApplySessionState, portalInfo *preparedstatement.PortalInfo) (map[string]string, []string, error) {
+	t.Helper()
+	state := &handler.MultiGatewayConnectionState{}
+	var tags []string
+	err := prim.PortalStreamExecute(context.Background(), nil, nil, state, portalInfo, 0, false,
+		func(_ context.Context, r *sqltypes.Result) error {
+			tags = append(tags, r.CommandTag)
+			return nil
+		})
+	return state.SessionSettings, tags, err
+}
+
+// TestApplySessionState_BoundValueResolves covers the Storage migration
+// shape: name and is_local literal, value bound. The text decode hits the
+// "TEXT OID, text format" branch — the byte-trivial case.
+func TestApplySessionState_BoundValueResolves(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("public,extensions")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$1__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 1},
+		})
+
+	settings, tags, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+	require.Nil(t, tags, "SilentTracking must suppress the SET CommandComplete; Route owns the response")
+	assert.Equal(t, "public,extensions", settings["search_path"])
+}
+
+// TestApplySessionState_BoundNameResolves covers the symmetric case: name
+// bound, value literal. Confirms the per-slot decode is independent.
+func TestApplySessionState_BoundNameResolves(t *testing.T) {
+	const sql = "SELECT set_config($1, 'public', false)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("search_path")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("__bind_$1__", "public"),
+		&BoundSetConfigRefs{
+			NameParam: &ast.ParamRef{Number: 1},
+		})
+
+	settings, _, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+	assert.Equal(t, "public", settings["search_path"])
+}
+
+// TestApplySessionState_BoundIsLocalTrueSkipsTracking pins the
+// transaction-scoped semantics: when bound is_local resolves to true, the
+// gateway must NOT update SessionSettings. PG handles SET LOCAL via the
+// trailing Route; mirroring it in the tracker would outlive the
+// transaction PG scoped the change to.
+func TestApplySessionState_BoundIsLocalTrueSkipsTracking(t *testing.T) {
+	const sql = "SELECT set_config('search_path', 'public', $1)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.BOOLOID)}, [][]byte{[]byte("true")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "public"),
+		&BoundSetConfigRefs{
+			IsLocalParam: &ast.ParamRef{Number: 1},
+		})
+
+	settings, tags, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+	assert.Nil(t, tags)
+	assert.Empty(t, settings, "is_local=true must leave SessionSettings untouched")
+}
+
+// TestApplySessionState_BoundIsLocalFalseTracksNormally pins the opposite
+// resolution of the same bound shape: when is_local resolves false, the
+// tracker write must fire. Same primitive, same binds shape; only the
+// resolved bool changes — proves the conditional branch is value-driven.
+func TestApplySessionState_BoundIsLocalFalseTracksNormally(t *testing.T) {
+	const sql = "SELECT set_config('search_path', 'public', $1)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.BOOLOID)}, [][]byte{[]byte("false")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "public"),
+		&BoundSetConfigRefs{
+			IsLocalParam: &ast.ParamRef{Number: 1},
+		})
+
+	settings, _, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+	assert.Equal(t, "public", settings["search_path"])
+}
+
+// TestApplySessionState_BoundAllThree exercises the full shape: name,
+// value, and is_local all resolved from binds. Confirms the resolution
+// order (is_local first, then name/value if tracking) doesn't drop
+// information when every slot is deferred.
+func TestApplySessionState_BoundAllThree(t *testing.T) {
+	const sql = "SELECT set_config($1, $2, $3)"
+	portalInfo := buildBoundPortalInfo(t, sql,
+		[]uint32{uint32(ast.TEXTOID), uint32(ast.TEXTOID), uint32(ast.BOOLOID)},
+		[][]byte{[]byte("search_path"), []byte("schema1, schema2"), []byte("false")},
+		[]int16{0, 0, 0},
+	)
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("__bind_$1__", "__bind_$2__"),
+		&BoundSetConfigRefs{
+			NameParam:    &ast.ParamRef{Number: 1},
+			ValueParam:   &ast.ParamRef{Number: 2},
+			IsLocalParam: &ast.ParamRef{Number: 3},
+		})
+
+	settings, _, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+	assert.Equal(t, "schema1, schema2", settings["search_path"])
+}
+
+// TestApplySessionState_NullBindRejected — PG's set_config is STRICT,
+// NULL input means no-op. If we silently tracked an empty string while PG
+// did nothing, gateway tracker and PG state would diverge. Reject
+// explicitly so the client sees the contract violation immediately.
+func TestApplySessionState_NullBindRejected(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{nil}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$1__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 1},
+		})
+
+	settings, _, err := runBindExecute(t, prim, portalInfo)
+	require.Error(t, err)
+	assertFeatureErrBind(t, err, "cannot be NULL")
+	assert.Empty(t, settings, "tracker must not be updated on bind error")
+}
+
+// TestApplySessionState_UnsupportedOidRejected — gateway never invents
+// type coercion. If the client declares the bound parameter as int4, the
+// safe answer is "no" with a message that tells the client how to fix it.
+func TestApplySessionState_UnsupportedOidRejected(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	const oidInt4 uint32 = 23
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{oidInt4}, [][]byte{[]byte("123")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$1__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 1},
+		})
+
+	_, _, err := runBindExecute(t, prim, portalInfo)
+	require.Error(t, err)
+	assertFeatureErrBind(t, err, "unsupported type oid=23")
+}
+
+// TestApplySessionState_BinaryBool covers the wire-format binary bool: a
+// single byte where 0 means false and non-zero means true. Mirrors PG's
+// boolrecv.
+func TestApplySessionState_BinaryBool(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  []byte
+		want bool
+	}{
+		{"binary true", []byte{1}, true},
+		{"binary false", []byte{0}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const sql = "SELECT set_config('search_path', 'public', $1)"
+			portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.BOOLOID)}, [][]byte{tc.raw}, []int16{1})
+
+			prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "public"),
+				&BoundSetConfigRefs{
+					IsLocalParam: &ast.ParamRef{Number: 1},
+				})
+
+			settings, _, err := runBindExecute(t, prim, portalInfo)
+			require.NoError(t, err)
+			if tc.want {
+				assert.Empty(t, settings, "is_local=true (binary 1) must skip tracker write")
+			} else {
+				assert.Equal(t, "public", settings["search_path"], "is_local=false (binary 0) must populate tracker")
+			}
+		})
+	}
+}
+
+// TestApplySessionState_PlanCacheReuseAcrossBinds is the regression for
+// the whole reason this is the deferred-resolution shape: the SAME
+// primitive (same plan, same BindRefs) must produce different tracker
+// writes for different portal binds. A baked-in literal would fail this
+// — iteration N would always see iteration 1's value.
+func TestApplySessionState_PlanCacheReuseAcrossBinds(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$1__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 1},
+		})
+
+	for _, want := range []string{"first", "second", "third"} {
+		portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte(want)}, []int16{0})
+		settings, _, err := runBindExecute(t, prim, portalInfo)
+		require.NoError(t, err, "iteration %q", want)
+		assert.Equal(t, want, settings["search_path"], "iteration %q must reflect that iteration's bind value", want)
+	}
+}
+
+// TestApplySessionState_OriginalVariableStmtUnmodified pins that
+// executeSetWithBinds does NOT mutate the synthetic VariableStmt. The
+// primitive is shared across concurrent Executes on the same cached plan;
+// a mutation would leak across executions.
+func TestApplySessionState_OriginalVariableStmtUnmodified(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	base := syntheticSetForTest("search_path", "__bind_$1__")
+	prim := NewApplySessionStateFromBind(sql, base, &BoundSetConfigRefs{
+		ValueParam: &ast.ParamRef{Number: 1},
+	})
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("public")}, []int16{0})
+
+	_, _, err := runBindExecute(t, prim, portalInfo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "search_path", base.Name, "base VariableStmt.Name must not be mutated by execute-time resolution")
+	require.NotNil(t, base.Args)
+	require.Equal(t, 1, base.Args.Len())
+	c, ok := base.Args.Items[0].(*ast.A_Const)
+	require.True(t, ok)
+	s, ok := c.Val.(*ast.String)
+	require.True(t, ok)
+	assert.Equal(t, "__bind_$1__", s.SVal, "base VariableStmt.Args[0] placeholder must not be overwritten")
+}
+
+// TestApplySessionState_OutOfRangeParamRef pins a defensive error path:
+// a ParamRef whose number exceeds the portal's bind count is a malformed
+// client request (or planner bug). Surface it explicitly rather than
+// panicking on slice access.
+func TestApplySessionState_OutOfRangeParamRef(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $2, false)"
+	portalInfo := buildBoundPortalInfo(t, sql, []uint32{uint32(ast.TEXTOID)}, [][]byte{[]byte("public")}, []int16{0})
+
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$2__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 2},
+		})
+
+	_, _, err := runBindExecute(t, prim, portalInfo)
+	require.Error(t, err)
+	assertFeatureErrBind(t, err, "but the portal carries 1 values")
+}
+
+// assertFeatureErrBind wraps the verbose unwrap-into-PgDiagnostic check.
+// All bind-resolution errors are FeatureNotSupported, matching the
+// planner's literal-rejection diagnostics so client-visible behavior is
+// uniform across plan-time and execute-time errors.
+func assertFeatureErrBind(t *testing.T, err error, contains string) {
+	t.Helper()
+	var diag *mterrors.PgDiagnostic
+	require.True(t, errors.As(err, &diag), "expected *mterrors.PgDiagnostic, got %T", err)
+	assert.Equal(t, mterrors.PgSSFeatureNotSupported, diag.Code)
+	assert.Contains(t, diag.Message, contains)
+}

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -15,6 +15,8 @@
 package planner
 
 import (
+	"fmt"
+
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
@@ -22,18 +24,27 @@ import (
 )
 
 // planSelectStmt plans a SELECT. When the target list contains one or more
-// set_config(literal, literal, false) calls the walker accepted, the plan
-// also tracks those in SessionSettings so the change survives pool rotation.
+// set_config(...) calls the walker accepted, the plan also tracks those in
+// SessionSettings so the change survives pool rotation.
 //
 // With set_configs present the plan is always
 //
-//	Sequence[silent ApplySessionState per call, Route(original SQL)]
+//	Sequence[ApplySessionState per call, Route(original SQL)]
 //
-// The silent primitives update the tracker without emitting anything to
-// the client; the Route then sends the unmodified query to PG, which
-// executes set_config normally and streams the result back. The extra
-// round-trip matters less than keeping the planning logic uniform — we
-// don't try to short-circuit the bare `SELECT set_config(...)` case.
+// The ApplySessionState primitive runs silently — it updates the tracker
+// without emitting anything to the client; the Route then sends the
+// unmodified query to PG, which executes set_config normally and streams
+// the result back. The extra round-trip matters less than keeping the
+// planning logic uniform — we don't try to short-circuit the bare
+// `SELECT set_config(...)` case.
+//
+// For literal-arg calls the primitive carries the value directly. For
+// calls with one or more bound-parameter args (extended-protocol shape
+// `SELECT set_config('search_path', $1, false)`) the primitive is built
+// via NewApplySessionStateFromBind, which defers per-slot resolution to
+// execute time when the portal's Bind values become available — keeping
+// the plan cache hit for repeated executions of the same prepared
+// statement regardless of bind values.
 func (p *Planner) planSelectStmt(
 	sql string,
 	stmt *ast.SelectStmt,
@@ -46,7 +57,17 @@ func (p *Planner) planSelectStmt(
 
 	primitives := make([]engine.Primitive, 0, len(setConfigs)+1)
 	for _, sc := range setConfigs {
-		primitives = append(primitives, engine.NewApplySessionStateSilent(sql, syntheticSetStmt(sc)))
+		base := syntheticSetStmt(sc)
+		if sc.Bound {
+			refs := &engine.BoundSetConfigRefs{
+				NameParam:    sc.NameBind,
+				ValueParam:   sc.ValueBind,
+				IsLocalParam: sc.IsLocalBind,
+			}
+			primitives = append(primitives, engine.NewApplySessionStateFromBind(sql, base, refs))
+		} else {
+			primitives = append(primitives, engine.NewApplySessionStateSilent(sql, base))
+		}
 	}
 	primitives = append(primitives, engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt))
 	return engine.NewPlan(sql, engine.NewSequence(primitives)), nil
@@ -55,13 +76,28 @@ func (p *Planner) planSelectStmt(
 // syntheticSetStmt builds a VariableSetStmt equivalent to `SET name = value`
 // for use inside ApplySessionState. Same shape as what the real
 // VariableSetStmt path feeds into the primitive, so execution is identical.
+//
+// For slots that were bound parameters, a `__bind_$N__` placeholder is
+// used. These placeholders are overwritten at execute time when
+// executeSetWithBinds resolves the actual value from the portal — they
+// exist only so SqlString-style debug output stays structurally valid and
+// so an accidental literal-mode execute would surface as an obvious bug
+// rather than silently leaking the placeholder into SessionSettings.
 func syntheticSetStmt(sc setConfigCall) *ast.VariableSetStmt {
+	name := sc.Name
+	if sc.NameBind != nil {
+		name = fmt.Sprintf("__bind_$%d__", sc.NameBind.Number)
+	}
+	value := sc.Value
+	if sc.ValueBind != nil {
+		value = fmt.Sprintf("__bind_$%d__", sc.ValueBind.Number)
+	}
 	return &ast.VariableSetStmt{
 		BaseNode: ast.BaseNode{Tag: ast.T_VariableSetStmt},
 		Kind:     ast.VAR_SET_VALUE,
-		Name:     sc.Name,
+		Name:     name,
 		Args: ast.NewNodeList(
-			ast.NewA_Const(ast.NewString(sc.Value), 0),
+			ast.NewA_Const(ast.NewString(value), 0),
 		),
 	}
 }

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -58,7 +58,7 @@ func (p *Planner) planSelectStmt(
 	primitives := make([]engine.Primitive, 0, len(setConfigs)+1)
 	for _, sc := range setConfigs {
 		base := syntheticSetStmt(sc)
-		if sc.Bound {
+		if sc.hasBoundParams() {
 			refs := &engine.BoundSetConfigRefs{
 				NameParam:    sc.NameBind,
 				ValueParam:   sc.ValueBind,

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -75,13 +75,13 @@ var funcBlocklist = map[string]string{
 //
 // Two shapes:
 //   - all-literal: Name and Value carry the parsed strings, *Bind fields
-//     are nil, Bound is false. is_local was literal false (literal true
-//     short-circuits below and never produces a setConfigCall).
+//     are nil. is_local was literal false (literal true short-circuits
+//     below and never produces a setConfigCall).
 //   - any-bound: at least one of NameBind/ValueBind/IsLocalBind is non-nil
 //     and points at the parser-produced ParamRef for that slot. Name/Value
-//     hold the parsed string for any slot that was NOT bound. Bound is
-//     true — the planner emits the deferred-resolution primitive that
-//     decodes the bound slots from the portal at execute time.
+//     hold the parsed string for any slot that was NOT bound. The planner
+//     emits the deferred-resolution primitive that decodes the bound slots
+//     from the portal at execute time.
 //
 // `is_local=true` literals never produce a setConfigCall — validation
 // returns (nil, nil) early so the call goes to PG via Route only, with no
@@ -95,11 +95,10 @@ type setConfigCall struct {
 	NameBind    *ast.ParamRef
 	ValueBind   *ast.ParamRef
 	IsLocalBind *ast.ParamRef
+}
 
-	// Bound is true when at least one of *Bind is non-nil. Callers branch
-	// on this to choose ApplySessionStateSilent (literal) vs
-	// ApplySessionStateFromBind (deferred resolution).
-	Bound bool
+func (sc setConfigCall) hasBoundParams() bool {
+	return sc.NameBind != nil || sc.ValueBind != nil || sc.IsLocalBind != nil
 }
 
 // expressionCheckResult carries the output of inspectExpressionFuncCalls.
@@ -277,7 +276,6 @@ func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 
 	if pr, isParam := unwrapTypeCast(fc.Args.Items[2]).(*ast.ParamRef); isParam {
 		sc.IsLocalBind = pr
-		sc.Bound = true
 	} else if isLocal, ok := constBoolArg(fc.Args.Items[2]); ok {
 		if isLocal {
 			return nil, nil
@@ -291,7 +289,6 @@ func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 
 	if pr, isParam := unwrapTypeCast(fc.Args.Items[0]).(*ast.ParamRef); isParam {
 		sc.NameBind = pr
-		sc.Bound = true
 	} else if name, ok := constStringArg(fc.Args.Items[0]); ok {
 		sc.Name = name
 	} else {
@@ -300,7 +297,6 @@ func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 
 	if pr, isParam := unwrapTypeCast(fc.Args.Items[1]).(*ast.ParamRef); isParam {
 		sc.ValueBind = pr
-		sc.Bound = true
 	} else if value, ok := constStringArg(fc.Args.Items[1]); ok {
 		sc.Value = value
 	} else {

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -69,15 +69,37 @@ var funcBlocklist = map[string]string{
 	"cursor_to_xmlschema":        "cursor_to_xmlschema is not supported: arbitrary SQL execution via XML helpers is not permitted through the connection pooler",
 }
 
-// setConfigCall is one `set_config(name, value, is_local=false)` call the
-// planner accepted as a tracked session-state update. The planner mints one
-// per allowed position and uses the list to build the execution plan.
+// setConfigCall is one `set_config(name, value, is_local)` call the planner
+// accepted as a tracked session-state update. The planner mints one per
+// allowed position and uses the list to build the execution plan.
 //
-// Only is_local=false calls appear here: is_local=true is transaction-scoped,
-// PG handles it directly, and there is nothing for the pooler to track.
+// Two shapes:
+//   - all-literal: Name and Value carry the parsed strings, *Bind fields
+//     are nil, Bound is false. is_local was literal false (literal true
+//     short-circuits below and never produces a setConfigCall).
+//   - any-bound: at least one of NameBind/ValueBind/IsLocalBind is non-nil
+//     and points at the parser-produced ParamRef for that slot. Name/Value
+//     hold the parsed string for any slot that was NOT bound. Bound is
+//     true — the planner emits the deferred-resolution primitive that
+//     decodes the bound slots from the portal at execute time.
+//
+// `is_local=true` literals never produce a setConfigCall — validation
+// returns (nil, nil) early so the call goes to PG via Route only, with no
+// SessionSettings write. That's also why we don't need to carry a literal
+// is_local: any returned setConfigCall implies is_local was literal false
+// or bound, and the executor defaults to false when IsLocalBind is nil.
 type setConfigCall struct {
 	Name  string
 	Value string
+
+	NameBind    *ast.ParamRef
+	ValueBind   *ast.ParamRef
+	IsLocalBind *ast.ParamRef
+
+	// Bound is true when at least one of *Bind is non-nil. Callers branch
+	// on this to choose ApplySessionStateSilent (literal) vs
+	// ApplySessionStateFromBind (deferred resolution).
+	Bound bool
 }
 
 // expressionCheckResult carries the output of inspectExpressionFuncCalls.
@@ -229,57 +251,74 @@ func collectTopLevelSetConfigs(stmt ast.Stmt) map[*ast.FuncCall]struct{} {
 }
 
 // validateAcceptedSetConfig verifies that an allowed-position set_config
-// call has the expected literal arguments, and returns its (name, value)
-// when is_local=false. Returns (nil, nil) when is_local=true — allowed but
-// not tracked.
+// call has the expected arguments and builds the setConfigCall the planner
+// will turn into a SessionSettings tracking entry. Each slot may be a
+// literal A_Const or a *ast.ParamRef — the latter is recorded as a *Bind
+// for execute-time resolution from the portal's wire-protocol Bind values.
+// Anything else (non-const non-ParamRef expression) errors out.
 //
-// is_local is inspected first so that is_local=true calls bypass the
-// strict literal check on name/value: those calls are not tracked, and
-// the normalizer is allowed to parameterize their args (see
-// isPlannerLiteralFunc / normalizer.go) so the plan-cache fingerprint
-// stays stable across a hot path like PostgREST's per-request
-// set_config('request.jwt.claims', '<dynamic JSON>', true).
+// is_local is inspected first because a literal `true` short-circuits:
+// transaction-scoped calls are not tracked at all (PG executes them via
+// Route, the gateway holds no state for them), so name/value need not be
+// validated and the normalizer is allowed to parameterize their args (see
+// isPlannerLiteralFunc / normalizer.go) — keeps the plan-cache fingerprint
+// stable for hot patterns like PostgREST's set_config('request.jwt.claims',
+// '<dynamic JSON>', true).
+//
+// A bound is_local cannot be short-circuited at plan time — the decision
+// to track is deferred to executeSetWithBinds.
 func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 	if fc.Args == nil || fc.Args.Len() != 3 {
 		return nil, mterrors.NewFeatureNotSupported(
 			"set_config requires three arguments: (name text, value text, is_local bool)")
 	}
 
-	isLocal, ok := constBoolArg(fc.Args.Items[2])
-	if !ok {
+	sc := &setConfigCall{}
+
+	if pr, isParam := unwrapTypeCast(fc.Args.Items[2]).(*ast.ParamRef); isParam {
+		sc.IsLocalBind = pr
+		sc.Bound = true
+	} else if isLocal, ok := constBoolArg(fc.Args.Items[2]); ok {
+		if isLocal {
+			return nil, nil
+		}
+		// is_local literal false: fall through. No field to set — the
+		// returned setConfigCall represents false implicitly via the
+		// absence of IsLocalBind.
+	} else {
 		return nil, setConfigArgError(fc.Args.Items[2], "is_local")
 	}
-	if isLocal {
-		// is_local=true: PG executes it as a transaction-scoped call and
-		// the pooler does not track it. Name/value need not be literals
-		// here — they may have been normalized to ParamRef.
-		return nil, nil
-	}
 
-	name, ok := constStringArg(fc.Args.Items[0])
-	if !ok {
+	if pr, isParam := unwrapTypeCast(fc.Args.Items[0]).(*ast.ParamRef); isParam {
+		sc.NameBind = pr
+		sc.Bound = true
+	} else if name, ok := constStringArg(fc.Args.Items[0]); ok {
+		sc.Name = name
+	} else {
 		return nil, setConfigArgError(fc.Args.Items[0], "name")
 	}
-	value, ok := constStringArg(fc.Args.Items[1])
-	if !ok {
+
+	if pr, isParam := unwrapTypeCast(fc.Args.Items[1]).(*ast.ParamRef); isParam {
+		sc.ValueBind = pr
+		sc.Bound = true
+	} else if value, ok := constStringArg(fc.Args.Items[1]); ok {
+		sc.Value = value
+	} else {
 		return nil, setConfigArgError(fc.Args.Items[1], "value")
 	}
-	return &setConfigCall{Name: name, Value: value}, nil
+
+	return sc, nil
 }
 
 // setConfigArgError builds the user-facing rejection for a set_config
-// argument that wasn't a recognizable literal. ParamRef gets a distinct
-// message because the fix is to inline the value, not to rewrite the
-// expression — extended-protocol clients that Parse "SELECT
-// set_config($1,$2,$3)" then Bind hit this path and need to be told the
-// difference.
+// argument that was neither a literal nor a bound parameter. Bound
+// parameters are no longer rejected — they go through the deferred
+// resolution path in ApplySessionState. This error fires only on
+// expression-shaped args (column refs, function calls, casts of non-const
+// values, etc.) which can never be safely tracked.
 func setConfigArgError(arg ast.Node, which string) error {
-	if _, isParam := unwrapTypeCast(arg).(*ast.ParamRef); isParam {
-		return mterrors.NewFeatureNotSupported(
-			"set_config " + which + " argument must be a literal, not a bound parameter; inline the value into the query text")
-	}
 	return mterrors.NewFeatureNotSupported(
-		"set_config " + which + " argument must be a literal constant")
+		"set_config " + which + " argument must be a literal constant or a bound parameter")
 }
 
 // resolveFuncName returns the lowercased built-in name targeted by funcname,

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -331,7 +331,7 @@ func TestInspectExpressionFuncCalls_BoundParametersAccepted(t *testing.T) {
 			require.NotNil(t, result)
 			require.Len(t, result.SetConfigs, 1)
 			sc := result.SetConfigs[0]
-			assert.True(t, sc.Bound, "expected Bound=true for any-slot ParamRef shape")
+			assert.True(t, sc.hasBoundParams(), "expected at least one bound slot for any-slot ParamRef shape")
 			assert.Equal(t, tt.wantNameBind, sc.NameBind != nil)
 			assert.Equal(t, tt.wantValueBind, sc.ValueBind != nil)
 			assert.Equal(t, tt.wantIsLocalBind, sc.IsLocalBind != nil)

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -251,34 +251,19 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 			wantMsg: "set_config is only supported as a top-level SELECT target list entry",
 		},
 		{
-			name:    "non-literal name arg",
+			name:    "non-literal non-bound name arg (column ref)",
 			sql:     "SELECT set_config(name, '256MB', false) FROM gucs",
-			wantMsg: "set_config name argument must be a literal constant",
+			wantMsg: "set_config name argument must be a literal constant or a bound parameter",
 		},
 		{
-			name:    "non-literal value arg",
+			name:    "non-literal non-bound value arg (column ref)",
 			sql:     "SELECT set_config('work_mem', v, false) FROM gucs",
-			wantMsg: "set_config value argument must be a literal constant",
+			wantMsg: "set_config value argument must be a literal constant or a bound parameter",
 		},
 		{
-			name:    "non-literal is_local",
+			name:    "non-literal non-bound is_local (column ref)",
 			sql:     "SELECT set_config('work_mem', '256MB', islocal) FROM gucs",
-			wantMsg: "set_config is_local argument must be a literal constant",
-		},
-		{
-			name:    "bound-parameter name arg gets parameter-specific message",
-			sql:     "SELECT set_config($1, '256MB', false)",
-			wantMsg: "must be a literal, not a bound parameter",
-		},
-		{
-			name:    "bound-parameter value arg gets parameter-specific message",
-			sql:     "SELECT set_config('work_mem', $1, false)",
-			wantMsg: "must be a literal, not a bound parameter",
-		},
-		{
-			name:    "bound-parameter is_local arg gets parameter-specific message",
-			sql:     "SELECT set_config('work_mem', '256MB', $1)",
-			wantMsg: "must be a literal, not a bound parameter",
+			wantMsg: "set_config is_local argument must be a literal constant or a bound parameter",
 		},
 	}
 
@@ -292,6 +277,90 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 			require.True(t, errors.As(err, &diag))
 			assert.Equal(t, mterrors.PgSSFeatureNotSupported, diag.Code)
 			assert.Contains(t, diag.Message, tt.wantMsg)
+		})
+	}
+}
+
+// TestInspectExpressionFuncCalls_BoundParametersAccepted pins the
+// extended-protocol shape: each set_config slot may be a wire-protocol
+// bound parameter and the walker accepts it, recording a setConfigCall
+// with the corresponding *Bind field populated. Decoding is deferred to
+// execute time inside ApplySessionState.executeSetWithBinds.
+func TestInspectExpressionFuncCalls_BoundParametersAccepted(t *testing.T) {
+	tests := []struct {
+		name            string
+		sql             string
+		wantNameBind    bool
+		wantValueBind   bool
+		wantIsLocalBind bool
+		wantLiteralName string
+		wantLiteralVal  string
+	}{
+		{
+			name:            "bound value (Slack repro)",
+			sql:             "SELECT set_config('search_path', $1, false)",
+			wantLiteralName: "search_path",
+			wantValueBind:   true,
+		},
+		{
+			name:           "bound name",
+			sql:            "SELECT set_config($1, 'public', false)",
+			wantNameBind:   true,
+			wantLiteralVal: "public",
+		},
+		{
+			name:            "bound is_local",
+			sql:             "SELECT set_config('search_path', 'public', $1)",
+			wantLiteralName: "search_path",
+			wantLiteralVal:  "public",
+			wantIsLocalBind: true,
+		},
+		{
+			name:            "all three bound",
+			sql:             "SELECT set_config($1, $2, $3)",
+			wantNameBind:    true,
+			wantValueBind:   true,
+			wantIsLocalBind: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			result, err := inspectExpressionFuncCalls(stmt)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result.SetConfigs, 1)
+			sc := result.SetConfigs[0]
+			assert.True(t, sc.Bound, "expected Bound=true for any-slot ParamRef shape")
+			assert.Equal(t, tt.wantNameBind, sc.NameBind != nil)
+			assert.Equal(t, tt.wantValueBind, sc.ValueBind != nil)
+			assert.Equal(t, tt.wantIsLocalBind, sc.IsLocalBind != nil)
+			if !tt.wantNameBind {
+				assert.Equal(t, tt.wantLiteralName, sc.Name)
+			}
+			if !tt.wantValueBind {
+				assert.Equal(t, tt.wantLiteralVal, sc.Value)
+			}
+		})
+	}
+}
+
+// TestInspectExpressionFuncCalls_LiteralIsLocalTrueShortCircuits pins that
+// a literal is_local=true call still returns no setConfigCall — the
+// transaction-scoped semantics are PG's job, gateway must not track. The
+// normalizer parameterizes name/value for these calls (PostgREST hot
+// path), so the walker must not require literals there either.
+func TestInspectExpressionFuncCalls_LiteralIsLocalTrueShortCircuits(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT set_config('request.jwt.claims', '{...}', true)",
+		"SELECT set_config($1, $2, true)",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			stmt := parseOne(t, sql)
+			result, err := inspectExpressionFuncCalls(stmt)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Empty(t, result.SetConfigs, "is_local literal true must not produce a tracker entry")
 		})
 	}
 }

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -645,14 +645,14 @@ func TestExtendedProtocol_TransactionIsolation(t *testing.T) {
 	}
 }
 
-// TestExtendedQueryProtocol_SetConfigBoundParam pins the Supabase Storage
-// migration shape: SELECT set_config('search_path', $1, false) over the
-// extended protocol. Without the bind-materialization path the multigateway
+// TestExtendedQueryProtocol_SetConfigBoundParam pins the extended-protocol
+// query shape SELECT set_config('search_path', $1, false). Without support
+// for bound set_config arguments, multigateway
 // planner rejects the bound parameter with
 // "set_config value argument must be a literal, not a bound parameter"
 // because the AST validator runs at Plan() time, when the AST still carries
-// a ParamRef. With the fix, MaterializeBoundSetConfigs substitutes the
-// portal's bind value before planning, and the gateway's session tracker is
+// a ParamRef. With the fix, the planner/executor path resolves portal bind
+// values for set_config and the gateway's session tracker is
 // updated alongside PG executing the call — visible via SHOW from a fresh
 // query on a possibly-rotated backend connection.
 //
@@ -672,7 +672,7 @@ func TestExtendedQueryProtocol_SetConfigBoundParam(t *testing.T) {
 
 	for _, target := range setup.GetComparisonTargets(t) {
 		t.Run(target.Name, func(t *testing.T) {
-			// Sub-test 1: text-format text value — the literal Storage shape.
+			// Sub-test 1: text-format text value.
 			// Parse declares the value parameter as TEXT (OID 25); psql's
 			// \bind emits this exact wire form.
 			t.Run("text value", func(t *testing.T) {

--- a/go/test/endtoend/queryserving/extended_query_protocol_test.go
+++ b/go/test/endtoend/queryserving/extended_query_protocol_test.go
@@ -644,3 +644,135 @@ func TestExtendedProtocol_TransactionIsolation(t *testing.T) {
 		})
 	}
 }
+
+// TestExtendedQueryProtocol_SetConfigBoundParam pins the Supabase Storage
+// migration shape: SELECT set_config('search_path', $1, false) over the
+// extended protocol. Without the bind-materialization path the multigateway
+// planner rejects the bound parameter with
+// "set_config value argument must be a literal, not a bound parameter"
+// because the AST validator runs at Plan() time, when the AST still carries
+// a ParamRef. With the fix, MaterializeBoundSetConfigs substitutes the
+// portal's bind value before planning, and the gateway's session tracker is
+// updated alongside PG executing the call — visible via SHOW from a fresh
+// query on a possibly-rotated backend connection.
+//
+// Runs against direct PostgreSQL and multigateway: PG has always accepted
+// this shape natively, so the comparison confirms parity rather than the
+// gateway diverging.
+func TestExtendedQueryProtocol_SetConfigBoundParam(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			// Sub-test 1: text-format text value — the literal Storage shape.
+			// Parse declares the value parameter as TEXT (OID 25); psql's
+			// \bind emits this exact wire form.
+			t.Run("text value", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				const stmtName = "setcfg_text"
+				require.NoError(t, conn.Parse(ctx, stmtName,
+					"SELECT set_config('search_path', $1, false)", []uint32{25}))
+
+				const want = "myschema_xyz"
+				var got string
+				_, err := conn.BindAndExecute(ctx, "", stmtName,
+					[][]byte{[]byte(want)}, []int16{0}, []int16{0}, 0,
+					func(_ context.Context, result *sqltypes.Result) error {
+						if len(result.Rows) > 0 {
+							got = string(result.Rows[0].Values[0])
+						}
+						return nil
+					})
+				require.NoError(t, err, "set_config with bound parameter should succeed")
+				assert.Equal(t, want, got, "set_config must return the bound value PG actually applied")
+
+				require.NoError(t, conn.CloseStatement(ctx, stmtName))
+
+				// Gateway tracker mirror: a fresh SHOW must return the same
+				// value, even though the backend connection serving SHOW may
+				// have been rotated between the two queries.
+				results, err := conn.Query(ctx, "SHOW search_path")
+				require.NoError(t, err)
+				require.NotEmpty(t, results)
+				require.NotEmpty(t, results[0].Rows)
+				assert.Equal(t, want, string(results[0].Rows[0].Values[0]),
+					"SHOW search_path must reflect the set_config value applied via bound parameter")
+			})
+
+			// Sub-test 2: unspecified parameter type (OID 0). Clients that
+			// elide ParameterTypes in Parse (some libpq callers, the psql
+			// \bind shorthand) end up here. The materializer must treat the
+			// raw bytes as text and accept them.
+			t.Run("unspecified param type", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				const stmtName = "setcfg_unspec"
+				require.NoError(t, conn.Parse(ctx, stmtName,
+					"SELECT set_config('search_path', $1, false)", nil))
+
+				const want = "public,extensions"
+				var got string
+				_, err := conn.BindAndExecute(ctx, "", stmtName,
+					[][]byte{[]byte(want)}, nil, nil, 0,
+					func(_ context.Context, result *sqltypes.Result) error {
+						if len(result.Rows) > 0 {
+							got = string(result.Rows[0].Values[0])
+						}
+						return nil
+					})
+				require.NoError(t, err)
+				assert.Equal(t, want, got)
+
+				require.NoError(t, conn.CloseStatement(ctx, stmtName))
+			})
+
+			// Sub-test 3: repeated Bind+Execute on the same prepared
+			// statement with different values. Each Execute must produce
+			// its own plan from its own binds — a cached plan would carry
+			// the first iteration's value into subsequent iterations and
+			// the gateway tracker would lie about the current search_path.
+			t.Run("repeated bind with different values", func(t *testing.T) {
+				conn := connectLowLevelToPort(t, ctx, target.Port)
+				defer conn.Close()
+
+				const stmtName = "setcfg_repeat"
+				require.NoError(t, conn.Parse(ctx, stmtName,
+					"SELECT set_config('search_path', $1, false)", []uint32{25}))
+
+				for _, want := range []string{"first", "second", "third"} {
+					var got string
+					_, err := conn.BindAndExecute(ctx, "", stmtName,
+						[][]byte{[]byte(want)}, []int16{0}, []int16{0}, 0,
+						func(_ context.Context, result *sqltypes.Result) error {
+							if len(result.Rows) > 0 {
+								got = string(result.Rows[0].Values[0])
+							}
+							return nil
+						})
+					require.NoError(t, err, "iteration %q failed", want)
+					assert.Equal(t, want, got, "iteration %q returned wrong value", want)
+
+					results, err := conn.Query(ctx, "SHOW search_path")
+					require.NoError(t, err)
+					require.NotEmpty(t, results)
+					require.NotEmpty(t, results[0].Rows)
+					assert.Equal(t, want, string(results[0].Rows[0].Values[0]),
+						"SHOW after iteration %q must reflect the latest bound value, not a cached one", want)
+				}
+
+				require.NoError(t, conn.CloseStatement(ctx, stmtName))
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Storage migrations against multigres hit `set_config value argument must be a literal, not a bound parameter` for `SELECT set_config('search_path', $1, false)` over the extended query protocol. Substitute the portal's bind values into a cloned AST at portal-execute time so the planner sees literals and mints the SessionSettings tracker entry it needs.
- Substituted plans are single-use (never cached). `Route` reissues the original portal + binds to PG, so the gateway tracker and PG decode the same bytes — no desync, no plan-cache poisoning.
- Position rules and the security blocklist are unchanged: set_config in WHERE/subquery/CTE/DEFAULT is still rejected, and `dblink`/`pg_read_file`/etc. with bound params are still rejected at the walker.

Fixes [MUL-531](https://linear.app/supabase/issue/MUL-531).

## Test plan

- [x] Unit tests in `planner/set_config_bind_test.go` — 11 cases (value/name/is_local slots, text+binary bool, NULL bind rejected, unsupported OID rejected, unspecified OID accepted, passthrough, schema-qualified, original AST unmodified, out-of-range param)
- [x] Integration test `TestExtendedQueryProtocol_SetConfigBoundParam` — 3 subtests × 2 targets (direct PG + multigateway): text value (Storage repro), unspecified param type, repeated bind with different values + SHOW mirror
- [x] Existing `TestMultiGateway_UnsafeFuncCallRejection`, `TestMultiGateway_SetConfigRoutedAsSET`, `TestMultiGateway_SessionSettings`, `TestExtendedQueryProtocol_*`, `TestPreparedStatement*` — no regression
- [x] Unit + race detector across `go/services/multigateway/...`, `go/common/parser/...`, `go/common/preparedstatement`
- [x] Manual psql against local cluster: Slack repro, Storage value, bound name/is_local/all-three slots, `pg_catalog.set_config(...)` qualified, repeated bind diff values, session isolation across clients, plus all rejection paths (WHERE, nested, dblink+bind, pg_read_file+bind, out-of-range param)