### PR TITLE
fix(multipooler): respect context deadline when a backend cancel doesn't take effect

### DIFF
--- a/go/services/multipooler/pools/regular/regular_conn.go
+++ b/go/services/multipooler/pools/regular/regular_conn.go
@@ -559,6 +559,34 @@ func (c *Conn) handleContextCancellation() {
 	}
 }
 
+// postCancelDrainGrace bounds how long we wait for an in-flight operation to
+// unwind after handleContextCancellation has requested a backend cancel.
+// pg_cancel_backend only reports that the cancel signal was *delivered*, not
+// that the statement actually stopped (PostgreSQL acts on it at
+// CHECK_FOR_INTERRUPTS points, and cancel requests can be lost or race). Without
+// an upper bound, a hung statement that never honors the cancel would block the
+// caller forever, ignoring the already-expired context deadline.
+const postCancelDrainGrace = 2 * time.Second
+
+// drainOpAfterCancel waits for the op goroutine (publishing on ch) to return
+// after a backend cancel has been requested. Because pg_cancel_backend is
+// best-effort, the statement may never abort on its own; if it does not drain
+// within postCancelDrainGrace, the connection is force-closed so the op unwinds
+// promptly on the broken socket. This guarantees the call returns near the
+// context deadline rather than hanging while holding the connection (which would
+// also block subsequent attempts that need it).
+func drainOpAfterCancel[T any](c *Conn, ch <-chan T) T {
+	timer := time.NewTimer(postCancelDrainGrace)
+	defer timer.Stop()
+	select {
+	case res := <-ch:
+		return res
+	case <-timer.C:
+		c.conn.ForceClose()
+		return <-ch
+	}
+}
+
 // execOnce executes an operation with context cancellation support.
 // Unlike execWithContextCancel, it does NOT close the connection on error,
 // allowing the caller (retry loop) to reconnect and retry.
