### PR TITLE
chore(release): backport selected changes to v0.1

### DIFF
--- a/.github/scripts/setup-test-environment.sh
+++ b/.github/scripts/setup-test-environment.sh
@@ -22,25 +22,22 @@ echo "==========================================="
 echo "Setting up test environment"
 echo "==========================================="
 
-# Install PostgreSQL
-echo "Installing PostgreSQL..."
+# Install PostgreSQL 17 and pgBackRest from PGDG.
+# Ubuntu 24.04's default `postgresql` metapackage is PG 16, but multigres
+# requires PG 17.x — `multigres cluster start` rejects other majors.
+echo "Installing PostgreSQL 17 and pgBackRest from PGDG..."
 sudo apt-get update
-sudo apt-get install -y postgresql postgresql-contrib postgresql-client-common postgresql-common
+sudo apt-get install -y postgresql-common
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+sudo apt-get install -y postgresql-17 postgresql-client-17 postgresql-contrib-17 pgbackrest
+pgbackrest version
 
 # Set up postgres user password for tests
 echo "Configuring PostgreSQL authentication..."
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';" || true
 
-# Install pgBackRest
-echo "Installing pgBackRest..."
-sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-sudo apt-get update
-sudo apt-get install -y pgbackrest
-pgbackrest version
-
-# Add PostgreSQL binaries to PATH for subsequent commands
-# shellcheck disable=SC2012
-POSTGRES_BIN="/usr/lib/postgresql/$(ls /usr/lib/postgresql/ | head -1)/bin"
+# Add PostgreSQL 17 binaries to PATH for subsequent commands
+POSTGRES_BIN="/usr/lib/postgresql/17/bin"
 export PATH="$POSTGRES_BIN:$PATH"
 echo "$POSTGRES_BIN" >>"$GITHUB_PATH"
 

--- a/config/README.md
+++ b/config/README.md
@@ -64,18 +64,23 @@ The following environment variables are recognized by `pgctld` (and to
 some extent, Multipooler) and follow the Docker `postgres` image
 convention.
 
-| Variable               | CLI flag               | Default    | Description                           |
-| ---------------------- | ---------------------- | ---------- | ------------------------------------- |
-| `POSTGRES_USER`        | `--pg-user` / `-U`     | `postgres` | PostgreSQL user name                  |
-| `POSTGRES_PASSWORD`    | _(none)_               | _(empty)_  | PostgreSQL password                   |
-| `POSTGRES_DB`          | `--pg-database` / `-D` | `postgres` | PostgreSQL database name              |
-| `POSTGRES_INITDB_ARGS` | `--pg-initdb-args`     | _(empty)_  | Extra arguments forwarded to `initdb` |
+| Variable                 | CLI flag               | Default    | Description                                                |
+| ------------------------ | ---------------------- | ---------- | ---------------------------------------------------------- |
+| `POSTGRES_USER`          | `--pg-user` / `-U`     | `postgres` | PostgreSQL user name                                       |
+| `POSTGRES_PASSWORD`      | _(none)_               | _(empty)_  | PostgreSQL password (inline)                               |
+| `POSTGRES_PASSWORD_FILE` | _(none)_               | _(empty)_  | Path to a file containing the password (preferred for k8s) |
+| `POSTGRES_DB`            | `--pg-database` / `-D` | `postgres` | PostgreSQL database name                                   |
+| `POSTGRES_INITDB_ARGS`   | `--pg-initdb-args`     | _(empty)_  | Extra arguments forwarded to `initdb`                      |
 
 `POSTGRES_USER`
-: PostgreSQL user for connecting to PostgreSQL server and perform administrative actions. This user requires `SUPERUSER` privileges and is expected to use SCRAM-256 password authentication over a local socket connection, but this is not enforced.
+: PostgreSQL user that Multigres uses to connect to the PostgreSQL server and perform administrative actions. This user **must have `SUPERUSER` privileges**.
+The default `initdb` configuration sets up SCRAM-SHA-256 authentication over a local socket connection, which is what we recommend. Multigres itself does not require any specific authentication method, so any `pg_hba.conf` policy (including `trust`) will work, but anything weaker than SCRAM is not secure.
 
 `POSTGRES_PASSWORD`
-: Password for the user provided in `POSTGRES_USER`.
+: Password for the user provided in `POSTGRES_USER`. Use `POSTGRES_PASSWORD_FILE` instead when running in environments that mount secrets as files (the k8s demo, for example).
+
+`POSTGRES_PASSWORD_FILE`
+: Path to a file containing the password for `POSTGRES_USER`. When set, `pgctld` reads the password from this file instead of `POSTGRES_PASSWORD`.
 
 `POSTGRES_DB`
 : PostgreSQL database name to use when connecting to the database.

--- a/demo/k8s/README.md
+++ b/demo/k8s/README.md
@@ -9,7 +9,13 @@ Prerequisites
 
 Step 1: Build Docker images
 
-Build the multigres images before starting (from the repo root — the scripts assume they already exist in your local Docker daemon).
+From the repo root:
+
+```bash
+make images
+```
+
+This builds the three required images (`multigres/multigres:latest`, `multigres/pgctld-postgres:latest`, `multigres/multiadmin-web:latest`) into your local Docker daemon. The scripts that follow assume they already exist there.
 
 Step 2: Create a data/ directory
 
@@ -43,16 +49,24 @@ The script also applies `k8s-postgres-password-secret.yaml`, which holds the pla
 
 Step 5 (optional): Load demo data with supafirehose
 
-# First build the supafirehose image (in the supafirehose directory):
+> **Note:** `supafirehose` is maintained in a separate repository and is not
+> included in this tree. Skip this step unless you have already cloned and
+> built it elsewhere.
 
+```bash
+# In a clone of the supafirehose repo:
 docker build -t supafirehose:latest .
 
-# Then run from demo/k8s/:
-
+# Then, from demo/k8s/ in this repo:
 ./start-qs.sh
+```
 
-This loads the image into kind, initializes the DB with 100k users, and deploys supafirehose. Port-forward to access its UI:
+This loads the `supafirehose:latest` image into kind, initializes the DB with
+100k users, and deploys supafirehose. Port-forward to access its UI:
+
+```bash
 kubectl port-forward svc/supafirehose 8080:8080
+```
 
 Access URLs (after port-forwards start)
 

--- a/demo/local/README.md
+++ b/demo/local/README.md
@@ -2,11 +2,33 @@
 
 Scripts and configuration for running Multigres locally.
 
+## Prerequisites
+
+- `multigres` binary built (`make build` from repo root) and on `PATH`, e.g.
+  `export PATH="$PWD/bin:$PATH"`
+- PostgreSQL 17.x installed locally (multigres invokes the system `postgres`)
+- Docker (only for the optional observability stack)
+- `psql` client (for connecting to the cluster)
+- `pgbench` (only for the traffic-generation example)
+
 ## Quick Start
 
+By default the cluster config lives in `./multigres_local` (relative to the
+directory you run the command from). Use `--config-path <dir>` to override, or
+set `MTDATAROOT`.
+
 ```bash
-# From repository root
-multigres cluster start --config-path /path/to/multigres_local
+# 1. Create the cluster config (one-time setup).
+multigres cluster init
+
+# 2. Start the cluster.
+multigres cluster start
+
+# 3. Connect.
+PGPASSWORD=postgres psql -h localhost -p 15432 -U postgres -d postgres
+
+# 4. Stop the cluster when done.
+multigres cluster stop
 ```
 
 ## Observability (Optional)
@@ -20,7 +42,7 @@ For development with metrics, traces, and logs visualization.
 demo/local/run-observability.sh
 
 # 2. Start cluster with OTel export (separate terminal)
-demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local
+demo/local/multigres-with-otel.sh cluster start
 
 # 3. Generate traffic (optional — pgbench with progress every 5s)
 PGPASSWORD=postgres pgbench -h localhost -p 15432 -U postgres -i postgres
@@ -41,7 +63,7 @@ Stop in this order to avoid OTel export errors at shutdown:
 
 ```bash
 # 1. Stop the cluster
-./bin/multigres cluster stop --config-path /path/to/multigres_local
+./bin/multigres cluster stop
 
 # 2. Stop the observability stack (Ctrl-C in run-observability.sh terminal, or:)
 docker rm -f multigres-observability
@@ -51,12 +73,12 @@ docker rm -f multigres-observability
 
 ```bash
 # 1. Stop everything
-./bin/multigres cluster stop --config-path /path/to/multigres_local
+./bin/multigres cluster stop
 docker rm -f multigres-observability
 
 # 2. Start everything
 demo/local/run-observability.sh          # terminal 1
