### PR TITLE
ci: trim query-serving cron load and split heavy suites behind a second label

### DIFF
--- a/.github/workflows/test-pgproto.yml
+++ b/.github/workflows/test-pgproto.yml
@@ -17,9 +17,10 @@ name: pgproto Wire-Protocol Conformance Suite
 # The suite gates on zero *unpatched* divergences: known divergences are
 # recorded as patches (testdata/patches/), so the Go test fails on anything
 # left. There is no baseline/regression tracking — the expected state is simply
-# "no unpatched divergences". Runs on the "Run Extended Query Serving Tests" PR
-# label (so a PR that introduces a divergence goes red) and once daily on cron
-# (which Slack-alerts on any failure).
+# "no unpatched divergences". Runs when a PR is labeled with either
+# "Run Extended Query Serving Tests" or "Run all Query Serving Tests" (so a PR
+# that introduces a divergence goes red) and once daily on cron (which
+# Slack-alerts on any failure).
 on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "30 9 * * *" # Daily 09:30 UTC
@@ -34,7 +35,8 @@ jobs:
     name: Run pgproto conformance suite
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
+      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests') ||
+      contains(github.event.pull_request.labels.*.name, 'Run all Query Serving Tests')
     runs-on: ubuntu-24.04
     environment:
       name: ci

--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -16,8 +16,9 @@ name: PostgreSQL Compatibility Tests
 
 on:
   schedule:
-    - cron: "0 3 * * *" # Nightly at 3:00 AM UTC
-    - cron: "0 9 * * 1" # Weekly summary: Monday 9:00 AM UTC
+    # Runs 3x/week. Monday's run also drives the weekly Slack summary.
+    - cron: "0 3 * * 1" # Monday 3:00 AM UTC (regression check + weekly summary)
+    - cron: "0 3 * * 3,5" # Wed/Fri 3:00 AM UTC (regression check only)
   pull_request:
     types: [labeled]
   workflow_dispatch:
@@ -171,7 +172,7 @@ jobs:
       - name: Notify Slack weekly summary
         if: >-
           !cancelled() &&
-          (github.event.schedule == '0 9 * * 1' || github.event_name == 'workflow_dispatch') &&
+          (github.event.schedule == '0 3 * * 1' || github.event_name == 'workflow_dispatch') &&
           steps.results.outputs.path != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PGREGRESS_WEBHOOK_URL }}

--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -30,7 +30,8 @@ jobs:
     name: Run PostgreSQL compatibility tests
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
+      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests') ||
+      contains(github.event.pull_request.labels.*.name, 'Run all Query Serving Tests')
     runs-on: ubuntu-24.04
     environment:
       name: ci

--- a/.github/workflows/test-sqllogictest.yml
+++ b/.github/workflows/test-sqllogictest.yml
@@ -29,7 +29,7 @@ jobs:
     name: Run sqllogictest differential suite
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
+      contains(github.event.pull_request.labels.*.name, 'Run all Query Serving Tests')
     runs-on: ubuntu-24.04
     environment:
       name: ci

--- a/.github/workflows/test-sqllogictest.yml
+++ b/.github/workflows/test-sqllogictest.yml
@@ -16,7 +16,8 @@ name: SQLLogicTest Differential Suite
 
 on: # yamllint disable-line rule:truthy
   schedule:
-    - cron: "30 9 * * 1" # Weekly: Monday 9:30 AM UTC
+    # Weekly Mon 10:00 UTC — staggered off pgproto's daily 09:30 slot.
+    - cron: "0 10 * * 1"
   pull_request:
     types: [labeled]
   workflow_dispatch:

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -54,7 +54,8 @@ than one is fine (the union runs):
 
 - `RUN_EXTENDED_QUERY_SERVING_TESTS=1` — runs **all** suites (regression,
   isolation, contrib). This is what CI uses (matches the "Run Extended Query
-  Serving Tests" PR label).
+  Serving Tests" PR label, and also the broader "Run all Query Serving Tests"
+  label).
 - `RUN_PGREGRESS=1` — runs the regression suite only. Useful for local
   iteration when you don't need isolation.
 - `RUN_PGISOLATION=1` — runs the isolation suite only.

