### PR TITLE
feat(multipooler): add transaction support to internal query serving interface

### DIFF
--- a/go/services/multipooler/executor/internal_query.go
+++ b/go/services/multipooler/executor/internal_query.go
@@ -17,10 +17,16 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multipooler/pools/reserved"
 )
+
+// errTxFinished is returned when a query is issued on an InternalTx that has
+// already been committed or rolled back.
+var errTxFinished = errors.New("transaction already finished")
 
 // InternalQueryService provides a simplified query interface for internal multipooler
 // components. It uses the admin connection pool, which authenticates as the configured
@@ -39,7 +45,57 @@ type InternalQueryService interface {
 	// QueryMultiStatement executes a multi-statement query (e.g. "BEGIN; ...; COMMIT;")
 	// using the simple query protocol. Unlike Query, it does not require exactly one result set.
 	QueryMultiStatement(ctx context.Context, query string) error
+
+	// Begin starts a transaction on a reserved connection and returns a handle
+	// for issuing queries within it. Reserved connections are the mechanism for
+	// holding a backend outside the regular pool's checkout/recycle cycle, which
+	// is exactly what a multi-statement transaction needs: every query run
+	// through the returned InternalTx executes on the same backend inside a
+	// single PostgreSQL transaction, so results from one statement can drive the
+	// next and the whole sequence commits or rolls back atomically.
+	//
+	// The reserved connection is held for the lifetime of the transaction. The
+	// caller MUST call Commit or Rollback exactly once to release it; the
+	// idiomatic pattern is to defer Rollback (a no-op once Commit succeeds):
+	//
+	//	tx, err := qs.Begin(ctx)
+	//	if err != nil {
+	//	    return err
+	//	}
+	//	defer tx.Rollback(ctx)
+	//	if _, err := tx.Query(ctx, "..."); err != nil {
+	//	    return err
+	//	}
+	//	return tx.Commit(ctx)
+	Begin(ctx context.Context) (InternalTx, error)
 }
+
+// InternalTx is a handle to an in-progress transaction held on a reserved
+// connection. It is returned by InternalQueryService.Begin. All queries issued
+// through it run on the same backend inside one PostgreSQL transaction.
+//
+// InternalTx is not safe for concurrent use: callers must serialize access, the
+// same as they would for a single database connection.
+type InternalTx interface {
+	// Query executes a query within the transaction and returns its single result.
+	Query(ctx context.Context, query string) (*sqltypes.Result, error)
+
+	// QueryArgs executes a parameterized query within the transaction. It accepts
+	// the same Go argument types as InternalQueryService.QueryArgs.
+	QueryArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error)
+
+	// Commit commits the transaction and releases the reserved connection. The
+	// InternalTx must not be used afterward.
+	Commit(ctx context.Context) error
+
+	// Rollback rolls back the transaction and releases the reserved connection.
+	// It is a no-op if the transaction was already committed or rolled back, so
+	// it is safe to defer unconditionally.
+	Rollback(ctx context.Context) error
+}
+
+// Compile-time check that internalTx implements InternalTx.
+var _ InternalTx = (*internalTx)(nil)
 
 // Compile-time check that Executor implements InternalQueryService.
 var _ InternalQueryService = (*Executor)(nil)
@@ -117,4 +173,120 @@ func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sql
 		return nil, errors.New("unexpected number of results")
 	}
 	return results[0], nil