-demo/local/multigres-with-otel.sh cluster start --config-path /path/to/multigres_local  # terminal 2
+demo/local/multigres-with-otel.sh cluster start  # terminal 2
 ```
 
 ### Ports

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,18 @@ to use Multigres for your applications, please refer to the
 - **[Github workflow](./workflow.md)**
 - **[Contributing](./contributing.md)**
 
+## Design Documents
+
+Browse the design and reference docs by area:
+
+- **[Query serving](./query_serving/)** — connection pooling, prepared
+  statements, transactions, session settings, plan caching, query
+  cancellation, failover buffering, replica reads, listen/notify, etc.
+- **[High availability](./ha/decision-log/)** — decision log for consensus,
+  failover, and primary-term changes.
+- **[General](./general/)** — cross-cutting topics (e.g. serving state
+  management).
+
 ## PostgreSQL Compatibility
 
 multigres runs the official PostgreSQL regression test suite to track compatibility.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,12 @@ MultiOrch's primary responsibility is to manage failovers.
 
 MultiOrch also orchestrates the initial bootstrap of a cluster.
 
+### MultiAdmin
+
+MultiAdmin's primary responsibility is to expose administrative endpoints for cluster management. It serves both HTTP and gRPC APIs used by the `multiadmin` web UI and by operators.
+
+MultiAdmin does not have any secondary responsibilities.
+
 ### Operator
 
 The Operator is a Kubernetes Operator. Its primary responsibility is to provision resources for a cluster and bring up all the required Multigres components.

--- a/docs/building.md
+++ b/docs/building.md
@@ -19,14 +19,17 @@ are organized in the other subdirectories of `go/`.
 
 ## Prerequisites
 
-You need to install:
+Multigres requires the following on your `$PATH` before running `multigres cluster start`:
 
 - Go (version 1.25 or later)
-- PostgreSQL (we have been working with version 17.6)
+- **PostgreSQL 17.x** — `postgres --version` must report `(PostgreSQL) 17.x`. PG 14, 15, 16, 18+ are rejected.
+- **pgBackRest ≥ 2.57** — `pgbackrest --version` must report `pgBackRest 2.57` or newer.
+- **etcd** — required for topology.
+
+`multigres cluster start` validates these before bootstrapping the cluster and fails fast with a clear error if anything is missing or wrong.
 
 Most other build dependencies (like protoc) are automatically installed by the
-make script, with the exception of PostgreSQL which needs to be installed
-separately on your system.
+make script.
 
 ## Setup
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,8 +23,17 @@ Go has evolved with newer constructs, and we prefer using such newer constructs
 where possible. Most code editors automatically recommend such modernizations.
 
 We have a few pre-commit hooks that perform some basic checks at commit time.
-When a pull request is created, we have a more elaborate set of linters that
-ensure that the code is up to standards.
+Run `make tools` to install them (it symlinks `misc/git/pre-commit` and
+`misc/git/commit-msg` into `.git/hooks/`). When a pull request is created, we
+have a more elaborate set of linters that ensure that the code is up to
+standards.
+
+## Sign Your Commits
+
+All commits must be signed off under the
+[Developer Certificate of Origin](https://developercertificate.org/). Use
+`git commit -s` (or configure `git config commit.gpgsign` and add a
+`Signed-off-by:` trailer) — unsigned commits will be rejected by CI.
 
 ## Testing
 

--- a/docs/ha/decision-log/2026-01-31-separate-voting-term-from-primary-term.md
+++ b/docs/ha/decision-log/2026-01-31-separate-voting-term-from-primary-term.md
@@ -1,7 +1,7 @@
 # Separate Voting Term from Primary Term for Primary Determination
 
 **Date:** 2026-01-31
-**Status:** In Progress
+**Status:** Implemented
 **Participants:** David W, Sugu S, Rafael C
 
 ## Context

--- a/go/common/parser/testdata/postgres/README.md
+++ b/go/common/parser/testdata/postgres/README.md
@@ -13,11 +13,15 @@ To regenerate these test files from PostgreSQL source:
 
 1. **Get PostgreSQL test files**:
 
+   The script reads from `../postgres-tests/` — a local scratch directory that
+   is **not** checked into this repo. Create it on demand:
+
    ```bash
    # Clone PostgreSQL repository (if not already done)
    git clone https://github.com/postgres/postgres.git
 
    # Copy test files to postgres-tests directory (one level up)
