### PR TITLE
fix(multiorch,multipooler): allow re-promoting previously demoted leader

### DIFF
--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -29,7 +30,6 @@ import (
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multiorchdatapb "github.com/multigres/multigres/go/pb/multiorchdata"
-	"github.com/multigres/multigres/go/services/multiorch/recovery/types"
 )
 
 // Coordinator orchestrates consensus-based leader election for shards.
@@ -75,27 +75,43 @@ func (c *Coordinator) AppointLeader(ctx context.Context, shardKey *clustermetada
 	return c.runFailover(ctx, cohort, reason)
 }
 
+// failoverCohortReachableThreshold bounds how stale a pooler's last successful
+// health check may be before it's excluded from the recruitment cohort. A pure
+// LastSeen staleness check absorbs transient stream blips without flapping on
+// every health-check error bit; 10 seconds is generous relative to the
+// sub-second polling cadence so legitimately reachable poolers are never
+// dropped, while genuinely dead ones don't waste Recruit RPC timeouts.
+const failoverCohortReachableThreshold = 10 * time.Second
+
 // runFailover wires the failover callbacks for a coordinatorLedRuleChange and
-// runs it. Poolers that have signaled REQUESTING_DEMOTION are excluded from
-// the cohort entirely: a writing leader's local LSN is always at least as
-// advanced as any replica's (async replication), so including a resigned
-// leader would let it dominate discovery and dead-end the proposal when health
-// check rejects it. The full cohort identity is preserved via OutgoingRule's
-// CohortMembers (replicas carry the same rule), so the consensus layer's
-// outgoing-quorum check still runs against the original cohort size.
+// runs it. A leader that signaled REQUESTING_DEMOTION stays in the recruitment
+// cohort and may be re-promoted at the new term if it remains the best
+// candidate — the signal is "please replace me if you can," not "remove me."
+// Excluding it dropped a 2-pooler AT_LEAST_2 cohort below quorum after a
+// Recruit fan-out emergency-demoted the primary (MUL-505). Unreachable
+// poolers (no successful health check within the threshold) are still
+// excluded so we don't burn Recruit timeouts on members we believe are dead.
+//
+// TODO: during a rule change, if some recruitable replicas would not require
+// a pg_rewind to follow the chosen leader, prefer them over candidates that
+// would. Picking a rewind-free replica makes failover faster; picking one
+// that needs rewinding is not fatal — the SetTermPrimary path runs pg_rewind
+// before the node serves writes or replicates.
 func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb.PoolerHealthState, reason string) error {
 	liveCohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohort))
 	for _, p := range cohort {
-		if types.LeaderNeedsReplacement(p) {
-			c.logger.InfoContext(ctx, "Excluding resigned pooler from failover cohort",
-				"pooler", p.GetMultiPooler().GetId().GetName())
+		last := p.GetLastSeen()
+		if last == nil || time.Since(last.AsTime()) > failoverCohortReachableThreshold {
+			c.logger.InfoContext(ctx, "Excluding unreachable pooler from failover cohort",
+				"pooler", p.GetMultiPooler().GetId().GetName(),
+				"last_seen", last.AsTime())
 			continue
 		}
 		liveCohort = append(liveCohort, p)
 	}
 	if len(liveCohort) == 0 {
 		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-			"no non-resigned poolers in cohort; cannot fail over")
+			"no reachable poolers in cohort; cannot fail over")
 	}
 
 	// Failover constructs the revocation via NewTermRevocation: outgoing_rule

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -71,7 +72,7 @@ func createMockNode(fakeClient *rpcclient.FakeClient, name string, term int64, w
 		}
 	}
 
-	return &multiorchdatapb.PoolerHealthState{
+	healthState := &multiorchdatapb.PoolerHealthState{
 		MultiPooler:      pooler,
 		IsLastCheckValid: healthy,
 		ConsensusStatus:  &clustermetadatapb.ConsensusStatus{TermRevocation: consensusTerm},
@@ -80,6 +81,10 @@ func createMockNode(fakeClient *rpcclient.FakeClient, name string, term int64, w
 			PostgresRunning: healthy,
 		},
 	}
+	if healthy {
+		healthState.LastSeen = timestamppb.Now()
+	}
+	return healthState
 }
 
 func TestAppointLeader(t *testing.T) {

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1329,6 +1329,14 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		return err
 	}
 
