### PR TITLE
fix(multipooler): use Pause/resume around stale-primary stopPostgresIfRunning

### DIFF
--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -1008,29 +1008,37 @@ func (pm *MultiPoolerManager) stopPostgresIfRunning(ctx context.Context) error {
 
 	pm.logger.InfoContext(ctx, "Stopping postgres if running")
 
-	// Close ONLY connection pools to release database connections.
-	// This allows postgres to stop cleanly without waiting for connections,
-	// but keeps the manager operational for subsequent operations.
-	pm.mu.Lock()
-	pm.closeConnectionsLocked()
-	pm.mu.Unlock()
+	resume := pm.Pause()
+	defer resume()
 
-	// Stop postgres (no-op if already stopped)
-	stopReq := &pgctldpb.StopRequest{Mode: "fast"}
-	if _, err := pm.pgctldClient.Stop(ctx, stopReq); err != nil {
-		// Treat "already stopped" errors as success to make this truly idempotent.
-		// This handles race conditions where postgres was stopped between our check and stop call.
+	var lastErr error
+	for _, m := range pgctldStopModes {
+		stepCtx, cancel := context.WithTimeout(ctx, m.timeout)
+		_, err := pm.pgctldClient.Stop(stepCtx, &pgctldpb.StopRequest{
+			Mode:    m.name,
+			Timeout: durationpb.New(m.timeout),
+		})
+		cancel()
+		if err == nil {
+			pm.logger.InfoContext(ctx, "pgctld.Stop succeeded", "mode", m.name)
+			return nil
+		}
+		// Treat "already stopped" as success: handles races where postgres
+		// stopped between our check and the stop call, and earlier-mode
+		// escalation that already brought postgres down.
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "not running") ||
 			strings.Contains(errMsg, "no child processes") ||
 			strings.Contains(errMsg, "no such process") {
-			pm.logger.InfoContext(ctx, "Postgres already stopped, continuing", "error", errMsg)
+			pm.logger.InfoContext(ctx, "Postgres already stopped, continuing",
+				"mode", m.name, "error", errMsg)
 			return nil
 		}
-		return mterrors.Wrap(err, "failed to stop postgres")
+		lastErr = err
+		pm.logger.WarnContext(ctx, "pgctld.Stop failed; escalating",
+			"mode", m.name, "timeout", m.timeout, "error", err)
 	}
-
-	return nil
+	return mterrors.Wrap(lastErr, "failed to stop postgres after fast/immediate escalation")
 }
 
 // runPgRewind runs pg_rewind to sync with source.


### PR DESCRIPTION
When multiorch's DemoteStalePrimary routed through demoteStalePrimaryLocked and pg_rewind failed (e.g. rewind source temporarily unreachable), the connection pool was left permanently closed: stopPostgresIfRunning closed the pool before pg_ctl, and only the success-path restartPostgresAsStandby reopened it. Every subsequent RPC on the demoted pooler surfaced "manager is closed" until the postgres monitor's next startPostgres cycle reopened the pool — observed in a k8s scale-up incident.

stopPostgresIfRunning now wraps the pgctld.Stop call with pm.Pause() and defer resume(), mirroring RewindToSource's pattern for "temporarily stop postgres, then bring it back." Pause sets NOT_SERVING and tears down the heartbeat/monitor for the stop window; the deferred resume() reopens on every exit path (including pg_rewind failure), so no caller is left holding a permanently closed pool.

pgctld.Stop additionally escalates fast → immediate (matching graceful shutdown). fast SIGTERMs postgres backends directly so a held client pool never blocks stop; immediate is the safety escalation if fast hangs.