### PR TITLE
feat(multigres): wait for cluster readiness on cluster start

### DIFF
--- a/go/cmd/multigres/command/cluster/start.go
+++ b/go/cmd/multigres/command/cluster/start.go
@@ -15,15 +15,107 @@
 package cluster
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/provisioner"
+	"github.com/multigres/multigres/go/tools/retry"
 
+	_ "github.com/lib/pq" // PostgreSQL driver for the readiness probe
 	"github.com/spf13/cobra"
 )
+
+// defaultPostgresUser, defaultPostgresPassword, and defaultPostgresDatabase
+// are fallback connection parameters used when the loaded config doesn't
+// override them. They match what the local provisioner writes by default.
+const (
+	defaultPostgresUser     = "postgres"
+	defaultPostgresPassword = "postgres"
+	defaultPostgresDatabase = "postgres"
+)
+
+// bootstrapCredentials are the postgres connection parameters the
+// readiness probe uses to authenticate against multigateway. We pull these
+// from the loaded config so a rotated password still works — hardcoding
+// "postgres" would break the moment an operator changed it.
+type bootstrapCredentials struct {
+	user     string
+	password string
+	database string
+}
+
+// extractBootstrapCredentials walks the provisioner config to find the
+// postgres user/password/database. It picks the first cell it sees (the
+// local provisioner writes the same credentials across cells); falls back
+// to defaults for any field that's missing.
+func extractBootstrapCredentials(provConfig map[string]any) bootstrapCredentials {
+	creds := bootstrapCredentials{
+		user:     defaultPostgresUser,
+		password: defaultPostgresPassword,
+		database: defaultPostgresDatabase,
+	}
+	cells, ok := provConfig["cells"].(map[string]any)
+	if !ok {
+		return creds
+	}
+	for _, cellRaw := range cells {
+		cell, ok := cellRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if pgctld, ok := cell["pgctld"].(map[string]any); ok {
+			if v, ok := pgctld["pg-user"].(string); ok && v != "" {
+				creds.user = v
+			}
+			if v, ok := pgctld["pg-password"].(string); ok && v != "" {
+				creds.password = v
+			}
+		}
+		if mp, ok := cell["multipooler"].(map[string]any); ok {
+			if v, ok := mp["database"].(string); ok && v != "" {
+				creds.database = v
+			}
+		}
+		return creds
+	}
+	return creds
+}
+
+// gatewayProbeFunc is the signature waitForGatewaysReady expects. Tests
+// can pass stubs directly to waitForGatewaysReady; start() wraps
+// runGatewayProbeFn in a closure that captures the bootstrap credentials.
+type gatewayProbeFunc func(ctx context.Context, host string, port int) error
+
+// runGatewayProbeFn runs `SELECT 1` through a multigateway as the
+// operator's configured postgres user. Going through the gateway's PG
+// protocol exercises the entire path psql will use moments later —
+// gateway PoolerDiscovery → primary multipooler → GetAuthCredentials →
+// pg_authid → SCRAM compare — so a successful probe is the strongest
+// practical guarantee that user queries will succeed. It is a var (not a
+// func) so tests can swap it out without spinning up a real cluster.
+var runGatewayProbeFn = func(ctx context.Context, host string, port int, creds bootstrapCredentials) error {
+	connStr := fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=2",
+		host, port, creds.user, creds.password, creds.database,
+	)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	probeCtx, cancel := context.WithTimeout(ctx, constants.LocalGatewayBootstrapProbeTimeout)
+	defer cancel()
+	_, err = db.ExecContext(probeCtx, "SELECT 1")
+	return err
+}
 
 // ServiceInfo holds information about a provisioned service
 type ServiceInfo struct {
@@ -124,6 +216,71 @@ func (s *ServiceSummary) PrintSummary() {
 	fmt.Println(strings.Repeat("=", 65))
 }
 
+// gatewayEndpoint identifies a single multigateway's PostgreSQL endpoint.
+type gatewayEndpoint struct {
+	name string
+	host string
+	port int
+}
+
+// collectGateways returns the PostgreSQL endpoint for every multigateway in
+// results. Results without a pg_port are skipped.
+func collectGateways(results []*provisioner.ProvisionResult) []gatewayEndpoint {
+	var gws []gatewayEndpoint
+	for _, r := range results {
+		if r.ServiceName != "multigateway" {
+			continue
+		}
+		port, ok := r.Ports["pg_port"]
+		if !ok {
+			continue
+		}
+		gws = append(gws, gatewayEndpoint{name: r.ServiceName, host: r.FQDN, port: port})
+	}
+	return gws
+}
+
+// waitForGatewaysReady polls every gateway via probe until each succeeds
+// or ctx is cancelled. Each gateway is polled in its own goroutine.
+// Returns an error listing the gateways that never became ready by the
+// time ctx expires.
+func waitForGatewaysReady(ctx context.Context, gateways []gatewayEndpoint, probe gatewayProbeFunc) error {
+	ready := make([]bool, len(gateways))
+	var wg sync.WaitGroup
+	for i, gw := range gateways {
+		wg.Add(1)
+		go func(i int, gw gatewayEndpoint) {
+			defer wg.Done()
+			r := retry.New(constants.LocalGatewayBootstrapPollInterval, constants.LocalGatewayBootstrapPollInterval)
+			for _, err := range r.Attempts(ctx) {
+				if err != nil {
+					return
+				}
+				if err := probe(ctx, gw.host, gw.port); err == nil {
+					ready[i] = true
+					fmt.Printf("✅ - %s ready at %s:%d\n", gw.name, gw.host, gw.port)
+					return
+				}
+			}
+		}(i, gw)
+	}
+	wg.Wait()
+
+	var pending []string
+	for i, gw := range gateways {
+		if !ready[i] {
+			pending = append(pending, fmt.Sprintf("%s (%s:%d)", gw.name, gw.host, gw.port))
+		}
+	}
+	if len(pending) > 0 {
+		return fmt.Errorf(
+			"cluster did not become ready to serve queries within %s; gateways not ready: %s. Check the multigateway and multipooler log files listed above for details",
+			constants.LocalBootstrapWaitTimeout, strings.Join(pending, ", "),
+		)
+	}
+	return nil
+}
+
 // start handles the cluster up command
 func start(cmd *cobra.Command, args []string) error {
 	fmt.Println("Multigres — Distributed Postgres made easy")
@@ -180,6 +337,30 @@ func start(cmd *cobra.Command, args []string) error {
 		summary.AddService(result.ServiceName, result)
 	}
 
+	waitForBootstrap, err := cmd.Flags().GetBool("wait-for-bootstrap")
+	if err != nil {
+		return fmt.Errorf("failed to get wait-for-bootstrap flag: %w", err)
+	}
+	if waitForBootstrap {
+		gateways := collectGateways(allResults)
+		if len(gateways) == 0 {
+			return errors.New("cluster bootstrap returned no multigateways with a pg_port; cluster cannot serve queries")
+		}
+
+		creds := extractBootstrapCredentials(config.ProvisionerConfig)
+		probe := func(ctx context.Context, host string, port int) error {
+			return runGatewayProbeFn(ctx, host, port, creds)
+		}
+
+		fmt.Println()
+		fmt.Printf("⏳ - Waiting up to %s for the cluster to start serving queries...\n", constants.LocalBootstrapWaitTimeout)
+		waitCtx, cancel := context.WithTimeout(ctx, constants.LocalBootstrapWaitTimeout)
+		defer cancel()
+		if err := waitForGatewaysReady(waitCtx, gateways, probe); err != nil {
+			return err
+		}
+	}
+
 	// Print comprehensive summary
 	fmt.Println()
 	summary.PrintSummary()
@@ -195,7 +376,8 @@ func AddStartCommand(clusterCmd *cobra.Command) {
 		RunE:  start,
 	}
 
-	// No additional flags needed - config-path is provided by viperutil via root command
+	startCmd.Flags().Bool("wait-for-bootstrap", true,
+		"Wait for every multigateway to execute SELECT 1 successfully (using the postgres password from the loaded config) before returning; on timeout the command exits with an error")
 
 	clusterCmd.AddCommand(startCmd)
 }

--- a/go/cmd/multigres/command/cluster/start_test.go
+++ b/go/cmd/multigres/command/cluster/start_test.go
@@ -97,6 +97,31 @@ func TestExtractBootstrapCredentials_PartialOverridesFallToDefault(t *testing.T)
 	}, got)
 }
 
