### PR TITLE
feat(provisioner): check pgbackrest and postgres versions before cluster start

### DIFF
--- a/.github/scripts/setup-test-environment.sh
+++ b/.github/scripts/setup-test-environment.sh
@@ -22,25 +22,22 @@ echo "==========================================="
 echo "Setting up test environment"
 echo "==========================================="
 
-# Install PostgreSQL
-echo "Installing PostgreSQL..."
+# Install PostgreSQL 17 and pgBackRest from PGDG.
+# Ubuntu 24.04's default `postgresql` metapackage is PG 16, but multigres
+# requires PG 17.x — `multigres cluster start` rejects other majors.
+echo "Installing PostgreSQL 17 and pgBackRest from PGDG..."
 sudo apt-get update
-sudo apt-get install -y postgresql postgresql-contrib postgresql-client-common postgresql-common
+sudo apt-get install -y postgresql-common
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+sudo apt-get install -y postgresql-17 postgresql-client-17 postgresql-contrib-17 pgbackrest
+pgbackrest version
 
 # Set up postgres user password for tests
 echo "Configuring PostgreSQL authentication..."
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';" || true
 
-# Install pgBackRest
-echo "Installing pgBackRest..."
-sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-sudo apt-get update
-sudo apt-get install -y pgbackrest
-pgbackrest version
-
-# Add PostgreSQL binaries to PATH for subsequent commands
-# shellcheck disable=SC2012
-POSTGRES_BIN="/usr/lib/postgresql/$(ls /usr/lib/postgresql/ | head -1)/bin"
+# Add PostgreSQL 17 binaries to PATH for subsequent commands
+POSTGRES_BIN="/usr/lib/postgresql/17/bin"
 export PATH="$POSTGRES_BIN:$PATH"
 echo "$POSTGRES_BIN" >>"$GITHUB_PATH"
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -19,14 +19,17 @@ are organized in the other subdirectories of `go/`.
 
 ## Prerequisites
 
-You need to install:
+Multigres requires the following on your `$PATH` before running `multigres cluster start`:
 
 - Go (version 1.25 or later)
-- PostgreSQL (we have been working with version 17.6)
+- **PostgreSQL 17.x** — `postgres --version` must report `(PostgreSQL) 17.x`. PG 14, 15, 16, 18+ are rejected.
+- **pgBackRest ≥ 2.57** — `pgbackrest --version` must report `pgBackRest 2.57` or newer.
+- **etcd** — required for topology.
+
+`multigres cluster start` validates these before bootstrapping the cluster and fails fast with a clear error if anything is missing or wrong.
 
 Most other build dependencies (like protoc) are automatically installed by the
-make script, with the exception of PostgreSQL which needs to be installed
-separately on your system.
+make script.
 
 ## Setup
 

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -310,6 +310,97 @@ func (p *localProvisioner) checkEtcdVersion(binaryPath, expectedVersion string) 
 	return nil
 }
 
