### PR TITLE
feat(eventlog): include reason in primary.promotion events

### DIFF
--- a/go/common/eventlog/eventlog_test.go
+++ b/go/common/eventlog/eventlog_test.go
@@ -59,10 +59,10 @@ func TestEmit(t *testing.T) {
 		{
 			name:          "event with fields",
 			outcome:       Success,
-			event:         PrimaryPromotion{NewPrimary: "pg-1"},
+			event:         PrimaryPromotion{NewPrimary: "pg-1", Reason: "ShardInit"},
 			wantLevel:     slog.LevelInfo,
 			wantEventType: "primary.promotion",
-			wantAttrs:     map[string]any{"outcome": "success", "new_primary": "pg-1"},
+			wantAttrs:     map[string]any{"outcome": "success", "new_primary": "pg-1", "reason": "ShardInit"},
 		},
 	}
 

--- a/go/common/eventlog/events.go
+++ b/go/common/eventlog/events.go
@@ -21,11 +21,17 @@ type NodeJoin struct{ NodeName string }
 func (NodeJoin) EventType() string       { return "node.join" }
 func (e NodeJoin) LogAttrs() []slog.Attr { return []slog.Attr{slog.String("node_name", e.NodeName)} }
 
-type PrimaryPromotion struct{ NewPrimary string }
+type PrimaryPromotion struct {
+	NewPrimary string
+	Reason     string // why the promotion was initiated, e.g. "ShardInit" or a failover trigger
+}
 
 func (PrimaryPromotion) EventType() string { return "primary.promotion" }
 func (e PrimaryPromotion) LogAttrs() []slog.Attr {
-	return []slog.Attr{slog.String("new_primary", e.NewPrimary)}
+	return []slog.Attr{
+		slog.String("new_primary", e.NewPrimary),
+		slog.String("reason", e.Reason),
+	}
 }
 
 type BackupAttempt struct{ BackupName string }

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -180,6 +180,7 @@ func (r *coordinatorLedRuleChange) Run(
 		}
 		eventlog.Emit(ctx, r.coordinator.logger, eventlog.Started, eventlog.PrimaryPromotion{
 			NewPrimary: p.GetProposalLeader().GetId().GetName(),
+			Reason:     r.reason,
 		})
 	}
 
@@ -232,11 +233,13 @@ func (r *coordinatorLedRuleChange) Run(
 	if leaderErr != nil {
 		eventlog.Emit(ctx, r.coordinator.logger, eventlog.Failed, eventlog.PrimaryPromotion{
 			NewPrimary: newPrimary,
+			Reason:     r.reason,
 		}, "error", leaderErr)
 		return mterrors.Wrapf(leaderErr, "leader %s failed to accept proposal", newPrimary)
 	}
 	eventlog.Emit(ctx, r.coordinator.logger, eventlog.Success, eventlog.PrimaryPromotion{
 		NewPrimary: newPrimary,
+		Reason:     r.reason,
 	})
 	return nil
 }


### PR DESCRIPTION
- Adds a `reason` field to `primary.promotion` event log records so operators can see *why* a promotion was initiated (e.g. `ShardInit` for bootstrap, or the failover trigger string).
- The reason already flows through `coordinatorLedRuleChange` into `ProposeRequest.Reason`; this just plumbs the same value into the `started`/`success`/`failed` event emits.