### PR TITLE
feat(pgregresstest): run pgvector's regression suite through multigateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export PGPROTO_VER
 CMDS = multigateway multipooler pgctld multiorch multigres multiadmin portpoolserver
 BIN_DIR = bin
 
-.PHONY: all build build-all clean images install test test-coverage pgregress pgregress-update-patches pgproto pgproto-update-patches proto tools parser help
+.PHONY: all build build-all clean images install test test-coverage pgregress pgregress-update-patches pgexternal pgexternal-update-patches pgproto pgproto-update-patches proto tools parser help
 
 ##@ General
 
@@ -162,6 +162,23 @@ pgregress: build ## Run the PostgreSQL regression suite with patch-based verific
 # diff before merging.
 pgregress-update-patches: build ## Regenerate testdata/pg17/patches/*.patch from the current run.
 	RUN_PGREGRESS=1 PGREGRESS_PATCH_MODE=generate \
+	go test -v -timeout 60m -run TestPostgreSQLRegression ./go/test/endtoend/pgregresstest/...
+
+# Run the external extension suite (e.g. pgvector). Clones and builds each
+# external extension as a PGXS module against the from-source PostgreSQL, then
+# runs its shipped pg_regress suite through multigateway with patch-based
+# verification. Known divergences are recorded under
+# testdata/pg17/patches/external/<ext>/.
+pgexternal: build ## Run the external extension suite (e.g. pgvector) with patch-based verification.
+	RUN_PGEXTERNAL=1 PGREGRESS_PATCH_MODE=verify \
+	go test -v -timeout 60m -run TestPostgreSQLRegression ./go/test/endtoend/pgregresstest/...
+
+# Re-run the external extension suite in generate mode: any residual diff between
+# actual output and patched-expected output is absorbed by (re)writing
+# testdata/pg17/patches/external/<ext>/<name>.patch. Review the resulting patches
+# in the PR diff before merging.
+pgexternal-update-patches: build ## Regenerate testdata/pg17/patches/external/*.patch from the current run.
+	RUN_PGEXTERNAL=1 PGREGRESS_PATCH_MODE=generate \
 	go test -v -timeout 60m -run TestPostgreSQLRegression ./go/test/endtoend/pgregresstest/...
 
 # Run the pgproto wire-protocol conformance suite (patch-verify mode). Requires

--- a/go/test/endtoend/pgbuilder/builder.go
+++ b/go/test/endtoend/pgbuilder/builder.go
@@ -56,6 +56,11 @@ type Builder struct {
 	BuildDir string
 	// InstallDir is the per-invocation install prefix (contains bin/, lib/, share/).
 	InstallDir string
+	// ExternalDir is the per-invocation root under which external extensions
+	// (KindExternal, e.g. pgvector) are cloned and built as PGXS modules. It is
+	// per-run (under the same build root as BuildDir) so concurrent callers
+	// don't share a checkout, and is removed by Cleanup along with the build.
+	ExternalDir string
 	// OutputDir is a persistent per-invocation directory for caller-written artifacts
 	// (reports, diffs, etc.). pgbuilder itself does not write here.
 	OutputDir string
@@ -82,10 +87,11 @@ func New(t *testing.T) *Builder {
 	buildRoot := filepath.Join(cacheDir, "builds", timestamp)
 
 	return &Builder{
-		SourceDir:  filepath.Join(cacheDir, "source", "postgres"),
-		BuildDir:   filepath.Join(buildRoot, "build"),
-		InstallDir: filepath.Join(buildRoot, "install"),
-		OutputDir:  filepath.Join(cacheDir, "results", timestamp),
+		SourceDir:   filepath.Join(cacheDir, "source", "postgres"),
+		BuildDir:    filepath.Join(buildRoot, "build"),
+		InstallDir:  filepath.Join(buildRoot, "install"),
+		ExternalDir: filepath.Join(buildRoot, "external"),
+		OutputDir:   filepath.Join(cacheDir, "results", timestamp),
 	}
 }
 
@@ -230,6 +236,59 @@ func (b *Builder) InstallContrib(t *testing.T, ctx context.Context) error {
 
 	t.Logf("contrib modules installed to %s", b.InstallDir)
 	return nil
+}
+
+// InstallExternalExtension clones an external extension's repo at a pinned tag
+// into b.ExternalDir/<name>, builds it as a PGXS module against this builder's
+// from-source PostgreSQL, and installs it into b.InstallDir. It returns the
+// checkout directory so the caller can drive the extension's shipped pg_regress
+// suite (sql/ + expected/) from there. Must be called after Build().
+//
+// The build is pointed at the per-run install tree via PG_CONFIG so the
+// extension's .so links against the exact PostgreSQL the cluster runs (the same
+// ABI-consistency guarantee Build provides for regress.so). The checkout is
+// per-run, so a shallow clone happens once per invocation; pinning the tag keeps
+// the suite reproducible.
+func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, name, repo, tag string) (string, error) {
+	t.Helper()
+
+	if err := os.MkdirAll(b.ExternalDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create external dir: %w", err)
+	}
+	cloneDir := filepath.Join(b.ExternalDir, name)
+
+	t.Logf("Cloning external extension %s (%s) from %s...", name, tag, repo)
+	clone := executil.Command(ctx, "git", "clone",
+		"--depth=1",
+		"--branch", tag,
+		repo,
+		cloneDir)
+	var stderr bytes.Buffer
+	clone.Stderr = &stderr
+	if err := clone.Run(); err != nil {
+		return "", fmt.Errorf("failed to clone %s: %w (stderr: %s)", name, err, stderr.String())
+	}
+
+	pgConfig := filepath.Join(b.BinDir(), "pg_config")
+
+	t.Logf("Building external extension %s with PGXS (PG_CONFIG=%s)...", name, pgConfig)
+	makeCmd := executil.Command(ctx, "make", "-C", cloneDir, "-j", "4", "PG_CONFIG="+pgConfig)
+	makeCmd.Stdout = os.Stdout
+	makeCmd.Stderr = os.Stderr
+	if err := makeCmd.Run(); err != nil {
+		return "", fmt.Errorf("make %s failed: %w", name, err)
+	}
+
+	t.Logf("Installing external extension %s into %s...", name, b.InstallDir)
+	installCmd := executil.Command(ctx, "make", "-C", cloneDir, "PG_CONFIG="+pgConfig, "install")
+	installCmd.Stdout = os.Stdout
+	installCmd.Stderr = os.Stderr
+	if err := installCmd.Run(); err != nil {
+		return "", fmt.Errorf("make %s install failed: %w", name, err)
+	}
+
+	t.Logf("External extension %s installed", name)
+	return cloneDir, nil
 }
 
 // Cleanup removes per-invocation build and install artifacts but leaves the

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -49,18 +49,20 @@ xcode-select --install
 
 ### Basic Usage
 