+}
+
+// Begin implements InternalQueryService. It reserves a connection (via the
+// reserved pool, the mechanism for holding a backend outside normal pooling)
+// and starts a transaction on it, returning a handle that owns the reserved
+// connection until Commit or Rollback is called.
+func (e *Executor) Begin(ctx context.Context) (InternalTx, error) {
+	// Enable SQL text in trace spans for internal queries (safe - no user data).
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
+	// Internal callers connect as the configured superuser and need no session
+	// settings or SCRAM passthrough keys.
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, nil, e.poolManager.PgUser(), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
+	}
+
+	// Begin runs "BEGIN" and records ReasonTransaction on the reservation. If it
+	// fails no transaction state was established; release frees the connection
+	// (tainting it if the failure closed the socket).
+	if err := reservedConn.Begin(ctx); err != nil {
+		reservedConn.Release(reserved.ReleaseError)
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	return &internalTx{conn: reservedConn}, nil
+}
+
+// internalTx is the Executor's implementation of InternalTx. It owns a reserved
+// connection for the duration of a transaction.
+type internalTx struct {
+	// conn is the reserved connection carrying the open transaction.
+	conn *reserved.Conn
+
+	// finished is set once the transaction has been committed or rolled back and
+	// the connection released. Further queries on a finished tx are rejected.
+	finished bool
+}
+
+// Query implements InternalTx.
+func (tx *internalTx) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errTxFinished
+	}
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
+	results, err := tx.conn.Query(ctx, queryStr)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) != 1 {
+		return nil, errors.New("unexpected number of results")
+	}
+	return results[0], nil
+}
+
+// QueryArgs implements InternalTx.
+func (tx *internalTx) QueryArgs(ctx context.Context, sql string, args ...any) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errTxFinished
+	}
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
+	results, err := tx.conn.QueryArgs(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) != 1 {
+		return nil, errors.New("unexpected number of results")
+	}
+	return results[0], nil
+}
+
+// Commit implements InternalTx.
+func (tx *internalTx) Commit(ctx context.Context) error {
+	if tx.finished {
+		return errTxFinished
+	}
+	tx.finished = true
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
+	if err := tx.conn.Commit(ctx); err != nil {
+		// COMMIT failed: the connection's state is no longer known to be clean,
+		// so release it as an error (which taints it) rather than recycling.
+		tx.conn.Release(reserved.ReleaseError)
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	tx.conn.Release(reserved.ReleaseCommit)
+	return nil
+}
+
+// Rollback implements InternalTx. It is a no-op once the transaction is
+// finished, so callers can defer it unconditionally alongside Commit.
+func (tx *internalTx) Rollback(ctx context.Context) error {
+	if tx.finished {
+		return nil
+	}
+	tx.finished = true
+	ctx = client.WithQueryTracing(ctx, client.QueryTracingConfig{
+		IncludeQueryText: true,
+	})
+
+	if err := tx.conn.Rollback(ctx); err != nil {
+		tx.conn.Release(reserved.ReleaseError)
+		return fmt.Errorf("failed to rollback transaction: %w", err)
+	}
+	tx.conn.Release(reserved.ReleaseRollback)
+	return nil
 }

--- a/go/services/multipooler/executor/internal_query_test.go
+++ b/go/services/multipooler/executor/internal_query_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/fakepgserver"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	"github.com/multigres/multigres/go/services/multipooler/connpoolmanager"
+	"github.com/multigres/multigres/go/tools/viperutil"
+)
+
+// newInternalQueryTestExecutor wires a real connpoolmanager.Manager to the given
+// fake server and returns an Executor backed by it. The manager is closed via
+// t.Cleanup.
+func newInternalQueryTestExecutor(t *testing.T, server *fakepgserver.Server) *Executor {
+	t.Helper()
+
+	reg := viperutil.NewRegistry()
+	config := connpoolmanager.NewConfig(reg)
+	// fakepgserver uses trust auth, so the password value is never consulted —
+	// resolving just satisfies the "Resolve ran before Open" invariant.
+	t.Setenv(constants.PgPasswordEnvVar, "test-password")
+	require.NoError(t, config.ResolvePgPassword())
+
+	manager := config.NewManager(slog.Default())
+	manager.Open(context.Background(), &connpoolmanager.ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	})
+	// Close the manager before the server: the server's listener blocks on
+	// Close until every client connection has gone away, so the manager's
+	// pooled connections must be torn down first to avoid a deadlock.
+	t.Cleanup(func() {
+		manager.Close()
+		server.Close()
+	})
+
+	poolerID := &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "pooler1"}
+	return NewExecutor(slog.Default(), manager, poolerID, false)
+}
+
+func TestInternalTx_CommitFlow(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Query(ctx, "INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	// BEGIN, the statement, and COMMIT all ran.
+	assert.Equal(t, 1, server.GetQueryCalledNum("BEGIN"))
+	assert.Equal(t, 1, server.GetQueryCalledNum("INSERT INTO t VALUES (1)"))
+	assert.Equal(t, 1, server.GetQueryCalledNum("COMMIT"))
+	assert.Equal(t, 0, server.GetQueryCalledNum("ROLLBACK"))
+}
+
+func TestInternalTx_RollbackFlow(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Query(ctx, "INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Rollback(ctx))
+
+	assert.Equal(t, 1, server.GetQueryCalledNum("BEGIN"))
+	assert.Equal(t, 1, server.GetQueryCalledNum("ROLLBACK"))
+	assert.Equal(t, 0, server.GetQueryCalledNum("COMMIT"))
+}
+
+func TestInternalTx_DeferredRollbackAfterCommitIsNoop(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	// Simulates the `defer tx.Rollback(ctx)` idiom firing after a successful
+	// Commit: it must be a no-op and not issue a ROLLBACK.
+	require.NoError(t, tx.Rollback(ctx))
+	assert.Equal(t, 0, server.GetQueryCalledNum("ROLLBACK"))
+}
+
+func TestInternalTx_QueryAfterFinishedFails(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	_, err = tx.Query(ctx, "SELECT 1")
+	require.ErrorIs(t, err, errTxFinished)
+
+	_, err = tx.QueryArgs(ctx, "SELECT $1", 1)
+	require.ErrorIs(t, err, errTxFinished)
+
+	require.ErrorIs(t, tx.Commit(ctx), errTxFinished)
+}
+
+func TestInternalTx_QueryArgsWithinTransaction(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// QueryArgs uses the extended query protocol; it must run on the same pinned
+	// connection inside the transaction.
+	res, err := tx.QueryArgs(ctx, "SELECT $1::int", 42)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.NoError(t, tx.Commit(ctx))
+}
+
+func TestInternalTx_SequentialTransactionsReleaseReservedConn(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	// Two transactions in sequence: the second can only Begin if the first's
+	// reserved connection was released back to the pool, so this guards against
+	// leaking the reservation on Commit.
+	for range 2 {
+		tx, err := e.Begin(ctx)
+		require.NoError(t, err)
+		_, err = tx.Query(ctx, "SELECT 1")
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+	}
+
+	assert.Equal(t, 2, server.GetQueryCalledNum("BEGIN"))
+	assert.Equal(t, 2, server.GetQueryCalledNum("COMMIT"))
+}
+
+func TestInternalTx_BeginErrorReleasesConnection(t *testing.T) {
+	server := fakepgserver.New(t)
+	server.SetNeverFail(true)
+	server.RejectQueryPattern("BEGIN", "cannot begin")
+
+	e := newInternalQueryTestExecutor(t, server)
+	ctx := context.Background()
+
+	tx, err := e.Begin(ctx)
+	require.Error(t, err)
+	assert.Nil(t, tx)
+	assert.Contains(t, err.Error(), "failed to begin transaction")
+}

--- a/go/services/multipooler/executor/mock/mock_querier.go
+++ b/go/services/multipooler/executor/mock/mock_querier.go
@@ -17,6 +17,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sync"
@@ -30,6 +31,7 @@ import (
 type QueryService struct {
 	mu       sync.Mutex
 	patterns []queryPattern
+	beginErr error
 }
 
 type queryPattern struct {
@@ -181,6 +183,92 @@ func (m *QueryService) QueryMultiStatement(ctx context.Context, queryStr string)
 // For the mock, arguments are ignored and matching is done solely on the query string.
 func (m *QueryService) QueryArgs(ctx context.Context, queryStr string, args ...any) (*sqltypes.Result, error) {
 	return m.Query(ctx, queryStr)
+}
+
+// SetBeginError configures Begin to fail with the given error. Pass nil to clear.
+// Useful for exercising transaction-start failure paths.
+func (m *QueryService) SetBeginError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.beginErr = err
+}
+
+// Begin implements executor.InternalQueryService. The returned transaction
+// routes Query/QueryArgs through the same pattern matcher as the stateless
+// methods, so tests register patterns for the statements run inside the
+// transaction (including BEGIN/COMMIT/ROLLBACK if they want to assert on them).
+// BEGIN, COMMIT, and ROLLBACK are matched only when a pattern exists for them;
+// otherwise they succeed silently so existing tests need not register them.
+func (m *QueryService) Begin(ctx context.Context) (executor.InternalTx, error) {
+	m.mu.Lock()
+	beginErr := m.beginErr
+	m.mu.Unlock()
+	if beginErr != nil {
+		return nil, beginErr
+	}
+	if err := m.queryIfMatched(ctx, "BEGIN"); err != nil {
+		return nil, err
+	}
+	return &mockTx{m: m}, nil
+}
+
+// queryIfMatched runs queryStr through the matcher only if a pattern matches it,
+// returning any configured error. Unmatched control statements succeed silently.
+func (m *QueryService) queryIfMatched(ctx context.Context, queryStr string) error {
+	m.mu.Lock()
+	matched := false
+	for i := range m.patterns {
+		if m.patterns[i].pattern.MatchString(queryStr) {
+			matched = true
+			break
+		}
+	}
+	m.mu.Unlock()
+	if !matched {
+		return nil
+	}
+	_, err := m.Query(ctx, queryStr)
+	return err
+}
+
+// mockTx is the mock implementation of executor.InternalTx.
+type mockTx struct {
+	m        *QueryService
+	finished bool
+}
+
+// Query implements executor.InternalTx.
+func (tx *mockTx) Query(ctx context.Context, queryStr string) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errors.New("transaction already finished")
+	}
+	return tx.m.Query(ctx, queryStr)
+}
+
+// QueryArgs implements executor.InternalTx.
+func (tx *mockTx) QueryArgs(ctx context.Context, queryStr string, args ...any) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errors.New("transaction already finished")
+	}
+	return tx.m.Query(ctx, queryStr)
+}
+
+// Commit implements executor.InternalTx.
+func (tx *mockTx) Commit(ctx context.Context) error {
+	if tx.finished {
+		return errors.New("transaction already finished")
+	}
+	tx.finished = true
+	return tx.m.queryIfMatched(ctx, "COMMIT")
+}
+
+// Rollback implements executor.InternalTx.
+func (tx *mockTx) Rollback(ctx context.Context) error {
+	if tx.finished {
+		return nil
+	}
+	tx.finished = true
+	return tx.m.queryIfMatched(ctx, "ROLLBACK")
 }
 
 // MakeQueryResult creates a sqltypes.Result from columns and rows.