+	// Promotion supersedes any pending rewind from a prior emergency demotion:
+	// the consensus protocol picked this node as the new leader at a higher
+	// term, so its WAL is by definition the rule going forward. Clear the
+	// flag so the postgres monitor and other operations resume.
+	if pm.rewindPending.Swap(false) {
+		pm.logger.InfoContext(ctx, "Cleared rewindPending before promotion")
+	}
+
 	// Clear primary_conninfo after promotion to prevent accidental replication on restart
 	if err := pm.resetPrimaryConnInfo(ctx); err != nil {
 		pm.logger.WarnContext(ctx, "Failed to clear primary_conninfo after promotion", "error", err)

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1388,19 +1388,24 @@ func (pm *MultiPoolerManager) waitForPromotionComplete(ctx context.Context) erro
 	}
 }
 
-// updateTopologyAfterPromotion updates the pooler type in topology from REPLICA to PRIMARY
+// updateTopologyAfterPromotion updates the pooler type in topology to PRIMARY
+// and transitions the serving state to SERVING.
+//
+// The serving-state transition must always run, even when the topology already
+// reports PRIMARY. That can happen on re-promotion of the same pooler at a
+// higher term: emergencyDemoteLocked left the topology Type=PRIMARY (only
+// stale-primary demote updates topology) but transitioned serving status to
+// NOT_SERVING. Skipping the SetState call left the pooler stuck at
+// PRIMARY/NOT_SERVING, which prevented the multigateway buffer from draining
+// after the failover.
 func (pm *MultiPoolerManager) updateTopologyAfterPromotion(ctx context.Context, state *promotionState) error {
-	// Return early if already updated
 	if state.isPrimaryInTopology {
-		pm.logger.InfoContext(ctx, "Topology already updated, skipping")
-		return nil
+		pm.logger.InfoContext(ctx, "Topology type already PRIMARY; ensuring serving status is SERVING")
+	} else {
+		pm.logger.InfoContext(ctx, "Updating pooler type in topology to PRIMARY")
 	}
 
-	pm.logger.InfoContext(ctx, "Topology update needed")
-	pm.logger.InfoContext(ctx, "Updating pooler type in topology to PRIMARY")
-
-	// Use the serving state manager to transition components (query service, heartbeat, health streamer)
-	// and update the multipooler record. The serving status stays SERVING during promotion.
+	// SetState is idempotent — if already at PRIMARY/SERVING it short-circuits.
 	if err := pm.servingState.SetState(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING); err != nil {
 		return mterrors.Wrap(err, "failed to set serving state for promotion")
 	}

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -275,15 +275,6 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION, err.Error())
 	}
 
-	// Refuse recruitment if a rewind is still pending from a prior emergency
-	// demotion. The node's WAL is in an indeterminate state until RewindToSource
-	// completes; allowing it to be recruited could elect a leader with divergent
-	// or missing WAL.
-	if pm.rewindPending.Load() {
-		return nil, mterrors.New(mtrpcpb.Code_FAILED_PRECONDITION,
-			"rewind pending after emergency demotion; call RewindToSource before Recruit")
-	}
-
 	isPrimary, err := pm.isPrimary(ctx)
 	if err != nil {
 		return nil, mterrors.Wrap(err, "failed to determine role for recruit")

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -497,7 +497,10 @@ func TestRecruit(t *testing.T) {
 		})
 	}
 
-	t.Run("RewindPending_RejectsRecruit", func(t *testing.T) {
+	t.Run("RewindPending_DoesNotBlockRecruit", func(t *testing.T) {
+		// rewindPending is intentionally not a Recruit gate: a node still
+		// pending a rewind may participate so multiorch can always form
+		// quorum. The actual rewind happens at SetTermPrimary.
 		mockQueryService := mock.NewQueryService()
 		pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(0)})
 		pm.rewindPending.Store(true)
@@ -511,8 +514,13 @@ func TestRecruit(t *testing.T) {
 			},
 		}
 		_, err := pm.Recruit(t.Context(), req)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "rewind pending")