@@ -576,10 +604,12 @@ func execOnce[T any](c *Conn, ctx context.Context, op func() (T, error)) (T, err
 
 	select {
 	case <-ctx.Done():
-		// Context cancelled - cancel the backend query.
+		// Context cancelled - cancel the backend query, then wait (bounded) for
+		// the operation to drain. drainOpAfterCancel force-closes the connection
+		// if the cancel does not take effect within the grace period, so this
+		// never blocks past the deadline.
 		c.handleContextCancellation()
-		// Wait for the operation to complete (it should return quickly after cancel).
-		<-ch
+		drainOpAfterCancel(c, ch)
 		var zero T
 		return zero, context.Cause(ctx)
 	case res := <-ch:
@@ -608,10 +638,12 @@ func execWithContextCancel[T any](c *Conn, ctx context.Context, op func() (T, er
 
 	select {
 	case <-ctx.Done():
-		// Context cancelled - cancel the backend query.
+		// Context cancelled - cancel the backend query, then wait (bounded) for
+		// the operation to drain. drainOpAfterCancel force-closes the connection
+		// if the cancel does not take effect within the grace period, so this
+		// never blocks past the deadline.
 		c.handleContextCancellation()
-		// Wait for the operation to complete (it should return quickly after cancel).
-		res := <-ch
+		res := drainOpAfterCancel(c, ch)
 		// If the operation had a connection error, close the connection.
 		if mterrors.IsConnectionError(res.err) {
 			c.conn.Close()

--- a/go/services/multipooler/pools/regular/regular_conn_test.go
+++ b/go/services/multipooler/pools/regular/regular_conn_test.go
@@ -17,7 +17,9 @@ package regular
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -666,6 +668,88 @@ func TestHandleContextCancellation_CancelErrors_ClosesConnection(t *testing.T) {
 	conn.handleContextCancellation()
 
 	assert.True(t, conn.IsClosed(), "connection should be closed when admin pool fails")
+}
+
+// TestHungQuery_ContextTimeoutNotRespected_AfterSuccessfulCancel guards against
+// a bug where a hung statement (e.g. an UPDATE / SELECT ... FOR UPDATE that
+// blocks on a row lock once NOWAIT is dropped) does not respect the context
+// timeout, so it cannot be cancelled and holds the connection, blocking
+// subsequent attempts.
+//
+// Root cause: when the context deadline fires, execWithContextCancel calls
+// handleContextCancellation, which runs pg_cancel_backend via the admin pool.
+// pg_cancel_backend is best-effort — it returns true when the cancel signal is
+// *delivered*, not when the query actually stops (PostgreSQL only acts on it at
+// CHECK_FOR_INTERRUPTS points, and cancel requests can be lost or race). The
+// original code, on a successful cancel, left the connection open and blocked on
+// `<-ch` waiting for the op goroutine to return; if the backend never aborted
+// the statement that wait was unbounded, so the call hung forever despite the
+// expired context. drainOpAfterCancel now force-closes the connection if the op
+// does not drain within postCancelDrainGrace, guaranteeing the call returns.
+//
+// This test sends a query that blocks while pg_cancel_backend reports success
+// without unblocking it, and asserts conn.Query returns ~at the deadline with
+// context.DeadlineExceeded rather than hanging until the watchdog fires.
+func TestHungQuery_ContextTimeoutNotRespected_AfterSuccessfulCancel(t *testing.T) {
+	server := fakepgserver.New(t)
+	t.Cleanup(server.Close)
+
+	// The UPDATE blocks until released, standing in for a backend stuck waiting
+	// on a row lock.
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var startOnce sync.Once
+	server.AddQueryPatternWithCallback(
+		`UPDATE .*`,
+		fakepgserver.MakeResult([]string{"col"}, [][]any{{"1"}}),
+		func(string) {
+			startOnce.Do(func() { close(started) })
+			<-release
+		},
+	)
+
+	// pg_cancel_backend "succeeds" (signal delivered) but does NOT unblock the
+	// hung UPDATE — faithfully modelling a best-effort cancel that misses.
+	server.AddQueryPattern(`SELECT pg_cancel_backend\(\d+\)`, fakepgserver.MakeResult(
+		[]string{"pg_cancel_backend"},
+		[][]any{{"t"}},
+	))
+
+	adminPool := newTestAdminPool(t, server)
+	conn := newTestDirectConnWithAdmin(t, server, adminPool)
+
+	// Registered last → runs first (LIFO), before pool/server teardown: unblock
+	// the hung op so its goroutine drains, then close the client connection so
+	// the fake server's handler sees EOF and exits cleanly.
+	t.Cleanup(func() {
+		close(release)
+		conn.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// done is buffered so the goroutine never blocks on send, even if the test
+	// has already moved on (or failed) by the time the query finally unwinds.
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.Query(ctx, "UPDATE foo SET x = 1 WHERE id = 1")
+		done <- err
+	}()
+
+	// Make sure the query is actually in flight before we start waiting.
+	<-started
+
+	select {
+	case err := <-done:
+		// Correct behavior: the call returns at ~the deadline.
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"hung query should be abandoned with the context deadline error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("BUG: conn.Query did not return ~200ms after the context deadline. " +
+			"execWithContextCancel blocks on <-ch after a successful pg_cancel_backend, " +
+			"so a hung statement ignores the context timeout and holds the connection.")
+	}
 }
 
 // TestPool_ClosedConnectionRecycled_CapacityPreserved verifies that when


### PR DESCRIPTION
## Summary

- A hung statement (e.g. an `UPDATE` / `SELECT ... FOR UPDATE` that blocks on a row lock once `NOWAIT` is dropped) could ignore its context deadline, hang forever, and hold the connection — blocking subsequent attempts that need it.
- The fix bounds the post-cancel wait: if `pg_cancel_backend` doesn't actually stop the statement within a short grace period, the connection is force-closed so the call returns near the deadline.
- Adds a regression test that reproduces the hang and verifies the deadline is now honored.

## Problem

In the internal query path (`InternalQueryService.Query` / `InternalTx.Query` → `reserved.Conn.Query` → `regular.Conn.Query`), query execution goes through `execWithContextCancel` / `execOnce`. When the context deadline fires, these call `handleContextCancellation`, which runs `pg_cancel_backend(pid)` via the admin pool.

`pg_cancel_backend` is best-effort: it returns `true` when the cancel signal is *delivered*, not when the query actually stops. PostgreSQL only acts on a cancel at `CHECK_FOR_INTERRUPTS` points, and cancel requests can be lost or race. On a successful cancel the original code deliberately left the connection open and then blocked on `<-ch` waiting for the op goroutine to return, with no upper bound. If the backend never aborted the statement, the call hung forever despite the expired context — and kept the connection checked out, so later attempts that needed it blocked too. This is the "drop NOWAIT and you can no longer cancel a hung query" symptom.

## Solution

Bound the wait after a cancel is requested. A new `drainOpAfterCancel` helper waits for the op goroutine to drain, but if it doesn't within `postCancelDrainGrace` (2s) it force-closes the connection so the read unwinds and the call returns `context.DeadlineExceeded`. It's used at both `execOnce` and `execWithContextCancel`. The common case — a cancel that takes effect promptly — is unchanged: the connection still drains and is recycled rather than force-closed.

The fix sits at the `regular.Conn` layer, so it covers both one-shot internal queries and the `InternalTx` / reserved-connection transaction path.

## Test plan

- `TestHungQuery_ContextTimeoutNotRespected_AfterSuccessfulCancel` fails (watchdog fires) without the fix and passes with it.
- `regular`, `reserved`, and `executor` package tests pass; `regular` is also clean under `-race`.