### PR TITLE
test(parser): import deparser round-trip cases from pganalyze/libpg_query

### DIFF
--- a/go/common/parser/ast/advanced_statements.go
+++ b/go/common/parser/ast/advanced_statements.go
@@ -866,6 +866,27 @@ func (n *CommentStmt) SqlString() string {
 			parts = append(parts, "COMMENT ON CAST (", sourceType, "AS", targetType, ") IS")
 		}
 
+	case OBJECT_POLICY:
+		if nodeList, ok := n.Object.(*NodeList); ok && len(nodeList.Items) > 1 {
+			// The grammar appends the policy name to the table's any_name list,
+			// so the last item is the policy name and the preceding items are
+			// the (possibly schema-qualified) table name: "POLICY name ON table".
+			last := len(nodeList.Items) - 1
+			policyName := ""
+			var tableNameParts []string
+			for i, item := range nodeList.Items {
+				if str, ok := item.(*String); ok {
+					if i == last {
+						policyName = str.SVal
+					} else {
+						tableNameParts = append(tableNameParts, str.SVal)
+					}
+				}
+			}
+			tableName := FormatQualifiedName(tableNameParts...)
+			parts = append(parts, "COMMENT ON POLICY", QuoteIdentifier(policyName), "ON", tableName, "IS")
+		}
+
 	default:
 		// Regular format for other object types
 		objectName := formatObjectName(n.Object)

--- a/go/common/parser/ast/ddl_statements.go
+++ b/go/common/parser/ast/ddl_statements.go
@@ -1244,6 +1244,18 @@ func (c *Constraint) indexConstraintTail() string {
 	if c.Including != nil && c.Including.Len() > 0 {
 		result += " INCLUDE (" + strings.Join(nodeListToStrings(c.Including), ", ") + ")"
 	}
+	// WITH (reloptions) for the underlying index, e.g. UNIQUE (a) WITH (fillfactor=70).
+	if c.Options != nil && c.Options.Len() > 0 {
+		opts := make([]string, 0, c.Options.Len())
+		for _, item := range c.Options.Items {
+			if defElem, ok := item.(*DefElem); ok {
+				opts = append(opts, defElem.SqlString())
+			}
+		}
+		if len(opts) > 0 {
+			result += " WITH (" + strings.Join(opts, ", ") + ")"
+		}
+	}
 	if c.Indexname != "" {
 		result += " USING INDEX " + QuoteIdentifier(c.Indexname)
 	}
@@ -3152,10 +3164,25 @@ func (a *AlterExtensionContentsStmt) String() string {
 	return fmt.Sprintf("AlterExtensionContentsStmt(%s %s)@%d", a.Extname, action, a.Location())
 }
 
-// SqlString returns the SQL representation of AlterExtensionContentsStmt
+// identifierFromNode renders a node that names an identifier. A String node is
+// quoted as an identifier (not as a string literal); any other node falls back
+// to its own SqlString.
+func identifierFromNode(n Node) string {
+	if s, ok := n.(*String); ok {
+		return QuoteIdentifier(s.SVal)
+	}
+	return n.SqlString()
+}
+
+// SqlString returns the SQL representation of AlterExtensionContentsStmt.
+// Mirrors PostgreSQL's deparseAlterExtensionContentsStmt: the object type
+// keyword is emitted, then the member object is rendered according to its
+// grammar shape (a bare name, a qualified any_name, a function/operator with
+// argtypes, a type name, a cast, an operator class/family with USING, or a
+// transform).
 func (a *AlterExtensionContentsStmt) SqlString() string {
 	var parts []string
-	parts = append(parts, "ALTER EXTENSION", a.Extname)
+	parts = append(parts, "ALTER EXTENSION", QuoteIdentifier(a.Extname))
 
 	if a.Action {
 		parts = append(parts, "ADD")
@@ -3163,71 +3190,117 @@ func (a *AlterExtensionContentsStmt) SqlString() string {
 		parts = append(parts, "DROP")
 	}
 
-	// Add object type and handle special formatting cases
-	switch a.Objtype {
-	case int(OBJECT_AGGREGATE):
+	// Object type keyword.
+	switch ObjectType(a.Objtype) {
+	case OBJECT_ACCESS_METHOD:
+		parts = append(parts, "ACCESS METHOD")
+	case OBJECT_AGGREGATE:
 		parts = append(parts, "AGGREGATE")
-	case int(OBJECT_CAST):
+	case OBJECT_CAST:
 		parts = append(parts, "CAST")
-		// For CAST, the object is a NodeList with two TypeNames
-		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
-			parts = append(parts, "(", nodeList.Items[0].SqlString(), "AS", nodeList.Items[1].SqlString(), ")")
-			return strings.Join(parts, " ")
-		}
-	case int(OBJECT_DOMAIN):
+	case OBJECT_COLLATION:
+		parts = append(parts, "COLLATION")
+	case OBJECT_CONVERSION:
+		parts = append(parts, "CONVERSION")
+	case OBJECT_DOMAIN:
 		parts = append(parts, "DOMAIN")
-	case int(OBJECT_FUNCTION):
+	case OBJECT_FUNCTION:
 		parts = append(parts, "FUNCTION")
-	case int(OBJECT_OPCLASS):
+	case OBJECT_LANGUAGE:
+		parts = append(parts, "LANGUAGE")
+	case OBJECT_OPERATOR:
+		parts = append(parts, "OPERATOR")
+	case OBJECT_OPCLASS:
 		parts = append(parts, "OPERATOR CLASS")
-		// For OPERATOR CLASS, need to handle "name USING method" format
-		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
-			// First item is method name, rest are class name parts
-			methodStr := nodeList.Items[0].SqlString()
-			var nameStr strings.Builder
-			for i := 1; i < nodeList.Len(); i++ {
-				if i > 1 {
-					nameStr.WriteString(".")
-				}
-				nameStr.WriteString(nodeList.Items[i].SqlString())
-			}
-			parts = append(parts, nameStr.String(), "USING", methodStr)
-			return strings.Join(parts, " ")
-		}
-	case int(OBJECT_OPFAMILY):
+	case OBJECT_OPFAMILY:
 		parts = append(parts, "OPERATOR FAMILY")
-		// For OPERATOR FAMILY, need to handle "name USING method" format
-		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
-			// First item is method name, rest are family name parts
-			methodStr := nodeList.Items[0].SqlString()
-			var nameStr strings.Builder
-			for i := 1; i < nodeList.Len(); i++ {
-				if i > 1 {
-					nameStr.WriteString(".")
-				}
-				nameStr.WriteString(nodeList.Items[i].SqlString())
-			}
-			parts = append(parts, nameStr.String(), "USING", methodStr)
-			return strings.Join(parts, " ")
-		}
-	case int(OBJECT_PROCEDURE):
+	case OBJECT_PROCEDURE:
 		parts = append(parts, "PROCEDURE")
-	case int(OBJECT_ROUTINE):
+	case OBJECT_ROUTINE:
 		parts = append(parts, "ROUTINE")
-	case int(OBJECT_TYPE):
-		parts = append(parts, "TYPE")
-	case int(OBJECT_TABLE):
+	case OBJECT_SCHEMA:
+		parts = append(parts, "SCHEMA")
+	case OBJECT_EVENT_TRIGGER:
+		parts = append(parts, "EVENT TRIGGER")
+	case OBJECT_TABLE:
 		parts = append(parts, "TABLE")
-	case int(OBJECT_VIEW):
+	case OBJECT_TSPARSER:
+		parts = append(parts, "TEXT SEARCH PARSER")
+	case OBJECT_TSDICTIONARY:
+		parts = append(parts, "TEXT SEARCH DICTIONARY")
+	case OBJECT_TSTEMPLATE:
+		parts = append(parts, "TEXT SEARCH TEMPLATE")
+	case OBJECT_TSCONFIGURATION:
+		parts = append(parts, "TEXT SEARCH CONFIGURATION")
+	case OBJECT_SEQUENCE:
+		parts = append(parts, "SEQUENCE")
+	case OBJECT_VIEW:
 		parts = append(parts, "VIEW")
-	default:
-		// For other object types, use simple case conversion
-		parts = append(parts, "OBJECT")
+	case OBJECT_MATVIEW:
+		parts = append(parts, "MATERIALIZED VIEW")
+	case OBJECT_FOREIGN_TABLE:
+		parts = append(parts, "FOREIGN TABLE")
+	case OBJECT_FDW:
+		parts = append(parts, "FOREIGN DATA WRAPPER")
+	case OBJECT_FOREIGN_SERVER:
+		parts = append(parts, "SERVER")
+	case OBJECT_TRANSFORM:
+		parts = append(parts, "TRANSFORM")
+	case OBJECT_TYPE:
+		parts = append(parts, "TYPE")
 	}
 
-	// Add object name for simple cases (non-special formatting)
-	if a.Object != nil && a.Objtype != int(OBJECT_CAST) && a.Objtype != int(OBJECT_OPCLASS) && a.Objtype != int(OBJECT_OPFAMILY) {
-		parts = append(parts, a.Object.SqlString())
+	// Member object, rendered by its grammar shape.
+	switch ObjectType(a.Objtype) {
+	case OBJECT_COLLATION, OBJECT_CONVERSION, OBJECT_TABLE, OBJECT_TSPARSER,
+		OBJECT_TSDICTIONARY, OBJECT_TSTEMPLATE, OBJECT_TSCONFIGURATION,
+		OBJECT_SEQUENCE, OBJECT_VIEW, OBJECT_MATVIEW, OBJECT_FOREIGN_TABLE:
+		// any_name: a possibly-qualified name held as a NodeList of String parts.
+		if nodeList, ok := a.Object.(*NodeList); ok {
+			parts = append(parts, nodeListToQualifiedName(nodeList))
+		}
+	case OBJECT_ACCESS_METHOD, OBJECT_LANGUAGE, OBJECT_SCHEMA,
+		OBJECT_EVENT_TRIGGER, OBJECT_FDW, OBJECT_FOREIGN_SERVER:
+		// name: a single identifier held as a String node.
+		if s, ok := a.Object.(*String); ok {
+			parts = append(parts, QuoteIdentifier(s.SVal))
+		}
+	case OBJECT_AGGREGATE, OBJECT_FUNCTION, OBJECT_PROCEDURE, OBJECT_ROUTINE,
+		OBJECT_OPERATOR, OBJECT_DOMAIN, OBJECT_TYPE:
+		// ObjectWithArgs (aggregate/function/operator) or a TypeName
+		// (domain/type); both render themselves.
+		if a.Object != nil {
+			parts = append(parts, a.Object.SqlString())
+		}
+	case OBJECT_CAST:
+		// A NodeList of two TypeNames: (source AS target).
+		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
+			parts = append(parts, "(", nodeList.Items[0].SqlString(), "AS", nodeList.Items[1].SqlString(), ")")
+		}
+	case OBJECT_OPCLASS, OBJECT_OPFAMILY:
+		// A NodeList of [method, name parts...]; rendered as "name USING method".
+		// Every element is an identifier (the method name and the qualified
+		// class/family name parts), so each must be quoted as an identifier
+		// rather than rendered as a String literal.
+		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
+			methodStr := identifierFromNode(nodeList.Items[0])
+			var nameStr strings.Builder
+			for i := 1; i < nodeList.Len(); i++ {
+				if i > 1 {
+					nameStr.WriteString(".")
+				}
+				nameStr.WriteString(identifierFromNode(nodeList.Items[i]))
+			}
+			parts = append(parts, nameStr.String(), "USING", methodStr)
+		}
+	case OBJECT_TRANSFORM:
+		// A NodeList of [TypeName, language String]: "FOR <type> LANGUAGE <lang>".
+		if nodeList, ok := a.Object.(*NodeList); ok && nodeList.Len() >= 2 {
+			parts = append(parts, "FOR", nodeList.Items[0].SqlString())
+			if lang, ok := nodeList.Items[1].(*String); ok {
+				parts = append(parts, "LANGUAGE", QuoteIdentifier(lang.SVal))
+			}
+		}
 	}
 
 	return strings.Join(parts, " ")
@@ -4058,7 +4131,9 @@ func (c *CreatedbStmt) formatDatabaseOption(opt *DefElem) string {
 		}
 		return fmt.Sprintf("%s = %s", optName, argStr)
 	}
-	return optName
+	// A nil arg is the DEFAULT form (e.g. LOCATION DEFAULT, TABLESPACE DEFAULT);
+	// emit the keyword so the option re-parses as a valid createdb_opt_item.
+	return optName + " DEFAULT"
 }
 
 // DropdbStmt represents a DROP DATABASE statement.

