### PR TITLE
fix(multipooler): increase promotion timeout and add OTel spans to election flow

### DIFF
--- a/go/common/timeouts/rpc.go
+++ b/go/common/timeouts/rpc.go
@@ -21,6 +21,13 @@ import "time"
 // RPC calls, etcd data fetches, and synchronous replication health checks.
 const RemoteOperationTimeout = 15 * time.Second
 
+// RuleWriteTimeout is the timeout for rule writes and the election-flow RPCs
+// (Recruit, Propose, SetTermPrimary). For promotions the rule_history write
+// blocks until a sync-standby WAL ack arrives after the full SetTermPrimary
+// round-trip, which includes optional pg_rewind. 60 s gives ~45 s of headroom
+// beyond the typical 8–14 s observed in the 9-pooler AZ-freeze test.
+const RuleWriteTimeout = 30 * time.Second
+
 // DefaultHealthStreamStalenessTimeout is the default staleness watchdog timeout for
 // ManagerHealthStream connections. If no message is received within this window
 // the client reconnects and the server advertises this value in the start response.

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -251,7 +251,7 @@ func (r *coordinatorLedRuleChange) recruit(
 	p *multiorchdatapb.PoolerHealthState,
 	revocation *clustermetadatapb.TermRevocation,
 ) *clustermetadatapb.ConsensusStatus {
-	rpcCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 	resp, err := r.coordinator.rpcClient.Recruit(rpcCtx, p.MultiPooler, &consensusdatapb.RecruitRequest{
 		TermRevocation: revocation,
@@ -286,7 +286,7 @@ func (r *coordinatorLedRuleChange) propose(
 	req *consensusdatapb.ProposeRequest,
 	isLeader bool,
 ) error {
-	rpcCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)
+	rpcCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
 	if isLeader {
 		_, err := r.coordinator.rpcClient.Propose(rpcCtx, p.MultiPooler, req)

--- a/go/services/multiorch/recovery/actions/appoint_leader.go
+++ b/go/services/multiorch/recovery/actions/appoint_leader.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	"github.com/multigres/multigres/go/services/multiorch/config"
@@ -154,7 +155,10 @@ func (a *AppointLeaderAction) Metadata() types.RecoveryMetadata {
 	return types.RecoveryMetadata{
 		Name:        "AppointLeader",
 		Description: "Elect a new primary for the shard using consensus",
-		Timeout:     60 * time.Second,
+		// Two sequential phases each bounded by RuleWriteTimeout
+		// (Recruit, then concurrent Propose/SetTermPrimary), plus margin so the
+		// action context does not race its own phases to the deadline.
+		Timeout:     2*timeouts.RuleWriteTimeout + 5*time.Second,
 		LockTimeout: 15 * time.Second,
 		Retryable:   true, // can retry if it fails
 	}

--- a/go/services/multiorch/recovery/actions/shard_init_action.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action.go
@@ -23,6 +23,7 @@ import (
 
 	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	commontypes "github.com/multigres/multigres/go/common/types"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -212,7 +213,10 @@ func (a *ShardInitAction) Metadata() types.RecoveryMetadata {
 	return types.RecoveryMetadata{
 		Name:        "ShardInit",
 		Description: "Establish initial cohort and appoint first leader for a bootstrapped shard",
-		Timeout:     60 * time.Second,
+		// Two sequential phases each bounded by RuleWriteTimeout
+		// (Recruit, then concurrent Propose/SetTermPrimary), plus margin so the
+		// action context does not race its own phases to the deadline.
+		Timeout:     2*timeouts.RuleWriteTimeout + 5*time.Second,
 		LockTimeout: 15 * time.Second,
 		Retryable:   true,
 	}

--- a/go/services/multiorch/recovery/actions/shard_init_action_test.go
+++ b/go/services/multiorch/recovery/actions/shard_init_action_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/timeouts"
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
@@ -116,7 +117,7 @@ func TestShardInitAction_Metadata(t *testing.T) {
 	m := action.Metadata()
 	assert.Equal(t, "ShardInit", m.Name)
 	assert.True(t, m.Retryable)
-	assert.Equal(t, 60*time.Second, m.Timeout)
+	assert.Equal(t, 2*timeouts.RuleWriteTimeout+5*time.Second, m.Timeout)
 }
 
 func TestShardInitAction_RequiresHealthyLeader(t *testing.T) {

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -357,6 +357,15 @@ func (pm *MultiPoolerManager) internalQueryService() executor.InternalQueryServi
 	return pm.qsc.InternalQueryService()
 }
 
+// DoUpdateRule applies a rule update to the manager's rule store and returns
+// the new position. This is used by the gRPC handler to implement rule updates
+// via the API.
+func (pm *MultiPoolerManager) DoUpdateRule(ctx context.Context, update *ruleUpdateBuilder) (*clustermetadatapb.PoolerPosition, error) {
+	ruleWriteCtx, ruleWriteSpan := telemetry.Tracer().Start(ctx, "consensus/rule-write")
+	defer ruleWriteSpan.End()
+	return pm.rules.updateRule(ruleWriteCtx, update)
+}
+
 // query executes a query using the internal query service and returns the result.
 // This is a convenience method for internal manager operations.
 func (pm *MultiPoolerManager) query(ctx context.Context, sql string) (*sqltypes.Result, error) {
@@ -1334,6 +1343,9 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		pm.logger.InfoContext(ctx, "PostgreSQL already promoted, skipping")
 		return nil
 	}
+
+	ctx, span := telemetry.Tracer().Start(ctx, "consensus/pg-promote")
+	defer span.End()
 
 	// Call pg_promote() to promote standby to primary
 	pm.logger.InfoContext(ctx, "PostgreSQL promotion needed")

--- a/go/services/multipooler/manager/rpc_consensus.go
+++ b/go/services/multipooler/manager/rpc_consensus.go
@@ -30,6 +30,7 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	"github.com/multigres/multigres/go/services/multipooler/poolerserver"
+	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
 // buildConsensusStatus constructs a ConsensusStatus from a pre-resolved revocation,
@@ -296,6 +297,9 @@ func (pm *MultiPoolerManager) clearResignedLeaderAtTerm(ctx context.Context) err
 //  4. Persist the TermRevocation only if the position is consistent.
 //  5. Return ConsensusStatus with the stable post-revoke position.
 func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.RecruitRequest) (*consensusdatapb.RecruitResponse, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "consensus/recruit")
+	defer span.End()
+
 	var err error
 	ctx, err = pm.actionLock.Acquire(ctx, "Recruit")
 	if err != nil {
@@ -332,27 +336,35 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 
 	// Stop replication participation.
 	var savedConnInfo string // non-empty if standby; used for recovery on race failure
-	if isPrimary {
-		pm.logger.InfoContext(ctx, "Recruiting primary: demoting and restarting as standby",
-			"revoked_below_term", revokedBelowTerm)
-		if err := pm.emergencyDemoteLocked(ctx, revokedBelowTerm, recruitDrainTimeout); err != nil {
+	{
+		stopCtx, stopSpan := telemetry.Tracer().Start(ctx, "consensus/stop-replication")
+		if isPrimary {
+			pm.logger.InfoContext(stopCtx, "Recruiting primary: demoting and restarting as standby",
+				"revoked_below_term", revokedBelowTerm)
+			err = pm.emergencyDemoteLocked(stopCtx, revokedBelowTerm, recruitDrainTimeout)
+		} else {
+			// Save primary_conninfo so we can restore it if the position check fails.
+			if savedConnInfo, err = pm.readPrimaryConnInfo(stopCtx); err != nil {
+				pm.logger.WarnContext(stopCtx, "Failed to save primary_conninfo before recruit; recovery from race condition will not be possible", "error", err)
+			}
+			pm.logger.InfoContext(stopCtx, "Recruiting standby: pausing replication",
+				"revoked_below_term", revokedBelowTerm)
+			_, err = pm.pauseReplication(stopCtx,
+				multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_RECEIVER_ONLY,
+				true /* wait */)
+		}
+		stopSpan.End()
+		if err != nil {
 			eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
-			return nil, mterrors.Wrap(err, "failed to demote primary during recruit")
+			return nil, mterrors.Wrap(err, "failed to stop replication during recruit")
 		}
-	} else {
-		// Save primary_conninfo so we can restore it if the position check fails.
-		if savedConnInfo, err = pm.readPrimaryConnInfo(ctx); err != nil {
-			pm.logger.WarnContext(ctx, "Failed to save primary_conninfo before recruit; recovery from race condition will not be possible", "error", err)
-		}
-		pm.logger.InfoContext(ctx, "Recruiting standby: pausing replication",
-			"revoked_below_term", revokedBelowTerm)
-		if _, err := pm.pauseReplication(ctx,
-			multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_RECEIVER_ONLY,
-			true /* wait */); err != nil {
-			eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
-			return nil, mterrors.Wrap(err, "failed to pause replication during recruit")
-		}
-		if _, err := pm.waitForReplayStabilize(ctx); err != nil {
+	}
+
+	if !isPrimary {
+		stabilizeCtx, stabilizeSpan := telemetry.Tracer().Start(ctx, "consensus/stabilize")
+		_, err = pm.waitForReplayStabilize(stabilizeCtx)
+		stabilizeSpan.End()
+		if err != nil {
 			eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
 			return nil, mterrors.Wrap(err, "failed waiting for replay to stabilize during recruit")
 		}
@@ -366,7 +378,12 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", err)
 		return nil, mterrors.Wrap(err, "failed to read stable status after stopping replication")
 	}
-	if err := pm.consensusState.AcceptRevocation(ctx, stableStatus, revocation); err != nil {
+	{
+		acceptCtx, acceptSpan := telemetry.Tracer().Start(ctx, "consensus/accept-revocation")
+		err = pm.consensusState.AcceptRevocation(acceptCtx, stableStatus, revocation)
+		acceptSpan.End()
+	}
+	if err != nil {
 		raceErr := mterrors.Wrap(err, "failed to persist term revocation")
 		eventlog.Emit(ctx, pm.logger, eventlog.Failed, termEvent, "error", raceErr)
 		// Attempt to restore the node to its prior replication role.
@@ -560,7 +577,7 @@ func (pm *MultiPoolerManager) Propose(ctx context.Context, req *consensusdatapb.
 	if req.GetProposal().GetSkipOutgoingQuorum() {
 		ruleUpdate.withSkipOutgoingQuorum()
 	}
-	if _, err = pm.rules.updateRule(ctx, ruleUpdate); err != nil {
+	if _, err = pm.DoUpdateRule(ctx, ruleUpdate); err != nil {
 		return nil, mterrors.Wrap(err, "propose failed: could not write rule")
 	}
 	pm.healthStreamer.UpdateLeaderObservation(&poolerserver.LeaderObservation{

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -446,7 +446,7 @@ func TestRecruit(t *testing.T) {
 				// No further mocks — emergencyDemoteLocked fails on its first query.
 			},
 			expectError:                true,
-			expectErrContains:          "failed to demote primary during recruit",
+			expectErrContains:          "failed to stop replication during recruit",
 			expectPersistedTerm:        3,
 			expectPersistedCoordinator: "",
 		},

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -512,7 +512,7 @@ func (pm *MultiPoolerManager) UpdateConsensusRule(ctx context.Context, operation
 		withPreviousRule(
 			expectedOutgoingRule.GetCoordinatorTerm(),
 			expectedOutgoingRule.GetLeaderSubterm())
-	if _, err := pm.rules.updateRule(ctx, standbyUpdate); err != nil {
+	if _, err := pm.DoUpdateRule(ctx, standbyUpdate); err != nil {
 		return mterrors.Wrap(err, "failed to record replication config history")
 	}
 

--- a/go/services/multipooler/manager/rule_store.go
+++ b/go/services/multipooler/manager/rule_store.go
@@ -24,6 +24,9 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/timeouts"
@@ -31,6 +34,7 @@ import (
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	"github.com/multigres/multigres/go/services/multipooler/executor"
+	"github.com/multigres/multigres/go/tools/telemetry"
 )
 
 // ruleStorer is the interface for reading and writing the current shard rule.
@@ -662,10 +666,21 @@ func (rs *ruleStore) updateRule(ctx context.Context, update *ruleUpdateBuilder) 
 		}
 	}
 
-	// Write the rule. The remote-operation timeout applies because this write must be
-	// acknowledged by synchronous standbys; a timeout indicates replication is not functioning.
-	execCtx, cancel := context.WithTimeout(ctx, timeouts.RemoteOperationTimeout)
+	// Write the rule. This write blocks until a sync-standby WAL ack arrives.
+	// For promotions the ack only arrives after the full SetTermPrimary round-trip
+	// (Recruit clears all replication; standbys reconnect only after SetTermPrimary,
+	// including optional pg_rewind). For primary-side cohort changes standbys are
+	// already streaming and the ack is nearly immediate. RuleWriteTimeout covers
+	// both cases.
+	execCtx, cancel := context.WithTimeout(ctx, timeouts.RuleWriteTimeout)
 	defer cancel()
+
+	if isPromotion {
+		var ackSpan trace.Span
+		execCtx, ackSpan = telemetry.Tracer().Start(execCtx, "consensus/standby-ack",
+			trace.WithAttributes(attribute.Bool("is_promotion", true)))
+		defer ackSpan.End()
+	}
 
 	result, err := rs.queryService.QueryArgs(execCtx, `
 		WITH


### PR DESCRIPTION
## Summary

- Introduces `RuleWriteTimeout = 30 s` and applies it to the three election-flow RPCs — Recruit, Propose, and SetTermPrimary — and to the `rule_history` postgres write inside `updateRule` for all callers. For promotions the ack arrives after the full SetTermPrimary round-trip; for primary-side cohort changes standbys are already streaming and the ack is nearly immediate either way.
- Action timeouts for `AppointLeader` and `ShardInit` are computed from the constant (`2×RuleWriteTimeout + 5 s = 65 s`) so they automatically track any future adjustment.
- Adds `DoUpdateRule` on `MultiPoolerManager`, which wraps `updateRule` with a `consensus/rule-write` OTel span. All callers (`Propose`, `UpdateConsensusRule`) go through `DoUpdateRule` so every rule write is traced. Two further spans cover the promotion path: `consensus/pg-promote` and `consensus/standby-ack`.
- Adds `consensus/recruit` on the pooler side with three sub-spans: `consensus/stop-replication` (pauseReplication / emergencyDemoteLocked), `consensus/stabilize` (waitForReplayStabilize), and `consensus/accept-revocation` (AcceptRevocation). Together with the coordinator-side `consensus/recruit`, this makes the full pooler execution time visible in addition to the round-trip time.
- All pooler spans correlate with coordinator spans via gRPC trace propagation already wired in `grpccommon.NewClient`.

## Background

The `rule_history` write in `updateRule` uses `synchronous_commit = on`, which blocks until at least one streaming standby sends a WAL acknowledgment. The write is the durability gate: it proves the new consensus rule has reached a quorum of servers before the election is declared complete.

The problem is timing. The Recruit round runs before Propose, and it intentionally clears replication on every cohort member — standbys call `pauseReplication()` to stop streaming, the old primary is demoted to a standalone standby. By the time `Propose` runs and `pg_promote()` completes, **zero standbys are streaming**. `SetTermPrimary` — which tells standbys to reconnect — is dispatched concurrently with `Propose`, so the ack can only arrive after the full `SetTermPrimary` round-trip, which includes optional `pg_rewind` if a standby has diverged.

In the 9-pooler AZ-freeze test this took **8–14 seconds** against a 15 s `RemoteOperationTimeout`. One promotion timed out. Any scenario where standby reconnection is slower — `pg_rewind`, pod restart, cross-AZ latency under load — exceeds the old budget and fails the election.

Because the timeout is a deadline, not a sleep, increasing it does not slow promotions: postgres returns immediately when an ack arrives.

## Sequence of events

```mermaid
sequenceDiagram
    participant C as Coordinator
    participant L as Leader Candidate
    participant Lpg as Leader postgres
    participant S as Standbys

    Note over C,S: Recruit phase
    par
        C->>L: Recruit(term=N)
        L->>L: pauseReplication()<br/>clear primary_conninfo, stop streaming
        L-->>C: RecruitResponse(WAL pos)
    and
        C->>S: Recruit(term=N)
        S->>S: pauseReplication()<br/>clear primary_conninfo, stop streaming
        S-->>C: RecruitResponse(WAL pos)
    end

    Note over C: quorum assembled — build proposal

    Note over C,S: Propose + SetTermPrimary dispatched concurrently
    par
        C->>L: Propose(term=N, leader=L)
        L->>Lpg: pg_promote()
        Lpg-->>L: postgres is primary ✓
        Note over L,Lpg: INSERT rule_history<br/>synchronous_commit = on<br/>BLOCKS — zero standbys streaming<br/>waiting for WAL ack
        Lpg-->>S: WAL record (streaming replication)
        S-->>Lpg: WAL ack ✓
        Note over L,Lpg: write unblocks (8–14 s in logs)
        L-->>C: ProposeResponse ✓
    and
        C->>S: SetTermPrimary(leader=L)
        S->>S: set primary_conninfo → L
        S->>Lpg: connect replication stream
        S-->>C: SetTermPrimaryResponse ✓
    end
```

## Changes

| File | Change |
|---|---|
| `go/common/timeouts/rpc.go` | Add `RuleWriteTimeout = 30 s` |
| `go/services/multiorch/consensus/rule_change.go` | Use `RuleWriteTimeout` for Recruit, Propose, SetTermPrimary |
| `go/services/multiorch/recovery/actions/appoint_leader.go` | Action timeout = `2×RuleWriteTimeout + 5 s` |
| `go/services/multiorch/recovery/actions/shard_init_action.go` | Action timeout = `2×RuleWriteTimeout + 5 s` |
| `go/services/multipooler/manager/manager.go` | Add `DoUpdateRule` with `consensus/rule-write` span; add `consensus/pg-promote` span |
| `go/services/multipooler/manager/rpc_consensus.go` | Use `DoUpdateRule` in `Propose`; add `consensus/recruit` span with `consensus/stop-replication`, `consensus/stabilize`, `consensus/accept-revocation` sub-spans |
| `go/services/multipooler/manager/rpc_manager.go` | Use `DoUpdateRule` in `UpdateConsensusRule` handler |
| `go/services/multipooler/manager/rule_store.go` | Use `RuleWriteTimeout` for all rule writes; add `consensus/standby-ack` span |

## Test plan

- [x] Unit tests: `go test -short ./go/common/timeouts/... ./go/services/multiorch/... ./go/services/multipooler/...`
- [ ] Integration: `multiorch` bootstrap and failover tests pass with the new timeouts
- [ ] Verify in Tempo that `consensus/pg-promote`, `consensus/rule-write`, and `consensus/standby-ack` appear as children of the pooler's `consensus/propose` span during a promotion
- [ ] Verify that `consensus/stop-replication`, `consensus/stabilize`, and `consensus/accept-revocation` appear as children of the pooler's `consensus/recruit` span
- [ ] Confirm `consensus/standby-ack` span duration matches the 8–14 s observed in the AZ-freeze log analysis

Fixes MUL-554
