### PR TITLE
refactor(multipooler): graceful shutdown advertises cohort ineligibility

### DIFF
--- a/go/services/multiorch/recovery/analysis/leader_resigned_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/leader_resigned_analyzer.go
@@ -23,12 +23,13 @@ import (
 )
 
 // LeaderResignedAnalyzer detects when the topology leader has explicitly
-// requested its own replacement via LEADERSHIP_SIGNAL_REQUESTING_DEMOTION
-// (emitted by Recruit's primary demote path and graceful shutdown of a
-// leader). Distinct from LeaderIsDeadAnalyzer, which infers leader loss
-// from reachability and health. Resignation is an unambiguous, intentional
-// signal so failover can fire immediately with no follower-connection
-// grace period.
+// signalled that it should be replaced. Two signals trigger this analyzer
+// (see types.LeaderNeedsReplacement): COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE
+// (advertised by graceful shutdown) and LEADERSHIP_SIGNAL_REQUESTING_DEMOTION
+// (emitted by Recruit's primary-demote path after a postgres crash). Distinct
+// from LeaderIsDeadAnalyzer, which infers leader loss from reachability and
+// health. Both signals are unambiguous, intentional indicators so failover
+// can fire immediately with no follower-connection grace period.
 type LeaderResignedAnalyzer struct {
 	factory *RecoveryActionFactory
 }

--- a/go/services/multiorch/recovery/types/pooler_signals.go
+++ b/go/services/multiorch/recovery/types/pooler_signals.go
@@ -29,9 +29,20 @@ import (
 // signalled that it should be replaced via a new election. It reads the
 // self-reported AvailabilityStatus from the consensus status RPC.
 //
-// The staleness check (leadership_status.primary_term == consensus primary_term)
-// ensures we don't act on a REQUESTING_DEMOTION signal left over from a previous
-// election cycle that was never cleared (e.g. after a process restart).
+// Two independent signals trigger replacement:
+//
+//   - CohortEligibilityStatus.Signal == INELIGIBLE: the pooler is unwilling to
+//     remain in the cohort (e.g. graceful shutdown advertises this before
+//     stopping postgres). Not term-gated — eligibility is a current preference
+//     and staleness comes from the freshness of the surrounding health
+//     snapshot; a node that doesn't want to be in the cohort certainly should
+//     not continue as leader.
+//
+//   - LeadershipStatus.Signal == REQUESTING_DEMOTION with leader_term ==
+//     current primary term: emitted by Recruit's primary-demote path after a
+//     postgres crash so the coordinator can correlate the request with the
+//     specific term and avoid acting on a leftover signal from a previous
+//     election cycle that was never cleared (e.g. after a process restart).
 //
 // TODO: once the coordinator synthesizes AvailabilityStatus into
 // PoolerHealthState directly (see clustermetadata.proto TODO), read from
@@ -39,7 +50,11 @@ import (
 // coordinator-synthesized signals (e.g. TEMPORARILY_UNAVAILABLE for unreachable
 // nodes) are handled here too.
 func LeaderNeedsReplacement(p *multiorchdatapb.PoolerHealthState) bool {
-	leadershipStatus := p.GetAvailabilityStatus().GetLeadershipStatus()
+	av := p.GetAvailabilityStatus()
+	if PoolerIsCohortIneligible(av) {
+		return true
+	}
+	leadershipStatus := av.GetLeadershipStatus()
 	if leadershipStatus == nil {
 		return false
 	}

--- a/go/services/multiorch/recovery/types/pooler_signals_test.go
+++ b/go/services/multiorch/recovery/types/pooler_signals_test.go
@@ -145,4 +145,38 @@ func TestLeaderNeedsReplacement(t *testing.T) {
 		}
 		assert.False(t, LeaderNeedsReplacement(p))
 	})
+
+	t.Run("CohortEligibility INELIGIBLE returns true even without leadership signal", func(t *testing.T) {
+		// Graceful-shutdown path: the pooler advertises INELIGIBLE without
+		// touching LeadershipStatus, and the analyzer must still trigger
+		// replacement.
+		p := poolerWithLeaderTerm(t, 5)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+			},
+		}
+		assert.True(t, LeaderNeedsReplacement(p))
+	})
+
+	t.Run("CohortEligibility INELIGIBLE returns true regardless of term", func(t *testing.T) {
+		// Cohort eligibility is not term-gated, unlike REQUESTING_DEMOTION.
+		p := poolerWithLeaderTerm(t, 0)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+			},
+		}
+		assert.True(t, LeaderNeedsReplacement(p))
+	})
+
+	t.Run("CohortEligibility ELIGIBLE returns false", func(t *testing.T) {
+		p := poolerWithLeaderTerm(t, 5)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+			},
+		}
+		assert.False(t, LeaderNeedsReplacement(p))
+	})
 }