--- a/go/services/multipooler/executor/mock/mock_querier_test.go
+++ b/go/services/multipooler/executor/mock/mock_querier_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockBegin_RoutesQueriesThroughMatcher(t *testing.T) {
+	m := NewQueryService()
+	m.AddQueryPattern("INSERT INTO t.*", MakeQueryResult([]string{"ok"}, [][]any{{"1"}}))
+
+	ctx := context.Background()
+	tx, err := m.Begin(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	res, err := tx.Query(ctx, "INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// QueryArgs matches on the query string just like Query.
+	res, err = tx.QueryArgs(ctx, "INSERT INTO t VALUES ($1)", 2)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.NoError(t, tx.Commit(ctx))
+}
+
+func TestMockBegin_UnmatchedControlStatementsSucceedSilently(t *testing.T) {
+	// No BEGIN/COMMIT/ROLLBACK patterns registered: those control statements
+	// must pass without requiring callers to register them.
+	m := NewQueryService()
+	ctx := context.Background()
+
+	tx, err := m.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	tx2, err := m.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx2.Rollback(ctx))
+}
+
+func TestMockBegin_SetBeginError(t *testing.T) {
+	m := NewQueryService()
+	wantErr := errors.New("boom")
+	m.SetBeginError(wantErr)
+
+	tx, err := m.Begin(context.Background())
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, tx)
+
+	// Clearing the error restores normal behavior.
+	m.SetBeginError(nil)
+	tx, err = m.Begin(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+}
+
+func TestMockBegin_BeginPatternErrorPropagates(t *testing.T) {
+	m := NewQueryService()
+	m.AddQueryPatternWithError("BEGIN", errors.New("cannot begin"))
+
+	tx, err := m.Begin(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, tx)
+	assert.Contains(t, err.Error(), "cannot begin")
+}
+
+func TestMockTx_CommitAndRollbackPatternErrorsPropagate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("commit error", func(t *testing.T) {
+		m := NewQueryService()
+		m.AddQueryPatternWithError("COMMIT", errors.New("commit failed"))
+		tx, err := m.Begin(ctx)
+		require.NoError(t, err)
+		err = tx.Commit(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "commit failed")
+	})
+
+	t.Run("rollback error", func(t *testing.T) {
+		m := NewQueryService()
+		m.AddQueryPatternWithError("ROLLBACK", errors.New("rollback failed"))
+		tx, err := m.Begin(ctx)
+		require.NoError(t, err)
+		err = tx.Rollback(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rollback failed")
+	})
+}
+
+func TestMockTx_UseAfterFinished(t *testing.T) {
+	ctx := context.Background()
+	m := NewQueryService()
+
+	tx, err := m.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	_, err = tx.Query(ctx, "SELECT 1")
+	require.Error(t, err)
+	_, err = tx.QueryArgs(ctx, "SELECT 1")
+	require.Error(t, err)
+	require.Error(t, tx.Commit(ctx))
+
+	// Rollback after finish is a no-op so it is safe to defer.
+	require.NoError(t, tx.Rollback(ctx))
+}

--- a/go/services/multipooler/manager/rule_store_pg_test.go
+++ b/go/services/multipooler/manager/rule_store_pg_test.go
@@ -110,6 +110,65 @@ func (s *connQueryService) QueryMultiStatement(ctx context.Context, query string
 	return err
 }
 
+func (s *connQueryService) Begin(ctx context.Context) (executor.InternalTx, error) {
+	if _, err := s.conn.Query(ctx, "BEGIN"); err != nil {
+		return nil, err
+	}
+	return &connTx{conn: s.conn}, nil
+}
+
+// connTx implements executor.InternalTx over a single *client.Conn for tests.
+type connTx struct {
+	conn     *client.Conn
+	finished bool
+}
+
+func (tx *connTx) Query(ctx context.Context, query string) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errors.New("transaction already finished")
+	}
+	results, err := tx.conn.QueryArgs(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return &sqltypes.Result{}, nil
+	}
+	return results[0], nil
+}
+
+func (tx *connTx) QueryArgs(ctx context.Context, query string, args ...any) (*sqltypes.Result, error) {
+	if tx.finished {
+		return nil, errors.New("transaction already finished")
+	}
+	results, err := tx.conn.QueryArgs(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return &sqltypes.Result{}, nil
+	}
+	return results[0], nil
+}
+
+func (tx *connTx) Commit(ctx context.Context) error {
+	if tx.finished {
+		return errors.New("transaction already finished")
+	}
+	tx.finished = true
+	_, err := tx.conn.Query(ctx, "COMMIT")
+	return err
+}
+
+func (tx *connTx) Rollback(ctx context.Context) error {
+	if tx.finished {
+		return nil
+	}
+	tx.finished = true
+	_, err := tx.conn.Query(ctx, "ROLLBACK")
+	return err
+}
+
 // TestMain sets up the PATH for PG binaries and the orphan-detection watchdog,
 // runs the tests, and tears down the postgres instance if it was started.
 // Postgres is started lazily by the first PG test (via skipIfNoPG) so that