+   mkdir -p ../postgres-tests
    cp postgres/src/test/regress/sql/*.sql ../postgres-tests/
    ```
 

--- a/go/provisioner/local/local.go
+++ b/go/provisioner/local/local.go
@@ -310,6 +310,97 @@ func (p *localProvisioner) checkEtcdVersion(binaryPath, expectedVersion string) 
 	return nil
 }
 
+// minPgBackrestVersion is the minimum supported pgBackRest version.
+// Updates here should be paired with docs/building.md.
+const minPgBackrestVersion = "v2.57.0"
+
+var pgbackrestVersionRe = regexp.MustCompile(`(?m)^pgBackRest\s+v?(\d+\.\d+(?:\.\d+)?)`)
+
+// checkPgBackrestVersion verifies that the pgbackrest binary is >= minPgBackrestVersion.
+func (p *localProvisioner) checkPgBackrestVersion(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get pgbackrest version: %w", err)
+	}
+	return p.checkPgBackrestVersionFromOutput(string(output))
+}
+
+// checkPgBackrestVersionFromOutput is the pure parsing/comparison core of
+// checkPgBackrestVersion, split out so tests do not need a real binary.
+func (p *localProvisioner) checkPgBackrestVersionFromOutput(versionStr string) error {
+	matches := pgbackrestVersionRe.FindStringSubmatch(versionStr)
+	if len(matches) < 2 {
+		return fmt.Errorf("could not parse pgbackrest version from output: %q", strings.TrimSpace(versionStr))
+	}
+	actual := semver.Canonical("v" + matches[1])
+	if semver.Compare(actual, minPgBackrestVersion) < 0 {
+		return fmt.Errorf("pgbackrest %s is too old; need >= %s",
+			strings.TrimPrefix(actual, "v"),
+			strings.TrimPrefix(minPgBackrestVersion, "v"))
+	}
+	fmt.Printf("🔍 - pgbackrest %s found — version compatible ✓\n",
+		strings.TrimPrefix(actual, "v"))
+	return nil
+}
+
+// requiredPostgresMajor is the only supported PostgreSQL major version.
+const requiredPostgresMajor = 17
+
+var postgresVersionRe = regexp.MustCompile(`(?m)^postgres\s+\(PostgreSQL\)\s+(\d+)(?:\.(\d+))?`)
+
+// checkPostgresVersion verifies that the postgres binary is major version requiredPostgresMajor.
+func (p *localProvisioner) checkPostgresVersion(binaryPath string) error {
+	cmd := exec.Command(binaryPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get postgres version: %w", err)
+	}
+	return p.checkPostgresVersionFromOutput(string(output))
+}
+
+// checkPostgresVersionFromOutput is the pure parsing/comparison core of
+// checkPostgresVersion.
+func (p *localProvisioner) checkPostgresVersionFromOutput(versionStr string) error {
+	matches := postgresVersionRe.FindStringSubmatch(versionStr)
+	if len(matches) < 2 {
+		return fmt.Errorf("could not parse postgres version from output: %q", strings.TrimSpace(versionStr))
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return fmt.Errorf("could not parse postgres major version %q: %w", matches[1], err)
+	}
+	if major != requiredPostgresMajor {
+		return fmt.Errorf("postgres major version %d is unsupported; need %d.x", major, requiredPostgresMajor)
+	}
+	display := matches[1]
+	if len(matches) > 2 && matches[2] != "" {
+		display = display + "." + matches[2]
+	}
+	fmt.Printf("🔍 - postgres %s found — version compatible ✓\n", display)
+	return nil
+}
+
+// checkRequiredBinaryVersions resolves the version-sensitive binaries on PATH
+// and verifies each is at a supported version. It is invoked from Bootstrap
+// after validateSystemBinaries has confirmed every required binary is present.
+// LookPath errors are not expected here, but are propagated defensively in case
+// PATH changes between the two calls.
+func (p *localProvisioner) checkRequiredBinaryVersions() error {
+	pgbackrestPath, err := exec.LookPath("pgbackrest")
+	if err != nil {
+		return fmt.Errorf("pgbackrest lookup failed after binary validation: %w", err)
+	}
+	if err := p.checkPgBackrestVersion(pgbackrestPath); err != nil {
+		return err
+	}
+	postgresPath, err := exec.LookPath("postgres")
+	if err != nil {
+		return fmt.Errorf("postgres lookup failed after binary validation: %w", err)
+	}
+	return p.checkPostgresVersion(postgresPath)
+}
+
 // readServiceLogs reads the last few lines from a service's log file for debugging
 func (p *localProvisioner) readServiceLogs(logFile string, lines int) string {
 	if logFile == "" {
@@ -1189,6 +1280,11 @@ func (p *localProvisioner) Bootstrap(ctx context.Context) ([]*provisioner.Provis
 		return nil, err
 	}
 
+	// Validate critical binary versions before starting any services.
+	if err := p.checkRequiredBinaryVersions(); err != nil {
+		return nil, err
+	}
+
 	fmt.Println("=== Bootstrapping Multigres cluster ===")
 	fmt.Println("")
 
@@ -2020,6 +2116,7 @@ func (p *localProvisioner) validateSystemBinaries() error {
 		"pg_ctl",
 		"postgres",
 		"pg_isready",
+		"pgbackrest",
 	}
 
 	var missingBinaries []string
@@ -2032,9 +2129,10 @@ func (p *localProvisioner) validateSystemBinaries() error {
 
 	if len(missingBinaries) > 0 {
 		return fmt.Errorf("required system binaries not found in PATH: %s\n\n"+
-			"Please ensure PostgreSQL and etcd are installed and available in your PATH.\n"+
-			"For PostgreSQL: Install PostgreSQL client tools (pg_ctl, postgres, pg_isready)\n"+
-			"For etcd: Install etcd client binary",
+			"Please ensure PostgreSQL, etcd, and pgBackRest are installed and available in your PATH.\n"+
+			"For PostgreSQL: Install PostgreSQL 17.x client tools (pg_ctl, postgres, pg_isready)\n"+
+			"For etcd: Install etcd client binary\n"+
+			"For pgBackRest: Install pgBackRest >= 2.57",
 			strings.Join(missingBinaries, ", "))
 	}
 

--- a/go/provisioner/local/local_test.go
+++ b/go/provisioner/local/local_test.go
@@ -15,7 +15,9 @@
 package local
 
 import (
+	"maps"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -101,4 +103,228 @@ func TestValidateUnixSocketPathLengthWithWorkingDirectory(t *testing.T) {
 
 	err = provisioner.validateUnixSocketPathLength(config)
 	require.NoError(t, err)
+}
+
+func TestCheckPgBackrestVersion_Parse(t *testing.T) {
+	p := &localProvisioner{}
+	tests := []struct {
+		name    string
+		out     string
+		wantErr string
+	}{
+		{"meets minimum", "pgBackRest 2.57.0\n", ""},
+		{"newer patch", "pgBackRest 2.57.3\n", ""},
+		{"newer minor", "pgBackRest 2.60.1\n", ""},
+		{"too old", "pgBackRest 2.55.1\n", "too old"},
+		{"way too old", "pgBackRest 1.99.99\n", "too old"},
+		{"unparsable", "garbage\n", "could not parse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.checkPgBackrestVersionFromOutput(tc.out)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCheckPostgresVersion_Parse(t *testing.T) {
+	p := &localProvisioner{}
+	tests := []struct {
+		name    string
+		out     string
+		wantErr string
+	}{
+		{"17.0", "postgres (PostgreSQL) 17.0\n", ""},
+		{"17.2 homebrew", "postgres (PostgreSQL) 17.2 (Homebrew)\n", ""},
+		{"14.20", "postgres (PostgreSQL) 14.20\n", "unsupported"},
+		{"18 beta", "postgres (PostgreSQL) 18beta1\n", "unsupported"},
+		{"16.5", "postgres (PostgreSQL) 16.5\n", "unsupported"},
+		{"unparsable", "garbage\n", "could not parse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.checkPostgresVersionFromOutput(tc.out)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// writeFakeBinary writes a tiny shell script to dir/name that prints stdout and exits 0,
+// or exits nonzero when exitNonZero is true. Returns the binary path.
+func writeFakeBinary(t *testing.T, dir, name, stdout string, exitNonZero bool) string {
+	t.Helper()
+	exitLine := ""
+	if exitNonZero {
+		exitLine = "exit 1\n"
+	}
+	script := "#!/bin/sh\nprintf %s " + shellQuote(stdout) + "\n" + exitLine
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func TestCheckPgBackrestVersion_ExecsBinary(t *testing.T) {
+	p := &localProvisioner{}
+	dir := t.TempDir()
+
+	t.Run("good version", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_good", "pgBackRest 2.57.0\n", false)
+		require.NoError(t, p.checkPgBackrestVersion(path))
+	})
+
+	t.Run("too old", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_old", "pgBackRest 2.55.1\n", false)
+		err := p.checkPgBackrestVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too old")
+	})
+
+	t.Run("binary exits nonzero", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "pgbackrest_fail", "", true)
+		err := p.checkPgBackrestVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get pgbackrest version")
+	})
+}
+
+func TestCheckPostgresVersion_ExecsBinary(t *testing.T) {
+	p := &localProvisioner{}
+	dir := t.TempDir()
+
+	t.Run("good version", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_good", "postgres (PostgreSQL) 17.2 (Homebrew)\n", false)
+		require.NoError(t, p.checkPostgresVersion(path))
+	})
+
+	t.Run("wrong major", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_old", "postgres (PostgreSQL) 14.20\n", false)
+		err := p.checkPostgresVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+
+	t.Run("binary exits nonzero", func(t *testing.T) {
+		path := writeFakeBinary(t, dir, "postgres_fail", "", true)
+		err := p.checkPostgresVersion(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get postgres version")
+	})
+}
+
+func TestValidateSystemBinaries(t *testing.T) {
+	p := &localProvisioner{}
+
+	t.Run("missing binaries reported", func(t *testing.T) {
+		// Point PATH at an empty temp dir so every required binary is missing.
+		dir := t.TempDir()
+		t.Setenv("PATH", dir)
+		err := p.validateSystemBinaries()
+		require.Error(t, err)
+		// All required binaries should be flagged.
+		for _, b := range []string{"etcd", "pg_ctl", "postgres", "pg_isready", "pgbackrest"} {
+			assert.Contains(t, err.Error(), b)
+		}
+	})
+
+	t.Run("all present succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		// Provide a no-op binary for each required tool.
+		for _, b := range []string{"etcd", "pg_ctl", "postgres", "pg_isready", "pgbackrest"} {
+			writeFakeBinary(t, dir, b, "", false)
+		}
+		t.Setenv("PATH", dir)
+		require.NoError(t, p.validateSystemBinaries())
+	})
+}
+
+func TestCheckRequiredBinaryVersions(t *testing.T) {
+	const (
+		goodPgbackrest = "pgBackRest 2.57.0\n"
+		oldPgbackrest  = "pgBackRest 2.55.1\n"
+		goodPostgres   = "postgres (PostgreSQL) 17.2 (Homebrew)\n"
+		oldPostgres    = "postgres (PostgreSQL) 14.20\n"
+	)
+
+	tests := []struct {
+		name          string
+		omit          map[string]bool   // binaries to omit from PATH
+		stdouts       map[string]string // binary name -> --version stdout (defaults to goodX)
+		exitNonZero   map[string]bool   // binary name -> shim exits nonzero
+		wantErrSubstr string
+	}{
+		{
+			name: "all good",
+		},
+		{
+			name:          "pgbackrest missing from PATH",
+			omit:          map[string]bool{"pgbackrest": true},
+			wantErrSubstr: "pgbackrest lookup failed",
+		},
+		{
+			name:          "postgres missing from PATH",
+			omit:          map[string]bool{"postgres": true},
+			wantErrSubstr: "postgres lookup failed",
+		},
+		{
+			name:          "pgbackrest too old",
+			stdouts:       map[string]string{"pgbackrest": oldPgbackrest},
+			wantErrSubstr: "too old",
+		},
+		{
+			name:          "postgres wrong major",
+			stdouts:       map[string]string{"postgres": oldPostgres},
+			wantErrSubstr: "unsupported",
+		},
+		{
+			name:          "pgbackrest --version errors",
+			exitNonZero:   map[string]bool{"pgbackrest": true},
+			wantErrSubstr: "failed to get pgbackrest version",
+		},
+		{
+			name:          "postgres --version errors",
+			exitNonZero:   map[string]bool{"postgres": true},
+			wantErrSubstr: "failed to get postgres version",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stdouts := map[string]string{
+				"pgbackrest": goodPgbackrest,
+				"postgres":   goodPostgres,
+			}
+			maps.Copy(stdouts, tc.stdouts)
+			for _, b := range []string{"pgbackrest", "postgres"} {
+				if tc.omit[b] {
+					continue
+				}
+				writeFakeBinary(t, dir, b, stdouts[b], tc.exitNonZero[b])
+			}
+			t.Setenv("PATH", dir)
+
+			p := &localProvisioner{}
+			err := p.checkRequiredBinaryVersions()
+			if tc.wantErrSubstr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSubstr)
+		})
+	}
 }

--- a/go/services/multiorch/recovery/analysis/leader_resigned_analyzer.go
+++ b/go/services/multiorch/recovery/analysis/leader_resigned_analyzer.go
@@ -23,12 +23,13 @@ import (
 )
 
 // LeaderResignedAnalyzer detects when the topology leader has explicitly
-// requested its own replacement via LEADERSHIP_SIGNAL_REQUESTING_DEMOTION
-// (emitted by Recruit's primary demote path and graceful shutdown of a
-// leader). Distinct from LeaderIsDeadAnalyzer, which infers leader loss
-// from reachability and health. Resignation is an unambiguous, intentional
-// signal so failover can fire immediately with no follower-connection
-// grace period.
+// signalled that it should be replaced. Two signals trigger this analyzer
+// (see types.LeaderNeedsReplacement): COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE
+// (advertised by graceful shutdown) and LEADERSHIP_SIGNAL_REQUESTING_DEMOTION
+// (emitted by Recruit's primary-demote path after a postgres crash). Distinct
+// from LeaderIsDeadAnalyzer, which infers leader loss from reachability and
+// health. Both signals are unambiguous, intentional indicators so failover
+// can fire immediately with no follower-connection grace period.
 type LeaderResignedAnalyzer struct {
 	factory *RecoveryActionFactory
 }

--- a/go/services/multiorch/recovery/types/pooler_signals.go
+++ b/go/services/multiorch/recovery/types/pooler_signals.go
@@ -29,9 +29,20 @@ import (
 // signalled that it should be replaced via a new election. It reads the
 // self-reported AvailabilityStatus from the consensus status RPC.
 //
-// The staleness check (leadership_status.primary_term == consensus primary_term)
-// ensures we don't act on a REQUESTING_DEMOTION signal left over from a previous
-// election cycle that was never cleared (e.g. after a process restart).
+// Two independent signals trigger replacement:
+//
+//   - CohortEligibilityStatus.Signal == INELIGIBLE: the pooler is unwilling to
+//     remain in the cohort (e.g. graceful shutdown advertises this before
+//     stopping postgres). Not term-gated — eligibility is a current preference
+//     and staleness comes from the freshness of the surrounding health
+//     snapshot; a node that doesn't want to be in the cohort certainly should
+//     not continue as leader.
+//
+//   - LeadershipStatus.Signal == REQUESTING_DEMOTION with leader_term ==
+//     current primary term: emitted by Recruit's primary-demote path after a
+//     postgres crash so the coordinator can correlate the request with the
+//     specific term and avoid acting on a leftover signal from a previous
+//     election cycle that was never cleared (e.g. after a process restart).
 //
 // TODO: once the coordinator synthesizes AvailabilityStatus into
 // PoolerHealthState directly (see clustermetadata.proto TODO), read from
@@ -39,7 +50,11 @@ import (
 // coordinator-synthesized signals (e.g. TEMPORARILY_UNAVAILABLE for unreachable
 // nodes) are handled here too.
 func LeaderNeedsReplacement(p *multiorchdatapb.PoolerHealthState) bool {
-	leadershipStatus := p.GetAvailabilityStatus().GetLeadershipStatus()
+	av := p.GetAvailabilityStatus()
+	if PoolerIsCohortIneligible(av) {
+		return true
+	}
+	leadershipStatus := av.GetLeadershipStatus()
 	if leadershipStatus == nil {
 		return false
 	}

--- a/go/services/multiorch/recovery/types/pooler_signals_test.go
+++ b/go/services/multiorch/recovery/types/pooler_signals_test.go
@@ -145,4 +145,38 @@ func TestLeaderNeedsReplacement(t *testing.T) {
 		}
 		assert.False(t, LeaderNeedsReplacement(p))
 	})
+
+	t.Run("CohortEligibility INELIGIBLE returns true even without leadership signal", func(t *testing.T) {
+		// Graceful-shutdown path: the pooler advertises INELIGIBLE without
+		// touching LeadershipStatus, and the analyzer must still trigger
+		// replacement.
+		p := poolerWithLeaderTerm(t, 5)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+			},
+		}
+		assert.True(t, LeaderNeedsReplacement(p))
+	})
+
+	t.Run("CohortEligibility INELIGIBLE returns true regardless of term", func(t *testing.T) {
+		// Cohort eligibility is not term-gated, unlike REQUESTING_DEMOTION.
+		p := poolerWithLeaderTerm(t, 0)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+			},
+		}
+		assert.True(t, LeaderNeedsReplacement(p))
+	})
+
+	t.Run("CohortEligibility ELIGIBLE returns false", func(t *testing.T) {
+		p := poolerWithLeaderTerm(t, 5)
+		p.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+			CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
+				Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+			},
+		}
+		assert.False(t, LeaderNeedsReplacement(p))
+	})
 }

--- a/go/services/multipooler/manager/graceful_shutdown.go
+++ b/go/services/multipooler/manager/graceful_shutdown.go
@@ -43,25 +43,16 @@ var pgctldStopModes = []struct {
 	{"immediate", 5 * time.Second},
 }
 
-// GracefulShutdown publishes REQUESTING_DEMOTION on the health stream (for a
-// current leader) and then stops Postgres. Registered as a servenv OnTermSync
+// GracefulShutdown drains traffic, publishes COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE on the
+// health stream and then stops Postgres. Registered as a servenv OnTermSync
 // hook so it runs on SIGTERM bounded by --onterm-timeout.
-//
-// The announcement is sequenced before pgctld.Stop because reading the
-// primary term requires querying postgres for the current rule position;
-// doing it post-stop would silently no-op and force the coordinator to wait
-// for stream EOF + LeaderIsDead grace period instead of firing
-// LeaderResignedAnalyzer immediately.
 //
 // The topology Type=DRAINED transition happens after this returns via the
 // existing OnClose -> mp.Shutdown -> tr.Unregister chain registered in
 // services/multipooler/init.go.
 //
-// The action lock is held for the whole sequence: pgctld.Stop is gated behind
-// the protectedPgctldClient action-lock check, and announcing the resignation
-// involves reading consensus state and writing resignedLeaderAtTerm under the
-// same lock — holding it across both serialises against any concurrent
-// consensus operation (Recruit, Propose, etc.).
+// The action lock is held for the whole sequence because pgctld.Stop is
+// gated behind the protectedPgctldClient action-lock check.
 func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 	pm.logger.InfoContext(ctx, "graceful shutdown starting")
 
@@ -84,26 +75,9 @@ func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 		}
 	}
 
-	// If we are the leader, announce REQUESTING_DEMOTION before stopping
-	// postgres. primaryTermLocked reads the current rule position from
-	// postgres, so the read must happen while postgres is still alive;
-	// running it post-stop would fail and the coordinator would have to wait
-	// for stream EOF + LeaderIsDead grace period instead. No-op for
-	// non-leaders and partially-initialized managers (consensus not wired).
-	// Mirrors the primary-demote pattern in Recruit (rpc_consensus.go).
-	if pm.consensusState != nil && pm.rules != nil {
-		primaryTerm, err := pm.primaryTermLocked(lockCtx)
-		switch {
-		case err != nil:
-			pm.logger.WarnContext(lockCtx, "could not read primary term for resignation announcement; coordinator will fail over via stream EOF",
-				"error", err)
-		case primaryTerm != 0:
-			if err := pm.setResignedLeaderAtTerm(lockCtx, primaryTerm); err != nil {
-				pm.logger.WarnContext(lockCtx, "failed to record resigned primary term",
-					"error", err)
-			}
-		}
-	}
+	// Advertise cohort ineligibility before stopping postgres just in case
+	// stopping is slow. We're favoring speed of failover rather than grace.
+	pm.setCohortEligibility(clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE)
 
 	pm.stopPostgresLocked(lockCtx)
 

--- a/go/services/multipooler/manager/graceful_shutdown.go
+++ b/go/services/multipooler/manager/graceful_shutdown.go
@@ -56,6 +56,10 @@ var pgctldStopModes = []struct {
 func (pm *MultiPoolerManager) GracefulShutdown(ctx context.Context) {
 	pm.logger.InfoContext(ctx, "graceful shutdown starting")
 
+	// TODO: issue a bounded CHECKPOINT before resigning so there's a recent
+	// checkpoint if the failover process doesn't go smoothly and rewinds are
+	// needed.
+
 	lockCtx, err := pm.actionLock.Acquire(ctx, "GracefulShutdown")
 	if err != nil {
 		pm.logger.ErrorContext(ctx, "failed to acquire action lock for graceful shutdown",

--- a/go/services/multipooler/manager/graceful_shutdown_test.go
+++ b/go/services/multipooler/manager/graceful_shutdown_test.go
@@ -21,14 +21,30 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
+
+// assertRecent fails the test if ts is nil or older than 5 seconds ago.
+// Used by lifecycle tests to verify that a write timestamp was set in the
+// recent past — a coarse sanity check rather than a precise comparison
+// (proto Timestamps round-trip through topology and can lose nanosecond
+// precision; we just want "this was written, not zero").
+func assertRecent(t *testing.T, ts *timestamppb.Timestamp, msg string) {
+	t.Helper()
+	require.NotNil(t, ts, msg+": timestamp is nil")
+	delta := time.Since(ts.AsTime())
+	assert.Less(t, delta, 5*time.Second, msg+": timestamp not recent (delta %s)", delta)
+}
 
 // recordingPgctldClient records each Stop call and returns whatever the
 // supplied stopFn dictates per mode. Other methods panic — keep usage scoped
@@ -63,8 +79,8 @@ func (r *recordingPgctldClient) modesCalled() []string {
 // newGracefulShutdownTestManager constructs a MultiPoolerManager wired with
 // stubs sufficient to exercise GracefulShutdown without needing topology,
 // gRPC services, or a real connection pool. The healthStreamer is constructed
-// because broadcastHealth is called on it; other subsystems are nil and must
-// not be touched by the code under test.
+// because setCohortEligibility -> broadcastHealth is called on it; other
+// subsystems are nil and must not be touched by the code under test.
 func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldClient) *MultiPoolerManager {
 	t.Helper()
 
@@ -82,6 +98,15 @@ func newGracefulShutdownTestManager(t *testing.T, pgctldClient pgctldpb.PgCtldCl
 		pgctldClient:   pgctldClient,
 		healthStreamer: newHealthStreamer(logger, id, "tg", "0"),
 		actionLock:     NewActionLock(),
+		// Match the production default set by topoclient.NewMultiPooler so
+		// the record's LifecycleStatus reads as STARTING from the start.
+		// (Real boot wires this in via NewMultiPoolerManager(multiPooler).)
+		record: newRecordFromProto(&clustermetadatapb.MultiPooler{
+			Id: id,
+			LifecycleStatus: &clustermetadatapb.PoolerLifecycle{
+				Status: clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+			},
+		}),
 		// Fresh on-disk consensus state at a temp dir. announceLeaderResignationLocked
 		// reads primary term via primaryTermLocked -> getConsensusStatus -> ConsensusState;
 		// without this it nil-pointers. With no revocation file it reads as term 0,
@@ -212,4 +237,226 @@ func TestGracefulShutdown_AnnouncesBeforeStop(t *testing.T) {
 	require.Equal(t, primaryTerm, got,
 		"resignedLeaderAtTerm must be set to the primary term; if 0, the announce was "+
 			"sequenced AFTER pgctld.Stop and observePosition failed for the dead postgres")
+}
+
+// TestGracefulShutdown_AnnouncesStopping verifies the in-memory lifecycle
+// flips to STOPPING under the action lock at the top of GracefulShutdown,
+// before any blocking work.
+func TestGracefulShutdown_AnnouncesStopping(t *testing.T) {
+	pm := newGracefulShutdownTestManager(t, nil)
+	seedRecordLifecycleForTest(t, pm, clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE)
+
+	pm.GracefulShutdown(context.Background())
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STOPPING,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"GracefulShutdown must announce STOPPING in its in-memory state")
+}
+
+// seedRecordLifecycleForTest mutates the record's LifecycleStatus to the
+// given value, briefly holding the action lock. Tests that need to put the
+// manager into a specific lifecycle state before exercising shutdown call
+// this directly because record.Mutate requires an action-locked context.
+func seedRecordLifecycleForTest(t *testing.T, pm *MultiPoolerManager, status clustermetadatapb.PoolerLifecycleStatus) {
+	t.Helper()
+	lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed-lifecycle")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	require.NoError(t, pm.record.Mutate(lockCtx, func(s *MutablePoolerRecordState) {
+		s.LifecycleStatus = &clustermetadatapb.PoolerLifecycle{Status: status}
+	}))
+}
+
+// TestGracefulShutdown_AnnouncesStoppingInTopology verifies that GracefulShutdown
+// records STOPPING + reason + updated timestamp in topology, so operators see
+// the announcement immediately rather than only after shutdown completes. The
+// publisher is driven synchronously here via publishIfNeeded so the assertion
+// doesn't depend on the goroutine clock.
+func TestGracefulShutdown_AnnouncesStoppingInTopology(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	mp.LifecycleStatus.Status = clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+
+	pm.GracefulShutdown(ctx)
+
+	// Drain the scheduled publish synchronously.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STOPPING,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle must announce STOPPING")
+	assert.Equal(t, "shutting down", stored.GetLifecycleStatus().GetReason(),
+		"announcement should carry the canonical reason string")
+	assertRecent(t, stored.GetLifecycleStatus().GetUpdated(),
+		"STOPPING announcement should set the updated timestamp")
+}
+
+// TestMarkPoolerActive_TransitionsLifecycle verifies the STARTING → ACTIVE
+// transition: markPoolerActive flips the record's LifecycleStatus to ACTIVE
+// via record.Mutate and the publisher reflects it to topology. publishIfNeeded
+// is driven synchronously here so the assertion doesn't race the goroutine
+// clock.
+func TestMarkPoolerActive_TransitionsLifecycle(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	require.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+		mp.GetLifecycleStatus().GetStatus(),
+		"NewMultiPooler factory should default to STARTING")
+	require.Equal(t, "process starting", mp.GetLifecycleStatus().GetReason(),
+		"NewMultiPooler factory should annotate STARTING with a reason")
+	assertRecent(t, mp.GetLifecycleStatus().GetUpdated(),
+		"NewMultiPooler factory should set the updated timestamp")
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+	require.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_STARTING,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"test manager should default to STARTING")
+
+	pm.markPoolerActive(ctx)
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"in-memory lifecycle must be ACTIVE after markPoolerActive")
+
+	// Drain the scheduled publish synchronously so we can assert against
+	// topology without racing the publisher goroutine.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle must be ACTIVE after markPoolerActive")
+	assert.Equal(t, "pooler active", stored.GetLifecycleStatus().GetReason(),
+		"markPoolerActive should annotate the topology write with a reason")
+	assertRecent(t, stored.GetLifecycleStatus().GetUpdated(),
+		"markPoolerActive should set the updated timestamp")
+}
+
+// TestMarkPoolerActive_Idempotent verifies that calling markPoolerActive
+// on an already-ACTIVE pooler is a no-op. The pgMonitor invokes this on
+// every tick once postgres is up; the cheap pre-check must short-circuit
+// before record.Mutate (and the action lock) is touched.
+func TestMarkPoolerActive_Idempotent(t *testing.T) {
+	ctx := t.Context()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	id := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test",
+	}
+	mp := topoclient.NewMultiPooler(id.Name, id.Cell, "localhost", "tg")
+	mp.ShardKey.Shard = "0"
+	mp.LifecycleStatus.Status = clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE
+	require.NoError(t, ts.CreateMultiPooler(ctx, mp))
+
+	pm := newGracefulShutdownTestManager(t, nil)
+	pm.serviceID = id
+	pm.topoClient = ts
+	pm.record = newPoolerRecord(pm.logger, ts, mp)
+
+	pm.markPoolerActive(ctx)
+
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		pm.record.Snapshot().GetLifecycleStatus().GetStatus(),
+		"in-memory lifecycle stays ACTIVE on idempotent call")
+
+	// The cheap pre-check must short-circuit before record.Mutate; the
+	// publisher's desired stays at the seeded ACTIVE so publishIfNeeded
+	// either no-ops or writes the same value back.
+	pm.record.publishIfNeeded(ctx)
+
+	stored, err := ts.GetMultiPooler(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t,
+		clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_ACTIVE,
+		stored.GetLifecycleStatus().GetStatus(),
+		"topology lifecycle stays ACTIVE on idempotent call")
+	assert.Equal(t, mp.GetLifecycleStatus().GetUpdated().GetSeconds(), stored.GetLifecycleStatus().GetUpdated().GetSeconds(),
+		"topology Updated seconds must not change on idempotent call")
+	assert.Equal(t, mp.GetLifecycleStatus().GetUpdated().GetNanos(), stored.GetLifecycleStatus().GetUpdated().GetNanos(),
+		"topology Updated nanos must not change on idempotent call")
+}
+
+// TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop is a regression
+// test for the ordering guarantee that cohort-ineligibility is broadcast
+// before pgctld.Stop. If the order flipped, the broadcast would race against
+// stream EOF and the coordinator would have to fall back to LeaderIsDead's
+// grace period instead of firing LeaderResignedAnalyzer immediately on the
+// INELIGIBLE signal.
+//
+// pgctld.Stop's callback captures the cohort eligibility state at the moment
+// of the call, so the assertion fails if the announce was sequenced after
+// the stop.
+func TestGracefulShutdown_AdvertisesCohortIneligibleBeforeStop(t *testing.T) {
+	pm := newGracefulShutdownTestManager(t, nil)
+
+	var atStopSignal clustermetadatapb.CohortEligibilitySignal
+	pgctld := &recordingPgctldClient{
+		stopFn: func(string) error {
+			pm.mu.Lock()
+			atStopSignal = pm.cohortEligibility
+			pm.mu.Unlock()
+			return nil
+		},
+	}
+	pm.pgctldClient = pgctld
+
+	pm.GracefulShutdown(context.Background())
+
+	require.Equal(t, []string{"fast"}, pgctld.modesCalled(),
+		"pgctld.Stop should have been called once (fast succeeded)")
+	require.Equal(t,
+		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		atStopSignal,
+		"cohort eligibility must be INELIGIBLE before pgctld.Stop runs; if it was "+
+			"the default ELIGIBLE, the announce was sequenced AFTER stop and the "+
+			"broadcast races stream EOF")
+
+	pm.mu.Lock()
+	finalSignal := pm.cohortEligibility
+	pm.mu.Unlock()
+	require.Equal(t,
+		clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE,
+		finalSignal,
+		"cohort eligibility must remain INELIGIBLE after GracefulShutdown returns")
 }

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiorch
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// fetchLeaderCohort calls Status on the current shard leader and returns the
+// names of recorded cohort members. Returns nil on any RPC failure so callers
+// can retry inside polling loops without a hard test failure.
+func fetchLeaderCohort(t *testing.T, setup *shardsetup.ShardSetup) []string {
+	t.Helper()
+	leader := setup.RefreshPrimary(t)
+	if leader == nil {
+		return nil
+	}
+	client, err := shardsetup.NewMultipoolerClient(leader.Multipooler.GrpcPort)
+	if err != nil {
+		return nil
+	}
+	defer client.Close()
+	resp, err := client.Manager.Status(utils.WithShortDeadline(t), &multipoolermanagerdatapb.StatusRequest{})
+	if err != nil || resp == nil || resp.Status == nil {
+		return nil
+	}
+	names := make([]string, 0, len(resp.Status.CohortMembers))
+	for _, m := range resp.Status.CohortMembers {
+		names = append(names, m.Name)
+	}
+	return names
+}
+
+// waitForCohortMembership blocks until the leader's cohort matches the
+// expected set of pooler names (order-insensitive), or the timeout fires.
+// Compares by Name because each test setup uses a single cell with
+// uniquely-named poolers.
+func waitForCohortMembership(t *testing.T, setup *shardsetup.ShardSetup, expected []string, timeout time.Duration) {
+	t.Helper()
+	expectedSet := make(map[string]struct{}, len(expected))
+	for _, name := range expected {
+		expectedSet[name] = struct{}{}
+	}
+	require.Eventually(t, func() bool {
+		members := fetchLeaderCohort(t, setup)
+		if len(members) != len(expected) {
+			return false
+		}
+		for _, m := range members {
+			if _, ok := expectedSet[m]; !ok {
+				return false
+			}
+		}
+		return true
+	}, timeout, 500*time.Millisecond,
+		"cohort never converged on %v", expected)
+}
+
+// TestCohortRotation_FullReplacement exercises a full rotation of the cohort:
+// expand from 3 to 5 poolers, then gracefully drain all 3 originals (primary
+// last). Verifies that writes through the multigateway continue to succeed
+// throughout, and that the final cohort consists only of the new poolers.
+//
+// This is the first e2e test of the cohort-INELIGIBLE-on-graceful-shutdown
+// path (CohortMismatchAnalyzer → ReconcileCohortAction REMOVE) and of
+// mid-cluster pooler join (CohortMismatchAnalyzer → ReconcileCohortAction
+// ADD), both of which have unit coverage but were not previously exercised
+// end-to-end.
+//
+// Why primary last: each follower drain doesn't trigger leader failover, so
+// chaining them is cheap. Draining the primary is the single failover event
+// in the test — running it after the cohort has already grown to 5 means
+// LeaderResignedAnalyzer can pick from the two new poolers as recruitment
+// candidates and the replacement is fast.
+func TestCohortRotation_FullReplacement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping integration test (no postgres binaries)")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.RequireRecovery(t, "multiorch", 30*time.Second)
+	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.PrimaryName
+	require.NotEmpty(t, initialPrimary, "initial primary must be elected")
+
+	originals := make([]string, 0, 3)
+	for name := range setup.Multipoolers {
+		originals = append(originals, name)
+	}
+	require.Len(t, originals, 3)
+	waitForCohortMembership(t, setup, originals, 30*time.Second)
+	t.Logf("Initial cohort established: primary=%s, members=%v", initialPrimary, originals)
+
+	// Continuous writer through the multigateway. The gateway re-routes on
+	// failover, so the writer sees the rotation as (mostly) transparent
+	// availability.
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	gatewayDB, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer gatewayDB.Close()
+	require.NoError(t, gatewayDB.Ping(), "failed to ping multigateway")
+
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
+		shardsetup.WithWorkerCount(4),
+		shardsetup.WithWriteInterval(10*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(validatorCleanup)
+	validator.Start(t)
+	t.Logf("Continuous writer started (table=%s)", validator.TableName())
+
+	// Phase 1: expand cohort from 3 to 5.
+	newPoolerNames := []string{"new-0", "new-1"}
+	for _, name := range newPoolerNames {
+		grpcPort := utils.GetFreePort(t)
+		pgPort := utils.GetFreePort(t)
+		multipoolerPort := utils.GetFreePort(t)
+		inst := setup.CreateMultipoolerInstance(t, name, grpcPort, pgPort, multipoolerPort)
+
+		ctx := t.Context()
+		require.NoError(t, inst.Pgctld.Start(ctx, t),
+			"failed to start pgctld for %s", name)
+		require.NoError(t, inst.Multipooler.Start(ctx, t),
+			"failed to start multipooler for %s", name)
+		shardsetup.WaitForManagerReady(t, inst.Multipooler, nil)
+		t.Logf("New pooler %s started; awaiting cohort admission", name)
+	}
+
+	expectedAfterExpand := append(append([]string{}, originals...), newPoolerNames...)
+	// Generous timeout: the new pooler join path runs fix-replication
+	// (configure standby + base backup) and then cohort-add — both gated by
+	// multiorch's analyzer tick, plus actual WAL streaming setup time.
+	waitForCohortMembership(t, setup, expectedAfterExpand, 30*time.Second)
+	t.Logf("Cohort expanded to %v", expectedAfterExpand)
+
+	expandSuccess, expandFailed := validator.Stats()
+	t.Logf("After expand: %d successful, %d failed writes", expandSuccess, expandFailed)
+	require.Positive(t, expandSuccess, "writes should have accumulated during expand")
+
+	// Phase 2: drain originals, primary last.
+	drainOrder := make([]string, 0, len(originals))
+	for _, name := range originals {
+		if name != initialPrimary {
+			drainOrder = append(drainOrder, name)
+		}
+	}
+	drainOrder = append(drainOrder, initialPrimary)
+
+	remaining := append([]string{}, expectedAfterExpand...)
+	for _, name := range drainOrder {
+		t.Logf("Draining %s gracefully", name)
+		terminateMultipoolerGracefully(t, setup.Multipoolers[name], 20*time.Second)
+
+		// Remove the drained pooler from the expected set, then wait for the
+		// leader's cohort view to converge.
+		next := make([]string, 0, len(remaining)-1)
+		for _, candidate := range remaining {
+			if candidate != name {
+				next = append(next, candidate)
+			}
+		}
+		remaining = next
+		waitForCohortMembership(t, setup, remaining, 30*time.Second)
+		t.Logf("Cohort after draining %s: %v", name, remaining)
+	}
+
+	// Final cohort should be exactly the two new poolers.
+	require.ElementsMatch(t, newPoolerNames, remaining,
+		"final cohort should be exactly the new poolers")
+
+	// And the leader must be one of them — we drained the original primary
+	// last, so a successful failover puts a new pooler in the leader slot.
+	finalLeader := setup.RefreshPrimary(t)
+	require.NotNil(t, finalLeader, "a primary must remain after rotation")
+	require.Contains(t, newPoolerNames, finalLeader.Name,
+		"final primary should be one of the new poolers, got %s", finalLeader.Name)
+	t.Logf("Final primary: %s; final cohort: %v", finalLeader.Name, remaining)
+
+	// Stop writes and verify continuity. Some failures during the single
+	// leader-failover window are expected (writes in flight when the old
+	// primary is killed will fail), but a clean rotation should keep the
+	// failure rate well below 25%. A higher rate indicates the cohort
+	// dropped below quorum or the gateway took too long to reroute.
+	validator.Stop()
+	successful, failed := validator.Stats()
+	t.Logf("Final write stats: %d successful, %d failed", successful, failed)
+	require.Positive(t, successful, "expected successful writes throughout rotation")
+
+	total := successful + failed
+	failureRate := float64(failed) / float64(total)
+	assert.Less(t, failureRate, 0.25,
+		"write failure rate %.1f%% during rotation is too high; errors: %v",
+		failureRate*100, validator.FailedErrors())
+
+	// Sanity: the writes that the validator recorded as successful must be
+	// readable from the new cohort. Read from each surviving pooler since the
+	// validator records only what the gateway acknowledged.
+	finalClients := make([]*shardsetup.MultiPoolerTestClient, 0, len(newPoolerNames))
+	for _, name := range newPoolerNames {
+		addr := fmt.Sprintf("localhost:%d", setup.Multipoolers[name].Multipooler.GrpcPort)
+		client, err := shardsetup.NewMultiPoolerTestClient(addr)
+		require.NoError(t, err)
+		t.Cleanup(func() { client.Close() })
+		finalClients = append(finalClients, client)
+	}
+	require.NoError(t, validator.Verify(t, finalClients),
+		"successful writes must be readable from the new cohort")
+}

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -15,13 +15,9 @@
 package multiorch
 
 import (
-	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
-	_ "github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -81,14 +77,16 @@ func waitForCohortMembership(t *testing.T, setup *shardsetup.ShardSetup, expecte
 
 // TestCohortRotation_FullReplacement exercises a full rotation of the cohort:
 // expand from 3 to 5 poolers, then gracefully drain all 3 originals (primary
-// last). Verifies that writes through the multigateway continue to succeed
-// throughout, and that the final cohort consists only of the new poolers.
+// last). Verifies that membership transitions converge correctly at each step
+// and that the final cohort consists only of the new poolers, with one of
+// them elected as the new leader.
 //
 // This is the first e2e test of the cohort-INELIGIBLE-on-graceful-shutdown
 // path (CohortMismatchAnalyzer → ReconcileCohortAction REMOVE) and of
 // mid-cluster pooler join (CohortMismatchAnalyzer → ReconcileCohortAction
 // ADD), both of which have unit coverage but were not previously exercised
-// end-to-end.
+// end-to-end. Write-buffering during failover is covered by
+// TestDeadPrimaryRecovery and intentionally out of scope here.
 //
 // Why primary last: each follower drain doesn't trigger leader failover, so
 // chaining them is cheap. Draining the primary is the single failover event
@@ -106,7 +104,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	setup, cleanup := shardsetup.NewIsolated(t,
 		shardsetup.WithMultipoolerCount(3),
 		shardsetup.WithMultiOrchCount(1),
-		shardsetup.WithMultigateway(),
 		shardsetup.WithDatabase("postgres"),
 		shardsetup.WithCellName("test-cell"),
 	)
@@ -115,7 +112,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	setup.StartMultiOrchs(t.Context(), t)
 	setup.RequireRecovery(t, "multiorch", 30*time.Second)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
-	setup.WaitForMultigatewayQueryServing(t)
 
 	initialPrimary := setup.PrimaryName
 	require.NotEmpty(t, initialPrimary, "initial primary must be elected")
@@ -127,24 +123,6 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	require.Len(t, originals, 3)
 	waitForCohortMembership(t, setup, originals, 30*time.Second)
 	t.Logf("Initial cohort established: primary=%s, members=%v", initialPrimary, originals)
-
-	// Continuous writer through the multigateway. The gateway re-routes on
-	// failover, so the writer sees the rotation as (mostly) transparent
-	// availability.
-	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
-	gatewayDB, err := sql.Open("postgres", connStr)
-	require.NoError(t, err)
-	defer gatewayDB.Close()
-	require.NoError(t, gatewayDB.Ping(), "failed to ping multigateway")
-
-	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
-		shardsetup.WithWorkerCount(4),
-		shardsetup.WithWriteInterval(10*time.Millisecond),
-	)
-	require.NoError(t, err)
-	t.Cleanup(validatorCleanup)
-	validator.Start(t)
-	t.Logf("Continuous writer started (table=%s)", validator.TableName())
 
 	// Phase 1: expand cohort from 3 to 5.
 	newPoolerNames := []string{"new-0", "new-1"}
@@ -164,15 +142,11 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	}
 
 	expectedAfterExpand := append(append([]string{}, originals...), newPoolerNames...)
-	// Generous timeout: the new pooler join path runs fix-replication
-	// (configure standby + base backup) and then cohort-add — both gated by
-	// multiorch's analyzer tick, plus actual WAL streaming setup time.
-	waitForCohortMembership(t, setup, expectedAfterExpand, 30*time.Second)
+	// The new pooler join path runs fix-replication (configure standby + base
+	// backup) and then cohort-add — both gated by multiorch's analyzer tick,
+	// plus actual WAL streaming setup time.
+	waitForCohortMembership(t, setup, expectedAfterExpand, 60*time.Second)
 	t.Logf("Cohort expanded to %v", expectedAfterExpand)
-
-	expandSuccess, expandFailed := validator.Stats()
-	t.Logf("After expand: %d successful, %d failed writes", expandSuccess, expandFailed)
-	require.Positive(t, expandSuccess, "writes should have accumulated during expand")
 
 	// Phase 2: drain originals, primary last.
 	drainOrder := make([]string, 0, len(originals))
@@ -186,7 +160,17 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	remaining := append([]string{}, expectedAfterExpand...)
 	for _, name := range drainOrder {
 		t.Logf("Draining %s gracefully", name)
+		isPrimary := name == initialPrimary
 		terminateMultipoolerGracefully(t, setup.Multipoolers[name], 20*time.Second)
+
+		// Draining the primary triggers failover. Wait for the new leader to
+		// be elected before polling cohort membership, otherwise the cohort
+		// poll loop spends its budget seeing "no primary found" and times out
+		// before failover completes on slower runners.
+		if isPrimary {
+			newPrimary := shardsetup.WaitForNewPrimary(t, setup, name, 90*time.Second)
+			t.Logf("New primary elected after draining %s: %s", name, newPrimary)
+		}
 
 		// Remove the drained pooler from the expected set, then wait for the
 		// leader's cohort view to converge.
@@ -212,34 +196,4 @@ func TestCohortRotation_FullReplacement(t *testing.T) {
 	require.Contains(t, newPoolerNames, finalLeader.Name,
 		"final primary should be one of the new poolers, got %s", finalLeader.Name)
 	t.Logf("Final primary: %s; final cohort: %v", finalLeader.Name, remaining)
-
-	// Stop writes and verify continuity. Some failures during the single
-	// leader-failover window are expected (writes in flight when the old
-	// primary is killed will fail), but a clean rotation should keep the
-	// failure rate well below 25%. A higher rate indicates the cohort
-	// dropped below quorum or the gateway took too long to reroute.
-	validator.Stop()
-	successful, failed := validator.Stats()
-	t.Logf("Final write stats: %d successful, %d failed", successful, failed)
-	require.Positive(t, successful, "expected successful writes throughout rotation")
-
-	total := successful + failed
-	failureRate := float64(failed) / float64(total)
-	assert.Less(t, failureRate, 0.25,
-		"write failure rate %.1f%% during rotation is too high; errors: %v",
-		failureRate*100, validator.FailedErrors())
-
-	// Sanity: the writes that the validator recorded as successful must be
-	// readable from the new cohort. Read from each surviving pooler since the
-	// validator records only what the gateway acknowledged.
-	finalClients := make([]*shardsetup.MultiPoolerTestClient, 0, len(newPoolerNames))
-	for _, name := range newPoolerNames {
-		addr := fmt.Sprintf("localhost:%d", setup.Multipoolers[name].Multipooler.GrpcPort)
-		client, err := shardsetup.NewMultiPoolerTestClient(addr)
-		require.NoError(t, err)
-		t.Cleanup(func() { client.Close() })
-		finalClients = append(finalClients, client)
-	}
-	require.NoError(t, validator.Verify(t, finalClients),
-		"successful writes must be readable from the new cohort")
 }

--- a/go/test/endtoend/multiorch/graceful_shutdown_test.go
+++ b/go/test/endtoend/multiorch/graceful_shutdown_test.go
@@ -30,10 +30,9 @@ import (
 
 // terminateMultipoolerGracefully sends SIGTERM to the multipooler binary (NOT
 // pgctld) and waits for it to exit. This drives the OnTermSync GracefulShutdown
-// hook end-to-end: pgctld.Stop (smart → fast → immediate escalation), and, for
-// the current leader, a LEADERSHIP_SIGNAL_REQUESTING_DEMOTION announcement on
-// the health stream. The OnClose chain that follows updates the topology entry
-// to PoolerType_DRAINED.
+// hook end-to-end: a COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE announcement on the
+// health stream and pgctld.Stop (fast → immediate escalation). The OnClose
+// chain that follows updates the topology entry to PoolerType_DRAINED.
 func terminateMultipoolerGracefully(t *testing.T, instance *shardsetup.MultipoolerInstance, timeout time.Duration) {
 	t.Helper()
 	require.NotNil(t, instance.Multipooler)
@@ -59,11 +58,12 @@ func terminateMultipoolerGracefully(t *testing.T, instance *shardsetup.Multipool
 
 // TestPrimaryGracefulShutdownTriggersFailover verifies the end-to-end
 // graceful-shutdown contract on the primary side: SIGTERM on the primary
-// produces an explicit REQUESTING_DEMOTION signal on the health stream, the
-// LeaderResignedAnalyzer fires, multiorch promotes a surviving standby, and
-// the terminated pooler's topology entry ends up as PoolerType_DRAINED. The
-// failover must happen quickly because resignation is an unambiguous signal —
-// no follower-disconnect grace period.
+// produces an explicit COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE signal on the
+// health stream, the LeaderResignedAnalyzer fires (via LeaderNeedsReplacement
+// treating INELIGIBLE as a resignation), multiorch promotes a surviving
+// standby, and the terminated pooler's topology entry ends up as
+// PoolerType_DRAINED. The failover must happen quickly because resignation
+// is an unambiguous signal — no follower-disconnect grace period.
 func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -86,10 +86,9 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// actually establish health streams to every pooler. The
 	// RequireRecovery-only gate is satisfied by topology state alone — it
 	// can return before the orchestrator has subscribed to the
-	// ManagerHealthStream, in which case the REQUESTING_DEMOTION snapshot
-	// our SIGTERM produces never reaches multiorch and failover falls back
-	// to the slow LeaderIsDeadAnalyzer path. The streams check closes that
-	// window.
+	// ManagerHealthStream, in which case the INELIGIBLE snapshot our SIGTERM
+	// produces never reaches multiorch and failover falls back to the slow
+	// LeaderIsDeadAnalyzer path. The streams check closes that window.
 	setup.RequireRecovery(t, "multiorch", 30*time.Second)
 	setup.WaitForHealthStreamsEstablished(t, "multiorch", 30*time.Second)
 
@@ -116,10 +115,10 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	}()
 
 	// multiorch should elect a new primary quickly: LeaderResignedAnalyzer
-	// fires as soon as it sees REQUESTING_DEMOTION, then AppointLeaderAction
-	// (Recruit + Propose) runs on the surviving cohort — concurrently with
-	// the old primary's pgctld.Stop, because runFailover excludes the
-	// resigned pooler from the cohort before recruit.
+	// fires as soon as it sees INELIGIBLE on the leader, then
+	// AppointLeaderAction (Recruit + Propose) runs on the surviving cohort
+	// — concurrently with the old primary's pgctld.Stop, because runFailover
+	// excludes the resigned pooler from the cohort before recruit.
 	t.Logf("Waiting for multiorch to elect a new primary...")
 	newPrimaryName := shardsetup.WaitForNewPrimary(t, setup, oldPrimaryName, 30*time.Second)
 	elapsed := time.Since(start)
@@ -135,7 +134,7 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 	// the resigned pooler) would blow past 5s.
 	require.Less(t, elapsed, 5*time.Second,
 		"graceful primary replacement took %s (expected well under 5s); "+
-			"likely a regression in REQUESTING_DEMOTION delivery, LeaderResignedAnalyzer firing, "+
+			"likely a regression in INELIGIBLE delivery, LeaderResignedAnalyzer firing, "+
 			"or the appointment cohort still containing the resigned pooler", elapsed)
 
 	// Confirm the dying primary actually exited cleanly. Generous bound
@@ -171,11 +170,11 @@ func TestPrimaryGracefulShutdownTriggersFailover(t *testing.T) {
 // a standby pooler does NOT cause spurious failover: the existing primary
 // stays primary, and the surviving standbys keep replicating from it.
 //
-// This is the role-symmetry property: the same shutdown sequence runs on
-// the standby (pgctld.Stop + exit), but because REQUESTING_DEMOTION is only
-// emitted by the current leader, the orchestrator's reaction is limited to
-// "stop trying to reconnect to the terminated standby" — no leader
-// appointment.
+// Even though the standby's GracefulShutdown advertises INELIGIBLE just like
+// the primary's does, INELIGIBLE on a non-leader doesn't trigger the
+// LeaderResignedAnalyzer (LeaderNeedsReplacement only fires for the current
+// leader). The orchestrator's reaction is limited to removing the terminated
+// standby from the cohort via ReconcileCohortAction — no leader appointment.
 func TestStandbyGracefulShutdownDoesNotTriggerFailover(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -228,9 +228,11 @@ RUN_EXTENDED_QUERY_SERVING_TESTS=1 go test -v -timeout 60m ./go/test/endtoend/pg
 ```text
 go/test/endtoend/pgregresstest/
 ├── README.md              # This file
-├── main_test.go          # TestMain, shared setup management
-├── postgres_builder.go   # PostgreSQL build and test execution
-└── pgregress_test.go     # Regression + isolation test implementation
+├── main_test.go           # TestMain, shared setup management
+├── postgres_builder.go    # PostgreSQL build and test execution
+├── pgregress_test.go      # Regression + isolation test implementation
+├── patch_verify.go        # Patch verification logic
+└── patch_verify_test.go   # Tests for patch verification
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/go/tools/asthelpergen/README.md
+++ b/go/tools/asthelpergen/README.md
@@ -76,15 +76,15 @@ go generate
 This executes the `//go:generate` directive in `generate.go`, which runs:
 
 ```bash
-go run ../../tools/asthelpergen/main \
+go run ../../../tools/asthelpergen/main \
   --in . \
-  --iface github.com/supabase/multigres/go/common/parser/ast.Node
+  --iface github.com/multigres/multigres/go/common/parser/ast.Node
 ```
 
 ### Command-Line Flags
 
 - `--in <package>`: Package(s) to analyze (default: current directory)
-- `--iface <interface>`: Fully qualified root interface name (e.g., `github.com/supabase/multigres/go/parser/ast.Node`)
+- `--iface <interface>`: Fully qualified root interface name (e.g., `github.com/multigres/multigres/go/common/parser/ast.Node`)
 - `--clone_exclude <types>`: Comma-separated list of types to exclude from deep cloning
 
 ## Generated Files

--- a/proto/README.md
+++ b/proto/README.md
@@ -16,3 +16,14 @@ style of the existing definitions first.
 
 Additionally, new definitions must adhere to the Google Cloud API Design Guide:
 <https://cloud.google.com/apis/design/>
+
+## Regenerating Generated Code
+
+After modifying any `.proto` file, regenerate the Go bindings from the repo
+root:
+
+```bash
+make proto
+```
+
+Generated `.pb.go` files land in `go/pb/` and are checked into the repository.

--- a/web/multiadmin/README.md
+++ b/web/multiadmin/README.md
@@ -1,6 +1,13 @@
 # Multiadmin Web UI
 
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Next.js frontend for the `multiadmin` service. It is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Prerequisites
+
+A running `multiadmin` backend reachable over HTTP. The UI proxies API
+requests to `http://localhost:15000` by default; override with the
+`MULTIADMIN_API_URL` environment variable (see `middleware.ts`). The local
+cluster from `demo/local/` or the k8s demo from `demo/k8s/` will start one.
 
 ## Getting Started
 
@@ -16,7 +23,10 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:18100](http://localhost:18100) with your browser to see the result.
+`next dev` binds to port `3000` by default — open
+[http://localhost:3000](http://localhost:3000) with your browser to see the
+result. Pass `-- --port <N>` (e.g. `npm run dev -- --port 18100`) to bind a
+different port.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 


### PR DESCRIPTION
## Summary

Backports selected changes from `main` to `release/v0.1`.

Included:

- #1049
- #1051
- #1053
