### PR TITLE
fix(multigateway): handle DISCARD ALL at the gateway instead of forwarding it

### DIFF
--- a/go/services/multigateway/engine/copy_statement_test.go
+++ b/go/services/multigateway/engine/copy_statement_test.go
@@ -55,6 +55,10 @@ type mockIExecute struct {
 	copyAbortCalled atomic.Int32
 	copyAbortErr    error
 
+	// ReleaseAllReservedConnections behavior
+	releaseAllCalled atomic.Int32
+	releaseAllErr    error
+
 	// CopyOutInitiate behavior (TO STDOUT direction)
 	copyOutInitiateErr     error
 	copyOutInitiateFormat  int16
@@ -207,7 +211,8 @@ func (m *mockIExecute) DiscardTempTables(ctx context.Context, conn *server.Conn,
 }
 
 func (m *mockIExecute) ReleaseAllReservedConnections(context.Context, *server.Conn, *handler.MultiGatewayConnectionState) error {
-	return nil
+	m.releaseAllCalled.Add(1)
+	return m.releaseAllErr
 }
 
 // Helper to create a CopyStatement for testing

--- a/go/services/multigateway/engine/discard_all_primitive.go
+++ b/go/services/multigateway/engine/discard_all_primitive.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// DiscardAllPrimitive handles DISCARD ALL entirely at the gateway.
+//
+// PostgreSQL documents DISCARD ALL as equivalent to:
+//
+//	CLOSE ALL; SET SESSION AUTHORIZATION DEFAULT; RESET ALL;
+//	DEALLOCATE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all();
+//	DISCARD PLANS; DISCARD TEMP;
+//
+// and rejects it inside a transaction block (see PreventInTransactionBlock in
+// PG's discard.c).
+//
+// We intentionally do NOT forward DISCARD ALL to a pooled backend. In the
+// pooled architecture a client's session state lives at the gateway, not on
+// any single backend: prepared statements (the consolidator), session GUCs
+// (SessionSettings + gateway-managed variables), and LISTEN subscriptions are
+// all gateway-side. The only backend-resident session state is whatever a
+// *reserved* connection holds — an open transaction, temp tables, or
+// `DECLARE … WITH HOLD` cursors — and that is cleaned up by handing the
+// reserved connection back to the pool.
+//
+// Forwarding the literal DISCARD ALL to a shared pooled backend would run
+// DEALLOCATE ALL on it, wiping the prepared statements the multipooler still
+// believes are prepared there (its per-connection tracking is not updated),
+// poisoning that backend for later sessions. Prepared statements already
+// parsed on pooled backends are therefore left in place: they form a
+// pool-wide dedup cache keyed by canonical (query, paramTypes), and leaving
+// them keeps the multipooler's connState accurate. Only the gateway's
+// per-session view (the consolidator) is cleared, which is what frees the
+// client's statement names.
+type DiscardAllPrimitive struct {
+	// Query is the original SQL string ("DISCARD ALL").
+	Query string
+}
+
+// NewDiscardAllPrimitive creates a new DiscardAllPrimitive.
+func NewDiscardAllPrimitive(sql string) *DiscardAllPrimitive {
+	return &DiscardAllPrimitive{Query: sql}
+}
+
+// StreamExecute resets the gateway's session state and releases any reserved
+// connection back to the pool, mirroring PG's DISCARD ALL without forwarding
+// the statement to a shared pooled backend.
+func (d *DiscardAllPrimitive) StreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	_ []*ast.A_Const,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	// PG rejects DISCARD ALL inside a transaction block — the idea is to
+	// catch mistakes that would otherwise leave the transaction uncommitted.
+	// conn.IsInTransaction() covers a deferred BEGIN too (the status flips at
+	// BEGIN even before the backend call), so the reserved connection below
+	// is only ever held for temp tables / WITH HOLD cursors here.
+	if conn.IsInTransaction() {
+		return mterrors.NewPgError("ERROR", mterrors.PgSSActiveTransaction,
+			"DISCARD ALL cannot run inside a transaction block", "")
+	}
+
+	// DEALLOCATE ALL — drop the session's prepared statements from the
+	// consolidator (same path DEALLOCATE ALL uses). Pooled backends keep their
+	// canonical statements; only the client-facing names are released.
+	if err := conn.Handler().HandleClose(ctx, conn, 'A', ""); err != nil {
+		return err
+	}
+
+	// RESET ALL + SET SESSION AUTHORIZATION DEFAULT — clear every SET-tracked
+	// GUC and the gateway-managed variables (e.g. statement_timeout). The next
+	// query replays an empty session-settings set, resetting the backend.
+	state.ResetAllSessionVariables()
+	state.ResetStatementTimeout()
+
+	// UNLISTEN * — drop all LISTEN subscriptions. Not in a transaction here, so
+	// apply immediately rather than queueing as a pending action.
+	if len(state.GetListenChannels()) > 0 {
+		state.ClearListenChannels()
+		if state.SubSync != nil {
+			state.SubSync.SyncSubscriptions(conn.Context(), conn, state, nil, nil, true)
+		}
+	}
+
+	// CLOSE ALL + DISCARD TEMP + rollback of a reserved backend — release any
+	// reserved connection regardless of reason. ReleaseAllReservedConnections
+	// rolls back, discards temp tables, releases portals, returns the backend
+	// to the pool clean, and clears local shard state. Clear the gateway's HOLD
+	// cursor bookkeeping to match.
+	state.ClearOpenHoldCursors()
+	if err := exec.ReleaseAllReservedConnections(ctx, conn, state); err != nil {
+		return err
+	}
+
+	return callback(ctx, &sqltypes.Result{CommandTag: "DISCARD ALL"})
+}
+
+// PortalStreamExecute satisfies the Primitive interface for the
+// extended-protocol path. DISCARD ALL carries no parameter binds and its
+// effects are purely on gateway session state and reserved-connection cleanup.
+// Delegate to StreamExecute.
+func (d *DiscardAllPrimitive) PortalStreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	_ *preparedstatement.PortalInfo,
+	_ int32,
+	_ bool,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	return d.StreamExecute(ctx, exec, conn, state, nil, callback)
+}
+
+// GetTableGroup returns empty string — DISCARD ALL does not target a tablegroup.
+func (d *DiscardAllPrimitive) GetTableGroup() string {
+	return ""
+}
+
+// GetQuery returns the SQL query.
+func (d *DiscardAllPrimitive) GetQuery() string {
+	return d.Query
+}
+
+// String returns a description of the primitive for debugging.
+func (d *DiscardAllPrimitive) String() string {
+	return fmt.Sprintf("DiscardAll(%s)", d.Query)
+}
+
+// Ensure DiscardAllPrimitive implements Primitive interface.
+var _ Primitive = (*DiscardAllPrimitive)(nil)