### PR DESCRIPTION
## Summary

- `InternalQueryService` (used by internal multipooler components — rule store, sync-standby manager, heartbeat, schema setup) previously acquired a fresh pooled connection per call and recycled it immediately, so it could not run a multi-statement transaction. The only escape hatch was passing a literal `"BEGIN; ...; COMMIT;"` string to `QueryMultiStatement`, which has no per-statement error handling and can't use one statement's result to drive the next.
- Adds `Begin(ctx) (InternalTx, error)` to `InternalQueryService`, returning a transaction handle with `Query`, `QueryArgs`, `Commit`, and `Rollback`.
- The transaction runs on a **reserved connection** — the existing mechanism for holding a backend outside the regular pool's checkout/recycle cycle (also used for client transactions, temp tables, portals, COPY, LISTEN, logical replication) — so all of the reserved pool's machinery (inactivity-timeout reclamation, kill, taint-on-error release) applies for free.

## Description

`Executor.Begin` reserves a connection via `NewReservedConn` and starts a transaction with `reserved.Conn.Begin` (which runs `BEGIN` and records `ReasonTransaction` on the reservation). The returned `InternalTx` issues every statement on that same reserved connection, so results from one statement can drive the next and the whole sequence commits or rolls back atomically.

`Commit`/`Rollback` finalize via the reserved conn and then `Release` it: `ReleaseCommit`/`ReleaseRollback` on success, `ReleaseError` (which taints the connection) if the finalizing command fails or the socket was closed underneath us. `Rollback` is a no-op once the transaction is finished, so callers can `defer tx.Rollback(ctx)` unconditionally alongside `Commit`. Statements inside the transaction use the reserved conn's non-retrying query methods, since a transparent reconnect mid-transaction would silently discard the open transaction.

Idiomatic usage:

```go
tx, err := qs.Begin(ctx)
if err != nil {
    return err
}
defer tx.Rollback(ctx) // no-op once Commit succeeds
if _, err := tx.Query(ctx, "CREATE SCHEMA multigres"); err != nil {
    return err
}
return tx.Commit(ctx)
```

The executor mock and the `connQueryService` PG test helper are extended to satisfy the widened interface. New unit tests (against a `fakepgserver`-backed real pool) cover commit, rollback, deferred-rollback-after-commit no-op, use-after-finish errors, `QueryArgs` within a transaction, sequential transactions (verifying the reserved connection is released and reusable — no leak), and begin failure.

No existing callers are migrated in this PR; this only adds the capability.