### PR TITLE
fix(multipooler): restore primary_conninfo after pg_rewind in RewindToSource

### DIFF
--- a/go/cmd/pgctld/command/server_test.go
+++ b/go/cmd/pgctld/command/server_test.go
@@ -642,6 +642,72 @@ func TestPgCtldService_Status_IncludesPgBackRest(t *testing.T) {
 	assert.Equal(t, int32(5), resp.PgbackrestStatus.RestartCount)
 }
 
+// TestPgCtldService_StopRewindStart verifies the stop→pg_rewind→start lifecycle.
+// This is a regression test for a bug where the pgctld service would fail to start
+// postgres after a stop+pg_rewind sequence. The fix ensures that the pgctld RPC
+// handlers have no internal "closed" state that prevents re-starting postgres after
+// a stop-for-rewind flow.
+func TestPgCtldService_StopRewindStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	baseDir := t.TempDir()
+	poolerDir := baseDir
+	dataDir := filepath.Join(baseDir, "pg_data")
+
+	// Set env vars expected by pgctld
+	t.Setenv(constants.PgDataDirEnvVar, dataDir)
+
+	// Create mock PostgreSQL binaries (including pg_rewind)
+	binDir := filepath.Join(baseDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	testutil.CreateMockPostgreSQLBinaries(t, binDir)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	// Initialize a mock data directory so IsDataDirInitialized() returns true
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "PG_VERSION"), []byte("16\n"), 0o644))
+
+	service, err := NewPgCtldService(logger, testServiceConfig, 30, poolerDir, "localhost", 0, "")
+	require.NoError(t, err)
+	defer service.Close()
+
+	ctx := context.Background()
+
+	// Step 1: Simulate a running postgres by installing a postmaster.pid that
+	// references a real process owned by the test. Using CreatePIDFile avoids
+	// spawning a real pg_ctl subprocess (which would leave orphaned children).
+	testutil.CreatePIDFile(t, dataDir, 0 /* pid is filled in by helper */)
+
+	// Step 2: Stop postgres. This is the first part of the stop→rewind→start sequence.
+	stopResp, err := service.Stop(ctx, &pb.StopRequest{Mode: "fast"})
+	require.NoError(t, err, "Stop must succeed — this is the first half of the stop→rewind→start sequence")
+	require.NotNil(t, stopResp)
+
+	// Step 3: Run pg_rewind (dry-run). The service must accept this call after a stop;
+	// if the stop had put the service into a closed state this call would fail.
+	rewindResp, err := service.PgRewind(ctx, &pb.PgRewindRequest{
+		SourceHost: "127.0.0.1",
+		SourcePort: 5433,
+		DryRun:     true,
+	})
+	require.NoError(t, err, "PgRewind must succeed after Stop")
+	require.NotNil(t, rewindResp)
+
+	// Step 4: Start postgres again as standby. This is the critical step: the service
+	// must be able to restart after stop+rewind without requiring a pgctld process restart.
+	restartResp, err := service.Restart(ctx, &pb.RestartRequest{
+		Mode:      "fast",
+		AsStandby: true,
+	})
+	require.NoError(t, err, "Restart as standby must succeed after stop+pg_rewind — REGRESSION: stop→rewind→start lifecycle must work")
+	require.NotNil(t, restartResp)
+	assert.Greater(t, restartResp.Pid, int32(0), "restarted postgres must have a valid PID")
+
+	// Cleanup: stop the mock postgres process created by the Restart call so the
+	// test does not leave an orphaned background subprocess.
+	_, _ = service.Stop(ctx, &pb.StopRequest{Mode: "fast"})
+}
+
 // testLogger returns a no-op logger for testing
 func testLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)