+func TestExtractBootstrapCredentials_NoCredentialsInConfig(t *testing.T) {
+	// Cells exist but neither the pgctld nor multipooler entries are
+	// present (or they have the wrong shape), so no credential fields are
+	// resolved. extractBootstrapCredentials should fall back to the
+	// defaults for every field rather than returning a partial/empty
+	// record. This catches a regression where, e.g., a future refactor
+	// makes the function return a zero-valued struct when nothing matches.
+	provConfig := map[string]any{
+		"cells": map[string]any{
+			"zone1": map[string]any{
+				// no pgctld, no multipooler — also covers the case where
+				// they exist but aren't maps:
+				"pgctld":      "wrong-type",
+				"multipooler": 42,
+			},
+		},
+	}
+	got := extractBootstrapCredentials(provConfig)
+	assert.Equal(t, bootstrapCredentials{
+		user:     defaultPostgresUser,
+		password: defaultPostgresPassword,
+		database: defaultPostgresDatabase,
+	}, got)
+}
+
 func TestWaitForGatewaysReady_AllReadyImmediately(t *testing.T) {
 	probe := func(_ context.Context, _ string, _ int) error { return nil }
 	gws := []gatewayEndpoint{

--- a/go/cmd/multigres/command/cluster/start_test.go
+++ b/go/cmd/multigres/command/cluster/start_test.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/provisioner"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectGateways(t *testing.T) {
+	results := []*provisioner.ProvisionResult{
+		{ServiceName: "etcd", FQDN: "localhost", Ports: map[string]int{"tcp": 2379}},
+		{ServiceName: "multigateway", FQDN: "host-a", Ports: map[string]int{"pg_port": 6432, "http_port": 8080}},
+		{ServiceName: "multipooler", FQDN: "localhost", Ports: map[string]int{"grpc_port": 5000}},
+		{ServiceName: "multigateway", FQDN: "host-b", Ports: map[string]int{"pg_port": 6433}},
+		// A multigateway with no pg_port should be skipped.
+		{ServiceName: "multigateway", FQDN: "host-c", Ports: map[string]int{"http_port": 8081}},
+	}
+
+	got := collectGateways(results)
+	require.Len(t, got, 2)
+	assert.Equal(t, gatewayEndpoint{name: "multigateway", host: "host-a", port: 6432}, got[0])
+	assert.Equal(t, gatewayEndpoint{name: "multigateway", host: "host-b", port: 6433}, got[1])
+}
+
+func TestExtractBootstrapCredentials_Defaults(t *testing.T) {
+	// Empty config → all defaults.
+	got := extractBootstrapCredentials(map[string]any{})
+	assert.Equal(t, bootstrapCredentials{
+		user:     defaultPostgresUser,
+		password: defaultPostgresPassword,
+		database: defaultPostgresDatabase,
+	}, got)
+}
+
+func TestExtractBootstrapCredentials_ReadsFromConfig(t *testing.T) {
+	provConfig := map[string]any{
+		"cells": map[string]any{
+			"zone1": map[string]any{
+				"pgctld": map[string]any{
+					"pg-user":     "supabase_admin",
+					"pg-password": "s3cret",
+				},
+				"multipooler": map[string]any{
+					"database": "supabase",
+				},
+			},
+		},
+	}
+	got := extractBootstrapCredentials(provConfig)
+	assert.Equal(t, bootstrapCredentials{
+		user:     "supabase_admin",
+		password: "s3cret",
+		database: "supabase",
+	}, got)
+}
+
+func TestExtractBootstrapCredentials_PartialOverridesFallToDefault(t *testing.T) {
+	// Only the password is set; user and database should fall back.
+	provConfig := map[string]any{
+		"cells": map[string]any{
+			"zone1": map[string]any{
+				"pgctld": map[string]any{
+					"pg-password": "rotated",
+				},
+			},
+		},
+	}
+	got := extractBootstrapCredentials(provConfig)
+	assert.Equal(t, bootstrapCredentials{
+		user:     defaultPostgresUser,
+		password: "rotated",
+		database: defaultPostgresDatabase,
+	}, got)
+}
+
+func TestWaitForGatewaysReady_AllReadyImmediately(t *testing.T) {
+	probe := func(_ context.Context, _ string, _ int) error { return nil }
+	gws := []gatewayEndpoint{
+		{name: "multigateway", host: "host-a", port: 6432},
+		{name: "multigateway", host: "host-b", port: 6433},
+	}
+	require.NoError(t, waitForGatewaysReady(context.Background(), gws, probe))
+}
+
+func TestWaitForGatewaysReady_BecomesReadyAfterRetries(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls = map[string]int{}
+	)
+	probe := func(_ context.Context, host string, _ int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls[host]++
+		// host-a ready on its second poll; host-b on its third.
+		switch host {
+		case "host-a":
+			if calls[host] >= 2 {
+				return nil
+			}
+		case "host-b":
+			if calls[host] >= 3 {
+				return nil
+			}
+		}
+		return errors.New("not ready")
+	}
+	gws := []gatewayEndpoint{
+		{name: "multigateway", host: "host-a", port: 6432},
+		{name: "multigateway", host: "host-b", port: 6433},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, waitForGatewaysReady(ctx, gws, probe))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, calls["host-a"], 2)
+	assert.GreaterOrEqual(t, calls["host-b"], 3)
+}
+
+func TestWaitForGatewaysReady_TimeoutReportsPending(t *testing.T) {
+	probe := func(_ context.Context, host string, _ int) error {
+		if host == "host-a" {
+			return nil
+		}
+		return errors.New("not ready")
+	}
+	gws := []gatewayEndpoint{
+		{name: "multigateway", host: "host-a", port: 6432},
+		{name: "multigateway", host: "host-b", port: 6433},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	err := waitForGatewaysReady(ctx, gws, probe)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host-b")
+	assert.Contains(t, err.Error(), "6433")
+	assert.NotContains(t, err.Error(), "host-a")
+}
+
+func TestStartCommand_WaitForBootstrapFlagDefault(t *testing.T) {
+	clusterCmd := &cobra.Command{Use: "cluster"}
+	AddStartCommand(clusterCmd)
+
+	startCmd, _, err := clusterCmd.Find([]string{"start"})
+	require.NoError(t, err)
+
+	flag := startCmd.Flag("wait-for-bootstrap")
+	require.NotNil(t, flag, "expected --wait-for-bootstrap to be registered")
+	assert.Equal(t, "true", flag.DefValue)
+}
+
+func TestStartCommand_WaitForBootstrapFalseSkipsProbe(t *testing.T) {
+	runStartWithFakeProvisioner(t, "", []*provisioner.ProvisionResult{
+		{ServiceName: "multigateway", FQDN: "host-a", Ports: map[string]int{"pg_port": 6432}},
+	}, "--wait-for-bootstrap=false", func(err error, probeCalls *int) {
+		require.NoError(t, err)
+		assert.Zero(t, *probeCalls, "gateway probe must not be invoked when --wait-for-bootstrap=false")
+	})
+}
+
+func TestStartCommand_WaitForBootstrapTrueWithNoGateways(t *testing.T) {
+	runStartWithFakeProvisioner(t, "", []*provisioner.ProvisionResult{
+		{ServiceName: "etcd", FQDN: "localhost", Ports: map[string]int{"tcp": 2379}},
+	}, "--wait-for-bootstrap=true", func(err error, probeCalls *int) {
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no multigateways")
+		assert.Zero(t, *probeCalls, "gateway probe must not be invoked when there are no gateways")
+	})
+}
+
+func TestStartCommand_WaitForBootstrapTrueRunsGatewayProbe(t *testing.T) {
+	results := []*provisioner.ProvisionResult{
+		{ServiceName: "multigateway", FQDN: "host-a", Ports: map[string]int{"pg_port": 6432}},
+	}
+	runStartWithFakeProvisioner(t, "", results, "--wait-for-bootstrap=true", func(err error, probeCalls *int) {
+		require.NoError(t, err)
+		assert.Equal(t, 1, *probeCalls, "gateway probe should run once when it succeeds immediately")
+	})
+}
+
+// runStartWithFakeProvisioner runs `multigres cluster start` with a fake
+// provisioner registered for this test only, the given Bootstrap results,
+// and the given extra flag. The gateway probe is replaced with a stub
+// that counts calls and returns success. The optional extraYAML is
+// appended to the temp multigres.yaml so tests can exercise password /
+// user / database extraction.
+func runStartWithFakeProvisioner(
+	t *testing.T,
+	extraYAML string,
+	bootstrapResults []*provisioner.ProvisionResult,
+	extraFlag string,
+	check func(err error, probeCalls *int),
+) {
+	t.Helper()
+
+	var probeCalls int
+	restoreProbe := overrideRunGatewayProbe(func(_ context.Context, _ string, _ int, _ bootstrapCredentials) error {
+		probeCalls++
+		return nil
+	})
+	defer restoreProbe()
+
+	const provisionerName = "fake-wait-for-bootstrap"
+	provisioner.RegisterProvisioner(provisionerName, func() (provisioner.Provisioner, error) {
+		return &fakeProvisioner{bootstrap: bootstrapResults}, nil
+	})
+
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, "multigres.yaml")
+	yaml := "provisioner: " + provisionerName + "\n" + extraYAML
+	require.NoError(t, os.WriteFile(configFile, []byte(yaml), 0o600))
+
+	rootCmd := &cobra.Command{Use: "test"}
+	rootCmd.PersistentFlags().StringSlice("config-path", []string{}, "config paths")
+	clusterCmd := &cobra.Command{Use: "cluster"}
+	rootCmd.AddCommand(clusterCmd)
+	AddStartCommand(clusterCmd)
+
+	args := []string{"cluster", "start", "--config-path", configDir}
+	if extraFlag != "" {
+		args = append(args, extraFlag)
+	}
+	rootCmd.SetArgs(args)
+
+	check(rootCmd.Execute(), &probeCalls)
+}
+
+// overrideRunGatewayProbe swaps the package-level runGatewayProbeFn used
+// by start() for the duration of a test and returns a restorer. Tests
+// need this hook because the production probe is constructed as a
+// closure in start() that captures bootstrapCredentials.
+func overrideRunGatewayProbe(fn func(context.Context, string, int, bootstrapCredentials) error) func() {
+	prev := runGatewayProbeFn
+	runGatewayProbeFn = fn
+	return func() { runGatewayProbeFn = prev }
+}
+
+// fakeProvisioner is a stub Provisioner used only by start_test.go to drive
+// the start command without touching real services.
+type fakeProvisioner struct {
+	bootstrap []*provisioner.ProvisionResult
+}
+
+func (f *fakeProvisioner) Name() string                          { return "fake-wait-for-bootstrap" }
+func (f *fakeProvisioner) LoadConfig(_ []string) error           { return nil }
+func (f *fakeProvisioner) ValidateConfig(_ map[string]any) error { return nil }
+func (f *fakeProvisioner) DefaultConfig(_ []string, _ map[string]string) map[string]any {
+	return nil
+}
+
+func (f *fakeProvisioner) Bootstrap(_ context.Context) ([]*provisioner.ProvisionResult, error) {
+	return f.bootstrap, nil
+}
+
+func (f *fakeProvisioner) Teardown(_ context.Context, _ bool) error { return nil }
+
+func (f *fakeProvisioner) ProvisionDatabase(_ context.Context, _ string, _ string) ([]*provisioner.ProvisionResult, error) {
+	return nil, nil
+}
+
+func (f *fakeProvisioner) DeprovisionDatabase(_ context.Context, _ string, _ string) error {
+	return nil
+}

