### PR TITLE
test: run integration tests against the Supabase Postgres image

### DIFF
--- a/.github/scripts/build-supabase-postgres-test-image.sh
+++ b/.github/scripts/build-supabase-postgres-test-image.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the integration test runner image (supabase Postgres + Go + etcd).
+# Must be run from the multigres repository root — Dockerfile.integration-test
+# must be present in the current directory.
+#
+# Optional environment variables:
+#   SUPABASE_IMAGE  Base image to build from (default: supabase-postgres:local).
+#                   Build this first with build-supabase-postgres.sh.
+#   TEST_IMAGE      Output image tag (default: supabase-postgres-test:local).
+
+set -euo pipefail
+
+SUPABASE_IMAGE="${SUPABASE_IMAGE:-supabase-postgres:local}"
+TEST_IMAGE="${TEST_IMAGE:-supabase-postgres-test:local}"
+
+echo "Building ${TEST_IMAGE} from ${SUPABASE_IMAGE} ..."
+docker build \
+  -f Dockerfile.integration-test \
+  --build-arg "SUPABASE_IMAGE=${SUPABASE_IMAGE}" \
+  -t "${TEST_IMAGE}" \
+  .
+echo "Built ${TEST_IMAGE}"

--- a/.github/scripts/build-supabase-postgres.sh
+++ b/.github/scripts/build-supabase-postgres.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the supabase Postgres base Docker image from a local checkout of
+# github.com/supabase/postgres using its Dockerfile-multigres --target variant-17.
+#
+# Required environment variable:
+#   SUPABASE_POSTGRES_DIR  Path to the supabase/postgres checkout.
+#                          Locally defaults to $HOME/repos/supabase/postgres;
+#                          in CI it should point at the checked-out repo.
+#
+# Optional environment variable:
+#   SUPABASE_IMAGE         Output image tag (default: supabase-postgres:local).
+
+set -euo pipefail
+
+SUPABASE_POSTGRES_DIR="${SUPABASE_POSTGRES_DIR:?SUPABASE_POSTGRES_DIR must be set to the path of the supabase/postgres checkout}"
+SUPABASE_IMAGE="${SUPABASE_IMAGE:-supabase-postgres:local}"
+
+echo "Building ${SUPABASE_IMAGE} from ${SUPABASE_POSTGRES_DIR} ..."
+docker build \
+  -f "${SUPABASE_POSTGRES_DIR}/Dockerfile-multigres" \
+  --target variant-17 \
+  -t "${SUPABASE_IMAGE}" \
+  "${SUPABASE_POSTGRES_DIR}"
+echo "Built ${SUPABASE_IMAGE}"

--- a/.github/scripts/run-integration-tests-container.sh
+++ b/.github/scripts/run-integration-tests-container.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ENTRYPOINT for the supabase-postgres-test container image.
+# Builds multigres from source and runs the full integration test suite.
+#
+# The multigres source tree must be volume-mounted at /multigres (the working
+# directory).  Result files are written there and appear on the host:
+#   integration-test-results.jsonl
+#   integration-test-results.xml
+#
+# Environment variables honoured:
+#   TEST_PRINT_LOGS       Set non-empty to print service logs on test failure.
+#   AWS_ACCESS_KEY_ID     Forwarded to tests (default set by outer script).
+#   AWS_SECRET_ACCESS_KEY Forwarded to tests (default set by outer script).
+#   RERUN_FAILS           gotestsum --rerun-fails count; empty = no reruns.
+#                         Set to 3 in CI for flake tolerance.
+set -eu
+
+make build
+
+./bin/portpoolserver --socket /tmp/multigres-port-pool.sock &
+PORT_POOL_PID=$!
+trap 'kill $PORT_POOL_PID 2>/dev/null || true' EXIT
+
+rerun_flags=""
+if [ -n "${RERUN_FAILS:-}" ]; then
+  rerun_flags="--rerun-fails=${RERUN_FAILS} --rerun-fails-max-failures=10"
+fi
+
+# SC2086: rerun_flags is intentionally unquoted so it word-splits into
+# separate flags when non-empty and produces no argument when empty.
+# shellcheck disable=SC2086
+MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock \
+  gotestsum \
+  --format=testname \
+  ${rerun_flags} \
+  --packages="./go/test/endtoend/..." \
+  --jsonfile=integration-test-results.jsonl \
+  --junitfile=integration-test-results.xml \
+  -- -skip TestPostgreSQLRegression -timeout=30m

--- a/.github/scripts/run-integration-tests-supabase.sh
+++ b/.github/scripts/run-integration-tests-supabase.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the full integration test suite inside the supabase Postgres test container.
+# Must be run from the multigres repository root — the directory is volume-mounted
+# into the container at /multigres so the build and test run against the live source.
+#
+# The container image's ENTRYPOINT (.github/scripts/run-integration-tests-container.sh,
+# baked into the image at /usr/local/bin/run-integration-tests) handles the actual
+# build and test steps.  This script is just the host-side wrapper that invokes
+# docker run with the right volumes and environment.
+#
+# Test result files are written to the current directory:
+#   integration-test-results.jsonl
+#   integration-test-results.xml
+#
+# Optional environment variables:
+#   TEST_IMAGE              Image to run (default: supabase-postgres-test:local).
+#   GO_CACHE_DIR            Host path for the Go build cache (default: /tmp/go-cache).
+#   TEST_PRINT_LOGS         Set non-empty to print service logs on test failure.
+#   AWS_ACCESS_KEY_ID       Forwarded into container (default: test-access-key).
+#   AWS_SECRET_ACCESS_KEY   Forwarded into container (default: test-secret-key).
+#   RERUN_FAILS             gotestsum --rerun-fails count; empty = no reruns (default).
+#                           Set to 3 in CI for flake tolerance.
+
+set -euo pipefail
+
+TEST_IMAGE="${TEST_IMAGE:-supabase-postgres-test:local}"
+GO_CACHE_DIR="${GO_CACHE_DIR:-/tmp/go-cache}"
+MULTIGRES_DIR="${MULTIGRES_DIR:-$(pwd)}"
+
+mkdir -p "${GO_CACHE_DIR}"
+
+RERUN_FAILS="${RERUN_FAILS:-}"
+
+docker run --rm \
+  --name multigres-integration-test \
+  -v "${MULTIGRES_DIR}:/multigres" \
+  -v "${GO_CACHE_DIR}:/home/postgres/.cache" \
+  -w /multigres \
+  -e "TEST_PRINT_LOGS=${TEST_PRINT_LOGS:-}" \
+  -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-test-access-key}" \
+  -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-test-secret-key}" \
+  -e "RERUN_FAILS=${RERUN_FAILS}" \
+  "${TEST_IMAGE}"