+// minPgBackrestVersion is the minimum supported pgBackRest version.
+// Updates here should be paired with docs/building.md.
+const minPgBackrestVersion = "v2.57.0"
+
+var pgbackrestVersionRe = regexp.MustCompile(`(?m)^pgBackRest\s+v?(\d+\.\d+(?:\.\d+)?)`)
+
+// checkPgBackrestVersion verifies that the pgbackrest binary is >= minPgBackrestVersion.
+func (p *localProvisioner) checkPgBackrestVersion(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get pgbackrest version: %w", err)
+	}
+	return p.checkPgBackrestVersionFromOutput(string(output))
+}
+
+// checkPgBackrestVersionFromOutput is the pure parsing/comparison core of
+// checkPgBackrestVersion, split out so tests do not need a real binary.
+func (p *localProvisioner) checkPgBackrestVersionFromOutput(versionStr string) error {
+	matches := pgbackrestVersionRe.FindStringSubmatch(versionStr)
+	if len(matches) < 2 {
+		return fmt.Errorf("could not parse pgbackrest version from output: %q", strings.TrimSpace(versionStr))
+	}
+	actual := semver.Canonical("v" + matches[1])
+	if semver.Compare(actual, minPgBackrestVersion) < 0 {
+		return fmt.Errorf("pgbackrest %s is too old; need >= %s",
+			strings.TrimPrefix(actual, "v"),
+			strings.TrimPrefix(minPgBackrestVersion, "v"))
+	}
+	fmt.Printf("🔍 - pgbackrest %s found — version compatible ✓\n",
+		strings.TrimPrefix(actual, "v"))
+	return nil
+}
+
+// requiredPostgresMajor is the only supported PostgreSQL major version.
+const requiredPostgresMajor = 17
+
+var postgresVersionRe = regexp.MustCompile(`(?m)^postgres\s+\(PostgreSQL\)\s+(\d+)(?:\.(\d+))?`)
+
+// checkPostgresVersion verifies that the postgres binary is major version requiredPostgresMajor.
+func (p *localProvisioner) checkPostgresVersion(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get postgres version: %w", err)
+	}
+	return p.checkPostgresVersionFromOutput(string(output))
+}
+
+// checkPostgresVersionFromOutput is the pure parsing/comparison core of
+// checkPostgresVersion.
+func (p *localProvisioner) checkPostgresVersionFromOutput(versionStr string) error {
+	matches := postgresVersionRe.FindStringSubmatch(versionStr)
+	if len(matches) < 2 {
+		return fmt.Errorf("could not parse postgres version from output: %q", strings.TrimSpace(versionStr))
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return fmt.Errorf("could not parse postgres major version %q: %w", matches[1], err)
+	}
+	if major != requiredPostgresMajor {
+		return fmt.Errorf("postgres major version %d is unsupported; need %d.x", major, requiredPostgresMajor)
+	}
+	display := matches[1]
+	if len(matches) > 2 && matches[2] != "" {
+		display = display + "." + matches[2]
+	}
+	fmt.Printf("🔍 - postgres %s found — version compatible ✓\n", display)
+	return nil
+}
+
+// checkRequiredBinaryVersions resolves the version-sensitive binaries on PATH
+// and verifies each is at a supported version. It is invoked from Bootstrap
+// after validateSystemBinaries has confirmed every required binary is present.
+// LookPath errors are not expected here, but are propagated defensively in case
+// PATH changes between the two calls.
+func (p *localProvisioner) checkRequiredBinaryVersions() error {
+	pgbackrestPath, err := exec.LookPath("pgbackrest")
+	if err != nil {
+		return fmt.Errorf("pgbackrest lookup failed after binary validation: %w", err)
+	}
+	if err := p.checkPgBackrestVersion(pgbackrestPath); err != nil {
+		return err
+	}
+	postgresPath, err := exec.LookPath("postgres")
+	if err != nil {
+		return fmt.Errorf("postgres lookup failed after binary validation: %w", err)
+	}
+	return p.checkPostgresVersion(postgresPath)
+}
+
 // readServiceLogs reads the last few lines from a service's log file for debugging
 func (p *localProvisioner) readServiceLogs(logFile string, lines int) string {
 	if logFile == "" {
@@ -1189,6 +1280,11 @@ func (p *localProvisioner) Bootstrap(ctx context.Context) ([]*provisioner.Provis
 		return nil, err
 	}
 
+	// Validate critical binary versions before starting any services.
+	if err := p.checkRequiredBinaryVersions(); err != nil {
+		return nil, err
+	}
+
 	fmt.Println("=== Bootstrapping Multigres cluster ===")
 	fmt.Println("")
 
@@ -2020,6 +2116,7 @@ func (p *localProvisioner) validateSystemBinaries() error {
 		"pg_ctl",
 		"postgres",
 		"pg_isready",
+		"pgbackrest",
 	}
 
 	var missingBinaries []string
@@ -2032,9 +2129,10 @@ func (p *localProvisioner) validateSystemBinaries() error {
 
 	if len(missingBinaries) > 0 {
 		return fmt.Errorf("required system binaries not found in PATH: %s\n\n"+
-			"Please ensure PostgreSQL and etcd are installed and available in your PATH.\n"+
-			"For PostgreSQL: Install PostgreSQL client tools (pg_ctl, postgres, pg_isready)\n"+
-			"For etcd: Install etcd client binary",
+			"Please ensure PostgreSQL, etcd, and pgBackRest are installed and available in your PATH.\n"+
+			"For PostgreSQL: Install PostgreSQL 17.x client tools (pg_ctl, postgres, pg_isready)\n"+
+			"For etcd: Install etcd client binary\n"+
+			"For pgBackRest: Install pgBackRest >= 2.57",
 			strings.Join(missingBinaries, ", "))
 	}
 

--- a/go/provisioner/local/local_test.go
+++ b/go/provisioner/local/local_test.go
@@ -15,7 +15,9 @@
 package local
 
 import (
+	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -101,4 +103,228 @@ func TestValidateUnixSocketPathLengthWithWorkingDirectory(t *testing.T) {
 
 	err = provisioner.validateUnixSocketPathLength(config)
 	require.NoError(t, err)
+}
+
+func TestCheckPgBackrestVersion_Parse(t *testing.T) {
+	p := &localProvisioner{}
+	tests := []struct {
+		name    string
+		out     string
+		wantErr string
+	}{
+		{"meets minimum", "pgBackRest 2.57.0\n", ""},
+		{"newer patch", "pgBackRest 2.57.3\n", ""},
+		{"newer minor", "pgBackRest 2.60.1\n", ""},
+		{"too old", "pgBackRest 2.55.1\n", "too old"},
+		{"way too old", "pgBackRest 1.99.99\n", "too old"},
+		{"unparsable", "garbage\n", "could not parse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.checkPgBackrestVersionFromOutput(tc.out)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCheckPostgresVersion_Parse(t *testing.T) {
+	p := &localProvisioner{}
+	tests := []struct {
+		name    string
+		out     string
+		wantErr string
+	}{
+		{"17.0", "postgres (PostgreSQL) 17.0\n", ""},
+		{"17.2 homebrew", "postgres (PostgreSQL) 17.2 (Homebrew)\n", ""},
+		{"14.20", "postgres (PostgreSQL) 14.20\n", "unsupported"},
+		{"18 beta", "postgres (PostgreSQL) 18beta1\n", "unsupported"},
+		{"16.5", "postgres (PostgreSQL) 16.5\n", "unsupported"},
+		{"unparsable", "garbage\n", "could not parse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.checkPostgresVersionFromOutput(tc.out)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// writeFakeBinary writes a tiny shell script to dir/name that prints stdout and exits 0,
+// or exits nonzero when exitNonZero is true. Returns the binary path.
+func writeFakeBinary(t *testing.T, dir, name, stdout string, exitNonZero bool) string {
+	t.Helper()
+	exitLine := ""
+	if exitNonZero {
+		exitLine = "exit 1\n"
+	}
+	script := "#!/bin/sh\nprintf %s " + shellQuote(stdout) + "\n" + exitLine
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func TestCheckPgBackrestVersion_ExecsBinary(t *testing.T) {
+	p := &localProvisioner{}
+	dir := t.TempDir()
+
+	t.Run("good version", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_good", "pgBackRest 2.57.0\n", false)
+		require.NoError(t, p.checkPgBackrestVersion(path))
+	})
+
+	t.Run("too old", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_old", "pgBackRest 2.55.1\n", false)
+		err := p.checkPgBackrestVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too old")
+	})
+
+	t.Run("binary exits nonzero", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_fail", "", true)
+		err := p.checkPgBackrestVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get pgbackrest version")
+	})
+}
+
+func TestCheckPostgresVersion_ExecsBinary(t *testing.T) {
+	p := &localProvisioner{}
+	dir := t.TempDir()
+
+	t.Run("good version", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_good", "postgres (PostgreSQL) 17.2 (Homebrew)\n", false)
+		require.NoError(t, p.checkPostgresVersion(path))
+	})
+
+	t.Run("wrong major", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_old", "postgres (PostgreSQL) 14.20\n", false)
+		err := p.checkPostgresVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+
+	t.Run("binary exits nonzero", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_fail", "", true)
+		err := p.checkPostgresVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get postgres version")
+	})
+}
+
+func TestValidateSystemBinaries(t *testing.T) {
+	p := &localProvisioner{}
+
+	t.Run("missing binaries reported", func(t *testing.T) {
+		// Point PATH at an empty temp dir so every required binary is missing.
+		dir := t.TempDir()
+		t.Setenv("PATH", dir)
+		err := p.validateSystemBinaries()
+		require.Error(t, err)
+		// All required binaries should be flagged.
+		for _, b := range []string{"etcd", "pg_ctl", "postgres", "pg_isready", "pgbackrest"} {
+			assert.Contains(t, err.Error(), b)
+		}
+	})
+
+	t.Run("all present succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		// Provide a no-op binary for each required tool.
+		for _, b := range []string{"etcd", "pg_ctl", "postgres", "pg_isready", "pgbackrest"} {
+			writeFakeBinary(t, dir, b, "", false)
+		}
+		t.Setenv("PATH", dir)
+		require.NoError(t, p.validateSystemBinaries())
+	})
+}
+
+func TestCheckRequiredBinaryVersions(t *testing.T) {
+	const (
+		goodPgbackrest = "pgBackRest 2.57.0\n"
+		oldPgbackrest  = "pgBackRest 2.55.1\n"
+		goodPostgres   = "postgres (PostgreSQL) 17.2 (Homebrew)\n"
+		oldPostgres    = "postgres (PostgreSQL) 14.20\n"
+	)
+
+	tests := []struct {
+		name          string
+		omit          map[string]bool   // binaries to omit from PATH
+		stdouts       map[string]string // binary name -> --version stdout (defaults to goodX)
+		exitNonZero   map[string]bool   // binary name -> shim exits nonzero
+		wantErrSubstr string
+	}{
+		{
+			name: "all good",
+		},
+		{
+			name:          "pgbackrest missing from PATH",
+			omit:          map[string]bool{"pgbackrest": true},
+			wantErrSubstr: "pgbackrest lookup failed",
+		},
+		{
+			name:          "postgres missing from PATH",
+			omit:          map[string]bool{"postgres": true},
+			wantErrSubstr: "postgres lookup failed",
+		},
+		{
+			name:          "pgbackrest too old",
+			stdouts:       map[string]string{"pgbackrest": oldPgbackrest},
+			wantErrSubstr: "too old",
+		},
+		{
+			name:          "postgres wrong major",
+			stdouts:       map[string]string{"postgres": oldPostgres},
+			wantErrSubstr: "unsupported",
+		},
+		{
+			name:          "pgbackrest --version errors",
+			exitNonZero:   map[string]bool{"pgbackrest": true},
+			wantErrSubstr: "failed to get pgbackrest version",
+		},
+		{
+			name:          "postgres --version errors",
+			exitNonZero:   map[string]bool{"postgres": true},
+			wantErrSubstr: "failed to get postgres version",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stdouts := map[string]string{
+				"pgbackrest": goodPgbackrest,
+				"postgres":   goodPostgres,
+			}
+			maps.Copy(stdouts, tc.stdouts)
+			for _, b := range []string{"pgbackrest", "postgres"} {
+				if tc.omit[b] {
+					continue
+				}
+				writeFakeBinary(t, dir, b, stdouts[b], tc.exitNonZero[b])
+			}
+			t.Setenv("PATH", dir)
+
+			p := &localProvisioner{}
+			err := p.checkRequiredBinaryVersions()
+			if tc.wantErrSubstr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSubstr)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- `multigres cluster start` now refuses to bootstrap unless `pgbackrest >= 2.57.0` and `postgres 17.x` are on `$PATH`.
- Adds `pgbackrest` to `validateSystemBinaries`' required-binary list and clarifies the missing-binary error message.
- Adds `checkPgBackrestVersion` and `checkPostgresVersion` modeled on the existing `checkEtcdVersion`, wired into `Bootstrap` right after `validateSystemBinaries`.
- Bumps CI's PostgreSQL install from the Ubuntu 24.04 default (PG 16) to **PostgreSQL 17** via the PGDG apt repo, so integration tests still pass under the new check.
- Documents the prerequisite versions in `docs/building.md`.

Closes MUL-539

## Problem

`multigres cluster start` would proceed even when `pgbackrest` was not installed at all and when `postgres` was a wrong major version (e.g. PG 14 or PG 18). The cluster appeared to start successfully but no primary was ever promoted, so client connections failed with cryptic "no primary cached for target" errors. Surfaced in [this thread](https://supabase.slack.com/archives/C09HZMQDAKD/p1779838675629389).

## Solution

Extend the existing local-provisioner dependency checks rather than introducing a parallel mechanism. The `Bootstrap` path already calls `validateSystemBinaries`; this PR adds `pgbackrest` to that list, then runs `pgbackrest --version` and `postgres --version` and rejects the bootstrap with a clear error if the binaries are too old or the wrong major. The version-comparison style matches `checkEtcdVersion` (`golang.org/x/mod/semver`).

Because Ubuntu 24.04's default `postgresql` metapackage installs PG 16, `.github/scripts/setup-test-environment.sh` now adds the PGDG repo (which we already use for pgBackRest) earlier and installs `postgresql-17`, `postgresql-client-17`, `postgresql-contrib-17` explicitly. `/usr/lib/postgresql/17/bin` is pinned on `\$PATH` in place of the previous "first directory under `/usr/lib/postgresql/`" glob.

## Example Output

```
Multigres — Distributed Postgres made easy
=================================================================
✨ Bootstrapping your local Multigres cluster — this may take a few moments ✨
📄 - Config loaded from: /tmp/mt/multigres.yaml
🛠️  - Provisioner: local

👋 Here we go! Starting core services...
=================================================================

Error: cluster bootstrap failed: required system binaries not found in PATH: pgbackrest

Please ensure PostgreSQL, etcd, and pgBackRest are installed and available in your PATH.
For PostgreSQL: Install PostgreSQL 17.x client tools (pg_ctl, postgres, pg_isready)
For etcd: Install etcd client binary
For pgBackRest: Install pgBackRest >= 2.57
```