--- a/go/test/endtoend/queryserving/pgproto/README.md
+++ b/go/test/endtoend/queryserving/pgproto/README.md
@@ -295,10 +295,12 @@ PGPASSWORD=<pw> bin/pgproto -h 127.0.0.1 -p <port> -u <user> -d <db> \
 
 `.github/workflows/test-pgproto.yml` runs the suite on:
 
-- **PRs labeled `Run Extended Query Serving Tests`** — opt-in per-PR (the same
-  label also triggers `sqllogictest` and `pgregresstest`). A PR that introduces
-  an unpatched divergence turns the check red, so you must either fix the gateway
-  or record the divergence with `make pgproto-update-patches`.
+- **PRs labeled `Run Extended Query Serving Tests` or `Run all Query Serving Tests`**
+  — opt-in per-PR. Both labels also trigger `pgregresstest`; only the broader
+  `Run all Query Serving Tests` additionally triggers the (much heavier)
+  `sqllogictest` suite. A PR that introduces an unpatched divergence turns the
+  check red, so you must either fix the gateway or record the divergence with
+  `make pgproto-update-patches`.
 - **Daily cron** (09:30 UTC) — a health check that Slack-alerts on any failure.
 - **`workflow_dispatch`** — manual kick.
 

--- a/go/test/endtoend/queryserving/sqllogictest/README.md
+++ b/go/test/endtoend/queryserving/sqllogictest/README.md
@@ -91,7 +91,7 @@ make tools
 make build
 
 # Run (skipped without RUN_EXTENDED_QUERY_SERVING_TESTS=1; matches the
-# "Run Extended Query Serving Tests" PR label).
+# "Run all Query Serving Tests" PR label).
 scripts/portpool.sh start
 RUN_EXTENDED_QUERY_SERVING_TESTS=1 \
   MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock \
@@ -154,8 +154,9 @@ Written under `builder.OutputDir` (i.e.
 
 `.github/workflows/test-sqllogictest.yml` runs the suite on:
 
-- **PRs labeled `Run Extended Query Serving Tests`** — opt-in per-PR. The
-  same label also triggers `pgregresstest`.
+- **PRs labeled `Run all Query Serving Tests`** — opt-in per-PR. This is the
+  "heavy tier" label; the cheaper `Run Extended Query Serving Tests` label
+  (pgproto + pgregresstest) does **not** trigger sqllogictest.
 - **Nightly cron** (`30 3 * * *` UTC) — baseline tracking.
 - **Weekly summary cron** (`30 9 * * 1` UTC) — Slack digest.
 - **`workflow_dispatch`** — manual kick.


### PR DESCRIPTION
## Summary

- Cut the pgregress nightly cron to 3×/week (Mon/Wed/Fri 03:00 UTC) and folded the Monday-only weekly Slack summary onto that same Monday run instead of a separate 09:00 cron — previously Monday triggered pgregress twice.
- Staggered the weekly sqllogictest cron from Monday 09:30 → Monday 10:00 UTC so it no longer collides with the daily pgproto run at 09:30.
- Split the existing `Run Extended Query Serving Tests` label into two tiers so the most expensive suite is opt-in for the few PRs that need it.

## Description

Today the `Run Extended Query Serving Tests` PR label fires pgproto, pgregress, and sqllogictest together. sqllogictest is by far the heaviest of the three (hundreds of corpus files × 4 invocations, 180-minute job timeout), and it's overkill for most PRs that touch query serving in small ways. This change introduces a second label, `Run all Query Serving Tests`, as a **superset** of the first:

| Label | pgproto | pgregress | sqllogictest |
| --- | :-: | :-: | :-: |
| `Run Extended Query Serving Tests` (existing) | ✓ | ✓ | — |
| `Run all Query Serving Tests` (new) | ✓ | ✓ | ✓ |

Reviewers who want the cheap tier pick the existing label; reviewers who want everything pick the new one. Nobody needs to apply both.

The Go-side env var (`RUN_EXTENDED_QUERY_SERVING_TESTS=1`) is unchanged — only the workflow-level PR-label gating moves. READMEs for pgproto, pgregresstest, and sqllogictest are updated to describe the new tiering.