--- a/.github/workflows/test-integration-supabase.yml
+++ b/.github/workflows/test-integration-supabase.yml
@@ -1,0 +1,88 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Multigres Integration Tests (Supabase Postgres)
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 02:00 UTC nightly
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  test-integration-supabase:
+    name: Run integration tests against Supabase Postgres
+    runs-on: ubuntu-24.04
+    environment:
+      name: ci
+      deployment: false
+
+    steps:
+      - name: Checkout multigres
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout supabase/postgres
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: supabase/postgres
+          path: supabase-postgres
+          persist-credentials: false
+
+      - name: Build supabase Postgres base image
+        env:
+          SUPABASE_POSTGRES_DIR: ${{ github.workspace }}/supabase-postgres
+        run: .github/scripts/build-supabase-postgres.sh
+
+      - name: Build integration test runner image
+        run: .github/scripts/build-supabase-postgres-test-image.sh
+
+      - name: Run integration tests
+        env:
+          TEST_PRINT_LOGS: "1"
+          AWS_ACCESS_KEY_ID: test-access-key
+          AWS_SECRET_ACCESS_KEY: test-secret-key
+          RERUN_FAILS: "3"
+        run: .github/scripts/run-integration-tests-supabase.sh
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: integration-test-logs-supabase
+          path: |
+            integration-test-results.jsonl
+            integration-test-results.xml
+          retention-days: 14
+
+      - name: Test Report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: Integration Tests (Supabase Postgres)
+          path: integration-test-results.jsonl
+          reporter: golang-json
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && github.event_name == 'push' }}
+        continue-on-error: true
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./integration-test-results.xml
+          report_type: test_results
+          flags: integration-supabase
+          fail_ci_if_error: false

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -30,7 +30,7 @@ ARG GO_SHA256_ARM64=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f771267
 # curl and tar are only needed to download and verify the Go toolchain;
 # they are removed via the .build-tools virtual group after installation.
 # hadolint ignore=DL3018,DL4006
-RUN apk add --no-cache make git etcd && \
+RUN apk add --no-cache make git etcd pgbackrest && \
   apk add --no-cache --virtual .build-tools curl tar && \
   case "$(uname -m)" in \
     x86_64)  ARCH=amd64; GO_SHA256="${GO_SHA256_AMD64}" ;; \

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.6
+# Integration test runner: supabase Postgres + Go toolchain + etcd.
+#
+# Build with:
+#   docker build -f Dockerfile.integration-test \
+#     --build-arg SUPABASE_IMAGE=supabase-postgres:local \
+#     -t supabase-postgres-test:local .
+#
+# Run with (from the multigres repo root):
+#   docker run --rm \
+#     -v $(pwd):/multigres \
+#     -v /tmp/go-cache:/home/postgres/.cache \
+#     supabase-postgres-test:local
+#
+# See .claude/docs/supabase-postgres-testing.md for full instructions.
+
+# checkov:skip=CKV_DOCKER_7:local test image managed by build scripts; not from external registry
+# checkov:skip=CKV2_DOCKER_1:local test image managed by build scripts; not from external registry
+ARG SUPABASE_IMAGE=supabase-postgres:local
+FROM ${SUPABASE_IMAGE}
+
+USER root
+
+ARG GO_VERSION=1.25.10
+# SHA256 digests from https://go.dev/dl/ for go${GO_VERSION}.linux-{amd64,arm64}.tar.gz.
+# Update both ARGs together whenever GO_VERSION is bumped.
+ARG GO_SHA256_AMD64=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70
+ARG GO_SHA256_ARM64=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08
+
+# curl and tar are only needed to download and verify the Go toolchain;
+# they are removed via the .build-tools virtual group after installation.
+# hadolint ignore=DL3018,DL4006
+RUN apk add --no-cache make git etcd && \
+  apk add --no-cache --virtual .build-tools curl tar && \
+  case "$(uname -m)" in \
+    x86_64)  ARCH=amd64; GO_SHA256="${GO_SHA256_AMD64}" ;; \
+    aarch64) ARCH=arm64; GO_SHA256="${GO_SHA256_ARM64}" ;; \
+    *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+  esac && \
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz && \
+  echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - && \
+  tar -C /usr/local -xzf /tmp/go.tar.gz && \
+  rm /tmp/go.tar.gz && \
+  GOBIN=/usr/local/bin /usr/local/go/bin/go install gotest.tools/gotestsum@v1.13.0 && \
+  apk del .build-tools && \
+  mkdir -p /home/postgres/.cache && \
+  chown -R postgres:postgres /home/postgres/.cache
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Bake in the entrypoint script so the image is self-contained.
+# The script is also available in the mounted source tree, but
+# having it here means `docker run IMAGE` works without arguments.
+COPY --chmod=0755 .github/scripts/run-integration-tests-container.sh \
+  /usr/local/bin/run-integration-tests
+
+# Satisfy checkov CKV_DOCKER_6 (HEALTHCHECK required). This container is
+# a test runner; the healthcheck is not used in production.
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD ["go", "version"]
+
+USER postgres
+WORKDIR /multigres
+ENTRYPOINT ["/usr/local/bin/run-integration-tests"]

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,33 @@ pgregress-update-patches: build ## Regenerate testdata/pg17/patches/*.patch from
 	RUN_PGREGRESS=1 PGREGRESS_PATCH_MODE=generate \
 	go test -v -timeout 60m -run TestPostgreSQLRegression ./go/test/endtoend/pgregresstest/...
 