+		// We don't require success here (the minimal mock setup doesn't
+		// satisfy the full Recruit path); we only assert that rewindPending
+		// is no longer the reason for rejection.
+		if err != nil {
+			assert.NotContains(t, err.Error(), "rewind pending",
+				"rewindPending should no longer block Recruit")
+		}
 	})
 }
 

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -239,13 +239,17 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	require.NotNil(t, recruitResp.GetConsensusStatus(), "Recruit response should carry consensus status")
 	t.Logf("Recruit accepted by primary, emergency demotion triggered")
 
-	// Allow 30s: emergency demotion drains active writes for up to 5s before
-	// restarting postgres as standby, so PostgresRunning lag plus grace period and
-	// election can need ~25s — 30s gives adequate headroom.
-	t.Logf("Waiting for multiorch to detect emergency demotion and elect new leader...")
-	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, currentPrimaryName, 30*time.Second)
-	require.NotEmpty(t, newPrimaryName, "Expected multiorch to elect new primary after emergency demotion")
-	t.Logf("New primary elected: %s", newPrimaryName)
+	// The demoted primary stays in the recruit cohort and may either
+	// re-promote (it had the most advanced WAL) or be replaced by a different
+	// pooler — both are valid post-demotion outcomes. We require that some
+	// primary advances to a higher term with at least 2 standbys streaming
+	// (cluster is 3 poolers, so the primary + 2 standbys = full topology),
+	// then wait for full recovery so multiorch's StaleLeader demote updates
+	// the old primary's topology entry from PRIMARY to REPLICA.
+	t.Logf("Waiting for multiorch to recover from emergency demotion (primary at term > %d with >= 2 standbys)...", oldPrimaryTerm)
+	newPrimaryName := shardsetup.WaitForHigherTermPrimary(t, setup, oldPrimaryTerm, 2, 45*time.Second)
+	t.Logf("Primary after emergency demotion: %s (was %s)", newPrimaryName, currentPrimaryName)
+	setup.RequireRecovery(t, "multiorch", 45*time.Second)
 
 	newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
 	require.NotNil(t, newPrimary, "new primary instance should exist")
@@ -253,13 +257,10 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 	require.NoError(t, err)
 	newStatusResp, err := newPrimaryClient.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
 	newPrimaryClient.Close()
-	require.NoError(t, err, "should be able to get status from new primary")
+	require.NoError(t, err, "should be able to get status from primary")
 	newPrimaryTerm := newStatusResp.ConsensusStatus.GetTermRevocation().GetRevokedBelowTerm()
