### PR TITLE
feat(pgregress): publish live compatibility badges via GitHub Pages

### DIFF
--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -31,6 +31,12 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'Run Extended Query Serving Tests')
     runs-on: ubuntu-24.04
+    # contents: write is needed to push the live badge endpoints to the
+    # gh-pages branch (see "Publish badge endpoints to GitHub Pages"). The push
+    # only happens on scheduled/manual runs; on pull_request (label) runs the
+    # publish step is gated off, and GITHUB_TOKEN is read-only for fork PRs.
+    permissions:
+      contents: write
     environment:
       name: ci
       deployment: false
@@ -88,6 +94,10 @@ jobs:
           results_file=$(find /tmp/multigres_pg_cache/results -name results.json -type f 2>/dev/null | head -1)
           if [[ -n "$results_file" ]]; then
             echo "path=$results_file" >> "$GITHUB_OUTPUT"
+            # The Go test writes shields.io endpoint JSON into a sibling badges/
+            # dir next to results.json (see WriteBadgeEndpoints). Publish this dir
+            # to GitHub Pages so the README/blog badges show the live pass count.
+            echo "badges=$(dirname "$results_file")/badges" >> "$GITHUB_OUTPUT"
             echo "Found results at: $results_file"
           else
             echo "No results.json found"
@@ -122,6 +132,25 @@ jobs:
           name: postgres-compatibility-results
           path: /tmp/multigres_pg_cache/results/**/*
           if-no-files-found: warn
+
+      # Publish the shields.io endpoint JSON to the gh-pages branch so the
+      # README/blog badges render the live pass count (e.g. 160/222). Republishing
+      # the JSON updates every badge that points at it — no markdown edits needed.
+      # keep_files: true preserves anything else already on gh-pages. Only runs on
+      # scheduled/manual runs (not PR-label runs) using the built-in GITHUB_TOKEN.
+      - name: Publish badge endpoints to GitHub Pages
+        if: >-
+          !cancelled() &&
+          steps.results.outputs.badges != '' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ steps.results.outputs.badges }}
+          publish_branch: gh-pages
+          destination_dir: pgregress
+          keep_files: true
+          commit_message: "chore(pgregress): update live badge endpoints"
 
       # On failure, surface the per-process logs from the shardsetup tempdir
       # (multipooler.log, pgctld.log, multigateway.log, multiorch.log). The
@@ -278,5 +307,6 @@ jobs:
           key: pgregress-baseline-${{ github.run_id }}
 
       # Note: the Go test writes the pass/fail summary (including shields.io badge)
-      # directly to GITHUB_STEP_SUMMARY via postgres_builder.go.
+      # directly to GITHUB_STEP_SUMMARY via postgres_builder.go, and the live
+      # badge endpoint JSON into results/badges/ (published to gh-pages above).
       # Full diffs are in the uploaded artifact (regression.diffs).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Multigres - Vitess for Postgres
 