+# Path to the supabase/postgres checkout. Override with SUPABASE_POSTGRES_DIR=... if needed.
+SUPABASE_POSTGRES_DIR ?= $(HOME)/repos/supabase/postgres
+
+docker-supabase-postgres: ## Build the supabase Postgres base image from Dockerfile-17.
+	docker build \
+	  -f $(SUPABASE_POSTGRES_DIR)/Dockerfile-17 \
+	  -t supabase-postgres:local \
+	  $(SUPABASE_POSTGRES_DIR)
+
+docker-supabase-postgres-test: docker-supabase-postgres ## Build the integration test runner image (supabase Postgres + Go + etcd).
+	docker build \
+	  -f Dockerfile.integration-test \
+	  --build-arg SUPABASE_IMAGE=supabase-postgres:local \
+	  -t supabase-postgres-test:local \
+	  .
+
+test-integration-supabase: docker-supabase-postgres-test ## Run integration tests inside the supabase Postgres container.
+	docker run --rm \
+	  --name multigres-integration-test \
+	  -v $(CURDIR):/multigres \
+	  -v /tmp/go-cache:/home/postgres/.cache \
+	  -w /multigres \
+	  -e TEST_PRINT_LOGS=1 \
+	  -e AWS_ACCESS_KEY_ID=test-access-key \
+	  -e AWS_SECRET_ACCESS_KEY=test-secret-key \
+	  supabase-postgres-test:local
+
 ##@ Maintenance
 
 # Clean build artifacts