--- a/go/common/constants/localprovisioner.go
+++ b/go/common/constants/localprovisioner.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "time"
+
+// Constants used by the local provisioner during `multigres cluster start`.
+const (
+	// LocalBootstrapWaitTimeout bounds how long `multigres cluster start`
+	// waits for every multigateway to serve queries end-to-end before
+	// giving up.
+	LocalBootstrapWaitTimeout = 2 * time.Minute
+
+	// LocalGatewayBootstrapPollInterval is the delay between consecutive
+	// readiness probes against a single gateway. The retry package
+	// applies full jitter, so actual delays range from 0 to this value.
+	LocalGatewayBootstrapPollInterval = 1 * time.Second
+
+	// LocalGatewayBootstrapProbeTimeout bounds a single readiness probe
+	// (a `SELECT 1` through multigateway) so a hung connection cannot
+	// stall the wait loop.
+	LocalGatewayBootstrapProbeTimeout = 5 * time.Second
+)

--- a/go/test/endtoend/localprovisioner/cluster_test.go
+++ b/go/test/endtoend/localprovisioner/cluster_test.go
@@ -768,10 +768,17 @@ func TestInitCommandConfigFileAlreadyExists(t *testing.T) {
 	assert.Contains(t, errorOutput, existingConfig)
 }
 