+[![Overall](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/overall.json)](https://github.com/multigres/multigres/actions/workflows/test-pgregress.yml)
+[![Regression](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/regression.json)](https://github.com/multigres/multigres/actions/workflows/test-pgregress.yml)
+[![Isolation](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/isolation.json)](https://github.com/multigres/multigres/actions/workflows/test-pgregress.yml)
+[![Contrib Extension](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/contrib-extension.json)](https://github.com/multigres/multigres/actions/workflows/test-pgregress.yml)
+
 Multigres is a Vitess adaptation for Postgres. The project is currently in the early stages of development.
 
 Please visit the [Multigres site](https://multigres.com) if you'd like to try it.

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -230,6 +230,41 @@ RUN_EXTENDED_QUERY_SERVING_TESTS=1 go test -v -timeout 60m ./go/test/endtoend/pg
 2. Free up space (source ~200MB, builds ~500MB)
 3. Use custom cache location: `export MULTIGRES_PG_CACHE_DIR=~/multigres_cache`
 
+## Live Results & Badges
+
+The nightly CI run publishes the current pass count to GitHub Pages as
+[shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON, so the
+README badges (and any blog post or doc that embeds them) render the live number
+and update automatically after each run — no markdown edits.
+
+Each suite gets a stable JSON URL under `https://multigres.github.io/multigres/pgregress/`:
+
+<!-- markdownlint-disable MD013 -->
+
+| Suite             | JSON endpoint                                                            | Badge markdown                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Overall           | `https://multigres.github.io/multigres/pgregress/overall.json`           | `![Overall](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/overall.json)`                     |
+| Regression        | `https://multigres.github.io/multigres/pgregress/regression.json`        | `![Regression](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/regression.json)`               |
+| Isolation         | `https://multigres.github.io/multigres/pgregress/isolation.json`         | `![Isolation](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/isolation.json)`                 |
+| Contrib Extension | `https://multigres.github.io/multigres/pgregress/contrib-extension.json` | `![Contrib Extension](https://img.shields.io/endpoint?url=https://multigres.github.io/multigres/pgregress/contrib-extension.json)` |
+
+<!-- markdownlint-enable MD013 -->
+
+The Go test writes these files (`WriteBadgeEndpoints` in `postgres_builder.go`)
+into a `badges/` directory next to `results.json`, and the `test-pgregress.yml`
+workflow pushes that directory to the `gh-pages` branch under `pgregress/` on
+scheduled/manual runs.
+
+### One-time setup
+
+GitHub Pages must be enabled once for the badges to resolve:
+
+1. **Settings → Pages → Build and deployment → Source: _Deploy from a branch_**,
+   branch `gh-pages`, folder `/ (root)`.
+2. Trigger the workflow once (**Actions → PostgreSQL Compatibility Tests → Run
+   workflow**) so the first JSON files are published. Until then the badges show
+   shields.io's "endpoint not found" placeholder.
+
 ## Architecture
 
 ### Component Flow

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -300,6 +300,9 @@ func TestPostgreSQLRegression(t *testing.T) {
 		if _, err := builder.WriteJSONResults(t, suites); err != nil {
 			t.Logf("Warning: Failed to write JSON results: %v", err)
 		}
+		if err := builder.WriteBadgeEndpoints(t, suites); err != nil {
+			t.Logf("Warning: Failed to write badge endpoints: %v", err)
+		}
 	}
 }
 

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -968,6 +968,42 @@ func (pb *PostgresBuilder) WriteJSONResults(t *testing.T, suites []SuiteResult) 
 	return resultsPath, nil
 }
 
+// WriteBadgeEndpoints writes one shields.io endpoint JSON per suite plus a
+// combined "overall.json" into pb.OutputDir/badges. CI publishes this directory
+// to GitHub Pages so the README and blog badges render the live pass count
+// (republishing the JSON updates the badge with no markdown edits).
+//
+// Filenames are the suite label slug: regression.json, isolation.json,
+// contrib-extension.json, and overall.json. These names are part of the public
+// badge URL, so keep them stable.
+func (pb *PostgresBuilder) WriteBadgeEndpoints(t *testing.T, suites []SuiteResult) error {
+	t.Helper()
+
+	badgeDir := filepath.Join(pb.OutputDir, "badges")
+
+	var totalPassed, totalTests, totalExpected int
+	var anyTimedOut bool
+	for _, s := range suites {
+		label := strings.TrimSuffix(s.Name, " Tests")
+		endpoint := suiteutil.NewBadgeEndpoint(label, s.Results.PassedTests, s.Results.TotalTests, s.ExpectedTests, s.Results.TimedOut)
+		if _, err := suiteutil.WriteJSON(badgeDir, suiteutil.BadgeSlug(label)+".json", endpoint); err != nil {
+			return err
+		}
+		totalPassed += s.Results.PassedTests
+		totalTests += s.Results.TotalTests
+		totalExpected += s.ExpectedTests
+		anyTimedOut = anyTimedOut || s.Results.TimedOut
+	}
+
+	overall := suiteutil.NewBadgeEndpoint("Overall", totalPassed, totalTests, totalExpected, anyTimedOut)
+	if _, err := suiteutil.WriteJSON(badgeDir, "overall.json", overall); err != nil {
+		return err
+	}
+
+	t.Logf("Badge endpoints written to: %s", badgeDir)
+	return nil
+}
+
 // patchIsolationtester rewrites two pieces of
 // src/test/isolation/isolationtester.c so the harness works against
 // multigateway:

--- a/go/test/endtoend/suiteutil/report.go
+++ b/go/test/endtoend/suiteutil/report.go
@@ -116,6 +116,47 @@ func BadgeMarkdown(label string, passed, total, expected int, timedOut bool) str
 	return fmt.Sprintf("![%s](https://img.shields.io/badge/%s-%s-%s)", label, encodeBadgeField(label), value, colour)
 }
 
+// BadgeEndpoint is the shields.io "endpoint" badge schema. Serialized to JSON
+// and published to a stable public URL, it lets a README or blog badge
+// re-render the current pass count at view time — republishing the JSON updates
+// every badge that references it, with no markdown edits.
+// See https://shields.io/badges/endpoint-badge.
+type BadgeEndpoint struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Label         string `json:"label"`
+	Message       string `json:"message"`
+	Color         string `json:"color"`
+}
+
+// NewBadgeEndpoint builds a shields.io endpoint badge payload from a suite's
+// pass count. It mirrors BadgeMarkdown's message and colour rules (the expected
+// denominator when a run is partial, and the timed-out downgrade) but renders
+// the message as plain text suitable for the endpoint "message" field — no URL
+// escaping, since shields reads it from JSON rather than the URL path.
+func NewBadgeEndpoint(label string, passed, total, expected int, timedOut bool) BadgeEndpoint {
+	colour := BadgeColor(passed, total)
+	message := fmt.Sprintf("%d/%d passed", passed, total)
+	if expected > 0 && expected > total {
+		message = fmt.Sprintf("%d/%d passed (of %d)", passed, total, expected)
+	}
+	if timedOut {
+		message += " (timed out)"
+		if colour == "brightgreen" {
+			colour = "yellow"
+		}
+	}
+	return BadgeEndpoint{SchemaVersion: 1, Label: label, Message: message, Color: colour}
+}
+
+// BadgeSlug converts a suite label into a stable, URL-safe filename stem for its
+// endpoint JSON (e.g. "Contrib Extension" -> "contrib-extension"). The slug is
+// the published URL path, so keep it stable: README/blog badge URLs depend on
+// it.
+func BadgeSlug(label string) string {
+	s := strings.ToLower(strings.TrimSpace(label))
+	return strings.ReplaceAll(s, " ", "-")
+}
+
 // encodeBadgeField escapes a string for use in a shields.io badge URL path
 // segment: literal underscores and dashes are doubled, then spaces become
 // single underscores (which shields.io renders back as spaces). Order matters —

--- a/go/test/endtoend/suiteutil/report_test.go
+++ b/go/test/endtoend/suiteutil/report_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package suiteutil
+
+import "testing"
+
+func TestNewBadgeEndpoint(t *testing.T) {
+	tests := []struct {
+		name                    string
+		label                   string
+		passed, total, expected int
+		timedOut                bool
+		wantMessage, wantColor  string
+	}{
+		{
+			name:        "partial pass",
+			label:       "Regression",
+			passed:      160,
+			total:       222,
+			wantMessage: "160/222 passed",
+			wantColor:   "orange", // 72% -> 50..79% -> orange
+		},
+		{
+			name:        "all pass",
+			label:       "Isolation",
+			passed:      80,
+			total:       80,
+			wantMessage: "80/80 passed",
+			wantColor:   "brightgreen",
+		},
+		{
+			name:        "timed out downgrades brightgreen and annotates",
+			label:       "Contrib Extension",
+			passed:      10,
+			total:       10,
+			timedOut:    true,
+			wantMessage: "10/10 passed (timed out)",
+			wantColor:   "yellow",
+		},
+		{
+			name:        "partial run shows expected denominator",
+			label:       "Regression",
+			passed:      100,
+			total:       150,
+			expected:    222,
+			timedOut:    true,
+			wantMessage: "100/150 passed (of 222) (timed out)",
+			wantColor:   "orange", // 66% -> orange, not brightgreen so no downgrade
+		},
+		{
+			name:        "no data",
+			label:       "Overall",
+			passed:      0,
+			total:       0,
+			wantMessage: "0/0 passed",
+			wantColor:   "lightgrey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := NewBadgeEndpoint(tt.label, tt.passed, tt.total, tt.expected, tt.timedOut)
+			if ep.SchemaVersion != 1 {
+				t.Errorf("SchemaVersion = %d, want 1", ep.SchemaVersion)
+			}
+			if ep.Label != tt.label {
+				t.Errorf("Label = %q, want %q", ep.Label, tt.label)
+			}
+			if ep.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", ep.Message, tt.wantMessage)
+			}
+			if ep.Color != tt.wantColor {
+				t.Errorf("Color = %q, want %q", ep.Color, tt.wantColor)
+			}
+		})
+	}
+}
+
+func TestBadgeSlug(t *testing.T) {
+	cases := map[string]string{
+		"Regression":        "regression",
+		"Isolation":         "isolation",
+		"Contrib Extension": "contrib-extension",
+		"Overall":           "overall",
+		"  Spaced  ":        "spaced",
+	}
+	for in, want := range cases {
+		if got := BadgeSlug(in); got != want {
+			t.Errorf("BadgeSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Make the pgregress pass counts (e.g. `160/222`) live and URL-addressable so they can be referenced from the README and external pages (blog posts, docs) without going stale — a fix bumps the number everywhere on the next nightly run, no edits needed.
- The nightly compatibility job now publishes [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON for each suite (Regression, Isolation, Contrib Extension) plus an overall total to GitHub Pages, and the project README shows the corresponding live badges.

## Description

shields.io endpoint badges read their text from a JSON file at view time, so republishing the JSON updates every badge that points at it. The pieces:

- `suiteutil/report.go`: `NewBadgeEndpoint(...)` builds the endpoint JSON (`schemaVersion`/`label`/`message`/`color`) from a suite's pass counts, reusing the existing `BadgeColor` and timeout/expected-denominator rules. `BadgeSlug(...)` derives the stable filename stem. Covered by `report_test.go`.
- `pgregresstest/postgres_builder.go`: `WriteBadgeEndpoints(...)` writes `regression.json`, `isolation.json`, `contrib-extension.json`, and `overall.json` into a `badges/` dir next to the existing `results.json`. Called from Phase 7 in `pgregress_test.go`.
- `.github/workflows/test-pgregress.yml`: on scheduled/manual runs (not PR-label runs), pushes that `badges/` dir to the `gh-pages` branch under `pgregress/` via SHA-pinned `peaceiris/actions-gh-pages`, using the built-in `GITHUB_TOKEN` (`contents: write`, `keep_files: true`). No secret to manage.
- `README.md`: four live badges at the top. `pgregresstest/README.md`: documents the URLs and the one-time Pages setup.

Only the public pass counts are exposed via the JSON — failing test names, diffs, and logs remain in the CI step summary and artifacts as before.

## One-time setup (after merge)

1. Settings → Pages → Source: Deploy from a branch → `gh-pages` / root.
2. Run the workflow once (Actions → PostgreSQL Compatibility Tests → Run workflow) so the first JSON files publish. Until then the badges show shields.io's "endpoint not found" placeholder.