--- a/go/cmd/pgctld/testutil/mock_postgres.go
+++ b/go/cmd/pgctld/testutil/mock_postgres.go
@@ -309,6 +309,26 @@ fi
 exit 0
 `)
 
+	// Mock pg_rewind
+	MockBinary(t, binDir, "pg_rewind", `
+# Parse flags
+DRY_RUN=false
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY_RUN=true
+            ;;
+    esac
+done
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo "servers diverged at WAL location 0/5000000 on timeline 1"
+else
+    echo "pg_rewind: done"
+fi
+exit 0
+`)
+
 	// Mock psql
 	MockBinary(t, binDir, "psql", `
 if [[ "$*" == *"SELECT version()"* ]]; then

--- a/go/services/multiorch/recovery/actions/fix_replication.go
+++ b/go/services/multiorch/recovery/actions/fix_replication.go
@@ -236,8 +236,9 @@ func (a *FixReplicationAction) fixNotReplicating(
 			return mterrors.Wrap(rewindErr, "pg_rewind failed")
 		}
 		// Re-verify replication after rewind. RewindToSource restarts
-		// PostgreSQL as a standby, and primary_conninfo in
-		// postgresql.auto.conf is preserved (pg_rewind doesn't touch it).
+		// PostgreSQL as a standby and re-establishes primary_conninfo,
+		// which pg_rewind may have cleared by syncing postgresql.auto.conf
+		// from the source.
 		if verifyErr := a.verifyReplicationStarted(ctx, replica); verifyErr != nil {
 			return mterrors.Wrap(verifyErr, "replication did not start after pg_rewind")
 		}

--- a/go/services/multiorch/recovery/actions/fix_replication_test.go
+++ b/go/services/multiorch/recovery/actions/fix_replication_test.go
@@ -521,6 +521,192 @@ func (c *replicationStatusClient) Status(
 	}, nil
 }
 