-// executeStartCommand runs the actual multigres binary with "cluster start" command
+// executeStartCommand runs the actual multigres binary with "cluster start" command.
+//
+// TODO: drop the `--wait-for-bootstrap=false` override and let the production default
+// (`true`) apply once the multiorch StaleLeader flap during bootstrap is resolved.
+// Today the cluster doesn't stably reach "ready to serve queries" within the probe's
+// 2-minute budget, so leaving the wait on causes `cluster start` to time out here.
+// The tests already perform their own downstream readiness checks (WaitForBootstrap,
+// waitForMultigatewayReady, etc.), so the in-process probe is redundant for them.
 func executeStartCommand(t *testing.T, args []string, tempDir string) (string, error) {
 	// Prepare the full command: "multigres cluster start <args>"
-	cmdArgs := append([]string{"cluster", "start"}, args...)
+	cmdArgs := append([]string{"cluster", "start", "--wait-for-bootstrap=false"}, args...)
 	cmd := exec.Command("multigres", cmdArgs...)
 
 	// Set MULTIGRES_TESTDATA_DIR for directory-deletion triggered cleanup


### PR DESCRIPTION
## Summary

`multigres cluster start` previously returned as soon as the local provisioner finished spawning processes, even though multigateway was often still reconciling with multipooler and postgres — so users hit "password authentication failed" right after seeing "Cluster started successfully." This PR adds a `--wait-for-bootstrap` flag that makes the command block until every provisioned multigateway can execute `SELECT 1` end-to-end, or until a 2-minute timeout fires with a user-readable error naming the gateways that never became ready.

The flag defaults to `true` for end users. The integration tests in `go/test/endtoend/localprovisioner/cluster_test.go` override it to `false` (see the note below) because an unrelated multiorch StaleLeader flap during bootstrap prevents the cluster from stably reaching "ready to serve queries" within the probe's budget today.

## Description

Implementation notes:

- The probe runs `SELECT 1` over PG protocol against every multigateway using `lib/pq`. Each gateway is polled in its own goroutine and retried via `go/tools/retry` until success or the shared 2-minute deadline expires.
- Connection credentials are pulled from the loaded config (`provisioner-config.cells.<cell>.pgctld.pg-user` / `pg-password`, `multipooler.database`) so a rotated postgres password still works. Defaults to `postgres`/`postgres`/`postgres` when missing.
- A successful `SELECT 1` exercises the full path psql will use moments later — gateway PoolerDiscovery → multipooler `GetAuthCredentials` → `pg_authid` → SCRAM compare — making it the strongest practical guarantee that user queries will succeed.
- Timings live in `go/common/constants/localprovisioner.go` (`LocalBootstrapWaitTimeout`, `LocalGatewayBootstrapPollInterval`, `LocalGatewayBootstrapProbeTimeout`).
- `runGatewayProbeFn` is a package-level var so unit tests can swap it out without standing up a real cluster; a stub provisioner registered via `provisioner.RegisterProvisioner` lets us drive `start()` end-to-end and verify the flag's behavior.

### Why tests default the flag to `false`

`executeStartCommand` in `go/test/endtoend/localprovisioner/cluster_test.go` appends `--wait-for-bootstrap=false` to every invocation. Reason: with the flag on, `cluster start` waits for the new readiness probe to succeed, but in CI the cluster doesn't actually become stably ready — multiorch repeatedly performs `StaleLeader` recovery actions (~500 per multiorch per minute, sustained for minutes after start) and the gateway keeps surfacing `planned failover in progress` errors. So the probe times out at 2 minutes, `cluster start` exits with an error, and the test fails. The integration tests already perform their own downstream readiness checks (`WaitForBootstrap`, `waitForMultigatewayReady`, `WaitForPoolerTypeAssigned`), so the in-process probe is redundant for them anyway. A `TODO` next to the override calls for dropping it once the multiorch StaleLeader behavior is fixed.