### PR TITLE
fix(multigateway): route by LeaderObservation, not topology PoolerType

### DIFF
--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -759,6 +759,7 @@ type Target struct {
 	Shard string `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
 	// pooler_type is the type of pooler to route to (PRIMARY, REPLICA)
 	// If not specified (UNKNOWN), defaults to PRIMARY
+	// TODO: Change from PoolerType something else, like a TargetType or ServingType enum.
 	PoolerType    clustermetadata.PoolerType `protobuf:"varint,3,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go/services/multigateway/discovery.go
+++ b/go/services/multigateway/discovery.go
@@ -244,13 +244,6 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 
 	poolerID := topoclient.MultiPoolerIDString(pooler.Id)
 
-	// If this is a PRIMARY, evict any other PRIMARY for the same TableGroup/Shard.
-	// This handles the failover case where a new PRIMARY comes up but the old
-	// crashed PRIMARY's record is still present.
-	if pooler.Type == clustermetadatapb.PoolerType_PRIMARY {
-		pd.evictConflictingPrimary(poolerID, pooler.GetShardKey().GetTableGroup(), pooler.GetShardKey().GetShard())
-	}
-
 	// Check if this is a new pooler
 	_, existed := pd.poolers[poolerID]
 	pd.poolers[poolerID] = pooler
@@ -350,34 +343,6 @@ func (pd *CellPoolerDiscovery) extractPoolerIDFromPath(path string) string {
 		return strings.Join(parts[1:len(parts)-1], "/")
 	}
 	return ""
-}
-
-// evictConflictingPrimary removes any existing PRIMARY pooler for the same
-// TableGroup/Shard that has a different pooler ID. This handles the failover
-// case where a new PRIMARY comes up but the old crashed PRIMARY's record is
-// still in the discovery cache.
-// Caller must hold pd.mu.
-func (pd *CellPoolerDiscovery) evictConflictingPrimary(newPoolerID, tableGroup, shard string) {
-	for poolerID, pooler := range pd.poolers {
-		// Skip if it's the same pooler (update case)
-		if poolerID == newPoolerID {
-			continue
-		}
-		// Check if this is a PRIMARY for the same TableGroup/Shard
-		if pooler.Type == clustermetadatapb.PoolerType_PRIMARY &&
-			pooler.GetShardKey().GetTableGroup() == tableGroup &&
-			pooler.GetShardKey().GetShard() == shard {
-			delete(pd.poolers, poolerID)
-			pd.logger.Info("Evicted stale PRIMARY pooler",
-				"evicted_id", poolerID,
-				"new_primary_id", newPoolerID,
-				"tableGroup", tableGroup,
-				"shard", shard)
-			if pd.onPoolerRemoved != nil {
-				pd.onPoolerRemoved(pooler.MultiPooler)
-			}
-		}
-	}
 }
 
 // Cell returns the cell this discovery is watching.

--- a/go/services/multigateway/discovery_test.go
+++ b/go/services/multigateway/discovery_test.go
@@ -638,12 +638,13 @@ func TestPoolerDiscovery_PoolerDeletion(t *testing.T) {
 	assert.Equal(t, "pooler2", poolers[0].Id.Name)
 }
 
