### PR TITLE
test(shardsetup): report startup timing stats to aid timeout tuning

### DIFF
--- a/.github/scripts/startup-timing-summary.py
+++ b/.github/scripts/startup-timing-summary.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Reads integration-test-results.jsonl (go test -json output), extracts
+# startup timing rows emitted by shardsetup.TimingCollector, and writes a
+# mean±95%CI / p50/p95/p99 markdown table to $GITHUB_STEP_SUMMARY.
+#
+# Usage: python3 .github/scripts/startup-timing-summary.py
+"""Summarise startup timing stats from integration test output into a markdown table."""
+
+# pylint: disable=invalid-name  # script filename uses hyphens (conventional for CLI scripts)
+
+import json
+import math
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import IO
+
+# t-distribution critical values at the 97.5th percentile (for a 95% two-sided
+# CI on the mean), keyed by degrees of freedom (n-1).  Values are taken from
+# standard t-tables.  For df > 120 the normal approximation 1.960 is used.
+_T_CRIT_97_5: dict[int, float] = {
+    1: 12.706,
+    2: 4.303,
+    3: 3.182,
+    4: 2.776,
+    5: 2.571,
+    6: 2.447,
+    7: 2.365,
+    8: 2.306,
+    9: 2.262,
+    10: 2.228,
+    12: 2.179,
+    15: 2.131,
+    20: 2.086,
+    25: 2.060,
+    30: 2.042,
+    40: 2.021,
+    60: 2.000,
+    120: 1.980,
+}
+
+
+def t_crit_95(df: int) -> float:
+    """Return the 97.5th-percentile t critical value for the given degrees of freedom.
+
+    Uses the nearest entry with df' ≤ df (conservative — slightly widens the
+    interval).  Falls back to the normal-distribution value 1.960 for df > 120.
+    """
+    if df >= 120:
+        return 1.960
+    for k in sorted(_T_CRIT_97_5, reverse=True):
+        if df >= k:
+            return _T_CRIT_97_5[k]
+    return _T_CRIT_97_5[1]
+
+
+def mean_ci_95(values: list[float]) -> tuple[float, float]:
+    """Return (mean, half_width) for a 95% CI on the mean, assuming normality.
+
+    For n=1 the half-width is 0.0 (a CI cannot be computed from a single sample).
+    """
+    n = len(values)
+    mean = sum(values) / n
+    if n < 2:
+        return mean, 0.0
+    variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+    margin = t_crit_95(n - 1) * math.sqrt(variance) / math.sqrt(n)
+    return mean, margin
+
+
+def clean_label(label: str) -> str:
+    """Normalise labels that vary by pooler instance.
+
+    "manager ready: pooler-N" → "manager ready"
+    """
+    return re.sub(r": pooler-\d+$", "", label).strip()
+
+
+def percentile(values: list[float], p: float) -> float:
+    """Return the p-th percentile of values using linear interpolation."""
+    s = sorted(values)
+    idx = (len(s) - 1) * p / 100
+    lo = int(idx)
+    if lo + 1 >= len(s):
+        return s[lo]
+    return s[lo] + (s[lo + 1] - s[lo]) * (idx - lo)
+
+
+def parse_duration_seconds(d: str) -> float:
+    """Parse a Go time.Duration string (e.g. '30s', '1m0s') into seconds."""
+    total = 0.0
+    for value, unit in re.findall(r"([\d.]+)([a-zµ]+)", d):
+        v = float(value)
+        if unit == "h":
+            total += v * 3600
+        elif unit == "m":
+            total += v * 60
+        elif unit == "s":
+            total += v
+        elif unit == "ms":
+            total += v / 1000
+        elif unit in ("us", "µs"):
+            total += v / 1_000_000
+    return total
+
+
+def format_elapsed(seconds: float) -> str:
+    """Format elapsed seconds as a compact duration string."""
+    if seconds < 1.0:
+        return f"{seconds * 1000:.0f}ms"
+    return f"{seconds:.1f}s"
+
+
+def format_cell(elapsed_seconds: float, limit_seconds: float) -> str:
+    """Format a percentile cell as 'Xs (P%)' showing elapsed time and percent of timeout."""
+    pct = elapsed_seconds / limit_seconds * 100.0
+    return f"{format_elapsed(elapsed_seconds)} ({pct:.0f}%)"
+
+
+def format_ci_cell(mean_s: float, margin_s: float, limit_s: float, n: int) -> str:
+    """Format a mean±CI cell as 'Xs ±Ys (P%, n=N)'.
+
+    Shows the mean elapsed time, the 95% CI half-width, the mean as a
+    percentage of the timeout, and the sample size so the reliability of the
+    interval is immediately visible.
+    """
+    pct = mean_s / limit_s * 100.0
+    return (
+        f"{format_elapsed(mean_s)} ±{format_elapsed(margin_s)}" f" ({pct:.0f}%, n={n})"
+    )
+
+
+def status_circle(
+    p95: float, p99: float, warn: float = 70.0, crit: float = 90.0
+) -> str:
+    """Return a colored circle emoji reflecting the worst percentile bucket.
+
+    🔴  p99 >= crit  (default 90 % of timeout)
+    🟡  p95 >= warn  (default 70 % of timeout)
+    🟢  otherwise
+    """
+    if p99 >= crit:
+        return "🔴"
+    if p95 >= warn:
+        return "🟡"
+    return "🟢"
+
+
+def main() -> None:
+    """Parse timing rows from the JSONL test output and write a summary table."""
+    jsonl_path = "integration-test-results.jsonl"
+    data: dict[str, list[float]] = defaultdict(list)  # label → [elapsed_seconds, ...]
+    limits: dict[str, str] = {}  # label → limit string (e.g. "30s")
+
+    try:
+        with open(jsonl_path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("Action") != "output":
+                    continue
+
+                # Strip the "    file.go:42: " prefix added by t.Log/t.Logf.
+                # Use a single trailing space (not \s*) to preserve the two
+                # leading spaces that are part of the timing row format.
+                stripped = re.sub(r"^\s+\S+:\d+: ", "", obj.get("Output", "")).rstrip(
+                    "\n"
+                )
+
+                # Match timing rows emitted by TimingCollector.Report:
+                #   "  <label>   <elapsed> / <limit>   <pct>%"
+                m = re.match(
+                    r"^  (.+?)\s{2,}(\S+)\s*/\s*(\S+)\s+([\d.]+)%\s*$", stripped
+                )
+                if not m:
+                    continue
+
+                label = clean_label(m.group(1))
+                data[label].append(parse_duration_seconds(m.group(2)))
+                limits[label] = m.group(3)
+
+    except FileNotFoundError:
+        print(f"No {jsonl_path} found — skipping timing summary", file=sys.stderr)
+        return
+
+    if not data:
+        print("No timing rows found — skipping timing summary", file=sys.stderr)
+        return
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    out: IO[str]
+    if not summary_path:
+        print("GITHUB_STEP_SUMMARY not set — printing to stdout instead")
+        out = sys.stdout
+    else:
+        out = open(
+            summary_path, "a", encoding="utf-8"
+        )  # pylint: disable=consider-using-with
+
+    try:
+        out.write("## Startup Timing\n\n")
+        out.write(
+            "| Operation | Timeout | mean ±95%CI | min | p50 | p95 | p99 | max |\n"
+        )
+        out.write("|---|---|---|---|---|---|---|---|\n")
+        for label in sorted(data):
+            vals = data[label]
+            limit_s = parse_duration_seconds(limits[label])
+            mean_s, margin_s = mean_ci_95(vals)
+            p50v = percentile(vals, 50)
+            p95v = percentile(vals, 95)
+            p99v = percentile(vals, 99)
+            circle = status_circle(p95v / limit_s * 100.0, p99v / limit_s * 100.0)
+            out.write(
+                f"| {circle} {label} | {limits[label]}"
+                f" | {format_ci_cell(mean_s, margin_s, limit_s, len(vals))}"
+                f" | {format_cell(min(vals), limit_s)}"
+                f" | {format_cell(p50v, limit_s)}"
+                f" | {format_cell(p95v, limit_s)}"
+                f" | {format_cell(p99v, limit_s)}"
+                f" | {format_cell(max(vals), limit_s)} |\n"
+            )
+    finally:
+        if out is not sys.stdout:
+            out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -69,10 +69,14 @@ jobs:
             --jsonfile=integration-test-results.jsonl \
             --junitfile=integration-test-results.xml \
             -- \
-            -skip TestPostgreSQLRegression -timeout=30m
+            -v -skip TestPostgreSQLRegression -timeout=30m
 
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
+
+      - name: Write startup timing to summary
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/startup-timing-summary.py
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -348,7 +348,7 @@ func TestBootstrapInitialization(t *testing.T) {
 		t.Logf("Restarted multipooler for %s (should auto-restore)", standbyName)
 
 		// Wait for multipooler to be ready
-		shardsetup.WaitForManagerReady(t, standbyInst.Multipooler)
+		shardsetup.WaitForManagerReady(t, standbyInst.Multipooler, nil)
 
 		// Wait for auto-restore to complete. We don't assert
 		// ConsensusStatus.TermRevocation.RevokedBelowTerm > 0 here: a

--- a/go/test/endtoend/multiorch/external_bootstrap_test.go
+++ b/go/test/endtoend/multiorch/external_bootstrap_test.go
@@ -86,7 +86,7 @@ func TestBootstrap_ViaExternalAPI(t *testing.T) {
 	// but stay uninitialized (no postgres data dir, no rule).
 	for name, inst := range setup.Multipoolers {
 		require.NoError(t, inst.Multipooler.Start(t.Context(), t), "should start multipooler %s", name)
-		shardsetup.WaitForManagerReady(t, inst.Multipooler)
+		shardsetup.WaitForManagerReady(t, inst.Multipooler, nil)
 	}
 
 	// Confirm uninitialized state on every pooler.

--- a/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
+++ b/go/test/endtoend/multipooler/backupfaults/backup_archive_lag_test.go
@@ -324,7 +324,7 @@ func TestPrimaryCrashWithUnarchivedWAL_NoDataLoss(t *testing.T) {
 	shardsetup.WaitForEvent(t, newReplica.Multipooler.LogFile, "restore.attempt", "success", 90*time.Second)
 	t.Logf("%s auto-restored from backup — post-failover archive is usable", newReplicaName)
 
-	shardsetup.WaitForManagerReady(t, newReplica.Multipooler)
+	shardsetup.WaitForManagerReady(t, newReplica.Multipooler, nil)
 
 	// Drive multiorch's recovery loop synchronously so FixReplication wires
 	// pooler-4's replication to the current primary on the current term.

--- a/go/test/endtoend/multipooler/bootstrap_sentinel_recovery_test.go
+++ b/go/test/endtoend/multipooler/bootstrap_sentinel_recovery_test.go
@@ -101,7 +101,7 @@ func TestBootstrapSentinelCrashRecovery(t *testing.T) {
 			// Start the multipooler. Its first monitor tick should detect the sentinel,
 			// remove any stale pg_data, run a fresh initdb, and complete the first backup.
 			require.NoError(t, inst.Multipooler.Start(t.Context(), t))
-			shardsetup.WaitForManagerReady(t, inst.Multipooler)
+			shardsetup.WaitForManagerReady(t, inst.Multipooler, nil)
 
 			// Poll GetBackups until at least one COMPLETE backup appears.
 			backupClient := createBackupClient(t, inst.Multipooler.GrpcPort)

--- a/go/test/endtoend/multipooler/setup_test.go
+++ b/go/test/endtoend/multipooler/setup_test.go
@@ -112,7 +112,7 @@ func getSharedTestSetup(t *testing.T) *MultipoolerTestSetup {
 // Deprecated: Use shardsetup.WaitForManagerReady directly.
 func waitForManagerReady(t *testing.T, _ *MultipoolerTestSetup, manager *ProcessInstance) {
 	t.Helper()
-	shardsetup.WaitForManagerReady(t, manager)
+	shardsetup.WaitForManagerReady(t, manager, nil)
 }
 
 // cleanupOption is a function that configures cleanup behavior.

--- a/go/test/endtoend/shardsetup/client.go
+++ b/go/test/endtoend/shardsetup/client.go
@@ -87,9 +87,23 @@ func (c *MultipoolerClient) Close() error {
 	return nil
 }
 
+// TimedEventually is require.Eventually that also records elapsed time to tc.
+// tc may be nil, in which case timing is not recorded.
+func TimedEventually(t *testing.T, tc *TimingCollector, label string,
+	condition func() bool, waitFor, tick time.Duration, msgAndArgs ...any,
+) {
+	t.Helper()
+	start := time.Now()
+	require.Eventually(t, condition, waitFor, tick, msgAndArgs...)
+	if tc != nil {
+		tc.Record(label, time.Since(start), waitFor)
+	}
+}
+
 // WaitForManagerReady waits for the manager to be in ready state.
 // Follows the pattern from multipooler/setup_test.go:waitForManagerReady.
-func WaitForManagerReady(t *testing.T, manager *ProcessInstance) {
+// Elapsed time is recorded to tc when tc is non-nil.
+func WaitForManagerReady(t *testing.T, manager *ProcessInstance, tc *TimingCollector) {
 	t.Helper()
 
 	// Connect to the manager
@@ -103,8 +117,7 @@ func WaitForManagerReady(t *testing.T, manager *ProcessInstance) {
 
 	client := multipoolermanagerpb.NewMultiPoolerManagerClient(conn)
 
-	// Use require.Eventually to wait for manager to be ready
-	require.Eventually(t, func() bool {
+	TimedEventually(t, tc, "manager ready: "+manager.Name, func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -113,6 +113,11 @@ type ShardSetup struct {
 	// - Primary: synchronous_standby_names, synchronous_commit
 	// - Replicas: primary_conninfo
 	BaselineGucs map[string]map[string]string
+
+	// Timings records elapsed durations for timeout-bounded setup operations.
+	// Reported at test teardown so you can see which operations are approaching
+	// their limits on slow runners.
+	Timings *TimingCollector
 }
 
 // Context returns the running context for this setup, which is cancelled when Cleanup() is called.

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -493,6 +493,7 @@ func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, time
 	t.Helper()
 
 	// Start the process in background with trace context propagation
+	start := time.Now()
 	err := p.Process.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start %s: %w", p.Name, err)
@@ -525,7 +526,7 @@ func (p *ProcessInstance) waitForStartup(ctx context.Context, t *testing.T, time
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", p.GrpcPort), 100*time.Millisecond)
 		if err == nil {
 			conn.Close()
-			t.Logf("%s started successfully on gRPC port %d (after %d attempts)", p.Name, p.GrpcPort, connectAttempts)
+			t.Logf("%s started successfully on gRPC port %d (after %d attempts, %s)", p.Name, p.GrpcPort, connectAttempts, time.Since(start).Round(time.Millisecond))
 			return nil
 		}
 		if connectAttempts%logInterval == 0 {
@@ -661,7 +662,8 @@ func (p *ProcessInstance) CleanupFunc(logf func(string, ...any)) func() {
 func WaitForPortReady(t *testing.T, name string, grpcPort int, timeout time.Duration) error {
 	t.Helper()
 
-	deadline := time.Now().Add(timeout)
+	start := time.Now()
+	deadline := start.Add(timeout)
 	connectAttempts := 0
 	for time.Now().Before(deadline) {
 		connectAttempts++
@@ -669,7 +671,7 @@ func WaitForPortReady(t *testing.T, name string, grpcPort int, timeout time.Dura
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", grpcPort), 100*time.Millisecond)
 		if err == nil {
 			conn.Close()
-			t.Logf("%s ready on gRPC port %d (after %d attempts)", name, grpcPort, connectAttempts)
+			t.Logf("%s ready on gRPC port %d (after %d attempts, %s)", name, grpcPort, connectAttempts, time.Since(start).Round(time.Millisecond))
 			return nil
 		}
 		if connectAttempts%10 == 0 {

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -559,7 +559,9 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		MultiOrchInstances: make(map[string]*ProcessInstance),
 		MetricsPorts:       make(map[string]int),
 		BackupLocation:     backupLocation,
+		Timings:            &TimingCollector{},
 	}
+	t.Cleanup(func() { setup.Timings.Report(t) })
 
 	// Provision postgres-side TLS assets up front so every pgctld + multipooler
 	// shares the same CA / server cert. Done before the per-pooler loop so the
@@ -618,7 +620,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 
 	// Start all processes (pgctld, multipooler, pgbackrest) for all nodes
 	// Use setup.ctx for process lifetime, passed ctx only for tracing
-	startMultipoolerInstances(setup.runningCtx, t, multipoolerInstances, config.DeferMultipoolerStart)
+	startMultipoolerInstances(setup.runningCtx, t, multipoolerInstances, config.DeferMultipoolerStart, setup.Timings)
 
 	// Create multiorch instances (if any requested by the test)
 	setup.createMultiOrchInstances(t, config)
@@ -1088,6 +1090,7 @@ func waitForShardBootstrap(ctx context.Context, t *testing.T, setup *ShardSetup)
 	ctx, cancel := context.WithTimeout(ctx, testconst.ShardBootstrapTimeout)
 	defer cancel()
 
+	start := time.Now()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -1104,6 +1107,7 @@ func waitForShardBootstrap(ctx context.Context, t *testing.T, setup *ShardSetup)
 				span.SetAttributes(
 					attribute.String("primary.name", primaryName),
 				)
+				setup.Timings.Record("shard bootstrap", time.Since(start), testconst.ShardBootstrapTimeout)
 				t.Logf("waitForShardBootstrap: primary=%s, all nodes initialized", primaryName)
 				return primaryName, nil
 			}
@@ -1283,7 +1287,7 @@ func checkBootstrapStatus(ctx context.Context, t *testing.T, setup *ShardSetup) 
 //
 // TODO: Consider parallelizing Start() calls using a WaitGroup for faster startup.
 // Currently processes are started sequentially which adds latency.
-func startMultipoolerInstances(ctx context.Context, t *testing.T, instances []*MultipoolerInstance, deferMultipoolerStart bool) {
+func startMultipoolerInstances(ctx context.Context, t *testing.T, instances []*MultipoolerInstance, deferMultipoolerStart bool, tc *TimingCollector) {
 	t.Helper()
 
 	ctx, span := telemetry.Tracer().Start(ctx, "shardsetup/startMultipoolerInstances")
@@ -1331,7 +1335,7 @@ func startMultipoolerInstances(ctx context.Context, t *testing.T, instances []*M
 		}
 
 		// Wait for multipooler to be ready
-		WaitForManagerReady(t, multipooler)
+		WaitForManagerReady(t, multipooler, tc)
 		t.Logf("Multipooler %s is ready (uninitialized)", inst.Name)
 
 		instSpan.End()
@@ -1658,7 +1662,7 @@ func (s *ShardSetup) ReinitializeCluster(t *testing.T) {
 		if err := inst.Multipooler.Start(ctx, t); err != nil {
 			t.Fatalf("ReinitializeCluster: failed to start multipooler %s: %v", name, err)
 		}
-		WaitForManagerReady(t, inst.Multipooler)
+		WaitForManagerReady(t, inst.Multipooler, s.Timings)
 		t.Logf("ReinitializeCluster: started %s (pgctld + multipooler)", name)
 	}
 

--- a/go/test/endtoend/shardsetup/timing.go
+++ b/go/test/endtoend/shardsetup/timing.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardsetup
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type timingEntry struct {
+	label   string
+	elapsed time.Duration
+	limit   time.Duration
+}
+
+// TimingCollector records elapsed durations for timeout-bounded setup operations
+// and prints a summary table at test teardown. The percentage column is the key
+// signal: values approaching 80–90% are at risk on slow CI runners.
+type TimingCollector struct {
+	mu      sync.Mutex
+	entries []timingEntry
+}
+
+// Record adds an elapsed/limit pair for the named operation.
+func (c *TimingCollector) Record(label string, elapsed, limit time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = append(c.entries, timingEntry{label, elapsed, limit})
+}
+
+// Report prints the collected timing table via t.Log. Output appears on failure
+// always and with -v always.
+func (c *TimingCollector) Report(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) == 0 {
+		return
+	}
+	t.Log("Startup timing:")
+	for _, e := range c.entries {
+		pct := float64(e.elapsed) / float64(e.limit) * 100
+		t.Logf("  %-40s %6s / %-6s  %3.0f%%",
+			e.label,
+			e.elapsed.Round(time.Millisecond),
+			e.limit,
+			pct,
+		)
+	}
+}


### PR DESCRIPTION
Add a TimingCollector that records elapsed/limit for each timeout-bounded setup operation and prints a percentage table at test teardown. Values approaching 80–90% flag operations at risk on slow CI runners.

Collected operations:
- manager ready: <pooler> (via WaitForManagerReady)
- shard bootstrap (via waitForShardBootstrap)

Process startup functions (waitForStartup, WaitForPortReady) log elapsed time inline on their success lines rather than feeding the collector.

The integration test workflow now passes -v so the table always appears in CI logs, and a post-run step writes a Startup Timing code block to the GitHub step summary via GITHUB_STEP_SUMMARY.