--- a/go/services/multipooler/manager/graceful_shutdown.go
+++ b/go/services/multipooler/manager/graceful_shutdown.go
@@ -44,25 +44,16 @@ var pgctldStopModes = []struct {
 	{"immediate", 5 * time.Second},
 }
 
-// GracefulShutdown publishes REQUESTING_DEMOTION on the health stream (for a
-// current leader) and then stops Postgres. Registered as a servenv OnTermSync
+// GracefulShutdown drains traffic, publishes COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE on the
+// health stream and then stops Postgres. Registered as a servenv OnTermSync
 // hook so it runs on SIGTERM bounded by --onterm-timeout.
-//
-// The announcement is sequenced before pgctld.Stop because reading the
-// primary term requires querying postgres for the current rule position;
-// doing it post-stop would silently no-op and force the coordinator to wait
-// for stream EOF + LeaderIsDead grace period instead of firing
-// LeaderResignedAnalyzer immediately.
 //
 // The topology Type=DRAINED transition happens after this returns via the
 // existing OnClose -> mp.Shutdown -> tr.Unregister chain registered in
 // services/multipooler/init.go.
 //
-// The action lock is held for the whole sequence: pgctld.Stop is gated behind
-// the protectedPgctldClient action-lock check, and announcing the resignation
-// involves reading consensus state and writing resignedLeaderAtTerm under the
-// same lock — holding it across both serialises against any concurrent
-// consensus operation (Recruit, Propose, etc.).
+// The action lock is held for the whole sequence because pgctld.Stop is
+// gated behind the protectedPgctldClient action-lock check.
 func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 	pm.logger.InfoContext(ctx, "graceful shutdown starting")
 
@@ -111,26 +102,9 @@ func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 		}
 	}
 
-	// If we are the leader, announce REQUESTING_DEMOTION before stopping
-	// postgres. primaryTermLocked reads the current rule position from
-	// postgres, so the read must happen while postgres is still alive;
-	// running it post-stop would fail and the coordinator would have to wait
-	// for stream EOF + LeaderIsDead grace period instead. No-op for
-	// non-leaders and partially-initialized managers (consensus not wired).
-	// Mirrors the primary-demote pattern in Recruit (rpc_consensus.go).
-	if pm.consensusState != nil && pm.rules != nil {
-		primaryTerm, err := pm.primaryTermLocked(lockCtx)
-		switch {
-		case err != nil:
-			pm.logger.WarnContext(lockCtx, "could not read primary term for resignation announcement; coordinator will fail over via stream EOF",
-				"error", err)
-		case primaryTerm != 0:
-			if err := pm.setResignedLeaderAtTerm(lockCtx, primaryTerm); err != nil {
-				pm.logger.WarnContext(lockCtx, "failed to record resigned primary term",
-					"error", err)
-			}
-		}
-	}
+	// Advertise cohort ineligibility before stopping postgres just in case
+	// stopping is slow. We're favoring speed of failover rather than grace.
+	pm.setCohortEligibility(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE)
 
 	pm.stopPostgresLocked(lockCtx)
 

--- a/go/services/multipooler/manager/graceful_shutdown.go
+++ b/go/services/multipooler/manager/graceful_shutdown.go
@@ -57,6 +57,10 @@ var pgctldStopModes = []struct {
 func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 	pm.logger.InfoContext(ctx, "graceful shutdown starting")
 
+	// TODO: issue a bounded CHECKPOINT before resigning so there's a recent
+	// checkpoint if the failover process doesn't go smoothly and rewinds are
+	// needed.
+
 	lockCtx, err := pm.actionLock.Acquire(ctx, "GracefulShutdown")
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "failed to acquire action lock for graceful shutdown",

--- a/go/services/multipooler/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/manager/graceful_shutdown_test.go
@@ -79,8 +79,8 @@ func (r *recordingPgctldClient) modesCalled() []string {
 // newGracefulShutdownTestManager constructs a MultiPoolerManager wired with
 // stubs sufficient to exercise GracefulShutdown without needing topology,
 // gRPC services, or a real connection pool. The healthStreamer is constructed
-// because broadcastHealth is called on it; other subsystems are nil and must
-// not be touched by the code under test.
+// because setCohortEligibility -> broadcastHealth is called on it; other
+// subsystems are nil and must not be touched by the code under test.
 func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldClient) *MultiPoolerManager {
 	t.Helper()
 
@@ -107,12 +107,6 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 				Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
 			},
 		}),
