### PR TITLE
docs(release): add release and EKS guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Multigres is a Vitess adaptation for Postgres. The project is currently in the early stages of development.
 
 Please visit the [Multigres site](https://multigres.com) if you'd like to try it.
+To run Multigres on EKS, see the [EKS getting started guide](docs/kubernetes/eks.md).
 
 If you have any questions or feedback, please start a [discussion](https://github.com/multigres/multigres/discussions/new).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,165 @@
+# Multigres Releases
+
+This page describes what a Multigres release contains, how to use those
+artifacts directly, and how to verify the container images before running them.
+For Kubernetes deployments, the normal entry point is the Multigres Operator.
+
+## Release Artifacts
+
+Each tagged Multigres core release publishes:
+
+- source archives on the GitHub release
+- downloadable binary archives for `linux` and `darwin`, on `amd64` and `arm64`
+- a `checksums.txt` file for downloadable binary archives
+- versioned container images on GitHub Container Registry
+- SBOM, provenance, and signature metadata for release container images
+
+Downloadable binary archives include:
+
+- `multigres`
+- `pgctld`
+- `multigateway`
+- `multiorch`
+- `multipooler`
+- `multiadmin`
+
+Container images include:
+
+- `ghcr.io/multigres/multigres`
+- `ghcr.io/multigres/pgctld`
+- `ghcr.io/multigres/multiadmin-web`
+
+`multiadmin-web` is distributed as a container image, not as a GoReleaser binary
+archive. `portpoolserver` is test and development infrastructure and is not a
+release artifact.
+
+## Kubernetes Installs
+
+For Kubernetes deployments, start with the Multigres Operator release you plan
+to install. The operator release notes or install docs should say which
+Multigres core image tag or digest that operator release uses.
+
+For the alpha EKS deployment path, see
+[Getting Started on EKS](docs/kubernetes/eks.md).
+
+Direct Multigres core releases are useful for:
+
+- inspecting or verifying published artifacts
+- running binaries outside Kubernetes
+- building from a tagged source release
+- debugging an operator-managed deployment with matching core binaries
+
+## Compatibility
+
+Multigres core and Multigres Operator are versioned separately. When a release
+is intended to work with a specific operator version, we document that pairing.
+
+| Release             | Operator  | Core     | Kubernetes                 | PostgreSQL      | Primary install path                 | Status            |
+| ------------------- | --------- | -------- | -------------------------- | --------------- | ------------------------------------ | ----------------- |
+| Initial OSS release | `v0.11.x` | `v0.1.x` | See operator release notes | PostgreSQL 17.x | Multigres Operator release manifests | Supported release |
+
+Combinations outside this table may work, but they are not the documented
+release pairing unless a specific operator release says so.
+
+## Build from Source
+
+```bash
+export VERSION=vX.Y.Z
+
+git clone https://github.com/multigres/multigres.git
+cd multigres
+git checkout "${VERSION}"
+
+make tools
+make build-release
+```
+
+The binaries are written to `bin/`.
+
+## Verify Binary Archives
+
+Replace `vX.Y.Z`, `linux`, and `amd64` with the release, operating system, and
+architecture you want to verify. Use `darwin` for macOS archives.
+
+```bash
+export VERSION=vX.Y.Z
+export VERSION_NO_V="${VERSION#v}"
+export OS=linux
+export ARCH=amd64
+export EXT=tar.gz
+export ARCHIVE="multigres-${VERSION_NO_V}-${OS}-${ARCH}.${EXT}"
+
+curl -fLO "https://github.com/multigres/multigres/releases/download/${VERSION}/${ARCHIVE}"
+curl -fLO "https://github.com/multigres/multigres/releases/download/${VERSION}/checksums.txt"
+
+grep "  ${ARCHIVE}$" checksums.txt | shasum -a 256 -c -
+```
+
+For macOS archives, set `OS=darwin` and `EXT=zip`.
+
+## Verify Container Images
+
+Release container images are signed by immutable digest using keyless
+Sigstore/cosign. The images also include BuildKit provenance and SBOM
+attestations tied to the published digest.
+
+Install Docker Buildx, cosign, and jq before running the commands below.
+
+### Inspect the Digest
+
+```bash
+export VERSION=vX.Y.Z
+export IMAGE=ghcr.io/multigres/multigres
+
+docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+export DIGEST="$(
+  docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+    --format '{{ json .Manifest }}' | jq -r .digest
+)"
+export IMAGE_BY_DIGEST="${IMAGE}@${DIGEST}"
+
+echo "${IMAGE_BY_DIGEST}"
+```
+
+Use `IMAGE_BY_DIGEST` for all subsequent verification commands. Pinning by
+digest avoids trusting a mutable tag after the digest has been inspected.
+
+### Verify the Signature
+
+```bash
+cosign verify \
+  --certificate-identity "https://github.com/multigres/multigres/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "${IMAGE_BY_DIGEST}" | jq .
+```
+
+This checks that the digest was signed by the Multigres release workflow using
+the GitHub Actions identity for the release tag.
+
+### Inspect Provenance
+
+```bash
+docker buildx imagetools inspect "${IMAGE_BY_DIGEST}" \
+  --format '{{ json .Provenance }}' | jq -e '.SLSA'
+```
+
+The command should print BuildKit provenance for the signed digest. A `null` or
+empty result means provenance was not found for that image digest.
+
+### Inspect the SBOM
+
+Inspect the full SBOM data attached to the image:
+
+```bash
+docker buildx imagetools inspect "${IMAGE_BY_DIGEST}" \
+  --format '{{ json .SBOM }}' | jq -e .
+```
+
+For a platform-specific SPDX SBOM, select the platform key:
+
+```bash
+docker buildx imagetools inspect "${IMAGE_BY_DIGEST}" \
+  --format '{{ json (index .SBOM "linux/amd64").SPDX }}' | jq -e .
+```
+
+Use `linux/arm64` instead of `linux/amd64` to inspect the arm64 image SBOM.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,9 +24,19 @@ Browse the design and reference docs by area:
 - **[General](./general/)** — cross-cutting topics (e.g. serving state
   management).
 
+## Alpha Deployment Notes
+
+- **[Getting started on EKS](./kubernetes/eks.md)**
+
+## Release Documentation
+
+- **[Release artifacts and verification](../RELEASE.md)**
+
 ## PostgreSQL Compatibility
 
 multigres runs the official PostgreSQL regression test suite to track compatibility.
 
 - **Results:** See the [latest workflow run](https://github.com/multigres/multigres/actions/workflows/test-pgregress.yml) for the detailed compatibility report in the Job Summary.
-- **Artifacts:** Each run uploads `compatibility-report.md` and `regression.diffs` as downloadable artifacts.
+- **PostgreSQL compatibility artifacts:** Each run uploads
+  `postgres-compatibility-results`, which includes the compatibility report and
+  PostgreSQL regression diffs when results are produced.

--- a/docs/kubernetes/eks.md
+++ b/docs/kubernetes/eks.md
@@ -36,16 +36,16 @@ The multi-AZ example below uses three cells to show an HA-oriented layout.
 
 Complete these steps before applying the `MultigresCluster` manifest:
 
-| Step | Command or check |
-| --- | --- |
-| Install the Multigres operator | `kubectl apply -f https://github.com/multigres/multigres-operator/releases/download/v0.1.0/install.yaml` |
-| Choose a namespace | `kubectl create namespace multigres-demo` |
-| Confirm persistent volume provisioning | `kubectl get storageclass` |
-| Confirm EKS zone labels | `kubectl get nodes -L topology.k8s.aws/zone-id,topology.kubernetes.io/zone` |
+| Step                                   | Command or check                                                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Install the Multigres operator         | `kubectl apply -f https://github.com/multigres/multigres-operator/releases/download/v0.1.0/install.yaml`           |
+| Choose a namespace                     | `kubectl create namespace multigres-demo`                                                                          |
+| Confirm persistent volume provisioning | `kubectl get storageclass`                                                                                         |
+| Confirm EKS zone labels                | `kubectl get nodes -L topology.k8s.aws/zone-id,topology.kubernetes.io/zone`                                        |
 | Prepare an S3 backup bucket and prefix | Create or select a bucket, choose a unique `keyPrefix`, and grant the backup service account access to that prefix |
-| Create the PostgreSQL password secret | `kubectl create secret generic multigres-admin-password --from-literal=password='<replace-me>'` |
-| Apply the `MultigresCluster` manifest | `kubectl apply -f multigres-demo.yaml` |
-| Verify the cluster with a SQL query | Run the `psql` check in [Verify Query Serving](#8-verify-query-serving) |
+| Create the PostgreSQL password secret  | `kubectl create secret generic multigres-admin-password --from-literal=password='<replace-me>'`                    |
+| Apply the `MultigresCluster` manifest  | `kubectl apply -f multigres-demo.yaml`                                                                             |
+| Verify the cluster with a SQL query    | Run the `psql` check in [Verify Query Serving](#8-verify-query-serving)                                            |
 
 ## 1. Install The Operator
 
@@ -212,27 +212,17 @@ Example IAM policy for a single bucket and prefix:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetBucketLocation"
-      ],
+      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
       "Resource": "arn:aws:s3:::your-backup-bucket",
       "Condition": {
         "StringLike": {
-          "s3:prefix": [
-            "multigres-demo/",
-            "multigres-demo/*"
-          ]
+          "s3:prefix": ["multigres-demo/", "multigres-demo/*"]
         }
       }
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject"
-      ],
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
       "Resource": "arn:aws:s3:::your-backup-bucket/multigres-demo/*"
     }
   ]

--- a/docs/kubernetes/eks.md
+++ b/docs/kubernetes/eks.md
@@ -1,15 +1,24 @@
 # Getting Started on EKS
 
 This guide describes the EKS prerequisites and reference configuration for
-running Multigres with the Kubernetes operator.
+running Multigres with the Kubernetes operator. It is intended as a tested path
+for users who already have access to an EKS cluster.
 
 It assumes an existing EKS cluster. Before creating a Multigres cluster, make
 sure you have:
 
 - `kubectl` configured for that cluster
 - permissions to create namespaces, CRDs, pods, services, PVCs, and secrets
-- the [Multigres operator](https://github.com/multigres/multigres-operator)
-  installed
+- permissions to install the
+  [Multigres operator](https://github.com/multigres/multigres-operator)
+
+This guide does not cover creating an
+[EKS cluster](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html),
+installing the
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html),
+or configuring
+[IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html) from
+scratch.
 
 ## Deployment Shape
 
@@ -23,12 +32,106 @@ cleanup in your own EKS environment.
 
 The multi-AZ example below uses three cells to show an HA-oriented layout.
 
-## Cluster Requirements
+## Setup Checklist
 
-### 1. EBS CSI Driver
+Complete these steps before applying the `MultigresCluster` manifest:
+
+| Step | Command or check |
+| --- | --- |
+| Install the Multigres operator | `kubectl apply -f https://github.com/multigres/multigres-operator/releases/download/v0.1.0/install.yaml` |
+| Choose a namespace | `kubectl create namespace multigres-demo` |
+| Confirm persistent volume provisioning | `kubectl get storageclass` |
+| Confirm EKS zone labels | `kubectl get nodes -L topology.k8s.aws/zone-id,topology.kubernetes.io/zone` |
+| Prepare an S3 backup bucket and prefix | Create or select a bucket, choose a unique `keyPrefix`, and grant the backup service account access to that prefix |
+| Create the PostgreSQL password secret | `kubectl create secret generic multigres-admin-password --from-literal=password='<replace-me>'` |
+| Apply the `MultigresCluster` manifest | `kubectl apply -f multigres-demo.yaml` |
+| Verify the cluster with a SQL query | Run the `psql` check in [Verify Query Serving](#8-verify-query-serving) |
+
+## 1. Install The Operator
+
+Install the operator version that matches the Multigres release you want to
+run. For example, for Multigres `v0.1.0`:
+
+```bash
+kubectl apply -f https://github.com/multigres/multigres-operator/releases/download/v0.1.0/install.yaml
+```
+
+If you are experimenting with the newest available operator release, you can
+use:
+
+```bash
+kubectl apply -f https://github.com/multigres/multigres-operator/releases/latest/download/install.yaml
+```
+
+For reproducible tests, prefer a versioned release URL over `latest`.
+
+Wait for the operator to become ready:
+
+```bash
+kubectl get pods -n multigres-operator
+```
+
+### Image Selection
+
+The `MultigresCluster` example below intentionally does not set
+`spec.images`. When image fields are omitted, the installed operator uses its
+default component images for that operator release.
+
+Use the matching operator release for the Multigres release you want to test.
+Only set `spec.images` when you deliberately need to override the release
+defaults, for example while testing a custom build.
+
+Optional image override shape:
+
+```yaml
+spec:
+  images:
+    multigateway: ghcr.io/multigres/multigres:<tag-or-digest>
+    multiorch: ghcr.io/multigres/multigres:<tag-or-digest>
+    multipooler: ghcr.io/multigres/multigres:<tag-or-digest>
+    multiadmin: ghcr.io/multigres/multigres:<tag-or-digest>
+    multiadminWeb: ghcr.io/multigres/multiadmin-web:<tag-or-digest>
+    postgres: ghcr.io/multigres/pgctld:<tag-or-digest>
+```
+
+After the cluster is created, you can inspect the actual images selected by the
+operator:
+
+```bash
+kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.containers[*]}{.name}{"="}{.image}{" "}{end}{"\n"}{end}'
+```
+
+## 2. Choose A Namespace
+
+Create a namespace for the Multigres cluster:
+
+```bash
+kubectl create namespace multigres-demo
+```
+
+Use the same namespace for the PostgreSQL password secret, backup service
+account, and `MultigresCluster` resource.
+
+You can either set the namespace on each command:
+
+```bash
+kubectl -n multigres-demo get pods
+```
+
+Or make it the default namespace for the current context:
+
+```bash
+kubectl config set-context --current --namespace=multigres-demo
+```
+
+The rest of this guide assumes your current context is set to the namespace
+where you want to deploy Multigres.
+
+## 3. Configure Storage
 
 Multigres poolers require persistent volumes. On EKS, install and configure the
-AWS EBS CSI driver before creating a Multigres cluster.
+[AWS EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
+before creating a Multigres cluster.
 
 Verify that dynamic volume provisioning works:
 
@@ -45,7 +148,7 @@ multigres-gp3
 If your cluster already has a suitable default StorageClass, you can omit the
 explicit storage class from the sample.
 
-### 2. Zone Labels
+## 4. Confirm Zone Labels
 
 Multigres cells map to Kubernetes topology labels.
 
@@ -65,12 +168,34 @@ use1-az6 -> us-east-1d
 
 Use the `topology.k8s.aws/zone-id` values for the Multigres `zoneId` fields.
 
-### 3. S3 Backup Bucket
+## 5. Prepare S3 Backups
 
 Create or select an S3 bucket for backups.
 
-The backup identity used by Multigres must be able to read, write, list, and
-delete objects under the configured backup prefix.
+Use a unique `keyPrefix` for each cluster if you plan to recreate clusters or
+run multiple demos in the same bucket.
+
+The backup service account used by Multigres must be able to read, write, list,
+and delete objects under the configured backup prefix. On EKS, use
+[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+to grant the Kubernetes service account access to S3.
+
+The sample manifest below uses a Kubernetes service account named
+`multigres-backup` for S3 access.
+
+Create the service account in the same namespace as the `MultigresCluster`:
+
+```bash
+kubectl create serviceaccount multigres-backup
+```
+
+If you use IRSA, annotate that service account with the IAM role that has S3
+access:
+
+```bash
+kubectl annotate serviceaccount multigres-backup \
+  eks.amazonaws.com/role-arn=arn:aws:iam::<account-id>:role/<multigres-backup-role>
+```
 
 At minimum, the backup identity needs access to:
 
@@ -79,14 +204,59 @@ At minimum, the backup identity needs access to:
 - `s3:PutObject`
 - `s3:DeleteObject`
 
-### 4. PostgreSQL Password Secret
+Example IAM policy for a single bucket and prefix:
 
-Create a Kubernetes secret containing the PostgreSQL superuser password:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::your-backup-bucket",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "multigres-demo/",
+            "multigres-demo/*"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::your-backup-bucket/multigres-demo/*"
+    }
+  ]
+}
+```
+
+## 6. Create Or Provide The PostgreSQL Password Secret
+
+Create or provide a Kubernetes secret containing the PostgreSQL superuser
+password. For a fresh test cluster, choose a password and create the secret
+manually:
 
 ```bash
 kubectl create secret generic multigres-admin-password \
-  --from-literal=password='<replace-me>'
+  --from-literal=password='change-this-password'
 ```
+
+Replace `change-this-password` with the password you want Multigres to use for
+the `postgres` user during cluster initialization. The verification command
+later in this guide reads the same password from this secret.
+
+If your environment manages secrets through another system, create an
+equivalent Kubernetes secret with the same name and key, or update
+`postgresPasswordSecretRef` in the manifest to point to your secret.
 
 The sample cluster references:
 
@@ -96,10 +266,11 @@ postgresPasswordSecretRef:
   key: password
 ```
 
-## Example Multi-AZ Cluster
+## 7. Create A Multi-AZ Cluster
 
 The manifest below shows a multi-AZ configuration. It defines three cells and
-places the shard's orchestration and read-write pool across those cells.
+places the shard's orchestration and read-write pool across those cells. It
+starts with one pooler per cell.
 
 ```yaml
 apiVersion: multigres.com/v1alpha1
@@ -112,6 +283,7 @@ spec:
     key: password
 
   pvcDeletionPolicy:
+    # Useful for repeatable alpha test runs.
     whenDeleted: Delete
     whenScaled: Delete
 
@@ -120,12 +292,12 @@ spec:
     s3:
       bucket: your-backup-bucket
       region: us-east-1
-      keyPrefix: multigres-demo/
-      serviceAccountName: multigres-backup
+      keyPrefix: multigres-demo/ # use a unique prefix per cluster
+      serviceAccountName: multigres-backup # service account with S3 access
 
   cells:
     - name: zone-a
-      zoneId: use1-az1
+      zoneId: use1-az1 # topology.k8s.aws/zone-id value
     - name: zone-b
       zoneId: use1-az2
     - name: zone-c
@@ -140,7 +312,7 @@ spec:
           shards:
             - name: 0-inf
               spec:
-                durabilityPolicy: AT_LEAST_2
+                durabilityPolicy: AT_LEAST_2 # start with the default alpha policy
                 multiorch:
                   cells:
                     - zone-a
@@ -154,14 +326,14 @@ spec:
                       - zone-a
                       - zone-b
                       - zone-c
-                    replicasPerCell: 1
-                    fsGroup: 999
+                    replicasPerCell: 1 # start modestly, then scale after validation
+                    fsGroup: 999 # postgres user group in the container
                     storage:
-                      size: 10Gi
-                      class: multigres-gp3
+                      size: 10Gi # example size for a test cluster
+                      class: multigres-gp3 # omit if using a suitable default class
 ```
 
-Apply it:
+Save the manifest as `multigres-demo.yaml`, then apply it:
 
 ```bash
 kubectl apply -f multigres-demo.yaml
@@ -171,8 +343,45 @@ Monitor the cluster:
 
 ```bash
 kubectl get pods -w
+```
+
+In another terminal, check the Multigres resources:
+
+```bash
 kubectl get multigresclusters
 kubectl get shards
+```
+
+## 8. Verify Query Serving
+
+After the cluster is healthy, run a simple SQL query through the Multigres
+gateway from inside the Kubernetes cluster.
+
+```bash
+POSTGRES_PASSWORD="$(
+  kubectl get secret multigres-admin-password \
+    -o jsonpath='{.data.password}' | base64 -d
+)"
+
+kubectl run psql-client \
+  --rm \
+  -i \
+  --restart=Never \
+  --image=postgres:17 \
+  --env="PGPASSWORD=${POSTGRES_PASSWORD}" \
+  -- psql \
+    -h multigres-demo-multigateway \
+    -U postgres \
+    -d postgres \
+    -c 'select 1 as result, current_database(), current_user;'
+```
+
+Expected result:
+
+```text
+ result | current_database | current_user
+--------+------------------+--------------
+      1 | postgres         | postgres
 ```
 
 ## Scaling
@@ -203,10 +412,9 @@ kubectl delete multigrescluster multigres-demo
 ```
 
 > [!WARNING]
-> Multigres is currently in alpha; for repeated EKS test deployments that reuse
-> the same cluster name and backup prefix, remove state from the previous run
-> before applying the manifest again. Remove only the state associated with the
-> deleted cluster:
+> For alpha test deployments, remove state from the previous run before
+> recreating a cluster with the same name and backup prefix. Remove only the
+> state associated with the deleted cluster:
 
 - persistent volume claims created for the deleted Multigres cluster
 - objects under the S3 backup prefix configured for that cluster

--- a/docs/kubernetes/eks.md
+++ b/docs/kubernetes/eks.md
@@ -1,0 +1,230 @@
+# Getting Started on EKS
+
+This guide describes the EKS prerequisites and reference configuration for
+running Multigres with the Kubernetes operator.
+
+It assumes an existing EKS cluster. Before creating a Multigres cluster, make
+sure you have:
+
+- `kubectl` configured for that cluster
+- permissions to create namespaces, CRDs, pods, services, PVCs, and secrets
+- the [Multigres operator](https://github.com/multigres/multigres-operator)
+  installed
+
+## Deployment Shape
+
+Multigres can run on a single Availability Zone or across multiple Availability
+Zones, as long as the cluster satisfies the minimum quorum requirements for the
+configured topology. Multigres is currently in alpha; for EKS deployments, begin
+with the smallest topology that satisfies your availability requirements and
+validate operational workflows before expanding the deployment. At minimum,
+validate cluster creation, backup and restore, failover behavior, scaling, and
+cleanup in your own EKS environment.
+
+The multi-AZ example below uses three cells to show an HA-oriented layout.
+
+## Cluster Requirements
+
+### 1. EBS CSI Driver
+
+Multigres poolers require persistent volumes. On EKS, install and configure the
+AWS EBS CSI driver before creating a Multigres cluster.
+
+Verify that dynamic volume provisioning works:
+
+```bash
+kubectl get storageclass
+```
+
+The example below uses a `gp3` StorageClass named:
+
+```text
+multigres-gp3
+```
+
+If your cluster already has a suitable default StorageClass, you can omit the
+explicit storage class from the sample.
+
+### 2. Zone Labels
+
+Multigres cells map to Kubernetes topology labels.
+
+On EKS, verify that nodes expose AWS zone IDs:
+
+```bash
+kubectl get nodes -L topology.k8s.aws/zone-id,topology.kubernetes.io/zone
+```
+
+Example:
+
+```text
+use1-az1 -> us-east-1a
+use1-az2 -> us-east-1b
+use1-az6 -> us-east-1d
+```
+
+Use the `topology.k8s.aws/zone-id` values for the Multigres `zoneId` fields.
+
+### 3. S3 Backup Bucket
+
+Create or select an S3 bucket for backups.
+
+The backup identity used by Multigres must be able to read, write, list, and
+delete objects under the configured backup prefix.
+
+At minimum, the backup identity needs access to:
+
+- `s3:ListBucket` on the bucket, scoped to the configured prefix
+- `s3:GetObject`
+- `s3:PutObject`
+- `s3:DeleteObject`
+
+### 4. PostgreSQL Password Secret
+
+Create a Kubernetes secret containing the PostgreSQL superuser password:
+
+```bash
+kubectl create secret generic multigres-admin-password \
+  --from-literal=password='<replace-me>'
+```
+
+The sample cluster references:
+
+```yaml
+postgresPasswordSecretRef:
+  name: multigres-admin-password
+  key: password
+```
+
+## Example Multi-AZ Cluster
+
+The manifest below shows a multi-AZ configuration. It defines three cells and
+places the shard's orchestration and read-write pool across those cells.
+
+```yaml
+apiVersion: multigres.com/v1alpha1
+kind: MultigresCluster
+metadata:
+  name: multigres-demo
+spec:
+  postgresPasswordSecretRef:
+    name: multigres-admin-password
+    key: password
+
+  pvcDeletionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+
+  backup:
+    type: s3
+    s3:
+      bucket: your-backup-bucket
+      region: us-east-1
+      keyPrefix: multigres-demo/
+      serviceAccountName: multigres-backup
+
+  cells:
+    - name: zone-a
+      zoneId: use1-az1
+    - name: zone-b
+      zoneId: use1-az2
+    - name: zone-c
+      zoneId: use1-az6
+
+  databases:
+    - name: postgres
+      default: true
+      tablegroups:
+        - name: default
+          default: true
+          shards:
+            - name: 0-inf
+              spec:
+                durabilityPolicy: AT_LEAST_2
+                multiorch:
+                  cells:
+                    - zone-a
+                    - zone-b
+                    - zone-c
+                  replicas: 1
+                pools:
+                  default:
+                    type: readWrite
+                    cells:
+                      - zone-a
+                      - zone-b
+                      - zone-c
+                    replicasPerCell: 1
+                    fsGroup: 999
+                    storage:
+                      size: 10Gi
+                      class: multigres-gp3
+```
+
+Apply it:
+
+```bash
+kubectl apply -f multigres-demo.yaml
+```
+
+Monitor the cluster:
+
+```bash
+kubectl get pods -w
+kubectl get multigresclusters
+kubectl get shards
+```
+
+## Scaling
+
+Scale through the `MultigresCluster` resource. Do not edit generated `Shard`
+resources directly.
+
+Example: scale from one pooler per cell to two:
+
+```bash
+kubectl patch multigrescluster multigres-demo \
+  --type=json \
+  -p='[
+    {
+      "op": "replace",
+      "path": "/spec/databases/0/tablegroups/0/shards/0/spec/pools/default/replicasPerCell",
+      "value": 2
+    }
+  ]'
+```
+
+## Cleanup
+
+Delete the Multigres cluster:
+
+```bash
+kubectl delete multigrescluster multigres-demo
+```
+
+> [!WARNING]
+> Multigres is currently in alpha; for repeated EKS test deployments that reuse
+> the same cluster name and backup prefix, remove state from the previous run
+> before applying the manifest again. Remove only the state associated with the
+> deleted cluster:
+
+- persistent volume claims created for the deleted Multigres cluster
+- objects under the S3 backup prefix configured for that cluster
+
+Check for PVCs in the namespace where the cluster was deployed:
+
+```bash
+kubectl get pvc
+```
+
+Remove PVCs for the deleted cluster if any remain:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=multigres-demo
+```
+
+Clear only the S3 backup prefix configured for this cluster:
+
+```bash
+aws s3 rm s3://your-backup-bucket/multigres-demo/ --recursive
+```


### PR DESCRIPTION
## Description

this PR adds release and deployment docs for the Multigres currently supported release path. This documents what artifacts a core release publishes, how to verify release outputs, and how to get started with Multigres on EKS using the Multigres Operator.

## Main Changes

- Adds `RELEASE.md` with release artifact inventory, compatibility notes, and verification steps for binary archives and container images.
- Adds an EKS getting started guide covering cluster prerequisites, storage, zone labels, S3 backups, PostgreSQL password setup, a sample `MultigresCluster`, scaling, and cleanup guidance.
- Links the new release and EKS documentation from the README and developer docs index.
- Updates the PostgreSQL compatibility docs entry to reference the `postgres-compatibility-results` workflow artifact.