--- a/go/services/multigateway/engine/discard_all_primitive.go
+++ b/go/services/multigateway/engine/discard_all_primitive.go
@@ -55,6 +55,14 @@ import (
 // them keeps the multipooler's connState accurate. Only the gateway's
 // per-session view (the consolidator) is cleared, which is what frees the
 // client's statement names.
+//
+// Out of scope: the `SELECT pg_advisory_unlock_all()` half of PG's DISCARD ALL
+// is NOT handled here. Session-level advisory locks live on whatever backend
+// executed pg_advisory_lock, and the reserved-connection release rolls back
+// (which only drops transaction-level locks) rather than running
+// pg_advisory_unlock_all on the backend. Session-level advisory locks are a
+// pre-existing limitation under pooling and are not addressed by this
+// primitive.
 type DiscardAllPrimitive struct {
 	// Query is the original SQL string ("DISCARD ALL").
 	Query string
@@ -86,6 +94,22 @@ func (d *DiscardAllPrimitive) StreamExecute(
 			"DISCARD ALL cannot run inside a transaction block", "")
 	}
 
+	// CLOSE ALL + DISCARD TEMP + rollback of a reserved backend — release any
+	// reserved connection regardless of reason. ReleaseAllReservedConnections
+	// rolls back, discards temp tables, releases portals, returns the backend
+	// to the pool clean, and clears local shard state.
+	//
+	// This is done FIRST because it is the only step that can fail (it makes an
+	// RPC to the multipooler). The gateway-side resets below are pure in-memory
+	// state mutations that cannot fail, so running the fallible release up front
+	// keeps DISCARD ALL effectively atomic: if the release errors we bail with
+	// the client's session untouched rather than half-reset.
+	if err := exec.ReleaseAllReservedConnections(ctx, conn, state); err != nil {
+		return err
+	}
+	// Clear the gateway's HOLD cursor bookkeeping to match the released backend.
+	state.ClearOpenHoldCursors()
+
 	// DEALLOCATE ALL — drop the session's prepared statements from the
 	// consolidator (same path DEALLOCATE ALL uses). Pooled backends keep their
 	// canonical statements; only the client-facing names are released.
@@ -106,16 +130,6 @@ func (d *DiscardAllPrimitive) StreamExecute(
 		if state.SubSync != nil {
 			state.SubSync.SyncSubscriptions(conn.Context(), conn, state, nil, nil, true)
 		}
-	}
-
-	// CLOSE ALL + DISCARD TEMP + rollback of a reserved backend — release any
-	// reserved connection regardless of reason. ReleaseAllReservedConnections
-	// rolls back, discards temp tables, releases portals, returns the backend
-	// to the pool clean, and clears local shard state. Clear the gateway's HOLD
-	// cursor bookkeeping to match.
-	state.ClearOpenHoldCursors()
-	if err := exec.ReleaseAllReservedConnections(ctx, conn, state); err != nil {
-		return err
 	}
 
 	return callback(ctx, &sqltypes.Result{CommandTag: "DISCARD ALL"})

--- a/go/services/multigateway/engine/discard_all_primitive_test.go
+++ b/go/services/multigateway/engine/discard_all_primitive_test.go
@@ -153,11 +153,16 @@ func TestDiscardAllPrimitive_Success(t *testing.T) {
 }
 
 // TestDiscardAllPrimitive_ReleaseError surfaces a reserved-connection release
-// failure to the caller.
+// failure to the caller and verifies DISCARD ALL is atomic on that failure: the
+// release runs first, so when it errors none of the gateway-side resets (prepared
+// statements, session GUCs, HOLD-cursor tracking) have run.
 func TestDiscardAllPrimitive_ReleaseError(t *testing.T) {
 	mockExec := &mockIExecute{releaseAllErr: errors.New("release boom")}
-	conn := newDiscardTestConn(t, &recordingHandler{})
+	h := &recordingHandler{}
+	conn := newDiscardTestConn(t, h)
 	state := handler.NewMultiGatewayConnectionState()
+	state.SetSessionVariable("work_mem", "64MB")
+	state.AddOpenHoldCursor("c1")
 
 	prim := NewDiscardAllPrimitive("DISCARD ALL")
 	err := prim.StreamExecute(context.Background(), mockExec, conn, state, nil,
@@ -165,6 +170,13 @@ func TestDiscardAllPrimitive_ReleaseError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "release boom")
+
+	// Atomic on failure: the session is left untouched, not half-reset.
+	assert.Empty(t, h.closeCalls, "prepared statements must not be dropped when release fails")
+	v, ok := state.GetSessionVariable("work_mem")
+	assert.True(t, ok, "session settings must be left intact when release fails")
+	assert.Equal(t, "64MB", v)
+	assert.True(t, state.HasAnyOpenHoldCursor(), "HOLD cursor tracking must be left intact when release fails")
 }
 
 // TestDiscardAllPrimitive_PortalStreamExecute exercises the extended-protocol

--- a/go/services/multigateway/engine/discard_all_primitive_test.go
+++ b/go/services/multigateway/engine/discard_all_primitive_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// recordingHandler is a server.Handler that records HandleClose calls. Only
+// HandleClose is exercised by DiscardAllPrimitive; the rest are no-ops.
+type recordingHandler struct {
+	closeCalls []struct {
+		typ  byte
+		name string
+	}
+}
+
+func (h *recordingHandler) HandleClose(_ context.Context, _ *server.Conn, typ byte, name string) error {
+	h.closeCalls = append(h.closeCalls, struct {
+		typ  byte
+		name string
+	}{typ, name})
+	return nil
+}
+
+func (h *recordingHandler) HandleQuery(context.Context, *server.Conn, string, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (h *recordingHandler) HandleParse(context.Context, *server.Conn, string, string, []uint32) error {
+	return nil
+}
+
+func (h *recordingHandler) HandleBind(context.Context, *server.Conn, string, string, [][]byte, []int16, []int16) error {
+	return nil
+}
+
+func (h *recordingHandler) HandleExecute(context.Context, *server.Conn, string, int32, bool, func(context.Context, *sqltypes.Result) error) error {
+	return nil
+}
+
+func (h *recordingHandler) HandleDescribe(context.Context, *server.Conn, byte, string) (*query.StatementDescription, error) {
+	return nil, nil
+}
+
+func (h *recordingHandler) HandleSync(context.Context, *server.Conn) error { return nil }
+
+func (h *recordingHandler) ConnectionClosed(*server.Conn) {}
+
+func (h *recordingHandler) GetPreparedStatementInfo(uint32, string) *preparedstatement.PreparedStatementInfo {
+	return nil
+}
+
+func newDiscardTestConn(t *testing.T, h server.Handler) *server.Conn {
+	t.Helper()
+	return server.NewTestConn(&bytes.Buffer{}, server.WithTestHandler(h)).Conn
+}
+
+// TestDiscardAllPrimitive_RejectsInTransaction verifies DISCARD ALL is rejected
+// with SQLSTATE 25001 inside a transaction block (matching PG's
+// PreventInTransactionBlock) and that it does NOT touch any state or release the
+// reserved connection in that case.
+func TestDiscardAllPrimitive_RejectsInTransaction(t *testing.T) {
+	mockExec := &mockIExecute{}
+	h := &recordingHandler{}
+	conn := newDiscardTestConn(t, h)
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.SetSessionVariable("work_mem", "64MB")
+
+	prim := NewDiscardAllPrimitive("DISCARD ALL")
+	var got *sqltypes.Result
+	err := prim.StreamExecute(context.Background(), mockExec, conn, state, nil,
+		func(_ context.Context, r *sqltypes.Result) error { got = r; return nil })
+
+	require.Error(t, err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSActiveTransaction),
+		"expected SQLSTATE %s, got %v", mterrors.PgSSActiveTransaction, err)
+	assert.Nil(t, got, "no result should be sent when DISCARD ALL is rejected")
+	assert.Empty(t, h.closeCalls, "prepared statements must not be dropped on rejection")
+	assert.Equal(t, int32(0), mockExec.releaseAllCalled.Load(),
+		"reserved connection must not be released on rejection")
+	v, ok := state.GetSessionVariable("work_mem")
+	assert.True(t, ok, "session settings must be left intact on rejection")
+	assert.Equal(t, "64MB", v)
+}
+
+// TestDiscardAllPrimitive_Success verifies the success path resets gateway
+// session state, drops all prepared statements, releases the reserved
+// connection, and returns the DISCARD ALL command tag — all without forwarding
+// the statement to a backend.
+func TestDiscardAllPrimitive_Success(t *testing.T) {
+	mockExec := &mockIExecute{}
+	h := &recordingHandler{}
+	conn := newDiscardTestConn(t, h)
+	// Idle (not in a transaction) — the default.
+
+	state := handler.NewMultiGatewayConnectionState()
+	state.SetSessionVariable("work_mem", "64MB")
+	state.AddOpenHoldCursor("c1")
+
+	prim := NewDiscardAllPrimitive("DISCARD ALL")
+	var got *sqltypes.Result
+	err := prim.StreamExecute(context.Background(), mockExec, conn, state, nil,
+		func(_ context.Context, r *sqltypes.Result) error { got = r; return nil })
+
+	require.NoError(t, err)
+
+	// DEALLOCATE ALL: HandleClose('A') drops every prepared statement.
+	require.Len(t, h.closeCalls, 1)
+	assert.Equal(t, byte('A'), h.closeCalls[0].typ)
+	assert.Empty(t, h.closeCalls[0].name)
+
+	// RESET ALL: session settings cleared.
+	_, ok := state.GetSessionVariable("work_mem")
+	assert.False(t, ok, "RESET ALL must clear session settings")
+
+	// CLOSE ALL: gateway HOLD-cursor bookkeeping cleared.
+	assert.False(t, state.HasAnyOpenHoldCursor(), "DISCARD ALL must clear HOLD cursor tracking")
+
+	// Reserved connection released exactly once.
+	assert.Equal(t, int32(1), mockExec.releaseAllCalled.Load())
+
+	require.NotNil(t, got)
+	assert.Equal(t, "DISCARD ALL", got.CommandTag)
+}
+
+// TestDiscardAllPrimitive_ReleaseError surfaces a reserved-connection release
+// failure to the caller.
+func TestDiscardAllPrimitive_ReleaseError(t *testing.T) {
+	mockExec := &mockIExecute{releaseAllErr: errors.New("release boom")}
+	conn := newDiscardTestConn(t, &recordingHandler{})
+	state := handler.NewMultiGatewayConnectionState()
+
+	prim := NewDiscardAllPrimitive("DISCARD ALL")
+	err := prim.StreamExecute(context.Background(), mockExec, conn, state, nil,
+		func(context.Context, *sqltypes.Result) error { return nil })
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "release boom")
+}
+
+// TestDiscardAllPrimitive_PortalStreamExecute exercises the extended-protocol
+// delegate path.
+func TestDiscardAllPrimitive_PortalStreamExecute(t *testing.T) {
+	mockExec := &mockIExecute{}
+	conn := newDiscardTestConn(t, &recordingHandler{})
+	state := handler.NewMultiGatewayConnectionState()
+
+	prim := NewDiscardAllPrimitive("DISCARD ALL")
+	var got *sqltypes.Result
+	err := prim.PortalStreamExecute(context.Background(), mockExec, conn, state, nil, 0, false,
+		func(_ context.Context, r *sqltypes.Result) error { got = r; return nil })
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "DISCARD ALL", got.CommandTag)
+	assert.Equal(t, int32(1), mockExec.releaseAllCalled.Load())
+}
+
+func TestDiscardAllPrimitive_StringAndGetters(t *testing.T) {
+	prim := NewDiscardAllPrimitive("DISCARD ALL")
+	assert.Equal(t, "DiscardAll(DISCARD ALL)", prim.String())
+	assert.Equal(t, "DISCARD ALL", prim.GetQuery())
+	assert.Empty(t, prim.GetTableGroup())
+}