--- a/go/common/parser/ast/ddl_statements.go
+++ b/go/common/parser/ast/ddl_statements.go
@@ -1859,6 +1859,10 @@ func (a *AlterTableCmd) SqlString() string {
 		parts = append(parts, "SET STATISTICS")
 		if a.Def != nil {
 			parts = append(parts, a.Def.SqlString())
+		} else {
+			// A nil value is the DEFAULT form (SET STATISTICS DEFAULT); the
+			// grammar's set_statistics_value maps DEFAULT to a nil node.
+			parts = append(parts, "DEFAULT")
 		}
 
 	case AT_SetExpression:

--- a/go/common/parser/ast/utility_statements.go
+++ b/go/common/parser/ast/utility_statements.go
@@ -1465,7 +1465,6 @@ func NewResetStmt(name string) *VariableSetStmt {
 	return NewVariableSetStmt(VAR_RESET, name, nil, false)
 }
 
-// SqlString returns the SQL representation of the SET statement
 // searchPathUsesSchemaForm reports whether a SET search_path can be rendered
 // with the idiomatic "SET SCHEMA <value>" syntax. That grammar production only
 // accepts a single string constant, so it applies only when there is exactly
@@ -1478,6 +1477,7 @@ func searchPathUsesSchemaForm(args *NodeList) bool {
 	return ok
 }
 
+// SqlString returns the SQL representation of the SET statement
 func (v *VariableSetStmt) SqlString() string {
 	var parts []string
 

--- a/go/common/parser/ast/utility_statements.go
+++ b/go/common/parser/ast/utility_statements.go
@@ -1466,6 +1466,18 @@ func NewResetStmt(name string) *VariableSetStmt {
 }
 
 // SqlString returns the SQL representation of the SET statement
+// searchPathUsesSchemaForm reports whether a SET search_path can be rendered
+// with the idiomatic "SET SCHEMA <value>" syntax. That grammar production only
+// accepts a single string constant, so it applies only when there is exactly
+// one argument and it is a String node.
+func searchPathUsesSchemaForm(args *NodeList) bool {
+	if args == nil || args.Len() != 1 {
+		return false
+	}
+	_, ok := args.Items[0].(*String)
+	return ok
+}
+
 func (v *VariableSetStmt) SqlString() string {
 	var parts []string
 
@@ -1487,9 +1499,11 @@ func (v *VariableSetStmt) SqlString() string {
 		case "catalog":
 			parts = append(parts, "CATALOG")
 		case "search_path":
-			// For single schema, use SET SCHEMA syntax (more idiomatic)
-			// For multiple schemas, use SET search_path = syntax
-			if v.Args != nil && v.Args.Len() == 1 {
+			// For a single *string* schema, use the idiomatic SET SCHEMA syntax.
+			// SET SCHEMA requires a string constant, so a non-string single
+			// value (e.g. SET search_path TO 10000) and the multi-value form
+			// both fall back to the generic search_path syntax.
+			if searchPathUsesSchemaForm(v.Args) {
 				parts = append(parts, "SCHEMA")
 			} else {
 				parts = append(parts, "search_path")
@@ -1523,7 +1537,7 @@ func (v *VariableSetStmt) SqlString() string {
 				v.Name == "client_encoding" || v.Name == "role" ||
 				v.Name == "session_authorization" || v.Name == "transaction_snapshot" ||
 				v.Name == "transaction_isolation" ||
-				(v.Name == "search_path" && v.Args != nil && v.Args.Len() == 1) {
+				(v.Name == "search_path" && searchPathUsesSchemaForm(v.Args)) {
 				// PostgreSQL-specific forms don't use = (e.g., SET TIME ZONE 'UTC', SET SCHEMA 'public')
 				var values []string
 				for _, arg := range v.Args.Items {

--- a/go/common/parser/parse_test.go
+++ b/go/common/parser/parse_test.go
@@ -493,6 +493,10 @@ func (s *parseTestSuite) TestParseDeparseRoundtrip() {
 	s.roundtripFile("ddl_cases.json")
 	s.roundtripFile("dml_cases.json")
 	s.roundtripFile("set_cases.json")
+	// deparse_cases.json is the curated deparse test corpus imported from
+	// pganalyze/libpg_query (test/deparse_tests.c). It targets deparser
+	// edge cases across statement types.
+	s.roundtripFile("deparse_cases.json")
 
 	postgresDir := "testdata/postgres"
 	files, err := os.ReadDir(postgresDir)

--- a/go/common/parser/parse_test.go
+++ b/go/common/parser/parse_test.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -111,34 +112,37 @@ func (s *parseTestSuite) testFile(filename string) {
 				secondParsedOutput, secondErr = getParserOutput(parsedOutput)
 			}
 
-			t.Run(testName, func(t *testing.T) {
-				defer func() {
-					// Use the actual output to store the files.
-					if current.Query != parsedOutput {
-						current.Expected = parsedOutput
-					} else {
-						current.Expected = ""
+			// Assertions are made with assert (non-fatal) inside the single
+			// per-file subtest rather than a t.Run per statement: the corpora
+			// hold tens of thousands of statements, and one subtest each
+			// overwhelms the CI test reporter. Each message names the query so
+			// failures are still identifiable.
+			if tcase.Error != "" {
+				assert.ErrorContainsf(t, err, tcase.Error, "case: %s", testName)
+			} else {
+				// We expect a successful parse.
+				if assert.NoErrorf(t, err, "case: %s", testName) {
+					assert.EqualValuesf(t, expectedQuery, parsedOutput, "case: %s", testName)
+					if assert.NoErrorf(t, secondErr, "re-parse failed\ncase: %s\nquery: %s", testName, tcase.Query) {
+						assert.EqualValuesf(t, expectedQuery, secondParsedOutput, "re-parse mismatch\ncase: %s\nquery: %s", testName, tcase.Query)
 					}
-					if err != nil {
-						current.Error = err.Error()
-					}
-					expected = append(expected, current)
-					if t.Failed() {
-						failed = true
-					}
-				}()
-
-				// Check if we expect an error
-				if tcase.Error != "" {
-					require.ErrorContains(t, err, tcase.Error)
-				} else {
-					// We expect a successful parse
-					require.NoError(t, err)
-					require.EqualValues(t, expectedQuery, parsedOutput)
-					require.NoError(t, secondErr, tcase.Query)
-					require.EqualValues(t, expectedQuery, secondParsedOutput, tcase.Query)
 				}
-			})
+			}
+
+			// Record the actual output so a failing run can rewrite the
+			// expectation file.
+			if current.Query != parsedOutput {
+				current.Expected = parsedOutput
+			} else {
+				current.Expected = ""
+			}
+			if err != nil {
+				current.Error = err.Error()
+			}
+			expected = append(expected, current)
+			if t.Failed() {
+				failed = true
+			}
 		}
 
 		// Write updated test file if there were failures
@@ -448,6 +452,11 @@ func deparseStmts(stmts []ast.Stmt) string {
 // the comparison.
 func (s *parseTestSuite) roundtripFile(filename string) {
 	s.T().Run(filename, func(t *testing.T) {
+		// Assertions use assert (non-fatal) within this single per-file subtest
+		// rather than a t.Run per statement: the corpora hold tens of thousands
+		// of statements, and a subtest each overwhelms the CI test reporter.
+		// Each message carries the query and its deparse so failures remain
+		// identifiable.
 		for _, tcase := range readJSONTests(filename) {
 			if tcase.Query == "" {
 				continue
@@ -460,24 +469,19 @@ func (s *parseTestSuite) roundtripFile(filename string) {
 				continue
 			}
 
-			testName := tcase.Comment
-			if testName == "" {
-				testName = tcase.Query
+			deparsed := deparseStmts(firstStmts)
+			secondStmts, err := ParseSQL(deparsed)
+			if !assert.NoErrorf(t, err,
+				"re-parsing the deparsed query failed\nquery:    %s\ndeparsed: %s",
+				tcase.Query, deparsed) {
+				continue
 			}
 
-			t.Run(testName, func(t *testing.T) {
-				deparsed := deparseStmts(firstStmts)
-				secondStmts, err := ParseSQL(deparsed)
-				require.NoError(t, err,
-					"re-parsing the deparsed query failed\nquery:    %s\ndeparsed: %s",
-					tcase.Query, deparsed)
-
-				canonicalizeStmts(firstStmts)
-				canonicalizeStmts(secondStmts)
-				require.Equal(t, firstStmts, secondStmts,
-					"AST changed after round-trip\nquery:    %s\ndeparsed: %s",
-					tcase.Query, deparsed)
-			})
+			canonicalizeStmts(firstStmts)
+			canonicalizeStmts(secondStmts)
+			assert.Equalf(t, firstStmts, secondStmts,
+				"AST changed after round-trip\nquery:    %s\ndeparsed: %s",
+				tcase.Query, deparsed)
 		}
 	})
 }
@@ -724,6 +728,11 @@ func (s *parseTestSuite) TestParseIdentifierRewriteRoundtrip() {
 // identifierRewriteFile runs the identifier-rewrite round-trip for one test file.
 func (s *parseTestSuite) identifierRewriteFile(filename string) {
 	s.T().Run(filename, func(t *testing.T) {
+		// Assertions use assert (non-fatal) within this single per-file subtest
+		// rather than a t.Run per statement: the corpora hold tens of thousands
+		// of statements, and a subtest each overwhelms the CI test reporter.
+		// Each message carries the query and its deparse so failures remain
+		// identifiable.
 		for _, tcase := range readJSONTests(filename) {
 			if tcase.Query == "" {
 				continue
@@ -736,30 +745,23 @@ func (s *parseTestSuite) identifierRewriteFile(filename string) {
 				continue
 			}
 
-			testName := tcase.Comment
-			if testName == "" {
-				testName = tcase.Query
+			rewritten := make([]ast.Stmt, len(stmts))
+			for i, stmt := range stmts {
+				rewritten[i] = rewriteIdentifiers(stmt)
 			}
 
-			t.Run(testName, func(t *testing.T) {
-				rewritten := make([]ast.Stmt, len(stmts))
-				for i, stmt := range stmts {
-					rewritten[i] = rewriteIdentifiers(stmt)
-				}
-
-				// We only assert that the deparsed SQL parses. We deliberately do
-				// not compare the re-parsed AST to the rewritten one: this test is
-				// about quoting identifiers in the right places, and the deparser is
-				// free to choose an equivalent spelling that re-parses to a slightly
-				// different (but valid) tree. AST round-trip fidelity is the job of
-				// TestParseDeparseRoundtrip. A parse error here means an identifier
-				// was emitted without the quoting its mangled form requires.
-				deparsed := deparseStmts(rewritten)
-				_, err := ParseSQL(deparsed)
-				require.NoError(t, err,
-					"re-parsing the identifier-mangled query failed — an identifier was deparsed without proper quoting\nquery:    %s\ndeparsed: %s",
-					tcase.Query, deparsed)
-			})
+			// We only assert that the deparsed SQL parses. We deliberately do
+			// not compare the re-parsed AST to the rewritten one: this test is
+			// about quoting identifiers in the right places, and the deparser is
+			// free to choose an equivalent spelling that re-parses to a slightly
+			// different (but valid) tree. AST round-trip fidelity is the job of
+			// TestParseDeparseRoundtrip. A parse error here means an identifier
+			// was emitted without the quoting its mangled form requires.
+			deparsed := deparseStmts(rewritten)
+			_, err = ParseSQL(deparsed)
+			assert.NoErrorf(t, err,
+				"re-parsing the identifier-mangled query failed — an identifier was deparsed without proper quoting\nquery:    %s\ndeparsed: %s",
+				tcase.Query, deparsed)
 		}
 	})
 }

--- a/go/common/parser/parse_test.go
+++ b/go/common/parser/parse_test.go
@@ -497,6 +497,11 @@ func (s *parseTestSuite) TestParseDeparseRoundtrip() {
 	// pganalyze/libpg_query (test/deparse_tests.c). It targets deparser
 	// edge cases across statement types.
 	s.roundtripFile("deparse_cases.json")
+	// deparse_complex_cases.json holds the complex/real-world query corpora
+	// imported from pganalyze/libpg_query 17-6.2.2 (test/sql/deparse and
+	// test/sql/deparse-depesz). They are pretty-printer fixtures upstream;
+	// here they exercise round-trip fidelity on large, realistic statements.
+	s.roundtripFile("deparse_complex_cases.json")
 
 	postgresDir := "testdata/postgres"
 	files, err := os.ReadDir(postgresDir)

--- a/go/common/parser/parse_test.go
+++ b/go/common/parser/parse_test.go
@@ -496,11 +496,13 @@ func (s *parseTestSuite) TestParseDeparseRoundtrip() {
 	// deparse_cases.json is the curated deparse test corpus imported from
 	// pganalyze/libpg_query (test/deparse_tests.c). It targets deparser
 	// edge cases across statement types.
+	// See testdata/THIRD_PARTY_NOTICES.md for source and license attribution.
 	s.roundtripFile("deparse_cases.json")
 	// deparse_complex_cases.json holds the complex/real-world query corpora
 	// imported from pganalyze/libpg_query 17-6.2.2 (test/sql/deparse and
 	// test/sql/deparse-depesz). They are pretty-printer fixtures upstream;
 	// here they exercise round-trip fidelity on large, realistic statements.
+	// See testdata/THIRD_PARTY_NOTICES.md for source and license attribution.
 	s.roundtripFile("deparse_complex_cases.json")
 
 	postgresDir := "testdata/postgres"

--- a/go/common/parser/testdata/THIRD_PARTY_NOTICES.md
+++ b/go/common/parser/testdata/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,132 @@
+# Third-Party Notices — Parser Test Data
+
+The SQL test corpora in this directory are derived from third-party open-source
+projects. The originals are redistributed (and, where noted, lightly transformed
+into JSON) under the licenses reproduced below. Each license's "retain the
+copyright notice, this list of conditions and the following disclaimer" clause is
+satisfied by this file.
+
+Transformations applied by the Multigres project are limited to: splitting source
+files into individual statements, normalizing whitespace, stripping comments, and
+recording the expected deparser output. The SQL statements themselves are
+unchanged in substance.
+
+## File provenance
+
+| File(s)                                                   | Upstream source                                                                                                                                                                 | License                  |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `deparse_cases.json`                                      | libpg_query `test/deparse_tests.c` (tags `17-6.1.0`, `17-6.2.2`); pg_query Ruby gem `spec/lib/pg_query/deparse_spec.rb`                                                         | BSD-3-Clause (pganalyze) |
+| `deparse_complex_cases.json` — `deparse/*` entries        | libpg_query `test/sql/deparse/*.sql` (tag `17-6.2.2`)                                                                                                                           | BSD-3-Clause (pganalyze) |
+| `deparse_complex_cases.json` — `deparse-depesz/*` entries | libpg_query `test/sql/deparse-depesz/**/*.psql` (tag `17-6.2.2`), based on depesz' pg-sql-prettyprinter                                                                         | BSD-3-Clause (depesz)    |
+| `postgres/*.json`                                         | PostgreSQL regression suite (`src/test/regress/sql/*.sql`, `src/pl/plpgsql/src/sql/*.sql`), obtained via libpg_query `test/sql/postgres_regress` and `test/sql/plpgsql_regress` | PostgreSQL License       |
+
+`convert_postgres_tests.py` is the conversion script used to produce the
+`postgres/*.json` files from upstream `.sql` sources.
+
+---
+
+## libpg_query / pg_query (pganalyze) — BSD-3-Clause
+
+Source: <https://github.com/pganalyze/libpg_query>, <https://github.com/pganalyze/pg_query>
+
+```text
+Copyright (c) 2015, Lukas Fittl <lukas@fittl.com>
+Copyright (c) 2016-2023, Duboce Labs, Inc. (pganalyze) <team@pganalyze.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the name of pg_query nor the names of its contributors may be used
+to endorse or promote products derived from this software without specific
+prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## depesz pg-sql-prettyprinter fixtures — BSD-3-Clause
+
+Source: <https://gitlab.com/depesz/pg-sql-prettyprinter/> (as vendored and modified
+in libpg_query `test/sql/deparse-depesz`)
+
+```text
+Copyright (c) 2022-2023, Hubert 'depesz' Lubaczewski <depesz@depesz.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## PostgreSQL regression suite — PostgreSQL License
+
+Source: <https://github.com/postgres/postgres> (`src/test/regress/sql`,
+`src/pl/plpgsql/src/sql`)
+
+```text
+PostgreSQL Database Management System
+(also known as Postgres, formerly known as Postgres95)
+
+Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN
+"AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+```

--- a/go/common/parser/testdata/deparse_cases.json
+++ b/go/common/parser/testdata/deparse_cases.json
@@ -1246,5 +1246,107 @@
   },
   {
     "query": "CREATE TABLE my_table (created_at int NOT NULL DEFAULT 1 + 2)"
+  },
+  {
+    "query": "SELECT (1 + 3)::int8"
+  },
+  {
+    "query": "ALTER TABLE a ALTER COLUMN b SET STATISTICS DEFAULT"
+  },
+  {
+    "query": "/* Comment 1 */ SELECT 1; /* Comment 2 */ SELECT 2"
+  },
+  {
+    "query": "SELECT memory_total_bytes, memory_swap_total_bytes - memory_swap_free_bytes AS swap, date_part($1, s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON snapshot_id = s.id WHERE s.database_id = $2 AND s.collected_at >= $3 AND s.collected_at <= $4 ORDER BY collected_at ASC"
+  },
+  {
+    "query": "SELECT 'a' INTERSECT SELECT 'b'"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y = z[$1]"
+  },
+  {
+    "query": "SELECT proname, (SELECT regexp_split_to_array(proargtypes::text, ' ') )[idx] AS argtype, proargnames[idx] AS argname FROM pg_proc"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y = z[$1][$2]"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = ALL($1)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = ANY($1)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = COALESCE(y, $1)"
+  },
+  {
+    "query": "SELECT $1::regclass"
+  },
+  {
+    "query": "SELECT 't'::boolean, 'f'::boolean"
+  },
+  {
+    "query": "UPDATE foo SET a = $1, b = $2"
+  },
+  {
+    "query": "SELECT a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(b))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))"
+  },
+  {
+    "query": "SELECT * FROM t0 JOIN t1 ON 1 JOIN t2 ON 1 JOIN t3 ON 1 JOIN t4 ON 1 JOIN t5 ON 1 JOIN t6 ON 1 JOIN t7 ON 1 JOIN t8 ON 1 JOIN t9 ON 1 JOIN t10 ON 1 JOIN t11 ON 1 JOIN t12 ON 1 JOIN t13 ON 1 JOIN t14 ON 1 JOIN t15 ON 1 JOIN t16 ON 1 JOIN t17 ON 1 JOIN t18 ON 1 JOIN t19 ON 1 JOIN t20 ON 1 JOIN t21 ON 1 JOIN t22 ON 1 JOIN t23 ON 1 JOIN t24 ON 1 JOIN t25 ON 1 JOIN t26 ON 1 JOIN t27 ON 1 JOIN t28 ON 1 JOIN t29 ON 1"
+  },
+  {
+    "query": "SELECT ARRAY[department, sub] AS row_cols, role, COUNT(id) FROM users GROUP BY department, role ORDER BY department, roleVALUES (admin::text), (ordinary::text)"
+  },
+  {
+    "query": "WITH moved AS ( DELETE FROM employees WHERE manager_name = 'Mary' ) INSERT INTO employees_of_mary SELECT * FROM moved"
+  },
+  {
+    "query": "WITH archived AS ( DELETE FROM employees WHERE manager_name = 'Mary' ) UPDATE users SET archived = true WHERE users.id IN (SELECT user_id FROM moved)"
+  },
+  {
+    "query": "WITH archived AS ( DELETE FROM employees WHERE manager_name = 'Mary' RETURNING user_id ) UPDATE users SET archived = true FROM archived WHERE archived.user_id = id RETURNING id"
+  },
+  {
+    "query": "WITH archived AS ( DELETE FROM employees WHERE manager_name = 'Mary' ) DELETE FROM users WHERE users.id IN (SELECT user_id FROM moved)"
+  },
+  {
+    "query": "CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$ SELECT * FROM \"users\" WHERE users.id = $1; $$ LANGUAGE sql"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$ SELECT * FROM \"users\" WHERE users.id = $1; $$ LANGUAGE sql"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$ SELECT * FROM \"users\" WHERE users.id = $1; $$ LANGUAGE sql IMMUTABLE"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$ SELECT * FROM \"users\" WHERE users.id = $1; $$ LANGUAGE sql IMMUTABLE RETURNS NULL ON NULL INPUT"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$ SELECT * FROM \"users\" WHERE users.id = $1; $$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo() RETURNS text AS $$ SELECT name FROM \"users\" LIMIT 1 $$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT"
+  },
+  {
+    "query": "CREATE UNLOGGED TABLE cities ( name text, population real, altitude double, identifier smallint, postal_code int, foreign_id bigint )"
+  },
+  {
+    "query": "CREATE TABLE IF NOT EXISTS distributors ( name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, \"time\" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len) )"
+  },
+  {
+    "query": "CREATE TABLE types (a float(2), b float(49), c NUMERIC(2, 3), d character(4), e char(5), f varchar(6), g character varying(7))"
+  },
+  {
+    "query": "CREATE TABLE types (a geometry(point) not null)"
+  },
+  {
+    "query": "CREATE TABLE tablename ( colname int NOT NULL DEFAULT nextval('tablename_colname_seq') )"
+  },
+  {
+    "query": "CREATE TABLE capitals ( state char(2) ) INHERITS (cities)"
+  },
+  {
+    "query": "SET SESSION search_path TO 10000"
   }
 ]

--- a/go/common/parser/testdata/deparse_cases.json
+++ b/go/common/parser/testdata/deparse_cases.json
@@ -1,1 +1,1250 @@
-null
+[
+  {
+    "query": "SELECT 1"
+  },
+  {
+    "query": "SELECT 1; SELECT 2"
+  },
+  {
+    "query": "SELECT 1 FROM t(1)"
+  },
+  {
+    "query": "SELECT sum(unique1) FILTER (WHERE unique1 IN (SELECT unique1 FROM onek WHERE unique1 < 100)) FROM tenk1"
+  },
+  {
+    "query": "SELECT a AS b FROM x WHERE y = 5 AND z = y"
+  },
+  {
+    "query": "SELECT FROM x WHERE y = 5 AND z = y"
+  },
+  {
+    "query": "SELECT a AS b FROM public.x WHERE y = 5 AND z = y"
+  },
+  {
+    "query": "SELECT DISTINCT a, b, * FROM c WHERE d = e"
+  },
+  {
+    "query": "SELECT DISTINCT ON (a) a, b FROM c"
+  },
+  {
+    "query": "SELECT * INTO films_recent FROM films WHERE date_prod >= '2002-01-01'"
+  },
+  {
+    "query": "SELECT current_timestamp"
+  },
+  {
+    "query": "SELECT current_time(2)"
+  },
+  {
+    "query": "SELECT memory_total_bytes, memory_swap_total_bytes - memory_swap_free_bytes AS swap, date_part('year', s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON snapshot_id = s.id WHERE s.database_id = 23 AND s.collected_at >= 90 AND s.collected_at <= 160 ORDER BY collected_at ASC"
+  },
+  {
+    "query": "SELECT * FROM a ORDER BY x ASC NULLS FIRST"
+  },
+  {
+    "query": "SELECT * FROM a ORDER BY x ASC NULLS LAST"
+  },
+  {
+    "query": "SELECT * FROM a ORDER BY x COLLATE \"tr_TR\" DESC NULLS LAST"
+  },
+  {
+    "query": "SELECT 'foo' COLLATE \"tr_TR\""
+  },
+  {
+    "query": "WITH kodsis AS (SELECT * FROM application), kodsis2 AS (SELECT * FROM application) SELECT * FROM kodsis UNION SELECT * FROM kodsis ORDER BY id DESC"
+  },
+  {
+    "query": "SELECT id, name FROM table1 UNION (SELECT id, name FROM table2 ORDER BY name) ORDER BY id ASC"
+  },
+  {
+    "query": "SELECT a FROM kodsis EXCEPT SELECT a FROM application"
+  },
+  {
+    "query": "SELECT * FROM (VALUES ('anne', 'smith'), ('bob', 'jones'), ('joe', 'blow')) names(first, last)"
+  },
+  {
+    "query": "SELECT * FROM users WHERE name LIKE 'postgresql:%'"
+  },
+  {
+    "query": "SELECT * FROM users WHERE name NOT LIKE 'postgresql:%'"
+  },
+  {
+    "query": "SELECT * FROM users WHERE name ILIKE 'postgresql:%'"
+  },
+  {
+    "query": "SELECT * FROM users WHERE name NOT ILIKE 'postgresql:%'"
+  },
+  {
+    "query": "WITH t AS (SELECT random() AS x FROM generate_series(1, 3)) SELECT * FROM t"
+  },
+  {
+    "query": "WITH RECURSIVE search_graph(id, link, data, depth, path, cycle) AS (SELECT g.id, g.link, g.data, 1, ARRAY[ROW(g.f1, g.f2)], false FROM graph g UNION ALL SELECT g.id, g.link, g.data, sg.depth + 1, path || ROW(g.f1, g.f2), ROW(g.f1, g.f2) = ANY(path) FROM graph g, search_graph sg WHERE g.id = sg.link AND NOT cycle) SELECT id, data, link FROM search_graph"
+  },
+  {
+    "query": "SELECT OVERLAY(m.name PLACING '******' FROM 3 FOR 6) AS tc_kimlik FROM tb_test m"
+  },
+  {
+    "query": "SELECT sum(price_cents) FROM products"
+  },
+  {
+    "query": "SELECT ARRAY(SELECT id FROM products)::bigint[]"
+  },
+  {
+    "query": "SELECT m.name AS mname, pname FROM manufacturers m, LATERAL get_product_names(m.id) pname"
+  },
+  {
+    "query": "SELECT m.name AS mname, pname FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true"
+  },
+  {
+    "query": "SELECT * FROM tb_test_main mh JOIN LATERAL (SELECT ftnrm.* FROM test ftnrm WHERE ftnrm.hizmet_id = mh.id UNION ALL SELECT ftarc.* FROM test.test2 ftarc WHERE ftarc.hizmet_id = mh.id) ft ON true"
+  },
+  {
+    "query": "SELECT x, y FROM a CROSS JOIN b"
+  },
+  {
+    "query": "SELECT x, y FROM a NATURAL JOIN b"
+  },
+  {
+    "query": "SELECT x, y FROM a LEFT JOIN b ON 1 > 0"
+  },
+  {
+    "query": "SELECT x, y FROM a RIGHT JOIN b ON 1 > 0"
+  },
+  {
+    "query": "SELECT x, y FROM a FULL JOIN b ON 1 > 0"
+  },
+  {
+    "query": "SELECT x, y FROM a JOIN b USING (z)"
+  },
+  {
+    "query": "SELECT 2 + 2"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS NULL"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS NOT NULL"
+  },
+  {
+    "query": "SELECT count(*) FROM x WHERE y IS NOT NULL"
+  },
+  {
+    "query": "SELECT count(DISTINCT a) FROM x WHERE y IS NOT NULL"
+  },
+  {
+    "query": "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' END FROM accounts a"
+  },
+  {
+    "query": "SELECT CASE 1 > 0 WHEN true THEN 'ok' ELSE NULL END"
+  },
+  {
+    "query": "SELECT CASE WHEN a.status = 1 THEN 'active' WHEN a.status = 2 THEN 'inactive' ELSE 'unknown' END FROM accounts a"
+  },
+  {
+    "query": "SELECT * FROM accounts WHERE status = CASE WHEN x = 1 THEN 'active' ELSE 'inactive' END"
+  },
+  {
+    "query": "SELECT CASE WHEN EXISTS (SELECT 1) THEN 1 ELSE 2 END"
+  },
+  {
+    "query": "SELECT (SELECT 'x')"
+  },
+  {
+    "query": "SELECT * FROM (SELECT generate_series(0, 100)) a"
+  },
+  {
+    "query": "SELECT * FROM x WHERE id IN (1, 2, 3)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE id IN (SELECT id FROM account)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE id NOT IN (1, 2, 3)"
+  },
+  {
+    "query": "SELECT * FROM x JOIN (SELECT n FROM z) b ON a.id = b.id"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y = z[5]"
+  },
+  {
+    "query": "SELECT (foo(1)).y"
+  },
+  {
+    "query": "SELECT proname, (SELECT regexp_split_to_array(proargtypes::text, ' '))[idx] AS argtype, proargnames[idx] AS argname FROM pg_proc"
+  },
+  {
+    "query": "SELECT COALESCE((SELECT customer.sp_person(n.id) AS sp_person).city_id, NULL::int) AS city_id FROM customer.tb_customer n"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y = z[1][4]"
+  },
+  {
+    "query": "SELECT (k #= hstore('{id}'::text[], ARRAY[1::text])).* FROM test k"
+  },
+  {
+    "query": "SELECT * FROM x WHERE NOT y"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x OR y"
+  },
+  {
+    "query": "SELECT 1 WHERE (1 = 1 OR 1 = 2) AND 1 = 2"
+  },
+  {
+    "query": "SELECT 1 WHERE (1 = 1 AND 2 = 2) OR 2 = 3"
+  },
+  {
+    "query": "SELECT 1 WHERE 1 = 1 OR 2 = 2 OR 2 = 3"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = ALL (SELECT x FROM y WHERE z = 20)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = ANY (SELECT x FROM y WHERE z = 20)"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x = COALESCE(y, z)"
+  },
+  {
+    "query": "SELECT a, b, max(c) FROM c WHERE d = 1 GROUP BY a, b"
+  },
+  {
+    "query": "SELECT * FROM x LIMIT 50"
+  },
+  {
+    "query": "SELECT * FROM x OFFSET 50"
+  },
+  {
+    "query": "SELECT amount * 0.5"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x BETWEEN '2016-01-01' AND '2016-02-02'"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x NOT BETWEEN '2016-01-01' AND '2016-02-02'"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x BETWEEN SYMMETRIC 20 AND 10"
+  },
+  {
+    "query": "SELECT * FROM x WHERE x NOT BETWEEN SYMMETRIC 20 AND 10"
+  },
+  {
+    "query": "SELECT NULLIF(id, 0) AS id FROM x"
+  },
+  {
+    "query": "SELECT NULL FROM x"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS TRUE"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS NOT TRUE"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS FALSE"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS NOT FALSE"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS UNKNOWN"
+  },
+  {
+    "query": "SELECT * FROM x WHERE y IS NOT UNKNOWN"
+  },
+  {
+    "query": "SELECT * FROM crosstab('SELECT department, role, COUNT(id) FROM users GROUP BY department, role ORDER BY department, role', 'VALUES (''admin''::text), (''ordinary''::text)') AS (department varchar, admin int, ordinary int)"
+  },
+  {
+    "query": "SELECT * FROM crosstab('SELECT department, role, COUNT(id) FROM users GROUP BY department, role ORDER BY department, role', 'VALUES (''admin''::text), (''ordinary''::text)') ctab (department varchar, admin int, ordinary int)"
+  },
+  {
+    "query": "SELECT row_cols[0] AS dept, row_cols[1] AS sub, admin, ordinary FROM crosstab('SELECT ARRAY[department, sub] AS row_cols, role, COUNT(id) FROM users GROUP BY department, role ORDER BY department, role', 'VALUES (''admin''::text), (''ordinary''::text)') AS (row_cols varchar[], admin int, ordinary int)"
+  },
+  {
+    "query": "SELECT 1::int8"
+  },
+  {
+    "query": "SELECT CAST(1 + 3 AS int8)"
+  },
+  {
+    "query": "SELECT x::regclass"
+  },
+  {
+    "query": "SELECT table_field::bool, table_field::boolean FROM t"
+  },
+  {
+    "query": "SELECT true, false"
+  },
+  {
+    "query": "SELECT 1::boolean, 0::boolean"
+  },
+  {
+    "query": "SELECT $5"
+  },
+  {
+    "query": "INSERT INTO x (y, z) VALUES (1, 'abc')"
+  },
+  {
+    "query": "INSERT INTO x (\"user\") VALUES ('abc')"
+  },
+  {
+    "query": "INSERT INTO x (y, z) VALUES (1, 'abc') RETURNING id"
+  },
+  {
+    "query": "INSERT INTO x SELECT * FROM y"
+  },
+  {
+    "query": "WITH moved AS (DELETE FROM employees WHERE manager_name = 'Mary') INSERT INTO employees_of_mary SELECT * FROM moved"
+  },
+  {
+    "query": "INSERT INTO x (y, z) VALUES (1, 'abc') ON CONFLICT (y) DO UPDATE SET \"user\" = excluded.\"user\" RETURNING y"
+  },
+  {
+    "query": "INSERT INTO x (y, z) VALUES (1, 'abc') ON CONFLICT (y) DO NOTHING RETURNING y"
+  },
+  {
+    "query": "INSERT INTO distributors (did, dname) VALUES (10, 'Conrad International') ON CONFLICT (did) WHERE is_active DO NOTHING"
+  },
+  {
+    "query": "INSERT INTO distributors (did, dname) VALUES (9, 'Antwerp Design') ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING"
+  },
+  {
+    "query": "INSERT INTO foo (a, b, c, d) VALUES ($1) ON CONFLICT (id) DO UPDATE SET (a, b, c, d) = (excluded.a, excluded.b, excluded.c, CASE WHEN foo.d = excluded.d THEN excluded.d END)"
+  },
+  {
+    "query": "INSERT INTO employees SELECT * FROM people WHERE 1 = 1 GROUP BY name HAVING count(name) > 1 ORDER BY name DESC LIMIT 10 OFFSET 15 FOR UPDATE"
+  },
+  {
+    "query": "INSERT INTO films VALUES ('T_601', 'Yojimbo', 106, DEFAULT, 'Drama', DEFAULT)"
+  },
+  {
+    "query": "SELECT * FROM people FOR UPDATE OF name, email"
+  },
+  {
+    "query": "SELECT name::varchar(255) FROM people"
+  },
+  {
+    "query": "SELECT name::varchar FROM people"
+  },
+  {
+    "query": "SELECT age::numeric(5, 2) FROM people"
+  },
+  {
+    "query": "SELECT age::numeric FROM people"
+  },
+  {
+    "query": "UPDATE x SET y = 1 WHERE z = 'abc'"
+  },
+  {
+    "query": "UPDATE ONLY x table_x SET y = 1 WHERE z = 'abc' RETURNING y AS changed_y"
+  },
+  {
+    "query": "WITH archived AS (DELETE FROM employees WHERE manager_name = 'Mary') UPDATE users SET archived = true WHERE users.id IN (SELECT user_id FROM moved)"
+  },
+  {
+    "query": "WITH archived AS (DELETE FROM employees WHERE manager_name = 'Mary' RETURNING user_id) UPDATE users SET archived = true FROM archived WHERE archived.user_id = id RETURNING id"
+  },
+  {
+    "query": "INSERT INTO jackdanger_card_totals (id, amount_cents, created_at) SELECT series.i, random() * 1000, (SELECT '2015-08-25 00:00:00 -0700'::timestamp + (('2015-08-25 23:59:59 -0700'::timestamp - '2015-08-25 00:00:00 -0700'::timestamp) * random())) FROM generate_series(1, 10000) series(i)"
+  },
+  {
+    "query": "UPDATE foo SET a = 24, b = true"
+  },
+  {
+    "query": "UPDATE x SET \"user\" = 'emin'"
+  },
+  {
+    "query": "DELETE FROM x WHERE y = 1"
+  },
+  {
+    "query": "DELETE FROM ONLY x table_x USING table_z WHERE y = 1 RETURNING *"
+  },
+  {
+    "query": "WITH archived AS (DELETE FROM employees WHERE manager_name = 'Mary') DELETE FROM users WHERE users.id IN (SELECT user_id FROM moved)"
+  },
+  {
+    "query": "CREATE CAST (bigint AS int4) WITH FUNCTION int4(bigint) AS ASSIGNMENT"
+  },
+  {
+    "query": "CREATE CAST (bigint AS int4) WITHOUT FUNCTION AS IMPLICIT"
+  },
+  {
+    "query": "CREATE CAST (bigint AS int4) WITH INOUT AS ASSIGNMENT"
+  },
+  {
+    "query": "CREATE DOMAIN us_postal_code AS text CHECK (\"VALUE\" ~ E'^\\\\d{5}$' OR \"VALUE\" ~ E'^\\\\d{5}-\\\\d{4}$')"
+  },
+  {
+    "query": "CREATE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \"users\" WHERE users.id = $1;$$ LANGUAGE sql"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \"users\" WHERE users.id = $1;$$ LANGUAGE sql"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \"users\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \"users\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE RETURNS NULL ON NULL INPUT"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo(int) RETURNS SETOF users AS $$SELECT * FROM \"users\" WHERE users.id = $1;$$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT"
+  },
+  {
+    "query": "CREATE OR REPLACE FUNCTION getfoo() RETURNS text AS $$SELECT name FROM \"users\" LIMIT 1$$ LANGUAGE sql IMMUTABLE CALLED ON NULL INPUT"
+  },
+  {
+    "query": "CREATE SCHEMA myschema"
+  },
+  {
+    "query": "CREATE SCHEMA AUTHORIZATION joe"
+  },
+  {
+    "query": "CREATE SCHEMA IF NOT EXISTS test AUTHORIZATION joe"
+  },
+  {
+    "query": "CREATE SCHEMA hollywood CREATE TABLE films (title text, release date, awards text[]) CREATE VIEW winners AS SELECT title, release FROM films WHERE awards IS NOT NULL"
+  },
+  {
+    "query": "CREATE UNLOGGED TABLE cities (name text, population real, altitude double, identifier smallint, postal_code int, foreign_id bigint)"
+  },
+  {
+    "query": "CREATE TABLE IF NOT EXISTS distributors (name varchar(40) DEFAULT 'Luso Films', len interval hour to second(3), name varchar(40) DEFAULT 'Luso Films', did int DEFAULT nextval('distributors_serial'), stamp timestamp DEFAULT now() NOT NULL, stamptz timestamp with time zone, \"time\" time NOT NULL, timetz time with time zone, CONSTRAINT name_len PRIMARY KEY (name, len))"
+  },
+  {
+    "query": "CREATE TABLE types (a real, b double precision, c numeric(2, 3), d char(4), e char(5), f varchar(6), g varchar(7))"
+  },
+  {
+    "query": "CREATE TABLE types (a geometry(point) NOT NULL)"
+  },
+  {
+    "query": "CREATE TABLE tablename (colname int NOT NULL DEFAULT nextval('tablename_colname_seq'))"
+  },
+  {
+    "query": "CREATE TABLE capitals (state char(2)) INHERITS (cities)"
+  },
+  {
+    "query": "CREATE TEMPORARY TABLE temp AS SELECT c FROM t"
+  },
+  {
+    "query": "CREATE TABLE films2 AS SELECT * FROM films"
+  },
+  {
+    "query": "CREATE TEMPORARY TABLE films_recent ON COMMIT DROP AS SELECT * FROM films WHERE date_prod > $1"
+  },
+  {
+    "query": "DROP SERVER IF EXISTS foo"
+  },
+  {
+    "query": "DROP PUBLICATION mypublication"
+  },
+  {
+    "query": "DROP TYPE box"
+  },
+  {
+    "query": "DROP TABLESPACE mystuff"
+  },
+  {
+    "query": "DROP CONVERSION myname"
+  },
+  {
+    "query": "DROP SEQUENCE serial"
+  },
+  {
+    "query": "DROP INDEX title_idx"
+  },
+  {
+    "query": "DROP MATERIALIZED VIEW order_summary"
+  },
+  {
+    "query": "DROP TRIGGER if_dist_exists ON films"
+  },
+  {
+    "query": "DROP RULE newrule ON mytable"
+  },
+  {
+    "query": "DROP CAST (text AS int)"
+  },
+  {
+    "query": "DROP OPERATOR FAMILY float_ops USING btree"
+  },
+  {
+    "query": "DROP AGGREGATE myavg(int), myavg(bigint)"
+  },
+  {
+    "query": "DROP COLLATION german"
+  },
+  {
+    "query": "DROP FOREIGN DATA WRAPPER dbi"
+  },
+  {
+    "query": "DROP ACCESS METHOD heptree"
+  },
+  {
+    "query": "DROP STATISTICS IF EXISTS accounting.users_uid_creation, public.grants_user_role"
+  },
+  {
+    "query": "DROP TEXT SEARCH DICTIONARY english"
+  },
+  {
+    "query": "DROP OPERATOR CLASS widget_ops USING btree"
+  },
+  {
+    "query": "DROP POLICY p1 ON my_table"
+  },
+  {
+    "query": "DROP SUBSCRIPTION mysub"
+  },
+  {
+    "query": "DROP TEXT SEARCH CONFIGURATION my_english"
+  },
+  {
+    "query": "DROP EVENT TRIGGER snitch"
+  },
+  {
+    "query": "DROP TEXT SEARCH PARSER my_parser"
+  },
+  {
+    "query": "DROP EXTENSION hstore"
+  },
+  {
+    "query": "DROP DOMAIN box"
+  },
+  {
+    "query": "DROP TEXT SEARCH TEMPLATE thesaurus"
+  },
+  {
+    "query": "DROP TRANSFORM FOR hstore LANGUAGE plpythonu"
+  },
+  {
+    "query": "DROP FOREIGN TABLE films, distributors"
+  },
+  {
+    "query": "DROP FUNCTION sqrt(int)"
+  },
+  {
+    "query": "DROP FUNCTION update_employee_salaries()"
+  },
+  {
+    "query": "DROP FUNCTION update_employee_salaries"
+  },
+  {
+    "query": "DROP TABLE IF EXISTS any_table CASCADE"
+  },
+  {
+    "query": "DROP TABLE IF EXISTS any_table"
+  },
+  {
+    "query": "DROP SCHEMA IF EXISTS any_schema"
+  },
+  {
+    "query": "ALTER TABLE distributors DROP CONSTRAINT distributors_pkey, ADD CONSTRAINT distributors_pkey PRIMARY KEY USING INDEX dist_id_temp_idx, ADD CONSTRAINT zipchk CHECK (char_length(zipcode) = 5), ALTER COLUMN tstamp DROP DEFAULT, ALTER COLUMN tstamp TYPE timestamp with time zone USING 'epoch'::timestamp with time zone + (date_part('epoch', tstamp) * '1 second'::interval), ALTER COLUMN tstamp SET DEFAULT now(), ALTER COLUMN tstamp DROP DEFAULT, ALTER COLUMN tstamp SET STATISTICS -5, ADD COLUMN some_int int NOT NULL, DROP IF EXISTS other_column CASCADE"
+  },
+  {
+    "query": "ALTER TABLE distributors RENAME TO suppliers"
+  },
+  {
+    "query": "ALTER TABLE distributors ADD CONSTRAINT distfk FOREIGN KEY (address) REFERENCES addresses (address)"
+  },
+  {
+    "query": "ALTER TABLE distributors ADD CONSTRAINT distfk FOREIGN KEY (address) REFERENCES addresses (address) NOT VALID"
+  },
+  {
+    "query": "ALTER TRIGGER emp_stamp ON emp RENAME TO emp_track_chgs"
+  },
+  {
+    "query": "ALTER CONVERSION iso_8859_1_to_utf8 RENAME TO latin1_to_unicode"
+  },
+  {
+    "query": "ALTER TABLE distributors RENAME CONSTRAINT zipchk TO zip_check"
+  },
+  {
+    "query": "ALTER INDEX distributors RENAME TO suppliers"
+  },
+  {
+    "query": "ALTER MATERIALIZED VIEW foo RENAME TO bar"
+  },
+  {
+    "query": "ALTER TABLESPACE index_space RENAME TO fast_raid"
+  },
+  {
+    "query": "ALTER TABLE distributors RENAME COLUMN address TO city"
+  },
+  {
+    "query": "ALTER COLLATION \"de_DE\" RENAME TO german"
+  },
+  {
+    "query": "ALTER TYPE electronic_mail RENAME TO email"
+  },
+  {
+    "query": "ALTER DOMAIN zipcode RENAME CONSTRAINT zipchk TO zip_check"
+  },
+  {
+    "query": "ALTER AGGREGATE myavg(int) RENAME TO my_average"
+  },
+  {
+    "query": "ALTER FUNCTION sqrt(int) RENAME TO square_root"
+  },
+  {
+    "query": "ALTER RULE notify_all ON emp RENAME TO notify_me"
+  },
+  {
+    "query": "BEGIN"
+  },
+  {
+    "query": "BEGIN ISOLATION LEVEL SERIALIZABLE"
+  },
+  {
+    "query": "BEGIN READ ONLY"
+  },
+  {
+    "query": "BEGIN ISOLATION LEVEL READ COMMITTED, DEFERRABLE"
+  },
+  {
+    "query": "START TRANSACTION READ ONLY"
+  },
+  {
+    "query": "ROLLBACK"
+  },
+  {
+    "query": "ROLLBACK AND CHAIN"
+  },
+  {
+    "query": "COMMIT"
+  },
+  {
+    "query": "COMMIT AND CHAIN"
+  },
+  {
+    "query": "SAVEPOINT \"x y\""
+  },
+  {
+    "query": "ROLLBACK TO SAVEPOINT x"
+  },
+  {
+    "query": "RELEASE x"
+  },
+  {
+    "query": "SELECT rank(*) OVER ()"
+  },
+  {
+    "query": "SELECT rank(*) OVER (PARTITION BY id)"
+  },
+  {
+    "query": "SELECT rank(*) OVER (ORDER BY id)"
+  },
+  {
+    "query": "SELECT rank(*) OVER (PARTITION BY id, id2 ORDER BY id DESC, id2)"
+  },
+  {
+    "query": "SELECT rank(*) OVER named_window"
+  },
+  {
+    "query": "SELECT max(create_date::date) FILTER (WHERE cancel_date IS NULL) OVER (ORDER BY create_date DESC) FROM tb_x"
+  },
+  {
+    "query": "ALTER VIEW foo RENAME TO bar"
+  },
+  {
+    "query": "CREATE OR REPLACE TEMPORARY VIEW view_a AS SELECT * FROM a(1) WITH CHECK OPTION"
+  },
+  {
+    "query": "DROP VIEW kinds"
+  },
+  {
+    "query": "CREATE VIEW view_a (a, b) AS WITH RECURSIVE view_a(a, b) AS (SELECT * FROM a(1)) SELECT a, b FROM view_a"
+  },
+  {
+    "query": "SET statement_timeout TO 10000"
+  },
+  {
+    "query": "SET search_path TO my_schema, public"
+  },
+  {
+    "query": "SET LOCAL search_path TO my_schema, public"
+  },
+  {
+    "query": "SET \"user\" TO 4"
+  },
+  {
+    "query": "SET TIME ZONE interval '+00:00' hour to minute"
+  },
+  {
+    "query": "SET timezone TO -7"
+  },
+  {
+    "query": "VACUUM"
+  },
+  {
+    "query": "VACUUM t"
+  },
+  {
+    "query": "VACUUM (FULL) t"
+  },
+  {
+    "query": "VACUUM (FREEZE) t"
+  },
+  {
+    "query": "VACUUM (VERBOSE) t"
+  },
+  {
+    "query": "VACUUM (ANALYZE) t"
+  },
+  {
+    "query": "VACUUM (FULL, FREEZE, VERBOSE, ANALYZE)"
+  },
+  {
+    "query": "VACUUM (ANALYZE) t(a, b)"
+  },
+  {
+    "query": "LOCK TABLE t"
+  },
+  {
+    "query": "LOCK TABLE t, u"
+  },
+  {
+    "query": "EXPLAIN SELECT a FROM b"
+  },
+  {
+    "query": "EXPLAIN (ANALYZE) SELECT a FROM b"
+  },
+  {
+    "query": "EXPLAIN (ANALYZE, BUFFERS) SELECT a FROM b"
+  },
+  {
+    "query": "COPY t FROM STDIN"
+  },
+  {
+    "query": "COPY t(c1, c2) FROM STDIN"
+  },
+  {
+    "query": "COPY t FROM PROGRAM '/bin/false'"
+  },
+  {
+    "query": "COPY t FROM '/dev/null'"
+  },
+  {
+    "query": "COPY t TO STDOUT"
+  },
+  {
+    "query": "COPY (SELECT 1 FROM foo) TO STDOUT"
+  },
+  {
+    "query": "COPY t FROM STDIN WITH (convert_selectively, some_str test, some_num 1, some_list (a), some_star *)"
+  },
+  {
+    "query": "DO $$BEGIN PERFORM * FROM information_schema.tables; END$$"
+  },
+  {
+    "query": "DO LANGUAGE plpgsql $$ BEGIN PERFORM * FROM information_schema.tables; END $$"
+  },
+  {
+    "query": "DO $$ BEGIN PERFORM * FROM information_schema.tables; END $$ LANGUAGE plpgsql"
+  },
+  {
+    "query": "DISCARD ALL"
+  },
+  {
+    "query": "DISCARD PLANS"
+  },
+  {
+    "query": "DISCARD SEQUENCES"
+  },
+  {
+    "query": "DISCARD TEMP"
+  },
+  {
+    "query": "CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1)"
+  },
+  {
+    "query": "CREATE AGGREGATE aggregate1 (int4, bool) (sfunc = sfunc1, stype = stype1)"
+  },
+  {
+    "query": "CREATE AGGREGATE aggregate1 (*) (sfunc = sfunc1, stype = stype1)"
+  },
+  {
+    "query": "CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_extra, mfinalfuncextra)"
+  },
+  {
+    "query": "CREATE AGGREGATE aggregate1 (int4) (sfunc = sfunc1, stype = stype1, finalfunc_modify = read_only, parallel = restricted)"
+  },
+  {
+    "query": "CREATE AGGREGATE percentile_disc (float8 ORDER BY anyelement) (sfunc = ordered_set_transition, stype = internal, finalfunc = percentile_disc_final, finalfunc_extra)"
+  },
+  {
+    "query": "CREATE OPERATOR + (procedure = plusfunc)"
+  },
+  {
+    "query": "CREATE OPERATOR + (procedure = plusfunc, leftarg = int4, rightarg = int4)"
+  },
+  {
+    "query": "CREATE OPERATOR + (procedure = plusfunc, hashes, merges)"
+  },
+  {
+    "query": "CREATE TYPE type1"
+  },
+  {
+    "query": "CREATE TYPE type1 AS (attr1 int4, attr2 bool)"
+  },
+  {
+    "query": "CREATE TYPE type1 AS (attr1 int4 COLLATE collation1, attr2 bool)"
+  },
+  {
+    "query": "CREATE TYPE type1 AS ENUM ('value1', 'value2', 'value3')"
+  },
+  {
+    "query": "CREATE TYPE type1 AS RANGE (subtype = int4)"
+  },
+  {
+    "query": "CREATE TYPE type1 AS RANGE (subtype = int4, receive = receive_func, passedbyvalue)"
+  },
+  {
+    "query": "CREATE TYPE type1 (input = input1, output = output1)"
+  },
+  {
+    "query": "CREATE TYPE type1 (input = input1, output = output1, passedbyvalue)"
+  },
+  {
+    "query": "GRANT select ON \"table\" TO \"user\""
+  },
+  {
+    "query": "GRANT select, update, insert ON \"table\" TO \"user\""
+  },
+  {
+    "query": "GRANT select ON ALL TABLES IN SCHEMA schema TO \"user\""
+  },
+  {
+    "query": "GRANT select ON \"table\" TO user1, user2"
+  },
+  {
+    "query": "GRANT select ON \"table\" TO public"
+  },
+  {
+    "query": "GRANT select ON \"table\" TO CURRENT_USER"
+  },
+  {
+    "query": "GRANT select ON \"table\" TO SESSION_USER"
+  },
+  {
+    "query": "GRANT ALL ON \"table\" TO \"user\""
+  },
+  {
+    "query": "GRANT select ON \"table\" TO \"user\" WITH GRANT OPTION"
+  },
+  {
+    "query": "GRANT select (\"column\") ON \"table\" TO \"user\""
+  },
+  {
+    "query": "GRANT select (column1, column2) ON \"table\" TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON SEQUENCE sequence TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON ALL SEQUENCES IN SCHEMA schema TO \"user\""
+  },
+  {
+    "query": "GRANT create ON DATABASE database TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON DOMAIN domain TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON FOREIGN DATA WRAPPER fdw TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON FOREIGN SERVER server TO \"user\""
+  },
+  {
+    "query": "GRANT execute ON FUNCTION function TO \"user\""
+  },
+  {
+    "query": "GRANT execute ON FUNCTION function() TO \"user\""
+  },
+  {
+    "query": "GRANT execute ON FUNCTION function(string) TO \"user\""
+  },
+  {
+    "query": "GRANT execute ON FUNCTION function(string, string, boolean) TO \"user\""
+  },
+  {
+    "query": "GRANT execute ON ALL FUNCTIONS IN SCHEMA schema TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON LANGUAGE plpgsql TO \"user\""
+  },
+  {
+    "query": "GRANT select ON LARGE OBJECT 1234 TO \"user\""
+  },
+  {
+    "query": "GRANT create ON SCHEMA schema TO \"user\""
+  },
+  {
+    "query": "GRANT create ON TABLESPACE tablespace TO \"user\""
+  },
+  {
+    "query": "GRANT usage ON TYPE type TO \"user\""
+  },
+  {
+    "query": "GRANT role TO \"user\""
+  },
+  {
+    "query": "GRANT role1, role2 TO \"user\""
+  },
+  {
+    "query": "GRANT role TO \"user\" WITH ADMIN OPTION"
+  },
+  {
+    "query": "DROP ROLE jonathan"
+  },
+  {
+    "query": "REVOKE ALL ON kinds FROM manuel"
+  },
+  {
+    "query": "REVOKE admins FROM joe"
+  },
+  {
+    "query": "REVOKE insert ON films FROM public"
+  },
+  {
+    "query": "SELECT m.name AS mname, pname FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true"
+  },
+  {
+    "query": "SELECT m.name AS mname, pname FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true; INSERT INTO manufacturers_daily (a, b) SELECT a, b FROM manufacturers"
+  },
+  {
+    "query": "SELECT m.name AS mname, pname FROM manufacturers m LEFT JOIN LATERAL get_product_names(m.id) pname ON true; UPDATE users SET name = 'bobby; drop tables'; INSERT INTO manufacturers_daily (a, b) SELECT a, b FROM manufacturers"
+  },
+  {
+    "query": "SELECT * FROM a CROSS JOIN (b CROSS JOIN c)"
+  },
+  {
+    "query": "SELECT 1 FOR UPDATE"
+  },
+  {
+    "query": "SELECT 1 FOR UPDATE NOWAIT"
+  },
+  {
+    "query": "SELECT 1 FOR UPDATE SKIP LOCKED"
+  },
+  {
+    "query": "COMMENT ON POLICY a ON b IS 'test'"
+  },
+  {
+    "query": "COMMENT ON PROCEDURE a() IS 'test'"
+  },
+  {
+    "query": "COMMENT ON ROUTINE a() IS 'test'"
+  },
+  {
+    "query": "COMMENT ON TRANSFORM FOR int4 LANGUAGE sql IS 'test'"
+  },
+  {
+    "query": "COMMENT ON OPERATOR CLASS a USING b IS 'test'"
+  },
+  {
+    "query": "COMMENT ON OPERATOR FAMILY a USING b IS 'test'"
+  },
+  {
+    "query": "COMMENT ON LARGE OBJECT 42 IS 'test'"
+  },
+  {
+    "query": "COMMENT ON CAST (int4 AS int8) IS 'test'"
+  },
+  {
+    "query": "SELECT ROW(1 + 2)"
+  },
+  {
+    "query": "ALTER TABLE a ALTER COLUMN b SET DEFAULT 1"
+  },
+  {
+    "query": "ALTER TABLE a ALTER COLUMN b DROP DEFAULT"
+  },
+  {
+    "query": "SELECT (3 + 3) OPERATOR(pg_catalog.*) 2"
+  },
+  {
+    "query": "SELECT 3 + (3 * 2)"
+  },
+  {
+    "query": "SELECT LIMIT ALL"
+  },
+  {
+    "query": "SELECT * FROM ROWS FROM (foo() AS (foo_res_a text COLLATE a, foo_res_b text))"
+  },
+  {
+    "query": "CREATE DATABASE x OWNER abc CONNECTION LIMIT 5"
+  },
+  {
+    "query": "CREATE DATABASE x ENCODING \"SQL_ASCII\""
+  },
+  {
+    "query": "CREATE DATABASE x LC_COLLATE \"en_US.UTF-8\""
+  },
+  {
+    "query": "CREATE DATABASE x LOCATION DEFAULT"
+  },
+  {
+    "query": "CREATE DATABASE x TABLESPACE abc"
+  },
+  {
+    "query": "CREATE DATABASE x TEMPLATE TRUE"
+  },
+  {
+    "query": "ALTER DATABASE x CONNECTION LIMIT 5"
+  },
+  {
+    "query": "ALTER DATABASE x ALLOW_CONNECTIONS FALSE"
+  },
+  {
+    "query": "ALTER DATABASE x IS_TEMPLATE TRUE"
+  },
+  {
+    "query": "ALTER DATABASE x TABLESPACE abc"
+  },
+  {
+    "query": "ALTER DATABASE x SET work_mem TO \"10MB\""
+  },
+  {
+    "query": "ALTER EXTENSION x UPDATE"
+  },
+  {
+    "query": "ALTER EXTENSION x UPDATE TO \"1.2\""
+  },
+  {
+    "query": "ALTER EXTENSION x ADD ACCESS METHOD a"
+  },
+  {
+    "query": "ALTER EXTENSION x DROP ACCESS METHOD a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD AGGREGATE a(b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD CAST (a AS b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD COLLATION a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD CONVERSION a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD DOMAIN a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD FUNCTION a(b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD LANGUAGE a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD OPERATOR ~~(a, b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD OPERATOR CLASS a USING b"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD OPERATOR FAMILY a USING b"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD PROCEDURE a(b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD ROUTINE a(b)"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD SCHEMA a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD EVENT TRIGGER a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TABLE a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TEXT SEARCH PARSER a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TEXT SEARCH DICTIONARY a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TEXT SEARCH TEMPLATE a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TEXT SEARCH CONFIGURATION a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD SEQUENCE a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD VIEW a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD MATERIALIZED VIEW a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD FOREIGN TABLE a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD FOREIGN DATA WRAPPER a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD SERVER a"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TRANSFORM FOR a LANGUAGE b"
+  },
+  {
+    "query": "ALTER EXTENSION x ADD TYPE a"
+  },
+  {
+    "query": "ALTER TABLESPACE x SET (seq_page_cost=3)"
+  },
+  {
+    "query": "ALTER TABLESPACE x RESET (random_page_cost)"
+  },
+  {
+    "query": "CREATE TABLESPACE x LOCATION 'a'"
+  },
+  {
+    "query": "CREATE TABLESPACE x OWNER a LOCATION 'b' WITH (random_page_cost=42, seq_page_cost=3)"
+  },
+  {
+    "query": "ALTER FUNCTION x(y) DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER FUNCTION x(y) NO DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER PROCEDURE x(y) DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER ROUTINE x(y) DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER TRIGGER x ON y DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER MATERIALIZED VIEW x DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "ALTER INDEX x DEPENDS ON EXTENSION a"
+  },
+  {
+    "query": "LOAD 'test file'"
+  },
+  {
+    "query": "ALTER SYSTEM SET fsync TO OFF"
+  },
+  {
+    "query": "ALTER SYSTEM RESET fsync"
+  },
+  {
+    "query": "CREATE EXTENSION x"
+  },
+  {
+    "query": "CREATE EXTENSION IF NOT EXISTS x CASCADE VERSION \"1.2\" SCHEMA a"
+  },
+  {
+    "query": "CREATE TABLE like_constraint_rename_cache (LIKE constraint_rename_cache INCLUDING ALL)"
+  },
+  {
+    "query": "COPY manual_export TO STDOUT CSV HEADER"
+  },
+  {
+    "query": "SELECT 1 FROM a.b.c"
+  },
+  {
+    "query": "CREATE PUBLICATION foo FOR TABLES IN SCHEMA bar"
+  },
+  {
+    "query": "ALTER TABLE ALL IN TABLESPACE foo OWNED BY bar, quux SET TABLESPACE fred NOWAIT"
+  },
+  {
+    "query": "MERGE INTO measurement m USING new_measurement nm ON m.city_id = nm.city_id AND m.logdate = nm.logdate WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE WHEN MATCHED THEN UPDATE SET peaktemp = GREATEST(m.peaktemp, nm.peaktemp), unitsales = m.unitsales + COALESCE(nm.unitsales, 0) WHEN NOT MATCHED THEN INSERT (city_id, logdate, peaktemp, unitsales) VALUES (city_id, logdate, peaktemp, unitsales)"
+  },
+  {
+    "query": "COPY vistest FROM STDIN FREEZE CSV"
+  },
+  {
+    "query": "CREATE INDEX \"foo.index\" ON foo USING btree (bar)"
+  },
+  {
+    "query": "CREATE TABLE distributors (did int, name varchar(40), UNIQUE (name) WITH (fillfactor=70)) WITH (fillfactor=70)"
+  },
+  {
+    "query": "SHOW ALL"
+  },
+  {
+    "query": "ALTER TABLE ONLY public.\"Test 123\" ADD CONSTRAINT \"Test 123_pkey\" PRIMARY KEY (c1)"
+  },
+  {
+    "query": "CREATE PROCEDURE insert_data(a int, b int) LANGUAGE sql BEGIN ATOMIC INSERT INTO tbl VALUES (a); INSERT INTO tbl VALUES (b); END"
+  },
+  {
+    "query": "CREATE PROCEDURE do_nothing() LANGUAGE sql BEGIN ATOMIC END"
+  },
+  {
+    "query": "CREATE PROCEDURE returns_one() LANGUAGE sql BEGIN ATOMIC RETURN 1; END"
+  },
+  {
+    "query": "CREATE PROCEDURE updates_and_returns_one() LANGUAGE sql BEGIN ATOMIC UPDATE tbl SET a = 1; RETURN 1; END"
+  },
+  {
+    "query": "SELECT 1 FROM tbl LIMIT COALESCE($1, $2)"
+  },
+  {
+    "query": "SELECT (false AND true) IS FALSE"
+  },
+  {
+    "query": "SELECT a = (true IS FALSE)"
+  },
+  {
+    "query": "ALTER TABLE a ENABLE TRIGGER b"
+  },
+  {
+    "query": "ALTER TABLE a ENABLE TRIGGER ALL"
+  },
+  {
+    "query": "ALTER TABLE a ENABLE TRIGGER USER"
+  },
+  {
+    "query": "ALTER TABLE a DISABLE TRIGGER b"
+  },
+  {
+    "query": "ALTER TABLE a DISABLE TRIGGER ALL"
+  },
+  {
+    "query": "ALTER TABLE a DISABLE TRIGGER USER"
+  },
+  {
+    "query": "CREATE INDEX myindex ON public.mytable USING btree (col1, (col2::varchar) varchar_pattern_ops)"
+  },
+  {
+    "query": "SELECT * FROM CAST(1 AS text)"
+  },
+  {
+    "query": "DECLARE \"Foo1\" SCROLL CURSOR FOR SELECT * FROM tenk1 ORDER BY unique2"
+  },
+  {
+    "query": "FETCH BACKWARD 23 \"Foo1\""
+  },
+  {
+    "query": "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT (now() AT TIME ZONE 'UTC'))"
+  },
+  {
+    "query": "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT (now() AT LOCAL))"
+  },
+  {
+    "query": "CREATE TABLE my_table (created_at timestamptz NOT NULL DEFAULT '1 hour'::interval + (current_timestamp AT TIME ZONE 'UTC'))"
+  },
+  {
+    "query": "ALTER TABLE my_table ADD COLUMN created_at timestamptz NOT NULL DEFAULT '1 hour'::interval + (current_timestamp AT TIME ZONE 'UTC')"
+  },
+  {
+    "query": "CREATE TABLE my_table (created_at int NOT NULL DEFAULT 1 + 2)"
+  }
+]

--- a/go/common/parser/testdata/deparse_complex_cases.json
+++ b/go/common/parser/testdata/deparse_complex_cases.json
@@ -1,0 +1,530 @@
+[
+  {
+    "comment": "deparse/case.sql",
+    "query": "SELECT CASE WHEN count(*) FILTER (WHERE col_state = 2) = count(col_id) THEN true WHEN count(*) FILTER (WHERE col_state = 3) > 0 THEN false ELSE NULL END AS col_alias FROM my_table"
+  },
+  {
+    "comment": "deparse/comment_multiline.sql",
+    "query": "CREATE EXTENSION IF NOT EXISTS btree_gin SCHEMA public"
+  },
+  {
+    "comment": "deparse/complex_depesz.sql",
+    "query": "SELECT decode(a.category, NULL, b.category, a.category) AS category, b.par AS \"Total object Request\", b.ps AS \"objects Served\", b.ar AS \"Total sushi Request\", a.sushis AS \"sushis Served\", round(decode(b.ar, 0, 0, (b.ar - decode(a.sushis, NULL, 0, a.sushis)::numeric) / b.ar) * 100, 3) AS \"USR\", a.clk AS points, decode(b.ps, 0, 0, round((a.clk / b.ps) * 100, 3)) AS \"CTR\", a.cpc AS \"CPC\", a.tc AS \"Cost\", decode(b.ps, 0, 0, (a.tc / b.ps) * 1000::numeric(8, 3)) AS effectcost FROM ( SELECT decode(b.category, NULL, 'N/A', b.category) AS category, sum(doughnuts) AS sushis, sum(points) AS clk, round(sum(total_cost)::numeric, 3) AS tc, decode(sum(points), 0, 0, round(sum(total_cost) / sum(points)::numeric, 3)) AS cpc FROM daily_city_dealer_summary a, category_dealer_map b WHERE a.category_dealer_id = b.category_dealer_id AND created_day BETWEEN '2010-05-01' AND '2010-05-25' GROUP BY b.category ) a FULL JOIN ( SELECT decode(a.category, NULL, 'N/A', decode(a.category, '-', 'World-Remaining countries', a.category)) AS category, sum(valid_object_request) AS par, sum(valid_sushi_request) AS ar, sum(object_doughnuts) AS ps FROM traffic_hit a WHERE request_date BETWEEN '2010-05-01' AND '2010-05-25' GROUP BY a.category ) b ON lower(a.category) = lower(b.category) ORDER BY 4 DESC"
+  },
+  {
+    "comment": "deparse/complex_gitlab.sql",
+    "query": "WITH my_data AS ( SELECT my_data.* FROM prod.my_data_with_a_long_table_name my_data JOIN prod.other_thing ON true WHERE my_data.filter = 'my_filter' ), some_cte AS ( SELECT DISTINCT id AS other_id, other_field_1, other_field_2, date_field_at, data_by_row, field_4, field_5, lag(other_field_2) OVER ( PARTITION BY other_id, other_field_1 ORDER BY 5 ) AS previous_other_field_2 FROM prod.my_other_data ), final AS ( SELECT my_data.field_1 AS detailed_field_1, my_data.field_2 AS detailed_field_2, my_data.detailed_field_3, date_trunc('month', some_cte.date_field_at) AS date_field_month, some_cte.data_by_row['id']::number AS id_field, iff(my_data.detailed_field_3 > my_data.field_2, true, false) AS is_boolean, CASE WHEN my_data.cancellation_date IS NULL AND my_data.expiration_date IS NOT NULL THEN my_data.expiration_date WHEN my_data.cancellation_date IS NULL THEN my_data.start_date + 7 ELSE my_data.cancellation_date END AS adjusted_cancellation_date, count(*) AS number_of_records, sum(some_cte.field_4) AS field_4_sum, max(some_cte.field_5) AS field_5_max FROM my_data LEFT JOIN some_cte ON my_data.id = some_cte.id WHERE my_data.field_1 = 'abc' AND (my_data.field_2 = 'def' OR my_data.field_2 = 'ghi') GROUP BY 1, 2, 3, 4, 5, 6 HAVING count(*) > 1 ORDER BY 8 DESC ) SELECT * FROM final"
+  },
+  {
+    "comment": "deparse/complex_mattm.sql",
+    "query": "WITH hubspot_interest AS ( SELECT email, timestamp_millis(property_beacon_interest) AS expressed_interest_at FROM hubspot.contact WHERE property_beacon_interest IS NOT NULL ), support_interest AS ( SELECT conversation.email, conversation.created_at AS expressed_interest_at FROM helpscout.conversation JOIN helpscout.conversation_tag ON conversation.id = conversation_tag.conversation_id WHERE conversation_tag.tag = 'beacon-interest' ), combined_interest AS ( SELECT * FROM hubspot_interest UNION ALL SELECT * FROM support_interest ), first_interest AS ( SELECT email, min(expressed_interest_at) AS expressed_interest_at FROM combined_interest GROUP BY email ) SELECT * FROM first_interest"
+  },
+  {
+    "comment": "deparse/ddl_alter_table_add_constraint.sql",
+    "query": "ALTER TABLE ONLY public.vacuum_insight_runs_7d ADD CONSTRAINT vacuum_insight_runs_7d_pkey PRIMARY KEY (server_id, check_name, run_at)"
+  },
+  {
+    "comment": "deparse/ddl_create_index.sql",
+    "query": "CREATE UNIQUE INDEX schema_tables_database_id_schema_name_table_name_idx ON public.schema_tables USING btree (database_id, schema_name, table_name) WHERE removed_at IS NULL"
+  },
+  {
+    "comment": "deparse/ddl_create_table.sql",
+    "query": "CREATE TABLE public.vacuum_run_stats_35d ( vacuum_run_stats_id uuid DEFAULT public.gen_random_uuid() NOT NULL, server_id uuid NOT NULL, vacuum_run_id uuid NOT NULL, collected_at timestamp NOT NULL, phase int NOT NULL, heap_blks_total bigint NOT NULL, heap_blks_scanned bigint NOT NULL, heap_blks_vacuumed bigint NOT NULL, index_vacuum_count bigint NOT NULL, max_dead_tuples bigint NOT NULL, num_dead_tuples bigint NOT NULL ) PARTITION BY RANGE (collected_at)"
+  },
+  {
+    "comment": "deparse/ddl_create_trigger.sql",
+    "query": "CREATE TRIGGER query_runs_notify AFTER INSERT ON public.query_runs REFERENCING NEW TABLE rows EXECUTE FUNCTION public.query_runs_notify()"
+  },
+  {
+    "comment": "deparse/ddl_create_type.sql",
+    "query": "CREATE TYPE public.schema_table_event_type AS ENUM ( 'manual_vacuum', 'auto_vacuum', 'manual_analyze', 'auto_analyze' )"
+  },
+  {
+    "comment": "deparse/insert_long.sql",
+    "query": "INSERT INTO schema_migrations (version) VALUES ('20121115104253'), ('20121115104424'), ('20121115144719'), ('20121222152557'), ('20121222210347'), ('20130129121255'), ('20130129163021'), ('20130129175021'), ('20130129180846'), ('20130130131612'), ('20130208115344'), ('20130217171132'), ('20130222164352'), ('20130305141105'), ('20130404094832'), ('20130429153359'), ('20130701150108'), ('20130706202400'), ('20130706202500')"
+  },
+  {
+    "comment": "deparse/nested_cte.sql",
+    "query": "WITH q AS ( SELECT 1 AS z ) INSERT INTO t (a) WITH qq AS ( SELECT * FROM q ) SELECT z FROM qq"
+  },
+  {
+    "comment": "deparse/simple.sql",
+    "query": "SELECT col1, col2 FROM xyz JOIN abc ON a = b WHERE c IN ( SELECT id FROM test ) AND col2 > 123"
+  },
+  {
+    "comment": "deparse/union.sql",
+    "query": "WITH input AS ( SELECT database_id, fingerprint, last_occurred_at, index FROM unnest($1::int[], $2::bigint[], $3::date[], $4::int[]) _(database_id, fingerprint, last_occurred_at, index) ), existing_queries AS ( SELECT queries.id AS query_id, input.database_id, input.fingerprint, input.last_occurred_at, input.index FROM queries JOIN input USING (database_id, fingerprint) ), update_occurrences AS ( UPDATE query_occurrences SET last = last_occurred_at FROM existing_queries q WHERE q.query_id = query_occurrences.query_id AND last < last_occurred_at RETURNING index ) SELECT index, $5 AS \"exists\" FROM update_occurrences UNION ( SELECT input.index, $6 AS \"exists\" FROM input LEFT JOIN existing_queries USING (database_id, fingerprint) WHERE existing_queries.database_id IS NULL LIMIT 1 ) LIMIT 5"
+  },
+  {
+    "comment": "deparse/union_2.sql",
+    "query": "( SELECT 1 LIMIT 1 ) UNION ( SELECT 1 LIMIT 1 ) LIMIT 2"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/01-numbers.psql",
+    "query": "SELECT 1, 1.5, 0, 0.0"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/02-string.psql",
+    "query": "SELECT 'abc', 'a''bc'"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/03-sql-functions.psql",
+    "query": "SELECT current_catalog, current_role, current_schema, current_user, session_user, user, current_date, current_time, current_timestamp, localtime, localtimestamp, current_time(0), current_timestamp(0), localtime(0), localtimestamp(0), current_time(2), current_timestamp(2), localtime(2), localtimestamp(2)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/04-functions.psql",
+    "query": "SELECT now(), upper('abc'), larger('abcd', 'efghijklmnop'), single('012345678901234567890123456789'), single_long('01234567890123456789012345678901234567890123456789'), nested(12, 13, other_function('fsajkh', 56, 67)), named_1(1, 2, a := 'b'), named_2(b := '2', a := 'b', c := NULL)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/06-column-aliases.psql",
+    "query": "SELECT now(), lower('x') AS lx, 1 AS a, 2 AS \"This\", 'z' AS other"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/07-casts.psql",
+    "query": "SELECT '12'::text, 12::varchar(20)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/08-fields-in-table.psql",
+    "query": "SELECT a, \"Weird\", t.b::int4, t.\"WeirdER\"::int8 FROM table1 t"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/09-operators.psql",
+    "query": "SELECT a + 1 AS new_a, a = 123 AS bool_a, c && '{x,y,z}'::text[] AS including_c, @ d AS abs_d FROM t"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/10-operators.psql",
+    "query": "SELECT (((a + b) + c) + d) + e, ((1 + 2) + 3) + 4, d + (b * 5), (e * c) + 2, (x - 1) * 3 FROM t"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/11-weird-operator.psql",
+    "query": "SELECT a OPERATOR(\"Schema\".-) b FROM c"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/12-boolean-operation.psql",
+    "query": "SELECT (a = b AND c = d AND e = f) OR g = h, NOT i FROM z"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/13-joins.psql",
+    "query": "SELECT a FROM b LEFT JOIN c ON b.x = c.y JOIN d USING (z)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/14-star.psql",
+    "query": "SELECT *, count(*) FROM a"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/15-where.psql",
+    "query": "SELECT * FROM a WHERE b = c AND d < (now() - '1 week'::interval)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/16-groupby.psql",
+    "query": "SELECT a, x, count(*), min(b) FROM c GROUP BY a, x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/17-orderby.psql",
+    "query": "SELECT * FROM a ORDER BY b, c ASC, d DESC, e NULLS FIRST, f NULLS LAST, g ASC NULLS FIRST, h DESC NULLS FIRST, i ASC NULLS LAST, j DESC NULLS LAST"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/18-limitoffset.psql",
+    "query": "SELECT a FROM b LIMIT 10 OFFSET 20"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/19-having.psql",
+    "query": "SELECT a, count(*) FROM b GROUP BY a HAVING count(*) > 10 AND min(id) > 123"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/20-case.psql",
+    "query": "SELECT CASE WHEN a = 1 THEN 2 WHEN a = 2 THEN 4 ELSE 5 END, CASE b WHEN 1 THEN 5 WHEN 2 THEN 15 ELSE 0 END FROM x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/21-in.psql",
+    "query": "SELECT a FROM b WHERE c IN (1, 2, 3) AND d IN ('something longer', 'something longer 2', 'something longer 3', 'something longer 4', 'something longer 5', '')"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/22-subselect.psql",
+    "query": "SELECT *, ( SELECT count(*) FROM x ), ARRAY( SELECT e FROM f ) FROM a WHERE b IN ( SELECT c FROM d ) AND EXISTS ( SELECT x FROM y )"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/23-null.psql",
+    "query": "SELECT a(b, NULL), c IS NULL, d IS NOT NULL FROM e"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/24-range-function.psql",
+    "query": "SELECT * FROM unnest('{1,2,3}'::int4[]) x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/25-coalesce.psql",
+    "query": "SELECT COALESCE(a, b || c, 'missing') FROM d"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/26-range-subselect.psql",
+    "query": "SELECT * FROM ( SELECT a FROM b ) x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/27-distinct.psql",
+    "query": "SELECT DISTINCT a, b FROM c"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/28-distinct-on.psql",
+    "query": "SELECT DISTINCT ON (a, b) a, b, c FROM t ORDER BY a, b"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/29-param-ref.psql",
+    "query": "SELECT $1, $2::int4, $3 || 'z'"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/30-array.psql",
+    "query": "SELECT ARRAY[1, 2, 3], ARRAY['a', NULL, 'c']::text[], format('%s, %s', VARIADIC ARRAY[1, 2]), format('%s, %s', ARRAY[1, 2], 'a')"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/31-indirection.psql",
+    "query": "SELECT a[2], a[2:], a[:2], a[2:3], b[2][2:][:2][2:3], ('{red,green,blue}'::text[])[2] FROM c"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/32-collate.psql",
+    "query": "SELECT a FROM b ORDER BY a COLLATE \"C\" DESC, z"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/33-window-functions.psql",
+    "query": "SELECT count(*) OVER (), sum(a) OVER ( PARTITION BY b, c ), sum(a) OVER ( ORDER BY c ), sum(a) OVER ( PARTITION BY b, c ORDER BY c DESC, a ASC ) FROM x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/34-framed-functions.psql",
+    "query": "SELECT sum(a) OVER ( PARTITION BY b ORDER BY c RANGE UNBOUNDED PRECEDING ), sum(a) OVER ( PARTITION BY b ORDER BY c GROUPS 2 PRECEDING EXCLUDE GROUP ), sum(a) OVER ( PARTITION BY b ORDER BY c ROWS CURRENT ROW EXCLUDE CURRENT ROW ), sum(a) OVER ( PARTITION BY b ORDER BY c RANGE UNBOUNDED PRECEDING EXCLUDE TIES ), sum(a) OVER ( PARTITION BY b ORDER BY c ROWS 10 PRECEDING ), sum(a) OVER ( PARTITION BY b ORDER BY c ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING ), sum(a) OVER ( PARTITION BY b ORDER BY c ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING ) FROM d"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/35-setops.psql",
+    "query": "( ( SELECT 1 UNION SELECT 2 ) UNION SELECT 3 ) EXCEPT ALL ( SELECT 4 INTERSECT SELECT 5 )"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/36-values.psql",
+    "query": "SELECT * FROM ( VALUES (1, 'a'), (2, 'b') ) x(f1, f2)"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/37-cte.psql",
+    "query": "WITH sub1 AS ( SELECT 1 AS x ), sub2(a, b) AS ( SELECT 2, 3 ), sub3 AS MATERIALIZED ( SELECT 4 AS y ) SELECT s1.*, s2.*, s3.* FROM sub1 s1, sub2 s2, sub3 s3"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/38-rcte.psql",
+    "query": "WITH RECURSIVE x AS ( SELECT 1 AS i UNION ALL SELECT i + 1 FROM x WHERE i < 5 ) SELECT * FROM x"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/39-any.psql",
+    "query": "SELECT * FROM pg_class WHERE oid = ANY('{112,113}'::int4[])"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/40-all.psql",
+    "query": "SELECT * FROM pg_class WHERE oid <> ALL('{112,113}'::int4[])"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/41-special-a-expr.psql",
+    "query": "SELECT 2 BETWEEN 1 AND 3, 2 BETWEEN 3 AND 1, 2 NOT BETWEEN 1 AND 3, 2 BETWEEN SYMMETRIC 3 AND 1, 2 NOT BETWEEN SYMMETRIC 3 AND 1, 1 IS DISTINCT FROM NULL, NULL IS DISTINCT FROM NULL, 1 IS NOT DISTINCT FROM NULL, NULL IS NOT DISTINCT FROM NULL, 1.5 IS NULL, 'null' IS NOT NULL, true IS TRUE, NULL::boolean IS TRUE, false IS NOT TRUE, NULL::boolean IS NOT TRUE, true IS FALSE, NULL::boolean IS FALSE, true IS NOT FALSE, NULL::boolean IS NOT FALSE, true IS UNKNOWN, NULL::boolean IS UNKNOWN, true IS NOT UNKNOWN, NULL::boolean IS NOT UNKNOWN, 'a' LIKE '%', 'a' ILIKE '%', NULLIF('a', 'a'), 'a' SIMILAR TO '%'"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/42-minimax.psql",
+    "query": "SELECT LEAST(a, b, c), GREATEST(d, e, f), LEAST(long_column_name * other_long_name, 31242352524) FROM t"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/43-rowexpr.psql",
+    "query": "SELECT * FROM t WHERE (a, b) = (1, 2) AND (c, d) = (long_table_column * other_long_column, '423543265666')"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/44-bitstring.psql",
+    "query": "SELECT b'', b'0', b'1', b'10101010', b'10000000', b'01111111111111111111111111111111'"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/45-grouping-sets.psql",
+    "query": "SELECT relkind, relhasindex, count(*) FROM pg_class GROUP BY GROUPING SETS ((), relkind, relhasindex, (relkind, relhasindex))"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/46-cube.psql",
+    "query": "SELECT d1, d2, d3, GROUPING(d1, d2, d3), sum(v) FROM test GROUP BY CUBE (d1, (d2, d3))"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/47-rollup.psql",
+    "query": "SELECT d1, d2, d3, sum(v) FROM test GROUP BY ROLLUP (d1, (d2, d3))"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/48-sublink-any-all.psql",
+    "query": "SELECT * FROM generate_series(1, 10) i WHERE i > ANY ( SELECT generate_series(1, 8, 2) ) AND i <> ALL ( SELECT generate_series(3, 7, 2) )"
+  },
+  {
+    "comment": "deparse-depesz/08-selects.d/49-variadic-func-call.psql",
+    "query": "SELECT fun1(VARIADIC ( SELECT array_agg(i) FROM generate_series(1, 5) i )), fun2(VARIADIC ARRAY[1, 2]), fun3('whatever', VARIADIC ARRAY[3, 4])"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/01-basic.psql",
+    "query": "INSERT INTO t VALUES ('a')"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/02-with-columns.psql",
+    "query": "INSERT INTO t (a, b) VALUES (1, 2)"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/03-many-columns.psql",
+    "query": "INSERT INTO t (a, b, c, d, e, f, g, h, i) VALUES ('value for column a', 'value for column b', 'value for column c', 'value for column d', 'value for column e', 'value for column f', 'value for column g', 'value for column h', 'value for column i')"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/04-with-schema.psql",
+    "query": "INSERT INTO \"BadOne\".t VALUES ('a')"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/05-multirow.psql",
+    "query": "INSERT INTO t (a, b) VALUES (1, 2), (3, 4), (5, 6), (7, 8), (9, 10), (11, 12), (13, 14), (15, 16), (17, 18), (19, 20)"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/06-returning-all.psql",
+    "query": "INSERT INTO t VALUES ('a') RETURNING *"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/07-returning-some.psql",
+    "query": "INSERT INTO t (a) VALUES ('a') RETURNING b, c, d"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/08-default.psql",
+    "query": "INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 3, DEFAULT, DEFAULT)"
+  },
+  {
+    "comment": "deparse-depesz/09-inserts.d/09-cte.psql",
+    "query": "WITH q AS ( SELECT 1 AS z ) INSERT INTO t (a) SELECT z FROM q"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/01-single-column-no-where.psql",
+    "query": "UPDATE t SET a = 123"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/02-many-columns-and-where.psql",
+    "query": "UPDATE t SET a = 123, b = 234, c = 56 WHERE d = 123"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/03-with.psql",
+    "query": "UPDATE a al SET b = x.w FROM whatever x WHERE al.id = x.id"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/04-returning-all.psql",
+    "query": "UPDATE t SET a = 1 WHERE id < 10 RETURNING *"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/05-returning-some.psql",
+    "query": "UPDATE t SET a = 1 WHERE id < 10 RETURNING a, id, b"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/06-multi-assign-simple.psql",
+    "query": "UPDATE t SET (a, b, c) = (1, 2, 3)"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/07-multi-assign-long.psql",
+    "query": "UPDATE t SET (a, b, c) = ( SELECT q.x, q.y, q.z FROM q WHERE q.w = t.v )"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/08-multi-assign-mix.psql",
+    "query": "UPDATE t SET a = 2, (b, c, d) = (3, 4, 5), e = 6"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/09-cte.psql",
+    "query": "WITH w AS ( SELECT 1 AS s, 2 AS d ) UPDATE t SET a = w.d FROM w WHERE w.s = t.a"
+  },
+  {
+    "comment": "deparse-depesz/10-updates.d/10-complex-where.psql",
+    "query": "UPDATE t SET a = x.b FROM b WHERE a.id = b.id AND a.t >= b.tmin AND a.t <= b.tmax"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/01-simple.psql",
+    "query": "DELETE FROM a"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/02-where.psql",
+    "query": "DELETE FROM a al WHERE al.id > 10"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/03-using.psql",
+    "query": "DELETE FROM a USING b WHERE a.id = b.id"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/04-returning-all.psql",
+    "query": "DELETE FROM a RETURNING *"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/05-returning-some.psql",
+    "query": "DELETE FROM a RETURNING b, c, d"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/06-cte.psql",
+    "query": "WITH w AS ( SELECT 2 AS x ) DELETE FROM t USING w WHERE w.x = t.a"
+  },
+  {
+    "comment": "deparse-depesz/11-deletes.d/07-complex-where.psql",
+    "query": "DELETE FROM x USING y WHERE x.a = y.a AND x.t >= t.tmin AND x.t <= t.tmax"
+  },
+  {
+    "comment": "deparse-depesz/12-explains.d/01-base.psql",
+    "query": "EXPLAIN SELECT 1"
+  },
+  {
+    "comment": "deparse-depesz/12-explains.d/02-analyze.psql",
+    "query": "EXPLAIN (ANALYZE) SELECT 1"
+  },
+  {
+    "comment": "deparse-depesz/12-explains.d/03-verbose.psql",
+    "query": "EXPLAIN (VERBOSE) SELECT 1"
+  },
+  {
+    "comment": "deparse-depesz/12-explains.d/04-analyze-verbose.psql",
+    "query": "EXPLAIN (ANALYZE, VERBOSE) SELECT 1"
+  },
+  {
+    "comment": "deparse-depesz/12-explains.d/05-other.psql",
+    "query": "EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, SETTINGS ON, BUFFERS OFF, WAL ON, TIMING OFF, SUMMARY ON, FORMAT \"json\") SELECT 1"
+  },
+  {
+    "comment": "deparse-depesz/13-tablesample.d/01-system.psql",
+    "query": "SELECT * FROM pg_class TABLESAMPLE system(5)"
+  },
+  {
+    "comment": "deparse-depesz/13-tablesample.d/02-bernoulli.psql",
+    "query": "SELECT * FROM pg_class x TABLESAMPLE bernoulli(5)"
+  },
+  {
+    "comment": "deparse-depesz/13-tablesample.d/03-repeatable.psql",
+    "query": "SELECT * FROM pg_class TABLESAMPLE system(5) REPEATABLE (123.5)"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/01-simple.psql",
+    "query": "SELECT xmlelement(name element, xmlattributes(1 AS one, 'deuce' AS two), 'content')"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/02-concat.psql",
+    "query": "SELECT xmlconcat('<?xml version=\"1.1\"?><foo/>', '<?xml version=\"1.1\" standalone=\"no\"?><bar/>')"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/03-forest.psql",
+    "query": "SELECT xmlforest(name, age, salary AS pay)"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/04-parse.psql",
+    "query": "SELECT xmlparse(document '<?xml version=\"1.0\"?><book><title>Manual</title><chapter>...</chapter></book>'), xmlparse(content 'abc<foo>bar</foo><bar>foo</bar>')"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/05-pi.psql",
+    "query": "SELECT xmlpi(name xxx), xmlpi(name zzz, 'whatever')"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/06-root.psql",
+    "query": "SELECT xmlroot('<foo/>'::xml, version no value, standalone no value), xmlroot('<foo/>'::xml, version '1.0', standalone yes), xmlroot('<foo/>'::xml, version '1.0', standalone no), xmlroot('<foo/>'::xml, version '1.0')"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/07-serialize.psql",
+    "query": "SELECT xmlserialize(content 'good' AS char(10)), xmlserialize(document 'bad' AS text)"
+  },
+  {
+    "comment": "deparse-depesz/14-xml.d/08-is-document.psql",
+    "query": "SELECT '<foo>bar</foo>'::xml IS DOCUMENT, NOT '<foo>bar</foo>'::xml IS DOCUMENT"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/01-lateral.psql",
+    "query": "SELECT c.oid::regclass, u.grantor FROM pg_class c, LATERAL ( SELECT u.usename AS grantor FROM aclexplode(c.relacl) x JOIN pg_user u ON x.grantor = u.usesysid WHERE x.privilege_type = 'SELECT' AND x.grantee = 16514 ) u"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/02-current-row.psql",
+    "query": "SELECT i, sum(i) OVER ( ORDER BY i ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING ), sum(i) OVER ( ORDER BY i ROWS BETWEEN 2 PRECEDING AND CURRENT ROW ) FROM generate_series(1, 10) i"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/03-filtered-aggregates.psql",
+    "query": "SELECT count(*) FILTER (WHERE relkind = 'r') FROM pg_class"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/04-cast-of-expression.psql",
+    "query": "SELECT (data ->> 'timestamp')::timestamptz, (1 = 1 OR 2 = 2)::int4 FROM z"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/05-literal-new-line.psql",
+    "query": "SELECT ' '"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/06-aggregate-filter-inside-case.psql",
+    "query": "SELECT CASE WHEN count(*) FILTER (WHERE col_state = 2) = count(col_id) THEN true WHEN count(*) FILTER (WHERE col_state = 3) > 0 THEN false ELSE NULL END AS col_alias FROM my_table"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/07-missing-ordinality-and-order-by.psql",
+    "query": "SELECT string_agg(E'\\\\U' || lpad(to_hex(ascii(unnest)), 8, '0'), '' ORDER BY ordinality) FROM unnest(regexp_split_to_array($1, '')) WITH ORDINALITY"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/08-missing-dot-before-start.psql",
+    "query": "SELECT (unnest('{\"(ACDT,10:30:00,t)\",\"(ACSST,10:30:00,t)\"}'::pg_timezone_abbrevs[])).*"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/09-missing-dot-before-column.psql",
+    "query": "SELECT (unnest('{\"(ACDT,10:30:00,t)\",\"(ACSST,10:30:00,t)\"}'::pg_timezone_abbrevs[])).abbrev"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/10-missing-not.psql",
+    "query": "SELECT 1 NOT IN (2, 3, 4), 'a' NOT LIKE 'z'"
+  },
+  {
+    "comment": "deparse-depesz/16-bugs.d/11-distinct-aggregate.psql",
+    "query": "SELECT count(DISTINCT x), array_agg(DISTINCT id, ', ' ORDER BY id DESC) FROM z"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/01-for-update.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR UPDATE"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/02-for-no-key-update.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR NO KEY UPDATE"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/03-for-share.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR SHARE"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/04-for-key-share.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR KEY SHARE"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/05-of-table.psql",
+    "query": "SELECT * FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid ORDER BY c.oid ASC LIMIT 5 FOR SHARE OF c"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/06-of-tables.psql",
+    "query": "SELECT * FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid ORDER BY c.oid ASC LIMIT 5 FOR SHARE OF c, n"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/07-nowait.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR UPDATE NOWAIT"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/08-skip-locked.psql",
+    "query": "SELECT * FROM pg_class ORDER BY oid LIMIT 5 FOR UPDATE SKIP LOCKED"
+  },
+  {
+    "comment": "deparse-depesz/17-locking-selects.d/09-multi.psql",
+    "query": "SELECT * FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid ORDER BY c.oid ASC LIMIT 5 FOR UPDATE OF c NOWAIT FOR SHARE OF n SKIP LOCKED"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/01-basic-nothing.psql",
+    "query": "INSERT INTO t (a, b, c) VALUES ('aa', 'bb', 'cc') ON CONFLICT DO NOTHING"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/02-constraint-nothing.psql",
+    "query": "INSERT INTO t (a, b, c) VALUES ('aa', 'bb', 'cc') ON CONFLICT ON CONSTRAINT some_constraint DO NOTHING"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/03-columns-nothing.psql",
+    "query": "INSERT INTO t (a, b, c) VALUES ('aa', 'bb', 'cc') ON CONFLICT (a, lower(b)) DO NOTHING"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/04-expr-complex.psql",
+    "query": "INSERT INTO t (a, b, c) VALUES ('aa', 'bb', 'cc') ON CONFLICT (a COLLATE \"C\", b text_pattern_ops, c COLLATE \"C\" text_pattern_ops) DO NOTHING"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/05-simple-update.psql",
+    "query": "INSERT INTO t (a, b, c) VALUES ('aa', 'bb', 'cc') ON CONFLICT DO UPDATE SET c = excluded.fruit"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/06-update-multicolumn.psql",
+    "query": "INSERT INTO insertconflicttest VALUES (1, 'Apple'), (2, 'Orange') ON CONFLICT (key) DO UPDATE SET (fruit, key) = (excluded.fruit, excluded.key)"
+  },
+  {
+    "comment": "deparse-depesz/18-conflicts.d/07-update-complex.psql",
+    "query": "INSERT INTO dropcol (key, drop1, keep1, drop2, keep2) VALUES (1, 2, '2', '2', 2) ON CONFLICT (key) DO UPDATE SET drop1 = excluded.drop1, keep1 = excluded.keep1, drop2 = excluded.drop2, keep2 = excluded.keep2 WHERE excluded.drop1 IS NOT NULL AND excluded.keep1 IS NOT NULL AND excluded.drop2 IS NOT NULL AND excluded.keep2 IS NOT NULL AND dropcol.drop1 IS NOT NULL AND dropcol.keep1 IS NOT NULL AND dropcol.drop2 IS NOT NULL AND dropcol.keep2 IS NOT NULL RETURNING *"
+  }
+]

--- a/go/common/parser/testdata/postgres/convert_postgres_tests.py
+++ b/go/common/parser/testdata/postgres/convert_postgres_tests.py
@@ -82,16 +82,27 @@ def extract_sql_statements(content: str) -> List[str]:
                         dollar_quote_tag = match.group(1)
                     in_function_body = True
                     function_quote_style = "dollar"
-            # Look for DO blocks with dollar quotes
-            elif re.search(r"^do\s+(\$\w*\$)", stmt_so_far, re.IGNORECASE):
+            # Look for DO blocks with dollar quotes. The optional LANGUAGE
+            # clause may precede the body (e.g. DO LANGUAGE plpgsql $$ ... $$),
+            # so allow it before the opening dollar tag; otherwise the body is
+            # split on its internal semicolons into invalid fragments.
+            elif re.search(
+                r"^do\s+(?:language\s+\w+\s+)?(\$\w*\$)", stmt_so_far, re.IGNORECASE
+            ):
                 # DO block starts
-                match = re.search(r"^do\s+(\$\w*\$)", stmt_so_far, re.IGNORECASE)
+                match = re.search(
+                    r"^do\s+(?:language\s+\w+\s+)?(\$\w*\$)",
+                    stmt_so_far,
+                    re.IGNORECASE,
+                )
                 if match:
                     dollar_quote_tag = match.group(1)
                 in_function_body = True
                 function_quote_style = "dollar"
-            # Look for DO blocks with single quotes
-            elif re.search(r"^do\s+\'\s*$", stmt_so_far, re.IGNORECASE):
+            # Look for DO blocks with single quotes (LANGUAGE clause optional).
+            elif re.search(
+                r"^do\s+(?:language\s+\w+\s+)?\'\s*$", stmt_so_far, re.IGNORECASE
+            ):
                 # DO block with single quote starts
                 in_function_body = True
                 function_quote_style = "single"

--- a/go/common/parser/testdata/postgres/convert_postgres_tests.py
+++ b/go/common/parser/testdata/postgres/convert_postgres_tests.py
@@ -1,6 +1,23 @@
 #!/usr/bin/env python3
+# Copyright 2025 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Script to convert PostgreSQL test files to JSON format for the parser tests.
+
+The generated postgres/*.json files are derived from the PostgreSQL regression
+suite and are redistributed under the PostgreSQL License. See
+../THIRD_PARTY_NOTICES.md for source and license attribution.
 
 IMPORTANT: Before running this script, you need to copy PostgreSQL test files:
 1. Copy test files from PostgreSQL source: src/test/regress/sql/*.sql

--- a/go/common/parser/testdata/postgres/plpgsql_array.json
+++ b/go/common/parser/testdata/postgres/plpgsql_array.json
@@ -1,0 +1,152 @@
+[
+  {
+    "comment": "plpgsql_array - Statement 1",
+    "query": "create type complex as (r float8, i float8)",
+    "expected": "CREATE TYPE complex AS (r FLOAT8, i FLOAT8)"
+  },
+  {
+    "comment": "plpgsql_array - Statement 2",
+    "query": "create type quadarray as (c1 complex[], c2 complex)",
+    "expected": "CREATE TYPE quadarray AS (c1 complex[], c2 complex)"
+  },
+  {
+    "comment": "plpgsql_array - Statement 3",
+    "query": "do $$ declare a int[]; begin a := array[1,2]; a[3] := 4; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := array[1,2]; a[3] := 4; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 4",
+    "query": "do $$ declare a int[]; begin a[3] := 4; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a[3] := 4; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 5",
+    "query": "do $$ declare a int[]; begin a[1][4] := 4; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a[1][4] := 4; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 6",
+    "query": "do $$ declare a int[]; begin a[1] := 23::text; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a[1] := 23::text; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 7",
+    "query": "do $$ declare a int[]; begin a := array[1,2]; a[2:3] := array[3,4]; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := array[1,2]; a[2:3] := array[3,4]; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 8",
+    "query": "do $$ declare a int[]; begin a := array[1,2]; a[2] := a[2] + 1; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := array[1,2]; a[2] := a[2] + 1; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 9",
+    "query": "do $$ declare a int[]; begin a[1:2] := array[3,4]; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a[1:2] := array[3,4]; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 10",
+    "query": "do $$ declare a int[]; begin a[1:2] := 4; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a[1:2] := 4; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 11",
+    "query": "do $$ declare a complex[]; begin a[1] := (1,2); a[1].i := 11; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a complex[]; begin a[1] := (1,2); a[1].i := 11; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 12",
+    "query": "do $$ declare a complex[]; begin a[1].i := 11; raise notice 'a = %, a[1].i = %', a, a[1].i; end$$",
+    "expected": "DO ' declare a complex[]; begin a[1].i := 11; raise notice ''a = %, a[1].i = %'', a, a[1].i; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 13",
+    "query": "do $$ declare a complex[]; begin a[1:2].i := array[11,12]; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a complex[]; begin a[1:2].i := array[11,12]; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 14",
+    "query": "do $$ declare a quadarray; begin a.c1[1].i := 11; raise notice 'a = %, a.c1[1].i = %', a, a.c1[1].i; end$$",
+    "expected": "DO ' declare a quadarray; begin a.c1[1].i := 11; raise notice ''a = %, a.c1[1].i = %'', a, a.c1[1].i; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 15",
+    "query": "do $$ declare a int[]; begin a := array_agg(x) from (values(1),(2),(3)) v(x); raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := array_agg(x) from (values(1),(2),(3)) v(x); raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 16",
+    "query": "create temp table onecol as select array[1,2] as f1",
+    "expected": "CREATE TEMP TABLE onecol AS SELECT ARRAY[1,2] AS f1"
+  },
+  {
+    "comment": "plpgsql_array - Statement 17",
+    "query": "do $$ declare a int[]; begin a := f1 from onecol; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := f1 from onecol; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 18",
+    "query": "do $$ declare a int[]; begin a := * from onecol for update; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := * from onecol for update; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 19",
+    "query": "do $$ declare a int[]; begin a := from onecol; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := from onecol; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 20",
+    "query": "do $$ declare a int[]; begin a := f1, f1 from onecol; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := f1, f1 from onecol; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 21",
+    "query": "insert into onecol values(array[11])",
+    "expected": "INSERT INTO onecol VALUES (ARRAY[11])"
+  },
+  {
+    "comment": "plpgsql_array - Statement 22",
+    "query": "do $$ declare a int[]; begin a := f1 from onecol limit 1; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a int[]; begin a := f1 from onecol limit 1; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 23",
+    "query": "do $$ declare a real; begin a[1] := 2; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a real; begin a[1] := 2; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 24",
+    "query": "do $$ declare a complex; begin a.r[1] := 2; raise notice 'a = %', a; end$$",
+    "expected": "DO ' declare a complex; begin a.r[1] := 2; raise notice ''a = %'', a; end'"
+  },
+  {
+    "comment": "plpgsql_array - Statement 25",
+    "query": "do $$ declare v int; v1 v%type; v2 v%type[]; v3 v%type[1]; v4 v%type[][]; v5 v%type[1][3]; v6 v%type array; v7 v%type array[]; v8 v%type array[1]; v9 v%type array[1][1]; v10 pg_catalog.pg_class%rowtype[]; begin raise notice '%', pg_typeof(v1); raise notice '%', pg_typeof(v2); raise notice '%', pg_typeof(v3); raise notice '%', pg_typeof(v4); raise notice '%', pg_typeof(v5); raise notice '%', pg_typeof(v6); raise notice '%', pg_typeof(v7); raise notice '%', pg_typeof(v8); raise notice '%', pg_typeof(v9); raise notice '%', pg_typeof(v10); end; $$",
+    "expected": "DO ' declare v int; v1 v%type; v2 v%type[]; v3 v%type[1]; v4 v%type[][]; v5 v%type[1][3]; v6 v%type array; v7 v%type array[]; v8 v%type array[1]; v9 v%type array[1][1]; v10 pg_catalog.pg_class%rowtype[]; begin raise notice ''%'', pg_typeof(v1); raise notice ''%'', pg_typeof(v2); raise notice ''%'', pg_typeof(v3); raise notice ''%'', pg_typeof(v4); raise notice ''%'', pg_typeof(v5); raise notice ''%'', pg_typeof(v6); raise notice ''%'', pg_typeof(v7); raise notice ''%'', pg_typeof(v8); raise notice ''%'', pg_typeof(v9); raise notice ''%'', pg_typeof(v10); end; '"
+  },
+  {
+    "comment": "plpgsql_array - Statement 26",
+    "query": "do $$ declare v pg_node_tree; v1 v%type[]; begin end; $$",
+    "expected": "DO ' declare v pg_node_tree; v1 v%type[]; begin end; '"
+  },
+  {
+    "comment": "plpgsql_array - Statement 27",
+    "query": "do $$ declare v1 int; v2 varchar; a1 v1%type[]; a2 v2%type[]; begin v1 := 10; v2 := 'Hi'; a1 := array[v1,v1]; a2 := array[v2,v2]; raise notice '% %', a1, a2; end; $$",
+    "expected": "DO ' declare v1 int; v2 varchar; a1 v1%type[]; a2 v2%type[]; begin v1 := 10; v2 := ''Hi''; a1 := array[v1,v1]; a2 := array[v2,v2]; raise notice ''% %'', a1, a2; end; '"
+  },
+  {
+    "comment": "plpgsql_array - Statement 28",
+    "query": "create table array_test_table(a int, b varchar)",
+    "expected": "CREATE TABLE array_test_table (a INT, b VARCHAR)"
+  },
+  {
+    "comment": "plpgsql_array - Statement 29",
+    "query": "insert into array_test_table values(1, 'first'), (2, 'second')",
+    "expected": "INSERT INTO array_test_table VALUES (1, 'first'), (2, 'second')"
+  },
+  {
+    "comment": "plpgsql_array - Statement 30",
+    "query": "do $$ declare tg array_test_table%rowtype[]; begin tg := array(select array_test_table from array_test_table); raise notice '%', tg; tg := array(select row(a,b) from array_test_table); raise notice '%', tg; end; $$",
+    "expected": "DO ' declare tg array_test_table%rowtype[]; begin tg := array(select array_test_table from array_test_table); raise notice ''%'', tg; tg := array(select row(a,b) from array_test_table); raise notice ''%'', tg; end; '"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_cache.json
+++ b/go/common/parser/testdata/postgres/plpgsql_cache.json
@@ -1,0 +1,47 @@
+[
+  {
+    "comment": "plpgsql_cache - Statement 1",
+    "query": "create table c_mutable(f1 int, f2 text)",
+    "expected": "CREATE TABLE c_mutable (f1 INT, f2 TEXT)"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 2",
+    "query": "create function c_sillyaddone(int) returns int language plpgsql as $$ declare r c_mutable; begin r.f1 := $1; return r.f1 + 1; end $$",
+    "expected": "CREATE FUNCTION c_sillyaddone (INT) RETURNS INT LANGUAGE plpgsql AS $$ declare r c_mutable; begin r.f1 := $1; return r.f1 + 1; end $$"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 3",
+    "query": "select c_sillyaddone(42)",
+    "expected": "SELECT c_sillyaddone(42)"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 4",
+    "query": "alter table c_mutable drop column f1",
+    "expected": "ALTER TABLE c_mutable DROP COLUMN f1"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 5",
+    "query": "alter table c_mutable add column f1 float8",
+    "expected": "ALTER TABLE c_mutable ADD COLUMN f1 FLOAT8"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 6",
+    "query": "discard plans",
+    "expected": "DISCARD PLANS"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 7",
+    "query": "create function show_result_type(text) returns text language plpgsql as $$ declare r record; t text; begin execute $1 into r; select pg_typeof(r.a) into t; return format('type %s value %s', t, r.a::text); end; $$",
+    "expected": "CREATE FUNCTION show_result_type (TEXT) RETURNS TEXT LANGUAGE plpgsql AS $$ declare r record; t text; begin execute $1 into r; select pg_typeof(r.a) into t; return format('type %s value %s', t, r.a::text); end; $$"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 8",
+    "query": "select show_result_type('select 1 as a')",
+    "expected": "SELECT show_result_type('select 1 as a')"
+  },
+  {
+    "comment": "plpgsql_cache - Statement 9",
+    "query": "select show_result_type('select 2.0 as a')",
+    "expected": "SELECT show_result_type('select 2.0 as a')"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_call.json
+++ b/go/common/parser/testdata/postgres/plpgsql_call.json
@@ -1,0 +1,364 @@
+[
+  {
+    "comment": "plpgsql_call - Statement 1",
+    "query": "CREATE PROCEDURE test_proc1() LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$",
+    "expected": "CREATE PROCEDURE test_proc1 () LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 2",
+    "query": "CALL test_proc1()"
+  },
+  {
+    "comment": "plpgsql_call - Statement 3",
+    "query": "CREATE PROCEDURE test_proc2() LANGUAGE plpgsql AS $$ BEGIN RETURN 5; END; $$",
+    "expected": "CREATE PROCEDURE test_proc2 () LANGUAGE plpgsql AS $$ BEGIN RETURN 5; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 4",
+    "query": "CREATE TABLE test1 (a int)",
+    "expected": "CREATE TABLE test1 (a INT)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 5",
+    "query": "CREATE PROCEDURE test_proc3(x int) LANGUAGE plpgsql AS $$ BEGIN INSERT INTO test1 VALUES (x); END; $$",
+    "expected": "CREATE PROCEDURE test_proc3 (x INT) LANGUAGE plpgsql AS $$ BEGIN INSERT INTO test1 VALUES (x); END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 6",
+    "query": "CALL test_proc3(55)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 7",
+    "query": "SELECT * FROM test1"
+  },
+  {
+    "comment": "plpgsql_call - Statement 8",
+    "query": "CREATE PROCEDURE test_proc3a() LANGUAGE plpgsql AS $$ BEGIN COMMIT; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; RAISE NOTICE 'done'; END; $$",
+    "expected": "CREATE PROCEDURE test_proc3a () LANGUAGE plpgsql AS $$ BEGIN COMMIT; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; RAISE NOTICE 'done'; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 9",
+    "query": "CALL test_proc3a()"
+  },
+  {
+    "comment": "plpgsql_call - Statement 10",
+    "query": "CREATE TEMP TABLE tt1(f1 int)",
+    "expected": "CREATE TEMPORARY TABLE tt1 (f1 INT)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 11",
+    "query": "TRUNCATE TABLE test1",
+    "expected": "TRUNCATE TABLE test1 CONTINUE IDENTITY RESTRICT"
+  },
+  {
+    "comment": "plpgsql_call - Statement 12",
+    "query": "CREATE PROCEDURE test_proc4(y int) LANGUAGE plpgsql AS $$ BEGIN CALL test_proc3(y); CALL test_proc3($1); END; $$",
+    "expected": "CREATE PROCEDURE test_proc4 (y INT) LANGUAGE plpgsql AS $$ BEGIN CALL test_proc3(y); CALL test_proc3($1); END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 13",
+    "query": "CALL test_proc4(66)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 14",
+    "query": "CREATE PROCEDURE test_proc5(INOUT a text) LANGUAGE plpgsql AS $$ BEGIN a := a || '+' || a; END; $$",
+    "expected": "CREATE PROCEDURE test_proc5 (INOUT a TEXT) LANGUAGE plpgsql AS $$ BEGIN a := a || '+' || a; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 15",
+    "query": "CALL test_proc5('abc')"
+  },
+  {
+    "comment": "plpgsql_call - Statement 16",
+    "query": "CREATE PROCEDURE test_proc6(a int, INOUT b int, INOUT c int) LANGUAGE plpgsql AS $$ BEGIN b := b * a; c := c * a; END; $$",
+    "expected": "CREATE PROCEDURE test_proc6 (a INT, INOUT b INT, INOUT c INT) LANGUAGE plpgsql AS $$ BEGIN b := b * a; c := c * a; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 17",
+    "query": "CALL test_proc6(2, 3, 4)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 18",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE x int := 3; y int := 4; BEGIN CALL test_proc6(2, x, y); RAISE INFO 'x = %, y = %', x, y; CALL test_proc6(2, c => y, b => x); RAISE INFO 'x = %, y = %', x, y; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE x int := 3; y int := 4; BEGIN CALL test_proc6(2, x, y); RAISE INFO ''x = %, y = %'', x, y; CALL test_proc6(2, c => y, b => x); RAISE INFO ''x = %, y = %'', x, y; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 19",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE x int := 3; y int := 4; BEGIN CALL test_proc6(2, x + 1, y); RAISE INFO 'x = %, y = %', x, y; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE x int := 3; y int := 4; BEGIN CALL test_proc6(2, x + 1, y); RAISE INFO ''x = %, y = %'', x, y; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 20",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE x constant int := 3; y int := 4; BEGIN CALL test_proc6(2, x, y); END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE x constant int := 3; y int := 4; BEGIN CALL test_proc6(2, x, y); END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 21",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE x int := 3; y int := 4; BEGIN FOR i IN 1..5 LOOP CALL test_proc6(i, x, y); RAISE INFO 'x = %, y = %', x, y; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE x int := 3; y int := 4; BEGIN FOR i IN 1..5 LOOP CALL test_proc6(i, x, y); RAISE INFO ''x = %, y = %'', x, y; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 22",
+    "query": "CREATE PROCEDURE test_proc7(x int, INOUT a int, INOUT b numeric) LANGUAGE plpgsql AS $$ BEGIN IF x > 1 THEN a := x / 10; b := x / 2; CALL test_proc7(b::int, a, b); END IF; END; $$",
+    "expected": "CREATE PROCEDURE test_proc7 (x INT, INOUT a INT, INOUT b NUMERIC) LANGUAGE plpgsql AS $$ BEGIN IF x > 1 THEN a := x / 10; b := x / 2; CALL test_proc7(b::int, a, b); END IF; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 23",
+    "query": "CALL test_proc7(100, -1, -1)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 24",
+    "query": "CREATE PROCEDURE test_proc7c(x int, INOUT a int, INOUT b numeric) LANGUAGE plpgsql AS $$ BEGIN a := x / 10; b := x / 2; COMMIT; END; $$",
+    "expected": "CREATE PROCEDURE test_proc7c (x INT, INOUT a INT, INOUT b NUMERIC) LANGUAGE plpgsql AS $$ BEGIN a := x / 10; b := x / 2; COMMIT; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 25",
+    "query": "CREATE PROCEDURE test_proc7cc(_x int) LANGUAGE plpgsql AS $$ DECLARE _a int; _b numeric; BEGIN CALL test_proc7c(_x, _a, _b); RAISE NOTICE '_x: %,_a: %, _b: %', _x, _a, _b; END $$",
+    "expected": "CREATE PROCEDURE test_proc7cc (_x INT) LANGUAGE plpgsql AS $$ DECLARE _a int; _b numeric; BEGIN CALL test_proc7c(_x, _a, _b); RAISE NOTICE '_x: %,_a: %, _b: %', _x, _a, _b; END $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 26",
+    "query": "CALL test_proc7cc(10)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 27",
+    "query": "CREATE PROCEDURE test_proc8a(INOUT a int, INOUT b int) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; a := a * 10; b := b + 10; END; $$",
+    "expected": "CREATE PROCEDURE test_proc8a (INOUT a INT, INOUT b INT) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; a := a * 10; b := b + 10; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 28",
+    "query": "CALL test_proc8a(10, 20)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 29",
+    "query": "CALL test_proc8a(b => 20, a => 10)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 30",
+    "query": "DO $$ DECLARE _a int; _b int; BEGIN _a := 10; _b := 30; CALL test_proc8a(_a, _b); RAISE NOTICE '_a: %, _b: %', _a, _b; CALL test_proc8a(b => _b, a => _a); RAISE NOTICE '_a: %, _b: %', _a, _b; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; BEGIN _a := 10; _b := 30; CALL test_proc8a(_a, _b); RAISE NOTICE ''_a: %, _b: %'', _a, _b; CALL test_proc8a(b => _b, a => _a); RAISE NOTICE ''_a: %, _b: %'', _a, _b; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 31",
+    "query": "CREATE PROCEDURE test_proc8b(INOUT a int, INOUT b int, INOUT c int) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; a := a * 10; b := b + 10; c := c * -10; END; $$",
+    "expected": "CREATE PROCEDURE test_proc8b (INOUT a INT, INOUT b INT, INOUT c INT) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; a := a * 10; b := b + 10; c := c * -10; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 32",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8b(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; CALL test_proc8b(_a, c => _c, b => _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8b(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; CALL test_proc8b(_a, c => _c, b => _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 33",
+    "query": "CREATE PROCEDURE test_proc8c(INOUT a int, INOUT b int, INOUT c int DEFAULT 11) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; a := a * 10; b := b + 10; c := c * -10; END; $$",
+    "expected": "CREATE PROCEDURE test_proc8c (INOUT a INT, INOUT b INT, INOUT c INT DEFAULT 11) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; a := a * 10; b := b + 10; c := c * -10; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 34",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, c => _c, b => _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; _a := 10; _b := 30; _c := 50; CALL test_proc8c(c => _c, b => _b, a => _a); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, c => _c, b => _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; _a := 10; _b := 30; _c := 50; CALL test_proc8c(c => _c, b => _b, a => _a); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 35",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 36",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, b => _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 50; CALL test_proc8c(_a, b => _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 37",
+    "query": "CREATE PROCEDURE test_proc9(IN a int, OUT b int) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; b := a * 2; END; $$",
+    "expected": "CREATE PROCEDURE test_proc9 (a INT, OUT b INT) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; b := a * 2; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 38",
+    "query": "DO $$ DECLARE _a int; _b int; BEGIN _a := 10; _b := 30; CALL test_proc9(_a, _b); RAISE NOTICE '_a: %, _b: %', _a, _b; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; BEGIN _a := 10; _b := 30; CALL test_proc9(_a, _b); RAISE NOTICE ''_a: %, _b: %'', _a, _b; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 39",
+    "query": "CREATE PROCEDURE test_proc10(IN a int, OUT b int, IN c int DEFAULT 11) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; b := a - c; END; $$",
+    "expected": "CREATE PROCEDURE test_proc10 (a INT, OUT b INT, c INT DEFAULT 11) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %, c: %', a, b, c; b := a - c; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 40",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b, c => _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(a => _a, b => _b, c => _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, c => _c, b => _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, b => _b); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(b => _b, a => _a); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b, c => _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(a => _a, b => _b, c => _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, c => _c, b => _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(_a, b => _b); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c;  _a := 10; _b := 30; _c := 7; CALL test_proc10(b => _b, a => _a); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 41",
+    "query": "CREATE PROCEDURE test_proc11(a OUT int, VARIADIC b int[]) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; a := b[1] + b[2]; END; $$",
+    "expected": "CREATE PROCEDURE test_proc11 (OUT a INT, VARIADIC b INT[]) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %, b: %', a, b; a := b[1] + b[2]; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 42",
+    "query": "DO $$ DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 7; CALL test_proc11(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int; BEGIN _a := 10; _b := 30; _c := 7; CALL test_proc11(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 43",
+    "query": "CREATE PROCEDURE test_proc12(a anyelement, OUT b anyelement, OUT c anyarray) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %', a; b := a; c := array[a]; END; $$",
+    "expected": "CREATE PROCEDURE test_proc12 (a anyelement, OUT b anyelement, OUT c anyarray) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'a: %', a; b := a; c := array[a]; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 44",
+    "query": "DO $$ DECLARE _a int; _b int; _c int[]; BEGIN _a := 10; CALL test_proc12(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c int[]; BEGIN _a := 10; CALL test_proc12(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 45",
+    "query": "DO $$ DECLARE _a int; _b int; _c text[]; BEGIN _a := 10; CALL test_proc12(_a, _b, _c); RAISE NOTICE '_a: %, _b: %, _c: %', _a, _b, _c; END $$",
+    "expected": "DO ' DECLARE _a int; _b int; _c text[]; BEGIN _a := 10; CALL test_proc12(_a, _b, _c); RAISE NOTICE ''_a: %, _b: %, _c: %'', _a, _b, _c; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 46",
+    "query": "TRUNCATE test1",
+    "expected": "TRUNCATE TABLE test1 CONTINUE IDENTITY RESTRICT"
+  },
+  {
+    "comment": "plpgsql_call - Statement 47",
+    "query": "CREATE FUNCTION triggerfunc1() RETURNS trigger LANGUAGE plpgsql AS $$ DECLARE z int := 0; BEGIN CALL test_proc6(2, NEW.a, NEW.a); RETURN NEW; END; $$",
+    "expected": "CREATE FUNCTION triggerfunc1 () RETURNS trigger LANGUAGE plpgsql AS $$ DECLARE z int := 0; BEGIN CALL test_proc6(2, NEW.a, NEW.a); RETURN NEW; END; $$"
+  },
+  {
+    "comment": "plpgsql_call - Statement 48",
+    "query": "CREATE TRIGGER t1 BEFORE INSERT ON test1 EXECUTE PROCEDURE triggerfunc1()",
+    "expected": "CREATE TRIGGER t1 BEFORE INSERT ON test1 EXECUTE FUNCTION triggerfunc1()"
+  },
+  {
+    "comment": "plpgsql_call - Statement 49",
+    "query": "INSERT INTO test1 VALUES (1), (2), (3)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 50",
+    "query": "UPDATE test1 SET a = 22 WHERE a = 2"
+  },
+  {
+    "comment": "plpgsql_call - Statement 51",
+    "query": "SELECT * FROM test1 ORDER BY a"
+  },
+  {
+    "comment": "plpgsql_call - Statement 52",
+    "query": "DROP PROCEDURE test_proc1"
+  },
+  {
+    "comment": "plpgsql_call - Statement 53",
+    "query": "DROP PROCEDURE test_proc3"
+  },
+  {
+    "comment": "plpgsql_call - Statement 54",
+    "query": "DROP PROCEDURE test_proc4"
+  },
+  {
+    "comment": "plpgsql_call - Statement 55",
+    "query": "DROP TABLE test1"
+  },
+  {
+    "comment": "plpgsql_call - Statement 56",
+    "query": "CREATE PROCEDURE p1(v_cnt int, v_Text inout text = NULL) AS $$ BEGIN v_Text := 'v_cnt = ' || v_cnt; END $$ LANGUAGE plpgsql",
+    "expected": "CREATE PROCEDURE p1 (v_cnt INT, INOUT v_text TEXT DEFAULT NULL) AS $$ BEGIN v_Text := 'v_cnt = ' || v_cnt; END $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 57",
+    "query": "DO $$ DECLARE v_Text text; v_cnt  integer := 42; BEGIN CALL p1(v_cnt := v_cnt); RAISE NOTICE '%', v_Text; END; $$",
+    "expected": "DO ' DECLARE v_Text text; v_cnt  integer := 42; BEGIN CALL p1(v_cnt := v_cnt); RAISE NOTICE ''%'', v_Text; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 58",
+    "query": "DO $$ DECLARE v_Text text; v_cnt  integer := 42; BEGIN CALL p1(v_cnt := v_cnt, v_Text := v_Text); RAISE NOTICE '%', v_Text; END; $$",
+    "expected": "DO ' DECLARE v_Text text; v_cnt  integer := 42; BEGIN CALL p1(v_cnt := v_cnt, v_Text := v_Text); RAISE NOTICE ''%'', v_Text; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 59",
+    "query": "DO $$ DECLARE v_Text text; BEGIN CALL p1(10, v_Text := v_Text); RAISE NOTICE '%', v_Text; END; $$",
+    "expected": "DO ' DECLARE v_Text text; BEGIN CALL p1(10, v_Text := v_Text); RAISE NOTICE ''%'', v_Text; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 60",
+    "query": "DO $$ DECLARE v_Text text; v_cnt  integer; BEGIN CALL p1(v_Text := v_Text, v_cnt := v_cnt); RAISE NOTICE '%', v_Text; END; $$",
+    "expected": "DO ' DECLARE v_Text text; v_cnt  integer; BEGIN CALL p1(v_Text := v_Text, v_cnt := v_cnt); RAISE NOTICE ''%'', v_Text; END; '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 61",
+    "query": "CREATE PROCEDURE inner_p (f1 int) AS $$ BEGIN RAISE NOTICE 'inner_p(%)', f1; END $$ LANGUAGE plpgsql",
+    "expected": "CREATE PROCEDURE inner_p (f1 INT) AS $$ BEGIN RAISE NOTICE 'inner_p(%)', f1; END $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 62",
+    "query": "CREATE FUNCTION f(int) RETURNS int AS $$ SELECT $1 + 1 $$ LANGUAGE sql",
+    "expected": "CREATE FUNCTION f (INT) RETURNS INT AS $$ SELECT $1 + 1 $$ LANGUAGE sql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 63",
+    "query": "CREATE PROCEDURE outer_p (f1 int) AS $$ BEGIN RAISE NOTICE 'outer_p(%)', f1; CALL inner_p(f(f1)); END $$ LANGUAGE plpgsql",
+    "expected": "CREATE PROCEDURE outer_p (f1 INT) AS $$ BEGIN RAISE NOTICE 'outer_p(%)', f1; CALL inner_p(f(f1)); END $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 64",
+    "query": "CREATE FUNCTION outer_f (f1 int) RETURNS void AS $$ BEGIN RAISE NOTICE 'outer_f(%)', f1; CALL inner_p(f(f1)); END $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION outer_f (f1 INT) RETURNS void AS $$ BEGIN RAISE NOTICE 'outer_f(%)', f1; CALL inner_p(f(f1)); END $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 65",
+    "query": "CALL outer_p(42)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 66",
+    "query": "SELECT outer_f(42)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 67",
+    "query": "DROP FUNCTION f(int)",
+    "expected": "DROP FUNCTION f(INT)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 68",
+    "query": "CREATE FUNCTION f(int) RETURNS int AS $$ SELECT $1 + 2 $$ LANGUAGE sql",
+    "expected": "CREATE FUNCTION f (INT) RETURNS INT AS $$ SELECT $1 + 2 $$ LANGUAGE sql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 69",
+    "query": "CREATE TABLE t_test (x int)",
+    "expected": "CREATE TABLE t_test (x INT)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 70",
+    "query": "INSERT INTO t_test VALUES (0)"
+  },
+  {
+    "comment": "plpgsql_call - Statement 71",
+    "query": "CREATE FUNCTION f_get_x () RETURNS int AS $$ DECLARE l_result int; BEGIN SELECT x INTO l_result FROM t_test; RETURN l_result; END $$ LANGUAGE plpgsql STABLE",
+    "expected": "CREATE FUNCTION f_get_x () RETURNS INT AS $$ DECLARE l_result int; BEGIN SELECT x INTO l_result FROM t_test; RETURN l_result; END $$ LANGUAGE plpgsql STABLE"
+  },
+  {
+    "comment": "plpgsql_call - Statement 72",
+    "query": "CREATE PROCEDURE f_print_x (x int) AS $$ BEGIN RAISE NOTICE 'f_print_x(%)', x; END $$ LANGUAGE plpgsql",
+    "expected": "CREATE PROCEDURE f_print_x (x INT) AS $$ BEGIN RAISE NOTICE 'f_print_x(%)', x; END $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_call - Statement 73",
+    "query": "DO $$ BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); ROLLBACK; END $$",
+    "expected": "DO ' BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); ROLLBACK; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 74",
+    "query": "DO $$ BEGIN BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); EXCEPTION WHEN division_by_zero THEN RAISE NOTICE '%', SQLERRM; END; ROLLBACK; END $$",
+    "expected": "DO ' BEGIN BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); EXCEPTION WHEN division_by_zero THEN RAISE NOTICE ''%'', SQLERRM; END; ROLLBACK; END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 75",
+    "query": "BEGIN"
+  },
+  {
+    "comment": "plpgsql_call - Statement 76",
+    "query": "DO $$ BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE 'f_get_x(%)', f_get_x(); CALL f_print_x(f_get_x()); END $$",
+    "expected": "DO ' BEGIN UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); UPDATE t_test SET x = x + 1; RAISE NOTICE ''f_get_x(%)'', f_get_x(); CALL f_print_x(f_get_x()); END '"
+  },
+  {
+    "comment": "plpgsql_call - Statement 77",
+    "query": "ROLLBACK"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_control.json
+++ b/go/common/parser/testdata/postgres/plpgsql_control.json
@@ -1,0 +1,247 @@
+[
+  {
+    "comment": "plpgsql_control - Statement 1",
+    "query": "do $$ begin  for i in 1..3 loop raise notice '1..3: i = %', i; end loop;  for i in 1..10 by 3 loop raise notice '1..10 by 3: i = %', i; end loop;  for i in 1..11 by 3 loop raise notice '1..11 by 3: i = %', i; end loop;  for i in 1..0 by 3 loop raise notice '1..0 by 3: i = %', i; end loop;  for i in reverse 10..0 by 3 loop raise notice 'reverse 10..0 by 3: i = %', i; end loop;  for i in 2147483620..2147483647 by 10 loop raise notice '2147483620..2147483647 by 10: i = %', i; end loop;  for i in reverse -2147483620..-2147483647 by 10 loop raise notice 'reverse -2147483620..-2147483647 by 10: i = %', i; end loop; end$$",
+    "expected": "DO ' begin  for i in 1..3 loop raise notice ''1..3: i = %'', i; end loop;  for i in 1..10 by 3 loop raise notice ''1..10 by 3: i = %'', i; end loop;  for i in 1..11 by 3 loop raise notice ''1..11 by 3: i = %'', i; end loop;  for i in 1..0 by 3 loop raise notice ''1..0 by 3: i = %'', i; end loop;  for i in reverse 10..0 by 3 loop raise notice ''reverse 10..0 by 3: i = %'', i; end loop;  for i in 2147483620..2147483647 by 10 loop raise notice ''2147483620..2147483647 by 10: i = %'', i; end loop;  for i in reverse -2147483620..-2147483647 by 10 loop raise notice ''reverse -2147483620..-2147483647 by 10: i = %'', i; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 2",
+    "query": "do $$ begin for i in 1..3 by 0 loop raise notice '1..3 by 0: i = %', i; end loop; end$$",
+    "expected": "DO ' begin for i in 1..3 by 0 loop raise notice ''1..3 by 0: i = %'', i; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 3",
+    "query": "do $$ begin for i in 1..3 by -1 loop raise notice '1..3 by -1: i = %', i; end loop; end$$",
+    "expected": "DO ' begin for i in 1..3 by -1 loop raise notice ''1..3 by -1: i = %'', i; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 4",
+    "query": "do $$ begin for i in reverse 1..3 by -1 loop raise notice 'reverse 1..3 by -1: i = %', i; end loop; end$$",
+    "expected": "DO ' begin for i in reverse 1..3 by -1 loop raise notice ''reverse 1..3 by -1: i = %'', i; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 5",
+    "query": "create table conttesttbl(idx serial, v integer)",
+    "expected": "CREATE TABLE conttesttbl (idx serial, v INT)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 6",
+    "query": "insert into conttesttbl(v) values(10)",
+    "expected": "INSERT INTO conttesttbl (v) VALUES (10)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 7",
+    "query": "insert into conttesttbl(v) values(20)",
+    "expected": "INSERT INTO conttesttbl (v) VALUES (20)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 8",
+    "query": "insert into conttesttbl(v) values(30)",
+    "expected": "INSERT INTO conttesttbl (v) VALUES (30)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 9",
+    "query": "insert into conttesttbl(v) values(40)",
+    "expected": "INSERT INTO conttesttbl (v) VALUES (40)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 10",
+    "query": "create function continue_test1() returns void as $$ declare _i integer = 0; _r record; begin raise notice '---1---'; loop _i := _i + 1; raise notice '%', _i; continue when _i < 10; exit; end loop;  raise notice '---2---'; <<lbl>> loop _i := _i - 1; loop raise notice '%', _i; continue lbl when _i > 0; exit lbl; end loop; end loop;  raise notice '---3---'; <<the_loop>> while _i < 10 loop _i := _i + 1; continue the_loop when _i % 2 = 0; raise notice '%', _i; end loop;  raise notice '---4---'; for _i in 1..10 loop begin  continue when _i < 5; raise notice '%', _i; end; end loop;  raise notice '---5---'; for _r in select * from conttesttbl loop continue when _r.v <= 20; raise notice '%', _r.v; end loop;  raise notice '---6---'; for _r in execute 'select * from conttesttbl' loop continue when _r.v <= 20; raise notice '%', _r.v; end loop;  raise notice '---7---'; <<looplabel>> for _i in 1..3 loop continue looplabel when _i = 2; raise notice '%', _i; end loop;  raise notice '---8---'; _i := 1; while _i <= 3 loop raise notice '%', _i; _i := _i + 1; continue when _i = 3; end loop;  raise notice '---9---'; for _r in select * from conttesttbl order by v limit 1 loop raise notice '%', _r.v; continue; end loop;  raise notice '---10---'; for _r in execute 'select * from conttesttbl order by v limit 1' loop raise notice '%', _r.v; continue; end loop;  raise notice '---11---'; <<outerlooplabel>> for _i in 1..2 loop raise notice 'outer %', _i; <<innerlooplabel>> for _j in 1..3 loop continue outerlooplabel when _j = 2; raise notice 'inner %', _j; end loop; end loop; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION continue_test1 () RETURNS void AS $$ declare _i integer = 0; _r record; begin raise notice '---1---'; loop _i := _i + 1; raise notice '%', _i; continue when _i < 10; exit; end loop;  raise notice '---2---'; <<lbl>> loop _i := _i - 1; loop raise notice '%', _i; continue lbl when _i > 0; exit lbl; end loop; end loop;  raise notice '---3---'; <<the_loop>> while _i < 10 loop _i := _i + 1; continue the_loop when _i % 2 = 0; raise notice '%', _i; end loop;  raise notice '---4---'; for _i in 1..10 loop begin  continue when _i < 5; raise notice '%', _i; end; end loop;  raise notice '---5---'; for _r in select * from conttesttbl loop continue when _r.v <= 20; raise notice '%', _r.v; end loop;  raise notice '---6---'; for _r in execute 'select * from conttesttbl' loop continue when _r.v <= 20; raise notice '%', _r.v; end loop;  raise notice '---7---'; <<looplabel>> for _i in 1..3 loop continue looplabel when _i = 2; raise notice '%', _i; end loop;  raise notice '---8---'; _i := 1; while _i <= 3 loop raise notice '%', _i; _i := _i + 1; continue when _i = 3; end loop;  raise notice '---9---'; for _r in select * from conttesttbl order by v limit 1 loop raise notice '%', _r.v; continue; end loop;  raise notice '---10---'; for _r in execute 'select * from conttesttbl order by v limit 1' loop raise notice '%', _r.v; continue; end loop;  raise notice '---11---'; <<outerlooplabel>> for _i in 1..2 loop raise notice 'outer %', _i; <<innerlooplabel>> for _j in 1..3 loop continue outerlooplabel when _j = 2; raise notice 'inner %', _j; end loop; end loop; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 11",
+    "query": "select continue_test1()",
+    "expected": "SELECT continue_test1()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 12",
+    "query": "create function continue_error1() returns void as $$ begin begin continue; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION continue_error1 () RETURNS void AS $$ begin begin continue; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 13",
+    "query": "create function exit_error1() returns void as $$ begin begin exit; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION exit_error1 () RETURNS void AS $$ begin begin exit; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 14",
+    "query": "create function continue_error2() returns void as $$ begin begin loop continue no_such_label; end loop; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION continue_error2 () RETURNS void AS $$ begin begin loop continue no_such_label; end loop; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 15",
+    "query": "create function exit_error2() returns void as $$ begin begin loop exit no_such_label; end loop; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION exit_error2 () RETURNS void AS $$ begin begin loop exit no_such_label; end loop; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 16",
+    "query": "create function continue_error3() returns void as $$ begin <<begin_block1>> begin loop continue begin_block1; end loop; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION continue_error3 () RETURNS void AS $$ begin <<begin_block1>> begin loop continue begin_block1; end loop; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 17",
+    "query": "create function exit_block1() returns void as $$ begin <<begin_block1>> begin loop exit begin_block1; raise exception 'should not get here'; end loop; end; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION exit_block1 () RETURNS void AS $$ begin <<begin_block1>> begin loop exit begin_block1; raise exception 'should not get here'; end loop; end; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 18",
+    "query": "select exit_block1()",
+    "expected": "SELECT exit_block1()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 19",
+    "query": "create function end_label1() returns void as $$ <<blbl>> begin <<flbl1>> for i in 1 .. 10 loop raise notice 'i = %', i; exit flbl1; end loop flbl1; <<flbl2>> for j in 1 .. 10 loop raise notice 'j = %', j; exit flbl2; end loop; end blbl; $$ language plpgsql",
+    "expected": "CREATE FUNCTION end_label1 () RETURNS void AS $$ <<blbl>> begin <<flbl1>> for i in 1 .. 10 loop raise notice 'i = %', i; exit flbl1; end loop flbl1; <<flbl2>> for j in 1 .. 10 loop raise notice 'j = %', j; exit flbl2; end loop; end blbl; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 20",
+    "query": "select end_label1()",
+    "expected": "SELECT end_label1()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 21",
+    "query": "create function end_label2() returns void as $$ begin for _i in 1 .. 10 loop exit; end loop flbl1; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION end_label2 () RETURNS void AS $$ begin for _i in 1 .. 10 loop exit; end loop flbl1; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 22",
+    "query": "create function end_label3() returns void as $$ <<outer_label>> begin <<inner_label>> for _i in 1 .. 10 loop exit; end loop outer_label; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION end_label3 () RETURNS void AS $$ <<outer_label>> begin <<inner_label>> for _i in 1 .. 10 loop exit; end loop outer_label; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 23",
+    "query": "create function end_label4() returns void as $$ <<outer_label>> begin for _i in 1 .. 10 loop exit; end loop outer_label; end; $$ language plpgsql",
+    "expected": "CREATE FUNCTION end_label4 () RETURNS void AS $$ <<outer_label>> begin for _i in 1 .. 10 loop exit; end loop outer_label; end; $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 24",
+    "query": "do $$ begin for i in 1..10 loop <<innerblock>> begin begin exit; raise notice 'should not get here'; end; raise notice 'should not get here, either'; end; raise notice 'nor here'; end loop; raise notice 'should get here'; end$$",
+    "expected": "DO ' begin for i in 1..10 loop <<innerblock>> begin begin exit; raise notice ''should not get here''; end; raise notice ''should not get here, either''; end; raise notice ''nor here''; end loop; raise notice ''should get here''; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 25",
+    "query": "do $$ <<outerblock>> begin <<innerblock>> begin <<moreinnerblock>> begin begin exit innerblock; raise notice 'should not get here'; end; raise notice 'should not get here, either'; end; raise notice 'nor here'; end; raise notice 'should get here'; end$$",
+    "expected": "DO ' <<outerblock>> begin <<innerblock>> begin <<moreinnerblock>> begin begin exit innerblock; raise notice ''should not get here''; end; raise notice ''should not get here, either''; end; raise notice ''nor here''; end; raise notice ''should get here''; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 26",
+    "query": "do $$ <<outerblock>> begin <<innerblock>> begin exit outerblock; raise notice 'should not get here'; end; raise notice 'should not get here, either'; end$$",
+    "expected": "DO ' <<outerblock>> begin <<innerblock>> begin exit outerblock; raise notice ''should not get here''; end; raise notice ''should not get here, either''; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 27",
+    "query": "do $$ begin <<outermostwhile>> while 1 > 0 loop <<outerwhile>> while 1 > 0 loop <<innerwhile>> while 1 > 0 loop exit; raise notice 'should not get here'; end loop; raise notice 'should get here'; exit outermostwhile; raise notice 'should not get here, either'; end loop; raise notice 'nor here'; end loop; raise notice 'should get here, too'; end$$",
+    "expected": "DO ' begin <<outermostwhile>> while 1 > 0 loop <<outerwhile>> while 1 > 0 loop <<innerwhile>> while 1 > 0 loop exit; raise notice ''should not get here''; end loop; raise notice ''should get here''; exit outermostwhile; raise notice ''should not get here, either''; end loop; raise notice ''nor here''; end loop; raise notice ''should get here, too''; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 28",
+    "query": "do $$ begin <<outerwhile>> while 1 > 0 loop while 1 > 0 loop exit outerwhile; raise notice 'should not get here'; end loop; raise notice 'should not get here, either'; end loop; raise notice 'should get here'; end$$",
+    "expected": "DO ' begin <<outerwhile>> while 1 > 0 loop while 1 > 0 loop exit outerwhile; raise notice ''should not get here''; end loop; raise notice ''should not get here, either''; end loop; raise notice ''should get here''; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 29",
+    "query": "do $$ declare i int := 0; begin <<outermostwhile>> while i < 2 loop raise notice 'outermostwhile, i = %', i; i := i + 1; <<outerwhile>> while 1 > 0 loop <<innerwhile>> while 1 > 0 loop continue outermostwhile; raise notice 'should not get here'; end loop; raise notice 'should not get here, either'; end loop; raise notice 'nor here'; end loop; raise notice 'out of outermostwhile, i = %', i; end$$",
+    "expected": "DO ' declare i int := 0; begin <<outermostwhile>> while i < 2 loop raise notice ''outermostwhile, i = %'', i; i := i + 1; <<outerwhile>> while 1 > 0 loop <<innerwhile>> while 1 > 0 loop continue outermostwhile; raise notice ''should not get here''; end loop; raise notice ''should not get here, either''; end loop; raise notice ''nor here''; end loop; raise notice ''out of outermostwhile, i = %'', i; end'"
+  },
+  {
+    "comment": "plpgsql_control - Statement 30",
+    "query": "create function return_from_while() returns int language plpgsql as $$ declare i int := 0; begin while i < 10 loop if i > 2 then return i; end if; i := i + 1; end loop; return null; end$$",
+    "expected": "CREATE FUNCTION return_from_while () RETURNS INT LANGUAGE plpgsql AS $$ declare i int := 0; begin while i < 10 loop if i > 2 then return i; end if; i := i + 1; end loop; return null; end$$"
+  },
+  {
+    "comment": "plpgsql_control - Statement 31",
+    "query": "select return_from_while()",
+    "expected": "SELECT return_from_while()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 32",
+    "query": "create function for_vect() returns void as $proc$ <<lbl>>declare a integer; b varchar; c varchar; r record; begin  for i in 1 .. 3 loop raise notice '%', i; end loop;  for r in select gs as aa, 'BB' as bb, 'CC' as cc from generate_series(1,4) gs loop raise notice '% % %', r.aa, r.bb, r.cc; end loop;  for a in select gs from generate_series(1,4) gs loop raise notice '%', a; end loop;  for a,b,c in select gs, 'BB','CC' from generate_series(1,4) gs loop raise notice '% % %', a, b, c; end loop;  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop raise notice '% % %', a, b, c; end loop; end; $proc$ language plpgsql",
+    "expected": "CREATE FUNCTION for_vect () RETURNS void AS $_$ <<lbl>>declare a integer; b varchar; c varchar; r record; begin  for i in 1 .. 3 loop raise notice '%', i; end loop;  for r in select gs as aa, 'BB' as bb, 'CC' as cc from generate_series(1,4) gs loop raise notice '% % %', r.aa, r.bb, r.cc; end loop;  for a in select gs from generate_series(1,4) gs loop raise notice '%', a; end loop;  for a,b,c in select gs, 'BB','CC' from generate_series(1,4) gs loop raise notice '% % %', a, b, c; end loop;  for lbl.a, lbl.b, lbl.c in execute $$select gs, 'bb','cc' from generate_series(1,4) gs$$ loop raise notice '% % %', a, b, c; end loop; end; $_$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 33",
+    "query": "select for_vect()",
+    "expected": "SELECT for_vect()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 34",
+    "query": "create or replace function case_test(bigint) returns text as $$ declare a int = 10; b int = 1; begin case $1 when 1 then return 'one'; when 2 then return 'two'; when 3,4,3+5 then return 'three, four or eight'; when a then return 'ten'; when a+b, a+b+1 then return 'eleven, twelve'; end case; end; $$ language plpgsql immutable",
+    "expected": "CREATE OR REPLACE FUNCTION case_test (BIGINT) RETURNS TEXT AS $$ declare a int = 10; b int = 1; begin case $1 when 1 then return 'one'; when 2 then return 'two'; when 3,4,3+5 then return 'three, four or eight'; when a then return 'ten'; when a+b, a+b+1 then return 'eleven, twelve'; end case; end; $$ LANGUAGE plpgsql IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_control - Statement 35",
+    "query": "select case_test(1)",
+    "expected": "SELECT case_test(1)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 36",
+    "query": "select case_test(2)",
+    "expected": "SELECT case_test(2)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 37",
+    "query": "select case_test(3)",
+    "expected": "SELECT case_test(3)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 38",
+    "query": "select case_test(4)",
+    "expected": "SELECT case_test(4)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 39",
+    "query": "select case_test(5)",
+    "expected": "SELECT case_test(5)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 40",
+    "query": "select case_test(8)",
+    "expected": "SELECT case_test(8)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 41",
+    "query": "select case_test(10)",
+    "expected": "SELECT case_test(10)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 42",
+    "query": "select case_test(11)",
+    "expected": "SELECT case_test(11)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 43",
+    "query": "select case_test(12)",
+    "expected": "SELECT case_test(12)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 44",
+    "query": "select case_test(13)",
+    "expected": "SELECT case_test(13)"
+  },
+  {
+    "comment": "plpgsql_control - Statement 45",
+    "query": "create or replace function catch() returns void as $$ begin raise notice '%', case_test(6); exception when case_not_found then raise notice 'caught case_not_found % %', SQLSTATE, SQLERRM; end $$ language plpgsql",
+    "expected": "CREATE OR REPLACE FUNCTION catch () RETURNS void AS $$ begin raise notice '%', case_test(6); exception when case_not_found then raise notice 'caught case_not_found % %', SQLSTATE, SQLERRM; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_control - Statement 46",
+    "query": "select catch()",
+    "expected": "SELECT catch()"
+  },
+  {
+    "comment": "plpgsql_control - Statement 47",
+    "query": "create or replace function case_test(bigint) returns text as $$ declare a int = 10; begin case when $1 = 1 then return 'one'; when $1 = a + 2 then return 'twelve'; else return 'other'; end case; end; $$ language plpgsql immutable",
+    "expected": "CREATE OR REPLACE FUNCTION case_test (BIGINT) RETURNS TEXT AS $$ declare a int = 10; begin case when $1 = 1 then return 'one'; when $1 = a + 2 then return 'twelve'; else return 'other'; end case; end; $$ LANGUAGE plpgsql IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_control - Statement 48",
+    "query": "create or replace function case_comment(int) returns text as $$ begin case $1 when 1 then return 'one'; else return 'other'; end case; end; $$ language plpgsql immutable",
+    "expected": "CREATE OR REPLACE FUNCTION case_comment (INT) RETURNS TEXT AS $$ begin case $1 when 1 then return 'one'; else return 'other'; end case; end; $$ LANGUAGE plpgsql IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_control - Statement 49",
+    "query": "select case_comment(1)",
+    "expected": "SELECT case_comment(1)"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_copy.json
+++ b/go/common/parser/testdata/postgres/plpgsql_copy.json
@@ -1,0 +1,35 @@
+[
+  {
+    "comment": "plpgsql_copy - Statement 1",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN COPY copy1 TO stdout; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN COPY copy1 TO stdout; END; '"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 2",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN COPY copy1 FROM stdin; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN COPY copy1 FROM stdin; END; '"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 3",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN EXECUTE 'COPY copy1 TO stdout'; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN EXECUTE ''COPY copy1 TO stdout''; END; '"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 4",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN EXECUTE 'COPY copy1 FROM stdin'; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN EXECUTE ''COPY copy1 FROM stdin''; END; '"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 5",
+    "query": "SELECT * FROM copy1 ORDER BY 1"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 6",
+    "query": "TRUNCATE copy1",
+    "expected": "TRUNCATE TABLE copy1 CONTINUE IDENTITY RESTRICT"
+  },
+  {
+    "comment": "plpgsql_copy - Statement 7",
+    "query": "DROP TABLE copy1"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_domain.json
+++ b/go/common/parser/testdata/postgres/plpgsql_domain.json
@@ -1,0 +1,406 @@
+[
+  {
+    "comment": "plpgsql_domain - Statement 1",
+    "query": "CREATE DOMAIN booltrue AS bool CHECK (VALUE IS TRUE OR VALUE IS NULL)",
+    "expected": "CREATE DOMAIN booltrue AS BOOLEAN CHECK (value IS TRUE OR value IS NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 2",
+    "query": "CREATE FUNCTION test_argresult_booltrue(x booltrue, y bool) RETURNS booltrue AS $$ begin return y; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_booltrue (x booltrue, y BOOLEAN) RETURNS booltrue AS $$ begin return y; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 3",
+    "query": "SELECT * FROM test_argresult_booltrue(true, true)",
+    "expected": "SELECT * FROM test_argresult_booltrue(TRUE, TRUE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 4",
+    "query": "SELECT * FROM test_argresult_booltrue(false, true)",
+    "expected": "SELECT * FROM test_argresult_booltrue(FALSE, TRUE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 5",
+    "query": "SELECT * FROM test_argresult_booltrue(true, false)",
+    "expected": "SELECT * FROM test_argresult_booltrue(TRUE, FALSE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 6",
+    "query": "CREATE FUNCTION test_assign_booltrue(x bool, y bool) RETURNS booltrue AS $$ declare v booltrue := x; begin v := y; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_booltrue (x BOOLEAN, y BOOLEAN) RETURNS booltrue AS $$ declare v booltrue := x; begin v := y; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 7",
+    "query": "SELECT * FROM test_assign_booltrue(true, true)",
+    "expected": "SELECT * FROM test_assign_booltrue(TRUE, TRUE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 8",
+    "query": "SELECT * FROM test_assign_booltrue(false, true)",
+    "expected": "SELECT * FROM test_assign_booltrue(FALSE, TRUE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 9",
+    "query": "SELECT * FROM test_assign_booltrue(true, false)",
+    "expected": "SELECT * FROM test_assign_booltrue(TRUE, FALSE)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 10",
+    "query": "CREATE DOMAIN uint2 AS int2 CHECK (VALUE >= 0)",
+    "expected": "CREATE DOMAIN uint2 AS SMALLINT CHECK (value >= 0)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 11",
+    "query": "CREATE FUNCTION test_argresult_uint2(x uint2, y int) RETURNS uint2 AS $$ begin return y; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_uint2 (x uint2, y INT) RETURNS uint2 AS $$ begin return y; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 12",
+    "query": "SELECT * FROM test_argresult_uint2(100::uint2, 50)",
+    "expected": "SELECT * FROM test_argresult_uint2(CAST(100 AS uint2), 50)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 13",
+    "query": "SELECT * FROM test_argresult_uint2(100::uint2, -50)",
+    "expected": "SELECT * FROM test_argresult_uint2(CAST(100 AS uint2), -50)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 14",
+    "query": "SELECT * FROM test_argresult_uint2(null, 1)",
+    "expected": "SELECT * FROM test_argresult_uint2(NULL, 1)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 15",
+    "query": "CREATE FUNCTION test_assign_uint2(x int, y int) RETURNS uint2 AS $$ declare v uint2 := x; begin v := y; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_uint2 (x INT, y INT) RETURNS uint2 AS $$ declare v uint2 := x; begin v := y; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 16",
+    "query": "SELECT * FROM test_assign_uint2(100, 50)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 17",
+    "query": "SELECT * FROM test_assign_uint2(100, -50)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 18",
+    "query": "SELECT * FROM test_assign_uint2(-100, 50)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 19",
+    "query": "SELECT * FROM test_assign_uint2(null, 1)",
+    "expected": "SELECT * FROM test_assign_uint2(NULL, 1)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 20",
+    "query": "CREATE DOMAIN nnint AS int NOT NULL",
+    "expected": "CREATE DOMAIN nnint AS INT NOT NULL"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 21",
+    "query": "CREATE FUNCTION test_argresult_nnint(x nnint, y int) RETURNS nnint AS $$ begin return y; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_nnint (x nnint, y INT) RETURNS nnint AS $$ begin return y; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 22",
+    "query": "SELECT * FROM test_argresult_nnint(10, 20)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 23",
+    "query": "SELECT * FROM test_argresult_nnint(null, 20)",
+    "expected": "SELECT * FROM test_argresult_nnint(NULL, 20)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 24",
+    "query": "SELECT * FROM test_argresult_nnint(10, null)",
+    "expected": "SELECT * FROM test_argresult_nnint(10, NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 25",
+    "query": "CREATE FUNCTION test_assign_nnint(x int, y int) RETURNS nnint AS $$ declare v nnint := x; begin v := y; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_nnint (x INT, y INT) RETURNS nnint AS $$ declare v nnint := x; begin v := y; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 26",
+    "query": "SELECT * FROM test_assign_nnint(10, 20)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 27",
+    "query": "SELECT * FROM test_assign_nnint(null, 20)",
+    "expected": "SELECT * FROM test_assign_nnint(NULL, 20)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 28",
+    "query": "SELECT * FROM test_assign_nnint(10, null)",
+    "expected": "SELECT * FROM test_assign_nnint(10, NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 29",
+    "query": "CREATE DOMAIN ordered_pair_domain AS integer[] CHECK (array_length(VALUE,1)=2 AND VALUE[1] < VALUE[2])",
+    "expected": "CREATE DOMAIN ordered_pair_domain AS INT[] CHECK (array_length(value, 1) = 2 AND value[1] < value[2])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 30",
+    "query": "CREATE FUNCTION test_argresult_array_domain(x ordered_pair_domain) RETURNS ordered_pair_domain AS $$ begin return x; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_array_domain (x ordered_pair_domain) RETURNS ordered_pair_domain AS $$ begin return x; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 31",
+    "query": "SELECT * FROM test_argresult_array_domain(ARRAY[0, 100]::ordered_pair_domain)",
+    "expected": "SELECT * FROM test_argresult_array_domain(CAST(ARRAY[0,100] AS ordered_pair_domain))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 32",
+    "query": "SELECT * FROM test_argresult_array_domain(NULL::ordered_pair_domain)",
+    "expected": "SELECT * FROM test_argresult_array_domain(CAST(NULL AS ordered_pair_domain))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 33",
+    "query": "CREATE FUNCTION test_argresult_array_domain_check_violation() RETURNS ordered_pair_domain AS $$ begin return array[2,1]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_array_domain_check_violation () RETURNS ordered_pair_domain AS $$ begin return array[2,1]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 34",
+    "query": "SELECT * FROM test_argresult_array_domain_check_violation()"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 35",
+    "query": "CREATE FUNCTION test_assign_ordered_pair_domain(x int, y int, z int) RETURNS ordered_pair_domain AS $$ declare v ordered_pair_domain := array[x, y]; begin v[2] := z; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_ordered_pair_domain (x INT, y INT, z INT) RETURNS ordered_pair_domain AS $$ declare v ordered_pair_domain := array[x, y]; begin v[2] := z; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 36",
+    "query": "SELECT * FROM test_assign_ordered_pair_domain(1,2,3)",
+    "expected": "SELECT * FROM test_assign_ordered_pair_domain(1, 2, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 37",
+    "query": "SELECT * FROM test_assign_ordered_pair_domain(1,2,0)",
+    "expected": "SELECT * FROM test_assign_ordered_pair_domain(1, 2, 0)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 38",
+    "query": "SELECT * FROM test_assign_ordered_pair_domain(2,1,3)",
+    "expected": "SELECT * FROM test_assign_ordered_pair_domain(2, 1, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 39",
+    "query": "CREATE FUNCTION test_read_uint2_array(x uint2[]) RETURNS uint2 AS $$ begin return x[1]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_read_uint2_array (x uint2[]) RETURNS uint2 AS $$ begin return x[1]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 40",
+    "query": "select test_read_uint2_array(array[1::uint2])",
+    "expected": "SELECT test_read_uint2_array(ARRAY[CAST(1 AS uint2)])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 41",
+    "query": "CREATE FUNCTION test_build_uint2_array(x int2) RETURNS uint2[] AS $$ begin return array[x, x]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_build_uint2_array (x SMALLINT) RETURNS uint2[] AS $$ begin return array[x, x]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 42",
+    "query": "select test_build_uint2_array(1::int2)",
+    "expected": "SELECT test_build_uint2_array(CAST(1 AS SMALLINT))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 43",
+    "query": "select test_build_uint2_array(-1::int2)",
+    "expected": "SELECT test_build_uint2_array(-CAST(1 AS SMALLINT))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 44",
+    "query": "CREATE FUNCTION test_argresult_domain_array(x integer[]) RETURNS ordered_pair_domain[] AS $$ begin return array[x::ordered_pair_domain, x::ordered_pair_domain]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_domain_array (x INT[]) RETURNS ordered_pair_domain[] AS $$ begin return array[x::ordered_pair_domain, x::ordered_pair_domain]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 45",
+    "query": "select test_argresult_domain_array(array[2,4])",
+    "expected": "SELECT test_argresult_domain_array(ARRAY[2,4])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 46",
+    "query": "select test_argresult_domain_array(array[4,2])",
+    "expected": "SELECT test_argresult_domain_array(ARRAY[4,2])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 47",
+    "query": "CREATE FUNCTION test_argresult_domain_array2(x ordered_pair_domain) RETURNS integer AS $$ begin return x[1]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_domain_array2 (x ordered_pair_domain) RETURNS INT AS $$ begin return x[1]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 48",
+    "query": "select test_argresult_domain_array2(array[2,4])",
+    "expected": "SELECT test_argresult_domain_array2(ARRAY[2,4])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 49",
+    "query": "select test_argresult_domain_array2(array[4,2])",
+    "expected": "SELECT test_argresult_domain_array2(ARRAY[4,2])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 50",
+    "query": "CREATE FUNCTION test_argresult_array_domain_array(x ordered_pair_domain[]) RETURNS ordered_pair_domain AS $$ begin return x[1]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_argresult_array_domain_array (x ordered_pair_domain[]) RETURNS ordered_pair_domain AS $$ begin return x[1]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 51",
+    "query": "select test_argresult_array_domain_array(array[array[2,4]::ordered_pair_domain])",
+    "expected": "SELECT test_argresult_array_domain_array(ARRAY[CAST(ARRAY[2,4] AS ordered_pair_domain)])"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 52",
+    "query": "CREATE TYPE nnint_container AS (f1 int, f2 nnint)",
+    "expected": "CREATE TYPE nnint_container AS (f1 INT, f2 nnint)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 53",
+    "query": "CREATE FUNCTION test_result_nnint_container(x int, y int) RETURNS nnint_container AS $$ begin return row(x, y)::nnint_container; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_result_nnint_container (x INT, y INT) RETURNS nnint_container AS $$ begin return row(x, y)::nnint_container; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 54",
+    "query": "SELECT test_result_nnint_container(null, 3)",
+    "expected": "SELECT test_result_nnint_container(NULL, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 55",
+    "query": "SELECT test_result_nnint_container(3, null)",
+    "expected": "SELECT test_result_nnint_container(3, NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 56",
+    "query": "CREATE FUNCTION test_assign_nnint_container(x int, y int, z int) RETURNS nnint_container AS $$ declare v nnint_container := row(x, y); begin v.f2 := z; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_nnint_container (x INT, y INT, z INT) RETURNS nnint_container AS $$ declare v nnint_container := row(x, y); begin v.f2 := z; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 57",
+    "query": "SELECT * FROM test_assign_nnint_container(1,2,3)",
+    "expected": "SELECT * FROM test_assign_nnint_container(1, 2, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 58",
+    "query": "SELECT * FROM test_assign_nnint_container(1,2,null)",
+    "expected": "SELECT * FROM test_assign_nnint_container(1, 2, NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 59",
+    "query": "SELECT * FROM test_assign_nnint_container(1,null,3)",
+    "expected": "SELECT * FROM test_assign_nnint_container(1, NULL, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 60",
+    "query": "SELECT null::nnint_container",
+    "expected": "SELECT CAST(NULL AS nnint_container)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 61",
+    "query": "CREATE FUNCTION test_assign_nnint_container2(x int, y int, z int) RETURNS nnint_container AS $$ declare v nnint_container; begin v.f2 := z; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_nnint_container2 (x INT, y INT, z INT) RETURNS nnint_container AS $$ declare v nnint_container; begin v.f2 := z; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 62",
+    "query": "SELECT * FROM test_assign_nnint_container2(1,2,3)",
+    "expected": "SELECT * FROM test_assign_nnint_container2(1, 2, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 63",
+    "query": "SELECT * FROM test_assign_nnint_container2(1,2,null)",
+    "expected": "SELECT * FROM test_assign_nnint_container2(1, 2, NULL)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 64",
+    "query": "CREATE TYPE named_pair AS ( i integer, j integer )",
+    "expected": "CREATE TYPE named_pair AS (i INT, j INT)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 65",
+    "query": "CREATE DOMAIN ordered_named_pair AS named_pair CHECK((VALUE).i <= (VALUE).j)",
+    "expected": "CREATE DOMAIN ordered_named_pair AS named_pair CHECK ((value).i <= (value).j)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 66",
+    "query": "CREATE FUNCTION read_ordered_named_pair(p ordered_named_pair) RETURNS integer AS $$ begin return p.i + p.j; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION read_ordered_named_pair (p ordered_named_pair) RETURNS INT AS $$ begin return p.i + p.j; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 67",
+    "query": "SELECT read_ordered_named_pair(row(1, 2))",
+    "expected": "SELECT read_ordered_named_pair(ROW(1, 2))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 68",
+    "query": "SELECT read_ordered_named_pair(row(2, 1))",
+    "expected": "SELECT read_ordered_named_pair(ROW(2, 1))"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 69",
+    "query": "CREATE FUNCTION build_ordered_named_pair(i int, j int) RETURNS ordered_named_pair AS $$ begin return row(i, j); end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_named_pair (i INT, j INT) RETURNS ordered_named_pair AS $$ begin return row(i, j); end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 70",
+    "query": "SELECT build_ordered_named_pair(1,2)",
+    "expected": "SELECT build_ordered_named_pair(1, 2)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 71",
+    "query": "SELECT build_ordered_named_pair(2,1)",
+    "expected": "SELECT build_ordered_named_pair(2, 1)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 72",
+    "query": "CREATE FUNCTION test_assign_ordered_named_pair(x int, y int, z int) RETURNS ordered_named_pair AS $$ declare v ordered_named_pair := row(x, y); begin v.j := z; return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_ordered_named_pair (x INT, y INT, z INT) RETURNS ordered_named_pair AS $$ declare v ordered_named_pair := row(x, y); begin v.j := z; return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 73",
+    "query": "SELECT * FROM test_assign_ordered_named_pair(1,2,3)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pair(1, 2, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 74",
+    "query": "SELECT * FROM test_assign_ordered_named_pair(1,2,0)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pair(1, 2, 0)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 75",
+    "query": "SELECT * FROM test_assign_ordered_named_pair(2,1,3)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pair(2, 1, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 76",
+    "query": "CREATE FUNCTION build_ordered_named_pairs(i int, j int) RETURNS ordered_named_pair[] AS $$ begin return array[row(i, j), row(i, j+1)]; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_named_pairs (i INT, j INT) RETURNS ordered_named_pair[] AS $$ begin return array[row(i, j), row(i, j+1)]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 77",
+    "query": "SELECT build_ordered_named_pairs(1,2)",
+    "expected": "SELECT build_ordered_named_pairs(1, 2)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 78",
+    "query": "SELECT build_ordered_named_pairs(2,1)",
+    "expected": "SELECT build_ordered_named_pairs(2, 1)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 79",
+    "query": "CREATE FUNCTION test_assign_ordered_named_pairs(x int, y int, z int) RETURNS ordered_named_pair[] AS $$ declare v ordered_named_pair[] := array[row(x, y)]; begin   return v; end $$ LANGUAGE plpgsql",
+    "expected": "CREATE FUNCTION test_assign_ordered_named_pairs (x INT, y INT, z INT) RETURNS ordered_named_pair[] AS $$ declare v ordered_named_pair[] := array[row(x, y)]; begin   return v; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 80",
+    "query": "SELECT * FROM test_assign_ordered_named_pairs(1,2,3)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pairs(1, 2, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 81",
+    "query": "SELECT * FROM test_assign_ordered_named_pairs(2,1,3)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pairs(2, 1, 3)"
+  },
+  {
+    "comment": "plpgsql_domain - Statement 82",
+    "query": "SELECT * FROM test_assign_ordered_named_pairs(1,2,0)",
+    "expected": "SELECT * FROM test_assign_ordered_named_pairs(1, 2, 0)"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_misc.json
+++ b/go/common/parser/testdata/postgres/plpgsql_misc.json
@@ -1,0 +1,67 @@
+[
+  {
+    "comment": "plpgsql_misc - Statement 1",
+    "query": "do $$ declare procedure int; begin create function test1() returns int begin atomic select 2 + 2; end; create or replace procedure test2(x int) begin atomic select x + 2; end; end $$",
+    "expected": "DO ' declare procedure int; begin create function test1() returns int begin atomic select 2 + 2; end; create or replace procedure test2(x int) begin atomic select x + 2; end; end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 2",
+    "query": "do $$ declare x foo%type; begin end $$",
+    "expected": "DO ' declare x foo%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 3",
+    "query": "do $$ declare x notice%type; begin end $$",
+    "expected": "DO ' declare x notice%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 4",
+    "query": "do $$ declare x foo.bar%type; begin end $$",
+    "expected": "DO ' declare x foo.bar%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 5",
+    "query": "do $$ declare x foo.bar.baz%type; begin end $$",
+    "expected": "DO ' declare x foo.bar.baz%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 6",
+    "query": "do $$ declare x public.foo.bar%type; begin end $$",
+    "expected": "DO ' declare x public.foo.bar%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 7",
+    "query": "do $$ declare x public.misc_table.zed%type; begin end $$",
+    "expected": "DO ' declare x public.misc_table.zed%type; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 8",
+    "query": "do $$ declare x foo%rowtype; begin end $$",
+    "expected": "DO ' declare x foo%rowtype; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 9",
+    "query": "do $$ declare x notice%rowtype; begin end $$",
+    "expected": "DO ' declare x notice%rowtype; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 10",
+    "query": "do $$ declare x foo.bar%rowtype; begin end $$",
+    "expected": "DO ' declare x foo.bar%rowtype; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 11",
+    "query": "do $$ declare x foo.bar.baz%rowtype; begin end $$",
+    "expected": "DO ' declare x foo.bar.baz%rowtype; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 12",
+    "query": "do $$ declare x public.foo%rowtype; begin end $$",
+    "expected": "DO ' declare x public.foo%rowtype; begin end '"
+  },
+  {
+    "comment": "plpgsql_misc - Statement 13",
+    "query": "do $$ declare x public.misc_table%rowtype; begin end $$",
+    "expected": "DO ' declare x public.misc_table%rowtype; begin end '"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_record.json
+++ b/go/common/parser/testdata/postgres/plpgsql_record.json
@@ -1,0 +1,607 @@
+[
+  {
+    "comment": "plpgsql_record - Statement 1",
+    "query": "create type two_int4s as (f1 int4, f2 int4)",
+    "expected": "CREATE TYPE two_int4s AS (f1 INT, f2 INT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 2",
+    "query": "create type more_int4s as (f0 text, f1 int4, f2 int4)",
+    "expected": "CREATE TYPE more_int4s AS (f0 TEXT, f1 INT, f2 INT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 3",
+    "query": "create type two_int8s as (q1 int8, q2 int8)",
+    "expected": "CREATE TYPE two_int8s AS (q1 BIGINT, q2 BIGINT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 4",
+    "query": "create type nested_int8s as (c1 two_int8s, c2 two_int8s)",
+    "expected": "CREATE TYPE nested_int8s AS (c1 two_int8s, c2 two_int8s)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 5",
+    "query": "create function retc(int) returns two_int8s language plpgsql as $$ begin return row($1,1)::two_int8s; end $$",
+    "expected": "CREATE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ begin return row($1,1)::two_int8s; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 6",
+    "query": "select retc(42)",
+    "expected": "SELECT retc(42)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 7",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ begin return row($1::int8, 1::int8); end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ begin return row($1::int8, 1::int8); end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 8",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ begin return row($1,1); end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ begin return row($1,1); end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 9",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ begin return row($1::int8, 1::int8, 42); end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ begin return row($1::int8, 1::int8, 42); end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 10",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ declare r record; begin r := row($1::int8, 1::int8); return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ declare r record; begin r := row($1::int8, 1::int8); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 11",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ declare r record; begin r := row($1,1); return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ declare r record; begin r := row($1,1); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 12",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ declare r record; begin r := row($1::int8, 1::int8, 42); return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ declare r record; begin r := row($1::int8, 1::int8, 42); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 13",
+    "query": "create or replace function retc(int) returns two_int8s language plpgsql as $$ declare r two_int8s; begin r := row($1::int8, 1::int8, 42); return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION retc (INT) RETURNS two_int8s LANGUAGE plpgsql AS $$ declare r two_int8s; begin r := row($1::int8, 1::int8, 42); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 14",
+    "query": "do $$ declare c two_int8s; begin c := row(1,2); raise notice 'c = %', c; end$$",
+    "expected": "DO ' declare c two_int8s; begin c := row(1,2); raise notice ''c = %'', c; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 15",
+    "query": "do $$ declare c two_int8s; begin for c in select 1,2 loop raise notice 'c = %', c; end loop; end$$",
+    "expected": "DO ' declare c two_int8s; begin for c in select 1,2 loop raise notice ''c = %'', c; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 16",
+    "query": "do $$ declare c4 two_int4s; c8 two_int8s; begin c8 := row(1,2); c4 := c8; c8 := c4; raise notice 'c4 = %', c4; raise notice 'c8 = %', c8; end$$",
+    "expected": "DO ' declare c4 two_int4s; c8 two_int8s; begin c8 := row(1,2); c4 := c8; c8 := c4; raise notice ''c4 = %'', c4; raise notice ''c8 = %'', c8; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 17",
+    "query": "do $$ declare c two_int8s; d nested_int8s; begin c := row(1,2); d := row(c, row(c.q1, c.q2+1)); raise notice 'c = %, d = %', c, d; c.q1 := 10; d.c1 := row(11,12); d.c2.q2 := 42; raise notice 'c = %, d = %', c, d; raise notice 'c.q1 = %, d.c2 = %', c.q1, d.c2; raise notice '(d).c2.q2 = %', (d).c2.q2; raise notice '(d.c2).q2 = %', (d.c2).q2; end$$",
+    "expected": "DO ' declare c two_int8s; d nested_int8s; begin c := row(1,2); d := row(c, row(c.q1, c.q2+1)); raise notice ''c = %, d = %'', c, d; c.q1 := 10; d.c1 := row(11,12); d.c2.q2 := 42; raise notice ''c = %, d = %'', c, d; raise notice ''c.q1 = %, d.c2 = %'', c.q1, d.c2; raise notice ''(d).c2.q2 = %'', (d).c2.q2; raise notice ''(d.c2).q2 = %'', (d.c2).q2; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 18",
+    "query": "do $$ <<b>> declare c two_int8s; d nested_int8s; begin b.c := row(1,2); b.d := row(b.c, row(b.c.q1, b.c.q2+1)); raise notice 'b.c = %, b.d = %', b.c, b.d; b.c.q1 := 10; b.d.c1 := row(11,12); b.d.c2.q2 := 42; raise notice 'b.c = %, b.d = %', b.c, b.d; raise notice 'b.c.q1 = %, b.d.c2 = %', b.c.q1, b.d.c2; raise notice '(b.d).c2.q2 = %', (b.d).c2.q2; raise notice '(b.d.c2).q2 = %', (b.d.c2).q2; end$$",
+    "expected": "DO ' <<b>> declare c two_int8s; d nested_int8s; begin b.c := row(1,2); b.d := row(b.c, row(b.c.q1, b.c.q2+1)); raise notice ''b.c = %, b.d = %'', b.c, b.d; b.c.q1 := 10; b.d.c1 := row(11,12); b.d.c2.q2 := 42; raise notice ''b.c = %, b.d = %'', b.c, b.d; raise notice ''b.c.q1 = %, b.d.c2 = %'', b.c.q1, b.d.c2; raise notice ''(b.d).c2.q2 = %'', (b.d).c2.q2; raise notice ''(b.d.c2).q2 = %'', (b.d.c2).q2; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 19",
+    "query": "do $$ declare c two_int8s; begin c.x = 1; end $$",
+    "expected": "DO ' declare c two_int8s; begin c.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 20",
+    "query": "do $$ declare c nested_int8s; begin c.x = 1; end $$",
+    "expected": "DO ' declare c nested_int8s; begin c.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 21",
+    "query": "do $$ declare c nested_int8s; begin c.x.q1 = 1; end $$",
+    "expected": "DO ' declare c nested_int8s; begin c.x.q1 = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 22",
+    "query": "do $$ declare c nested_int8s; begin c.c2.x = 1; end $$",
+    "expected": "DO ' declare c nested_int8s; begin c.c2.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 23",
+    "query": "do $$ declare c nested_int8s; begin d.c2.x = 1; end $$",
+    "expected": "DO ' declare c nested_int8s; begin d.c2.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 24",
+    "query": "do $$ <<b>> declare c two_int8s; begin b.c.x = 1; end $$",
+    "expected": "DO ' <<b>> declare c two_int8s; begin b.c.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 25",
+    "query": "do $$ <<b>> declare c nested_int8s; begin b.c.x = 1; end $$",
+    "expected": "DO ' <<b>> declare c nested_int8s; begin b.c.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 26",
+    "query": "do $$ <<b>> declare c nested_int8s; begin b.c.x.q1 = 1; end $$",
+    "expected": "DO ' <<b>> declare c nested_int8s; begin b.c.x.q1 = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 27",
+    "query": "do $$ <<b>> declare c nested_int8s; begin b.c.c2.x = 1; end $$",
+    "expected": "DO ' <<b>> declare c nested_int8s; begin b.c.c2.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 28",
+    "query": "do $$ <<b>> declare c nested_int8s; begin b.d.c2.x = 1; end $$",
+    "expected": "DO ' <<b>> declare c nested_int8s; begin b.d.c2.x = 1; end '"
+  },
+  {
+    "comment": "plpgsql_record - Statement 29",
+    "query": "create function getq1(two_int8s) returns int8 language plpgsql as $$ declare r two_int8s; begin r := $1; return r.q1; end $$",
+    "expected": "CREATE FUNCTION getq1 (two_int8s) RETURNS BIGINT LANGUAGE plpgsql AS $$ declare r two_int8s; begin r := $1; return r.q1; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 30",
+    "query": "select getq1(retc(344))",
+    "expected": "SELECT getq1(retc(344))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 31",
+    "query": "select getq1(row(1,2))",
+    "expected": "SELECT getq1(ROW(1, 2))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 32",
+    "query": "do $$ declare r1 two_int8s; r2 record; x int8; begin r1 := retc(345); perform getq1(r1); x := getq1(r1); raise notice 'x = %', x; r2 := retc(346); perform getq1(r2); x := getq1(r2); raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare r1 two_int8s; r2 record; x int8; begin r1 := retc(345); perform getq1(r1); x := getq1(r1); raise notice ''x = %'', x; r2 := retc(346); perform getq1(r2); x := getq1(r2); raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 33",
+    "query": "do $$ declare r1 two_int8s; r2 two_int8s; r3 record; r4 record; begin r1 := row(1,2); raise notice 'r1 = %', r1; r1 := r1; raise notice 'r1 = %', r1; r2 := r1; raise notice 'r1 = %', r1; raise notice 'r2 = %', r2; r2.q2 = r1.q1 + 3; raise notice 'r1 = %', r1; raise notice 'r2 = %', r2; r1 := null; raise notice 'r1 = %', r1; raise notice 'r2 = %', r2; r1 := row(7,11)::two_int8s; r2 := r1; raise notice 'r1 = %', r1; raise notice 'r2 = %', r2; r3 := row(1,2); r4 := r3; raise notice 'r3 = %', r3; raise notice 'r4 = %', r4; r4.f1 := r4.f1 + 3; raise notice 'r3 = %', r3; raise notice 'r4 = %', r4; r1 := r3; raise notice 'r1 = %', r1; r4 := r1; raise notice 'r4 = %', r4; r4.q2 := r4.q2 + 1; raise notice 'r4 = %', r4; end$$",
+    "expected": "DO ' declare r1 two_int8s; r2 two_int8s; r3 record; r4 record; begin r1 := row(1,2); raise notice ''r1 = %'', r1; r1 := r1; raise notice ''r1 = %'', r1; r2 := r1; raise notice ''r1 = %'', r1; raise notice ''r2 = %'', r2; r2.q2 = r1.q1 + 3; raise notice ''r1 = %'', r1; raise notice ''r2 = %'', r2; r1 := null; raise notice ''r1 = %'', r1; raise notice ''r2 = %'', r2; r1 := row(7,11)::two_int8s; r2 := r1; raise notice ''r1 = %'', r1; raise notice ''r2 = %'', r2; r3 := row(1,2); r4 := r3; raise notice ''r3 = %'', r3; raise notice ''r4 = %'', r4; r4.f1 := r4.f1 + 3; raise notice ''r3 = %'', r3; raise notice ''r4 = %'', r4; r1 := r3; raise notice ''r1 = %'', r1; r4 := r1; raise notice ''r4 = %'', r4; r4.q2 := r4.q2 + 1; raise notice ''r4 = %'', r4; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 34",
+    "query": "do $$ declare r1 two_int8s; begin raise notice 'r1 = %', r1; raise notice 'r1.q1 = %', r1.q1; raise notice 'r1.q2 = %', r1.q2; raise notice 'r1 = %', r1; end$$",
+    "expected": "DO ' declare r1 two_int8s; begin raise notice ''r1 = %'', r1; raise notice ''r1.q1 = %'', r1.q1; raise notice ''r1.q2 = %'', r1.q2; raise notice ''r1 = %'', r1; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 35",
+    "query": "do $$ declare r1 two_int8s; begin raise notice 'r1.q1 = %', r1.q1; raise notice 'r1.q2 = %', r1.q2; raise notice 'r1 = %', r1; raise notice 'r1.nosuchfield = %', r1.nosuchfield; end$$",
+    "expected": "DO ' declare r1 two_int8s; begin raise notice ''r1.q1 = %'', r1.q1; raise notice ''r1.q2 = %'', r1.q2; raise notice ''r1 = %'', r1; raise notice ''r1.nosuchfield = %'', r1.nosuchfield; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 36",
+    "query": "do $$ declare r1 record; begin raise notice 'r1 = %', r1; raise notice 'r1.f1 = %', r1.f1; raise notice 'r1.f2 = %', r1.f2; raise notice 'r1 = %', r1; end$$",
+    "expected": "DO ' declare r1 record; begin raise notice ''r1 = %'', r1; raise notice ''r1.f1 = %'', r1.f1; raise notice ''r1.f2 = %'', r1.f2; raise notice ''r1 = %'', r1; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 37",
+    "query": "do $$ declare r1 record; begin raise notice 'r1 = %', r1; r1 := row(1,2); raise notice 'r1.f1 = %', r1.f1; raise notice 'r1.f2 = %', r1.f2; raise notice 'r1 = %', r1; raise notice 'r1.nosuchfield = %', r1.nosuchfield; end$$",
+    "expected": "DO ' declare r1 record; begin raise notice ''r1 = %'', r1; r1 := row(1,2); raise notice ''r1.f1 = %'', r1.f1; raise notice ''r1.f2 = %'', r1.f2; raise notice ''r1 = %'', r1; raise notice ''r1.nosuchfield = %'', r1.nosuchfield; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 38",
+    "query": "do $$ <<blk>> declare v int; r two_int8s; v1 v%type; v2 blk.v%type; r1 r%type; r2 blk.r%type; begin raise notice '%', pg_typeof(v1); raise notice '%', pg_typeof(v2); raise notice '%', pg_typeof(r1); raise notice '%', pg_typeof(r2); end$$",
+    "expected": "DO ' <<blk>> declare v int; r two_int8s; v1 v%type; v2 blk.v%type; r1 r%type; r2 blk.r%type; begin raise notice ''%'', pg_typeof(v1); raise notice ''%'', pg_typeof(v2); raise notice ''%'', pg_typeof(r1); raise notice ''%'', pg_typeof(r2); end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 39",
+    "query": "do $$ declare r1 record; r2 r1%type; begin r2 := row(1,2); raise notice 'r2 = %', r2; r2 := row(3,4,5); raise notice 'r2 = %', r2; end$$",
+    "expected": "DO ' declare r1 record; r2 r1%type; begin r2 := row(1,2); raise notice ''r2 = %'', r2; r2 := row(3,4,5); raise notice ''r2 = %'', r2; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 40",
+    "query": "do $$ declare r1 record[]; begin end$$",
+    "expected": "DO ' declare r1 record[]; begin end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 41",
+    "query": "do $$ declare r1 record; r2 r1%type[]; begin end$$",
+    "expected": "DO ' declare r1 record; r2 r1%type[]; begin end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 42",
+    "query": "create table some_table (id int, data text)",
+    "expected": "CREATE TABLE some_table (id INT, data TEXT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 43",
+    "query": "do $$ declare r some_table; begin r := (23, 'skidoo'); for i in 1 .. 10 loop r.id := r.id + i; r.data := r.data || ' ' || i; end loop; raise notice 'r = %', r; end$$",
+    "expected": "DO ' declare r some_table; begin r := (23, ''skidoo''); for i in 1 .. 10 loop r.id := r.id + i; r.data := r.data || '' '' || i; end loop; raise notice ''r = %'', r; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 44",
+    "query": "create function returnsrecord(int) returns record language plpgsql as $$ begin return row($1,$1+1); end $$",
+    "expected": "CREATE FUNCTION returnsrecord (INT) RETURNS record LANGUAGE plpgsql AS $$ begin return row($1,$1+1); end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 45",
+    "query": "select returnsrecord(42)",
+    "expected": "SELECT returnsrecord(42)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 46",
+    "query": "select * from returnsrecord(42) as r(x int, y int)",
+    "expected": "SELECT * FROM returnsrecord(42) AS r (x INT, y INT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 47",
+    "query": "select * from returnsrecord(42) as r(x int, y int, z int)",
+    "expected": "SELECT * FROM returnsrecord(42) AS r (x INT, y INT, z INT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 48",
+    "query": "select * from returnsrecord(42) as r(x int, y bigint)",
+    "expected": "SELECT * FROM returnsrecord(42) AS r (x INT, y BIGINT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 49",
+    "query": "create or replace function returnsrecord(int) returns record language plpgsql as $$ declare r record; begin r := row($1,$1+1); return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION returnsrecord (INT) RETURNS record LANGUAGE plpgsql AS $$ declare r record; begin r := row($1,$1+1); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 50",
+    "query": "create table has_hole(f1 int, f2 int, f3 int)",
+    "expected": "CREATE TABLE has_hole (f1 INT, f2 INT, f3 INT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 51",
+    "query": "alter table has_hole drop column f2",
+    "expected": "ALTER TABLE has_hole DROP COLUMN f2"
+  },
+  {
+    "comment": "plpgsql_record - Statement 52",
+    "query": "create or replace function returnsrecord(int) returns record language plpgsql as $$ begin return row($1,$1+1)::has_hole; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION returnsrecord (INT) RETURNS record LANGUAGE plpgsql AS $$ begin return row($1,$1+1)::has_hole; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 53",
+    "query": "create or replace function returnsrecord(int) returns record language plpgsql as $$ declare r record; begin r := row($1,$1+1)::has_hole; return r; end $$",
+    "expected": "CREATE OR REPLACE FUNCTION returnsrecord (INT) RETURNS record LANGUAGE plpgsql AS $$ declare r record; begin r := row($1,$1+1)::has_hole; return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 54",
+    "query": "create function getf1(x record) returns int language plpgsql as $$ begin return x.f1; end $$",
+    "expected": "CREATE FUNCTION getf1 (x record) RETURNS INT LANGUAGE plpgsql AS $$ begin return x.f1; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 55",
+    "query": "select getf1(1)",
+    "expected": "SELECT getf1(1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 56",
+    "query": "select getf1(row(1,2))",
+    "expected": "SELECT getf1(ROW(1, 2))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 57",
+    "query": "select getf1(row(1,2)::two_int4s)",
+    "expected": "SELECT getf1(CAST(ROW(1, 2) AS two_int4s))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 58",
+    "query": "select getf1(row('foo',123,456)::more_int4s)",
+    "expected": "SELECT getf1(CAST(ROW('foo', 123, 456) AS more_int4s))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 59",
+    "query": "create function getf2(record) returns int language plpgsql as $$ begin return $1.f2; end $$",
+    "expected": "CREATE FUNCTION getf2 (record) RETURNS INT LANGUAGE plpgsql AS $$ begin return $1.f2; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 60",
+    "query": "select getf2(row(1,2))",
+    "expected": "SELECT getf2(ROW(1, 2))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 61",
+    "query": "select getf2(row(1,2)::two_int4s)",
+    "expected": "SELECT getf2(CAST(ROW(1, 2) AS two_int4s))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 62",
+    "query": "select getf2(row('foo',123,456)::more_int4s)",
+    "expected": "SELECT getf2(CAST(ROW('foo', 123, 456) AS more_int4s))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 63",
+    "query": "do $$ declare r two_int8s; begin for r in select i, i+1 from generate_series(1,4) i loop raise notice 'r = %', r; end loop; end$$",
+    "expected": "DO ' declare r two_int8s; begin for r in select i, i+1 from generate_series(1,4) i loop raise notice ''r = %'', r; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 64",
+    "query": "create function returnssetofholes() returns setof has_hole language plpgsql as $$ declare r record; h has_hole; begin return next h; r := (1,2); h := (3,4); return next r; return next h; return next row(5,6); return next row(7,8)::has_hole; end$$",
+    "expected": "CREATE FUNCTION returnssetofholes () RETURNS SETOF has_hole LANGUAGE plpgsql AS $$ declare r record; h has_hole; begin return next h; r := (1,2); h := (3,4); return next r; return next h; return next row(5,6); return next row(7,8)::has_hole; end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 65",
+    "query": "select returnssetofholes()",
+    "expected": "SELECT returnssetofholes()"
+  },
+  {
+    "comment": "plpgsql_record - Statement 66",
+    "query": "create or replace function returnssetofholes() returns setof has_hole language plpgsql as $$ declare r record; begin return next r; end$$",
+    "expected": "CREATE OR REPLACE FUNCTION returnssetofholes () RETURNS SETOF has_hole LANGUAGE plpgsql AS $$ declare r record; begin return next r; end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 67",
+    "query": "create or replace function returnssetofholes() returns setof has_hole language plpgsql as $$ begin return next row(1,2,3); end$$",
+    "expected": "CREATE OR REPLACE FUNCTION returnssetofholes () RETURNS SETOF has_hole LANGUAGE plpgsql AS $$ begin return next row(1,2,3); end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 68",
+    "query": "create table mutable(f1 int, f2 text)",
+    "expected": "CREATE TABLE mutable (f1 INT, f2 TEXT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 69",
+    "query": "create function sillyaddone(int) returns int language plpgsql as $$ declare r mutable; begin r.f1 := $1; return r.f1 + 1; end $$",
+    "expected": "CREATE FUNCTION sillyaddone (INT) RETURNS INT LANGUAGE plpgsql AS $$ declare r mutable; begin r.f1 := $1; return r.f1 + 1; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 70",
+    "query": "select sillyaddone(42)",
+    "expected": "SELECT sillyaddone(42)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 71",
+    "query": "alter table mutable drop column f1",
+    "expected": "ALTER TABLE mutable DROP COLUMN f1"
+  },
+  {
+    "comment": "plpgsql_record - Statement 72",
+    "query": "select getf3(null::mutable)",
+    "expected": "SELECT getf3(CAST(NULL AS mutable))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 73",
+    "query": "alter table mutable add column f3 int",
+    "expected": "ALTER TABLE mutable ADD COLUMN f3 INT"
+  },
+  {
+    "comment": "plpgsql_record - Statement 74",
+    "query": "alter table mutable drop column f3",
+    "expected": "ALTER TABLE mutable DROP COLUMN f3"
+  },
+  {
+    "comment": "plpgsql_record - Statement 75",
+    "query": "create function sillyaddtwo(int) returns int language plpgsql as $$ declare r mutable2; begin r.f1 := $1; return r.f1 + 2; end $$",
+    "expected": "CREATE FUNCTION sillyaddtwo (INT) RETURNS INT LANGUAGE plpgsql AS $$ declare r mutable2; begin r.f1 := $1; return r.f1 + 2; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 76",
+    "query": "reset check_function_bodies",
+    "expected": "RESET check_function_bodies"
+  },
+  {
+    "comment": "plpgsql_record - Statement 77",
+    "query": "select sillyaddtwo(42)",
+    "expected": "SELECT sillyaddtwo(42)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 78",
+    "query": "create table mutable2(f1 int, f2 text)",
+    "expected": "CREATE TABLE mutable2 (f1 INT, f2 TEXT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 79",
+    "query": "drop table mutable2",
+    "expected": "DROP TABLE mutable2"
+  },
+  {
+    "comment": "plpgsql_record - Statement 80",
+    "query": "select sillyaddtwo(43)",
+    "expected": "SELECT sillyaddtwo(43)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 81",
+    "query": "create function sillytrig() returns trigger language plpgsql as $$begin raise notice 'old.ctid = %', old.ctid; raise notice 'old.tableoid = %', old.tableoid::regclass; return new; end$$",
+    "expected": "CREATE FUNCTION sillytrig () RETURNS trigger LANGUAGE plpgsql AS $$begin raise notice 'old.ctid = %', old.ctid; raise notice 'old.tableoid = %', old.tableoid::regclass; return new; end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 82",
+    "query": "create trigger mutable_trig before update on mutable for each row execute procedure sillytrig()",
+    "expected": "CREATE TRIGGER mutable_trig BEFORE UPDATE ON mutable FOR EACH ROW EXECUTE FUNCTION sillytrig()"
+  },
+  {
+    "comment": "plpgsql_record - Statement 83",
+    "query": "insert into mutable values ('foo'), ('bar')",
+    "expected": "INSERT INTO mutable VALUES ('foo'), ('bar')"
+  },
+  {
+    "comment": "plpgsql_record - Statement 84",
+    "query": "update mutable set f2 = f2 || ' baz'",
+    "expected": "UPDATE mutable SET f2 = f2 || ' baz'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 85",
+    "query": "table mutable",
+    "expected": "SELECT * FROM mutable"
+  },
+  {
+    "comment": "plpgsql_record - Statement 86",
+    "query": "create or replace function sillytrig() returns trigger language plpgsql as $$begin return row(new.*); end$$",
+    "expected": "CREATE OR REPLACE FUNCTION sillytrig () RETURNS trigger LANGUAGE plpgsql AS $$begin return row(new.*); end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 87",
+    "query": "create or replace function sillytrig() returns trigger language plpgsql as $$declare r record; begin r := row(new.*); return r; end$$",
+    "expected": "CREATE OR REPLACE FUNCTION sillytrig () RETURNS trigger LANGUAGE plpgsql AS $$declare r record; begin r := row(new.*); return r; end$$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 88",
+    "query": "create domain ordered_int8s as two_int8s check((value).q1 <= (value).q2)",
+    "expected": "CREATE DOMAIN ordered_int8s AS two_int8s CHECK ((value).q1 <= (value).q2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 89",
+    "query": "create function read_ordered_int8s(p ordered_int8s) returns int8 as $$ begin return p.q1 + p.q2; end $$ language plpgsql",
+    "expected": "CREATE FUNCTION read_ordered_int8s (p ordered_int8s) RETURNS BIGINT AS $$ begin return p.q1 + p.q2; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 90",
+    "query": "select read_ordered_int8s(row(1, 2))",
+    "expected": "SELECT read_ordered_int8s(ROW(1, 2))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 91",
+    "query": "select read_ordered_int8s(row(2, 1))",
+    "expected": "SELECT read_ordered_int8s(ROW(2, 1))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 92",
+    "query": "create function build_ordered_int8s(i int8, j int8) returns ordered_int8s as $$ begin return row(i,j); end $$ language plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_int8s (i BIGINT, j BIGINT) RETURNS ordered_int8s AS $$ begin return row(i,j); end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 93",
+    "query": "select build_ordered_int8s(1,2)",
+    "expected": "SELECT build_ordered_int8s(1, 2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 94",
+    "query": "select build_ordered_int8s(2,1)",
+    "expected": "SELECT build_ordered_int8s(2, 1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 95",
+    "query": "create function build_ordered_int8s_2(i int8, j int8) returns ordered_int8s as $$ declare r record; begin r := row(i,j); return r; end $$ language plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_int8s_2 (i BIGINT, j BIGINT) RETURNS ordered_int8s AS $$ declare r record; begin r := row(i,j); return r; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 96",
+    "query": "select build_ordered_int8s_2(1,2)",
+    "expected": "SELECT build_ordered_int8s_2(1, 2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 97",
+    "query": "select build_ordered_int8s_2(2,1)",
+    "expected": "SELECT build_ordered_int8s_2(2, 1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 98",
+    "query": "create function build_ordered_int8s_3(i int8, j int8) returns ordered_int8s as $$ declare r two_int8s; begin r := row(i,j); return r; end $$ language plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_int8s_3 (i BIGINT, j BIGINT) RETURNS ordered_int8s AS $$ declare r two_int8s; begin r := row(i,j); return r; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 99",
+    "query": "select build_ordered_int8s_3(1,2)",
+    "expected": "SELECT build_ordered_int8s_3(1, 2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 100",
+    "query": "select build_ordered_int8s_3(2,1)",
+    "expected": "SELECT build_ordered_int8s_3(2, 1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 101",
+    "query": "create function build_ordered_int8s_4(i int8, j int8) returns ordered_int8s as $$ declare r ordered_int8s; begin r := row(i,j); return r; end $$ language plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_int8s_4 (i BIGINT, j BIGINT) RETURNS ordered_int8s AS $$ declare r ordered_int8s; begin r := row(i,j); return r; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 102",
+    "query": "select build_ordered_int8s_4(1,2)",
+    "expected": "SELECT build_ordered_int8s_4(1, 2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 103",
+    "query": "select build_ordered_int8s_4(2,1)",
+    "expected": "SELECT build_ordered_int8s_4(2, 1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 104",
+    "query": "create function build_ordered_int8s_a(i int8, j int8) returns ordered_int8s[] as $$ begin return array[row(i,j), row(i,j+1)]; end $$ language plpgsql",
+    "expected": "CREATE FUNCTION build_ordered_int8s_a (i BIGINT, j BIGINT) RETURNS ordered_int8s[] AS $$ begin return array[row(i,j), row(i,j+1)]; end $$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_record - Statement 105",
+    "query": "select build_ordered_int8s_a(1,2)",
+    "expected": "SELECT build_ordered_int8s_a(1, 2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 106",
+    "query": "select build_ordered_int8s_a(2,1)",
+    "expected": "SELECT build_ordered_int8s_a(2, 1)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 107",
+    "query": "do $$ declare r ordered_int8s; begin r.q1 := null; r.q2 := 43; r.q1 := 42; r.q2 := 41; end$$",
+    "expected": "DO ' declare r ordered_int8s; begin r.q1 := null; r.q2 := 43; r.q1 := 42; r.q2 := 41; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 108",
+    "query": "do $$ declare r ordered_int8s; begin r := null; r := row(null,null); r := row(1,2); r := row(2,1); end$$",
+    "expected": "DO ' declare r ordered_int8s; begin r := null; r := row(null,null); r := row(1,2); r := row(2,1); end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 109",
+    "query": "do $$ declare r ordered_int8s; begin for r in values (1,2),(3,4),(6,5) loop raise notice 'r = %', r; end loop; end$$",
+    "expected": "DO ' declare r ordered_int8s; begin for r in values (1,2),(3,4),(6,5) loop raise notice ''r = %'', r; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 110",
+    "query": "create type two_texts as (f1 text, f2 text)",
+    "expected": "CREATE TYPE two_texts AS (f1 TEXT, f2 TEXT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 111",
+    "query": "create domain ordered_texts as two_texts check((value).f1 <= (value).f2)",
+    "expected": "CREATE DOMAIN ordered_texts AS two_texts CHECK ((value).f1 <= (value).f2)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 112",
+    "query": "create table sometable (id int, a text, b text)",
+    "expected": "CREATE TABLE sometable (id INT, a TEXT, b TEXT)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 113",
+    "query": "insert into sometable values (1, 'a', repeat('ffoob',1000))",
+    "expected": "INSERT INTO sometable VALUES (1, 'a', repeat('ffoob', 1000))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 114",
+    "query": "insert into sometable values (2, 'a', repeat('ffoob',100000))",
+    "expected": "INSERT INTO sometable VALUES (2, 'a', repeat('ffoob', 100000))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 115",
+    "query": "insert into sometable values (3, 'z', repeat('ffoob',100000))",
+    "expected": "INSERT INTO sometable VALUES (3, 'z', repeat('ffoob', 100000))"
+  },
+  {
+    "comment": "plpgsql_record - Statement 116",
+    "query": "do $$ declare d ordered_texts; begin for d in select a, b from sometable loop raise notice 'succeeded at \"%\"', d.f1; end loop; end$$",
+    "expected": "DO ' declare d ordered_texts; begin for d in select a, b from sometable loop raise notice ''succeeded at \"%\"'', d.f1; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 117",
+    "query": "do $$ declare r record; d ordered_texts; begin for r in select * from sometable loop raise notice 'processing row %', r.id; d := row(r.a, r.b); end loop; end$$",
+    "expected": "DO ' declare r record; d ordered_texts; begin for r in select * from sometable loop raise notice ''processing row %'', r.id; d := row(r.a, r.b); end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 118",
+    "query": "do $$ declare r record; d ordered_texts; begin for r in select * from sometable loop raise notice 'processing row %', r.id; d := null; d.f1 := r.a; d.f2 := r.b; end loop; end$$",
+    "expected": "DO ' declare r record; d ordered_texts; begin for r in select * from sometable loop raise notice ''processing row %'', r.id; d := null; d.f1 := r.a; d.f2 := r.b; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_record - Statement 119",
+    "query": "create function compresult(int8) returns two_int8s language plpgsql as $$ declare r record; begin r := row($1,$1); return r; end $$",
+    "expected": "CREATE FUNCTION compresult (BIGINT) RETURNS two_int8s LANGUAGE plpgsql AS $$ declare r record; begin r := row($1,$1); return r; end $$"
+  },
+  {
+    "comment": "plpgsql_record - Statement 120",
+    "query": "create table two_int8s_tab (f1 two_int8s)",
+    "expected": "CREATE TABLE two_int8s_tab (f1 two_int8s)"
+  },
+  {
+    "comment": "plpgsql_record - Statement 121",
+    "query": "insert into two_int8s_tab values (compresult(42))",
+    "expected": "INSERT INTO two_int8s_tab VALUES (compresult(42))"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_simple.json
+++ b/go/common/parser/testdata/postgres/plpgsql_simple.json
@@ -1,0 +1,82 @@
+[
+  {
+    "comment": "plpgsql_simple - Statement 1",
+    "query": "create function simplesql(int) returns int language sql as 'select $1'",
+    "expected": "CREATE FUNCTION simplesql (INT) RETURNS INT LANGUAGE sql AS $$select $1$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 2",
+    "query": "create function simplecaller() returns int language plpgsql as $$ declare sum int := 0; begin for n in 1..10 loop sum := sum + simplesql(n); if n = 5 then create or replace function simplesql(int) returns int language sql as 'select $1 + 100'; end if; end loop; return sum; end$$",
+    "expected": "CREATE FUNCTION simplecaller () RETURNS INT LANGUAGE plpgsql AS $$ declare sum int := 0; begin for n in 1..10 loop sum := sum + simplesql(n); if n = 5 then create or replace function simplesql(int) returns int language sql as 'select $1 + 100'; end if; end loop; return sum; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 3",
+    "query": "select simplecaller()",
+    "expected": "SELECT simplecaller()"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 4",
+    "query": "create schema simple1",
+    "expected": "CREATE SCHEMA simple1"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 5",
+    "query": "create function simple1.simpletarget(int) returns int language plpgsql as $$begin return $1; end$$",
+    "expected": "CREATE FUNCTION simple1.simpletarget (INT) RETURNS INT LANGUAGE plpgsql AS $$begin return $1; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 6",
+    "query": "create function simpletarget(int) returns int language plpgsql as $$begin return $1 + 100; end$$",
+    "expected": "CREATE FUNCTION simpletarget (INT) RETURNS INT LANGUAGE plpgsql AS $$begin return $1 + 100; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 7",
+    "query": "create or replace function simplecaller() returns int language plpgsql as $$ declare sum int := 0; begin for n in 1..10 loop sum := sum + simpletarget(n); if n = 5 then set local search_path = 'simple1'; end if; end loop; return sum; end$$",
+    "expected": "CREATE OR REPLACE FUNCTION simplecaller () RETURNS INT LANGUAGE plpgsql AS $$ declare sum int := 0; begin for n in 1..10 loop sum := sum + simpletarget(n); if n = 5 then set local search_path = 'simple1'; end if; end loop; return sum; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 8",
+    "query": "alter function simple1.simpletarget(int) immutable",
+    "expected": "ALTER FUNCTION simple1.simpletarget(INT) IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 9",
+    "query": "alter function simpletarget(int) immutable",
+    "expected": "ALTER FUNCTION simpletarget(INT) IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 10",
+    "query": "create function simplesql() returns int language sql as $$select 1 / 0$$",
+    "expected": "CREATE FUNCTION simplesql () RETURNS INT LANGUAGE sql AS $$select 1 / 0$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 11",
+    "query": "create or replace function simplecaller() returns int language plpgsql as $$ declare x int; begin select simplesql() into x; return x; end$$",
+    "expected": "CREATE OR REPLACE FUNCTION simplecaller () RETURNS INT LANGUAGE plpgsql AS $$ declare x int; begin select simplesql() into x; return x; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 12",
+    "query": "create or replace function simplesql() returns int language sql as $$select 2 + 2$$",
+    "expected": "CREATE OR REPLACE FUNCTION simplesql () RETURNS INT LANGUAGE sql AS $$select 2 + 2$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 13",
+    "query": "create or replace function simplecaller() returns int language plpgsql as $$ declare x int; begin x := simplesql(); return x; end$$",
+    "expected": "CREATE OR REPLACE FUNCTION simplecaller () RETURNS INT LANGUAGE plpgsql AS $$ declare x int; begin x := simplesql(); return x; end$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 14",
+    "query": "drop function simplesql()",
+    "expected": "DROP FUNCTION simplesql()"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 15",
+    "query": "create function simplesql() returns setof int language sql as $$select 22 + 22$$",
+    "expected": "CREATE FUNCTION simplesql () RETURNS SETOF INT LANGUAGE sql AS $$select 22 + 22$$"
+  },
+  {
+    "comment": "plpgsql_simple - Statement 16",
+    "query": "do $$ declare p_CurData refcursor; val int; begin open p_CurData scroll for select 42; fetch p_CurData into val; raise notice 'val = %', val; end; $$",
+    "expected": "DO ' declare p_CurData refcursor; val int; begin open p_CurData scroll for select 42; fetch p_CurData into val; raise notice ''val = %'', val; end; '"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_transaction.json
+++ b/go/common/parser/testdata/postgres/plpgsql_transaction.json
@@ -1,0 +1,346 @@
+[
+  {
+    "comment": "plpgsql_transaction - Statement 1",
+    "query": "CREATE TABLE test1 (a int, b text)",
+    "expected": "CREATE TABLE test1 (a INT, b TEXT)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 2",
+    "query": "CREATE PROCEDURE transaction_test1(x int, y text) LANGUAGE plpgsql AS $$ BEGIN FOR i IN 0..x LOOP INSERT INTO test1 (a, b) VALUES (i, y); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END $$",
+    "expected": "CREATE PROCEDURE transaction_test1 (x INT, y TEXT) LANGUAGE plpgsql AS $$ BEGIN FOR i IN 0..x LOOP INSERT INTO test1 (a, b) VALUES (i, y); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 3",
+    "query": "CALL transaction_test1(9, 'foo')"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 4",
+    "query": "SELECT * FROM test1"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 5",
+    "query": "TRUNCATE test1",
+    "expected": "TRUNCATE TABLE test1 CONTINUE IDENTITY RESTRICT"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 6",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN FOR i IN 0..9 LOOP INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN FOR i IN 0..9 LOOP INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 7",
+    "query": "START TRANSACTION"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 8",
+    "query": "CALL transaction_test1(9, 'error')"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 9",
+    "query": "COMMIT"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 10",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN COMMIT; END $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN COMMIT; END '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 11",
+    "query": "CREATE FUNCTION transaction_test2() RETURNS int LANGUAGE plpgsql AS $$ BEGIN FOR i IN 0..9 LOOP INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; RETURN 1; END $$",
+    "expected": "CREATE FUNCTION transaction_test2 () RETURNS INT LANGUAGE plpgsql AS $$ BEGIN FOR i IN 0..9 LOOP INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; RETURN 1; END $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 12",
+    "query": "SELECT transaction_test2()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 13",
+    "query": "CREATE FUNCTION transaction_test3() RETURNS int LANGUAGE plpgsql AS $$ BEGIN CALL transaction_test1(9, 'error'); RETURN 1; END; $$",
+    "expected": "CREATE FUNCTION transaction_test3 () RETURNS INT LANGUAGE plpgsql AS $$ BEGIN CALL transaction_test1(9, 'error'); RETURN 1; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 14",
+    "query": "SELECT transaction_test3()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 15",
+    "query": "CREATE FUNCTION transaction_test4() RETURNS int LANGUAGE plpgsql AS $$ BEGIN EXECUTE 'DO LANGUAGE plpgsql $x$ BEGIN COMMIT; END $x$'; RETURN 1; END; $$",
+    "expected": "CREATE FUNCTION transaction_test4 () RETURNS INT LANGUAGE plpgsql AS $$ BEGIN EXECUTE 'DO LANGUAGE plpgsql $x$ BEGIN COMMIT; END $x$'; RETURN 1; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 16",
+    "query": "SELECT transaction_test4()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 17",
+    "query": "CREATE PROCEDURE transaction_test5() LANGUAGE plpgsql SET work_mem = 555 AS $$ BEGIN COMMIT; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test5 () LANGUAGE plpgsql SET work_mem = 555 AS $$ BEGIN COMMIT; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 18",
+    "query": "CALL transaction_test5()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 19",
+    "query": "CREATE PROCEDURE transaction_test5b() LANGUAGE plpgsql SECURITY DEFINER AS $$ BEGIN COMMIT; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test5b () LANGUAGE plpgsql SECURITY DEFINER AS $$ BEGIN COMMIT; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 20",
+    "query": "CALL transaction_test5b()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 21",
+    "query": "CREATE PROCEDURE transaction_test6(c text) LANGUAGE plpgsql AS $$ BEGIN CALL transaction_test1(9, c); END; $$",
+    "expected": "CREATE PROCEDURE transaction_test6 (c TEXT) LANGUAGE plpgsql AS $$ BEGIN CALL transaction_test1(9, c); END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 22",
+    "query": "CALL transaction_test6('bar')"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 23",
+    "query": "CREATE PROCEDURE transaction_test7() LANGUAGE plpgsql AS $$ BEGIN DO 'BEGIN CALL transaction_test1(9, $x$baz$x$); END;'; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test7 () LANGUAGE plpgsql AS $$ BEGIN DO 'BEGIN CALL transaction_test1(9, $x$baz$x$); END;'; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 24",
+    "query": "CALL transaction_test7()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 25",
+    "query": "CREATE PROCEDURE transaction_test8() LANGUAGE plpgsql AS $$ BEGIN EXECUTE 'CALL transaction_test1(10, $x$baz$x$)'; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test8 () LANGUAGE plpgsql AS $$ BEGIN EXECUTE 'CALL transaction_test1(10, $x$baz$x$)'; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 26",
+    "query": "CALL transaction_test8()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 27",
+    "query": "CREATE TABLE test2 (x int)",
+    "expected": "CREATE TABLE test2 (x INT)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 28",
+    "query": "INSERT INTO test2 VALUES (0), (1), (2), (3), (4)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 29",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); COMMIT; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); COMMIT; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 30",
+    "query": "SELECT * FROM pg_cursors"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 31",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (12/(r.x-2)); COMMIT; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (12/(r.x-2)); COMMIT; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 32",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); ROLLBACK; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); ROLLBACK; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 33",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); IF r.x % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN SELECT * FROM test2 ORDER BY x LOOP INSERT INTO test1 (a) VALUES (r.x); IF r.x % 2 = 0 THEN COMMIT; ELSE ROLLBACK; END IF; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 34",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN UPDATE test2 SET x = x * 2 RETURNING x LOOP INSERT INTO test1 (a) VALUES (r.x); ROLLBACK; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN UPDATE test2 SET x = x * 2 RETURNING x LOOP INSERT INTO test1 (a) VALUES (r.x); ROLLBACK; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 35",
+    "query": "SELECT * FROM test2"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 36",
+    "query": "INSERT INTO test1 VALUES (1,'one'), (2,'two'), (3,'three')",
+    "expected": "INSERT INTO test1 VALUES (1, 'one'), (2, 'two'), (3, 'three')"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 37",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE l_cur CURSOR FOR SELECT a FROM test1 ORDER BY 1 FOR UPDATE; BEGIN FOR r IN l_cur LOOP UPDATE test1 SET b = b || ' ' || b WHERE a = r.a; COMMIT; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE l_cur CURSOR FOR SELECT a FROM test1 ORDER BY 1 FOR UPDATE; BEGIN FOR r IN l_cur LOOP UPDATE test1 SET b = b || '' '' || b WHERE a = r.a; COMMIT; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 38",
+    "query": "DO LANGUAGE plpgsql $$ DECLARE r RECORD; BEGIN FOR r IN SELECT a FROM test1 FOR UPDATE LOOP UPDATE test1 SET b = b || ' ' || b WHERE a = r.a; COMMIT; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' DECLARE r RECORD; BEGIN FOR r IN SELECT a FROM test1 FOR UPDATE LOOP UPDATE test1 SET b = b || '' '' || b WHERE a = r.a; COMMIT; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 39",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN BEGIN INSERT INTO test1 (a) VALUES (1); COMMIT; INSERT INTO test1 (a) VALUES (1/0); COMMIT; EXCEPTION WHEN division_by_zero THEN RAISE NOTICE 'caught division_by_zero'; END; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN BEGIN INSERT INTO test1 (a) VALUES (1); COMMIT; INSERT INTO test1 (a) VALUES (1/0); COMMIT; EXCEPTION WHEN division_by_zero THEN RAISE NOTICE ''caught division_by_zero''; END; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 40",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN BEGIN INSERT INTO test1 (a) VALUES (1); ROLLBACK; INSERT INTO test1 (a) VALUES (1/0); ROLLBACK; EXCEPTION WHEN division_by_zero THEN RAISE NOTICE 'caught division_by_zero'; END; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN BEGIN INSERT INTO test1 (a) VALUES (1); ROLLBACK; INSERT INTO test1 (a) VALUES (1/0); ROLLBACK; EXCEPTION WHEN division_by_zero THEN RAISE NOTICE ''caught division_by_zero''; END; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 41",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN FOR i IN 1..10 LOOP BEGIN INSERT INTO test1 VALUES (i, 'good'); INSERT INTO test1 VALUES (i/0, 'bad'); EXCEPTION WHEN division_by_zero THEN INSERT INTO test1 VALUES (i, 'exception'); IF (i % 3) > 0 THEN COMMIT; ELSE ROLLBACK; END IF; END; END LOOP; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN FOR i IN 1..10 LOOP BEGIN INSERT INTO test1 VALUES (i, ''good''); INSERT INTO test1 VALUES (i/0, ''bad''); EXCEPTION WHEN division_by_zero THEN INSERT INTO test1 VALUES (i, ''exception''); IF (i % 3) > 0 THEN COMMIT; ELSE ROLLBACK; END IF; END; END LOOP; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 42",
+    "query": "CREATE TEMP TABLE test4(f1 text)",
+    "expected": "CREATE TEMPORARY TABLE test4 (f1 TEXT)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 43",
+    "query": "ALTER TABLE test4 ALTER COLUMN f1 SET STORAGE EXTERNAL",
+    "expected": "ALTER TABLE test4 ALTER COLUMN f1 SET STORAGE external"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 44",
+    "query": "INSERT INTO test4 SELECT repeat('xyzzy', 2000)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 45",
+    "query": "CREATE FUNCTION data_source(i int) RETURNS TEXT LANGUAGE sql AS 'select f1 from test4' IMMUTABLE",
+    "expected": "CREATE FUNCTION data_source (i INT) RETURNS TEXT LANGUAGE sql AS $$select f1 from test4$$ IMMUTABLE"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 46",
+    "query": "DO $$ declare x text; begin for i in 1..3 loop x := data_source(i); commit; end loop; raise notice 'length(x) = %', length(x); end $$",
+    "expected": "DO ' declare x text; begin for i in 1..3 loop x := data_source(i); commit; end loop; raise notice ''length(x) = %'', length(x); end '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 47",
+    "query": "DO LANGUAGE plpgsql $$ declare c test1 := row(42, 'hello'); r bool; begin for i in 1..3 loop r := c is not null; raise notice 'r = %', r; commit; end loop; for i in 1..3 loop r := c is null; raise notice 'r = %', r; rollback; end loop; end $$",
+    "expected": "DO LANGUAGE plpgsql ' declare c test1 := row(42, ''hello''); r bool; begin for i in 1..3 loop r := c is not null; raise notice ''r = %'', r; commit; end loop; for i in 1..3 loop r := c is null; raise notice ''r = %'', r; rollback; end loop; end '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 48",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN CREATE TABLE test3 (y int UNIQUE DEFERRABLE INITIALLY DEFERRED); COMMIT; INSERT INTO test3 (y) VALUES (1); COMMIT; INSERT INTO test3 (y) VALUES (1); INSERT INTO test3 (y) VALUES (2); COMMIT; INSERT INTO test3 (y) VALUES (3); END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN CREATE TABLE test3 (y int UNIQUE DEFERRABLE INITIALLY DEFERRED); COMMIT; INSERT INTO test3 (y) VALUES (1); COMMIT; INSERT INTO test3 (y) VALUES (1); INSERT INTO test3 (y) VALUES (2); COMMIT; INSERT INTO test3 (y) VALUES (3); END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 49",
+    "query": "SELECT * FROM test3"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 50",
+    "query": "CREATE PROCEDURE cursor_fail_during_commit() LANGUAGE plpgsql AS $$ DECLARE id int; BEGIN FOR id IN SELECT 1/(x-1000) FROM generate_series(1,1000) x LOOP INSERT INTO test1 VALUES(id); COMMIT; END LOOP; END; $$",
+    "expected": "CREATE PROCEDURE cursor_fail_during_commit () LANGUAGE plpgsql AS $$ DECLARE id int; BEGIN FOR id IN SELECT 1/(x-1000) FROM generate_series(1,1000) x LOOP INSERT INTO test1 VALUES(id); COMMIT; END LOOP; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 51",
+    "query": "CALL cursor_fail_during_commit()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 52",
+    "query": "SELECT count(*) FROM test1",
+    "expected": "SELECT COUNT(*) FROM test1"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 53",
+    "query": "CREATE PROCEDURE cursor_fail_during_rollback() LANGUAGE plpgsql AS $$ DECLARE id int; BEGIN FOR id IN SELECT 1/(x-1000) FROM generate_series(1,1000) x LOOP INSERT INTO test1 VALUES(id); ROLLBACK; END LOOP; END; $$",
+    "expected": "CREATE PROCEDURE cursor_fail_during_rollback () LANGUAGE plpgsql AS $$ DECLARE id int; BEGIN FOR id IN SELECT 1/(x-1000) FROM generate_series(1,1000) x LOOP INSERT INTO test1 VALUES(id); ROLLBACK; END LOOP; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 54",
+    "query": "CALL cursor_fail_during_rollback()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 55",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN PERFORM 1; RAISE INFO '%', current_setting('transaction_isolation'); COMMIT; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; PERFORM 1; RAISE INFO '%', current_setting('transaction_isolation'); COMMIT; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; PERFORM 1; RAISE INFO '%', current_setting('transaction_isolation'); COMMIT; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN PERFORM 1; RAISE INFO ''%'', current_setting(''transaction_isolation''); COMMIT; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; PERFORM 1; RAISE INFO ''%'', current_setting(''transaction_isolation''); COMMIT; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; PERFORM 1; RAISE INFO ''%'', current_setting(''transaction_isolation''); COMMIT; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 56",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 57",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN SAVEPOINT foo; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN SAVEPOINT foo; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 58",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN EXECUTE 'COMMIT'; END; $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN EXECUTE ''COMMIT''; END; '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 59",
+    "query": "TRUNCATE test2",
+    "expected": "TRUNCATE TABLE test2 CONTINUE IDENTITY RESTRICT"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 60",
+    "query": "CREATE PROCEDURE transaction_test9() LANGUAGE SQL AS $$ INSERT INTO test2 VALUES (42); $$",
+    "expected": "CREATE PROCEDURE transaction_test9 () LANGUAGE sql AS $$ INSERT INTO test2 VALUES (42); $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 61",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN ROLLBACK; CALL transaction_test9(); END $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN ROLLBACK; CALL transaction_test9(); END '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 62",
+    "query": "CREATE FUNCTION report_count() RETURNS int STABLE LANGUAGE sql AS $$ SELECT COUNT(*) FROM test2 $$",
+    "expected": "CREATE FUNCTION report_count () RETURNS INT STABLE LANGUAGE sql AS $$ SELECT COUNT(*) FROM test2 $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 63",
+    "query": "CREATE PROCEDURE transaction_test9b(cnt int) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'count = %', cnt; END $$",
+    "expected": "CREATE PROCEDURE transaction_test9b (cnt INT) LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'count = %', cnt; END $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 64",
+    "query": "DO $$ BEGIN CALL transaction_test9b(report_count()); INSERT INTO test2 VALUES(43); CALL transaction_test9b(report_count()); END $$",
+    "expected": "DO ' BEGIN CALL transaction_test9b(report_count()); INSERT INTO test2 VALUES(43); CALL transaction_test9b(report_count()); END '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 65",
+    "query": "CREATE PROCEDURE transaction_test10a(INOUT x int) LANGUAGE plpgsql AS $$ BEGIN x := x + 1; COMMIT; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test10a (INOUT x INT) LANGUAGE plpgsql AS $$ BEGIN x := x + 1; COMMIT; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 66",
+    "query": "CALL transaction_test10a(10)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 67",
+    "query": "CREATE PROCEDURE transaction_test10b(INOUT x int) LANGUAGE plpgsql AS $$ BEGIN x := x - 1; ROLLBACK; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test10b (INOUT x INT) LANGUAGE plpgsql AS $$ BEGIN x := x - 1; ROLLBACK; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 68",
+    "query": "CALL transaction_test10b(10)"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 69",
+    "query": "CREATE PROCEDURE transaction_test11() LANGUAGE plpgsql AS $$ DECLARE s1 timestamp with time zone; s2 timestamp with time zone; s3 timestamp with time zone; t1 timestamp with time zone; t2 timestamp with time zone; t3 timestamp with time zone; BEGIN s1 := statement_timestamp(); t1 := transaction_timestamp(); ASSERT s1 = t1; PERFORM pg_sleep(0.001); COMMIT; s2 := statement_timestamp(); t2 := transaction_timestamp(); ASSERT s2 = s1; ASSERT t2 > t1; PERFORM pg_sleep(0.001); ROLLBACK; s3 := statement_timestamp(); t3 := transaction_timestamp(); ASSERT s3 = s1; ASSERT t3 > t2; END; $$",
+    "expected": "CREATE PROCEDURE transaction_test11 () LANGUAGE plpgsql AS $$ DECLARE s1 timestamp with time zone; s2 timestamp with time zone; s3 timestamp with time zone; t1 timestamp with time zone; t2 timestamp with time zone; t3 timestamp with time zone; BEGIN s1 := statement_timestamp(); t1 := transaction_timestamp(); ASSERT s1 = t1; PERFORM pg_sleep(0.001); COMMIT; s2 := statement_timestamp(); t2 := transaction_timestamp(); ASSERT s2 = s1; ASSERT t2 > t1; PERFORM pg_sleep(0.001); ROLLBACK; s3 := statement_timestamp(); t3 := transaction_timestamp(); ASSERT s3 = s1; ASSERT t3 > t2; END; $$"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 70",
+    "query": "CALL transaction_test11()"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 71",
+    "query": "DO LANGUAGE plpgsql $$ BEGIN ROLLBACK; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; FOR i IN 0..3 LOOP RAISE INFO 'transaction_isolation = %', current_setting('transaction_isolation'); INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT AND CHAIN; ELSE ROLLBACK AND CHAIN; END IF; END LOOP; END $$",
+    "expected": "DO LANGUAGE plpgsql ' BEGIN ROLLBACK; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; FOR i IN 0..3 LOOP RAISE INFO ''transaction_isolation = %'', current_setting(''transaction_isolation''); INSERT INTO test1 (a) VALUES (i); IF i % 2 = 0 THEN COMMIT AND CHAIN; ELSE ROLLBACK AND CHAIN; END IF; END LOOP; END '"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 72",
+    "query": "DROP TABLE test1"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 73",
+    "query": "DROP TABLE test2"
+  },
+  {
+    "comment": "plpgsql_transaction - Statement 74",
+    "query": "DROP TABLE test3"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_trap.json
+++ b/go/common/parser/testdata/postgres/plpgsql_trap.json
@@ -1,0 +1,202 @@
+[
+  {
+    "comment": "plpgsql_trap - Statement 1",
+    "query": "create function trap_zero_divide(int) returns int as $$ declare x int; sx smallint; begin begin raise notice 'should see this'; x := 100 / $1; raise notice 'should see this only if % <> 0', $1; sx := $1; raise notice 'should see this only if % fits in smallint', $1; if $1 < 0 then raise exception '% is less than zero', $1; end if; exception when division_by_zero then raise notice 'caught division_by_zero'; x := -1; when NUMERIC_VALUE_OUT_OF_RANGE then raise notice 'caught numeric_value_out_of_range'; x := -2; end; return x; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION trap_zero_divide (INT) RETURNS INT AS $$ declare x int; sx smallint; begin begin raise notice 'should see this'; x := 100 / $1; raise notice 'should see this only if % <> 0', $1; sx := $1; raise notice 'should see this only if % fits in smallint', $1; if $1 < 0 then raise exception '% is less than zero', $1; end if; exception when division_by_zero then raise notice 'caught division_by_zero'; x := -1; when NUMERIC_VALUE_OUT_OF_RANGE then raise notice 'caught numeric_value_out_of_range'; x := -2; end; return x; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 2",
+    "query": "select trap_zero_divide(50)",
+    "expected": "SELECT trap_zero_divide(50)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 3",
+    "query": "select trap_zero_divide(0)",
+    "expected": "SELECT trap_zero_divide(0)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 4",
+    "query": "select trap_zero_divide(100000)",
+    "expected": "SELECT trap_zero_divide(100000)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 5",
+    "query": "select trap_zero_divide(-100)",
+    "expected": "SELECT trap_zero_divide(-100)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 6",
+    "query": "create table match_source as select x as id, x*10 as data, x/10 as ten from generate_series(1,100) x",
+    "expected": "CREATE TABLE match_source AS SELECT x AS id, x * 10 AS data, x / 10 AS ten FROM generate_series(1, 100) AS x"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 7",
+    "query": "create function trap_matching_test(int) returns int as $$ declare x int; sx smallint; y int; begin begin x := 100 / $1; sx := $1; select into y data from match_source where id = (select id from match_source b where ten = $1); exception when data_exception then raise notice 'caught data_exception'; x := -1; when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then raise notice 'caught numeric_value_out_of_range or cardinality_violation'; x := -2; end; return x; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION trap_matching_test (INT) RETURNS INT AS $$ declare x int; sx smallint; y int; begin begin x := 100 / $1; sx := $1; select into y data from match_source where id = (select id from match_source b where ten = $1); exception when data_exception then raise notice 'caught data_exception'; x := -1; when NUMERIC_VALUE_OUT_OF_RANGE OR CARDINALITY_VIOLATION then raise notice 'caught numeric_value_out_of_range or cardinality_violation'; x := -2; end; return x; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 8",
+    "query": "select trap_matching_test(50)",
+    "expected": "SELECT trap_matching_test(50)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 9",
+    "query": "select trap_matching_test(0)",
+    "expected": "SELECT trap_matching_test(0)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 10",
+    "query": "select trap_matching_test(100000)",
+    "expected": "SELECT trap_matching_test(100000)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 11",
+    "query": "select trap_matching_test(1)",
+    "expected": "SELECT trap_matching_test(1)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 12",
+    "query": "create temp table foo (f1 int)",
+    "expected": "CREATE TEMPORARY TABLE foo (f1 INT)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 13",
+    "query": "create function subxact_rollback_semantics() returns int as $$ declare x int; begin x := 1; insert into foo values(x); begin x := x + 1; insert into foo values(x); raise exception 'inner'; exception when others then x := x * 10; end; insert into foo values(x); return x; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION subxact_rollback_semantics () RETURNS INT AS $$ declare x int; begin x := 1; insert into foo values(x); begin x := x + 1; insert into foo values(x); raise exception 'inner'; exception when others then x := x * 10; end; insert into foo values(x); return x; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 14",
+    "query": "select subxact_rollback_semantics()",
+    "expected": "SELECT subxact_rollback_semantics()"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 15",
+    "query": "select * from foo",
+    "expected": "SELECT * FROM foo"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 16",
+    "query": "drop table foo",
+    "expected": "DROP TABLE foo"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 17",
+    "query": "create function trap_timeout() returns void as $$ begin declare x int; begin  select count(*) into x from generate_series(1, 1_000_000_000_000); exception when others then raise notice 'caught others?'; when query_canceled then raise notice 'nyeah nyeah, can''t stop me'; end;   raise exception 'end of function'; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION trap_timeout () RETURNS void AS $$ begin declare x int; begin  select count(*) into x from generate_series(1, 1_000_000_000_000); exception when others then raise notice 'caught others?'; when query_canceled then raise notice 'nyeah nyeah, can''t stop me'; end;   raise exception 'end of function'; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 18",
+    "query": "begin",
+    "expected": "BEGIN"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 19",
+    "query": "set statement_timeout to 1000",
+    "expected": "SET statement_timeout = 1000"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 20",
+    "query": "select trap_timeout()",
+    "expected": "SELECT trap_timeout()"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 21",
+    "query": "rollback",
+    "expected": "ROLLBACK"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 22",
+    "query": "create function test_variable_storage() returns text as $$ declare x text; begin x := '1234'; begin x := x || '5678';  perform trap_zero_divide(-100); exception when others then x := x || '9012'; end; return x; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION test_variable_storage () RETURNS TEXT AS $$ declare x text; begin x := '1234'; begin x := x || '5678';  perform trap_zero_divide(-100); exception when others then x := x || '9012'; end; return x; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 23",
+    "query": "select test_variable_storage()",
+    "expected": "SELECT test_variable_storage()"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 24",
+    "query": "create temp table root(f1 int primary key)",
+    "expected": "CREATE TEMPORARY TABLE root (f1 INT PRIMARY KEY)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 25",
+    "query": "create temp table leaf(f1 int references root deferrable)",
+    "expected": "CREATE TEMPORARY TABLE leaf (f1 INT REFERENCES root DEFERRABLE)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 26",
+    "query": "insert into root values(1)",
+    "expected": "INSERT INTO root VALUES (1)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 27",
+    "query": "insert into leaf values(1)",
+    "expected": "INSERT INTO leaf VALUES (1)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 28",
+    "query": "insert into leaf values(2)",
+    "expected": "INSERT INTO leaf VALUES (2)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 29",
+    "query": "create function trap_foreign_key(int) returns int as $$ begin begin insert into leaf values($1); exception when foreign_key_violation then raise notice 'caught foreign_key_violation'; return 0; end; return 1; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION trap_foreign_key (INT) RETURNS INT AS $$ begin begin insert into leaf values($1); exception when foreign_key_violation then raise notice 'caught foreign_key_violation'; return 0; end; return 1; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 30",
+    "query": "create function trap_foreign_key_2() returns int as $$ begin begin set constraints all immediate; exception when foreign_key_violation then raise notice 'caught foreign_key_violation'; return 0; end; return 1; end$$ language plpgsql",
+    "expected": "CREATE FUNCTION trap_foreign_key_2 () RETURNS INT AS $$ begin begin set constraints all immediate; exception when foreign_key_violation then raise notice 'caught foreign_key_violation'; return 0; end; return 1; end$$ LANGUAGE plpgsql"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 31",
+    "query": "select trap_foreign_key(1)",
+    "expected": "SELECT trap_foreign_key(1)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 32",
+    "query": "select trap_foreign_key(2)",
+    "expected": "SELECT trap_foreign_key(2)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 33",
+    "query": "set constraints all deferred",
+    "expected": "SET CONSTRAINTS ALL DEFERRED"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 34",
+    "query": "savepoint x",
+    "expected": "SAVEPOINT x"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 35",
+    "query": "set constraints all immediate",
+    "expected": "SET CONSTRAINTS ALL IMMEDIATE"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 36",
+    "query": "rollback to x",
+    "expected": "ROLLBACK TO SAVEPOINT x"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 37",
+    "query": "select trap_foreign_key_2()",
+    "expected": "SELECT trap_foreign_key_2()"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 38",
+    "query": "commit",
+    "expected": "COMMIT"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 39",
+    "query": "drop function trap_foreign_key(int)",
+    "expected": "DROP FUNCTION trap_foreign_key(INT)"
+  },
+  {
+    "comment": "plpgsql_trap - Statement 40",
+    "query": "drop function trap_foreign_key_2()",
+    "expected": "DROP FUNCTION trap_foreign_key_2()"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_trigger.json
+++ b/go/common/parser/testdata/postgres/plpgsql_trigger.json
@@ -1,0 +1,32 @@
+[
+  {
+    "comment": "plpgsql_trigger - Statement 1",
+    "query": "create table testtr (a int, b text)",
+    "expected": "CREATE TABLE testtr (a INT, b TEXT)"
+  },
+  {
+    "comment": "plpgsql_trigger - Statement 2",
+    "query": "create function testtr_trigger() returns trigger language plpgsql as $$begin raise notice 'tg_op = %', tg_op; raise notice 'old(%) = %', old.a, row(old.*); raise notice 'new(%) = %', new.a, row(new.*); if (tg_op = 'DELETE') then return old; else return new; end if; end$$",
+    "expected": "CREATE FUNCTION testtr_trigger () RETURNS trigger LANGUAGE plpgsql AS $$begin raise notice 'tg_op = %', tg_op; raise notice 'old(%) = %', old.a, row(old.*); raise notice 'new(%) = %', new.a, row(new.*); if (tg_op = 'DELETE') then return old; else return new; end if; end$$"
+  },
+  {
+    "comment": "plpgsql_trigger - Statement 3",
+    "query": "create trigger testtr_trigger before insert or delete or update on testtr for each row execute function testtr_trigger()",
+    "expected": "CREATE TRIGGER testtr_trigger BEFORE INSERT OR UPDATE OR DELETE ON testtr FOR EACH ROW EXECUTE FUNCTION testtr_trigger()"
+  },
+  {
+    "comment": "plpgsql_trigger - Statement 4",
+    "query": "insert into testtr values (1, 'one'), (2, 'two')",
+    "expected": "INSERT INTO testtr VALUES (1, 'one'), (2, 'two')"
+  },
+  {
+    "comment": "plpgsql_trigger - Statement 5",
+    "query": "update testtr set a = a + 1",
+    "expected": "UPDATE testtr SET a = a + 1"
+  },
+  {
+    "comment": "plpgsql_trigger - Statement 6",
+    "query": "delete from testtr",
+    "expected": "DELETE FROM testtr"
+  }
+]

--- a/go/common/parser/testdata/postgres/plpgsql_varprops.json
+++ b/go/common/parser/testdata/postgres/plpgsql_varprops.json
@@ -1,0 +1,187 @@
+[
+  {
+    "comment": "plpgsql_varprops - Statement 1",
+    "query": "create type var_record as (f1 int4, f2 int4)",
+    "expected": "CREATE TYPE var_record AS (f1 INT, f2 INT)"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 2",
+    "query": "create domain int_nn as int not null",
+    "expected": "CREATE DOMAIN int_nn AS INT NOT NULL"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 3",
+    "query": "create domain var_record_nn as var_record not null",
+    "expected": "CREATE DOMAIN var_record_nn AS var_record NOT NULL"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 4",
+    "query": "create domain var_record_colnn as var_record check((value).f2 is not null)",
+    "expected": "CREATE DOMAIN var_record_colnn AS var_record CHECK ((value).f2 IS NOT NULL)"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 5",
+    "query": "do $$ declare x constant int := 42; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x constant int := 42; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 6",
+    "query": "do $$ declare x constant int; begin x := 42; end$$",
+    "expected": "DO ' declare x constant int; begin x := 42; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 7",
+    "query": "do $$ declare x constant int; y int; begin for x, y in select 1, 2 loop end loop; end$$",
+    "expected": "DO ' declare x constant int; y int; begin for x, y in select 1, 2 loop end loop; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 8",
+    "query": "do $$ declare x constant int[]; begin x[1] := 42; end$$",
+    "expected": "DO ' declare x constant int[]; begin x[1] := 42; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 9",
+    "query": "do $$ declare x constant int[]; y int; begin for x[1], y in select 1, 2 loop end loop; end$$",
+    "expected": "DO ' declare x constant int[]; y int; begin for x[1], y in select 1, 2 loop end loop; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 10",
+    "query": "do $$ declare x constant var_record; begin x.f1 := 42; end$$",
+    "expected": "DO ' declare x constant var_record; begin x.f1 := 42; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 11",
+    "query": "do $$ declare x constant var_record; y int; begin for x.f1, y in select 1, 2 loop end loop; end$$",
+    "expected": "DO ' declare x constant var_record; y int; begin for x.f1, y in select 1, 2 loop end loop; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 12",
+    "query": "do $$ declare x int := sin(0); begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int := sin(0); begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 13",
+    "query": "do $$ declare x int := 1/0; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int := 1/0; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 14",
+    "query": "do $$ declare x bigint[] := array[1,3,5]; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x bigint[] := array[1,3,5]; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 15",
+    "query": "do $$ declare x record := row(1,2,3); begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x record := row(1,2,3); begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 16",
+    "query": "do $$ declare x var_record := row(1,2); begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record := row(1,2); begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 17",
+    "query": "do $$ declare x int not null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int not null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 18",
+    "query": "do $$ declare x int not null := 42; begin raise notice 'x = %', x; x := null; end$$",
+    "expected": "DO ' declare x int not null := 42; begin raise notice ''x = %'', x; x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 19",
+    "query": "do $$ declare x int not null := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int not null := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 20",
+    "query": "do $$ declare x record not null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x record not null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 21",
+    "query": "do $$ declare x record not null := row(42); begin raise notice 'x = %', x; x := row(null); raise notice 'x = %', x; x := null; end$$",
+    "expected": "DO ' declare x record not null := row(42); begin raise notice ''x = %'', x; x := row(null); raise notice ''x = %'', x; x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 22",
+    "query": "do $$ declare x record not null := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x record not null := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 23",
+    "query": "do $$ declare x var_record not null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record not null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 24",
+    "query": "do $$ declare x var_record not null := row(41,42); begin raise notice 'x = %', x; x := row(null,null); raise notice 'x = %', x; x := null; end$$",
+    "expected": "DO ' declare x var_record not null := row(41,42); begin raise notice ''x = %'', x; x := row(null,null); raise notice ''x = %'', x; x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 25",
+    "query": "do $$ declare x var_record not null := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record not null := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 26",
+    "query": "do $$ begin for i in 1..3 loop declare x int; y int := i; r record; c var_record; begin if i = 1 then x := 42; r := row(i, i+1); c := row(i, i+1); end if; raise notice 'x = %', x; raise notice 'y = %', y; raise notice 'r = %', r; raise notice 'c = %', c; end; end loop; end$$",
+    "expected": "DO ' begin for i in 1..3 loop declare x int; y int := i; r record; c var_record; begin if i = 1 then x := 42; r := row(i, i+1); c := row(i, i+1); end if; raise notice ''x = %'', x; raise notice ''y = %'', y; raise notice ''r = %'', r; raise notice ''c = %'', c; end; end loop; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 27",
+    "query": "do $$ declare x int_nn; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int_nn; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 28",
+    "query": "do $$ declare x int_nn := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x int_nn := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 29",
+    "query": "do $$ declare x int_nn := 42; begin raise notice 'x = %', x; x := null; end$$",
+    "expected": "DO ' declare x int_nn := 42; begin raise notice ''x = %'', x; x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 30",
+    "query": "do $$ declare x var_record_nn; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record_nn; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 31",
+    "query": "do $$ declare x var_record_nn := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record_nn := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 32",
+    "query": "do $$ declare x var_record_nn := row(1,2); begin raise notice 'x = %', x; x := row(null,null); x := null; end$$",
+    "expected": "DO ' declare x var_record_nn := row(1,2); begin raise notice ''x = %'', x; x := row(null,null); x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 33",
+    "query": "do $$ declare x var_record_colnn; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record_colnn; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 34",
+    "query": "do $$ declare x var_record_colnn := null; begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record_colnn := null; begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 35",
+    "query": "do $$ declare x var_record_colnn := row(1,null); begin raise notice 'x = %', x; end$$",
+    "expected": "DO ' declare x var_record_colnn := row(1,null); begin raise notice ''x = %'', x; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 36",
+    "query": "do $$ declare x var_record_colnn := row(1,2); begin raise notice 'x = %', x; x := null; end$$",
+    "expected": "DO ' declare x var_record_colnn := row(1,2); begin raise notice ''x = %'', x; x := null; end'"
+  },
+  {
+    "comment": "plpgsql_varprops - Statement 37",
+    "query": "do $$ declare x var_record_colnn := row(1,2); begin raise notice 'x = %', x; x := row(null,null); end$$",
+    "expected": "DO ' declare x var_record_colnn := row(1,2); begin raise notice ''x = %'', x; x := row(null,null); end'"
+  }
+]


### PR DESCRIPTION
## Summary

- Imports pganalyze's deparser test corpora into our parser test suite to harden parse → deparse → re-parse round-trip fidelity, adding ~1700 new cases across curated, complex/real-world, and PL/pgSQL statements.
- Fixes the deparser bugs these cases surfaced (see below) and one converter bug in the PostgreSQL regression importer.
- Adds third-party license attribution for the imported data.

## Description

We're pinned to PostgreSQL 17, so all imports are sourced from PG17-line releases of pganalyze's tooling (`libpg_query` tags `17-6.1.0` / `17-6.2.2` and the matching `pg_query` Ruby gem). Concretely:

- **`deparse_cases.json`** (450 cases) — the curated deparser corpus from `libpg_query/test/deparse_tests.c`, plus genuinely-new cases from the `pg_query` Ruby `deparse_spec.rb` (param refs, `INTERSECT`, boolean-string casts, deep-nesting stress tests).
- **`deparse_complex_cases.json`** (132 cases) — the complex/real-world query corpora from `libpg_query/test/sql/deparse` and `test/sql/deparse-depesz` (depesz' pg-sql-prettyprinter fixtures). All round-trip cleanly.
- **`postgres/plpgsql_*.json`** (13 files) — the PL/pgSQL regression files we were missing relative to `libpg_query`'s regression list.

All new corpora are wired into `TestParseDeparseRoundtrip` (and the postgres files into the existing exact-match `TestPostgresTestsParsing`).

### Deparser bugs fixed

The imported cases surfaced and we fixed:

- `AlterExtensionContentsStmt` (`ALTER EXTENSION ... ADD/DROP <object>`) emitted garbage like `ADD OBJECT 'a'` for most object kinds — rewritten to render each member object by its grammar shape, mirroring PostgreSQL's `deparseAlterExtensionContentsStmt`.
- `COMMENT ON POLICY a ON b` deparsed to `COMMENT ON POLICY b.a` (wrong name order).
- `CREATE DATABASE x LOCATION DEFAULT` deparsed to invalid `CREATE DATABASE x WITH LOCATION`.
- Index-constraint `WITH (...)` reloptions (e.g. `UNIQUE (a) WITH (fillfactor=70)`) were silently dropped.
- `SET search_path TO <integer>` deparsed to invalid `SET SCHEMA 10000` (the `SET SCHEMA` idiom only accepts a string constant).
- `ALTER TABLE ... SET STATISTICS DEFAULT` dropped the `DEFAULT`.

Also fixed `convert_postgres_tests.py` so it recognizes `DO LANGUAGE plpgsql $$ ... $$` blocks (the `LANGUAGE` clause before the body was not handled, causing bodies to be split on internal semicolons).

### Licensing

Added `go/common/parser/testdata/THIRD_PARTY_NOTICES.md` with full upstream license texts and a file-by-file mapping: libpg_query/pg_query (BSD-3-Clause, pganalyze), the depesz fixtures (BSD-3-Clause), and the PostgreSQL regression data (PostgreSQL License). The Multigres-authored converter script gained the standard Apache-2.0 header.

## Acknowledgements

Huge thanks to **[pganalyze](https://github.com/pganalyze)** — their **[libpg_query](https://github.com/pganalyze/libpg_query)** (and the **[pg_query](https://github.com/pganalyze/pg_query)** Ruby gem) was the driving source for these extra tests. Their thorough, well-maintained deparser corpus is what let us find and fix real round-trip bugs here. Thank you! 🙏 