### PR TITLE
test(pgproto): add adversarial corpus sequences and fix error SQLSTATEs

### DIFF
--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -928,6 +928,25 @@ func (c *Conn) handleQuery() error {
 	return c.writeReadyForQuery()
 }
 
+// preserveExtendedQueryError returns err unchanged when it already carries a
+// structured PostgreSQL diagnostic, so the client sees the real SQLSTATE the
+// handler produced (e.g. 42601 syntax_error from the parser on Parse, 26000
+// invalid_sql_statement_name for a missing prepared statement on Bind/Describe,
+// 34000 invalid_cursor_name for a missing portal on Describe). Only an opaque
+// error with no SQLSTATE is wrapped with fallback, which marks a genuinely
+// internal failure of the extended-query step. Drivers branch on these
+// SQLSTATEs, so blanket-wrapping a structured error as an internal MTDxx code
+// (which clients read as a proxy bug) would be a real protocol divergence from
+// PostgreSQL — see the pgproto conformance suite's bind_before_parse and
+// describe_unknown corpus files.
+func preserveExtendedQueryError(err error, fallback *mterrors.MTError) error {
+	var diag *mterrors.PgDiagnostic
+	if errors.As(err, &diag) {
+		return err
+	}
+	return fallback.NewWithDetail(err.Error())
+}
+
 // handleParse handles a 'P' (Parse) message - extended query protocol.
 // Parse message format:
 // - Statement name (string, null-terminated)
@@ -994,15 +1013,10 @@ func (c *Conn) handleParse() error {
 		// The error packet stays buffered until Sync flushes the batch — same shape
 		// as upstream PostgreSQL, which also defers error delivery to Sync/Flush.
 		//
-		// Preserve a structured PostgreSQL diagnostic when the handler produced
-		// one (e.g. a 42601 syntax_error from the parser) so the client sees the
-		// same SQLSTATE PostgreSQL would send. Only opaque errors with no SQLSTATE
-		// are wrapped as MTD04, which marks a genuinely internal Parse failure.
-		var diag *mterrors.PgDiagnostic
-		if !errors.As(err, &diag) {
-			err = mterrors.MTD04.NewWithDetail(err.Error())
-		}
-		return c.writeExtendedQueryError(err)
+		// Preserve a structured PostgreSQL diagnostic (e.g. 42601 syntax_error
+		// from the parser); only opaque errors are wrapped as MTD04, a genuinely
+		// internal Parse failure. See preserveExtendedQueryError.
+		return c.writeExtendedQueryError(preserveExtendedQueryError(err, mterrors.MTD04))
 	}
 
 	// Send ParseComplete message. Stays buffered for the rest of the batch.
@@ -1088,7 +1102,11 @@ func (c *Conn) handleBind() error {
 		// Do NOT send ReadyForQuery here — same reasoning as handleParse.
 		// ReadyForQuery is sent only in response to Sync. The error packet
 		// stays buffered until Sync flushes the batch.
-		return c.writeExtendedQueryError(mterrors.MTD05.NewWithDetail(err.Error()))
+		//
+		// Preserve a structured diagnostic (e.g. 26000 for a Bind referencing a
+		// prepared statement that was never Parsed); only opaque errors become
+		// MTD05. See preserveExtendedQueryError.
+		return c.writeExtendedQueryError(preserveExtendedQueryError(err, mterrors.MTD05))
 	}
 
 	// Send BindComplete message. Stays buffered for the rest of the batch.
