### PR TITLE
feat(multigres): surface progress and raise timeout for bootstrap wait

### DIFF
--- a/go/cmd/multigres/command/cluster/start.go
+++ b/go/cmd/multigres/command/cluster/start.go
@@ -19,10 +19,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/provisioner"
@@ -102,7 +104,7 @@ type gatewayProbeFunc func(ctx context.Context, host string, port int) error
 // func) so tests can swap it out without spinning up a real cluster.
 var runGatewayProbeFn = func(ctx context.Context, host string, port int, creds bootstrapCredentials) error {
 	connStr := fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=2",
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=1",
 		host, port, creds.user, creds.password, creds.database,
 	)
 	db, err := sql.Open("postgres", connStr)
@@ -116,6 +118,12 @@ var runGatewayProbeFn = func(ctx context.Context, host string, port int, creds b
 	_, err = db.ExecContext(probeCtx, "SELECT 1")
 	return err
 }
+
+// bootstrapHeartbeatInterval controls how often waitForGatewaysReady prints a
+// "still waiting" line when no gateway status has changed. It's a var (not a
+// constant) so tests can shrink it to avoid 30s real-time waits. Not
+// user-tunable via a flag.
+var bootstrapHeartbeatInterval = 30 * time.Second
 
 // ServiceInfo holds information about a provisioned service
 type ServiceInfo struct {
@@ -240,44 +248,143 @@ func collectGateways(results []*provisioner.ProvisionResult) []gatewayEndpoint {
 	return gws
 }
 
-// waitForGatewaysReady polls every gateway via probe until each succeeds
-// or ctx is cancelled. Each gateway is polled in its own goroutine.
-// Returns an error listing the gateways that never became ready by the
-// time ctx expires.
-func waitForGatewaysReady(ctx context.Context, gateways []gatewayEndpoint, probe gatewayProbeFunc) error {
-	ready := make([]bool, len(gateways))
-	var wg sync.WaitGroup
-	for i, gw := range gateways {
-		wg.Add(1)
-		go func(i int, gw gatewayEndpoint) {
-			defer wg.Done()
-			r := retry.New(constants.LocalGatewayBootstrapPollInterval, constants.LocalGatewayBootstrapPollInterval)
-			for _, err := range r.Attempts(ctx) {
-				if err != nil {
-					return
-				}
-				if err := probe(ctx, gw.host, gw.port); err == nil {
-					ready[i] = true
-					fmt.Printf("✅ - %s ready at %s:%d\n", gw.name, gw.host, gw.port)
-					return
-				}
-			}
-		}(i, gw)
-	}
-	wg.Wait()
+// gwStatus is the latest known readiness state of a single gateway, shared
+// between its probe goroutine (the writer) and the printer goroutine (the
+// reader) under a mutex.
+type gwStatus struct {
+	ready   bool   // probe has succeeded at least once
+	lastErr string // sanitized text of the most recent failed probe; shown only in the timeout summary
+}
 
+// sanitizeProbeErr renders a probe error as a single trimmed line so it fits on
+// one terminal row when included in the timeout summary.
+func sanitizeProbeErr(err error) string {
+	return strings.TrimSpace(strings.ReplaceAll(err.Error(), "\n", " "))
+}
+
+// progressPrinter owns all progress output for waitForGatewaysReady. Keeping
+// every write in one place (driven by a single goroutine) guarantees stdout
+// lines never interleave. It remembers what it last printed per gateway so it
+// emits each gateway's "waiting" and "ready" lines exactly once.
+type progressPrinter struct {
+	w            io.Writer
+	gateways     []gatewayEndpoint
+	printedReady []bool
+	printedWait  []bool
+	lastActivity time.Time // when we last printed anything
+}
+
+func newProgressPrinter(w io.Writer, gateways []gatewayEndpoint, start time.Time) *progressPrinter {
+	return &progressPrinter{
+		w:            w,
+		gateways:     gateways,
+		printedReady: make([]bool, len(gateways)),
+		printedWait:  make([]bool, len(gateways)),
+		lastActivity: start,
+	}
+}
+
+// renderChanges prints each gateway's state the first time it is seen: a
+// "waiting" line when a gateway is still pending, then a "ready" line once it
+// answers. Probe errors are intentionally not shown here — they only surface in
+// the timeout summary — so the live output stays terse.
+func (p *progressPrinter) renderChanges(snapshot []gwStatus) {
+	for i, gw := range p.gateways {
+		switch {
+		case snapshot[i].ready && !p.printedReady[i]:
+			p.printedReady[i] = true
+			fmt.Fprintf(p.w, "✅ - %s ready at %s:%d\n", gw.name, gw.host, gw.port)
+			p.lastActivity = time.Now()
+		case !snapshot[i].ready && !p.printedWait[i]:
+			p.printedWait[i] = true
+			fmt.Fprintf(p.w, "⏳ - waiting for %s at %s:%d to become available\n",
+				gw.name, gw.host, gw.port)
+			p.lastActivity = time.Now()
+		}
+	}
+}
+
+// renderHeartbeat prints a single "still waiting" line listing every pending
+// gateway, but only when nothing has been printed for at least
+// bootstrapHeartbeatInterval. This reassures the operator that a long-running,
+// unchanged wait hasn't hung.
+func (p *progressPrinter) renderHeartbeat(snapshot []gwStatus, elapsed time.Duration) {
+	if time.Since(p.lastActivity) < bootstrapHeartbeatInterval {
+		return
+	}
+	var pending []string
+	for i, gw := range p.gateways {
+		if snapshot[i].ready {
+			continue
+		}
+		pending = append(pending, fmt.Sprintf("%s (%s:%d)", gw.name, gw.host, gw.port))
+	}
+	if len(pending) == 0 {
+		return
+	}
+	fmt.Fprintf(p.w, "⏳ - Still waiting (%s elapsed): %s\n",
+		elapsed.Round(time.Second), strings.Join(pending, ", "))
+	p.lastActivity = time.Now()
+}
+
+// waitForGatewaysReady probes every gateway until each succeeds or ctx is
+// cancelled. Gateways are probed sequentially in a single goroutine: every
+// probe self-caps (LocalGatewayBootstrapProbeTimeout), so on localhost a full
+// cycle is fast and there's no need for concurrency, channels, or locks. The
+// printer runs inline, so progress lines never interleave. On success it prints
+// a summary line and returns nil; on ctx expiry it returns an error listing the
+// gateways that never became ready and how long it waited.
+func waitForGatewaysReady(ctx context.Context, w io.Writer, gateways []gatewayEndpoint, probe gatewayProbeFunc) error {
+	start := time.Now()
+	statuses := make([]gwStatus, len(gateways))
+	printer := newProgressPrinter(w, gateways, start)
+
+	r := retry.New(constants.LocalGatewayBootstrapPollInterval, constants.LocalGatewayBootstrapPollInterval)
+	for _, rerr := range r.Attempts(ctx) {
+		if rerr != nil {
+			break // ctx cancelled or timed out
+		}
+		allUp := true
+		for i, gw := range gateways {
+			if statuses[i].ready {
+				continue
+			}
+			if perr := probe(ctx, gw.host, gw.port); perr == nil {
+				statuses[i].ready = true
+			} else {
+				allUp = false
+				statuses[i].lastErr = sanitizeProbeErr(perr)
+			}
+		}
+		printer.renderChanges(statuses)
+		if allUp {
+			break
+		}
+		printer.renderHeartbeat(statuses, time.Since(start))
+	}
+
+	// On timeout the last probe error is the most useful diagnostic, so include
+	// it per pending gateway here even though the live progress lines omit it.
 	var pending []string
 	for i, gw := range gateways {
-		if !ready[i] {
+		if statuses[i].ready {
+			continue
+		}
+		if statuses[i].lastErr != "" {
+			pending = append(pending, fmt.Sprintf("%s (%s:%d, last error: %s)", gw.name, gw.host, gw.port, statuses[i].lastErr))
+		} else {
 			pending = append(pending, fmt.Sprintf("%s (%s:%d)", gw.name, gw.host, gw.port))
 		}
 	}
+
+	elapsed := time.Since(start).Round(time.Second)
 	if len(pending) > 0 {
 		return fmt.Errorf(
-			"cluster did not become ready to serve queries within %s; gateways not ready: %s. Check the multigateway and multipooler log files listed above for details",
-			constants.LocalBootstrapWaitTimeout, strings.Join(pending, ", "),
+			"cluster did not become ready to serve queries within %s; gateways not ready: %s. Check the multigateway and multipooler log files listed above for details (waited %s)",
+			constants.LocalBootstrapWaitTimeout, strings.Join(pending, ", "), elapsed,
 		)
 	}
+	fmt.Fprintf(w, "✅ - Cluster ready to serve queries (total wait: %s)\n", elapsed)
 	return nil
 }
 
@@ -356,7 +463,7 @@ func start(cmd *cobra.Command, args []string) error {
 		fmt.Printf("⏳ - Waiting up to %s for the cluster to start serving queries...\n", constants.LocalBootstrapWaitTimeout)
 		waitCtx, cancel := context.WithTimeout(ctx, constants.LocalBootstrapWaitTimeout)
 		defer cancel()
-		if err := waitForGatewaysReady(waitCtx, gateways, probe); err != nil {
+		if err := waitForGatewaysReady(waitCtx, os.Stdout, gateways, probe); err != nil {
 			return err
 		}
 	}

--- a/go/cmd/multigres/command/cluster/start_test.go
+++ b/go/cmd/multigres/command/cluster/start_test.go
@@ -15,10 +15,13 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -128,7 +131,7 @@ func TestWaitForGatewaysReady_AllReadyImmediately(t *testing.T) {
 		{name: "multigateway", host: "host-a", port: 6432},
 		{name: "multigateway", host: "host-b", port: 6433},
 	}
-	require.NoError(t, waitForGatewaysReady(context.Background(), gws, probe))
+	require.NoError(t, waitForGatewaysReady(context.Background(), io.Discard, gws, probe))
 }
 
 func TestWaitForGatewaysReady_BecomesReadyAfterRetries(t *testing.T) {
@@ -160,7 +163,7 @@ func TestWaitForGatewaysReady_BecomesReadyAfterRetries(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	require.NoError(t, waitForGatewaysReady(ctx, gws, probe))
+	require.NoError(t, waitForGatewaysReady(ctx, io.Discard, gws, probe))
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -181,11 +184,80 @@ func TestWaitForGatewaysReady_TimeoutReportsPending(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer cancel()
-	err := waitForGatewaysReady(ctx, gws, probe)
+	err := waitForGatewaysReady(ctx, io.Discard, gws, probe)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "host-b")
 	assert.Contains(t, err.Error(), "6433")
 	assert.NotContains(t, err.Error(), "host-a")
+	assert.Contains(t, err.Error(), "(waited ")
+	// The timeout summary surfaces the last probe error for each pending gateway.
+	assert.Contains(t, err.Error(), "last error: not ready")
+}
+
+func TestWaitForGatewaysReady_PrintsWaitingThenReadySummary(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	// Fail once (so the "waiting" line prints), then succeed.
+	probe := func(_ context.Context, _ string, _ int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return errors.New("connection refused")
+		}
+		return nil
+	}
+	gws := []gatewayEndpoint{{name: "multigateway", host: "host-a", port: 6432}}
+
+	var buf bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, waitForGatewaysReady(ctx, &buf, gws, probe))
+
+	out := buf.String()
+	assert.Contains(t, out, "⏳ - waiting for multigateway at host-a:6432 to become available")
+	assert.Contains(t, out, "✅ - multigateway ready at host-a:6432")
+	assert.Contains(t, out, "✅ - Cluster ready to serve queries (total wait: ")
+	// Per-gateway elapsed time is not shown; the probe error is not shown on a
+	// successful wait.
+	assert.NotContains(t, out, "(after")
+	assert.NotContains(t, out, "connection refused")
+}
+
+func TestWaitForGatewaysReady_HeartbeatListsPendingGateways(t *testing.T) {
+	restore := setBootstrapHeartbeatInterval(20 * time.Millisecond)
+	defer restore()
+
+	// host-a stays ready; host-b and host-c fail forever.
+	probe := func(_ context.Context, host string, _ int) error {
+		if host == "host-a" {
+			return nil
+		}
+		return errors.New("not ready")
+	}
+	gws := []gatewayEndpoint{
+		{name: "multigateway-1", host: "host-a", port: 6432},
+		{name: "multigateway-2", host: "host-b", port: 6433},
+		{name: "multigateway-3", host: "host-c", port: 6434},
+	}
+
+	var buf bytes.Buffer
+	// The heartbeat is checked once per (jittered, 0–1s) poll cycle, so span a
+	// few cycles to guarantee one fires while host-b/host-c stay pending. The
+	// 1s base/max poll delay means ~2–3 cycles land inside 2.5s.
+	ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+	defer cancel()
+	err := waitForGatewaysReady(ctx, &buf, gws, probe)
+	require.Error(t, err) // host-b and host-c never become ready
+
+	out := buf.String()
+	assert.Contains(t, out, "⏳ - Still waiting (")
+	assert.Contains(t, out, "multigateway-2 (host-b:6433)")
+	assert.Contains(t, out, "multigateway-3 (host-c:6434)")
+	// The ready gateway must not appear in the heartbeat's pending list.
+	assert.NotContains(t, out, "multigateway-1 (host-a:6432)")
 }
 
 func TestStartCommand_WaitForBootstrapFlagDefault(t *testing.T) {
@@ -286,6 +358,15 @@ func overrideRunGatewayProbe(fn func(context.Context, string, int, bootstrapCred
 	return func() { runGatewayProbeFn = prev }
 }
 
+// setBootstrapHeartbeatInterval shrinks the heartbeat interval for the
+// duration of a test and returns a restorer, so heartbeat behavior can be
+// exercised without 30s real-time waits.
+func setBootstrapHeartbeatInterval(d time.Duration) func() {
+	prev := bootstrapHeartbeatInterval
+	bootstrapHeartbeatInterval = d
+	return func() { bootstrapHeartbeatInterval = prev }
+}
+
 // fakeProvisioner is a stub Provisioner used only by start_test.go to drive
 // the start command without touching real services.
 type fakeProvisioner struct {
@@ -311,4 +392,87 @@ func (f *fakeProvisioner) ProvisionDatabase(_ context.Context, _ string, _ strin
 
 func (f *fakeProvisioner) DeprovisionDatabase(_ context.Context, _ string, _ string) error {
 	return nil
+}
+
+func TestSanitizeProbeErr_CollapsesNewlinesAndTrims(t *testing.T) {
+	err := errors.New("  dial error:\nconnection refused\n")
+	assert.Equal(t, "dial error: connection refused", sanitizeProbeErr(err))
+}
+
+func TestProgressPrinter_ReadyLinePrintsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	gws := []gatewayEndpoint{{name: "multigateway", host: "host-a", port: 6432}}
+	p := newProgressPrinter(&buf, gws, time.Now())
+
+	ready := []gwStatus{{ready: true}}
+	p.renderChanges(ready)
+	p.renderChanges(ready) // second call must not reprint
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "✅ - multigateway ready at host-a:6432"))
+	// Per-gateway elapsed time is intentionally not shown; only the overall
+	// total wait is reported in the final summary line.
+	assert.NotContains(t, out, "(after")
+}
+
+func TestProgressPrinter_WaitingLinePrintsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	gws := []gatewayEndpoint{{name: "multigateway", host: "host-a", port: 6432}}
+	p := newProgressPrinter(&buf, gws, time.Now())
+
+	// A gateway stays pending across several renders; the "waiting" line must
+	// print exactly once regardless of probe error churn (errors aren't shown).
+	for _, msg := range []string{"err A", "err A", "err B"} {
+		p.renderChanges([]gwStatus{{lastErr: msg}})
+	}
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "⏳ - waiting for multigateway at host-a:6432 to become available"))
+	assert.NotContains(t, out, "err A")
+	assert.NotContains(t, out, "err B")
+}
+
+func TestProgressPrinter_HeartbeatListsPending(t *testing.T) {
+	var buf bytes.Buffer
+	gws := []gatewayEndpoint{
+		{name: "multigateway-1", host: "host-a", port: 6432},
+		{name: "multigateway-2", host: "host-b", port: 6433},
+	}
+	start := time.Now()
+	p := newProgressPrinter(&buf, gws, start)
+	// Force the heartbeat to fire by pretending nothing was printed recently.
+	p.lastActivity = start.Add(-time.Hour)
+
+	// lastErr is set but must not leak into the heartbeat line.
+	snapshot := []gwStatus{
+		{lastErr: "connection refused"},
+		{lastErr: "no available multipoolers"},
+	}
+	p.renderHeartbeat(snapshot, 80*time.Second)
+
+	out := buf.String()
+	assert.Contains(t, out, "⏳ - Still waiting (1m20s elapsed):")
+	assert.Contains(t, out, "multigateway-1 (host-a:6432)")
+	assert.Contains(t, out, "multigateway-2 (host-b:6433)")
+	assert.NotContains(t, out, "connection refused")
+	assert.NotContains(t, out, "no available multipoolers")
+}
+
+func TestProgressPrinter_HeartbeatSuppressedWhenRecentlyPrinted(t *testing.T) {
+	var buf bytes.Buffer
+	gws := []gatewayEndpoint{{name: "multigateway", host: "host-a", port: 6432}}
+	p := newProgressPrinter(&buf, gws, time.Now())
+	// lastActivity is "now" (set by newProgressPrinter), so a heartbeat within
+	// the interval must produce no output.
+	p.renderHeartbeat([]gwStatus{{}}, 5*time.Second)
+	assert.Empty(t, buf.String())
+}
+
+func TestProgressPrinter_HeartbeatSkippedWhenAllReady(t *testing.T) {
+	var buf bytes.Buffer
+	gws := []gatewayEndpoint{{name: "multigateway", host: "host-a", port: 6432}}
+	p := newProgressPrinter(&buf, gws, time.Now())
+	p.lastActivity = time.Now().Add(-time.Hour) // would fire if anything pending
+	p.renderHeartbeat([]gwStatus{{ready: true}}, 90*time.Second)
+	assert.Empty(t, buf.String())
 }