+// streamingAfterRewindClient wraps FakeClient to simulate the full pg_rewind
+// success path: the replica has no primary_conninfo initially, the WAL receiver
+// stays idle through the first verifyReplicationStarted window (exhausting all
+// attempts), then streams after RewindToSource restores primary_conninfo.
+//
+// Call sequence (with verifyMaxAttempts = N):
+//  1. verifyProblemExists        → no PrimaryConnInfo (triggers fix)
+//     2..N+1. verifyReplicationStarted after SetTermPrimary  → not streaming (all fail)
+//     N+2+.  verifyReplicationStarted after RewindToSource → streaming
+type streamingAfterRewindClient struct {
+	*rpcclient.FakeClient
+	replicaCallCount  int
+	nonStreamingCalls int // number of non-streaming calls after call 1 before transitioning
+}
+
+func (c *streamingAfterRewindClient) Status(
+	ctx context.Context,
+	pooler *clustermetadatapb.MultiPooler,
+	request *multipoolermanagerdatapb.StatusRequest,
+) (*multipoolermanagerdatapb.StatusResponse, error) {
+	if pooler == nil || pooler.Id == nil || pooler.Id.Name != "replica1" {
+		return c.FakeClient.Status(ctx, pooler, request)
+	}
+	c.replicaCallCount++
+	switch {
+	case c.replicaCallCount == 1:
+		// verifyProblemExists: no primary_conninfo → triggers fix
+		return &multipoolermanagerdatapb.StatusResponse{
+			Status: &multipoolermanagerdatapb.Status{
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{},
+			},
+		}, nil
+	case c.replicaCallCount <= 1+c.nonStreamingCalls:
+		// verifyReplicationStarted after SetTermPrimary: WAL receiver idle
+		return &multipoolermanagerdatapb.StatusResponse{
+			Status: &multipoolermanagerdatapb.Status{
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					WalReceiverStatus: "",
+				},
+			},
+		}, nil
+	default:
+		// verifyReplicationStarted after RewindToSource: streaming
+		return &multipoolermanagerdatapb.StatusResponse{
+			Status: &multipoolermanagerdatapb.Status{
+				ReplicationStatus: &multipoolermanagerdatapb.StandbyReplicationStatus{
+					WalReceiverStatus: "streaming",
+					LastReceiveLsn:    "0/5000100",
+				},
+			},
+		}, nil
+	}
+}
+
+// TestFixReplicationAction_SucceedsViaRewind is a regression test for the bug where
+// RewindToSource did not restore primary_conninfo after pg_rewind, leaving the WAL
+// receiver with no primary to connect to. The full path under test:
+//
+//  1. SetTermPrimary is called but the WAL receiver never starts streaming.
+//  2. tryPgRewind → RewindToSource runs (which now restores primary_conninfo).
+//  3. verifyReplicationStarted sees "streaming" and the action succeeds.
+func TestFixReplicationAction_SucceedsViaRewind(t *testing.T) {
+	ctx := context.Background()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")
+	defer ts.Close()
+
+	const verifyAttempts = 3 // override default to keep test fast
+
+	baseFakeClient := rpcclient.NewFakeClient()
+	baseFakeClient.SetStatusResponse("multipooler-cell1-primary", &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			IsInitialized: true,
+			PoolerType:    clustermetadatapb.PoolerType_PRIMARY,
+		},
+	})
+	baseFakeClient.ConsensusStatusResponses = map[string]*consensusdatapb.StatusResponse{
+		"multipooler-cell1-primary": {
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+			},
+		},
+		"multipooler-cell1-replica1": {
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+			},
+		},
+	}
+	baseFakeClient.UpdateConsensusRuleResponses = map[string]*multipoolermanagerdatapb.UpdateConsensusRuleResponse{
+		"multipooler-cell1-primary": {},
+	}
+	// RewindToSource succeeds, simulating pg_rewind running and primary_conninfo
+	// being restored by the fix in rpc_manager.go.
+	baseFakeClient.RewindToSourceResponses = map[string]*multipoolermanagerdatapb.RewindToSourceResponse{
+		"multipooler-cell1-replica1": {
+			Success:         true,
+			RewindPerformed: true,
+		},
+	}
+
+	fakeClient := &streamingAfterRewindClient{
+		FakeClient:        baseFakeClient,
+		nonStreamingCalls: verifyAttempts,
+	}
+	poolerStore := store.NewPoolerStore(fakeClient, slog.Default())
+
+	replicaID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "cell1",
+		Name:      "replica1",
+	}
+	replica := &clustermetadatapb.MultiPooler{
+		Id: replicaID,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Type: clustermetadatapb.PoolerType_REPLICA,
+	}
+	primary := &clustermetadatapb.MultiPooler{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "cell1",
+			Name:      "primary",
+		},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		Type:     clustermetadatapb.PoolerType_PRIMARY,
+		Hostname: "primary.example.com",
+		PortMap:  map[string]int32{"postgres": 5432},
+	}
+
+	require.NoError(t, ts.CreateMultiPooler(ctx, replica))
+	require.NoError(t, ts.CreateMultiPooler(ctx, primary))
+
+	poolerStore.Set("multipooler-cell1-replica1", &multiorchdatapb.PoolerHealthState{
+		MultiPooler: replica,
+	})
+	poolerStore.Set("multipooler-cell1-primary", &multiorchdatapb.PoolerHealthState{
+		MultiPooler: primary,
+		Status:      &multipoolermanagerdatapb.Status{PostgresReady: true},
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+			CurrentPosition: &clustermetadatapb.PoolerPosition{
+				Rule: &clustermetadatapb.ShardRule{
+					RuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1},
+				},
+			},
+		},
+	})
+
+	action := NewFixReplicationAction(config.NewTestConfig(), fakeClient, poolerStore, ts, slog.Default())
+	action.verifyPollInterval = 10 * time.Millisecond
+	action.verifyMaxAttempts = verifyAttempts
+
+	problem := types.Problem{
+		Code: types.ProblemReplicaNotReplicating,
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: "default",
+			Shard:      "0",
+		},
+		PoolerID: replicaID,
+	}
+
+	err := action.Execute(ctx, problem)
+	require.NoError(t, err, "fixNotReplicating must succeed via pg_rewind path")
+
+	// Verify the expected call sequence.
+	assert.Contains(t, fakeClient.CallLog, "SetTermPrimary(multipooler-cell1-replica1)",
+		"SetTermPrimary must be called first")
+	assert.Contains(t, fakeClient.CallLog, "RewindToSource(multipooler-cell1-replica1)",
+		"RewindToSource must be called when SetTermPrimary doesn't start streaming")
+
+	// REGRESSION: the pooler must NOT be drained — RewindToSource succeeded and
+	// streaming started. Before the fix, primary_conninfo was wiped by pg_rewind
+	// so verifyReplicationStarted always failed, eventually routing to DRAINED.
+	updatedPooler, err := ts.GetMultiPooler(ctx, replicaID)
+	require.NoError(t, err)
+	assert.NotEqual(t, clustermetadatapb.PoolerType_DRAINED, updatedPooler.Type,
+		"pooler must not be drained when replication starts successfully after rewind")
+}
+
 func TestFixReplicationAction_FailsWhenReplicationDoesNotStart(t *testing.T) {
 	ctx := context.Background()
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "cell1")

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -970,6 +970,17 @@ func (pm *MultiPoolerManager) RewindToSource(ctx context.Context, source *cluste
 		return nil, mterrors.Wrap(err, "failed to reconnect to database after pg_rewind")
 	}
 