--- a/go/services/multigateway/engine/plan.go
+++ b/go/services/multigateway/engine/plan.go
@@ -38,6 +38,7 @@ const (
 	PlanTypeTempTableRoute      = "TempTableRoute"
 	PlanTypeHoldCursorRoute     = "HoldCursorRoute"
 	PlanTypeCloseCursorRoute    = "CloseCursorRoute"
+	PlanTypeDiscardAll          = "DiscardAll"
 	PlanTypeUnknown             = "Unknown"
 )
 

--- a/go/services/multigateway/planner/cursor_stmt_test.go
+++ b/go/services/multigateway/planner/cursor_stmt_test.go
@@ -96,8 +96,9 @@ func TestPlan_ClosePortal(t *testing.T) {
 	}
 }
 
-// TestPlan_DiscardAll routes DISCARD ALL through CloseCursorRoute(CloseAll)
-// so any tracked HOLD-cursor pins drain alongside PG's session wipe.
+// TestPlan_DiscardAll routes DISCARD ALL through DiscardAllPrimitive, which
+// resets the gateway's session state and releases any reserved connection
+// without forwarding the statement to a shared pooled backend.
 func TestPlan_DiscardAll(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
 	p := NewPlanner("default", logger, nil)
@@ -108,11 +109,10 @@ func TestPlan_DiscardAll(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
-	route, ok := plan.Primitive.(*engine.CloseCursorRoute)
-	require.True(t, ok, "DISCARD ALL must route through CloseCursorRoute, got %T", plan.Primitive)
-	assert.True(t, route.CloseAll, "DISCARD ALL must drain every tracked HOLD pin")
-	assert.Equal(t, "DISCARD ALL", route.Query, "forwarded SQL must be preserved for PG")
-	assert.Equal(t, engine.PlanTypeCloseCursorRoute, plan.Type)
+	prim, ok := plan.Primitive.(*engine.DiscardAllPrimitive)
+	require.True(t, ok, "DISCARD ALL must route through DiscardAllPrimitive, got %T", plan.Primitive)
+	assert.Equal(t, "DISCARD ALL", prim.Query)
+	assert.Equal(t, engine.PlanTypeDiscardAll, plan.Type)
 }
 
 // TestPlan_DiscardPlansSequences keeps the existing planDefault behavior for

--- a/go/services/multigateway/planner/discard_stmt.go
+++ b/go/services/multigateway/planner/discard_stmt.go
@@ -15,7 +15,6 @@
 package planner
 
 import (
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
@@ -26,14 +25,10 @@ import (
 // For DISCARD TEMP, uses DiscardTempPrimitive which handles removing the
 // temp table reservation reason on the multipooler side.
 //
-// For DISCARD ALL, uses CloseCursorRoute(CloseAll) so any open
-// `DECLARE … WITH HOLD` cursor pins are released alongside PG's
-// session-level cleanup. PG documents DISCARD ALL as equivalent to
-// `CLOSE ALL; SET SESSION AUTHORIZATION DEFAULT; RESET ALL; DEALLOCATE
-// ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS;
-// DISCARD TEMP;` — the cursor-close half is what we mirror here so the
-// reserved backend isn't leaked with a stale `ReasonPortal` after the
-// session-level cursor wipe.
+// For DISCARD ALL, uses DiscardAllPrimitive, which resets the gateway's
+// session state and releases any reserved connection back to the pool
+// without forwarding the statement to a shared pooled backend (see that
+// primitive for the rationale).
 //
 // DISCARD PLANS / DISCARD SEQUENCES carry no cursor or temp-table side
 // effects and fall through to planDefault.
@@ -54,14 +49,18 @@ func (p *Planner) planDiscardStmt(
 
 	if stmt.Target == ast.DISCARD_ALL {
 		p.logger.Debug("planning discard all statement", "sql", sql)
-		// CloseCursorRoute snapshots OpenHoldCursorNames at execution
-		// time and forwards them as release_portal_names, so any HOLD
-		// pin on the reserved backend is drained before/with the
-		// DISCARD ALL itself. The actual SQL forwarded to PG is
-		// unchanged — PG handles every other DISCARD ALL side effect.
-		route := engine.NewCloseAllCursorRoute(p.defaultTableGroup, constants.DefaultShard, sql)
-		plan := engine.NewPlan(sql, route)
-		plan.Type = engine.PlanTypeCloseCursorRoute
+		// DISCARD ALL is handled entirely at the gateway and is NOT
+		// forwarded to a pooled backend. In the pooled model the
+		// session state DISCARD ALL resets lives at the gateway
+		// (prepared statements, session GUCs, LISTEN subscriptions);
+		// the only backend-resident state is on a reserved connection,
+		// which DiscardAllPrimitive releases back to the pool. Forwarding
+		// the literal DISCARD ALL would run DEALLOCATE ALL on a shared
+		// backend and desync the multipooler's prepared-statement
+		// tracking. See DiscardAllPrimitive for the full rationale.
+		primitive := engine.NewDiscardAllPrimitive(sql)
+		plan := engine.NewPlan(sql, primitive)
+		plan.Type = engine.PlanTypeDiscardAll
 		return plan, nil
 	}
 

--- a/go/test/endtoend/queryserving/multigateway_pg_test.go
+++ b/go/test/endtoend/queryserving/multigateway_pg_test.go
@@ -675,9 +675,10 @@ func TestMultiGateway_ExtendedQueryProtocol(t *testing.T) {
 				assert.Equal(t, 1, n)
 			})
 
-			// MUL-389 follow-up: DISCARD ALL closes every cursor — verify
-			// the gateway forwards release_portal_names so the
-			// multipooler's portal pin set drains alongside PG's wipe.
+			// MUL-389 follow-up: DISCARD ALL closes every cursor. The
+			// gateway handles DISCARD ALL locally and releases the reserved
+			// connection (pinned by the HOLD cursor) back to the pool, so
+			// the multipooler's portal pin set drains alongside PG's wipe.
 			t.Run("DISCARD ALL releases HOLD cursor pins", func(t *testing.T) {
 				tableName := fmt.Sprintf("hold_da_test_%d", time.Now().UnixNano())
 

--- a/go/test/endtoend/queryserving/pgbouncertests/LICENSE
+++ b/go/test/endtoend/queryserving/pgbouncertests/LICENSE
@@ -1,0 +1,28 @@
+The test scenarios in this directory are derived from PgBouncer's test suite
+(https://github.com/pgbouncer/pgbouncer/tree/master/test), which is distributed
+under the ISC License reproduced below. That license is retained here for the
+derived material.
+
+All modifications and new code in this directory (the Go re-implementation, the
+test harness, and everything else) are part of Multigres and are licensed under
+the Apache License, Version 2.0 — see the LICENSE file at the repository root.
+
+----------------------------------------------------------------------
+
+PgBouncer - Lightweight connection pooler for PostgreSQL.
+
+ISC License
+
+Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/go/test/endtoend/queryserving/pgbouncertests/large_statement_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/large_statement_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
-	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/test/utils"
 )
 
@@ -48,7 +47,6 @@ const (
 // PostgreSQL is the oracle: each case runs against both direct PostgreSQL and
 // the multigateway and must return identical results.
 func TestLargePreparedStatementRelay(t *testing.T) {
-	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -106,7 +104,6 @@ func TestLargePreparedStatementRelay(t *testing.T) {
 // full literal intact. Black-box (see that test for the rationale): rotation is
 // driven by concurrent churn and observed via pg_backend_pid() in results.
 func TestLargePreparedStatementAcrossPooledBackends(t *testing.T) {
-	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}

--- a/go/test/endtoend/queryserving/pgbouncertests/large_statement_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/large_statement_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Message sizes chosen to exceed PgBouncer's historical 4 KB packet buffer
+// (PKT_BUF_SIZE) and its 4x threshold, so they exercise the multigateway's
+// large-message relay the same way test_prepared.py's
+// test_{parse,bind}_larger_than_pkt_buf{,_but_smaller_than_4x} do.
+const (
+	largeParseBytes = 16 * 1024 // 16 KB of SQL text in the Parse message
+	largeBindBytes  = 64 * 1024 // 64 KB of parameter data in the Bind message
+)
+
+// TestLargePreparedStatementRelay verifies that the multigateway relays Parse
+// and Bind messages far larger than a typical 4 KB packet buffer without
+// truncation or corruption. Ported from PgBouncer's
+// test_prepared.py::test_parse_larger_than_pkt_buf and
+// test_bind_larger_than_pkt_buf.
+//
+// PostgreSQL is the oracle: each case runs against both direct PostgreSQL and
+// the multigateway and must return identical results.
+func TestLargePreparedStatementRelay(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	// All-'x' / all-'y' payloads contain no quote or backslash, so they embed
+	// safely in a string literal and round-trip as a bind value unchanged.
+	largeLiteral := strings.Repeat("x", largeParseBytes)
+	largeParam := strings.Repeat("y", largeBindBytes)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+
+			t.Run("large parse message", func(t *testing.T) {
+				conn := connectGateway(t, ctx, connStr)
+				defer conn.Close(ctx)
+
+				// The big literal lives in the SQL text, so the Parse message
+				// is ~16 KB. Returning it also confirms it survived intact.
+				sql := "SELECT $1::int AS v, '" + largeLiteral + "'::text AS big"
+				var v int
+				var big string
+				require.NoError(t, conn.QueryRow(ctx, sql, 7).Scan(&v, &big))
+				assert.Equal(t, 7, v)
+				assert.Equal(t, largeLiteral, big, "large SQL literal must round-trip intact")
+			})
+
+			t.Run("large bind parameter", func(t *testing.T) {
+				conn := connectGateway(t, ctx, connStr)
+				defer conn.Close(ctx)
+
+				// The big value travels as a bind parameter, so the Bind
+				// message is ~64 KB.
+				var got string
+				var n int
+				require.NoError(t, conn.QueryRow(ctx,
+					"SELECT $1::text AS p, length($1::text) AS n", largeParam).Scan(&got, &n))
+				assert.Equal(t, largeBindBytes, n, "server-side length must match the sent parameter")
+				assert.Equal(t, largeParam, got, "large bind parameter must round-trip intact")
+			})
+		})
+	}
+}
+
+// TestLargePreparedStatementAcrossPooledBackends combines the large-Parse path
+// with the pooled-backend rotation of TestPreparedStatementAcrossPooledBackends:
+// a ~16 KB prepared statement must re-prepare correctly (multipooler
+// ensurePrepared) on every backend the pool serves it from and always return the
+// full literal intact. Black-box (see that test for the rationale): rotation is
+// driven by concurrent churn and observed via pg_backend_pid() in results.
+func TestLargePreparedStatementAcrossPooledBackends(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 90*time.Second)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	largeLiteral := strings.Repeat("x", largeParseBytes)
+	const psName = "ps_large_swap"
+	_, err := conn.Prepare(ctx, psName, "SELECT pg_backend_pid(), $1::int, '"+largeLiteral+"'::text")
+	require.NoError(t, err)
+
+	stopChurn := startPoolChurn(t, ctx, gatewayDSN, churnClients)
+	defer stopChurn()
+
+	runAcrossBackends(t, ctx, func(ctx context.Context, i int) int {
+		var pid, v int
+		var big string
+		require.NoError(t, conn.QueryRow(ctx, psName, i).Scan(&pid, &v, &big),
+			"large prepared statement must re-prepare on its backend (execute %d)", i)
+		require.Equal(t, i, v, "execute %d returned the wrong bound parameter", i)
+		require.Equal(t, largeLiteral, big, "execute %d: large SQL literal must survive re-prepare", i)
+		return pid
+	})
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/main_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/main_test.go
@@ -18,9 +18,6 @@
 // scenarios from PgBouncer's test suite (https://github.com/pgbouncer/pgbouncer,
 // ISC License — see the LICENSE file in this directory) to Go end-to-end tests
 // against the multigateway → multipooler → postgres path.
-//
-// See README.md for the triage that selects which PgBouncer scenarios are
-// ported here (and which are out of scope / already covered elsewhere).
 package pgbouncertests
 
 import (

--- a/go/test/endtoend/queryserving/pgbouncertests/main_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/main_test.go
@@ -21,10 +21,6 @@
 //
 // See README.md for the triage that selects which PgBouncer scenarios are
 // ported here (and which are out of scope / already covered elsewhere).
-//
-// The suite is gated behind RUN_EXTENDED_QUERY_SERVING_TESTS (the "Run Extended
-// Query Serving Tests" PR label); every test self-skips otherwise, so the shared
-// cluster is never built during a plain `go test ./...`.
 package pgbouncertests
 
 import (

--- a/go/test/endtoend/queryserving/pgbouncertests/main_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/main_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pgbouncertests ports the proxy-generic, stateful pooling/resilience
+// scenarios from PgBouncer's test suite (https://github.com/pgbouncer/pgbouncer,
+// ISC License — see the LICENSE file in this directory) to Go end-to-end tests
+// against the multigateway → multipooler → postgres path.
+//
+// See README.md for the triage that selects which PgBouncer scenarios are
+// ported here (and which are out of scope / already covered elsewhere).
+//
+// The suite is gated behind RUN_EXTENDED_QUERY_SERVING_TESTS (the "Run Extended
+// Query Serving Tests" PR label); every test self-skips otherwise, so the shared
+// cluster is never built during a plain `go test ./...`.
+package pgbouncertests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+)
+
+// setupManager manages the shared 2-node (primary + standby) cluster with
+// multigateway enabled, reused across the tests in this package.
+var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardsetup.ShardSetup {
+	return shardsetup.New(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+	)
+})
+
+// TestMain runs the shared test-main harness and dumps logs on failure.
+func TestMain(m *testing.M) {
+	exitCode := shardsetup.RunTestMain(m)
+	if exitCode != 0 {
+		setupManager.DumpLogs()
+	}
+	setupManager.Cleanup()
+	os.Exit(exitCode) //nolint:forbidigo // TestMain() is allowed to call os.Exit
+}
+
+// getSharedSetup returns the shared cluster for tests in this package.
+func getSharedSetup(t *testing.T) *shardsetup.ShardSetup {
+	t.Helper()
+	return setupManager.Get(t)
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/prepared_reset_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/prepared_reset_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPreparedStatementResetSemantics verifies that DEALLOCATE ALL makes
+// previously-prepared statements unavailable, identically on direct PostgreSQL
+// and through the multigateway. Ported from test_prepared.py::test_deallocate_all.
+//
+// After DEALLOCATE ALL, an EXECUTE of a previously-prepared statement must fail
+// with invalid_sql_statement_name; running both targets makes PostgreSQL the
+// oracle. DISCARD ALL (test_discard_all) is intentionally NOT covered here — see
+// TestPreparedStatementDiscardAll for why it is quarantined.
+func TestPreparedStatementResetSemantics(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			for _, reset := range []string{"DEALLOCATE ALL"} {
+				t.Run(reset, func(t *testing.T) {
+					connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+					db, err := sql.Open("postgres", connStr)
+					require.NoError(t, err)
+					defer db.Close()
+					db.SetMaxOpenConns(1) // one client session for all statements
+
+					_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
+					require.NoError(t, err)
+					_, err = db.ExecContext(ctx, "PREPARE rs2 AS SELECT 2")
+					require.NoError(t, err)
+
+					// Sanity: both prepared statements execute before the reset.
+					var n int
+					require.NoError(t, db.QueryRowContext(ctx, "EXECUTE rs1").Scan(&n))
+					require.Equal(t, 1, n)
+					require.NoError(t, db.QueryRowContext(ctx, "EXECUTE rs2").Scan(&n))
+					require.Equal(t, 2, n)
+
+					_, err = db.ExecContext(ctx, reset)
+					require.NoError(t, err, "%s should succeed", reset)
+
+					// After the reset, both statements must be gone.
+					_, err = db.ExecContext(ctx, "EXECUTE rs1")
+					assertInvalidStatementName(t, err, "EXECUTE rs1 after %s", reset)
+					_, err = db.ExecContext(ctx, "EXECUTE rs2")
+					assertInvalidStatementName(t, err, "EXECUTE rs2 after %s", reset)
+				})
+			}
+		})
+	}
+}
+
+// TestPreparedStatementDiscardAll is the DISCARD ALL counterpart of
+// TestPreparedStatementResetSemantics, ported from test_prepared.py::test_discard_all.
+//
+// It currently FAILS on the multigateway target: this is a real, unfixed
+// multigres bug, not a test problem. PostgreSQL's DISCARD ALL includes
+// DEALLOCATE ALL, so after it the prepared-statement name is free and PREPARE of
+// the same name succeeds again. Through the gateway, DISCARD ALL does NOT clear
+// the prepared-statement consolidator, so the name stays taken and re-PREPARE
+// fails with "prepared statement already exists". (The same un-cleared state
+// also leaves the multipooler's per-connection tracking stale, poisoning the
+// pooled backend for later sessions — a separate symptom of the same gap.)
+//
+// We assert the re-PREPARE outcome rather than "EXECUTE fails" because the
+// latter is an unreliable signal: on a single connection the post-DISCARD
+// EXECUTE lands on the very backend DISCARD ALL ran on, whose now-stale tracking
+// makes Bind fail with the same SQLSTATE PostgreSQL returns for a genuinely
+// dropped statement — so it would pass for the wrong reason. The re-PREPARE
+// check is deterministic and independent of backend routing.
+//
+// The fix is deferred pending a design decision — notably whether the proxy
+// should forward DISCARD ALL to a shared pooled backend at all (PgBouncer
+// special-cases it). The test runs in its OWN isolated cluster so the poisoned
+// pooled connection cannot corrupt the other tests in this package: this test
+// fails, the rest stay green.
+func TestPreparedStatementDiscardAll(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
+			db, err := sql.Open("postgres", connStr)
+			require.NoError(t, err)
+			defer db.Close()
+			db.SetMaxOpenConns(1) // one client session for all statements
+
+			_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
+			require.NoError(t, err)
+
+			// Sanity: the prepared statement executes before the reset.
+			var n int
+			require.NoError(t, db.QueryRowContext(ctx, "EXECUTE rs1").Scan(&n))
+			require.Equal(t, 1, n)
+
+			_, err = db.ExecContext(ctx, "DISCARD ALL")
+			require.NoError(t, err, "DISCARD ALL should succeed")
+
+			// DISCARD ALL includes DEALLOCATE ALL, so the name is free again and
+			// re-PREPARE must succeed (it does on PostgreSQL; it fails through the
+			// gateway today because the consolidator was not cleared).
+			_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
+			require.NoError(t, err,
+				"re-PREPARE after DISCARD ALL should succeed — DISCARD ALL must drop the session's prepared statements")
+		})
+	}
+}
+
+// assertInvalidStatementName asserts that err is a pq error with the
+// invalid_sql_statement_name SQLSTATE (what PostgreSQL returns for EXECUTE of a
+// non-existent prepared statement).
+func assertInvalidStatementName(t *testing.T, err error, msgAndArgs ...any) {
+	t.Helper()
+	require.Error(t, err, msgAndArgs...)
+	var pqErr *pq.Error
+	require.True(t, errors.As(err, &pqErr), "expected *pq.Error, got %T (%v)", err, err)
+	assert.Equal(t, pq.ErrorCode(mterrors.PgSSInvalidSQLStatementName), pqErr.Code, msgAndArgs...)
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/prepared_reset_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/prepared_reset_test.go
@@ -28,20 +28,19 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
-	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestPreparedStatementResetSemantics verifies that DEALLOCATE ALL makes
-// previously-prepared statements unavailable, identically on direct PostgreSQL
-// and through the multigateway. Ported from test_prepared.py::test_deallocate_all.
+// TestPreparedStatementResetSemantics verifies that both DEALLOCATE ALL and
+// DISCARD ALL drop the session's prepared statements, identically on direct
+// PostgreSQL and through the multigateway. Ported from
+// test_prepared.py::test_deallocate_all and ::test_discard_all.
 //
-// After DEALLOCATE ALL, an EXECUTE of a previously-prepared statement must fail
-// with invalid_sql_statement_name; running both targets makes PostgreSQL the
-// oracle. DISCARD ALL (test_discard_all) is intentionally NOT covered here — see
-// TestPreparedStatementDiscardAll for why it is quarantined.
+// For each reset we assert two things, with PostgreSQL as the oracle (both
+// targets run the same sequence): an EXECUTE of a previously-prepared statement
+// fails with invalid_sql_statement_name, and the statement name is free to
+// re-PREPARE.
 func TestPreparedStatementResetSemantics(t *testing.T) {
-	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
@@ -54,7 +53,7 @@ func TestPreparedStatementResetSemantics(t *testing.T) {
 
 	for _, target := range setup.GetComparisonTargets(t) {
 		t.Run(target.Name, func(t *testing.T) {
-			for _, reset := range []string{"DEALLOCATE ALL"} {
+			for _, reset := range []string{"DEALLOCATE ALL", "DISCARD ALL"} {
 				t.Run(reset, func(t *testing.T) {
 					connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
 					db, err := sql.Open("postgres", connStr)
@@ -82,78 +81,13 @@ func TestPreparedStatementResetSemantics(t *testing.T) {
 					assertInvalidStatementName(t, err, "EXECUTE rs1 after %s", reset)
 					_, err = db.ExecContext(ctx, "EXECUTE rs2")
 					assertInvalidStatementName(t, err, "EXECUTE rs2 after %s", reset)
+
+					// ...and the names are free again, so re-PREPARE must succeed.
+					_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
+					require.NoError(t, err,
+						"re-PREPARE after %s should succeed — the reset must drop the session's prepared statements", reset)
 				})
 			}
-		})
-	}
-}
-
-// TestPreparedStatementDiscardAll is the DISCARD ALL counterpart of
-// TestPreparedStatementResetSemantics, ported from test_prepared.py::test_discard_all.
-//
-// It currently FAILS on the multigateway target: this is a real, unfixed
-// multigres bug, not a test problem. PostgreSQL's DISCARD ALL includes
-// DEALLOCATE ALL, so after it the prepared-statement name is free and PREPARE of
-// the same name succeeds again. Through the gateway, DISCARD ALL does NOT clear
-// the prepared-statement consolidator, so the name stays taken and re-PREPARE
-// fails with "prepared statement already exists". (The same un-cleared state
-// also leaves the multipooler's per-connection tracking stale, poisoning the
-// pooled backend for later sessions — a separate symptom of the same gap.)
-//
-// We assert the re-PREPARE outcome rather than "EXECUTE fails" because the
-// latter is an unreliable signal: on a single connection the post-DISCARD
-// EXECUTE lands on the very backend DISCARD ALL ran on, whose now-stale tracking
-// makes Bind fail with the same SQLSTATE PostgreSQL returns for a genuinely
-// dropped statement — so it would pass for the wrong reason. The re-PREPARE
-// check is deterministic and independent of backend routing.
-//
-// The fix is deferred pending a design decision — notably whether the proxy
-// should forward DISCARD ALL to a shared pooled backend at all (PgBouncer
-// special-cases it). The test runs in its OWN isolated cluster so the poisoned
-// pooled connection cannot corrupt the other tests in this package: this test
-// fails, the rest stay green.
-func TestPreparedStatementDiscardAll(t *testing.T) {
-	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
-	if testing.Short() {
-		t.Skip("skipping in short mode")
-	}
-	if utils.ShouldSkipRealPostgres() {
-		t.Skip("PostgreSQL binaries not found, skipping")
-	}
-
-	setup, cleanup := shardsetup.NewIsolated(t,
-		shardsetup.WithMultipoolerCount(2),
-		shardsetup.WithMultigateway(),
-	)
-	defer cleanup()
-
-	ctx := utils.WithTimeout(t, 60*time.Second)
-
-	for _, target := range setup.GetComparisonTargets(t) {
-		t.Run(target.Name, func(t *testing.T) {
-			connStr := shardsetup.GetTestUserDSN("localhost", target.Port, "sslmode=disable", "connect_timeout=5")
-			db, err := sql.Open("postgres", connStr)
-			require.NoError(t, err)
-			defer db.Close()
-			db.SetMaxOpenConns(1) // one client session for all statements
-
-			_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
-			require.NoError(t, err)
-
-			// Sanity: the prepared statement executes before the reset.
-			var n int
-			require.NoError(t, db.QueryRowContext(ctx, "EXECUTE rs1").Scan(&n))
-			require.Equal(t, 1, n)
-
-			_, err = db.ExecContext(ctx, "DISCARD ALL")
-			require.NoError(t, err, "DISCARD ALL should succeed")
-
-			// DISCARD ALL includes DEALLOCATE ALL, so the name is free again and
-			// re-PREPARE must succeed (it does on PostgreSQL; it fails through the
-			// gateway today because the consolidator was not cleared).
-			_, err = db.ExecContext(ctx, "PREPARE rs1 AS SELECT 1")
-			require.NoError(t, err,
-				"re-PREPARE after DISCARD ALL should succeed — DISCARD ALL must drop the session's prepared statements")
 		})
 	}
 }

--- a/go/test/endtoend/queryserving/pgbouncertests/prepared_swap_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/prepared_swap_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPreparedStatementAcrossPooledBackends is the headline pooled-backend
+// test, ported from PgBouncer's test_prepared.py::test_prepared_statement.
+//
+// PgBouncer's scenario: a statement prepared once must keep working as the
+// client's session is served by different backend servers. Multigres has no
+// ReasonPrepared reservation, so a named Parse does NOT pin the backend; the
+// multipooler executor instead re-prepares the statement (ensurePrepared) on
+// whichever pooled connection each Execute lands on
+// (go/services/multipooler/executor/executor.go). The bug class this guards
+// against is a swap where the statement is not re-prepared, surfacing as
+// "prepared statement does not exist".
+//
+// This is a black-box test: it only speaks the PostgreSQL wire protocol to the
+// multigateway and only observes what a normal client can — including the
+// backend identity, which it reads from its own query results via
+// pg_backend_pid(), not from any side channel into the underlying PostgreSQL.
+// It prepares once, then executes the statement many times under concurrent
+// load that keeps the multipooler's pool rotating. The invariant is that every
+// Execute returns correct results; observing the statement run on >=2 distinct
+// backends proves the re-prepare path was actually exercised (the test is not
+// vacuous).
+func TestPreparedStatementAcrossPooledBackends(t *testing.T) {
+	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 90*time.Second)
+
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	const psName = "ps_swap"
+	_, err := conn.Prepare(ctx, psName, "SELECT pg_backend_pid(), $1::int")
+	require.NoError(t, err)
+
+	stopChurn := startPoolChurn(t, ctx, gatewayDSN, churnClients)
+	defer stopChurn()
+
+	runAcrossBackends(t, ctx, func(ctx context.Context, i int) int {
+		var pid, v int
+		require.NoError(t, conn.QueryRow(ctx, psName, i).Scan(&pid, &v),
+			"execute %d must succeed (statement must be re-prepared on its backend)", i)
+		require.Equal(t, i, v, "execute %d returned the wrong bound parameter", i)
+		return pid
+	})
+}
+
+// --- shared helpers for the load-and-observe black-box swap tests ---
+
+const (
+	// churnClients is how many background clients keep the multipooler pool
+	// rotating so a session's repeated Executes land on different backends.
+	churnClients = 8
+
+	// minExecutes is the minimum number of times an across-backends test runs
+	// its statement, so the re-prepare path is exercised repeatedly even once
+	// the >=2-backends bar is met.
+	minExecutes = 40
+)
+
+// runAcrossBackends repeatedly calls exec (which runs the statement once with a
+// monotonic counter and returns the backend pid it ran on) until the statement
+// has been observed on at least two distinct backends AND it has run at least
+// minExecutes times — or a deadline passes. exec is expected to assert the
+// per-execution result itself, so any failure to re-prepare on a swapped backend
+// fails the test immediately. Finally it asserts >=2 distinct backends were
+// seen, which keeps the test from passing vacuously when no swap occurred.
+func runAcrossBackends(t *testing.T, ctx context.Context, exec func(ctx context.Context, i int) int) {
+	t.Helper()
+	seen := map[int]bool{}
+	deadline := time.Now().Add(45 * time.Second)
+	i := 0
+	for i < minExecutes || len(seen) < 2 {
+		if i >= minExecutes && time.Now().After(deadline) {
+			break
+		}
+		seen[exec(ctx, i)] = true
+		i++
+	}
+	require.GreaterOrEqualf(t, len(seen), 2,
+		"prepared statement ran on only %d distinct backend(s) across %d executes under churn; "+
+			"expected the pool to serve it from >=2 backends so the re-prepare path is exercised",
+		len(seen), i)
+	t.Logf("statement ran across %d distinct backends in %d executes", len(seen), i)
+}
+
+// startPoolChurn launches n background clients that each run a cheap query in a
+// tight loop through the gateway. Their constant borrow-and-return cycling keeps
+// returning connections to the top of the multipooler's (LIFO) pool faster than
+// a single foreground session loops, so the foreground session's consecutive
+// Executes are handed different backends rather than its own just-returned one.
+// It returns a stop function that cancels the churn and closes the connections;
+// defer it. Pure wire-protocol load — no knowledge of, or dependence on, the
+// pool's internals.
+func startPoolChurn(t *testing.T, ctx context.Context, gatewayDSN string, n int) func() {
+	t.Helper()
+	churnCtx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	for range n {
+		conn := connectGateway(t, ctx, gatewayDSN)
+		wg.Go(func() {
+			defer func() {
+				closeCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+				defer c()
+				_ = conn.Close(closeCtx)
+			}()
+			for churnCtx.Err() == nil {
+				// Cheap round-trip: borrow a pooled backend, return it. The
+				// error on cancellation is expected and ends the loop.
+				_, _ = conn.Exec(churnCtx, "SELECT 1")
+			}
+		})
+	}
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+// connectGateway opens a pgx connection and fails the test on error.
+func connectGateway(t *testing.T, ctx context.Context, dsn string) *pgx.Conn {
+	t.Helper()
+	conn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	return conn
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/prepared_swap_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/prepared_swap_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
-	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/test/utils"
 )
 
@@ -52,7 +51,6 @@ import (
 // backends proves the re-prepare path was actually exercised (the test is not
 // vacuous).
 func TestPreparedStatementAcrossPooledBackends(t *testing.T) {
-	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -193,6 +193,9 @@ func (p *ProcessInstance) multipoolerArgs() []string {
 	if p.VpidStampEnabled {
 		args = append(args, "--vpid-stamp-enabled=true")
 	}
+	// Append any extra args (e.g., connpool capacity/timeout flags from
+	// WithMultipoolerExtraArgs). Placed last so they can override defaults.
+	args = append(args, p.ExtraArgs...)
 	return args
 }
 

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -78,6 +78,7 @@ type SetupConfig struct {
 	S3BackupEndpoint                   string   // S3 endpoint (empty = use AWS, otherwise s3mock/custom)
 	EnableMultigatewayReplicaPort      bool     // Enable replica-reads port on multigateway
 	MultigatewayExtraArgs              []string // Extra CLI flags for multigateway (e.g., buffer config)
+	MultipoolerExtraArgs               []string // Extra CLI flags appended to every multipooler (e.g., connpool capacity/timeout flags)
 	OTelCollectorEndpoint              string   // OTLP HTTP endpoint for multigateway span export (empty = disabled)
 	EnableMetricsExport                bool     // Enable Prometheus metrics export on all services
 	LogLevel                           string   // --log-level for multipooler/multiorch/multigateway (empty = "debug")
@@ -96,6 +97,17 @@ type SetupOption func(*SetupConfig)
 func WithMultipoolerCount(count int) SetupOption {
 	return func(c *SetupConfig) {
 		c.MultipoolerCount = count
+	}
+}
+
+// WithMultipoolerExtraArgs appends extra CLI flags to every multipooler in the
+// setup. Use for connpool tuning that has no dedicated option yet, e.g.
+// shardsetup.WithMultipoolerExtraArgs("--connpool-global-capacity=4",
+// "--connpool-user-reserved-inactivity-timeout=2s"). Flags are appended last,
+// so they override the multipooler defaults.
+func WithMultipoolerExtraArgs(args ...string) SetupOption {
+	return func(c *SetupConfig) {
+		c.MultipoolerExtraArgs = append(c.MultipoolerExtraArgs, args...)
 	}
 }
 
@@ -580,6 +592,7 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 		multipoolerPort := utils.GetFreePort(t)
 
 		inst := setup.CreateMultipoolerInstance(t, name, grpcPort, pgPort, multipoolerPort)
+		inst.Multipooler.ExtraArgs = append(inst.Multipooler.ExtraArgs, config.MultipoolerExtraArgs...)
 		if config.EnableMultipoolerPGTLS {
 			paths := setup.MultipoolerPGTLSCertPaths
 			// Append SSL config to postgresql.conf at init time.

--- a/go/test/endtoend/shardsetup/temp_table_test.go
+++ b/go/test/endtoend/shardsetup/temp_table_test.go
@@ -148,7 +148,8 @@ func TestTempTable_DiscardTempUnpins(t *testing.T) {
 }
 
 // TestTempTable_DiscardAllDropsTempTables verifies DISCARD ALL drops temp tables.
-// The session stays pinned (DISCARD ALL handling is out of scope for temp table pinning).
+// DISCARD ALL is handled at the gateway and releases the reserved (pinned)
+// connection back to the pool — its cleanup discards the temp tables.
 func TestTempTable_DiscardAllDropsTempTables(t *testing.T) {
 	skipIfShort(t)
 	setup := getSharedSetup(t)


### PR DESCRIPTION
## Summary

- Handle `DISCARD ALL` entirely at the gateway and stop forwarding it to a shared pooled backend, which fixes prepared-statement tracking going stale after `DISCARD ALL`.
- Import a small suite of pooling/resilience tests ported from PgBouncer's `test_prepared.py`, run them in normal integration CI (no longer behind the extended-tests gate).

## Problem

`DISCARD ALL` was planned as `CloseCursorRoute(CloseAll)`, which forwarded the literal statement to one pooled backend. Since PG's `DISCARD ALL` runs `DEALLOCATE ALL`, that backend silently dropped its prepared statements while neither the gateway's consolidator nor the multipooler's per-connection tracking were told. Result: re-`PREPARE` of the same name failed with "already exists", and the desynced backend tracking poisoned the pooled connection for later sessions (`ensurePrepared` would skip the `Parse`, so `Bind` failed). A reserved backend was also left with stale temp-table / HOLD-cursor reasons.

## Solution

A new gateway-local `DiscardAllPrimitive` reproduces PG's `DISCARD ALL` against the virtual session state instead of a backend: it rejects the statement inside a transaction block (SQLSTATE 25001), clears the prepared-statement consolidator (`DEALLOCATE ALL`), resets session GUCs (`RESET ALL`), drops LISTEN subscriptions (`UNLISTEN *`), and releases any reserved connection back to the pool via the existing `ReleaseReservedConnection` RPC (which rolls back, discards temp tables, and unpins cursors). Prepared statements already parsed on pooled backends are intentionally left in place — they are a pool-wide dedup cache, and not running `DEALLOCATE ALL` on a shared backend is exactly what keeps the multipooler's tracking accurate.

Verified against PostgreSQL 17 as the oracle: `TestPreparedStatementResetSemantics` now passes through the gateway for both `DEALLOCATE ALL` and `DISCARD ALL` (EXECUTE fails + re-PREPARE succeeds), alongside the prepared-statement swap and large-message relay tests.