-The test is **disabled by default**. Four env vars enable it; setting more
+The test is **disabled by default**. Five env vars enable it; setting more
 than one is fine (the union runs):
 
 - `RUN_EXTENDED_QUERY_SERVING_TESTS=1` — runs **all** suites (regression,
-  isolation, contrib). This is what CI uses (matches the "Run Extended Query
-  Serving Tests" PR label, and also the broader "Run all Query Serving Tests"
-  label).
+  isolation, contrib, external). This is what CI uses (matches the "Run Extended
+  Query Serving Tests" PR label, and also the broader "Run all Query Serving
+  Tests" label).
 - `RUN_PGREGRESS=1` — runs the regression suite only. Useful for local
   iteration when you don't need isolation.
 - `RUN_PGISOLATION=1` — runs the isolation suite only.
 - `RUN_PGCONTRIB=1` — runs the contrib extension suite only (see
   "Contrib Extension Tests" below).
+- `RUN_PGEXTERNAL=1` — runs the external extension suite only (see
+  "External Extension Tests" below).
 
 ```bash
 # Run both suites (unified report) — same as CI
@@ -87,6 +89,9 @@ PGISOLATION_TESTS="deadlock-simple tuplelock-update" RUN_PGISOLATION=1 go test -
 
 # Run specific contrib modules only (directory names under contrib/)
 PGCONTRIB_TESTS="citext hstore" RUN_PGCONTRIB=1 go test -v -timeout 60m ./go/test/endtoend/pgregresstest/...
+
+# Run specific external extensions only (catalog names)
+PGEXTERNAL_TESTS="vector" RUN_PGEXTERNAL=1 go test -v -timeout 60m ./go/test/endtoend/pgregresstest/...
 ```
 
 ## Contrib Extension Tests
@@ -133,6 +138,49 @@ results: covered extensions expand to one row per sub-test with the live
 pass/fail, while pending/unsupported/external extensions show a single row with
 the reason. The table is the living coverage tracker — it updates automatically
 as catalog entries move to `covered` and their suites run.
+
+## External Extension Tests
+
+The external suite runs the pg_regress suites of extensions that live **outside**
+the PostgreSQL source tree (separate repositories), executed through
+multigateway. pgvector is the first: catalog name `vector`, pinned to a tag in
+`externalSpecs` (`extensions.go`).
+
+How it works, and how it differs from the contrib suite:
+
+- **Build**: each external extension is a [PGXS](https://www.postgresql.org/docs/current/extend-pgxs.html)
+  module. `Builder.InstallExternalExtension` shallow-clones the pinned tag into
+  the per-run build root, then runs `make && make install` with
+  `PG_CONFIG` pointed at the from-source PostgreSQL so the extension `.so` links
+  against the exact server ABI the cluster runs (the same guarantee the suite
+  gives `regress.so`). pgvector needs only a C compiler — no extra system libs.
+- **Test execution**: unlike contrib we cannot use `make installcheck`. Under
+  PGXS that target invokes `$(top_builddir)/src/test/regress/pg_regress`, and
+  PGXS resolves `top_builddir` into the **install** tree, where `pg_regress` is
+  not installed. The harness instead invokes the `pg_regress` it built directly,
+  with the same flags the contrib suite relies on
+  (`--use-existing --dbname=postgres`, because multigateway rejects DROP/CREATE
+  DATABASE) plus the extension's `--inputdir`/`--load-extension`. The test list
+  is derived from `test/sql/*.sql`, mirroring the extension's
+  `REGRESS = $(patsubst test/sql/%.sql,%,$(wildcard test/sql/*.sql))`.
+- **Per-extension isolation** and **verification** work exactly like contrib:
+  the `public` schema is reset on the primary between extensions, and results go
+  through the same patch pipeline (`PGREGRESS_PATCH_MODE`). Genuine
+  multigres-specific output differences are captured under
+  `testdata/pg17/patches/external/<ext>/`.
+
+Enrolling another external extension is a two-line change: add its
+`externalSpecs` entry (repo + pinned tag) and flip its `ExtensionCatalog` row to
+`StatusCovered`. The catalog and report update automatically. Extensions that
+need toolchains the harness doesn't provision (Rust: `pg_graphql`, `wrappers`)
+or that the pooler blocks by design (outbound connections) stay `StatusExternal`
+/ `StatusUnsupported`.
+
+Regenerate the patches after an output change with:
+
+```bash
+make pgexternal-update-patches   # RUN_PGEXTERNAL=1 PGREGRESS_PATCH_MODE=generate
+```
 
 ### First Run vs Cached Runs
 

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -28,7 +28,10 @@ const (
 	// contrib/, so the pgregress harness can build and run its suite directly.
 	KindContrib ExtKind = "contrib"
 	// KindExternal: the extension lives in a separate repository (not in the
-	// PostgreSQL source tree) and needs bespoke build infrastructure.
+	// PostgreSQL source tree) and needs bespoke build infrastructure (clone its
+	// repo at a pinned tag, build it as a PGXS module against the from-source
+	// PostgreSQL, then run its shipped pg_regress suite — see externalSpecs and
+	// Builder.InstallExternalExtension).
 	KindExternal ExtKind = "external"
 )
 
@@ -36,8 +39,10 @@ const (
 type ExtStatus string
 
 const (
-	// StatusCovered: wired into the contrib suite (see ExtensionCatalog →
-	// CoveredContribModules); its pg_regress suite runs through multigateway.
+	// StatusCovered: wired into a suite that runs the extension's pg_regress
+	// tests through multigateway. For KindContrib that is the contrib suite
+	// (ExtensionCatalog → CoveredContribModules); for KindExternal it is the
+	// external suite (CoveredExternalExtensions, backed by externalSpecs).
 	StatusCovered ExtStatus = "covered"
 	// StatusPending: a core-contrib module with a pg_regress suite that this
 	// harness could run but has not been wired up yet.
@@ -102,17 +107,70 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"supabase_vault", KindExternal, StatusExternal, ""},
 	{"unaccent", KindContrib, StatusCovered, ""},
 	{"uuid-ossp", KindContrib, StatusCovered, "needs --with-uuid"},
-	{"vector", KindExternal, StatusExternal, "pgvector"},
+	{"vector", KindExternal, StatusCovered, "pgvector; built as a PGXS module from externalSpecs"},
 	{"wrappers", KindExternal, StatusExternal, "Rust"},
 }
 
+// ExternalExtension describes one external (non-contrib) extension wired into
+// the external suite: its catalog name plus the git coordinates the harness
+// clones and builds it from.
+type ExternalExtension struct {
+	Name string
+	Repo string
+	Tag  string
+}
+
+// externalSpecs holds the build coordinates (git repo + pinned tag) for every
+// external extension the harness can build. An ExtensionCatalog entry with
+// Kind==KindExternal can only be StatusCovered if it also has a spec here; the
+// pinned tag keeps the suite reproducible (and matches the pgvector ABI the
+// from-source PostgreSQL was built against). Keyed by catalog Name.
+var externalSpecs = map[string]ExternalExtension{
+	"vector": {Name: "vector", Repo: "https://github.com/pgvector/pgvector", Tag: "v0.8.1"},
+}
+
+// CoveredExternalExtensions returns the external extensions the suite builds and
+// tests, derived from ExtensionCatalog (every KindExternal+StatusCovered entry)
+// joined with its build spec. An entry marked covered without a matching spec is
+// a configuration error and is skipped (CheckExternalSpecs surfaces it as a
+// hard failure so it can't silently drop coverage).
+func CoveredExternalExtensions() []ExternalExtension {
+	var exts []ExternalExtension
+	for _, e := range ExtensionCatalog {
+		if e.Kind == KindExternal && e.Status == StatusCovered {
+			if spec, ok := externalSpecs[e.Name]; ok {
+				exts = append(exts, spec)
+			}
+		}
+	}
+	return exts
+}
+
+// CheckExternalSpecs verifies every covered external extension has a build spec.
+// Returns the names missing a spec so the caller can fail loudly rather than
+// silently testing nothing.
+func CheckExternalSpecs() []string {
+	var missing []string
+	for _, e := range ExtensionCatalog {
+		if e.Kind == KindExternal && e.Status == StatusCovered {
+			if _, ok := externalSpecs[e.Name]; !ok {
+				missing = append(missing, e.Name)
+			}
+		}
+	}
+	return missing
+}
+
 // CoveredContribModules returns the contrib module directories the suite runs,
-// derived from ExtensionCatalog (every StatusCovered entry). This is the single
-// source of truth; DefaultContribModules is built from it.
+// derived from ExtensionCatalog (every KindContrib+StatusCovered entry). This is
+// the single source of truth; DefaultContribModules is built from it. External
+// covered extensions are intentionally excluded — they ship outside the
+// PostgreSQL source tree and run through the separate external suite
+// (CoveredExternalExtensions).
 func CoveredContribModules() []string {
 	var mods []string
 	for _, e := range ExtensionCatalog {
-		if e.Status == StatusCovered {
+		if e.Kind == KindContrib && e.Status == StatusCovered {
 			mods = append(mods, e.Name)
 		}
 	}
@@ -158,13 +216,18 @@ func statusCell(s ExtStatus) string {
 // rest so the grouping reads cleanly. Non-covered extensions get a single row
 // with the reason in Notes.
 //
-// contrib may be nil (no contrib suite ran), in which case covered extensions
-// show "—" results.
-func ExtensionCoverageMarkdown(contrib *TestResults) string {
-	// Group this run's per-test results by module ("mod/test" → mod).
+// suites are this run's per-test result sets whose tests are named "mod/test"
+// (the contrib and external suites). Any may be nil (that suite did not run), in
+// which case its covered extensions show "—" results.
+func ExtensionCoverageMarkdown(suites ...*TestResults) string {
+	// Group this run's per-test results by module ("mod/test" → mod) across
+	// every suite (contrib + external share the same module-prefixed naming).
 	byModule := map[string][]IndividualTestResult{}
-	if contrib != nil {
-		for _, tr := range contrib.Tests {
+	for _, suite := range suites {
+		if suite == nil {
+			continue
+		}
+		for _, tr := range suite.Tests {
 			mod, test, ok := strings.Cut(tr.Name, "/")
 			if !ok {
 				continue

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -38,32 +38,46 @@ import (
 // 6. Runs regression tests through multigateway (if enabled)
 // 7. Runs isolation tests through multigateway (if enabled)
 // 8. Runs contrib extension tests through multigateway (if enabled)
-// 9. Generates a unified compatibility report
+// 9. Runs external extension tests (e.g. pgvector) through multigateway (if enabled)
+// 10. Generates a unified compatibility report
 //
 // The test is skipped by default. Enable via one of:
 //   - RUN_EXTENDED_QUERY_SERVING_TESTS=1 — runs all suites (what CI uses)
 //   - RUN_PGREGRESS=1 — runs the regression suite only (local iteration)
 //   - RUN_PGISOLATION=1 — runs the isolation suite only (local iteration)
 //   - RUN_PGCONTRIB=1 — runs the contrib extension suite only (local iteration)
+//   - RUN_PGEXTERNAL=1 — runs the external extension suite only (local iteration)
 //
 // Setting more than one is fine; the union is run.
 //
 // Environment variables:
-//   - RUN_EXTENDED_QUERY_SERVING_TESTS=1 — enable regression, isolation, and contrib
+//   - RUN_EXTENDED_QUERY_SERVING_TESTS=1 — enable regression, isolation, contrib, and external
 //   - RUN_PGREGRESS=1 — enable regression only
 //   - RUN_PGISOLATION=1 — enable isolation only
 //   - RUN_PGCONTRIB=1 — enable contrib extension suite only
+//   - RUN_PGEXTERNAL=1 — enable external extension suite only
 //   - PGREGRESS_TESTS="boolean char" — run only specific regression tests
 //   - PGISOLATION_TESTS="deadlock-simple tuplelock-update" — run only specific isolation tests
 //   - PGCONTRIB_TESTS="citext hstore" — run only specific contrib modules (directory names)
+//   - PGEXTERNAL_TESTS="vector" — run only specific external extensions (catalog names)
 func TestPostgreSQLRegression(t *testing.T) {
 	extendedGate := os.Getenv(suiteutil.EnvRunExtendedQueryServingTests) == "1"
 	runRegress := extendedGate || os.Getenv("RUN_PGREGRESS") == "1"
 	runIsolation := extendedGate || os.Getenv("RUN_PGISOLATION") == "1"
 	runContrib := extendedGate || os.Getenv("RUN_PGCONTRIB") == "1"
-	if !runRegress && !runIsolation && !runContrib {
-		t.Skipf("skipping: set %s=1, or RUN_PGREGRESS=1 / RUN_PGISOLATION=1 / RUN_PGCONTRIB=1, to run",
+	runExternal := extendedGate || os.Getenv("RUN_PGEXTERNAL") == "1"
+	if !runRegress && !runIsolation && !runContrib && !runExternal {
+		t.Skipf("skipping: set %s=1, or RUN_PGREGRESS=1 / RUN_PGISOLATION=1 / RUN_PGCONTRIB=1 / RUN_PGEXTERNAL=1, to run",
 			suiteutil.EnvRunExtendedQueryServingTests)
+	}
+
+	// External extensions (e.g. pgvector) are built as PGXS modules; fail loudly
+	// if one is marked covered in the catalog but lacks build coordinates rather
+	// than silently testing nothing.
+	if runExternal {
+		if missing := CheckExternalSpecs(); len(missing) > 0 {
+			t.Fatalf("external extensions marked covered but missing a build spec: %v", missing)
+		}
 	}
 
 	// Check build dependencies first (before doing anything expensive)
@@ -133,6 +147,19 @@ func TestPostgreSQLRegression(t *testing.T) {
 		t.Logf("Phase 2c: Installing contrib modules...")
 		if err := builder.InstallContrib(t, buildCtx); err != nil {
 			t.Fatalf("Failed to install contrib modules: %v", err)
+		}
+	}
+
+	// Phase 2d: Clone, build, and install external extensions (only when that
+	// suite will run). Each is a PGXS module living outside the PostgreSQL source
+	// tree (e.g. pgvector); it is built against the just-installed PostgreSQL so
+	// its .so matches the running server's ABI.
+	if runExternal {
+		t.Logf("Phase 2d: Installing external extensions...")
+		for _, ext := range CoveredExternalExtensions() {
+			if _, err := builder.InstallExternalExtension(t, buildCtx, ext.Name, ext.Repo, ext.Tag); err != nil {
+				t.Fatalf("Failed to install external extension %s: %v", ext.Name, err)
+			}
 		}
 	}
 
@@ -288,6 +315,45 @@ func TestPostgreSQLRegression(t *testing.T) {
 
 			if err != nil && results.TotalTests == 0 {
 				t.Fatalf("Contrib test harness failed to execute: %v", err)
+			}
+		})
+	}
+
+	// Reinitialize before the external suite if any prior suite ran — earlier
+	// suites can leave PostgreSQL in a degraded state.
+	if runExternal && (runRegress || runIsolation || runContrib) {
+		t.Logf("Reinitializing cluster before external suite...")
+		setup.ReinitializeCluster(t)
+	}
+
+	// Phase 6c: Run external extension tests
+	if runExternal {
+		t.Run("external", func(t *testing.T) {
+			suiteCtx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
+			defer cancel()
+
+			exts := ExternalModules()
+			// directPgPort lets the harness reset the public schema on the
+			// primary between extensions (bypassing the gateway's DDL block).
+			directPgPort := setup.GetPrimary(t).Pgctld.PgPort
+			results, err := builder.RunExternalTests(t, suiteCtx, exts, setup.MultigatewayPgPort, directPgPort, shardsetup.TestPostgresPassword)
+			if results == nil {
+				if err != nil {
+					t.Fatalf("External test harness failed to execute: %v", err)
+				}
+				t.Fatal("External test harness returned nil results")
+				return
+			}
+
+			logSuiteResults(t, "External", results)
+
+			suites = append(suites, SuiteResult{
+				Name:    "External Extension Tests",
+				Results: results,
+			})
+
+			if err != nil && results.TotalTests == 0 {
+				t.Fatalf("External test harness failed to execute: %v", err)
 			}
 		})
 	}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -512,6 +512,13 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			t.Logf("external/%s: warning: public schema reset failed: %v", ext.Name, err)
 		}
 
+		// Preload the extension: --use-existing skips pg_regress's own
+		// --load-extension step, and pgvector's fixtures assume it is already
+		// installed (see createExtensionViaGateway).
+		if err := createExtensionViaGateway(multigatewayPort, password, ext.Name); err != nil {
+			t.Logf("external/%s: warning: CREATE EXTENSION failed: %v", ext.Name, err)
+		}
+
 		t.Logf("Running external/%s pg_regress (%d tests) against multigateway...", ext.Name, len(tests))
 		args := []string{
 			"--inputdir=" + testDir,
@@ -522,7 +529,11 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			"--load-extension=" + ext.Name,
 		}
 		args = append(args, tests...)
-		cmd := executil.Command(ctx, pgRegress, args...).WithProcessGroup()
+		// Run from the clone root so psql's client-side \copy resolves the
+		// relative paths the fixtures use (e.g. pgvector's copy test does
+		// \copy t TO 'results/vector.bin'); pg_regress writes its results/ dir
+		// under --outputdir=cloneDir, which is this same directory.
+		cmd := executil.Command(ctx, pgRegress, args...).WithProcessGroup().SetDir(cloneDir)
 
 		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
 			suiteName: "External/" + ext.Name,
@@ -712,6 +723,39 @@ func resetContribState(directPgPort int, password string) error {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("exec [%s]: %w", stmt, err)
 		}
+	}
+	return nil
+}
+
+// createExtensionViaGateway runs CREATE EXTENSION IF NOT EXISTS through
+// multigateway — the same path the test queries take, so there's no
+// create-on-primary-then-read-from-standby replication race, and it doubles as
+// real coverage that CREATE EXTENSION works over the pooled path (CREATE
+// EXTENSION is not on the gateway's blocked-DDL list; contrib tests create their
+// own extensions through the gateway too).
+//
+// This is needed because pg_regress applies its --load-extension flag only
+// inside create_database(), which it calls solely when !use_existing (see
+// pg_regress.c). The external suite must pass --use-existing (multigateway
+// rejects CREATE/DROP DATABASE), so that load step never fires. Extensions whose
+// test fixtures assume the extension is preloaded (e.g. pgvector — its tests
+// open with a bare CREATE TABLE t (val vector(3)) and never CREATE EXTENSION
+// themselves) would otherwise fail every statement with "type ... does not
+// exist". Creating it here reproduces what create_database would have done.
+func createExtensionViaGateway(multigatewayPort int, password, ext string) error {
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		multigatewayPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer db.Close()
+
+	// ext comes from the controlled extension catalog, not user input; quote it
+	// as an identifier defensively all the same.
+	stmt := fmt.Sprintf(`CREATE EXTENSION IF NOT EXISTS "%s"`, ext)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("exec [%s]: %w", stmt, err)
 	}
 	return nil
 }

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -410,6 +411,162 @@ func (pb *PostgresBuilder) RunContribTests(t *testing.T, ctx context.Context, mo
 	return merged, nil
 }
 
+// ExternalModules returns the external extensions to test, defaulting to the
+// covered set (CoveredExternalExtensions). PGEXTERNAL_TESTS (space-separated
+// catalog names, e.g. "vector") selects a subset for local iteration.
+func ExternalModules() []ExternalExtension {
+	all := CoveredExternalExtensions()
+	sel := strings.Fields(os.Getenv("PGEXTERNAL_TESTS"))
+	if len(sel) == 0 {
+		return all
+	}
+	want := make(map[string]bool, len(sel))
+	for _, s := range sel {
+		want[s] = true
+	}
+	var out []ExternalExtension
+	for _, e := range all {
+		if want[e.Name] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// listRegressTests returns the regression test names for an external extension,
+// derived from the .sql files under <testDir>/sql. This mirrors the PGXS
+// convention REGRESS = $(patsubst test/sql/%.sql,%,$(wildcard test/sql/*.sql)).
+// Names are sorted so the run order is deterministic and matches make's sorted
+// $(wildcard).
+func listRegressTests(testDir string) []string {
+	matches, err := filepath.Glob(filepath.Join(testDir, "sql", "*.sql"))
+	if err != nil {
+		return nil
+	}
+	sort.Strings(matches)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, strings.TrimSuffix(filepath.Base(m), ".sql"))
+	}
+	return names
+}
+
+// RunExternalTests runs each external extension's shipped pg_regress suite
+// against multigateway and returns one merged TestResults across all of them.
+//
+// External (KindExternal) extensions are PGXS modules that live outside the
+// PostgreSQL source tree (see Builder.InstallExternalExtension, which has
+// already cloned and installed each one before this is called). They ship the
+// same sql/ + expected/ fixture layout as contrib, so verification reuses the
+// shared pipeline (verifyModuleResults). Per-test names are prefixed with the
+// extension name ("vector/btree") to stay unique in the merged report.
+//
+// Unlike contrib we cannot use `make installcheck`: under PGXS that target runs
+// $(top_builddir)/src/test/regress/pg_regress, and PGXS resolves top_builddir
+// into the install tree, where pg_regress is not installed. We instead invoke
+// the pg_regress we built directly, passing the same flags the contrib suite
+// relies on (--use-existing --dbname=postgres, because multigateway rejects
+// DROP/CREATE DATABASE) plus the extension's --inputdir/--load-extension.
+//
+// As with contrib, all extensions share the single postgres database, so before
+// each one we reset the public schema directly on the primary (directPgPort,
+// bypassing the gateway's DDL block) to clear objects a prior extension left
+// behind; pg_regress's --load-extension re-creates the extension per test.
+func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, exts []ExternalExtension, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	// Ensure the pg_regress we drive directly is built (a contrib/regression run
+	// would have built it already; an external-only run must build it here).
+	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
+	pgRegress := filepath.Join(regressDir, "pg_regress")
+	if !suiteutil.FileExists(pgRegress) {
+		if out, err := executil.Command(ctx, "make", "-C", regressDir, "all").CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to build pg_regress: %w\n%s", err, truncateForLog(string(out), 2000))
+		}
+	}
+
+	merged := &TestResults{
+		FailureDetails: []TestFailure{},
+		Tests:          []IndividualTestResult{},
+	}
+	mode := GetPatchMode()
+	pgBinDir := pb.BinDir()
+
+	for _, ext := range exts {
+		cloneDir := filepath.Join(pb.ExternalDir, ext.Name)
+		testDir := filepath.Join(cloneDir, "test")
+		if !suiteutil.FileExists(filepath.Join(testDir, "sql")) {
+			t.Logf("external/%s: no test/sql in checkout, skipping", ext.Name)
+			continue
+		}
+
+		tests := listRegressTests(testDir)
+		if len(tests) == 0 {
+			t.Logf("external/%s: no .sql tests found, skipping", ext.Name)
+			continue
+		}
+
+		// Clean slate for this extension: drop anything a prior extension left in
+		// public. Best-effort — log and proceed if it fails.
+		if err := resetContribState(directPgPort, password); err != nil {
+			t.Logf("external/%s: warning: public schema reset failed: %v", ext.Name, err)
+		}
+
+		t.Logf("Running external/%s pg_regress (%d tests) against multigateway...", ext.Name, len(tests))
+		args := []string{
+			"--inputdir=" + testDir,
+			"--outputdir=" + cloneDir,
+			"--bindir=" + pgBinDir,
+			"--use-existing",
+			"--dbname=postgres",
+			"--load-extension=" + ext.Name,
+		}
+		args = append(args, tests...)
+		cmd := executil.Command(ctx, pgRegress, args...).WithProcessGroup()
+
+		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+			suiteName: "External/" + ext.Name,
+			outputDir: filepath.Join(pb.OutputDir, "external", ext.Name),
+			srcOutDir: cloneDir,
+		}, multigatewayPort, password)
+		if res == nil {
+			t.Logf("external/%s: no test results (%v)", ext.Name, err)
+			continue
+		}
+
+		// Re-evaluate each test via the patch pipeline. pg_regress wrote results
+		// to <cloneDir>/results (--outputdir); expected lives in <cloneDir>/test
+		// (--inputdir), and patches are per-extension under patches/external/<ext>.
+		patchDir := filepath.Join(PatchesDir(), "external", ext.Name)
+		pb.verifyModuleResults(ctx, testDir, filepath.Join(cloneDir, "results"), patchDir, res, mode)
+
+		for _, tr := range res.Tests {
+			tr.Name = ext.Name + "/" + tr.Name
+			merged.Tests = append(merged.Tests, tr)
+			switch tr.Status {
+			case "fail":
+				merged.FailedTests++
+				detail := tr.FailReason
+				if detail == "" {
+					detail = "see external/" + ext.Name + "/regression.diffs"
+				}
+				merged.FailureDetails = append(merged.FailureDetails, TestFailure{
+					TestName: tr.Name,
+					Error:    detail,
+				})
+			case "skip":
+				merged.SkippedTests++
+			default:
+				merged.PassedTests++
+			}
+		}
+		merged.TimedOut = merged.TimedOut || res.TimedOut
+	}
+
+	merged.TotalTests = merged.PassedTests + merged.FailedTests + merged.SkippedTests
+	return merged, nil
+}
+
 // verifyContribModule re-evaluates each test in a contrib module's results
 // using the patch-based pipeline (see patch_verify.go), replacing pg_regress's
 // strict text verdict. Expected output lives in the source tree
@@ -422,8 +579,18 @@ func (pb *PostgresBuilder) RunContribTests(t *testing.T, ctx context.Context, mo
 // caller afterwards). Statuses are updated in place.
 func (pb *PostgresBuilder) verifyContribModule(ctx context.Context, mod string, res *TestResults, mode PatchMode) {
 	moduleSrcDir := filepath.Join(pb.SourceDir, "contrib", mod)
-	moduleBuildDir := filepath.Join(pb.BuildDir, "contrib", mod)
+	moduleResultsDir := filepath.Join(pb.BuildDir, "contrib", mod, "results")
 	patchDir := filepath.Join(PatchesDir(), "contrib", mod)
+	pb.verifyModuleResults(ctx, moduleSrcDir, moduleResultsDir, patchDir, res, mode)
+}
+
+// verifyModuleResults is the shared per-test verification loop behind both the
+// contrib and external suites. expectedDir is the directory whose expected/
+// subdirectory holds the upstream .out files (and numbered variants); resultsDir
+// holds the .out files pg_regress wrote for this run; patchDir holds the
+// per-test patches for genuine multigres-specific differences. Statuses in
+// res.Tests are updated in place; skipped tests are left untouched.
+func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir, resultsDir, patchDir string, res *TestResults, mode PatchMode) {
 	repoRoot := findRepoRoot()
 
 	for i := range res.Tests {
@@ -439,8 +606,8 @@ func (pb *PostgresBuilder) verifyContribModule(ctx context.Context, mod string, 
 		// actual matches ANY variant; mirror that here before falling back to
 		// patch-based verification, otherwise a canonical-only comparison
 		// manufactures diffs that aren't multigres behavior at all.
-		variants := expectedVariants(moduleSrcDir, test.Name)
-		actPath := filepath.Join(moduleBuildDir, "results", test.Name+".out")
+		variants := expectedVariants(expectedDir, test.Name)
+		actPath := filepath.Join(resultsDir, test.Name+".out")
 		if len(variants) == 0 || !suiteutil.FileExists(actPath) {
 			// Test didn't run or expected missing; keep the TAP verdict.
 			test.FailReason = "expected or actual output missing; kept TAP verdict"
@@ -874,11 +1041,11 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 	patchURLPrefix := githubBlobURLPrefix()
 
 	for _, s := range suites {
-		// The contrib suite's per-test detail is rendered by the richer
-		// Extension Coverage table below (it carries the same per-test results
-		// plus catalog context), so skip the generic per-test section here. The
-		// contrib badge above is still shown.
-		if s.Name == "Contrib Extension Tests" {
+		// The contrib and external suites' per-test detail is rendered by the
+		// richer Extension Coverage table below (it carries the same per-test
+		// results plus catalog context), so skip the generic per-test section
+		// here. Their badges above are still shown.
+		if s.Name == "Contrib Extension Tests" || s.Name == "External Extension Tests" {
 			continue
 		}
 
@@ -922,14 +1089,20 @@ func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResu
 	}
 
 	// Extension coverage map: the full catalog (covered / pending / unsupported
-	// / external) merged with this run's per-test contrib results. Rendered
-	// whenever a contrib suite ran so the report doubles as the living coverage
-	// tracker (see extensions.go).
+	// / external) merged with this run's per-test results from both the contrib
+	// and external suites. Rendered whenever either ran so the report doubles as
+	// the living coverage tracker (see extensions.go).
+	var contribResults, externalResults *TestResults
 	for _, s := range suites {
-		if s.Name == "Contrib Extension Tests" {
-			sb.WriteString(ExtensionCoverageMarkdown(s.Results))
-			break
+		switch s.Name {
+		case "Contrib Extension Tests":
+			contribResults = s.Results
+		case "External Extension Tests":
+			externalResults = s.Results
 		}
+	}
+	if contribResults != nil || externalResults != nil {
+		sb.WriteString(ExtensionCoverageMarkdown(contribResults, externalResults))
 	}
 
 	summary := sb.String()


### PR DESCRIPTION
## Summary

Adds an external-extension suite to `pgregresstest`: clones an out-of-tree PGXS extension, builds it against the from-source PostgreSQL, and runs its pg_regress suite through multigateway. pgvector v0.8.1 is the first; enrolling another is a 2-line catalog edit (`externalSpecs` + flip the row to covered). Runs under `RUN_EXTENDED_QUERY_SERVING_TESTS`, so CI picks it up with no workflow changes.

## Result: 11/14 pgvector tests pass

The 3 failures share one root cause this surfaced — a multigateway bug (#1090): **`SET` is applied to local session state and not validated against Postgres until the next query** (`apply_session_state.go`). So `SET hnsw.ef_search = 1001` doesn't raise its range error at SET time; it surfaces later on an unrelated statement. That fails `hnsw_vector` and `ivfflat_vector` directly, and `ivfflat_bit` downstream — the deferred error is flushed onto a later `DROP TABLE`, aborting it and leaking a table into the next test.

Fix tracked in #1090; the 3 tests stay red until then (no divergence patches committed to mask them).