--- a/go/common/constants/localprovisioner.go
+++ b/go/common/constants/localprovisioner.go
@@ -21,7 +21,7 @@ const (
 	// LocalBootstrapWaitTimeout bounds how long `multigres cluster start`
 	// waits for every multigateway to serve queries end-to-end before
 	// giving up.
-	LocalBootstrapWaitTimeout = 2 * time.Minute
+	LocalBootstrapWaitTimeout = 5 * time.Minute
 
 	// LocalGatewayBootstrapPollInterval is the delay between consecutive
 	// readiness probes against a single gateway. The retry package
@@ -29,7 +29,8 @@ const (
 	LocalGatewayBootstrapPollInterval = 1 * time.Second
 
 	// LocalGatewayBootstrapProbeTimeout bounds a single readiness probe
-	// (a `SELECT 1` through multigateway) so a hung connection cannot
-	// stall the wait loop.
-	LocalGatewayBootstrapProbeTimeout = 5 * time.Second
+	// (a `SELECT 1` through multigateway) so a hung gateway cannot stall the
+	// sequential wait loop. Kept short because probes target localhost, where
+	// a healthy gateway answers in milliseconds.
+	LocalGatewayBootstrapProbeTimeout = 1 * time.Second
 )


### PR DESCRIPTION
**If we can't reproduce local bootstrap timeouts soon, I'll close this.**

## Summary

- `multigres cluster start --wait-for-bootstrap` now prints per-gateway progress while it waits, so an operator can see whether a slow start is making progress, stuck, or about to time out — previously it printed nothing per gateway until success.
- Raises `LocalBootstrapWaitTimeout` from 2m to 5m for slower machines.
- Reports the total bootstrap wait time once on completion (success or timeout).

## Description

While waiting, each pending gateway prints a single `⏳ - waiting for multigateway at host:port to become available` line, then a `✅ - multigateway ready at host:port` line once it answers. A 30s heartbeat (`⏳ - Still waiting (… elapsed): …`) lists the still-pending gateways so an unchanged wait never looks hung. Probe errors are kept out of the live output and surfaced only in the timeout error, where the last error per pending gateway is the most useful diagnostic.

Gateways are probed sequentially in a single loop, with each probe self-capped at 1s (`LocalGatewayBootstrapProbeTimeout`, lowered from 5s). Since probes target localhost — where a healthy gateway answers in milliseconds — concurrency buys nothing, and a single inline printer keeps output from interleaving without locks, channels, or goroutines.

## Test plan

- [x] `go test ./go/cmd/multigres/command/cluster/...` passes, including with `-race -count=5` (no data races, no flakes across runs).
- New unit tests cover the printer rendering (waiting/ready lines printed once, heartbeat lists pending gateways without error text) and end-to-end behavior through `waitForGatewaysReady` (waiting→ready→summary, heartbeat firing, and the timeout summary including the last probe error).