### PR TITLE
docs: clean up stale references and gaps

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -64,18 +64,23 @@ The following environment variables are recognized by `pgctld` (and to
 some extent, Multipooler) and follow the Docker `postgres` image
 convention.
 
-| Variable               | CLI flag               | Default    | Description                           |
-| ---------------------- | ---------------------- | ---------- | ------------------------------------- |
-| `POSTGRES_USER`        | `--pg-user` / `-U`     | `postgres` | PostgreSQL user name                  |
-| `POSTGRES_PASSWORD`    | _(none)_               | _(empty)_  | PostgreSQL password                   |
-| `POSTGRES_DB`          | `--pg-database` / `-D` | `postgres` | PostgreSQL database name              |
-| `POSTGRES_INITDB_ARGS` | `--pg-initdb-args`     | _(empty)_  | Extra arguments forwarded to `initdb` |
+| Variable                 | CLI flag               | Default    | Description                                                |
+| ------------------------ | ---------------------- | ---------- | ---------------------------------------------------------- |
+| `POSTGRES_USER`          | `--pg-user` / `-U`     | `postgres` | PostgreSQL user name                                       |
+| `POSTGRES_PASSWORD`      | _(none)_               | _(empty)_  | PostgreSQL password (inline)                               |
+| `POSTGRES_PASSWORD_FILE` | _(none)_               | _(empty)_  | Path to a file containing the password (preferred for k8s) |
+| `POSTGRES_DB`            | `--pg-database` / `-D` | `postgres` | PostgreSQL database name                                   |
+| `POSTGRES_INITDB_ARGS`   | `--pg-initdb-args`     | _(empty)_  | Extra arguments forwarded to `initdb`                      |
 
 `POSTGRES_USER`
-: PostgreSQL user for connecting to PostgreSQL server and perform administrative actions. This user requires `SUPERUSER` privileges and is expected to use SCRAM-256 password authentication over a local socket connection, but this is not enforced.
+: PostgreSQL user that Multigres uses to connect to the PostgreSQL server and perform administrative actions. This user **must have `SUPERUSER` privileges**.
+The default `initdb` configuration sets up SCRAM-SHA-256 authentication over a local socket connection, which is what we recommend. Multigres itself does not require any specific authentication method, so any `pg_hba.conf` policy (including `trust`) will work, but anything weaker than SCRAM is not secure.
 
 `POSTGRES_PASSWORD`
-: Password for the user provided in `POSTGRES_USER`.
+: Password for the user provided in `POSTGRES_USER`. Use `POSTGRES_PASSWORD_FILE` instead when running in environments that mount secrets as files (the k8s demo, for example).
+
+`POSTGRES_PASSWORD_FILE`
+: Path to a file containing the password for `POSTGRES_USER`. When set, `pgctld` reads the password from this file instead of `POSTGRES_PASSWORD`.
 
 `POSTGRES_DB`
 : PostgreSQL database name to use when connecting to the database.

--- a/demo/k8s/README.md
+++ b/demo/k8s/README.md
@@ -9,7 +9,13 @@ Prerequisites
 
 Step 1: Build Docker images
 
-Build the multigres images before starting (from the repo root — the scripts assume they already exist in your local Docker daemon).
+From the repo root:
+
+```bash
+make images
+```
+
+This builds the three required images (`multigres/multigres:latest`, `multigres/pgctld-postgres:latest`, `multigres/multiadmin-web:latest`) into your local Docker daemon. The scripts that follow assume they already exist there.
 
 Step 2: Create a data/ directory
 
@@ -43,16 +49,24 @@ The script also applies `k8s-postgres-password-secret.yaml`, which holds the pla
 
 Step 5 (optional): Load demo data with supafirehose
 
-# First build the supafirehose image (in the supafirehose directory):
+> **Note:** `supafirehose` is maintained in a separate repository and is not
+> included in this tree. Skip this step unless you have already cloned and
+> built it elsewhere.
 
+```bash
+# In a clone of the supafirehose repo:
 docker build -t supafirehose:latest .
 
-# Then run from demo/k8s/:
-
+# Then, from demo/k8s/ in this repo:
 ./start-qs.sh
+```
 
-This loads the image into kind, initializes the DB with 100k users, and deploys supafirehose. Port-forward to access its UI:
+This loads the `supafirehose:latest` image into kind, initializes the DB with
+100k users, and deploys supafirehose. Port-forward to access its UI:
+
+```bash
 kubectl port-forward svc/supafirehose 8080:8080
+```
 
 Access URLs (after port-forwards start)
 

--- a/demo/local/README.md
+++ b/demo/local/README.md
@@ -2,11 +2,33 @@
 
 Scripts and configuration for running Multigres locally.
 
+## Prerequisites
+
+- `multigres` binary built (`make build` from repo root) and on `PATH`, e.g.
+  `export PATH="$PWD/bin:$PATH"`
+- PostgreSQL 17.x installed locally (multigres invokes the system `postgres`)
+- Docker (only for the optional observability stack)
+- `psql` client (for connecting to the cluster)
+- `pgbench` (only for the traffic-generation example)
+
 ## Quick Start
 
