### PR TITLE
chore(release): sign and attest release images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
             done
           done
 
-          shasum -a 256 -c dist/checksums.txt
+          (cd dist && shasum -a 256 -c checksums.txt)
 
           mkdir -p release-artifacts
           for artifact in "${archives[@]}" "${checksums[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,11 @@ jobs:
   build-release-images:
     name: Build Release Images
     needs: test-go
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
       packages: write
 
     strategy:
@@ -120,11 +121,18 @@ jobs:
       - name: Set release image tags
         env:
           IMAGE: ${{ matrix.image }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          image_tag="$TAG_NAME"
+          if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            image_tag="dry-run-${GITHUB_RUN_ID}"
+          fi
+
           {
-            echo "RELEASE_TAG=$TAG_NAME"
+            echo "RELEASE_TAG=$image_tag"
             echo "PUSH_IMAGE=true"
             echo "IMAGE_REF=ghcr.io/${REPOSITORY_OWNER}/${IMAGE}"
           } >> "$GITHUB_ENV"
@@ -139,13 +147,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
       - name: Build release image
+        id: build-release-image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ env.IMAGE_REF }}:${{ env.RELEASE_TAG }}
+          provenance: mode=max
+          sbom: true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -155,7 +171,24 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Verify published image
-        run: docker buildx imagetools inspect "${IMAGE_REF}:${RELEASE_TAG}"
+        env:
+          IMAGE_DIGEST: ${{ steps.build-release-image.outputs.digest }}
+        run: docker buildx imagetools inspect "${IMAGE_REF}@${IMAGE_DIGEST}"
+
+      - name: Sign release image
+        env:
+          IMAGE_DIGEST: ${{ steps.build-release-image.outputs.digest }}
+        run: cosign sign --yes "${IMAGE_REF}@${IMAGE_DIGEST}"
+
+      - name: Verify release image signature
+        env:
+          CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+          IMAGE_DIGEST: ${{ steps.build-release-image.outputs.digest }}
+        run: |
+          cosign verify \
+            --certificate-identity "$CERTIFICATE_IDENTITY" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE_REF}@${IMAGE_DIGEST}"
 
   goreleaser:
     name: Publish GitHub Release


### PR DESCRIPTION
## Description

this PR strengthens the Multigres release image path by publishing verifiable supply-chain metadata for release images and adding a safe manual dry-run path for validating that behaviour before a real GitHub release.

The release workflow now builds the published GHCR images with BuildKit provenance and SBOM attestations, signs each pushed image digest with keyless Sigstore/cosign, and verifies the resulting signature in CI. Manual workflow runs publish clearly marked `dry-run-<run-id>` image tags so maintainers can test the image supply-chain path without creating a GitHub Release, publishing release notes, or consuming a SemVer release tag.

## Main Changes

- Adds SBOM, provenance, digest inspection, keyless cosign signing, and signature verification to the release image job.
- Extends manual release workflow runs to publish dry-run GHCR image tags through the same image attestation/signing path used by real releases.
- Keeps GoReleaser publishing tag-only, so dry runs do not create GitHub Releases, release notes, or release assets.

## Validation

The intended validation is to manually run the upstream `Release` workflow against this PR branch, confirm the `dry-run-<run-id>` images are pushed, signed, and verified, and confirm the GoReleaser GitHub Release job is skipped.