+	// Re-establish primary_conninfo. pg_rewind syncs files from the source including
+	// postgresql.auto.conf, which does not have primary_conninfo set on the primary.
+	// Without this, the WAL receiver has no primary to connect to after restart.
+	pm.logger.InfoContext(ctx, "Re-establishing primary_conninfo after pg_rewind",
+		"source_host", source.Hostname,
+		"source_port", port)
+	if err := pm.setPrimaryConnInfoLocked(ctx, source.Hostname, port, false, false); err != nil {
+		pm.logger.ErrorContext(ctx, "Failed to re-establish primary_conninfo after pg_rewind", "error", err)
+		return nil, mterrors.Wrap(err, "failed to re-establish replication after pg_rewind")
+	}
+
 	// Rewind succeeded: allow the monitor to resume normal operation.
 	pm.rewindPending.Store(false)
 

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -39,6 +39,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
 
 // setTermForTest writes the consensus term file directly for testing.
@@ -962,6 +963,124 @@ func TestRewindToSource_ManagerReopenedOnError(t *testing.T) {
 		defer manager.mu.Unlock()
 		return manager.isOpen
 	}, 2*time.Second, 50*time.Millisecond, "REGRESSION: Manager should be reopened even when RewindToSource fails")
+}
+
+// TestRewindToSource_RestoresPrimaryConnInfo is a regression test for the bug where
+// RewindToSource did not call setPrimaryConnInfoLocked after pg_rewind. When actual
+// pg_rewind runs it syncs postgresql.auto.conf from the source (which has no
+// primary_conninfo), wiping the value set by the earlier SetTermPrimary call and
+// leaving the WAL receiver with no primary to connect to.
+func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx := context.Background()
+
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	poolerDir := t.TempDir()
+	serviceID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test-pooler",
+	}
+
+	multipooler := &clustermetadatapb.MultiPooler{
+		Id:        serviceID,
+		PoolerDir: poolerDir,
+		Type:      clustermetadatapb.PoolerType_REPLICA,
+		PortMap: map[string]int32{
+			"postgres": 5432,
+		},
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+	}
+
+	// Mock pgctld: dry-run reports divergence so actual pg_rewind runs; all else succeeds.
+	mockPgctld := &testutil.MockPgCtldService{
+		PgRewindResponse: &pgctldpb.PgRewindResponse{
+			Message: "pg_rewind completed",
+			Output:  "servers diverged at WAL location 0/5000000 on timeline 1",
+		},
+	}
+	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, mockPgctld)
+	t.Cleanup(cleanupPgctld)
+
+	// Track whether primary_conninfo was set with the expected value.
+	var primaryConnInfoSet string
+
+	mockQueryService := mock.NewQueryService()
+	// SELECT 1 for waitForDatabaseConnection
+	mockQueryService.AddQueryPattern("SELECT 1",
+		mock.MakeQueryResult([]string{"?column?"}, [][]any{{1}}))
+	// pg_is_in_recovery check inside setPrimaryConnInfoLocked
+	mockQueryService.AddQueryPattern("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{true}}))
+	// Record that ALTER SYSTEM SET primary_conninfo was called
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil),
+		func(query string) { primaryConnInfoSet = query },
+	)
+	// pg_conf_load_time before reload (consumed once)
+	mockQueryService.AddQueryPatternOnce("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:00"}}))
+	// pg_reload_conf
+	mockQueryService.AddQueryPattern("SELECT pg_reload_conf",
+		mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
+	// pg_conf_load_time after reload (different value signals reload completed)
+	mockQueryService.AddQueryPattern("SELECT pg_conf_load_time",
+		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:01"}}))
+
+	config := &Config{
+		TopoClient: ts,
+		PgctldAddr: pgctldAddr,
+	}
+
+	manager, err := NewMultiPoolerManager(logger, multipooler, config)
+	require.NoError(t, err)
+	defer manager.ShutdownForTest(t.Context())
+
+	createPgDataDir(t, poolerDir)
+	require.NoError(t, manager.setInitialized())
+
+	manager.qsc = &mockPoolerController{queryService: mockQueryService}
+	manager.rules = newRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
+
+	manager.mu.Lock()
+	manager.isOpen = true
+	manager.state = ManagerStateReady
+	manager.ctx, manager.cancel = context.WithCancel(ctx)
+	manager.mu.Unlock()
+
+	source := &clustermetadatapb.MultiPooler{
+		Id: &clustermetadatapb.ID{
+			Component: clustermetadatapb.ID_MULTIPOOLER,
+			Cell:      "zone1",
+			Name:      "source-pooler",
+		},
+		Hostname: "source-host",
+		PortMap:  map[string]int32{"postgres": 5433},
+	}
+
+	resp, err := manager.RewindToSource(ctx, source)
+	require.NoError(t, err)
+	assert.True(t, resp.RewindPerformed, "actual pg_rewind should have run (divergence detected)")
+
+	// Verify both actual rewind calls were made (dry-run + actual).
+	rewindCalls := mockPgctld.PgRewindCalls
+	require.Len(t, rewindCalls, 2, "expected dry-run and actual pg_rewind calls")
+	assert.True(t, rewindCalls[0].DryRun, "first call should be dry-run")
+	assert.False(t, rewindCalls[1].DryRun, "second call should be actual rewind")
+
+	// REGRESSION TEST: primary_conninfo must be set after pg_rewind so the WAL
+	// receiver can connect to the primary. Before the fix, this was never called
+	// and the WAL receiver had no primary_conninfo to use.
+	assert.NotEmpty(t, primaryConnInfoSet, "primary_conninfo must be set after pg_rewind")
+	assert.Contains(t, primaryConnInfoSet, "source-host", "primary_conninfo must reference the source host")
+	assert.Contains(t, primaryConnInfoSet, "5433", "primary_conninfo must reference the source postgres port")
 }
 
 func TestSetPostgresRestartsEnabledRPC(t *testing.T) {


### PR DESCRIPTION
pg_rewind syncs postgresql.auto.conf from the source server, which does not have primary_conninfo set (it is the primary). After the actual rewind runs, the replica restarts as standby but the WAL receiver has no primary to connect to, leaving it permanently idle.

Fix: call setPrimaryConnInfoLocked after the restart in RewindToSource, matching what demoteStalePrimaryLocked already does. This re-establishes primary_conninfo and triggers pg_reload_conf so the WAL receiver connects immediately.

Observed in mg-scale12 AZ-outage test (2026-05-29): newly added replicas that entered the pg_rewind path via fixNotReplicating ended up with no streaming WAL receiver after restart.

Also add two regression tests:
- TestRewindToSource_RestoresPrimaryConnInfo: verifies setPrimaryConnInfoLocked is called with the source host/port after a successful rewind.
- TestPgCtldService_StopRewindStart: verifies the pgctld stop→pg_rewind→start sequence completes without error across all three RPC handlers.

Fixes MUL-559