+By default the cluster config lives in `./multigres_local` (relative to the
+directory you run the command from). Use `--config-path <dir>` to override, or
+set `MTDATAROOT`.
+
 ```bash
-# From repository root
-multigres cluster start --config-path /path/to/multigres_local
+# 1. Create the cluster config (one-time setup).
+multigres cluster init
+
+# 2. Start the cluster.
+multigres cluster start
+
+# 3. Connect.
+PGPASSWORD=postgres psql -h localhost -p 15432 -U postgres -d postgres
+
+# 4. Stop the cluster when done.
+multigres cluster stop
 ```
 
 ## Observability (Optional)
@@ -20,7 +42,7 @@ For development with metrics, traces, and logs visualization.
 demo/local/run-observability.sh
 
 # 2. Start cluster with OTel export (separate terminal)
-demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local
+demo/local/multigres-with-otel.sh cluster start
 
 # 3. Generate traffic (optional — pgbench with progress every 5s)
 PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -i postgres
@@ -41,7 +63,7 @@ Stop in this order to avoid OTel export errors at shutdown:
 
 ```bash
 # 1. Stop the cluster
-./bin/multigres cluster stop --config-path /path/to/multigres_local
+./bin/multigres cluster stop
 
 # 2. Stop the observability stack (Ctrl-C in run-observability.sh terminal, or:)
 docker rm -f multigres-observability
@@ -51,12 +73,12 @@ docker rm -f multigres-observability
 
 ```bash
 # 1. Stop everything
-./bin/multigres cluster stop --config-path /path/to/multigres_local
+./bin/multigres cluster stop
 docker rm -f multigres-observability
 
 # 2. Start everything
 demo/local/run-observability.sh          # terminal 1
-demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local  # terminal 2
+demo/local/multigres-with-otel.sh cluster start  # terminal 2
 ```
 
 ### Ports

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,18 @@ to use Multigres for your applications, please refer to the
 - **[Github workflow](./workflow.md)**
 - **[Contributing](./contributing.md)**
 
+## Design Documents
+
+Browse the design and reference docs by area:
+
+- **[Query serving](./query_serving/)** — connection pooling, prepared
+  statements, transactions, session settings, plan caching, query
+  cancellation, failover buffering, replica reads, listen/notify, etc.
+- **[High availability](./ha/decision-log/)** — decision log for consensus,
+  failover, and primary-term changes.
+- **[General](./general/)** — cross-cutting topics (e.g. serving state
+  management).
+
 ## PostgreSQL Compatibility
 
 multigres runs the official PostgreSQL regression test suite to track compatibility.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,12 @@ MultiOrch's primary responsibility is to manage failovers.
 
 MultiOrch also orchestrates the initial bootstrap of a cluster.
 
+### MultiAdmin
+
+MultiAdmin's primary responsibility is to expose administrative endpoints for cluster management. It serves both HTTP and gRPC APIs used by the `multiadmin` web UI and by operators.
+
+MultiAdmin does not have any secondary responsibilities.
+
 ### Operator
 
 The Operator is a Kubernetes Operator. Its primary responsibility is to provision resources for a cluster and bring up all the required Multigres components.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,8 +23,17 @@ Go has evolved with newer constructs, and we prefer using such newer constructs
 where possible. Most code editors automatically recommend such modernizations.
 
 We have a few pre-commit hooks that perform some basic checks at commit time.
-When a pull request is created, we have a more elaborate set of linters that
-ensure that the code is up to standards.
+Run `make tools` to install them (it symlinks `misc/git/pre-commit` and
+`misc/git/commit-msg` into `.git/hooks/`). When a pull request is created, we
+have a more elaborate set of linters that ensure that the code is up to
+standards.
+
+## Sign Your Commits
+
+All commits must be signed off under the
+[Developer Certificate of Origin](https://developercertificate.org/). Use
+`git commit -s` (or configure `git config commit.gpgsign` and add a
+`Signed-off-by:` trailer) — unsigned commits will be rejected by CI.
 
 ## Testing
 

--- a/docs/ha/decision-log/2026-01-31-separate-voting-term-from-primary-term.md
+++ b/docs/ha/decision-log/2026-01-31-separate-voting-term-from-primary-term.md
@@ -1,7 +1,7 @@
 # Separate Voting Term from Primary Term for Primary Determination
 
 **Date:** 2026-01-31
-**Status:** In Progress
+**Status:** Implemented
 **Participants:** David W, Sugu S, Rafael C
 
 ## Context

--- a/go/common/parser/testdata/postgres/README.md
+++ b/go/common/parser/testdata/postgres/README.md
@@ -13,11 +13,15 @@ To regenerate these test files from PostgreSQL source:
 
 1. **Get PostgreSQL test files**:
 
+   The script reads from `../postgres-tests/` — a local scratch directory that
+   is **not** checked into this repo. Create it on demand:
+
    ```bash
    # Clone PostgreSQL repository (if not already done)
    git clone https://github.com/postgres/postgres.git
 
    # Copy test files to postgres-tests directory (one level up)