-		// Fresh on-disk consensus state at a temp dir. announceLeaderResignationLocked
-		// reads primary term via primaryTermLocked -> getConsensusStatus -> ConsensusState;
-		// without this it nil-pointers. With no revocation file it reads as term 0,
-		// matching the "not currently the leader" path so the test exercises a no-op
-		// announce.
-		consensusState: NewConsensusState(t.TempDir(), id),
 	}
 }
 
@@ -350,75 +344,46 @@ func TestMarkPoolerActive_Idempotent(t *testing.T) {
 		"topology Updated nanos must not change on idempotent call")
 }
 
-// TestGracefulShutdown_AnnouncesBeforeStop is a regression test for the
-// ordering bug where primaryTermLocked was called after pgctld.Stop:
-// primaryTermLocked reads from postgres (via rules.observePosition), so it
-// would silently no-op once postgres was down and the coordinator would have
-// to wait for stream-EOF + LeaderIsDead grace period instead of firing
-// LeaderResignedAnalyzer on REQUESTING_DEMOTION.
+// TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop is a regression
+// test for the ordering guarantee that cohort-ineligibility is broadcast
+// before pgctld.Stop. If the order flipped, the broadcast would race against
+// stream EOF and the coordinator would have to fall back to LeaderIsDead's
+// grace period instead of firing LeaderResignedAnalyzer immediately on the
+// INELIGIBLE signal.
 //