-	t.Logf("New primary %s is on term %d", newPrimaryName, newPrimaryTerm)
-
-	require.Greater(t, newPrimaryTerm, oldPrimaryTerm, "New primary should have higher term than old primary's original term")
-
-	waitForNodeToRejoinAsStandby(t, setup, currentPrimaryName, newPrimaryName, newPrimaryTerm, 30*time.Second)
+	t.Logf("Primary %s is on term %d", newPrimaryName, newPrimaryTerm)
+	require.Greater(t, newPrimaryTerm, oldPrimaryTerm, "Primary's term should be strictly greater than the demoted primary's original term")
 
 	successWrites, failedWrites := validator.Stats()
 	t.Logf("Iteration 4: %d successful, %d failed writes so far (multigateway auto-routing to %s)",

--- a/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
+++ b/go/test/endtoend/multiorch/spurious_failover_recovery_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	consensuspb "github.com/multigres/multigres/go/pb/consensus"
+	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+)
+
+// TestSpuriousFailoverRecovery as a regression test: after a bootstrap that
+// commits a minimum-size cohort (here, 2 members under AT_LEAST_2 — the
+// production scenario where one of three intended poolers had not finished
+// restoring when the orch claimed), a coordinator-led rule change Recruits
+// all cohort members, which demotes the outgoing primary. The
+// cluster must recover from that state on its own — multiorch should
+// re-recruit, propose a new leader, and clear any lingering pooler-side
+// state (e.g. rewindPending) so no problems remain.
+//
+// A 2-member cohort with AT_LEAST_2 has zero failover headroom (2-of-2
+// outgoing quorum required), so the demoted primary must still be able
+// to participate in consensus progress.
+// We drive only the Recruit step and let multiorch handle the rest, then
+// assert recovery completes with no remaining problems.
+func TestSpuriousFailoverRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping spurious failover recovery test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end spurious failover recovery test (no postgres binaries)")
+	}
+
+	// Use only two poolers so bootstrap commits a 2-member cohort, matching
+	// the production MUL-505 scenario where headroom was zero.
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		shardsetup.WithDurabilityPolicy("AT_LEAST_2"),
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+
+	// Wait for bootstrap to complete and sync replication to be configured on
+	// the single standby. The committed cohort size is 2.
+	primaryName := waitForShardReady(t, setup, 1 /*expectedStandbyCount*/, 60*time.Second)
+	t.Logf("Bootstrap complete; primary=%s (cohort size = 2)", primaryName)
+
+	// Quiet multiorch while we issue the Recruit fan-out so it does not race
+	// our manual rule change. We re-enable below and let multiorch drive
+	// recovery from the resulting state.
+	resumeRecovery := setup.DisableRecovery(t, "multiorch")
+
+	// Open a consensus gRPC client to each pooler.
+	type poolerClient struct {
+		name      string
+		consensus consensuspb.MultiPoolerConsensusClient
+	}
+	poolerClients := make([]*poolerClient, 0, len(setup.Multipoolers))
+	for name, inst := range setup.Multipoolers {
+		conn, err := grpc.NewClient(
+			fmt.Sprintf("localhost:%d", inst.Multipooler.GrpcPort),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err, "dial multipooler %s", name)
+		t.Cleanup(func() { conn.Close() })
+		poolerClients = append(poolerClients, &poolerClient{
+			name:      name,
+			consensus: consensuspb.NewMultiPoolerConsensusClient(conn),
+		})
+	}
+
+	// Snapshot the current consensus statuses so we can build a fresh
+	// TermRevocation at the next term.
+	statuses := make([]*clustermetadatapb.ConsensusStatus, 0, len(poolerClients))
+	for _, pc := range poolerClients {
+		resp, err := pc.consensus.Status(utils.WithShortDeadline(t), &consensusdatapb.StatusRequest{})
+		require.NoError(t, err, "Status on %s", pc.name)
+		require.NotNil(t, resp.GetConsensusStatus(), "ConsensusStatus from %s", pc.name)
+		statuses = append(statuses, resp.GetConsensusStatus())
+	}
+
+	// Build the new revocation using the same helper multiorch uses during
+	// AppointLeader. A synthetic test coordinator ID is sufficient.
+	testCoordinatorID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+	revocation, err := commonconsensus.NewTermRevocation(statuses, testCoordinatorID, timestamppb.Now())
+	require.NoError(t, err, "build term revocation")
+	t.Logf("Recruiting at new term: %d", revocation.GetRevokedBelowTerm())
+
+	// Fan out Recruit RPCs to all three poolers concurrently. The current
+	// primary will emergency-demote as a side effect (rpc_consensus.go's
+	// Recruit handler routes through emergencyDemoteLocked when isPrimary).
+	// We deliberately do NOT issue a follow-up Propose — recovery is
+	// multiorch's job once we re-enable it below.
+	type recruitResult struct {
+		name string
+		err  error
+	}
+	recruitCh := make(chan recruitResult, len(poolerClients))
+	for _, pc := range poolerClients {
+		go func(pc *poolerClient) {
+			_, callErr := pc.consensus.Recruit(utils.WithTimeout(t, 30*time.Second), &consensusdatapb.RecruitRequest{
+				TermRevocation: revocation,
+			})
+			recruitCh <- recruitResult{name: pc.name, err: callErr}
+		}(pc)
+	}
+	for range poolerClients {
+		r := <-recruitCh
+		require.NoError(t, r.err, "Recruit on %s", r.name)
+	}
+	t.Logf("Recruit complete at term %d — original primary %s has been emergency-demoted", revocation.GetRevokedBelowTerm(), primaryName)
+
+	// Hand control back to multiorch and require it to bring the shard back
+	// to a problem-free state. RequireRecovery loops TriggerRecoveryNow until
+	// no problem codes remain, or fails the test on timeout.
+	resumeRecovery()
+	setup.RequireRecovery(t, "multiorch", 90*time.Second)
+}