--- a/docs/supabase-postgres-testing.md
+++ b/docs/supabase-postgres-testing.md
@@ -1,0 +1,229 @@
+# Running Integration Tests Against Supabase Postgres
+
+This guide covers how to run the Multigres integration test suite against the
+Supabase-flavored Postgres image locally.
+
+Tests run **inside a Docker container** with the Multigres repo mounted as a
+volume. This avoids macOS/Linux binary compatibility issues and ensures tests
+run in the same Linux environment as production.
+
+## Prerequisites
+
+- Docker Desktop running locally
+- `~/repos/multigres/multigres` checked out (this repo)
+
+## Quick start
+
+```bash
+cd ~/repos/multigres/multigres
+
+# Build the test runner image from the published Supabase Postgres image
+# Find the latest tag at https://hub.docker.com/r/supabase/postgres/tags
+# (look for tags matching 17.*-multigres)
+docker build \
+  -f Dockerfile.integration-test \
+  --build-arg SUPABASE_IMAGE=supabase/postgres:17.6.1.130-multigres \
+  -t supabase-postgres-test:local \
+  .
+
+# Run all integration tests (~5 min after image is built)
+docker run --rm \
+  --name multigres-integration-test \
+  -v $(pwd):/multigres \
+  -v /tmp/go-cache:/home/postgres/.cache \
+  -w /multigres \
+  -e TEST_PRINT_LOGS=1 \
+  -e AWS_ACCESS_KEY_ID=test-access-key \
+  -e AWS_SECRET_ACCESS_KEY=test-secret-key \
+  supabase-postgres-test:local
+```
+
+The `supabase/postgres` image is published on Docker Hub at
+[docker.io/supabase/postgres](https://hub.docker.com/r/supabase/postgres/tags).
+Tags matching `17.*-multigres` are built with the Multigres-specific extensions.
+The image supports both `linux/amd64` and `linux/arm64`.
+
+## Step-by-step
+
+### Step 1: Build the test runner image
+
+```bash
+docker build \
+  -f Dockerfile.integration-test \
+  --build-arg SUPABASE_IMAGE=supabase/postgres:17.6.1.130-multigres \
+  -t supabase-postgres-test:local \
+  .
+```
+
+This extends the published Supabase Postgres image with Go 1.25.10, etcd, and
+the test entrypoint script. Takes ~3 minutes on first run; cached thereafter.
+
+To use a different tag, substitute the value of `SUPABASE_IMAGE`. Check
+[Docker Hub](https://hub.docker.com/r/supabase/postgres/tags) for the latest
+`17.*-multigres` tag.
+
+### Step 2: Verify the Postgres binary origin
+
+```bash
+docker run --rm --entrypoint which supabase-postgres-test:local initdb
+# → /nix/var/nix/profiles/default/bin/initdb
+
+docker run --rm --entrypoint postgres supabase-postgres-test:local --version
+# → postgres (PostgreSQL) 17.x
+```
+
+### Step 3: Run the full integration suite
+
+```bash
+docker run --rm \
+  --name multigres-integration-test \
+  -v $(pwd):/multigres \
+  -v /tmp/go-cache:/home/postgres/.cache \
+  -w /multigres \
+  -e TEST_PRINT_LOGS=1 \
+  -e AWS_ACCESS_KEY_ID=test-access-key \
+  -e AWS_SECRET_ACCESS_KEY=test-secret-key \
+  supabase-postgres-test:local
+```
+
+Result files are written to the repository root on the host (via the volume
+mount) when the container exits:
+
+- `integration-test-results.jsonl` — JSON test event stream (for CI reporting)
+- `integration-test-results.xml` — JUnit XML (for Codecov and test reporters)
+
+## Building the base image from source
+
+If you need to test against an unreleased Supabase Postgres change that isn't
+yet published on Docker Hub, build the base image locally from the
+`supabase/postgres` source checkout instead.
+
+**Additional prerequisite**: `~/repos/supabase/postgres` checked out. If your
+checkout is elsewhere, override the path:
+
+```bash
+export SUPABASE_POSTGRES_DIR=/path/to/supabase/postgres
+```
+
+Then use the Makefile targets:
+
+```bash
+cd ~/repos/multigres/multigres
+
+# Build both images and run all integration tests (~20–25 min on first run)
+make test-integration-supabase
+```
+
+This runs the following sequence:
+
+1. `make docker-supabase-postgres` — runs `docker build -f Dockerfile-17`
+   from the supabase/postgres repo. Nix pulls pre-built packages from
+   `nix-postgres-artifacts.s3.amazonaws.com`. Expect 10–20 minutes on a
+   cold build; subsequent runs reuse Docker layer cache.
+2. `make docker-supabase-postgres-test` — extends the locally built base image
+   with Go 1.25.10, etcd, and the test entrypoint script. Takes ~3 minutes on
+   first run; cached thereafter.
+3. `docker run` — runs the full integration suite inside the container.
+
+### Makefile targets reference
+
+| Target                               | What it does                                                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------- |
+| `make docker-supabase-postgres`      | Build `supabase-postgres:local` from `~/repos/supabase/postgres` (rarely needed alone) |
+| `make docker-supabase-postgres-test` | Build both images (`supabase-postgres:local` then `supabase-postgres-test:local`)      |
+| `make test-integration-supabase`     | Build images if needed, then run all integration tests in the container                |
+
+## How it works
+
+The test runner image has a baked-in ENTRYPOINT:
+
+```text
+/usr/local/bin/run-integration-tests
+```
+
+This is `.github/scripts/run-integration-tests-container.sh` copied into the
+image at build time. When `docker run supabase-postgres-test:local` runs with
+no command, this script is executed inside the container:
+
+1. `make build` — compiles multigres binaries from the volume-mounted source
+2. Starts `portpoolserver` on a Unix socket
+3. Runs `gotestsum` over `./go/test/endtoend/...`, skipping
+   `TestPostgreSQLRegression`
+4. Writes result files to the working directory (`/multigres`, which is the
+   volume mount)
+
+The host-side wrapper (`.github/scripts/run-integration-tests-supabase.sh`)
+only handles the `docker run` invocation — volumes, environment variables, and
+the image tag. All test logic lives in the container-side script.
+
+The supabase image sets:
+
+```dockerfile
+ENV PATH="/nix/var/nix/profiles/default/bin:/usr/lib/postgresql/bin:${PATH}"
+```
+
+Multigres tests discover `initdb`, `postgres`, `pg_ctl`, and `pg_isready` via
+`exec.LookPath` — so the supabase-built binaries are found automatically with
+no changes to test code.
+
+The `pgctld` binary used by tests is the **multigres-compiled** one from
+`./bin/pgctld` (built via `make build`), not the one baked into the supabase
+image. This is intentional: we test multigres's pgctld against supabase
+Postgres, not supabase's own pgctld.
+
+## Running a subset of tests
+
+Override the ENTRYPOINT to get a shell, then drive the test run manually:
+
+```bash
+docker run --rm -it \
+  --entrypoint sh \
+  -v $(pwd):/multigres \
+  -v /tmp/go-cache:/home/postgres/.cache \
+  -w /multigres \
+  -e TEST_PRINT_LOGS=1 \
+  supabase-postgres-test:local
+```
+
+From that shell you can run any subset:
+
+```bash
+# Inside the container:
+make build
+./bin/portpoolserver --socket /tmp/multigres-port-pool.sock &
+PORT_POOL_PID=$!
+
+MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock \
+  go test -v -run TestConnPool -timeout 10m \
+  ./go/test/endtoend/multipooler/...
+
+kill $PORT_POOL_PID
+```
+
+See `.github/scripts/run-integration-tests-container.sh` for the full setup
+the ENTRYPOINT uses — it's the reference for the portpoolserver dance.
+
+## Debugging failures
+
+The interactive shell approach above also works for debugging. Additional
+things to check:
+
+```bash
+# Confirm binary paths
+which initdb postgres pg_ctl
+
+# Check the Supabase-built version
+initdb --version
+
+# Inspect environment inherited by test processes
+env | grep POSTGRES
+```
+
+## Scripts reference
+
+| Script                                                  | Role                                                           |
+| ------------------------------------------------------- | -------------------------------------------------------------- |
+| `.github/scripts/build-supabase-postgres.sh`            | Builds the supabase base image from a local checkout           |
+| `.github/scripts/build-supabase-postgres-test-image.sh` | Builds the test runner image from the base image               |
+| `.github/scripts/run-integration-tests-supabase.sh`     | Host-side wrapper: invokes `docker run` with right env/volumes |
+| `.github/scripts/run-integration-tests-container.sh`    | Container-side ENTRYPOINT: build + run tests                   |

--- a/docs/supabase-postgres-testing.md
+++ b/docs/supabase-postgres-testing.md
@@ -55,8 +55,15 @@ docker build \
   .
 ```
 
-This extends the published Supabase Postgres image with Go 1.25.10, etcd, and
-the test entrypoint script. Takes ~3 minutes on first run; cached thereafter.
+This extends the published Supabase Postgres image with Go 1.25.10, etcd,
+pgbackrest, and the test entrypoint script. Takes ~3 minutes on first run;
+cached thereafter.
+
+pgbackrest is required because the Multigres bootstrap process
+(`createFirstBackupAndInitializeLocked`) runs `pgbackrest stanza-create` and
+takes the first backup before marking a shard as initialized. The locally-built
+`supabase-postgres:local` image (from `Dockerfile-17`) does not ship pgbackrest;
+the test runner image installs it from Alpine's community repo.
 
 To use a different tag, substitute the value of `SUPABASE_IMAGE`. Check
 [Docker Hub](https://hub.docker.com/r/supabase/postgres/tags) for the latest

--- a/go/cmd/pgctld/command/init.go
+++ b/go/cmd/pgctld/command/init.go
@@ -360,7 +360,7 @@ func initializeDataDir(logger *slog.Logger, cfg PgCtldServiceConfig) error {
 	// pgBackRest will validate checksums for the Postgres cluster it's backing up.
 	// However, pgBackRest merely logs checksum validation errors but does not fail
 	// the backup.
-	args := []string{"-D", dataDir, "--data-checksums", "--auth-local=trust", "--auth-host=scram-sha-256", "-U", cfg.User}
+	args := []string{"-D", dataDir, "--data-checksums", "--auth-local=scram-sha-256", "--auth-host=scram-sha-256", "-U", cfg.User}
 
 	// Invariant: production callers (runInit, the InitDataDir gRPC handler)
 	// populate Password, PasswordSource (and PasswordFile when source==File)

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -381,7 +381,7 @@ func (rs *ruleStore) readCurrentRule(ctx context.Context, forUpdate bool) (*clus
 		       created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
 		         ELSE pg_current_wal_lsn()
 		       END::text AS current_lsn
 		FROM multigres.current_rule
@@ -740,7 +740,7 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		       updated.created_at,
 		       CASE
 		         WHEN pg_is_in_recovery()
-		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())
+		           THEN COALESCE(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn(), '0/0'::pg_lsn)
 		         ELSE pg_current_wal_lsn()
 		       END::text AS current_lsn
 		FROM updated, inserted`,

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -342,10 +342,22 @@ func checkCellExistsInTopology(etcdAddress, globalRootPath, cellName string) err
 }
 
 // getProcessArgs returns the full command-line of a running process as a single space-separated string.
+//
+// On Linux we read /proc/<pid>/cmdline directly, which is NUL-separated and
+// works on Alpine/BusyBox where "ps -o args=" is not supported.  On non-Linux
+// systems (macOS dev machines) we fall back to ps.
 func getProcessArgs(pid int) (string, error) {
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
-	if err != nil {
-		return "", fmt.Errorf("ps -p %d failed: %w", pid, err)
+	// Linux fast-path: /proc/<pid>/cmdline is NUL-separated argv.
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err == nil {
+		args := strings.ReplaceAll(string(data), "\x00", " ")
+		return strings.TrimSpace(args), nil
+	}
+
+	// Fallback for macOS and other systems.
+	out, psErr := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if psErr != nil {
+		return "", fmt.Errorf("ps -p %d failed: %w", pid, psErr)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -783,7 +795,7 @@ func executeStartCommand(t *testing.T, args []string, tempDir string) (string, e
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup
 	// LC_ALL is required to avoid "postmaster became multithreaded during startup" on macOS
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(utils.BaseTestEnv(),
 		"MULTIGRES_TESTDATA_DIR="+tempDir,
 		"LC_ALL=en_US.UTF-8",
 	)
@@ -859,7 +871,7 @@ func testPostgreSQLTCPConnection(t *testing.T, port int, zone string) {
 
 	// Connect via TCP using the default password "postgres" (from PgPassword config)
 	cmd := exec.Command("psql", "-h", "127.0.0.1", "-p", strconv.Itoa(port), "-U", "postgres", "-d", "postgres", "-c", fmt.Sprintf("SELECT 'Zone %s TCP auth works!' as status;", zone))
-	cmd.Env = append(os.Environ(), "PGPASSWORD=postgres")
+	cmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD=postgres")
 
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "PostgreSQL TCP connection with password failed on port %d (Zone %s): %s", port, zone, string(output))

--- a/go/test/endtoend/pgctld/pgctld_test.go
+++ b/go/test/endtoend/pgctld/pgctld_test.go
@@ -546,7 +546,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		t.Logf("Initializing PostgreSQL with POSTGRES_PASSWORD")
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
 
-		initCmd.Env = append(os.Environ(),
+		initCmd.Env = append(utils.BaseTestEnv(),
 			"PGCONNECT_TIMEOUT=5",
 			"POSTGRES_PASSWORD="+testPassword,
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
@@ -563,7 +563,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		// Start the PostgreSQL server
 		t.Logf("Starting PostgreSQL server")
 		startCmd := exec.Command("pgctld", "start", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
-		startCmd.Env = append(os.Environ(),
+		startCmd.Env = append(utils.BaseTestEnv(),
 			"PGCONNECT_TIMEOUT=5",
 			"POSTGRES_PASSWORD="+testPassword,
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
@@ -593,7 +593,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-c", "SELECT current_user, current_database();",
 		)
-		socketCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		socketCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		t.Logf("psql command: %v", socketCmd.Args)
 		output, err = socketCmd.CombinedOutput()
 		require.NoError(t, err, "Socket connection should succeed, output: %s", string(output))
@@ -601,7 +601,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 
 		// Get the actual port from the status output
 		statusCmd := exec.Command("pgctld", "status", "--pooler-dir", baseDir)
-		statusCmd.Env = append(os.Environ(), constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"))
+		statusCmd.Env = append(utils.BaseTestEnv(), constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"))
 		statusOutput, err := statusCmd.CombinedOutput()
 		require.NoError(t, err, "pgctld status should succeed")
 		t.Logf("Status output: %s", string(statusOutput))
@@ -615,7 +615,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-c", "SELECT current_user, current_database();",
 		)
-		tcpCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		tcpCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		output, err = tcpCmd.CombinedOutput()
 		require.NoError(t, err, "TCP connection with correct password should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "postgres", "Should connect as postgres user")
@@ -629,7 +629,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-c", "SELECT 1;",
 		)
-		wrongPasswordCmd.Env = append(os.Environ(), "PGPASSWORD=wrong_password")
+		wrongPasswordCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD=wrong_password")
 		output, err = wrongPasswordCmd.CombinedOutput()
 		assert.Error(t, err, "TCP connection with wrong password should fail")
 		assert.Contains(t, string(output), "password authentication failed", "Should fail with authentication error")
@@ -645,7 +645,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-t", "-c", "SELECT rolname FROM pg_roles WHERE rolname = 'postgres';",
 		)
-		roleCheckCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		roleCheckCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		output, err = roleCheckCmd.CombinedOutput()
 		require.NoError(t, err, "Role check should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "postgres", "postgres role should exist")
@@ -658,7 +658,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-t", "-c", "SELECT datname FROM pg_database WHERE datname = 'postgres';",
 		)
-		dbCheckCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		dbCheckCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		output, err = dbCheckCmd.CombinedOutput()
 		require.NoError(t, err, "Database check should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "postgres", "postgres database should exist")
@@ -671,7 +671,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-t", "-c", "SELECT rolsuper FROM pg_roles WHERE rolname = 'postgres';",
 		)
-		privilegeCheckCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		privilegeCheckCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		output, err = privilegeCheckCmd.CombinedOutput()
 		require.NoError(t, err, "Privilege check should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "t", "postgres role should have superuser privileges")
@@ -679,7 +679,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		// Clean shutdown
 		t.Logf("Shutting down PostgreSQL")
 		stopCmd := exec.Command("pgctld", "stop", "--pooler-dir", baseDir)
-		stopCmd.Env = append(os.Environ(),
+		stopCmd.Env = append(utils.BaseTestEnv(),
 			"PGCONNECT_TIMEOUT=5",
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
 			"POSTGRES_PASSWORD="+testPassword,
@@ -706,7 +706,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 		require.NoError(t, os.WriteFile(pwFile, []byte(testPassword+"\n"), 0o600))
 
 		envWithFile := func() []string {
-			env := filterEnv(os.Environ(), "POSTGRES_PASSWORD")
+			env := filterEnv(utils.BaseTestEnv(), "POSTGRES_PASSWORD")
 			env = append(env,
 				"PGCONNECT_TIMEOUT=5",
 				"POSTGRES_PASSWORD_FILE="+pwFile,
@@ -742,7 +742,7 @@ func TestPostgreSQLAuthentication(t *testing.T) {
 			"-d", "postgres",
 			"-c", "SELECT current_user;",
 		)
-		tcpCmd.Env = append(os.Environ(), "PGPASSWORD="+testPassword)
+		tcpCmd.Env = append(utils.BaseTestEnv(), "PGPASSWORD="+testPassword)
 		output, err = tcpCmd.CombinedOutput()
 		require.NoError(t, err, "TCP connection should succeed, output: %s", string(output))
 		assert.Contains(t, string(output), "postgres")
@@ -770,9 +770,9 @@ func TestPgctldRequiresPassword(t *testing.T) {
 
 		port := utils.GetFreePort(t)
 		initCmd := exec.Command("pgctld", "init", "--pooler-dir", baseDir, "--pg-port", strconv.Itoa(port))
-		// Build env without POSTGRES_PASSWORD: copy os.Environ() but drop any
+		// Build env without POSTGRES_PASSWORD: copy utils.BaseTestEnv() but drop any
 		// inherited POSTGRES_PASSWORD set by the test runner.
-		initCmd.Env = filterEnv(os.Environ(), "POSTGRES_PASSWORD")
+		initCmd.Env = filterEnv(utils.BaseTestEnv(), "POSTGRES_PASSWORD")
 		initCmd.Env = append(initCmd.Env,
 			"PGCONNECT_TIMEOUT=5",
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
@@ -800,7 +800,7 @@ func TestPgctldRequiresPassword(t *testing.T) {
 			"--grpc-port", strconv.Itoa(grpcPort),
 			"--http-port", strconv.Itoa(httpPort),
 		)
-		serverCmd.Env = filterEnv(os.Environ(), "POSTGRES_PASSWORD")
+		serverCmd.Env = filterEnv(utils.BaseTestEnv(), "POSTGRES_PASSWORD")
 		serverCmd.Env = append(serverCmd.Env,
 			"PGCONNECT_TIMEOUT=5",
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
@@ -855,7 +855,7 @@ func TestCustomDatabaseCreation(t *testing.T) {
 		port := utils.GetFreePort(t)
 		socketDir := filepath.Join(baseDir, "pg_sockets")
 
-		baseEnv := append(os.Environ(), "PGCONNECT_TIMEOUT=5",
+		baseEnv := append(utils.BaseTestEnv(), "PGCONNECT_TIMEOUT=5",
 			constants.PgDataDirEnvVar+"="+filepath.Join(baseDir, "pg_data"),
 			constants.PgPasswordEnvVar+"=test-password",
 			"PGPASSWORD=test-password",

--- a/go/test/endtoend/pgctld/test_helpers.go
+++ b/go/test/endtoend/pgctld/test_helpers.go
@@ -15,6 +15,7 @@
 package pgctld
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -147,16 +148,16 @@ func verifyServerStopped(t *testing.T, port int) bool {
 	return false
 }
 
-// getPgBackRestPID finds the pgbackrest server process ID for a specific config path
-// Returns PID or 0 if not found
+// getPgBackRestPID finds the pgbackrest server process ID for a specific config path.
+// Returns the PID or 0 if not found.
 func getPgBackRestPID(t *testing.T, configPath string) int {
 	t.Helper()
 
-	// Get all pgbackrest server processes
+	// Get all pgbackrest server processes.
 	cmd := exec.Command("pgrep", "-f", "pgbackrest server")
 	output, err := cmd.Output()
 	if err != nil {
-		// Process not found
+		// No matching processes found.
 		return 0
 	}
 
@@ -165,28 +166,48 @@ func getPgBackRestPID(t *testing.T, configPath string) int {
 		return 0
 	}
 
-	// Check each PID to find one using our specific config
+	// Check each PID to find one using our specific config.
 	for pidLine := range strings.SplitSeq(pidStr, "\n") {
 		var pid int
 		_, err = fmt.Sscanf(pidLine, "%d", &pid)
 		if err != nil {
 			continue
 		}
-
-		// Check if this process is using our config by checking environment
-		envCmd := exec.Command("sh", "-c", fmt.Sprintf("ps eww -p %d | grep -o 'PGBACKREST_CONFIG=[^[:space:]]*'", pid))
-		envOutput, err := envCmd.Output()
-		if err != nil {
-			continue
-		}
-
-		envStr := strings.TrimSpace(string(envOutput))
-		if strings.Contains(envStr, configPath) {
+		if pidUsesConfig(pid, configPath) {
 			return pid
 		}
 	}
 
 	return 0
+}
+
+// pidUsesConfig reports whether the process with the given PID was started
+// with PGBACKREST_CONFIG set to (or containing) configPath.
+//
+// On Linux we read /proc/<pid>/environ directly — this avoids relying on
+// "ps eww", whose -e flag (print environment) is not supported by
+// Alpine/BusyBox ps.  On non-Linux systems (macOS CI) we fall back to ps.
+func pidUsesConfig(pid int, configPath string) bool {
+	// Linux fast-path: /proc/<pid>/environ is NUL-separated env entries.
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err == nil {
+		for entry := range bytes.SplitSeq(data, []byte{0}) {
+			if bytes.HasPrefix(entry, []byte("PGBACKREST_CONFIG=")) &&
+				bytes.Contains(entry, []byte(configPath)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Fallback for macOS and other systems that expose proc env via ps.
+	envCmd := exec.Command("sh", "-c",
+		fmt.Sprintf("ps eww -p %d | grep -o 'PGBACKREST_CONFIG=[^[:space:]]*'", pid))
+	envOutput, envErr := envCmd.Output()
+	if envErr != nil {
+		return false
+	}
+	return strings.Contains(strings.TrimSpace(string(envOutput)), configPath)
 }
 
 // killProcess sends SIGKILL to process by PID
@@ -320,7 +341,7 @@ func getPgBackRestStatus(t *testing.T, client pgctldservice.PgCtldClient) *pgctl
 // PGPASSWORD so pgctld init/start/stop subprocesses can satisfy the scram-sha-256
 // requirement without needing a real PostgreSQL instance.
 func mockBinEnv(binDir, pgDataDir string) []string {
-	env := append(os.Environ(),
+	env := append(utils.BaseTestEnv(),
 		"PATH="+binDir+":"+os.Getenv("PATH"),
 		constants.PgDataDirEnvVar+"="+pgDataDir,
 		constants.PgPasswordEnvVar+"=test-password",
@@ -336,7 +357,13 @@ func mockBinEnv(binDir, pgDataDir string) []string {
 // Includes a default POSTGRES_PASSWORD because pgctld now refuses to init or
 // serve without one (pg_hba.conf requires scram-sha-256 for all connections).
 // Also sets PGPASSWORD so psql subprocesses can authenticate.
+//
+// Uses utils.BaseTestEnv() as the base environment to strip container-specific
+// variables (POSTGRES_USER=supabase_admin, POSTGRES_INITDB_SQL_FILES) that would
+// otherwise be inherited from the Supabase Postgres container and corrupt the
+// test cluster. POSTGRES_USER=postgres is set by BaseTestEnv().
 func setupTestEnv(cmd *executil.Cmd, poolerDir string) {
+	cmd.SetEnv(utils.BaseTestEnv())
 	cmd.AddEnv(
 		"PGCONNECT_TIMEOUT=5",
 		constants.PgDataDirEnvVar+"="+filepath.Join(poolerDir, "pg_data"),

--- a/go/test/endtoend/shardsetup/client.go
+++ b/go/test/endtoend/shardsetup/client.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/test/endtoend/testconst"
+
 	consensuspb "github.com/multigres/multigres/go/pb/consensus"
 	multiorchpb "github.com/multigres/multigres/go/pb/multiorch"
 	multipoolermanagerpb "github.com/multigres/multigres/go/pb/multipoolermanager"
@@ -111,7 +113,7 @@ func WaitForManagerReady(t *testing.T, manager *ProcessInstance) {
 			return false
 		}
 		return resp.Status != nil && resp.Status.PostgresReady
-	}, 30*time.Second, 100*time.Millisecond, "Manager should become ready within 30 seconds")
+	}, testconst.ManagerStartTimeout, 100*time.Millisecond, "Manager should become ready within %s", testconst.ManagerStartTimeout)
 
 	t.Logf("Manager %s is ready", manager.Name)
 }

--- a/go/test/endtoend/shardsetup/cluster.go
+++ b/go/test/endtoend/shardsetup/cluster.go
@@ -181,6 +181,11 @@ func (s *ShardSetup) GetPrimary(t *testing.T) *MultipoolerInstance {
 }
 
 // RefreshPrimary queries all multipoolers to find the current primary and updates PrimaryName.
+// Returns nil (without failing the test) when no primary is found — callers that require a
+// primary should assert on the return value (e.g. require.NotNil). Returning nil rather than
+// calling t.Fatal is important because RefreshPrimary is used inside assert.Never callbacks,
+// which spawn goroutines; a t.Fatal from such a goroutine would fail the test spuriously when
+// cleanup tears down the multipoolers after the assertion window has already passed.
 func (s *ShardSetup) RefreshPrimary(t *testing.T) *MultipoolerInstance {
 	t.Helper()
 
@@ -206,7 +211,7 @@ func (s *ShardSetup) RefreshPrimary(t *testing.T) *MultipoolerInstance {
 		}
 	}
 
-	t.Fatal("RefreshPrimary: no primary found in cluster")
+	t.Logf("RefreshPrimary: no primary found in cluster")
 	return nil
 }
 
@@ -300,7 +305,7 @@ func CreatePgctldInstance(t *testing.T, name, baseDir string, grpcPort, pgPort, 
 		PgBackRestPort:    pgbackrestPort,
 		PgBackRestCertDir: pgbackrestCertDir,
 		BackupLocation:    backupLocation,
-		Environment:       append(os.Environ(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data")),
+		Environment:       append(utils.BaseTestEnv(), "PGCONNECT_TIMEOUT=5", "LC_ALL=en_US.UTF-8", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(dataDir, "pg_data")),
 	}
 }
 
@@ -330,7 +335,7 @@ func CreateMultipoolerProcessInstance(t *testing.T, name, baseDir string, grpcPo
 		EtcdAddr:    etcdAddr,
 		Binary:      "multipooler",
 		SocketFile:  socketFile,
-		Environment: append(os.Environ(), "PGCONNECT_TIMEOUT=5", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(pgctldDataDir, "pg_data")),
+		Environment: append(utils.BaseTestEnv(), "PGCONNECT_TIMEOUT=5", "POSTGRES_PASSWORD="+TestPostgresPassword, constants.PgDataDirEnvVar+"="+filepath.Join(pgctldDataDir, "pg_data")),
 	}
 
 	// Store pgBackRest cert paths struct and port for later use when starting multipooler

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -35,6 +35,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/multigres/multigres/go/test/endtoend/testconst"
+
 	"github.com/multigres/multigres/go/cmd/pgctld/testutil"
 	"github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
@@ -1083,7 +1085,7 @@ func waitForShardBootstrap(ctx context.Context, t *testing.T, setup *ShardSetup)
 	ctx, span := telemetry.Tracer().Start(ctx, "shardsetup/waitForShardBootstrap")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testconst.ShardBootstrapTimeout)
 	defer cancel()
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -1093,8 +1095,8 @@ func waitForShardBootstrap(ctx context.Context, t *testing.T, setup *ShardSetup)
 	for {
 		select {
 		case <-ctx.Done():
-			span.SetStatus(codes.Error, "timeout after 60s")
-			return "", errors.New("timeout waiting for shard bootstrap after 60s")
+			span.SetStatus(codes.Error, fmt.Sprintf("timeout after %s", testconst.ShardBootstrapTimeout))
+			return "", fmt.Errorf("timeout waiting for shard bootstrap after %s", testconst.ShardBootstrapTimeout)
 		case <-ticker.C:
 			checkCount++
 			primaryName, allInitialized := checkBootstrapStatus(ctx, t, setup)

--- a/go/test/endtoend/testconst/constants.go
+++ b/go/test/endtoend/testconst/constants.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testconst holds shared constants for the endtoend test suite.
+package testconst
+
+import "time"
+
+const (
+	// ManagerStartTimeout is the maximum time to wait for a multipooler manager
+	// to become ready. Generous to accommodate slow CI environments.
+	ManagerStartTimeout = 120 * time.Second
+
+	// ShardBootstrapTimeout is the maximum time waitForShardBootstrap will wait
+	// for all poolers to report a primary and complete initialization. Generous
+	// to accommodate slow CI environments (e.g. GitHub Actions runners).
+	ShardBootstrapTimeout = 240 * time.Second
+)

--- a/go/test/utils/process.go
+++ b/go/test/utils/process.go
@@ -16,10 +16,54 @@ package utils
 
 import (
 	"context"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/tools/executil"
 )
+
+// BaseTestEnv returns a copy of os.Environ() safe for use in pgctld and multipooler
+// test processes. It strips variables that the Supabase Postgres container exports
+// and that would corrupt the test cluster setup:
+//
+//   - POSTGRES_USER=supabase_admin — causes initdb to create a "supabase_admin"
+//     superuser instead of "postgres", so "postgres" gets no SCRAM verifier and all
+//     test connections (which authenticate as "postgres") fail with "password
+//     authentication failed".
+//   - POSTGRES_INITDB_SQL_FILES — points at Supabase migration SQL that assumes a
+//     pre-existing "supabase_admin" role; running it under the test user breaks
+//     initdb post-setup.
+//   - POSTGRES_INITDB_SQL_DIRS — same concern as POSTGRES_INITDB_SQL_FILES.
+//
+// POSTGRES_INITDB_ARGS is intentionally NOT stripped. The Supabase image sets it to
+// "--locale-provider=icu --icu-locale=en_US.UTF-8 --allow-group-access". The ICU
+// locale flags are necessary: the Supabase Postgres binary requires ICU locale data
+// for startup, and that data is available via LOCALE_ARCHIVE inside the container.
+// Stripping these flags causes Postgres to start but crash immediately (before
+// multipooler can connect), because the binary cannot fall back to a glibc-only
+// locale configuration.  On a developer's macOS machine POSTGRES_INITDB_ARGS is
+// typically absent, so leaving it unstripped is a no-op there.
+//
+// After stripping, POSTGRES_USER=postgres is appended so initdb always creates
+// "postgres" as the superuser — the role every test connection uses.
+func BaseTestEnv() []string {
+	strip := map[string]bool{
+		constants.PgUserEnvVar:           true,
+		constants.PgInitdbSQLFilesEnvVar: true,
+		constants.PgInitdbSQLDirsEnvVar:  true,
+	}
+	base := make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		if !strip[key] {
+			base = append(base, kv)
+		}
+	}
+	base = append(base, constants.PgUserEnvVar+"="+constants.DefaultPostgresUser)
+	return base
+}
 
 // CommandWithOrphanProtection creates a command wrapped in run_in_test.sh for orphan
 // process protection. The process uses context.Background() for its lifetime, avoiding

--- a/misc/hooks/shfmt
+++ b/misc/hooks/shfmt
@@ -9,13 +9,19 @@ if ! command -v shfmt >/dev/null 2>&1; then
   exit 0
 fi
 
-FILES=$(git diff --cached --name-only --diff-filter=ACMR)
-[ -z "$FILES" ] && exit 0
-
-# Format all selected files
-echo "$FILES" | xargs shfmt --apply-ignore -w
-
-# Add back the modified/formatted files to staging
-echo "$FILES" | xargs git add
-
+# Filter to shell files only: shfmt errors on files that start with '#' but
+# are not shell (Makefile, *.md) because it mistakes the comment character for
+# a shell comment and then fails on the first non-shell token.
+# Collect shell files into an array. The natural form `files=($(command))`
+# triggers shellcheck SC2207 (word-splitting / glob expansion). mapfile is
+# the usual fix but requires bash 4+, which macOS does not ship. The while-
+# read loop below is equivalent, portable to bash 3.2, and shellcheck-clean.
+files=()
+while IFS= read -r f; do
+  files+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(sh|bash|bats|mksh|zsh)$' || true)
+if [ ${#files[@]} -ne 0 ]; then
+  shfmt --apply-ignore -w "${files[@]}"
+  git add "${files[@]}"
+fi
 exit 0


### PR DESCRIPTION
## Run integration tests against the Supabase Postgres image

This PR adds the ability to run the Multigres integration test suite against the Supabase-flavored Postgres image (from `github.com/supabase/postgres`) and fixes the test failures that surface when doing so.

### Background

The existing integration tests run against vanilla Postgres. Testing against the Supabase image is important because it ships with a different default user (`supabase_admin` instead of `postgres`), a patched socket directory, and Supabase-specific init SQL — all of which exposed real incompatibilities in the test infrastructure.

### What breaks and why

The Supabase container exports `POSTGRES_USER=supabase_admin` into its environment. Test processes inherited this via `os.Environ()`, causing `initdb -U supabase_admin`. This gave `supabase_admin` the SCRAM verifier and left `postgres` with none. Since `pg_hba_template.conf` requires `scram-sha-256` for all connections, every test connection (authenticating as `postgres`) failed with *password authentication failed*.

The container also exports `POSTGRES_INITDB_SQL_FILES` pointing at Supabase migration SQL that assumes a pre-existing `supabase_admin` role — running that during tests would break initdb post-setup.

### Fixes (commit 1)

- **`go/test/utils/process.go`**: new `BaseTestEnv()` helper that strips `POSTGRES_USER`, `POSTGRES_INITDB_SQL_FILES`, and `POSTGRES_INITDB_SQL_DIRS` from `os.Environ()` and appends `POSTGRES_USER=postgres`, ensuring `initdb` always creates `postgres` as the superuser.
- **`test_helpers.go`, `pgctld_test.go`, `cluster.go`, `cluster_test.go`**: replace all `os.Environ()` calls in pgctld, shardsetup, and localprovisioner test processes with `BaseTestEnv()`.
- **`go/cmd/pgctld/command/init.go`**: change `--auth-local` from `trust` to `scram-sha-256` to match `--auth-host` and the `pg_hba` template.
- **`go/test/endtoend/shardsetup/setup.go`**: raise `waitForShardBootstrap` timeout from 60 s to 240 s for Docker and slow CI runners.

After these fixes the full integration suite passes against the Supabase image: **947 tests, 0 failures**.

### Infrastructure (commit 2)

- **`Dockerfile.integration-test`**: extends the supabase-postgres base image with Go, etcd, and gotestsum; the multigres source tree is volume-mounted at runtime.
- **`.github/scripts/`**: three scripts (`build-supabase-postgres.sh`, `build-supabase-postgres-test-image.sh`, `run-integration-tests-supabase.sh`) that encapsulate the docker build/run steps and are shared between the Makefile and the workflow.
- **`.github/workflows/test-integration-supabase.yml`**: CI workflow that checks out both repos, builds the images, runs the suite with `RERUN_FAILS=3`, and uploads JUnit/JSON artifacts. Runs nightly at 02:00 UTC and on demand via `workflow_dispatch`.
- **`Makefile`**: `docker-supabase-postgres`, `docker-supabase-postgres-test`, and `test-integration-supabase` targets for local use.
- **`docs/supabase-postgres-testing.md`**: local usage guide.

Fixes MUL-534