-// The fake ruleStore is configured to fail observePosition the moment
-// pgctld.Stop has been called. If GracefulShutdown stops postgres before
-// announcing, observePosition fails and resignedLeaderAtTerm stays 0 — the
-// assertion that resignedLeaderAtTerm == primary_term would then fail.
-func TestGracefulShutdown_AnnouncesBeforeStop(t *testing.T) {
-	const primaryTerm int64 = 42
+// pgctld.Stop's callback captures the cohort eligibility state at the moment
+// of the call, so the assertion fails if the announce was sequenced after
+// the stop.
+func TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop(t *testing.T) {
+	pm := newGracefulShutdownTestManager(t, nil)
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	id := &clustermetadatapb.ID{
-		Component: clustermetadatapb.ID_MULTIPOOLER,
-		Cell:      "zone1",
-		Name:      "test",
-	}
-
-	// rules returns a position where this pooler is leader at term=primaryTerm,
-	// but only until pgctld.Stop is first called — afterwards observePosition
-	// fails, mirroring the "postgres is down" reality.
-	rules := &fakeRuleStore{
-		pos: &clustermetadatapb.PoolerPosition{
-			Rule: &clustermetadatapb.ShardRule{
-				LeaderId:   id,
-				RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: primaryTerm},
-			},
-		},
-	}
-
+	var atStopSignal clustermetadatapb.CohortEligibilitySignal
 	pgctld := &recordingPgctldClient{
 		stopFn: func(string) error {
-			// Simulate postgres going away: observePosition starts failing.
-			rules.mu.Lock()
-			rules.observeErr = errors.New("postgres unreachable: process stopped")
-			rules.mu.Unlock()
+			pm.mu.Lock()
+			atStopSignal = pm.cohortEligibility
+			pm.mu.Unlock()
 			return nil
 		},
 	}
-
-	pm := &MultiPoolerManager{
-		logger:         logger,
-		serviceID:      id,
-		config:         &Config{},
-		pgctldClient:   pgctld,
-		healthStreamer: newHealthStreamer(logger, id, "tg", "0"),
-		actionLock:     NewActionLock(),
-		consensusState: NewConsensusState(t.TempDir(), id),
-		rules:          rules,
-		record: newRecordFromProto(&clustermetadatapb.MultiPooler{
-			Id: id,
-			LifecycleStatus: &clustermetadatapb.PoolerLifecycle{
-				Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
-			},
-		}),
-	}
+	pm.pgctldClient = pgctld
 
 	pm.GracefulShutdown(context.Background())
 
 	require.Equal(t, []string{"fast"}, pgctld.modesCalled(),
 		"pgctld.Stop should have been called once (fast succeeded)")
+	require.Equal(t,
+		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		atStopSignal,
+		"cohort eligibility must be INELIGIBLE before pgctld.Stop runs; if it was "+
+			"the default ELIGIBLE, the announce was sequenced AFTER stop and the "+
+			"broadcast races stream EOF")
 
 	pm.mu.Lock()
-	got := pm.resignedLeaderAtTerm
+	finalSignal := pm.cohortEligibility
 	pm.mu.Unlock()
-	require.Equal(t, primaryTerm, got,
-		"resignedLeaderAtTerm must be set to the primary term; if 0, the announce was "+
-			"sequenced AFTER pgctld.Stop and observePosition failed for the dead postgres")
+	require.Equal(t,
+		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		finalSignal,
+		"cohort eligibility must remain INELIGIBLE after GracefulShutdown returns")
 }

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// fetchLeaderCohort calls Status on the current shard leader and returns the
+// names of recorded cohort members. Returns nil on any RPC failure so callers
+// can retry inside polling loops without a hard test failure.
+func fetchLeaderCohort(t *testing.T, setup *shardsetup.ShardSetup) []string {
+	t.Helper()
+	leader := setup.RefreshPrimary(t)
+	if leader == nil {
+		return nil
+	}
+	client, err := shardsetup.NewMultipoolerClient(leader.Multipooler.GrpcPort)
+	if err != nil {
+		return nil
+	}
+	defer client.Close()
+	resp, err := client.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+	if err != nil || resp == nil || resp.Status == nil {
+		return nil
+	}
+	names := make([]string, 0, len(resp.Status.CohortMembers))
+	for _, m := range resp.Status.CohortMembers {
+		names = append(names, m.Name)
+	}
+	return names
+}
+
+// waitForCohortMembership blocks until the leader's cohort matches the
+// expected set of pooler names (order-insensitive), or the timeout fires.
+// Compares by Name because each test setup uses a single cell with
+// uniquely-named poolers.
+func waitForCohortMembership(t *testing.T, setup *shardsetup.ShardSetup, expected []string, timeout time.Duration) {
+	t.Helper()
+	expectedSet := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		expectedSet[name] = struct{}{}
+	}
+	require.Eventually(t, func() bool {
+		members := fetchLeaderCohort(t, setup)
+		if len(members) != len(expected) {
+			return false
+		}
+		for _, m := range members {
+			if _, ok := expectedSet[m]; !ok {
+				return false
+			}
+		}
+		return true
+	}, timeout, 500*time.Millisecond,
+		"cohort never converged on %v", expected)
+}
+
+// TestCohortRotation_FullReplacement exercises a full rotation of the cohort:
+// expand from 3 to 5 poolers, then gracefully drain all 3 originals (primary
+// last). Verifies that writes through the multigateway continue to succeed
+// throughout, and that the final cohort consists only of the new poolers.
+//
+// This is the first e2e test of the cohort-INELIGIBLE-on-graceful-shutdown
+// path (CohortMismatchAnalyzer → ReconcileCohortAction REMOVE) and of
+// mid-cluster pooler join (CohortMismatchAnalyzer → ReconcileCohortAction
+// ADD), both of which have unit coverage but were not previously exercised
+// end-to-end.
+//
+// Why primary last: each follower drain doesn't trigger leader failover, so
+// chaining them is cheap. Draining the primary is the single failover event
+// in the test — running it after the cohort has already grown to 5 means
+// LeaderResignedAnalyzer can pick from the two new poolers as recruitment
+// candidates and the replacement is fast.
+func TestCohortRotation_FullReplacement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping integration test (no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.PrimaryName
+	require.NotEmpty(t, initialPrimary, "initial primary must be elected")
+
+	originals := make([]string, 0, 3)
+	for name := range setup.Multipoolers {
+		originals = append(originals, name)
+	}
+	require.Len(t, originals, 3)
+	waitForCohortMembership(t, setup, originals, 30*time.Second)
+	t.Logf("Initial cohort established: primary=%s, members=%v", initialPrimary, originals)
+
+	// Continuous writer through the multigateway. The gateway re-routes on
+	// failover, so the writer sees the rotation as (mostly) transparent
+	// availability.
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	gatewayDB, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer gatewayDB.Close()
+	require.NoError(t, gatewayDB.Ping(), "failed to ping multigateway")
+
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
+		shardsetup.WithWorkerCount(4),
+		shardsetup.WithWriteInterval(10*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(validatorCleanup)
+	validator.Start(t)
+	t.Logf("Continuous writer started (table=%s)", validator.TableName())
+
+	// Phase 1: expand cohort from 3 to 5.
+	newPoolerNames := []string{"new-0", "new-1"}
+	for _, name := range newPoolerNames {
+		grpcPort := utils.GetFreePort(t)
+		pgPort := utils.GetFreePort(t)
+		multipoolerPort := utils.GetFreePort(t)
+		inst := setup.CreateMultipoolerInstance(t, name, grpcPort, pgPort, multipoolerPort)
+
+		ctx := t.Context()
+		require.NoError(t, inst.Pgctld.Start(ctx, t),
+			"failed to start pgctld for %s", name)
+		require.NoError(t, inst.Multipooler.Start(ctx, t),
+			"failed to start multipooler for %s", name)
+		shardsetup.WaitForManagerReady(t, inst.Multipooler, nil)
+		t.Logf("New pooler %s started; awaiting cohort admission", name)
+	}
+
+	expectedAfterExpand := append(append([]string{}, originals...), newPoolerNames...)
+	// Generous timeout: the new pooler join path runs fix-replication
+	// (configure standby + base backup) and then cohort-add — both gated by
+	// multiorch's analyzer tick, plus actual WAL streaming setup time.
+	waitForCohortMembership(t, setup, expectedAfterExpand, 30*time.Second)
+	t.Logf("Cohort expanded to %v", expectedAfterExpand)
+
+	expandSuccess, expandFailed := validator.Stats()
+	t.Logf("After expand: %d successful, %d failed writes", expandSuccess, expandFailed)
+	require.Positive(t, expandSuccess, "writes should have accumulated during expand")
+
+	// Phase 2: drain originals, primary last.
+	drainOrder := make([]string, 0, len(originals))
+	for _, name := range originals {
+		if name != initialPrimary {
+			drainOrder = append(drainOrder, name)
+		}
+	}
+	drainOrder = append(drainOrder, initialPrimary)
+
+	remaining := append([]string{}, expectedAfterExpand...)
+	for _, name := range drainOrder {
+		t.Logf("Draining %s gracefully", name)
+		terminateMultipoolerGracefully(t, setup.Multipoolers[name], 20*time.Second)
+
+		// Remove the drained pooler from the expected set, then wait for the
+		// leader's cohort view to converge.
+		next := make([]string, 0, len(remaining)-1)
+		for _, candidate := range remaining {
+			if candidate != name {
+				next = append(next, candidate)
+			}
+		}
+		remaining = next
+		waitForCohortMembership(t, setup, remaining, 30*time.Second)
+		t.Logf("Cohort after draining %s: %v", name, remaining)
+	}
+
+	// Final cohort should be exactly the two new poolers.
+	require.ElementsMatch(t, newPoolerNames, remaining,
+		"final cohort should be exactly the new poolers")
+
+	// And the leader must be one of them — we drained the original primary
+	// last, so a successful failover puts a new pooler in the leader slot.
+	finalLeader := setup.RefreshPrimary(t)
+	require.NotNil(t, finalLeader, "a primary must remain after rotation")
+	require.Contains(t, newPoolerNames, finalLeader.Name,
+		"final primary should be one of the new poolers, got %s", finalLeader.Name)
+	t.Logf("Final primary: %s; final cohort: %v", finalLeader.Name, remaining)
+
+	// Stop writes and verify continuity. Some failures during the single
+	// leader-failover window are expected (writes in flight when the old
+	// primary is killed will fail), but a clean rotation should keep the
+	// failure rate well below 25%. A higher rate indicates the cohort
+	// dropped below quorum or the gateway took too long to reroute.
+	validator.Stop()
+	successful, failed := validator.Stats()
+	t.Logf("Final write stats: %d successful, %d failed", successful, failed)
+	require.Positive(t, successful, "expected successful writes throughout rotation")
+
+	total := successful + failed
+	failureRate := float64(failed) / float64(total)
+	assert.Less(t, failureRate, 0.25,
+		"write failure rate %.1f%% during rotation is too high; errors: %v",
+		failureRate*100, validator.FailedErrors())
+
+	// Sanity: the writes that the validator recorded as successful must be
+	// readable from the new cohort. Read from each surviving pooler since the
+	// validator records only what the gateway acknowledged.
+	finalClients := make([]*shardsetup.MultiPoolerTestClient, 0, len(newPoolerNames))
+	for _, name := range newPoolerNames {
+		addr := fmt.Sprintf("localhost:%d", setup.Multipoolers[name].Multipooler.GrpcPort)
+		client, err := shardsetup.NewMultiPoolerTestClient(addr)
+		require.NoError(t, err)
+		t.Cleanup(func() { client.Close() })
+		finalClients = append(finalClients, client)
+	}
+	require.NoError(t, validator.Verify(t, finalClients),
+		"successful writes must be readable from the new cohort")
+}

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -15,13 +15,9 @@
 package multiorch
 
 import (
-	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
-	_ "github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -81,14 +77,16 @@ func waitForCohortMembership(t *testing.T, setup *shardsetup.ShardSetup, expecte
 
 // TestCohortRotation_FullReplacement exercises a full rotation of the cohort:
 // expand from 3 to 5 poolers, then gracefully drain all 3 originals (primary
-// last). Verifies that writes through the multigateway continue to succeed
-// throughout, and that the final cohort consists only of the new poolers.
+// last). Verifies that membership transitions converge correctly at each step
+// and that the final cohort consists only of the new poolers, with one of
+// them elected as the new leader.
 //
 // This is the first e2e test of the cohort-INELIGIBLE-on-graceful-shutdown
 // path (CohortMismatchAnalyzer → ReconcileCohortAction REMOVE) and of
 // mid-cluster pooler join (CohortMismatchAnalyzer → ReconcileCohortAction
 // ADD), both of which have unit coverage but were not previously exercised
-// end-to-end.
+// end-to-end. Write-buffering during failover is covered by
+// TestDeadPrimaryRecovery and intentionally out of scope here.
 //
 // Why primary last: each follower drain doesn't trigger leader failover, so
 // chaining them is cheap. Draining the primary is the single failover event
@@ -106,7 +104,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	setup, cleanup := shardsetup.NewIsolated(t,
 		shardsetup.WithMultipoolerCount(3),
 		shardsetup.WithMultiOrchCount(1),
-		shardsetup.WithMultigateway(),
 		shardsetup.WithDatabase("postgres"),
 		shardsetup.WithCellName("test-cell"),
 	)
@@ -115,7 +112,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	setup.StartMultiOrchs(t.Context(), t)
 	setup.RequireRecovery(t, "multiorch", 30*time.Second)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
-	setup.WaitForMultigatewayQueryServing(t)
 
 	initialPrimary := setup.PrimaryName
 	require.NotEmpty(t, initialPrimary, "initial primary must be elected")
@@ -127,24 +123,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	require.Len(t, originals, 3)
 	waitForCohortMembership(t, setup, originals, 30*time.Second)
 	t.Logf("Initial cohort established: primary=%s, members=%v", initialPrimary, originals)
-
-	// Continuous writer through the multigateway. The gateway re-routes on
-	// failover, so the writer sees the rotation as (mostly) transparent
-	// availability.
-	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
-	gatewayDB, err := sql.Open("postgres", connStr)
-	require.NoError(t, err)
-	defer gatewayDB.Close()
-	require.NoError(t, gatewayDB.Ping(), "failed to ping multigateway")
-
-	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
-		shardsetup.WithWorkerCount(4),
-		shardsetup.WithWriteInterval(10*time.Millisecond),
-	)
-	require.NoError(t, err)
-	t.Cleanup(validatorCleanup)
-	validator.Start(t)
-	t.Logf("Continuous writer started (table=%s)", validator.TableName())
 
 	// Phase 1: expand cohort from 3 to 5.
 	newPoolerNames := []string{"new-0", "new-1"}
@@ -164,15 +142,11 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	}
 
 	expectedAfterExpand := append(append([]string{}, originals...), newPoolerNames...)