--- a/go/test/endtoend/shardsetup/pooler_diagnostics.go
+++ b/go/test/endtoend/shardsetup/pooler_diagnostics.go
@@ -157,6 +157,48 @@ func RequirePoolerCondition(
 	}
 }
 
+// WaitForHigherTermPrimary polls all multipoolers in setup until one reports
+// IsInitialized + PoolerType_PRIMARY + PostgresReady at a term strictly
+// greater than oldTerm AND has at least minStandbyCount followers actively
+// streaming from it, then returns its name. The elected primary may be the
+// same pooler as before (re-elected at a higher term) or a different one;
+// callers that need a *different* pooler should use WaitForNewPrimary
+// instead. Fails the test if no qualifying primary appears within timeout.
+func WaitForHigherTermPrimary(t *testing.T, setup *ShardSetup, oldTerm int64, minStandbyCount int, timeout time.Duration) string {
+	t.Helper()
+
+	poolers := make([]*MultipoolerInstance, 0, len(setup.Multipoolers))
+	for _, inst := range setup.Multipoolers {
+		poolers = append(poolers, inst)
+	}
+
+	return EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
+		func(statuses []PoolerStatusResult) (string, bool, string) {
+			for _, r := range statuses {
+				if r.Err != nil || r.Status == nil {
+					continue
+				}
+				if !(r.Status.IsInitialized &&
+					r.Status.PoolerType == clustermetadatapb.PoolerType_PRIMARY &&
+					r.Status.PostgresReady) {
+					continue
+				}
+				term := r.ConsensusStatus.GetTermRevocation().GetRevokedBelowTerm()
+				if term <= oldTerm {
+					continue
+				}
+				connected := len(r.Status.GetPrimaryStatus().GetConnectedFollowers())
+				if connected < minStandbyCount {
+					continue
+				}
+				return r.Name, true, ""
+			}
+			return "", false, fmt.Sprintf("no primary at term > %d with >= %d connected followers yet", oldTerm, minStandbyCount)
+		},
+		"primary at term > %d with >= %d connected followers not elected within %v", oldTerm, minStandbyCount, timeout,
+	)
+}
+
 // WaitForNewPrimary polls all multipoolers in setup until one other than oldPrimaryName
 // reports IsInitialized + PoolerType_PRIMARY + PostgresReady, then returns its name.
 // Fails the test if no new primary is elected within timeout.


### PR DESCRIPTION
A 2-pooler AT_LEAST_2 cohort wedges after a Recruit fan-out emergency-demotes the primary: runFailover excluded the resigning leader from the cohort, leaving 1 of 2 members recruitable.

Three small changes:

- coordinator.runFailover stops excluding leaders that signaled REQUESTING_DEMOTION. The signal means "please replace me if you can," not "remove me from the cohort," so a resigning leader stays a recruitment candidate and may be re-promoted at the new term. To avoid wasting Recruit RPCs on members we believe are dead, cohort membership now requires LastSeen freshness within 10s.

- Recruit no longer hard-rejects when rewindPending=true. The proper rewind happens at SetTermPrimary before the node serves writes or replicates from a new primary; keeping the gate at Recruit was unnecessarily strict and could block the only path back to quorum.

- promoteStandbyToPrimary clears rewindPending. The consensus protocol picked this node as the new leader at a higher term, so its WAL is by definition the rule going forward; the postgres monitor can resume.

TestSpuriousFailoverRecovery reproduces the wedge. TestDeadPrimaryRecovery iteration 4 is updated to wait on cluster recovery rather than assume the old primary is excluded; a new WaitForHigherTermPrimary helper waits for any pooler to advance the term with enough connected followers.