+   mkdir -p ../postgres-tests
    cp postgres/src/test/regress/sql/*.sql ../postgres-tests/
    ```
 

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -228,9 +228,11 @@ RUN_EXTENDED_QUERY_SERVING_TESTS=1 go test -v -timeout 60m ./go/test/endtoend/pg
 ```text
 go/test/endtoend/pgregresstest/
 ├── README.md              # This file
-├── main_test.go          # TestMain, shared setup management
-├── postgres_builder.go   # PostgreSQL build and test execution
-└── pgregress_test.go     # Regression + isolation test implementation
+├── main_test.go           # TestMain, shared setup management
+├── postgres_builder.go    # PostgreSQL build and test execution
+├── pgregress_test.go      # Regression + isolation test implementation
+├── patch_verify.go        # Patch verification logic
+└── patch_verify_test.go   # Tests for patch verification
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/go/tools/asthelpergen/README.md
+++ b/go/tools/asthelpergen/README.md
@@ -76,15 +76,15 @@ go generate
 This executes the `//go:generate` directive in `generate.go`, which runs:
 
 ```bash
-go run ../../tools/asthelpergen/main \
+go run ../../../tools/asthelpergen/main \
   --in . \
-  --iface github.com/supabase/multigres/go/common/parser/ast.Node
+  --iface github.com/multigres/multigres/go/common/parser/ast.Node
 ```
 
 ### Command-Line Flags
 
 - `--in <package>`: Package(s) to analyze (default: current directory)
-- `--iface <interface>`: Fully qualified root interface name (e.g., `github.com/supabase/multigres/go/parser/ast.Node`)
+- `--iface <interface>`: Fully qualified root interface name (e.g., `github.com/multigres/multigres/go/common/parser/ast.Node`)
 - `--clone_exclude <types>`: Comma-separated list of types to exclude from deep cloning
 
 ## Generated Files

--- a/proto/README.md
+++ b/proto/README.md
@@ -16,3 +16,14 @@ style of the existing definitions first.
 
 Additionally, new definitions must adhere to the Google Cloud API Design Guide:
 <https://cloud.google.com/apis/design/>
+
+## Regenerating Generated Code
+
+After modifying any `.proto` file, regenerate the Go bindings from the repo
+root:
+
+```bash
+make proto
+```
+
+Generated `.pb.go` files land in `go/pb/` and are checked into the repository.

--- a/web/multiadmin/README.md
+++ b/web/multiadmin/README.md
@@ -1,6 +1,13 @@
 # Multiadmin Web UI
 
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Next.js frontend for the `multiadmin` service. It is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Prerequisites
+
+A running `multiadmin` backend reachable over HTTP. The UI proxies API
+requests to `http://localhost:15000` by default; override with the
+`MULTIADMIN_API_URL` environment variable (see `middleware.ts`). The local
+cluster from `demo/local/` or the k8s demo from `demo/k8s/` will start one.
 
 ## Getting Started
 
@@ -16,7 +23,10 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:18100](http://localhost:18100) with your browser to see the result.
+`next dev` binds to port `3000` by default — open
+[http://localhost:3000](http://localhost:3000) with your browser to see the
+result. Pass `-- --port <N>` (e.g. `npm run dev -- --port 18100`) to bind a
+different port.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 


### PR DESCRIPTION
Reviewed README.md files and docs/:

- demo/local/README.md: add Prerequisites, prepend `cluster init` to Quick Start so first-time users do not hit a missing-config error.
- demo/k8s/README.md: add `make images` command to Step 1, flag the supafirehose step as external/optional since the directory is not in this repo.
- web/multiadmin/README.md: document `MULTIADMIN_API_URL` (defaults to `http://localhost:15000`), correct dev server port to 3000 and explain how to override.
- docs/architecture.md: add MultiAdmin to the Components section.
- go/tools/asthelpergen/README.md: fix module path examples (`github.com/supabase/multigres` -> `github.com/multigres/multigres`) and restore the missing `common/` segment in the iface path.
- docs/ha/decision-log/2026-01-31-separate-voting-term-from-primary-term.md: flip Status from `In Progress` to `Implemented` (shipped via `primary_term` in proto + consensus code).
- docs/contributing.md: note that `make tools` installs the pre-commit hooks from `misc/git/`, add DCO sign-off (`git commit -s`) requirement.
- docs/README.md: add Design Documents section linking to `query_serving/`, `ha/`, and `general/` subtrees (previously unreachable from any index).
- proto/README.md: document `make proto` for regenerating bindings.
- config/README.md: document `POSTGRES_PASSWORD_FILE` (used by the k8s demo).
- go/test/endtoend/pgregresstest/README.md: list `patch_verify.go` / `patch_verify_test.go` in the File Structure section.
- go/common/parser/testdata/postgres/README.md: clarify that `../postgres-tests/` is a local scratch directory and not checked in.