-	// Generous timeout: the new pooler join path runs fix-replication
-	// (configure standby + base backup) and then cohort-add — both gated by
-	// multiorch's analyzer tick, plus actual WAL streaming setup time.
-	waitForCohortMembership(t, setup, expectedAfterExpand, 30*time.Second)
+	// The new pooler join path runs fix-replication (configure standby + base
+	// backup) and then cohort-add — both gated by multiorch's analyzer tick,
+	// plus actual WAL streaming setup time.
+	waitForCohortMembership(t, setup, expectedAfterExpand, 60*time.Second)
 	t.Logf("Cohort expanded to %v", expectedAfterExpand)
-
-	expandSuccess, expandFailed := validator.Stats()
-	t.Logf("After expand: %d successful, %d failed writes", expandSuccess, expandFailed)
-	require.Positive(t, expandSuccess, "writes should have accumulated during expand")
 
 	// Phase 2: drain originals, primary last.
 	drainOrder := make([]string, 0, len(originals))
@@ -186,7 +160,17 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	remaining := append([]string{}, expectedAfterExpand...)
 	for _, name := range drainOrder {
 		t.Logf("Draining %s gracefully", name)
+		isPrimary := name == initialPrimary
 		terminateMultipoolerGracefully(t, setup.Multipoolers[name], 20*time.Second)
+
+		// Draining the primary triggers failover. Wait for the new leader to
+		// be elected before polling cohort membership, otherwise the cohort
+		// poll loop spends its budget seeing "no primary found" and times out
+		// before failover completes on slower runners.
+		if isPrimary {
+			newPrimary := shardsetup.WaitForNewPrimary(t, setup, name, 90*time.Second)
+			t.Logf("New primary elected after draining %s: %s", name, newPrimary)
+		}
 
 		// Remove the drained pooler from the expected set, then wait for the
 		// leader's cohort view to converge.
@@ -212,34 +196,4 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	require.Contains(t, newPoolerNames, finalLeader.Name,
 		"final primary should be one of the new poolers, got %s", finalLeader.Name)
 	t.Logf("Final primary: %s; final cohort: %v", finalLeader.Name, remaining)
-
-	// Stop writes and verify continuity. Some failures during the single
-	// leader-failover window are expected (writes in flight when the old
-	// primary is killed will fail), but a clean rotation should keep the
-	// failure rate well below 25%. A higher rate indicates the cohort
-	// dropped below quorum or the gateway took too long to reroute.
-	validator.Stop()
-	successful, failed := validator.Stats()
-	t.Logf("Final write stats: %d successful, %d failed", successful, failed)
-	require.Positive(t, successful, "expected successful writes throughout rotation")
-
-	total := successful + failed
-	failureRate := float64(failed) / float64(total)
-	assert.Less(t, failureRate, 0.25,
-		"write failure rate %.1f%% during rotation is too high; errors: %v",
-		failureRate*100, validator.FailedErrors())
-
-	// Sanity: the writes that the validator recorded as successful must be
-	// readable from the new cohort. Read from each surviving pooler since the
-	// validator records only what the gateway acknowledged.
-	finalClients := make([]*shardsetup.MultiPoolerTestClient, 0, len(newPoolerNames))
-	for _, name := range newPoolerNames {
-		addr := fmt.Sprintf("localhost:%d", setup.Multipoolers[name].Multipooler.GrpcPort)
-		client, err := shardsetup.NewMultiPoolerTestClient(addr)
-		require.NoError(t, err)
-		t.Cleanup(func() { client.Close() })
-		finalClients = append(finalClients, client)
-	}
-	require.NoError(t, validator.Verify(t, finalClients),
-		"successful writes must be readable from the new cohort")
 }