@@ -1271,7 +1289,10 @@ func (c *Conn) handleDescribe() error {
 	// Describe('P') was already flushed by handleMessage before this call.
 	desc, err := c.handler.HandleDescribe(c.ctx, c, typ, name)
 	if err != nil {
-		return c.writeExtendedQueryError(mterrors.MTD06.NewWithDetail(err.Error()))
+		// Preserve a structured diagnostic — 26000 for an unknown prepared
+		// statement, 34000 for an unknown portal — so the two cases stay
+		// distinguishable; only opaque errors become MTD06.
+		return c.writeExtendedQueryError(preserveExtendedQueryError(err, mterrors.MTD06))
 	}
 
 	// Send ParameterDescription only for statement describes ('S').
@@ -1312,7 +1333,9 @@ func (c *Conn) resolveDeferredPortalDescribe() error {
 	c.deferredPortalDescribeName = ""
 	desc, err := c.handler.HandleDescribe(c.ctx, c, 'P', name)
 	if err != nil {
-		return c.writeExtendedQueryError(mterrors.MTD06.NewWithDetail(err.Error()))
+		// Preserve a structured diagnostic (34000 for an unknown portal); only
+		// opaque errors become MTD06. See preserveExtendedQueryError.
+		return c.writeExtendedQueryError(preserveExtendedQueryError(err, mterrors.MTD06))
 	}
 	if desc != nil && desc.Fields != nil {
 		return c.writeRowDescription(desc.Fields)

--- a/go/common/pgprotocol/server/extended_query_sqlstate_test.go
+++ b/go/common/pgprotocol/server/extended_query_sqlstate_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/pb/query"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errorResponseSQLSTATE reads the next message off buf, asserts it is an
+// ErrorResponse, and returns the SQLSTATE carried in its 'C' field. The
+// ErrorResponse body is a sequence of fields, each a one-byte field type
+// followed by a NUL-terminated value, terminated by a lone zero byte.
+func errorResponseSQLSTATE(t *testing.T, buf *bytes.Buffer) string {
+	t.Helper()
+	msgType, _, body := readMessageTypeAndLength(t, buf)
+	require.Equal(t, byte(protocol.MsgErrorResponse), msgType, "expected ErrorResponse")
+	for i := 0; i < len(body) && body[i] != 0; {
+		field := body[i]
+		i++
+		start := i
+		for i < len(body) && body[i] != 0 {
+			i++
+		}
+		val := string(body[start:i])
+		i++ // skip the NUL terminator
+		if field == 'C' {
+			return val
+		}
+	}
+	t.Fatalf("ErrorResponse had no 'C' (SQLSTATE) field: %q", body)
+	return ""
+}
+
+// These tests pin the multigateway's extended-query error SQLSTATEs to match
+// PostgreSQL. The handlers (handleBind/handleDescribe) used to blanket-wrap any
+// handler error as an internal MTDxx code, clobbering the real SQLSTATE the
+// handler produced; drivers branch on these codes, so that was a genuine
+// protocol divergence (caught by the pgproto conformance suite's
+// bind_before_parse and describe_unknown corpus files). preserveExtendedQueryError
+// now forwards a structured *PgDiagnostic unchanged and only wraps opaque errors.
+
+// TestBindUnknownStatementPreservesSQLSTATE: a Bind referencing a prepared
+// statement that was never Parsed must surface PostgreSQL's 26000
+// (invalid_sql_statement_name), not the internal MTD05.
+func TestBindUnknownStatementPreservesSQLSTATE(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		bindFunc: func(ctx context.Context, conn *Conn, portalName, stmtName string, params [][]byte, paramFormats, resultFormats []int16) error {
+			return mterrors.NewInvalidPreparedStatementError(stmtName)
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	writeBindMessage(&readBuf, "p_ghost", "ghost")
+	require.NoError(t, conn.handleBind())
+
+	assert.Equal(t, mterrors.PgSSInvalidSQLStatementName, errorResponseSQLSTATE(t, &writeBuf))
+}
+
+// TestBindOpaqueErrorWrappedAsMTD05: an error with no SQLSTATE still falls back
+// to MTD05 — preserving the diagnostic must not swallow the internal-failure
+// signal for genuinely opaque errors.
+func TestBindOpaqueErrorWrappedAsMTD05(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		bindFunc: func(ctx context.Context, conn *Conn, portalName, stmtName string, params [][]byte, paramFormats, resultFormats []int16) error {
+			return errors.New("something opaque went wrong")
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	writeBindMessage(&readBuf, "p", "s")
+	require.NoError(t, conn.handleBind())
+
+	assert.Equal(t, mterrors.MTD05.ID, errorResponseSQLSTATE(t, &writeBuf))
+}
+
+// TestDescribeUnknownStatementPreservesSQLSTATE: Describe('S') of an unknown
+// prepared statement must surface 26000 (invalid_sql_statement_name).
+func TestDescribeUnknownStatementPreservesSQLSTATE(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		describeFunc: func(ctx context.Context, conn *Conn, typ byte, name string) (*query.StatementDescription, error) {
+			return nil, mterrors.NewInvalidPreparedStatementError(name)
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// handleDescribe reads a length-prefixed body of type byte + name.
+	writeTestInt32(&readBuf, int32(4+1+len("no_such_stmt")+1))
+	readBuf.WriteByte('S')
+	writeTestString(&readBuf, "no_such_stmt")
+	require.NoError(t, conn.handleDescribe())
+
+	assert.Equal(t, mterrors.PgSSInvalidSQLStatementName, errorResponseSQLSTATE(t, &writeBuf))
+}
+
+// TestDescribeUnknownPortalPreservesSQLSTATE: Describe('P') of an unknown portal
+// must surface 34000 (invalid_cursor_name) — a distinct SQLSTATE from the
+// statement case, which the old blanket MTD06 collapsed into one code. The 'P'
+// describe is deferred, so it is driven through the message loop the way the
+// server resolves it (resolveDeferredPortalDescribe on the following Sync).
+func TestDescribeUnknownPortalPreservesSQLSTATE(t *testing.T) {
+	var readBuf, writeBuf bytes.Buffer
+	handler := &testHandler{
+		describeFunc: func(ctx context.Context, conn *Conn, typ byte, name string) (*query.StatementDescription, error) {
+			return nil, mterrors.NewInvalidPortalError(name)
+		},
+	}
+	conn := createExtendedQueryTestConn(t, &readBuf, &writeBuf, handler)
+
+	// Describe('P', "no_such_portal") — deferred until the next message.
+	readBuf.WriteByte(protocol.MsgDescribe)
+	writeTestInt32(&readBuf, int32(4+1+len("no_such_portal")+1))
+	readBuf.WriteByte('P')
+	writeTestString(&readBuf, "no_such_portal")
+
+	// Sync — resolves the deferred Describe, which errors.
+	readBuf.WriteByte(protocol.MsgSync)
+	writeTestInt32(&readBuf, 4)
+
+	conn.startWriterBuffering()
+	for i := range 2 {
+		msgType, err := conn.ReadMessageType()
+		require.NoError(t, err, "ReadMessageType iter %d", i)
+		require.NoError(t, conn.handleMessage(msgType), "handleMessage iter %d", i)
+	}
+	require.NoError(t, conn.endWriterBuffering())
+
+	assert.Equal(t, mterrors.PgSSInvalidCursorName, errorResponseSQLSTATE(t, &writeBuf))
+}
+
+// writeBindMessage writes a zero-parameter Bind message body (length-prefixed)
+// into buf, ready for handleBind to read.
+func writeBindMessage(buf *bytes.Buffer, portalName, stmtName string) {
+	length := int32(4 + len(portalName) + 1 + len(stmtName) + 1 + 2 + 2 + 2)
+	writeTestInt32(buf, length)
+	writeTestString(buf, portalName)
+	writeTestString(buf, stmtName)
+	writeTestInt16(buf, 0) // parameter format count
+	writeTestInt16(buf, 0) // parameter count
+	writeTestInt16(buf, 0) // result format count
+}

--- a/go/test/endtoend/queryserving/pgproto/README.md
+++ b/go/test/endtoend/queryserving/pgproto/README.md
@@ -189,6 +189,19 @@ matches PostgreSQL exactly).
   PostgreSQL would require eager bind-time planning against the backend (an
   extra round-trip on the latency-sensitive path) for negligible client benefit,
   so the divergence is recorded rather than fixed.
+- **`copy.patch`** — the `COPY … TO STDOUT` block of `copy.pgproto` is **not
+  implemented yet**. The multigateway rejects it at plan time with SQLSTATE
+  `0A000` (feature_not_supported), so PostgreSQL's `CopyOutResponse`/`CopyData…`/
+  `CopyDone`/`CommandComplete` collapses to a single `ErrorResponse(0A000)`. The
+  rest of `copy.pgproto` (COPY FROM STDIN, CopyFail) matches PostgreSQL exactly;
+  the patch covers only the TO STDOUT lines. Unlike `error_recovery.patch`, this
+  records a divergence we intend to **fix**: when the feature lands the patch
+  stops applying and the suite flags it for deletion.
+- **`function_call.patch`** — fast-path **FunctionCall is not implemented yet**.
+  The multigateway has no `'F'` message handler, so PostgreSQL's
+  `FunctionCallResponse` becomes the gateway's `ErrorResponse(MTD03)`. Same
+  ship-the-test-early intent as `copy_out.patch`: delete when fast-path support
+  lands.
 
 ## Tool install
 

--- a/go/test/endtoend/queryserving/pgproto/testdata/bind_before_parse.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/bind_before_parse.pgproto
@@ -1,0 +1,27 @@
+#
+# Extended-query: Bind referencing a statement that was never Parsed.
+#
+# A Bind names a prepared statement; if that statement does not exist the
+# backend must reject the Bind with SQLSTATE 26000 (invalid_sql_statement_name)
+# and then skip every following message until the next Sync. This is a pure
+# relay-ordering case for a proxy: it never sees a Parse for "ghost", so it must
+# forward the Bind/Execute and surface the backend's error rather than
+# inventing its own.
+#
+
+# Bind to a statement name that was never created -> ErrorResponse(26000).
+# The Execute that follows targets the portal the failed Bind would have made
+# and must be skipped until the Sync.
+'B'	"p_ghost"	"ghost"	0	0	0
+'E'	"p_ghost"	0
+'S'
+'Y'
+
+# After Sync the session recovers: an unnamed prepared statement runs normally.
+'P'	"ok"	"SELECT 1"	0
+'B'	"p_ok"	"ok"	0	0	0
+'E'	"p_ok"	0
+'S'
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/closed_portal.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/closed_portal.pgproto
@@ -1,0 +1,34 @@
+#
+# Extended-query: Execute against a portal that was already Closed.
+#
+# A portal is created by Bind and destroyed by Close('P'). Executing a portal
+# that no longer exists must fail with SQLSTATE 34000 (invalid_cursor_name) and
+# then skip to the next Sync. We Parse/Bind/Close/Execute all in one batch so
+# the Close and the doomed Execute are pipelined before a single Sync — the
+# backend processes them in order and the Execute sees no portal.
+#
+
+'Q'	"CREATE TABLE pgproto_portal (id int)"
+'Y'
+'Q'	"INSERT INTO pgproto_portal VALUES (1), (2)"
+'Y'
+
+# Bind a portal, Close it, then try to Execute the now-closed portal.
+# Expect: ParseComplete, BindComplete, CloseComplete, ErrorResponse(34000),
+# ReadyForQuery.
+'P'	"s_portal"	"SELECT id FROM pgproto_portal ORDER BY id"	0
+'B'	"port_closed"	"s_portal"	0	0	0
+'C'	'P'	"port_closed"
+'E'	"port_closed"	0
+'S'
+'Y'
+
+# The prepared statement itself still exists (only the portal was closed), so
+# re-binding a fresh portal from it and executing succeeds — proving the error
+# was scoped to the portal, not the statement.
+'B'	"port_fresh"	"s_portal"	0	0	0
+'E'	"port_fresh"	0
+'S'
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/copy.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/copy.pgproto
@@ -5,9 +5,12 @@
 # aborted with CopyFail (ErrorResponse). Each block ends with 'Y' to drain to
 # ReadyForQuery.
 #
-# COPY ... TO STDOUT is intentionally omitted: the multigateway does not support
-# it yet ("COPY TO STDOUT not yet supported"), so the divergence is known. Add a
-# TO STDOUT case here once it is implemented.
+# COPY ... TO STDOUT is covered too, but the multigateway does not support it
+# yet ("COPY TO STDOUT not yet supported", SQLSTATE 0A000), so that block
+# diverges from PostgreSQL and the divergence is recorded in
+# testdata/patches/copy.patch. The corpus exercise ships now so the test is
+# ready; when COPY TO STDOUT is implemented the patch stops applying and the
+# suite flags it for deletion. See that patch's comment.
 #
 # pgproto sends each 'd' (CopyData) string verbatim and cannot embed tab or
 # newline bytes in a data-file string (an unescaped tab/newline terminates the
@@ -32,6 +35,13 @@
 
 # The aborted COPY must not have committed its row: count stays 1.
 'Q'	"SELECT count(*) FROM pgproto_copy"
+'Y'
+
+# COPY ... TO STDOUT (the one committed "hello" row). PostgreSQL streams it as
+# CopyOutResponse, one CopyData, CopyDone, CommandComplete(COPY 1). The
+# multigateway rejects it at plan time -> ErrorResponse(0A000) (recorded via
+# testdata/patches/copy.patch until COPY TO STDOUT is supported).
+'Q'	"COPY pgproto_copy TO STDOUT"
 'Y'
 
 'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/describe_unknown.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/describe_unknown.pgproto
@@ -1,0 +1,28 @@
+#
+# Extended-query: Describe of objects that do not exist.
+#
+# Describe('S', name) on an unknown prepared statement fails with SQLSTATE 26000
+# (invalid_sql_statement_name); Describe('P', name) on an unknown portal fails
+# with 34000 (invalid_cursor_name). Each is exercised in its own Sync-delimited
+# batch so the SQLSTATEs do not mask one another, and a valid Describe follows
+# to show the session recovers.
+#
+
+# Describe an unknown prepared statement -> ErrorResponse(26000).
+'D'	'S'	"no_such_stmt"
+'S'
+'Y'
+
+# Describe an unknown portal -> ErrorResponse(34000).
+'D'	'P'	"no_such_portal"
+'S'
+'Y'
+
+# A valid Describe('S') after a real Parse returns ParameterDescription +
+# RowDescription, proving the session recovered from the two errors above.
+'P'	"real"	"SELECT 1 AS one"	0
+'D'	'S'	"real"
+'S'
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/flush.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/flush.pgproto
@@ -1,0 +1,46 @@
+#
+# Extended-query: Flush forces buffered responses out without a Sync.
+#
+# In the extended protocol the backend buffers its replies and does not push
+# them to the client until either a Sync (which also ends the implicit
+# transaction and sends ReadyForQuery) or a Flush (which pushes whatever is
+# buffered *without* a ReadyForQuery and without ending the transaction). A
+# client driving an incremental conversation relies on Flush to read a
+# statement's result before deciding what to send next. A proxy that only
+# forwards on Sync — or that withholds bytes until it sees ReadyForQuery — would
+# hang or reorder here.
+#
+# 'H' sends Flush; 'y' reads whatever has arrived for up to 1s and then stops
+# (unlike 'Y', which blocks until ReadyForQuery — there is no ReadyForQuery
+# after a Flush, so 'Y' would hang). Each 'y' below should surface exactly the
+# messages the preceding Flush pushed, and no ReadyForQuery.
+#
+
+'Q'	"CREATE TABLE pgproto_flush (id int)"
+'Y'
+'Q'	"INSERT INTO pgproto_flush VALUES (7)"
+'Y'
+
+# Parse, then Flush -> ParseComplete arrives on its own (no ReadyForQuery).
+'P'	"s_flush"	"SELECT id FROM pgproto_flush ORDER BY id"	0
+'H'
+'y'
+
+# Bind + Describe(portal), then Flush -> BindComplete + RowDescription arrive,
+# still no ReadyForQuery.
+'B'	"p_flush"	"s_flush"	0	0	0
+'D'	'P'	"p_flush"
+'H'
+'y'
+
+# Execute, then Flush -> DataRow + CommandComplete arrive, still no
+# ReadyForQuery (the implicit transaction is still open).
+'E'	"p_flush"	0
+'H'
+'y'
+
+# Finally Sync closes the implicit transaction and yields ReadyForQuery.
+'S'
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/function_call.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/function_call.pgproto
@@ -21,4 +21,12 @@
 'F'	177	1	0	2	1	"2"	1	"3"	0
 'Y'
 
-'X'
+# NOTE: no trailing 'X' (Terminate) on purpose. Because the gateway does not
+# recognise the 'F' message it rejects it and *closes the connection* after the
+# ErrorResponse + ReadyForQuery. A Terminate sent after that close writes into a
+# dead socket and pgproto dies with SIGPIPE on Linux (it passed on macOS, where
+# the write-after-close did not fault) — a non-zero exit the harness records as a
+# runner error, not a trace divergence. Ending at 'Y' means the last byte we send
+# is the FunctionCall itself, before the close, so the trace is captured cleanly
+# on every platform. When fast-path support lands the gateway will keep the
+# connection open and this file can regain its 'X'.

--- a/go/test/endtoend/queryserving/pgproto/testdata/function_call.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/function_call.pgproto
@@ -1,0 +1,24 @@
+#
+# Fast-path FunctionCall ('F') — a feature the multigateway does NOT support yet.
+#
+# The fast-path protocol invokes a function by OID without parsing SQL. libpq's
+# large-object API still uses it; a proxy that means to be a drop-in PostgreSQL
+# replacement has to relay it. PostgreSQL answers with FunctionCallResponse; the
+# multigateway has no case for the 'F' message type and rejects it, so this file
+# diverges from PostgreSQL today. The divergence is RECORDED as a patch
+# (testdata/patches/function_call.patch) rather than fixed — see that patch's
+# comment. When fast-path support lands, the gateway will start matching
+# PostgreSQL, the patch will stop applying, and the suite will flag it so the
+# patch can be deleted. The test is already here, waiting.
+#
+# Data-file field layout (tab-separated):
+#   'F'  <foid> <ncodes> <code...> <nparams> <plen> "val" ... <resultcode>
+#
+# int4pl(2, 3) — OID 177, a pure two-int function with no side effects and no
+# transaction requirement, so PostgreSQL's baseline is deterministic. One text
+# argument-format code (0) applies to both args; the result is requested in text
+# (0). PostgreSQL returns FunctionCallResponse (= 5) then ReadyForQuery.
+'F'	177	1	0	2	1	"2"	1	"3"	0
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/multi_statement.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/multi_statement.pgproto
@@ -1,0 +1,32 @@
+#
+# Simple-query: multiple statements in one Query message.
+#
+# A single 'Q' may carry several statements separated by ';'. The backend runs
+# them in one implicit transaction and emits a CommandComplete per statement,
+# followed by a single ReadyForQuery for the whole message. A proxy must relay
+# every per-statement CommandComplete (not collapse them) and must run the
+# statements as one implicit transaction.
+#
+
+# Multi-statement that succeeds: three statements, three CommandCompletes, then
+# one ReadyForQuery. The trailing SELECT also yields RowDescription + DataRow.
+'Q'	"CREATE TABLE pgproto_multi (id int); INSERT INTO pgproto_multi VALUES (1); SELECT id FROM pgproto_multi"
+'Y'
+
+# Multi-statement where the middle statement errors. Statements run in order
+# until one fails: the first INSERT executes and its CommandComplete(INSERT 0 1)
+# is already streamed, then SELECT 1/0 raises ErrorResponse(22012) and the third
+# INSERT never runs. Because the whole message is one implicit transaction the
+# error rolls it back — so the streamed first INSERT does not persist — but the
+# CommandComplete for it has already gone out on the wire. Expect:
+# CommandComplete(INSERT 0 1), ErrorResponse(22012), ReadyForQuery.
+'Q'	"INSERT INTO pgproto_multi VALUES (2); SELECT 1/0; INSERT INTO pgproto_multi VALUES (3)"
+'Y'
+
+# The table still holds exactly the one row from the first (committed) message;
+# neither row from the aborted second message survives. (Row value is not shown
+# in the trace — this query just confirms the session is usable again.)
+'Q'	"SELECT count(*) FROM pgproto_multi"
+'Y'
+
+'X'

--- a/go/test/endtoend/queryserving/pgproto/testdata/patches/copy.patch
+++ b/go/test/endtoend/queryserving/pgproto/testdata/patches/copy.patch
@@ -1,0 +1,29 @@
+# Known divergence: COPY ... TO STDOUT is not supported by the multigateway.
+#
+# Only the trailing COPY TO STDOUT block of copy.pgproto diverges; the COPY FROM
+# STDIN and CopyFail blocks above match PostgreSQL exactly and are untouched
+# here. PostgreSQL streams the one committed row as CopyOutResponse, one
+# CopyData, CopyDone, CommandComplete(COPY 1). The multigateway rejects COPY TO
+# STDOUT at plan time (planner/copy_stmt.go) with SQLSTATE 0A000
+# (feature_not_supported, "COPY TO STDOUT not yet supported"), so the copy-out
+# exchange collapses to a single ErrorResponse(0A000) before the trailing
+# ReadyForQuery.
+#
+# This patch records the CURRENT (unsupported) behaviour so the corpus exercise
+# can ship before the feature exists. When COPY TO STDOUT is implemented the
+# gateway will stream the rows and match PostgreSQL, this patch will stop
+# applying (a residual diff appears) and the suite will flag it — delete the
+# patch then.
+--- a
++++ b
+@@ -19,9 +19,6 @@
+ <= BE CommandComplete(SELECT 1)
+ <= BE ReadyForQuery(I)
+ FE=> Query (query="COPY pgproto_copy TO STDOUT")
+-<= BE CopyOutResponse
+-<= BE CopyData
+-<= BE CopyDone
+-<= BE CommandComplete(COPY 1)
++<= BE ErrorResponse(C 0A000)
+ <= BE ReadyForQuery(I)
+ FE=> Terminate

--- a/go/test/endtoend/queryserving/pgproto/testdata/patches/function_call.patch
+++ b/go/test/endtoend/queryserving/pgproto/testdata/patches/function_call.patch
@@ -1,0 +1,22 @@
+# Known divergence: fast-path FunctionCall is not supported by the multigateway.
+#
+# PostgreSQL answers a fast-path FunctionCall ('F') with FunctionCallResponse.
+# The multigateway has no handler for the 'F' message type — it falls through to
+# the default case in handleMessage (conn.go), which emits an internal-error
+# ErrorResponse (SQLSTATE MTD03) and tears the connection down. So PostgreSQL's
+# FunctionCallResponse becomes the gateway's ErrorResponse(MTD03) here. (The
+# trailing ReadyForQuery is the gateway's own teardown reply; pgproto still
+# reads it and the Terminate that follows, so the trace stays diffable.)
+#
+# This patch records the CURRENT (unsupported) behaviour so the corpus file can
+# ship before the feature exists. When fast-path FunctionCall is implemented the
+# gateway will return FunctionCallResponse and match PostgreSQL, this patch will
+# stop applying (a residual diff appears) and the suite will flag it — delete the
+# patch then.
+--- a
++++ b
+@@ -1,3 +1,3 @@
+-<= BE FunctionCallResponse
++<= BE ErrorResponse(C MTD03)
+ <= BE ReadyForQuery(I)
+ FE=> Terminate

--- a/go/test/endtoend/queryserving/pgproto/testdata/patches/function_call.patch
+++ b/go/test/endtoend/queryserving/pgproto/testdata/patches/function_call.patch
@@ -3,10 +3,13 @@
 # PostgreSQL answers a fast-path FunctionCall ('F') with FunctionCallResponse.
 # The multigateway has no handler for the 'F' message type — it falls through to
 # the default case in handleMessage (conn.go), which emits an internal-error
-# ErrorResponse (SQLSTATE MTD03) and tears the connection down. So PostgreSQL's
-# FunctionCallResponse becomes the gateway's ErrorResponse(MTD03) here. (The
-# trailing ReadyForQuery is the gateway's own teardown reply; pgproto still
-# reads it and the Terminate that follows, so the trace stays diffable.)
+# ErrorResponse (SQLSTATE MTD03) and closes the connection. So PostgreSQL's
+# FunctionCallResponse becomes the gateway's ErrorResponse(MTD03) here. The
+# trailing ReadyForQuery is the gateway's own teardown reply.
+#
+# function_call.pgproto deliberately omits the trailing Terminate ('X') because
+# the gateway has already closed the socket by then — see that file's NOTE — so
+# the trace ends at ReadyForQuery on both targets.
 #
 # This patch records the CURRENT (unsupported) behaviour so the corpus file can
 # ship before the feature exists. When fast-path FunctionCall is implemented the
@@ -15,8 +18,7 @@
 # patch then.
 --- a
 +++ b
-@@ -1,3 +1,3 @@
+@@ -1,2 +1,2 @@
 -<= BE FunctionCallResponse
 +<= BE ErrorResponse(C MTD03)
  <= BE ReadyForQuery(I)
- FE=> Terminate

--- a/go/test/endtoend/queryserving/pgproto/testdata/pipeline_error.pgproto
+++ b/go/test/endtoend/queryserving/pgproto/testdata/pipeline_error.pgproto
@@ -1,0 +1,45 @@
+#
+# Extended-query: a pipelined batch that errors mid-batch.
+#
+# Several Parse/Bind/Execute groups are pipelined before a single Sync. The
+# whole run between Syncs is one implicit transaction: when a message in the
+# middle errors, the backend reports the ErrorResponse, skips every later
+# message until the Sync, and rolls back the *entire* implicit transaction —
+# including the inserts that already "succeeded" earlier in the same batch.
+# A proxy that splits the pipeline into separate transactions, or that lets the
+# earlier inserts commit, would diverge here.
+#
+# What the trace pins down is the *message sequencing*: ParseComplete/
+# BindComplete/CommandComplete for the first INSERT, then ParseComplete/
+# BindComplete/ErrorResponse(23505) for the duplicate, and then NOTHING for the
+# third group — its Parse/Bind/Execute are skipped, so no third ParseComplete
+# appears before ReadyForQuery. (The row count itself is invisible: pgproto
+# prints DataRow without its payload, so 0 vs 1 look identical in the trace.)
+#
+
+'Q'	"CREATE TABLE pgproto_pipe (id int primary key)"
+'Y'
+
+# One pipeline, one Sync. Order of operations:
+#   INSERT 1   -> succeeds
+#   INSERT 1   -> duplicate key, ErrorResponse(23505)
+#   INSERT 2   -> skipped (after the error, before the Sync)
+# At the Sync the implicit transaction aborts, so NOTHING is committed.
+'P'	"ins_a"	"INSERT INTO pgproto_pipe VALUES (1)"	0
+'B'	"b_a"	"ins_a"	0	0	0
+'E'	"b_a"	0
+'P'	"ins_dup"	"INSERT INTO pgproto_pipe VALUES (1)"	0
+'B'	"b_dup"	"ins_dup"	0	0	0
+'E'	"b_dup"	0
+'P'	"ins_c"	"INSERT INTO pgproto_pipe VALUES (2)"	0
+'B'	"b_c"	"ins_c"	0	0	0
+'E'	"b_c"	0
+'S'
+'Y'
+
+# Recovery after the aborted batch: a plain simple query runs normally,
+# proving the session resynced to ReadyForQuery on the simple-query path.
+'Q'	"SELECT count(*) FROM pgproto_pipe"
+'Y'
+
+'X'


### PR DESCRIPTION
## Summary

- Expands the pgproto wire-protocol conformance corpus (added in #1050) with the six adversarial sequences from that PR's follow-up checklist: Bind before Parse, Execute against a closed portal, a pipelined batch that errors mid-batch, multi-statement simple Query, Describe of unknown statements, and Flush behaviour.
- Fixes two real multigateway bugs the new files surfaced: Bind/Describe of a nonexistent prepared statement or portal returned the internal `MTD05`/`MTD06` codes instead of PostgreSQL's `26000`/`34000`. Drivers branch on these SQLSTATEs.
- Adds coverage for two features the gateway does not implement yet — fast-path FunctionCall and `COPY ... TO STDOUT` — recording each divergence as a patch that carries the gateway's current failure, so the tests ship now and flip to a fix-signal when support lands.
- Net result: the suite is 11 corpus files, 3 absorbed by patches (`error_recovery`, `copy`, `function_call`), zero unpatched divergences. Verified locally with `make pgproto`.

## Problem

The extended-query handlers blanket-wrapped every handler error as an internal `MTDxx` code, clobbering the structured SQLSTATE the handler had already produced — the same class of bug #1050 fixed for the Parse path (`MTD04` → `42601`). A Bind referencing a never-Parsed statement returned `MTD05` instead of `26000` (invalid_sql_statement_name); a Describe of an unknown statement or an unknown portal both returned `MTD06`, not even distinguishing `26000` (statement) from `34000` (invalid_cursor_name, portal). Clients read `MTDxx` as a proxy bug and branch on the standard SQLSTATEs, so this was a genuine protocol divergence from PostgreSQL.

## Solution

Introduce `preserveExtendedQueryError(err, fallback)` in `conn.go`: forward a structured `*PgDiagnostic` unchanged, and wrap only opaque errors with the fallback `MTDxx`. Applied to all four extended-query error sites (Parse, Bind, Describe, deferred Describe), unifying the pattern #1050 added inline for Parse. The inner handlers already produced correctly-coded diagnostics — which is why Execute against a closed portal already matched at `34000` — so the fix is purely to stop discarding them. New unit tests in `extended_query_sqlstate_test.go` pin the `26000`/`34000` preservation and the `MTD05` opaque-error fallback.

## Unsupported-feature tests (carried as patches)

`function_call.pgproto` (fast-path FunctionCall) and a new `COPY ... TO STDOUT` block in `copy.pgproto` exercise paths the gateway rejects today — FunctionCall has no `'F'` handler (`ErrorResponse(MTD03)` + connection teardown), and COPY TO STDOUT is refused at plan time (`0A000` feature_not_supported). Each divergence is recorded in a patch (`function_call.patch`, `copy.patch`) with a comment preamble explaining the current behaviour and noting the patch should be deleted once the feature is implemented — at which point the gateway will match PostgreSQL, the patch will stop applying, and the suite will flag it. The corpus files were each validated against a real PostgreSQL 17 oracle.

## Test plan

- [x] Each new `.pgproto` file validated against a standalone PostgreSQL 17.
- [x] `make pgproto` (verify mode) → 11/11 files match, 3 via patch, 0 unpatched divergences.
- [x] New `extended_query_sqlstate_test.go` unit tests pass; existing `go/common/pgprotocol/server` unit tests pass.
- [x] Confirmed the SQLSTATE fix is load-bearing: without it, `bind_before_parse` and `describe_unknown` turn the gate red.