-// TestPoolerDiscovery_NewPrimaryEvictsOldPrimary tests that when a new PRIMARY
-// pooler is discovered for the same TableGroup/Shard, any existing PRIMARY for
-// that TableGroup/Shard is evicted from the discovery cache.
-// This handles the failover case where a new PRIMARY comes up but the old
-// crashed PRIMARY's record hasn't been cleaned up yet.
-func TestPoolerDiscovery_NewPrimaryEvictsOldPrimary(t *testing.T) {
+// TestPoolerDiscovery_TwoPrimariesCoexistDuringFailover is the regression test
+// for the eviction bug in the failover archive. When a demoted-then-restarted
+// pooler re-asserts Type=PRIMARY in topology before multiorch corrects it,
+// discovery must NOT delete the actual leader from its cache. Both topology
+// entries coexist; the LoadBalancer arbitrates leader identity via
+// LeaderObservation term, not topology.
+func TestPoolerDiscovery_TwoPrimariesCoexistDuringFailover(t *testing.T) {
 	ctx := t.Context()
 	store, _ := memorytopo.NewServerAndFactory(ctx, "test-cell")
 	defer store.Close()
@@ -651,92 +652,31 @@ func TestPoolerDiscovery_NewPrimaryEvictsOldPrimary(t *testing.T) {
 
 	pd := NewCellPoolerDiscovery(ctx, store, "test-cell", logger)
 
-	// Create old primary (simulating a crashed primary that hasn't been cleaned up)
-	oldPrimary := createTestPooler("old-primary", "test-cell", "old-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, store.CreateMultiPooler(ctx, oldPrimary))
+	// Create the stale "ex-primary" entry that hasn't been cleaned up yet.
+	stalePrimary := createTestPooler("stale-primary", "test-cell", "stale-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
+	require.NoError(t, store.CreateMultiPooler(ctx, stalePrimary))
 
 	pd.Start()
 	defer pd.Stop()
 
-	// Wait for initial discovery
 	waitForPoolerCount(t, pd, 1)
 
-	// Verify old primary is discovered
-	poolers := pd.GetPoolersForAdmin()
-	require.Len(t, poolers, 1)
-	assert.Equal(t, "old-primary", poolers[0].Id.Name)
-
-	// Now add a new primary for the same tablegroup/shard (simulating failover)
+	// New PRIMARY (real leader after failover) arrives in topology.
 	newPrimary := createTestPooler("new-primary", "test-cell", "new-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
 	require.NoError(t, store.CreateMultiPooler(ctx, newPrimary))
 
-	// Wait for the new primary to be discovered and old one evicted
-	// The count should still be 1 because old primary gets evicted
-	waitForCondition(t, func() bool {
-		poolers := pd.GetPoolersForAdmin()
-		if len(poolers) != 1 {
-			return false
-		}
-		return poolers[0].Id.Name == "new-primary"
-	}, "Expected new-primary to replace old-primary")
-
-	// Verify only new primary is present
-	poolers = pd.GetPoolersForAdmin()
-	require.Len(t, poolers, 1)
-	assert.Equal(t, "new-primary", poolers[0].Id.Name)
-	assert.Equal(t, "new-host", poolers[0].Hostname)
-}
-
-// TestPoolerDiscovery_MultipleShardsPrimaryEviction tests that PRIMARY eviction
-// only affects poolers with the same TableGroup/Shard combination.
-func TestPoolerDiscovery_MultipleShardsPrimaryEviction(t *testing.T) {
-	ctx := t.Context()
-	store, _ := memorytopo.NewServerAndFactory(ctx, "test-cell")
-	defer store.Close()
-	logger := slog.Default()
-
-	pd := NewCellPoolerDiscovery(ctx, store, "test-cell", logger)
-
-	// Create primaries for different shards
-	primary1 := createTestPooler("primary-shard1", "test-cell", "host1", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
-	primary2 := createTestPooler("primary-shard2", "test-cell", "host2", "db1", "shard2", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, store.CreateMultiPooler(ctx, primary1))
-	require.NoError(t, store.CreateMultiPooler(ctx, primary2))
-
-	pd.Start()
-	defer pd.Stop()
-
-	// Wait for initial discovery
 	waitForPoolerCount(t, pd, 2)
 
-	// Add new primary only for shard1
-	newPrimary := createTestPooler("new-primary-shard1", "test-cell", "new-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, store.CreateMultiPooler(ctx, newPrimary))
-
-	// Wait for the new primary to be discovered and old shard1 primary evicted
-	waitForCondition(t, func() bool {
-		poolers := pd.GetPoolersForAdmin()
-		if len(poolers) != 2 {
-			return false
-		}
-		names := make(map[string]bool)
-		for _, p := range poolers {
-			names[p.Id.Name] = true
-		}
-		// Should have new-primary-shard1 and primary-shard2, NOT primary-shard1
-		return names["new-primary-shard1"] && names["primary-shard2"] && !names["primary-shard1"]
-	}, "Expected new-primary-shard1 and primary-shard2 to be present")
-
-	// Verify the correct primaries are present
+	// Both entries must be present. Discovery does not eject either one based
+	// on Type; that's the LoadBalancer's job via LeaderObservation.
 	poolers := pd.GetPoolersForAdmin()
 	require.Len(t, poolers, 2)
-	names := make(map[string]bool)
+	names := make(map[string]bool, len(poolers))
 	for _, p := range poolers {
 		names[p.Id.Name] = true
 	}
-	assert.True(t, names["new-primary-shard1"], "Should have new-primary-shard1")
-	assert.True(t, names["primary-shard2"], "Should have primary-shard2")
-	assert.False(t, names["primary-shard1"], "Should NOT have old primary-shard1")
+	assert.True(t, names["new-primary"], "new-primary must be present")
+	assert.True(t, names["stale-primary"], "stale-primary must NOT be evicted by discovery")
 }
 
 // TestPoolerDiscovery_ReplicaDoesNotEvictPrimary tests that adding a REPLICA
@@ -775,60 +715,6 @@ func TestPoolerDiscovery_ReplicaDoesNotEvictPrimary(t *testing.T) {
 	}
 	assert.True(t, names["primary"], "Primary should still be present")
 	assert.True(t, names["replica"], "Replica should be present")
-}
-
-// TestPoolerDiscovery_EvictionCallsOnPoolerRemoved verifies that onPoolerRemoved
-// is called when a conflicting primary is evicted during failover.
-func TestPoolerDiscovery_EvictionCallsOnPoolerRemoved(t *testing.T) {
-	ctx := t.Context()
-	store, _ := memorytopo.NewServerAndFactory(ctx, "test-cell")
-	defer store.Close()
-	logger := slog.Default()
-
-	pd := NewCellPoolerDiscovery(ctx, store, "test-cell", logger)
-
-	// Track callback invocations
-	listener := &mockPoolerListener{}
-	pd.onPoolerChanged = listener.OnPoolerChanged
-	pd.onPoolerRemoved = listener.OnPoolerRemoved
-
-	// Create old primary
-	oldPrimary := createTestPooler("old-primary", "test-cell", "old-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, store.CreateMultiPooler(ctx, oldPrimary))
-
-	pd.Start()
-	defer pd.Stop()
-
-	// Wait for initial discovery
-	waitForPoolerCount(t, pd, 1)
-
-	// Clear the tracked callbacks (initial discovery triggers OnPoolerChanged)
-	listener.mu.Lock()
-	listener.changedPoolers = nil
-	listener.removedPoolers = nil
-	listener.mu.Unlock()
-
-	// Add new primary for the same tablegroup/shard (triggers eviction)
-	newPrimary := createTestPooler("new-primary", "test-cell", "new-host", "db1", "shard1", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, store.CreateMultiPooler(ctx, newPrimary))
-
-	// Wait for the new primary to be discovered and old one evicted
-	waitForCondition(t, func() bool {
-		poolers := pd.GetPoolersForAdmin()
-		if len(poolers) != 1 {
-			return false
-		}
-		return poolers[0].Id.Name == "new-primary"
-	}, "Expected new-primary to replace old-primary")
-
-	// Verify OnPoolerRemoved was called for the evicted old primary
-	removedPoolers := listener.getRemovedPoolers()
-	require.Len(t, removedPoolers, 1, "OnPoolerRemoved should be called for evicted primary")
-	assert.Equal(t, topoclient.MultiPoolerIDString(oldPrimary.Id), removedPoolers[0])
-
-	// Verify OnPoolerChanged was called for the new primary
-	changedPoolers := listener.getChangedPoolers()
-	require.Contains(t, changedPoolers, topoclient.MultiPoolerIDString(newPrimary.Id))
 }
 
 // TestGlobalPoolerDiscovery_WatchDiscoversNewCells tests that the watch-based

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -125,10 +125,19 @@ func (lb *LoadBalancer) SetReplicationLagThresholds(lowLag, highTolerance time.D
 // AddPooler creates a new PoolerConnection for the given pooler.
 // If a connection already exists for this pooler, it updates the pooler info.
 //
-// AddPooler does not touch leader state — that comes exclusively from
-// LeaderObservation. When a newly-added connection happens to be the leader
-// already-known via prior observations, the buffer is drained promptly via
-// notifyIfLeaderServingLocked.
+// AddPooler does not establish leader identity from real consensus state —
+// that comes exclusively from LeaderObservation on health streams. The one
+// concession is a cold-start fallback: if no LeaderObservation has been
+// received for the shard yet and topology says this pooler is PRIMARY, we
+// seed `leaders[shard]` with a synthetic LeaderObservation at term 0. Any
+// real observation (term >= 1) beats this seed unconditionally, so a stale
+// Type=PRIMARY assertion from a demoted-then-restarted pooler cannot
+// override consensus. The seed only matters during the gateway's startup
+// window before health streams have produced any observations.
+//
+// TODO: once multipooler publishes its current LeaderObservation into its
+// etcd record (the proto would need a `last_observed_leader` field), drop
+// the synthetic seed and use that real observation instead.
 func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	poolerID := poolerIDString(pooler.Id)
 
@@ -137,9 +146,14 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 	key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
 
-	// Existing pooler — just refresh topology metadata. No leader-state effects.
+	// Existing pooler — refresh topology metadata. The cold-start hint below
+	// can also fire here: at cluster bootstrap, poolers are first discovered
+	// as REPLICA, then their Type transitions to PRIMARY after multiorch
+	// promotes one. That transition is the first topology signal of who
+	// leads, before any health stream reports a LeaderObservation.
 	if conn, exists := lb.connections[poolerID]; exists {
 		conn.UpdatePoolerInfo(pooler)
+		lb.maybeSeedColdStartLeaderLocked(key, pooler)
 		lb.notifyIfLeaderServingLocked(key, conn)
 		return nil
 	}
@@ -150,6 +164,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	}
 
 	lb.connections[poolerID] = conn
+	lb.maybeSeedColdStartLeaderLocked(key, pooler)
 
 	// If a prior LeaderObservation already named this pooler the leader, the
 	// first health update may be slow — trigger buffer drain now so traffic
@@ -162,6 +177,34 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 		"cell", pooler.Id.GetCell())
 
 	return nil
+}
+
+// maybeSeedColdStartLeaderLocked sets `leaders[key]` to a term-0 synthetic
+// LeaderObservation when topology says this pooler is PRIMARY and no real
+// observation has been received yet for the shard. Any real observation
+// (term >= 1) overrides this seed via the standard term-reconciliation in
+// onPoolerHealthUpdate, so a stale Type=PRIMARY assertion from a
+// demoted-then-restarted pooler cannot override consensus. Caller must hold
+// lb.mu.
+//
+// TODO: once multipooler publishes its current LeaderObservation into its
+// etcd record (the proto would need a `last_observed_leader` field), drop
+// this synthetic seed and use the real observation instead.
+func (lb *LoadBalancer) maybeSeedColdStartLeaderLocked(key shardKey, pooler *clustermetadatapb.MultiPooler) {
+	if pooler.Type != clustermetadatapb.PoolerType_PRIMARY {
+		return
+	}
+	if lb.leaders[key] != nil {
+		return
+	}
+	lb.leaders[key] = &multipoolerservice.LeaderObservation{
+		LeaderId:   pooler.Id,
+		LeaderTerm: 0,
+	}
+	lb.logger.Debug("cold-start leader hint from topology",
+		"pooler_id", poolerIDString(pooler.Id),
+		"tablegroup", key.tableGroup,
+		"shard", key.shard)
 }
 
 // RemovePooler closes and removes the PoolerConnection for the given pooler ID.
@@ -224,23 +267,28 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 		return conn, nil
 	}
 
-	// REPLICA: collect every connection in the shard except the known leader.
-	leaderID := ""
-	if leaderObs != nil {
-		leaderID = poolerIDString(leaderObs.LeaderId)
+	// REPLICA: collect every connection in the shard except the consensus-
+	// confirmed leader. A confirmed leader has term >= 1 from a real
+	// LeaderObservation; the cold-start topology seed (term 0) is ignored
+	// here so a pooler that has since transitioned to Type=REPLICA in
+	// topology can still be selected as a replica candidate.
+	confirmedLeaderID := ""
+	if leaderObs != nil && leaderObs.LeaderTerm > 0 {
+		confirmedLeaderID = poolerIDString(leaderObs.LeaderId)
 	}
 	var candidates []*PoolerConnection
 	for id, conn := range lb.connections {
 		if !matchesShardTarget(conn, target) {
 			continue
 		}
-		if leaderObs != nil {
-			if id == leaderID {
+		if confirmedLeaderID != "" {
+			if id == confirmedLeaderID {
 				continue
 			}
 		} else if conn.Type() != clustermetadatapb.PoolerType_REPLICA {
-			// Cold start: no LeaderObservation yet. Fall back to topology hint
-			// so we don't accidentally serve reads from a future leader.
+			// No confirmed leader yet. Fall back to topology Type so we don't
+			// accidentally serve reads from a pooler that may turn out to be
+			// the leader.
 			continue
 		}
 		candidates = append(candidates, conn)
@@ -449,10 +497,19 @@ func (lb *LoadBalancer) onPoolerHealthUpdate(conn *PoolerConnection) {
 	}
 }
 
-// notifyIfLeaderServingLocked calls onPrimaryServing if the given connection is
-// the known leader of the shard and is serving. StopBuffering is idempotent,
-// so calling this on every health update is safe and ensures buffering stops
-// promptly once the leader is ready. Caller must hold lb.mu.
+// notifyIfLeaderServingLocked calls onPrimaryServing if the given connection
+// is the known leader of the shard and is both SERVING and self-reporting
+// PoolerType_PRIMARY on its health stream. StopBuffering is idempotent, so
+// calling this on every health update is safe and ensures buffering stops
+// promptly once the leader is ready.
+//
+// The PoolerType_PRIMARY check is critical: a LeaderObservation can arrive
+// before the named pooler has finished transitioning its query server to
+// PRIMARY/SERVING (e.g. during Promote, UpdateLeaderObservation fires before
+// changeTypeLocked). Draining buffered requests too early would send them
+// to a pooler that still rejects PRIMARY traffic.
+//
+// Caller must hold lb.mu.
 func (lb *LoadBalancer) notifyIfLeaderServingLocked(key shardKey, conn *PoolerConnection) {
 	if lb.onPrimaryServing == nil {
 		return
@@ -461,7 +518,11 @@ func (lb *LoadBalancer) notifyIfLeaderServingLocked(key shardKey, conn *PoolerCo
 	if leader == nil || poolerIDString(leader.LeaderId) != conn.ID() {
 		return
 	}
-	if !conn.Health().IsServing() {
+	health := conn.Health()
+	if health == nil || !health.IsServing() {
+		return
+	}
+	if health.Target.GetPoolerType() != clustermetadatapb.PoolerType_PRIMARY {
 		return
 	}
 	lb.onPrimaryServing(key.tableGroup, key.shard)

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -29,28 +29,25 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
+	"github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 )
 
-// shardKey identifies a shard for primary caching.
+// shardKey identifies a shard for leader tracking.
 type shardKey struct {
 	tableGroup string
 	shard      string
-}
-
-// cachedPrimary holds the cached primary connection for a shard.
-type cachedPrimary struct {
-	conn *PoolerConnection
-	term int64
 }
 
 // LoadBalancer manages PoolerConnections and selects connections for queries.
 // It creates connections based on discovery events and destroys them when poolers
 // are removed from discovery.
 //
-// For PRIMARY targets, the LoadBalancer caches the primary connection per-shard.
-// The cache is updated via health stream callbacks, so the hot path (GetConnection)
-// is a simple map lookup rather than iterating all poolers.
+// Leader identity is tracked per-shard via the leaders map, populated only from
+// LeaderObservation messages on health streams. The pooler.Type field from etcd
+// topology is a hint about intended role — never the source of truth for which
+// pooler leads a shard. A leaders entry survives connection lifecycle events:
+// removing a pooler does not erase consensus's choice of leader.
 type LoadBalancer struct {
 	// localCell is the cell where this gateway is running
 	localCell string
@@ -61,15 +58,17 @@ type LoadBalancer struct {
 	// ctx is the service-lifetime context for child goroutines (health streams)
 	ctx context.Context
 
-	// mu protects connections and cachedPrimaries
+	// mu protects connections and leaders
 	mu sync.Mutex
 
 	// connections maps pooler ID to PoolerConnection
 	connections map[string]*PoolerConnection
 
-	// cachedPrimaries maps shard key to the cached primary connection.
-	// Updated by onPoolerHealthUpdate when health streams report LeaderObservation.
-	cachedPrimaries map[shardKey]*cachedPrimary
+	// leaders maps shard key to the highest-term LeaderObservation seen for that
+	// shard. Populated only from health-stream observations; never from topology.
+	// The leader_id field of the observation may name a pooler we are not
+	// currently connected to — GetConnection handles that case at read time.
+	leaders map[shardKey]*multipoolerservice.LeaderObservation
 
 	// onPrimaryServing is called when a new primary is detected via health stream.
 	// Used to stop failover buffering for the shard. May be nil.
@@ -94,12 +93,12 @@ type LoadBalancer struct {
 // The grpcDialOpt configures transport credentials for gRPC connections to poolers.
 func NewLoadBalancer(ctx context.Context, localCell string, logger *slog.Logger, grpcDialOpt grpc.DialOption) *LoadBalancer {
 	return &LoadBalancer{
-		localCell:       localCell,
-		logger:          logger,
-		ctx:             ctx,
-		connections:     make(map[string]*PoolerConnection),
-		cachedPrimaries: make(map[shardKey]*cachedPrimary),
-		grpcDialOpt:     grpcDialOpt,
+		localCell:   localCell,
+		logger:      logger,
+		ctx:         ctx,
+		connections: make(map[string]*PoolerConnection),
+		leaders:     make(map[shardKey]*multipoolerservice.LeaderObservation),
+		grpcDialOpt: grpcDialOpt,
 	}
 }
 
@@ -124,40 +123,24 @@ func (lb *LoadBalancer) SetReplicationLagThresholds(lowLag, highTolerance time.D
 }
 
 // AddPooler creates a new PoolerConnection for the given pooler.
-// If a connection already exists for this pooler, it updates the pooler info
-// (e.g., when type changes from UNKNOWN to PRIMARY).
+// If a connection already exists for this pooler, it updates the pooler info.
+//
+// AddPooler does not touch leader state — that comes exclusively from
+// LeaderObservation. When a newly-added connection happens to be the leader
+// already-known via prior observations, the buffer is drained promptly via
+// notifyIfLeaderServingLocked.
 func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	poolerID := poolerIDString(pooler.Id)
 
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	// Check if already exists - update info instead of skipping
+	key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
+
+	// Existing pooler — just refresh topology metadata. No leader-state effects.
 	if conn, exists := lb.connections[poolerID]; exists {
-		oldType := conn.Type()
 		conn.UpdatePoolerInfo(pooler)
-		newType := conn.Type()
-
-		// Invalidate seed if type changed away from PRIMARY
-		if oldType == clustermetadatapb.PoolerType_PRIMARY && newType != clustermetadatapb.PoolerType_PRIMARY {
-			key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
-			if cached, ok := lb.cachedPrimaries[key]; ok && cached.conn == conn && cached.term == 0 {
-				delete(lb.cachedPrimaries, key)
-				lb.logger.Debug("invalidated seeded primary cache on type change",
-					"pooler_id", poolerID, "old_type", oldType, "new_type", newType)
-			}
-		}
-
-		// Seed if type changed to PRIMARY
-		if oldType != clustermetadatapb.PoolerType_PRIMARY && newType == clustermetadatapb.PoolerType_PRIMARY {
-			key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
-			if existing, ok := lb.cachedPrimaries[key]; !ok || existing.term == 0 {
-				lb.cachedPrimaries[key] = &cachedPrimary{conn: conn, term: 0}
-				lb.logger.Debug("seeded primary cache on type change",
-					"pooler_id", poolerID, "old_type", oldType, "new_type", newType)
-			}
-		}
-
+		lb.notifyIfLeaderServingLocked(key, conn)
 		return nil
 	}
 
@@ -168,16 +151,10 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 	lb.connections[poolerID] = conn
 
-	// Seed primary cache from discovery type (term 0 = unconfirmed).
-	// Health stream callbacks will overwrite with real term data.
-	if pooler.Type == clustermetadatapb.PoolerType_PRIMARY {
-		key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
-		if existing, ok := lb.cachedPrimaries[key]; !ok || existing.term == 0 {
-			lb.cachedPrimaries[key] = &cachedPrimary{conn: conn, term: 0}
-			lb.logger.Debug("seeded primary cache from discovery",
-				"pooler_id", poolerID, "tablegroup", key.tableGroup, "shard", key.shard)
-		}
-	}
+	// If a prior LeaderObservation already named this pooler the leader, the
+	// first health update may be slow — trigger buffer drain now so traffic
+	// waiting on the leader's arrival proceeds as soon as it reports SERVING.
+	lb.notifyIfLeaderServingLocked(key, conn)
 
 	lb.logger.Debug("added pooler connection",
 		"pooler_id", poolerID,
@@ -197,12 +174,6 @@ func (lb *LoadBalancer) RemovePooler(poolerID string) {
 		return
 	}
 	delete(lb.connections, poolerID)
-	// Invalidate cached primary if the removed pooler was the cached primary.
-	for key, cached := range lb.cachedPrimaries {
-		if cached.conn == conn {
-			delete(lb.cachedPrimaries, key)
-		}
-	}
 	lb.mu.Unlock()
 
 	// Close outside the lock
@@ -219,8 +190,13 @@ func (lb *LoadBalancer) RemovePooler(poolerID string) {
 // Returns an error immediately if no suitable connection is available.
 //
 // Selection logic:
-// - For PRIMARY: uses cached primary (updated by health stream callbacks)
-// - For REPLICA: prefers local cell serving replicas, with randomization
+//   - For PRIMARY: consults `leaders` (highest-term LeaderObservation) to identify
+//     the leader, then looks up its connection. Two distinct error cases: no
+//     leader observed yet, vs. leader known but not connected.
+//   - For REPLICA: any connected pooler in the shard that is not the known
+//     leader. If no leader is known yet (cold start), falls back to topology
+//     pooler.Type == REPLICA to avoid serving reads from a pooler that may
+//     turn out to be the leader.
 func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, error) {
 	if target == nil {
 		return nil, errors.New("target cannot be nil")
@@ -229,28 +205,45 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	targetType := target.PoolerType
+	key := shardKey{tableGroup: target.TableGroup, shard: target.Shard}
+	leaderObs := lb.leaders[key]
 
-	if targetType == clustermetadatapb.PoolerType_PRIMARY {
-		// Use cached primary (populated by health stream callbacks).
-		// The health stream's LeaderObservation is the authoritative source
-		// for leader identity — no type-based fallback.
-		key := shardKey{tableGroup: target.TableGroup, shard: target.Shard}
-		if cached, ok := lb.cachedPrimaries[key]; ok {
-			return cached.conn, nil
+	if target.PoolerType == clustermetadatapb.PoolerType_PRIMARY {
+		if leaderObs == nil {
+			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+				"no leader observed yet for tablegroup=%s, shard=%s",
+				target.TableGroup, target.Shard)
 		}
-
-		return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
-			"no primary cached for target: tablegroup=%s, shard=%s (waiting for health stream)",
-			target.TableGroup, target.Shard)
+		leaderID := poolerIDString(leaderObs.LeaderId)
+		conn, ok := lb.connections[leaderID]
+		if !ok {
+			return nil, mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE,
+				"leader %s known but not connected for tablegroup=%s, shard=%s",
+				leaderID, target.TableGroup, target.Shard)
+		}
+		return conn, nil
 	}
 
-	// For REPLICA: collect only replica-type poolers
+	// REPLICA: collect every connection in the shard except the known leader.
+	leaderID := ""
+	if leaderObs != nil {
+		leaderID = poolerIDString(leaderObs.LeaderId)
+	}
 	var candidates []*PoolerConnection
-	for _, conn := range lb.connections {
-		if matchesTarget(conn, target) {
-			candidates = append(candidates, conn)
+	for id, conn := range lb.connections {
+		if !matchesShardTarget(conn, target) {
+			continue
 		}
+		if leaderObs != nil {
+			if id == leaderID {
+				continue
+			}
+		} else if conn.Type() != clustermetadatapb.PoolerType_REPLICA {
+			// Cold start: no LeaderObservation yet. Fall back to topology hint
+			// so we don't accidentally serve reads from a future leader.
+			continue
+		}
+		candidates = append(candidates, conn)
 	}
 
 	if len(candidates) == 0 {
@@ -395,8 +388,11 @@ func (lb *LoadBalancer) selectReplicaConnection(candidates []*PoolerConnection) 
 }
 
 // onPoolerHealthUpdate is the callback invoked by PoolerConnection when health
-// state changes. It updates the cached primary for the connection's shard
-// based on LeaderObservation term reconciliation.
+// state changes. It updates `leaders` based on LeaderObservation term
+// reconciliation — recording the named leader unconditionally, regardless of
+// whether we currently have a connection to that leader. The connection
+// lookup happens at GetConnection time, not at observation time, so identity
+// survives any connection lifecycle event.
 //
 // This is safe to call concurrently: both processHealthResponse and setHealthError
 // release healthMu before invoking this callback.
@@ -410,41 +406,42 @@ func (lb *LoadBalancer) onPoolerHealthUpdate(conn *PoolerConnection) {
 		tableGroup: health.Target.GetTableGroup(),
 		shard:      health.Target.GetShard(),
 	}
-	term := health.LeaderObservation.LeaderTerm
-	primaryID := poolerIDString(health.LeaderObservation.LeaderId)
+	obs := health.LeaderObservation
 
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	cached := lb.cachedPrimaries[key]
+	existing := lb.leaders[key]
 
 	switch {
-	case cached == nil || term > cached.term:
-		// New primary or higher term — update the cached primary.
-		primaryConn, exists := lb.connections[primaryID]
-		if !exists {
-			return
-		}
-		lb.cachedPrimaries[key] = &cachedPrimary{conn: primaryConn, term: term}
-		lb.logger.Debug("cached primary updated",
+	case existing == nil || obs.LeaderTerm > existing.LeaderTerm:
+		// New leader or higher term — record identity unconditionally. The
+		// named pooler may not be in `connections` yet; that's fine.
+		lb.leaders[key] = obs
+		lb.logger.Debug("leader observation recorded",
 			"tablegroup", key.tableGroup,
 			"shard", key.shard,
-			"primary_id", primaryID,
-			"term", term)
+			"leader_id", poolerIDString(obs.LeaderId),
+			"term", obs.LeaderTerm)
 
-		// Only stop failover buffering when the primary is confirmed to be
-		// PRIMARY type and SERVING. The LeaderObservation can arrive before
-		// the pooler has transitioned its query server to PRIMARY/SERVING
-		// (e.g., during Promote, UpdateLeaderObservation fires before
-		// changeTypeLocked). Draining buffered requests too early would send
-		// them to a pooler that still rejects PRIMARY traffic.
-		lb.notifyIfPrimaryServingLocked(key, primaryConn)
+		// If the named leader is connected and serving, drain the buffer.
+		// (Only stop failover buffering when the leader is SERVING — the
+		// LeaderObservation can arrive before the pooler has transitioned
+		// its query server to PRIMARY/SERVING, e.g. during Promote where
+		// UpdateLeaderObservation fires before changeTypeLocked. Draining
+		// buffered requests too early would send them to a pooler that
+		// still rejects PRIMARY traffic.)
+		if leaderConn, ok := lb.connections[poolerIDString(obs.LeaderId)]; ok {
+			lb.notifyIfLeaderServingLocked(key, leaderConn)
+		}
 
-	case term == cached.term:
-		// Same term — the primary is already cached but may not have been
+	case obs.LeaderTerm == existing.LeaderTerm:
+		// Same term — the leader is already known but may not have been
 		// SERVING when we first saw the observation. Re-check now so that
-		// StopBuffering fires once the primary transitions to PRIMARY/SERVING.
-		lb.notifyIfPrimaryServingLocked(key, cached.conn)
+		// StopBuffering fires once the leader transitions to SERVING.
+		if leaderConn, ok := lb.connections[poolerIDString(existing.LeaderId)]; ok {
+			lb.notifyIfLeaderServingLocked(key, leaderConn)
+		}
 
 	default:
 		// Stale term — ignore.
@@ -452,17 +449,22 @@ func (lb *LoadBalancer) onPoolerHealthUpdate(conn *PoolerConnection) {
 	}
 }
 
-// notifyIfPrimaryServingLocked calls onPrimaryServing if the primary connection
-// is confirmed to be PRIMARY type and SERVING. StopBuffering is idempotent, so
-// calling this on every health update is safe and ensures buffering stops
-// promptly once the primary is ready. Caller must hold lb.mu.
-func (lb *LoadBalancer) notifyIfPrimaryServingLocked(key shardKey, primaryConn *PoolerConnection) {
-	primaryHealth := primaryConn.Health()
-	if lb.onPrimaryServing != nil && primaryHealth != nil &&
-		primaryHealth.Target.GetPoolerType() == clustermetadatapb.PoolerType_PRIMARY &&
-		primaryHealth.IsServing() {
-		lb.onPrimaryServing(key.tableGroup, key.shard)
+// notifyIfLeaderServingLocked calls onPrimaryServing if the given connection is
+// the known leader of the shard and is serving. StopBuffering is idempotent,
+// so calling this on every health update is safe and ensures buffering stops
+// promptly once the leader is ready. Caller must hold lb.mu.
+func (lb *LoadBalancer) notifyIfLeaderServingLocked(key shardKey, conn *PoolerConnection) {
+	if lb.onPrimaryServing == nil {
+		return
 	}
+	leader := lb.leaders[key]
+	if leader == nil || poolerIDString(leader.LeaderId) != conn.ID() {
+		return
+	}
+	if !conn.Health().IsServing() {
+		return
+	}
+	lb.onPrimaryServing(key.tableGroup, key.shard)
 }
 
 // matchesShardTarget checks if a connection matches the tablegroup and shard,
@@ -483,24 +485,6 @@ func matchesShardTarget(conn *PoolerConnection, target *query.Target) bool {
 	return true
 }
 
-// matchesTarget checks if a connection matches the target specification.
-func matchesTarget(conn *PoolerConnection, target *query.Target) bool {
-	if !matchesShardTarget(conn, target) {
-		return false
-	}
-
-	// Check type match
-	poolerType := conn.Type()
-	switch target.PoolerType {
-	case clustermetadatapb.PoolerType_PRIMARY:
-		return poolerType == clustermetadatapb.PoolerType_PRIMARY
-	case clustermetadatapb.PoolerType_REPLICA:
-		return poolerType == clustermetadatapb.PoolerType_REPLICA
-	default:
-		return false
-	}
-}
-
 // poolerIDString returns the string ID for a pooler.
 // Uses the same format as PoolerConnection.ID() for consistency.
 func poolerIDString(id *clustermetadatapb.ID) string {
@@ -519,7 +503,7 @@ func (lb *LoadBalancer) Close() error {
 	lb.mu.Lock()
 	connections := lb.connections
 	lb.connections = make(map[string]*PoolerConnection)
-	lb.cachedPrimaries = make(map[shardKey]*cachedPrimary)
+	lb.leaders = make(map[shardKey]*multipoolerservice.LeaderObservation)
 	lb.mu.Unlock()
 
 	lb.logger.Info("closing all pooler connections", "count", len(connections))

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -267,31 +267,20 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 		return conn, nil
 	}
 
-	// REPLICA: collect every connection in the shard except the consensus-
-	// confirmed leader. A confirmed leader has term >= 1 from a real
-	// LeaderObservation; the cold-start topology seed (term 0) is ignored
-	// here so a pooler that has since transitioned to Type=REPLICA in
-	// topology can still be selected as a replica candidate.
+	// REPLICA: collect every connection eligible to serve reads in the shard.
+	// A consensus-confirmed leader (term >= 1) is excluded by ID; the
+	// cold-start topology seed (term 0) is treated as if no leader is known
+	// yet, so a pooler that has since transitioned to Type=REPLICA can still
+	// be selected.
 	confirmedLeaderID := ""
 	if leaderObs != nil && leaderObs.LeaderTerm > 0 {
 		confirmedLeaderID = poolerIDString(leaderObs.LeaderId)
 	}
 	var candidates []*PoolerConnection
 	for id, conn := range lb.connections {
-		if !matchesShardTarget(conn, target) {
-			continue
+		if matchesReplicaTarget(id, conn, target, confirmedLeaderID) {
+			candidates = append(candidates, conn)
 		}
-		if confirmedLeaderID != "" {
-			if id == confirmedLeaderID {
-				continue
-			}
-		} else if conn.Type() != clustermetadatapb.PoolerType_REPLICA {
-			// No confirmed leader yet. Fall back to topology Type so we don't
-			// accidentally serve reads from a pooler that may turn out to be
-			// the leader.
-			continue
-		}
-		candidates = append(candidates, conn)
 	}
 
 	if len(candidates) == 0 {
@@ -544,6 +533,21 @@ func matchesShardTarget(conn *PoolerConnection, target *query.Target) bool {
 	}
 
 	return true
+}
+
+// matchesReplicaTarget reports whether conn is eligible to serve REPLICA
+// traffic for target. With a consensus-confirmed leader, eligibility is
+// "in the shard and not the leader." With no confirmed leader yet (cold
+// start), fall back to topology Type==REPLICA so we don't accidentally
+// serve reads from a pooler that may turn out to be the leader.
+func matchesReplicaTarget(id string, conn *PoolerConnection, target *query.Target, confirmedLeaderID string) bool {
+	if !matchesShardTarget(conn, target) {
+		return false
+	}
+	if confirmedLeaderID != "" {
+		return id != confirmedLeaderID
+	}
+	return conn.Type() == clustermetadatapb.PoolerType_REPLICA
 }
 
 // poolerIDString returns the string ID for a pooler.

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -62,8 +62,9 @@ func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	// Initially empty
 	assert.Equal(t, 0, lb.ConnectionCount())
 
-	// Add a pooler
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	// Add a pooler (type=REPLICA so it's selectable as a replica without a
+	// LeaderObservation having been recorded yet).
+	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	err := lb.AddPooler(pooler)
 	require.NoError(t, err)
 	assert.Equal(t, 1, lb.ConnectionCount())
@@ -73,7 +74,7 @@ func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, lb.ConnectionCount())
 
-	// Updating pooler type (simulating topology update from UNKNOWN to PRIMARY)
+	// Updating pooler type (simulating topology refresh)
 	poolerUpdated := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	err = lb.AddPooler(poolerUpdated)
 	require.NoError(t, err)
@@ -368,66 +369,71 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		assert.Equal(t, poolerID(primary1), conn.ID(), "Should trust replica's observation with highest term")
 	})
 
-	t.Run("no observations uses discovery seed", func(t *testing.T) {
+	t.Run("no observations returns UNAVAILABLE (not a topology guess)", func(t *testing.T) {
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
+		// Topology says these are PRIMARY/REPLICA, but no LeaderObservation has
+		// arrived yet — gateway must not guess. Clients see UNAVAILABLE and
+		// retry briefly until consensus is observed.
 		primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 		replica := createTestMultiPooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 
 		require.NoError(t, lb.AddPooler(primary))
 		require.NoError(t, lb.AddPooler(replica))
 
-		// No health updates — but discovery seed (term 0) provides a primary
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
 			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 		}
-		conn, err := lb.GetConnection(target)
-		require.NoError(t, err)
-		assert.Equal(t, poolerID(primary), conn.ID(),
-			"Should return discovery-seeded primary before health stream connects")
+		_, err := lb.GetConnection(target)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no leader observed yet")
 	})
 
-	t.Run("unwatched primary keeps discovery seed", func(t *testing.T) {
+	t.Run("leader known but not connected", func(t *testing.T) {
+		// A LeaderObservation names a pooler we have no connection to. The
+		// gateway must remember the identity so that when the connection
+		// arrives, routing immediately works.
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-		primary1 := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
-		require.NoError(t, lb.AddPooler(primary1))
+		observer := createTestMultiPooler("observer", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+		require.NoError(t, lb.AddPooler(observer))
 
 		lb.mu.Lock()
-		connPrimary1 := lb.connections[poolerID(primary1)]
+		connObserver := lb.connections[poolerID(observer)]
 		lb.mu.Unlock()
 
-		// primary1 observes a primary in zone3 that we don't have a connection to
-		unknownPrimaryID := &clustermetadatapb.ID{
+		unknownLeaderID := &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      "zone3",
-			Name:      "unknown-primary",
+			Name:      "unknown-leader",
 		}
-		simulateHealthUpdate(connPrimary1,
+		simulateHealthUpdate(connObserver,
 			clustermetadatapb.PoolerServingStatus_SERVING,
 			&multipoolerservice.LeaderObservation{
-				LeaderId:   unknownPrimaryID,
+				LeaderId:   unknownLeaderID,
 				LeaderTerm: 100,
 			})
 
-		// Cache NOT updated (unknown-primary not in connections).
-		// Discovery seed (term 0) for primary1 remains intact.
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
 			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 		}
-		conn, err := lb.GetConnection(target)
-		require.NoError(t, err)
-		assert.Equal(t, poolerID(primary1), conn.ID(),
-			"Discovery seed should survive when observed primary is not in connections")
+		_, err := lb.GetConnection(target)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "leader",
+			"Error should explain that we know who the leader is but can't reach them")
+		assert.Contains(t, err.Error(), "not connected")
 	})
 
-	t.Run("cache invalidated on pooler removal", func(t *testing.T) {
+	t.Run("leader identity preserved on pooler removal", func(t *testing.T) {
+		// When the connection to the known leader is removed, leader identity
+		// in `leaders` persists. GetConnection returns "known but not connected"
+		// until either the connection comes back or a higher term arrives.
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
@@ -438,7 +444,6 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		connPrimary := lb.connections[poolerID(primary)]
 		lb.mu.Unlock()
 
-		// Health update populates cache
 		simulateHealthUpdate(connPrimary,
 			clustermetadatapb.PoolerServingStatus_SERVING,
 			&multipoolerservice.LeaderObservation{
@@ -446,7 +451,6 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 				LeaderTerm: 1,
 			})
 
-		// Verify cached
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
@@ -456,20 +460,24 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, poolerID(primary), conn.ID())
 
-		// Remove the pooler — cache should be invalidated
+		// Connection torn down — but consensus hasn't changed.
 		lb.RemovePooler(poolerID(primary))
 
 		_, err = lb.GetConnection(target)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no primary cached")
+		assert.Contains(t, err.Error(), "not connected",
+			"Leader identity must persist; error should distinguish from 'no leader observed yet'")
 	})
 }
 
-func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
+func TestLoadBalancer_TopologyTypeDoesNotEstablishLeader(t *testing.T) {
+	// AddPooler with PRIMARY type is purely a connection event — it must not
+	// register the pooler as the shard's leader. This is the regression for
+	// the failover bug where a demoted-then-restarted pooler re-asserted
+	// Type=PRIMARY in etcd and the gateway redirected traffic back to it.
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	// AddPooler with PRIMARY type seeds the cache — no health update needed
 	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	require.NoError(t, lb.AddPooler(primary))
 
@@ -478,61 +486,10 @@ func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
 		Shard:      "0",
 		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 	}
-	conn, err := lb.GetConnection(target)
-	require.NoError(t, err)
-	assert.Equal(t, poolerID(primary), conn.ID(), "Should find primary seeded from discovery")
-}
-
-func TestLoadBalancer_PrimarySeedInvalidatedOnTypeChange(t *testing.T) {
-	logger := slog.Default()
-	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	// Add as PRIMARY — seeds cache
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, lb.AddPooler(pooler))
-
-	// Topo update: type changed to REPLICA — seed should be invalidated
-	poolerAsReplica := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
-	require.NoError(t, lb.AddPooler(poolerAsReplica))
-
-	target := &query.Target{
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      "0",
-		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
-	}
 	_, err := lb.GetConnection(target)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no primary cached")
-}
-
-func TestLoadBalancer_HealthStreamOverridesSeed(t *testing.T) {
-	logger := slog.Default()
-	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	// Add as PRIMARY — seeds cache with term 0
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
-	require.NoError(t, lb.AddPooler(pooler))
-
-	// Health stream confirms primary with real term
-	lb.mu.Lock()
-	conn := lb.connections[poolerID(pooler)]
-	lb.mu.Unlock()
-	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: pooler.Id, LeaderTerm: 5})
-
-	// Topo update: type changed to REPLICA — but health-confirmed entry (term > 0) is NOT invalidated
-	poolerAsReplica := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
-	require.NoError(t, lb.AddPooler(poolerAsReplica))
-
-	target := &query.Target{
-		TableGroup: constants.DefaultTableGroup,
-		Shard:      "0",
-		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
-	}
-	conn2, err := lb.GetConnection(target)
-	require.NoError(t, err)
-	assert.Equal(t, poolerID(pooler), conn2.ID(),
-		"Health-confirmed primary (term > 0) should survive topo type change")
+	assert.Contains(t, err.Error(), "no leader observed yet",
+		"AddPooler(PRIMARY) must not promote a pooler to leader; only LeaderObservation can")
 }
 
 func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
@@ -563,7 +520,7 @@ func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
 		}
 		_, err := lb.GetConnection(target)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no primary cached",
+		assert.Contains(t, err.Error(), "no leader observed yet",
 			"Should not fall back to UNKNOWN type poolers")
 	})
 
@@ -663,13 +620,157 @@ func TestLoadBalancer_SelectReplicaByLocalityAndServingStatus(t *testing.T) {
 	})
 }
 
+// TestLoadBalancer_LeaderObservationBeforeConnection covers the silent-drop
+// race from the failover archive: a higher-term LeaderObservation arrives for
+// pooler X before X has been added via AddPooler. With the old shape, the
+// observation was dropped because the connection didn't exist yet. With the
+// new shape, leader identity is recorded regardless and routing works the
+// moment X is added.
+func TestLoadBalancer_LeaderObservationBeforeConnection(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// observer is in the shard but is NOT the leader; we use its health stream
+	// to deliver an observation naming a pooler we have not added yet.
+	observer := createTestMultiPooler("observer", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	require.NoError(t, lb.AddPooler(observer))
+
+	lb.mu.Lock()
+	connObserver := lb.connections[poolerID(observer)]
+	lb.mu.Unlock()
+
+	// The future leader exists in topology but has not been added yet.
+	futureLeader := createTestMultiPooler("future-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+
+	// observer reports that future-leader is the consensus leader at term 7.
+	simulateHealthUpdate(connObserver,
+		clustermetadatapb.PoolerServingStatus_SERVING,
+		&multipoolerservice.LeaderObservation{
+			LeaderId:   futureLeader.Id,
+			LeaderTerm: 7,
+		})
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+	}
+
+	// Leader identity must be recorded even though we have no connection.
+	_, err := lb.GetConnection(target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected",
+		"Identity must be recorded; the gateway should distinguish 'known but unreachable' from 'unknown'")
+
+	// AddPooler the leader. No additional observation needed — routing must
+	// work immediately, proving identity was not dropped at observation time.
+	require.NoError(t, lb.AddPooler(futureLeader))
+	conn, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(futureLeader), conn.ID())
+}
+
+// TestLoadBalancer_StalePrimaryTypeDoesNotEvict is the regression for the
+// failover archive: a demoted-then-restarted pooler re-asserts Type=PRIMARY
+// in topology. The gateway must not redirect traffic to it; the known leader
+// at the higher term wins.
+func TestLoadBalancer_StalePrimaryTypeDoesNotEvict(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	demoted := createTestMultiPooler("demoted", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	newLeader := createTestMultiPooler("new-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	require.NoError(t, lb.AddPooler(demoted))
+	require.NoError(t, lb.AddPooler(newLeader))
+
+	lb.mu.Lock()
+	connNewLeader := lb.connections[poolerID(newLeader)]
+	lb.mu.Unlock()
+
+	// new-leader's health stream confirms itself as leader at term 2 (the
+	// post-failover state).
+	simulateHealthUpdate(connNewLeader,
+		clustermetadatapb.PoolerServingStatus_SERVING,
+		&multipoolerservice.LeaderObservation{
+			LeaderId:   newLeader.Id,
+			LeaderTerm: 2,
+		})
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+	}
+	conn, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(newLeader), conn.ID())
+
+	// Now the demoted pooler's stale topology record flips to Type=PRIMARY
+	// (its pod restarted before multiorch corrected etcd). The gateway sees
+	// the same connection re-asserting itself as PRIMARY.
+	demotedReasserted := createTestMultiPooler("demoted", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	require.NoError(t, lb.AddPooler(demotedReasserted))
+
+	// Both connections must still be present — discovery does not evict, and
+	// the LoadBalancer ignores the topology hint for leader identity.
+	assert.Equal(t, 2, lb.ConnectionCount(),
+		"Stale Type=PRIMARY assertion must NOT cause the real leader's connection to be dropped")
+
+	// Routing must still go to new-leader, the consensus-elected term-2 leader.
+	conn, err = lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(newLeader), conn.ID(),
+		"Stale topology must not redirect PRIMARY traffic away from the consensus-elected leader")
+}
+
+// TestLoadBalancer_ReplicaCandidatesExcludeLeader verifies that REPLICA
+// selection consults the LeaderObservation instead of topology Type. A pooler
+// that consensus has elected leader must never be considered a replica
+// candidate, even if its topology Type still says REPLICA.
+func TestLoadBalancer_ReplicaCandidatesExcludeLeader(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// All three are Type=REPLICA in topology; one is actually leader.
+	a := createTestMultiPooler("pooler-a", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	b := createTestMultiPooler("pooler-b", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	c := createTestMultiPooler("pooler-c", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	require.NoError(t, lb.AddPooler(a))
+	require.NoError(t, lb.AddPooler(b))
+	require.NoError(t, lb.AddPooler(c))
+
+	lb.mu.Lock()
+	connA := lb.connections[poolerID(a)]
+	lb.mu.Unlock()
+
+	// a observes itself as leader; b and c are eligible replica candidates.
+	simulateHealthUpdate(connA,
+		clustermetadatapb.PoolerServingStatus_SERVING,
+		&multipoolerservice.LeaderObservation{LeaderId: a.Id, LeaderTerm: 1})
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_REPLICA,
+	}
+
+	// Run several iterations: the leader must never be selected, regardless of
+	// which non-leader the load balancer picks at random.
+	for range 50 {
+		conn, err := lb.GetConnection(target)
+		require.NoError(t, err)
+		assert.NotEqual(t, poolerID(a), conn.ID(),
+			"Known leader (pooler-a) must never be returned as a REPLICA candidate")
+	}
+}
+
 func TestLoadBalancerListener(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	listener := NewLoadBalancerListener(lb)
 
 	// OnPoolerChanged should add pooler
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	listener.OnPoolerChanged(pooler)
 	assert.Equal(t, 1, lb.ConnectionCount())
 

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -62,9 +62,8 @@ func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	// Initially empty
 	assert.Equal(t, 0, lb.ConnectionCount())
 
-	// Add a pooler (type=REPLICA so it's selectable as a replica without a
-	// LeaderObservation having been recorded yet).
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	// Add a pooler
+	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	err := lb.AddPooler(pooler)
 	require.NoError(t, err)
 	assert.Equal(t, 1, lb.ConnectionCount())
@@ -74,7 +73,7 @@ func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, lb.ConnectionCount())
 
-	// Updating pooler type (simulating topology refresh)
+	// Updating pooler type (simulating topology update from UNKNOWN to PRIMARY)
 	poolerUpdated := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	err = lb.AddPooler(poolerUpdated)
 	require.NoError(t, err)
@@ -369,71 +368,29 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		assert.Equal(t, poolerID(primary1), conn.ID(), "Should trust replica's observation with highest term")
 	})
 
-	t.Run("no observations returns UNAVAILABLE (not a topology guess)", func(t *testing.T) {
+	t.Run("no observations uses discovery seed", func(t *testing.T) {
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-		// Topology says these are PRIMARY/REPLICA, but no LeaderObservation has
-		// arrived yet — gateway must not guess. Clients see UNAVAILABLE and
-		// retry briefly until consensus is observed.
 		primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 		replica := createTestMultiPooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 
 		require.NoError(t, lb.AddPooler(primary))
 		require.NoError(t, lb.AddPooler(replica))
 
+		// No health updates — but discovery seed (term 0) provides a primary
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
 			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 		}
-		_, err := lb.GetConnection(target)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no leader observed yet")
-	})
-
-	t.Run("leader known but not connected", func(t *testing.T) {
-		// A LeaderObservation names a pooler we have no connection to. The
-		// gateway must remember the identity so that when the connection
-		// arrives, routing immediately works.
-		logger := slog.Default()
-		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-		observer := createTestMultiPooler("observer", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
-		require.NoError(t, lb.AddPooler(observer))
-
-		lb.mu.Lock()
-		connObserver := lb.connections[poolerID(observer)]
-		lb.mu.Unlock()
-
-		unknownLeaderID := &clustermetadatapb.ID{
-			Component: clustermetadatapb.ID_MULTIPOOLER,
-			Cell:      "zone3",
-			Name:      "unknown-leader",
-		}
-		simulateHealthUpdate(connObserver,
-			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   unknownLeaderID,
-				LeaderTerm: 100,
-			})
-
-		target := &query.Target{
-			TableGroup: constants.DefaultTableGroup,
-			Shard:      "0",
-			PoolerType: clustermetadatapb.PoolerType_PRIMARY,
-		}
-		_, err := lb.GetConnection(target)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "leader",
-			"Error should explain that we know who the leader is but can't reach them")
-		assert.Contains(t, err.Error(), "not connected")
+		conn, err := lb.GetConnection(target)
+		require.NoError(t, err)
+		assert.Equal(t, poolerID(primary), conn.ID(),
+			"Should return discovery-seeded primary before health stream connects")
 	})
 
 	t.Run("leader identity preserved on pooler removal", func(t *testing.T) {
-		// When the connection to the known leader is removed, leader identity
-		// in `leaders` persists. GetConnection returns "known but not connected"
-		// until either the connection comes back or a higher term arrives.
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
@@ -444,6 +401,8 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		connPrimary := lb.connections[poolerID(primary)]
 		lb.mu.Unlock()
 
+		// Health update populates the leader entry with a real (term > 0)
+		// observation.
 		simulateHealthUpdate(connPrimary,
 			clustermetadatapb.PoolerServingStatus_SERVING,
 			&multipoolerservice.LeaderObservation{
@@ -451,6 +410,7 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 				LeaderTerm: 1,
 			})
 
+		// Verify routing
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
@@ -460,7 +420,9 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, poolerID(primary), conn.ID())
 
-		// Connection torn down — but consensus hasn't changed.
+		// Remove the pooler — leader identity must persist; GetConnection
+		// distinguishes "known but not connected" (transient, after removal)
+		// from "no leader observed yet" (operational, never saw consensus).
 		lb.RemovePooler(poolerID(primary))
 
 		_, err = lb.GetConnection(target)
@@ -470,14 +432,11 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 	})
 }
 
-func TestLoadBalancer_TopologyTypeDoesNotEstablishLeader(t *testing.T) {
-	// AddPooler with PRIMARY type is purely a connection event — it must not
-	// register the pooler as the shard's leader. This is the regression for
-	// the failover bug where a demoted-then-restarted pooler re-asserted
-	// Type=PRIMARY in etcd and the gateway redirected traffic back to it.
+func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
+	// AddPooler with PRIMARY type seeds the cache — no health update needed
 	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	require.NoError(t, lb.AddPooler(primary))
 
@@ -486,10 +445,39 @@ func TestLoadBalancer_TopologyTypeDoesNotEstablishLeader(t *testing.T) {
 		Shard:      "0",
 		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 	}
-	_, err := lb.GetConnection(target)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no leader observed yet",
-		"AddPooler(PRIMARY) must not promote a pooler to leader; only LeaderObservation can")
+	conn, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(primary), conn.ID(), "Should find primary seeded from discovery")
+}
+
+func TestLoadBalancer_HealthStreamOverridesSeed(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// Add as PRIMARY — seeds cache with term 0
+	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	require.NoError(t, lb.AddPooler(pooler))
+
+	// Health stream confirms primary with real term
+	lb.mu.Lock()
+	conn := lb.connections[poolerID(pooler)]
+	lb.mu.Unlock()
+	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
+		&multipoolerservice.LeaderObservation{LeaderId: pooler.Id, LeaderTerm: 5})
+
+	// Topo update: type changed to REPLICA — but health-confirmed entry (term > 0) is NOT invalidated
+	poolerAsReplica := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	require.NoError(t, lb.AddPooler(poolerAsReplica))
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+	}
+	conn2, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(pooler), conn2.ID(),
+		"Health-confirmed primary (term > 0) should survive topo type change")
 }
 
 func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
@@ -770,7 +758,7 @@ func TestLoadBalancerListener(t *testing.T) {
 	listener := NewLoadBalancerListener(lb)
 
 	// OnPoolerChanged should add pooler
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
 	listener.OnPoolerChanged(pooler)
 	assert.Equal(t, 1, lb.ConnectionCount())
 

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -201,6 +201,7 @@ message Target {
 
   // pooler_type is the type of pooler to route to (PRIMARY, REPLICA)
   // If not specified (UNKNOWN), defaults to PRIMARY
+  // TODO: Change from PoolerType something else, like a TargetType or ServingType enum.
   clustermetadata.PoolerType pooler_type = 3;
 }
 


### PR DESCRIPTION
## What

Replaces the gateway's `cachedPrimaries map[shardKey]{*PoolerConnection,term}` with `leaders map[shardKey]*LeaderObservation`. Leader identity is now sourced exclusively from the highest-term `LeaderObservation` received on health streams. Topology `pooler.Type` is reduced to a cold-start hint and to replica filtering.

## Why

The connection-keyed cache coupled leader identity to a resource lifecycle: removing a pooler erased identity, and observations arriving before the named pooler was connected were silently dropped. Combined with `evictConflictingPrimary` — which deleted the real leader's connection whenever a stale pooler re-asserted `Type=PRIMARY` in etcd — this could pin the gateway to a demoted pooler for the rest of its process lifetime.

## Bugs fixed

- **Eviction-induced primary loss.** A demoted-then-restarted pooler re-asserting `Type=PRIMARY` no longer causes the gateway to drop its connection to the actual leader. `evictConflictingPrimary` is deleted; two `Type=PRIMARY` entries in topology during a failover are now normal and harmless.
- **Silent-drop on out-of-order discovery.** Higher-term observations naming a not-yet-connected pooler are now recorded and applied as soon as the connection arrives, instead of being dropped.
- **Identity erased on connection removal.** `leaders[shard]` survives `RemovePooler` so a brief connection drop no longer reverts the gateway to "no leader observed yet."

## Notes

- Cold-start: when no observation has arrived yet, `AddPooler` seeds a term-0 synthetic `LeaderObservation` from `pooler.Type == PRIMARY`. Any real observation (term ≥ 1) wins on term comparison.
- Buffer drain still requires the leader to self-report `PoolerType_PRIMARY` on its health stream, matching pre-refactor invariants.
- Follow-up: have multipooler publish its current `LeaderObservation` into its etcd record so the synthetic seed can be dropped.