--- a/go/test/endtoend/multiorch/graceful_shutdown_test.go
+++ b/go/test/endtoend/multiorch/graceful_shutdown_test.go
@@ -30,10 +30,9 @@ import (
 
 // terminateMultipoolerGracefully sends SIGTERM to the multipooler binary (NOT
 // pgctld) and waits for it to exit. This drives the OnTermSync GracefulShutdown
-// hook end-to-end: pgctld.Stop (smart → fast → immediate escalation), and, for
-// the current leader, a LEADERSHIP_SIGNAL_REQUESTING_DEMOTION announcement on
-// the health stream. The OnClose chain that follows updates the topology entry
-// to PoolerType_DRAINED.
+// hook end-to-end: a COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE announcement on the
+// health stream and pgctld.Stop (fast → immediate escalation). The OnClose
+// chain that follows updates the topology entry to PoolerType_DRAINED.
 func terminateMultipoolerGracefully(t *testing.T, instance *shardsetup.MultipoolerInstance, timeout time.Duration) {
 	t.Helper()
 	require.NotNil(t, instance.Multipooler)
@@ -59,11 +58,12 @@ func terminateMultipoolerGracefully(t *testing.T, instance *shardsetup.Multipool
 
 // TestPrimaryGracefulShutdownTriggersFailover verifies the end-to-end
 // graceful-shutdown contract on the primary side: SIGTERM on the primary
-// produces an explicit REQUESTING_DEMOTION signal on the health stream, the
-// LeaderResignedAnalyzer fires, multiorch promotes a surviving standby, and
-// the terminated pooler's topology entry ends up as PoolerType_DRAINED. The
-// failover must happen quickly because resignation is an unambiguous signal —
-// no follower-disconnect grace period.
+// produces an explicit COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE signal on the
+// health stream, the LeaderResignedAnalyzer fires (via LeaderNeedsReplacement
+// treating INELIGIBLE as a resignation), multiorch promotes a surviving
+// standby, and the terminated pooler's topology entry ends up as
+// PoolerType_DRAINED. The failover must happen quickly because resignation
+// is an unambiguous signal — no follower-disconnect grace period.
 func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -86,10 +86,9 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// actually establish health streams to every pooler. The
 	// RequireRecovery-only gate is satisfied by topology state alone — it
 	// can return before the orchestrator has subscribed to the
-	// ManagerHealthStream, in which case the REQUESTING_DEMOTION snapshot
-	// our SIGTERM produces never reaches multiorch and failover falls back
-	// to the slow LeaderIsDeadAnalyzer path. The streams check closes that
-	// window.
+	// ManagerHealthStream, in which case the INELIGIBLE snapshot our SIGTERM
+	// produces never reaches multiorch and failover falls back to the slow
+	// LeaderIsDeadAnalyzer path. The streams check closes that window.
 	setup.RequireRecovery(t, "multiorch", 30*time.Second)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
@@ -116,10 +115,10 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	}()
 
 	// multiorch should elect a new primary quickly: LeaderResignedAnalyzer
-	// fires as soon as it sees REQUESTING_DEMOTION, then AppointLeaderAction
-	// (Recruit + Propose) runs on the surviving cohort — concurrently with
-	// the old primary's pgctld.Stop, because runFailover excludes the
-	// resigned pooler from the cohort before recruit.
+	// fires as soon as it sees INELIGIBLE on the leader, then
+	// AppointLeaderAction (Recruit + Propose) runs on the surviving cohort
+	// — concurrently with the old primary's pgctld.Stop, because runFailover
+	// excludes the resigned pooler from the cohort before recruit.
 	t.Logf("Waiting for multiorch to elect a new primary...")
 	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
 	elapsed := time.Since(start)
@@ -135,7 +134,7 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// the resigned pooler) would blow past 5s.
 	require.Less(t, elapsed, 5*time.Second,
 		"graceful primary replacement took %s (expected well under 5s); "+
-			"likely a regression in REQUESTING_DEMOTION delivery, LeaderResignedAnalyzer firing, "+
+			"likely a regression in INELIGIBLE delivery, LeaderResignedAnalyzer firing, "+
 			"or the appointment cohort still containing the resigned pooler", elapsed)
 
 	// Confirm the dying primary actually exited cleanly. Generous bound
@@ -171,11 +170,11 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 // a standby pooler does NOT cause spurious failover: the existing primary
 // stays primary, and the surviving standbys keep replicating from it.
 //
-// This is the role-symmetry property: the same shutdown sequence runs on
-// the standby (pgctld.Stop + exit), but because REQUESTING_DEMOTION is only
-// emitted by the current leader, the orchestrator's reaction is limited to
-// "stop trying to reconnect to the terminated standby" — no leader
-// appointment.
+// Even though the standby's GracefulShutdown advertises INELIGIBLE just like
+// the primary's does, INELIGIBLE on a non-leader doesn't trigger the
+// LeaderResignedAnalyzer (LeaderNeedsReplacement only fires for the current
+// leader). The orchestrator's reaction is limited to removing the terminated
+// standby from the cohort via ReconcileCohortAction — no leader appointment.
 func TestStandbyGracefulShutdownDoesNotTriggerFailover(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")


### PR DESCRIPTION
Replace the LEADERSHIP_SIGNAL_REQUESTING_DEMOTION announcement with COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE; multiorch's LeaderNeedsReplacement now treats an INELIGIBLE leader as needing replacement. REQUESTING_DEMOTION stays in place for Recruit's post-crash demote, where term correlation matters.