### PR TITLE
fix(consensus): prefer postgres-ready poolers during leader election

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -498,6 +498,63 @@ func (CohortEligibilitySignal) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{6}
 }
 
+// LeadershipAvailabilitySignal describes whether a pooler is ready to be
+// promoted to consensus leader.
+type LeadershipAvailabilitySignal int32
+
+const (
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN LeadershipAvailabilitySignal = 0
+	// Pooler's postgres is still initialising (starting, in crash recovery,
+	// socket not yet open). The node can still be elected if it has the most
+	// advanced WAL position and no READY node is tied with it.
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING LeadershipAvailabilitySignal = 1
+	// Pooler's postgres is running and accepting connections. When multiple
+	// nodes are tied at the same WAL position the coordinator prefers a READY
+	// node over a STARTING one.
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY LeadershipAvailabilitySignal = 2
+)
+
+// Enum value maps for LeadershipAvailabilitySignal.
+var (
+	LeadershipAvailabilitySignal_name = map[int32]string{
+		0: "LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN",
+		1: "LEADERSHIP_AVAILABILITY_SIGNAL_STARTING",
+		2: "LEADERSHIP_AVAILABILITY_SIGNAL_READY",
+	}
+	LeadershipAvailabilitySignal_value = map[string]int32{
+		"LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN":  0,
+		"LEADERSHIP_AVAILABILITY_SIGNAL_STARTING": 1,
+		"LEADERSHIP_AVAILABILITY_SIGNAL_READY":    2,
+	}
+)
+
+func (x LeadershipAvailabilitySignal) Enum() *LeadershipAvailabilitySignal {
+	p := new(LeadershipAvailabilitySignal)
+	*p = x
+	return p
+}
+
+func (x LeadershipAvailabilitySignal) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LeadershipAvailabilitySignal) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[7].Descriptor()
+}
+
+func (LeadershipAvailabilitySignal) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[7]
+}
+
+func (x LeadershipAvailabilitySignal) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LeadershipAvailabilitySignal.Descriptor instead.
+func (LeadershipAvailabilitySignal) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{7}
+}
+
 // ComponentType represents the type of Multigres component
 type ID_ComponentType int32
 
@@ -539,11 +596,11 @@ func (x ID_ComponentType) String() string {
 }
 
 func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[7].Descriptor()
+	return file_clustermetadata_proto_enumTypes[8].Descriptor()
 }
 
 func (ID_ComponentType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[7]
+	return &file_clustermetadata_proto_enumTypes[8]
 }
 
 func (x ID_ComponentType) Number() protoreflect.EnumNumber {
@@ -2823,8 +2880,13 @@ type AvailabilityStatus struct {
 	// suspected divergence may be slower to endorse a new rule proposal because it
 	// needs to stop, run pg_rewind, and restart.
 	SuspectedDivergence bool `protobuf:"varint,3,opt,name=suspected_divergence,json=suspectedDivergence,proto3" json:"suspected_divergence,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// leadership_availability reports whether the pooler's postgres is ready to
+	// accept promotion to consensus leader. Published by every pooler. UNKNOWN
+	// (the default for older poolers) is treated the same as ELIGIBLE so that
+	// the coordinator can fall back gracefully when the field is absent.
+	LeadershipAvailability *LeadershipAvailability `protobuf:"bytes,4,opt,name=leadership_availability,json=leadershipAvailability,proto3" json:"leadership_availability,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *AvailabilityStatus) Reset() {
@@ -2878,6 +2940,13 @@ func (x *AvailabilityStatus) GetSuspectedDivergence() bool {
 	return false
 }
 
+func (x *AvailabilityStatus) GetLeadershipAvailability() *LeadershipAvailability {
+	if x != nil {
+		return x.LeadershipAvailability
+	}
+	return nil
+}
+
 // CohortEligibilityStatus carries the pooler's cohort-eligibility signal.
 // Unlike LeadershipStatus there is no per-term gating: eligibility is a
 // current preference, not tied to a specific epoch. Staleness comes from the
@@ -2924,6 +2993,64 @@ func (x *CohortEligibilityStatus) GetSignal() CohortEligibilitySignal {
 		return x.Signal
 	}
 	return CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_UNKNOWN
+}
+
+// LeadershipAvailability carries the pooler's self-reported readiness to
+// accept leader promotion. Unlike CohortEligibilityStatus this is not a
+// permanent preference — it reflects the transient startup state of postgres.
+// Staleness comes from the freshness of the surrounding health snapshot.
+type LeadershipAvailability struct {
+	state  protoimpl.MessageState       `protogen:"open.v1"`
+	Signal LeadershipAvailabilitySignal `protobuf:"varint,1,opt,name=signal,proto3,enum=clustermetadata.LeadershipAvailabilitySignal" json:"signal,omitempty"`
+	// reason is a human-readable explanation of why the signal was set.
+	// Intended for debugging and observability only; not used in decision logic.
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeadershipAvailability) Reset() {
+	*x = LeadershipAvailability{}
+	mi := &file_clustermetadata_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeadershipAvailability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeadershipAvailability) ProtoMessage() {}
+
+func (x *LeadershipAvailability) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeadershipAvailability.ProtoReflect.Descriptor instead.
+func (*LeadershipAvailability) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *LeadershipAvailability) GetSignal() LeadershipAvailabilitySignal {
+	if x != nil {
+		return x.Signal
+	}
+	return LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN
+}
+
+func (x *LeadershipAvailability) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 var File_clustermetadata_proto protoreflect.FileDescriptor
@@ -3085,13 +3212,17 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x10LeadershipStatus\x12\x1f\n" +
 	"\vleader_term\x18\x01 \x01(\x03R\n" +
 	"leaderTerm\x129\n" +
-	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"\xfd\x01\n" +
+	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"\xdf\x02\n" +
 	"\x12AvailabilityStatus\x12N\n" +
 	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus\x12d\n" +
 	"\x19cohort_eligibility_status\x18\x02 \x01(\v2(.clustermetadata.CohortEligibilityStatusR\x17cohortEligibilityStatus\x121\n" +
-	"\x14suspected_divergence\x18\x03 \x01(\bR\x13suspectedDivergence\"[\n" +
+	"\x14suspected_divergence\x18\x03 \x01(\bR\x13suspectedDivergence\x12`\n" +
+	"\x17leadership_availability\x18\x04 \x01(\v2'.clustermetadata.LeadershipAvailabilityR\x16leadershipAvailability\"[\n" +
 	"\x17CohortEligibilityStatus\x12@\n" +
-	"\x06signal\x18\x01 \x01(\x0e2(.clustermetadata.CohortEligibilitySignalR\x06signal*D\n" +
+	"\x06signal\x18\x01 \x01(\x0e2(.clustermetadata.CohortEligibilitySignalR\x06signal\"w\n" +
+	"\x16LeadershipAvailability\x12E\n" +
+	"\x06signal\x18\x01 \x01(\x0e2-.clustermetadata.LeadershipAvailabilitySignalR\x06signal\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason*D\n" +
 	"\n" +
 	"PoolerType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
@@ -3125,7 +3256,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x17CohortEligibilitySignal\x12%\n" +
 	"!COHORT_ELIGIBILITY_SIGNAL_UNKNOWN\x10\x00\x12&\n" +
 	"\"COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE\x10\x01\x12(\n" +
-	"$COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
+	"$COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE\x10\x02*\xa1\x01\n" +
+	"\x1cLeadershipAvailabilitySignal\x12*\n" +
+	"&LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN\x10\x00\x12+\n" +
+	"'LEADERSHIP_AVAILABILITY_SIGNAL_STARTING\x10\x01\x12(\n" +
+	"$LEADERSHIP_AVAILABILITY_SIGNAL_READY\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
 
 var (
 	file_clustermetadata_proto_rawDescOnce sync.Once
@@ -3139,8 +3274,8 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                       // 0: clustermetadata.PoolerType
 	(PoolerLifecycleStatus)(0),            // 1: clustermetadata.PoolerLifecycleStatus
@@ -3149,103 +3284,107 @@ var file_clustermetadata_proto_goTypes = []any{
 	(RoutingRole)(0),                      // 4: clustermetadata.RoutingRole
 	(LeadershipSignal)(0),                 // 5: clustermetadata.LeadershipSignal
 	(CohortEligibilitySignal)(0),          // 6: clustermetadata.CohortEligibilitySignal
-	(ID_ComponentType)(0),                 // 7: clustermetadata.ID.ComponentType
-	(*GlobalTopoConfig)(nil),              // 8: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),                          // 9: clustermetadata.Cell
-	(*Database)(nil),                      // 10: clustermetadata.Database
-	(*ShardInitClaim)(nil),                // 11: clustermetadata.ShardInitClaim
-	(*BackupLocation)(nil),                // 12: clustermetadata.BackupLocation
-	(*FilesystemBackup)(nil),              // 13: clustermetadata.FilesystemBackup
-	(*S3Backup)(nil),                      // 14: clustermetadata.S3Backup
-	(*PoolerAddress)(nil),                 // 15: clustermetadata.PoolerAddress
-	(*Multipooler)(nil),                   // 16: clustermetadata.Multipooler
-	(*Multigateway)(nil),                  // 17: clustermetadata.Multigateway
-	(*ShardKey)(nil),                      // 18: clustermetadata.ShardKey
-	(*Multiorch)(nil),                     // 19: clustermetadata.Multiorch
-	(*ID)(nil),                            // 20: clustermetadata.ID
-	(*KeyRange)(nil),                      // 21: clustermetadata.KeyRange
-	(*PoolerLifecycle)(nil),               // 22: clustermetadata.PoolerLifecycle
-	(*DurabilityPolicy)(nil),              // 23: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),                    // 24: clustermetadata.RuleNumber
-	(*ShardRule)(nil),                     // 25: clustermetadata.ShardRule
-	(*RulePosition)(nil),                  // 26: clustermetadata.RulePosition
-	(*PoolerPosition)(nil),                // 27: clustermetadata.PoolerPosition
-	(*RuleNumberPosition)(nil),            // 28: clustermetadata.RuleNumberPosition
-	(*LsnPosition)(nil),                   // 29: clustermetadata.LsnPosition
-	(*ConsensusPromises)(nil),             // 30: clustermetadata.ConsensusPromises
-	(*RoutingState)(nil),                  // 31: clustermetadata.RoutingState
-	(*ReplicationPrimary)(nil),            // 32: clustermetadata.ReplicationPrimary
-	(*TermRevocation)(nil),                // 33: clustermetadata.TermRevocation
-	(*ExternallyCertifiedRevocation)(nil), // 34: clustermetadata.ExternallyCertifiedRevocation
-	(*ConsensusStatus)(nil),               // 35: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),              // 36: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),            // 37: clustermetadata.AvailabilityStatus
-	(*CohortEligibilityStatus)(nil),       // 38: clustermetadata.CohortEligibilityStatus
-	nil,                                   // 39: clustermetadata.Multipooler.PortMapEntry
-	nil,                                   // 40: clustermetadata.Multigateway.PortMapEntry
-	nil,                                   // 41: clustermetadata.Multiorch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),         // 42: google.protobuf.Timestamp
+	(LeadershipAvailabilitySignal)(0),     // 7: clustermetadata.LeadershipAvailabilitySignal
+	(ID_ComponentType)(0),                 // 8: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil),              // 9: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),                          // 10: clustermetadata.Cell
+	(*Database)(nil),                      // 11: clustermetadata.Database
+	(*ShardInitClaim)(nil),                // 12: clustermetadata.ShardInitClaim
+	(*BackupLocation)(nil),                // 13: clustermetadata.BackupLocation
+	(*FilesystemBackup)(nil),              // 14: clustermetadata.FilesystemBackup
+	(*S3Backup)(nil),                      // 15: clustermetadata.S3Backup
+	(*PoolerAddress)(nil),                 // 16: clustermetadata.PoolerAddress
+	(*Multipooler)(nil),                   // 17: clustermetadata.Multipooler
+	(*Multigateway)(nil),                  // 18: clustermetadata.Multigateway
+	(*ShardKey)(nil),                      // 19: clustermetadata.ShardKey
+	(*Multiorch)(nil),                     // 20: clustermetadata.Multiorch
+	(*ID)(nil),                            // 21: clustermetadata.ID
+	(*KeyRange)(nil),                      // 22: clustermetadata.KeyRange
+	(*PoolerLifecycle)(nil),               // 23: clustermetadata.PoolerLifecycle
+	(*DurabilityPolicy)(nil),              // 24: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),                    // 25: clustermetadata.RuleNumber
+	(*ShardRule)(nil),                     // 26: clustermetadata.ShardRule
+	(*RulePosition)(nil),                  // 27: clustermetadata.RulePosition
+	(*PoolerPosition)(nil),                // 28: clustermetadata.PoolerPosition
+	(*RuleNumberPosition)(nil),            // 29: clustermetadata.RuleNumberPosition
+	(*LsnPosition)(nil),                   // 30: clustermetadata.LsnPosition
+	(*ConsensusPromises)(nil),             // 31: clustermetadata.ConsensusPromises
+	(*RoutingState)(nil),                  // 32: clustermetadata.RoutingState
+	(*ReplicationPrimary)(nil),            // 33: clustermetadata.ReplicationPrimary
+	(*TermRevocation)(nil),                // 34: clustermetadata.TermRevocation
+	(*ExternallyCertifiedRevocation)(nil), // 35: clustermetadata.ExternallyCertifiedRevocation
+	(*ConsensusStatus)(nil),               // 36: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),              // 37: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),            // 38: clustermetadata.AvailabilityStatus
+	(*CohortEligibilityStatus)(nil),       // 39: clustermetadata.CohortEligibilityStatus
+	(*LeadershipAvailability)(nil),        // 40: clustermetadata.LeadershipAvailability
+	nil,                                   // 41: clustermetadata.Multipooler.PortMapEntry
+	nil,                                   // 42: clustermetadata.Multigateway.PortMapEntry
+	nil,                                   // 43: clustermetadata.Multiorch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),         // 44: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	12, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	23, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	20, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	20, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
-	13, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
-	14, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	20, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
-	20, // 7: clustermetadata.Multipooler.id:type_name -> clustermetadata.ID
-	18, // 8: clustermetadata.Multipooler.shard_key:type_name -> clustermetadata.ShardKey
-	21, // 9: clustermetadata.Multipooler.key_range:type_name -> clustermetadata.KeyRange
+	13, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
+	24, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	21, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	21, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	14, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
+	15, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
+	21, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
+	21, // 7: clustermetadata.Multipooler.id:type_name -> clustermetadata.ID
+	19, // 8: clustermetadata.Multipooler.shard_key:type_name -> clustermetadata.ShardKey
+	22, // 9: clustermetadata.Multipooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 10: clustermetadata.Multipooler.type:type_name -> clustermetadata.PoolerType
 	2,  // 11: clustermetadata.Multipooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	39, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
-	22, // 13: clustermetadata.Multipooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
-	31, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
-	20, // 15: clustermetadata.Multigateway.id:type_name -> clustermetadata.ID
-	40, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
-	20, // 17: clustermetadata.Multiorch.id:type_name -> clustermetadata.ID
-	41, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
-	7,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	41, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
+	23, // 13: clustermetadata.Multipooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
+	32, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
+	21, // 15: clustermetadata.Multigateway.id:type_name -> clustermetadata.ID
+	42, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
+	21, // 17: clustermetadata.Multiorch.id:type_name -> clustermetadata.ID
+	43, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
+	8,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
 	1,  // 20: clustermetadata.PoolerLifecycle.status:type_name -> clustermetadata.PoolerLifecycleStatus
-	42, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
+	44, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
 	3,  // 22: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	24, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	20, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	20, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	23, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	20, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	42, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	25, // 29: clustermetadata.RulePosition.decision:type_name -> clustermetadata.ShardRule
-	25, // 30: clustermetadata.RulePosition.proposal:type_name -> clustermetadata.ShardRule
-	26, // 31: clustermetadata.PoolerPosition.position:type_name -> clustermetadata.RulePosition
-	24, // 32: clustermetadata.RuleNumberPosition.decision:type_name -> clustermetadata.RuleNumber
-	24, // 33: clustermetadata.RuleNumberPosition.proposal:type_name -> clustermetadata.RuleNumber
-	28, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
-	33, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
-	29, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	25, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	21, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	21, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	24, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	21, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	44, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	26, // 29: clustermetadata.RulePosition.decision:type_name -> clustermetadata.ShardRule
+	26, // 30: clustermetadata.RulePosition.proposal:type_name -> clustermetadata.ShardRule
+	27, // 31: clustermetadata.PoolerPosition.position:type_name -> clustermetadata.RulePosition
+	25, // 32: clustermetadata.RuleNumberPosition.decision:type_name -> clustermetadata.RuleNumber
+	25, // 33: clustermetadata.RuleNumberPosition.proposal:type_name -> clustermetadata.RuleNumber
+	29, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
+	34, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
+	30, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	4,  // 37: clustermetadata.RoutingState.role:type_name -> clustermetadata.RoutingRole
-	24, // 38: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
-	26, // 39: clustermetadata.ReplicationPrimary.position:type_name -> clustermetadata.RulePosition
-	15, // 40: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
-	20, // 41: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	42, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	24, // 43: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
-	33, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	33, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	27, // 46: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	32, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
-	20, // 48: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	29, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	25, // 38: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
+	27, // 39: clustermetadata.ReplicationPrimary.position:type_name -> clustermetadata.RulePosition
+	16, // 40: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
+	21, // 41: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	44, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	25, // 43: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
+	34, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	34, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	28, // 46: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	33, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	21, // 48: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	30, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	5,  // 50: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	36, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	38, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
-	6,  // 53: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
-	54, // [54:54] is the sub-list for method output_type
-	54, // [54:54] is the sub-list for method input_type
-	54, // [54:54] is the sub-list for extension type_name
-	54, // [54:54] is the sub-list for extension extendee
-	0,  // [0:54] is the sub-list for field type_name
+	37, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	39, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	40, // 53: clustermetadata.AvailabilityStatus.leadership_availability:type_name -> clustermetadata.LeadershipAvailability
+	6,  // 54: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
+	7,  // 55: clustermetadata.LeadershipAvailability.signal:type_name -> clustermetadata.LeadershipAvailabilitySignal
+	56, // [56:56] is the sub-list for method output_type
+	56, // [56:56] is the sub-list for method input_type
+	56, // [56:56] is the sub-list for extension type_name
+	56, // [56:56] is the sub-list for extension extendee
+	0,  // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }
@@ -3262,8 +3401,8 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   34,
+			NumEnums:      9,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -498,6 +498,63 @@ func (CohortEligibilitySignal) EnumDescriptor() ([]byte, []int) {
 	return file_clustermetadata_proto_rawDescGZIP(), []int{6}
 }
 
+// LeadershipAvailabilitySignal describes whether a pooler is ready to be
+// promoted to consensus leader.
+type LeadershipAvailabilitySignal int32
+
+const (
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN LeadershipAvailabilitySignal = 0
+	// Pooler's postgres is still initialising (starting, in crash recovery,
+	// socket not yet open). The node can still be elected if it has the most
+	// advanced WAL position and no READY node is tied with it.
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING LeadershipAvailabilitySignal = 1
+	// Pooler's postgres is running and accepting connections. When multiple
+	// nodes are tied at the same WAL position the coordinator prefers a READY
+	// node over a STARTING one.
+	LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY LeadershipAvailabilitySignal = 2
+)
+
+// Enum value maps for LeadershipAvailabilitySignal.
+var (
+	LeadershipAvailabilitySignal_name = map[int32]string{
+		0: "LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN",
+		1: "LEADERSHIP_AVAILABILITY_SIGNAL_STARTING",
+		2: "LEADERSHIP_AVAILABILITY_SIGNAL_READY",
+	}
+	LeadershipAvailabilitySignal_value = map[string]int32{
+		"LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN":  0,
+		"LEADERSHIP_AVAILABILITY_SIGNAL_STARTING": 1,
+		"LEADERSHIP_AVAILABILITY_SIGNAL_READY":    2,
+	}
+)
+
+func (x LeadershipAvailabilitySignal) Enum() *LeadershipAvailabilitySignal {
+	p := new(LeadershipAvailabilitySignal)
+	*p = x
+	return p
+}
+
+func (x LeadershipAvailabilitySignal) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LeadershipAvailabilitySignal) Descriptor() protoreflect.EnumDescriptor {
+	return file_clustermetadata_proto_enumTypes[7].Descriptor()
+}
+
+func (LeadershipAvailabilitySignal) Type() protoreflect.EnumType {
+	return &file_clustermetadata_proto_enumTypes[7]
+}
+
+func (x LeadershipAvailabilitySignal) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LeadershipAvailabilitySignal.Descriptor instead.
+func (LeadershipAvailabilitySignal) EnumDescriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{7}
+}
+
 // ComponentType represents the type of Multigres component
 type ID_ComponentType int32
 
@@ -539,11 +596,11 @@ func (x ID_ComponentType) String() string {
 }
 
 func (ID_ComponentType) Descriptor() protoreflect.EnumDescriptor {
-	return file_clustermetadata_proto_enumTypes[7].Descriptor()
+	return file_clustermetadata_proto_enumTypes[8].Descriptor()
 }
 
 func (ID_ComponentType) Type() protoreflect.EnumType {
-	return &file_clustermetadata_proto_enumTypes[7]
+	return &file_clustermetadata_proto_enumTypes[8]
 }
 
 func (x ID_ComponentType) Number() protoreflect.EnumNumber {
@@ -2798,8 +2855,13 @@ type AvailabilityStatus struct {
 	// suspected divergence may be slower to endorse a new rule proposal because it
 	// needs to stop, run pg_rewind, and restart.
 	SuspectedDivergence bool `protobuf:"varint,3,opt,name=suspected_divergence,json=suspectedDivergence,proto3" json:"suspected_divergence,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// leadership_availability reports whether the pooler's postgres is ready to
+	// accept promotion to consensus leader. Published by every pooler. UNKNOWN
+	// (the default for older poolers) is treated the same as ELIGIBLE so that
+	// the coordinator can fall back gracefully when the field is absent.
+	LeadershipAvailability *LeadershipAvailability `protobuf:"bytes,4,opt,name=leadership_availability,json=leadershipAvailability,proto3" json:"leadership_availability,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *AvailabilityStatus) Reset() {
@@ -2853,6 +2915,13 @@ func (x *AvailabilityStatus) GetSuspectedDivergence() bool {
 	return false
 }
 
+func (x *AvailabilityStatus) GetLeadershipAvailability() *LeadershipAvailability {
+	if x != nil {
+		return x.LeadershipAvailability
+	}
+	return nil
+}
+
 // CohortEligibilityStatus carries the pooler's cohort-eligibility signal.
 // Unlike LeadershipStatus there is no per-term gating: eligibility is a
 // current preference, not tied to a specific epoch. Staleness comes from the
@@ -2899,6 +2968,64 @@ func (x *CohortEligibilityStatus) GetSignal() CohortEligibilitySignal {
 		return x.Signal
 	}
 	return CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_UNKNOWN
+}
+
+// LeadershipAvailability carries the pooler's self-reported readiness to
+// accept leader promotion. Unlike CohortEligibilityStatus this is not a
+// permanent preference — it reflects the transient startup state of postgres.
+// Staleness comes from the freshness of the surrounding health snapshot.
+type LeadershipAvailability struct {
+	state  protoimpl.MessageState       `protogen:"open.v1"`
+	Signal LeadershipAvailabilitySignal `protobuf:"varint,1,opt,name=signal,proto3,enum=clustermetadata.LeadershipAvailabilitySignal" json:"signal,omitempty"`
+	// reason is a human-readable explanation of why the signal was set.
+	// Intended for debugging and observability only; not used in decision logic.
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeadershipAvailability) Reset() {
+	*x = LeadershipAvailability{}
+	mi := &file_clustermetadata_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeadershipAvailability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeadershipAvailability) ProtoMessage() {}
+
+func (x *LeadershipAvailability) ProtoReflect() protoreflect.Message {
+	mi := &file_clustermetadata_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeadershipAvailability.ProtoReflect.Descriptor instead.
+func (*LeadershipAvailability) Descriptor() ([]byte, []int) {
+	return file_clustermetadata_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *LeadershipAvailability) GetSignal() LeadershipAvailabilitySignal {
+	if x != nil {
+		return x.Signal
+	}
+	return LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN
+}
+
+func (x *LeadershipAvailability) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 var File_clustermetadata_proto protoreflect.FileDescriptor
@@ -3059,13 +3186,17 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x10LeadershipStatus\x12\x1f\n" +
 	"\vleader_term\x18\x01 \x01(\x03R\n" +
 	"leaderTerm\x129\n" +
-	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"\xfd\x01\n" +
+	"\x06signal\x18\x02 \x01(\x0e2!.clustermetadata.LeadershipSignalR\x06signal\"\xdf\x02\n" +
 	"\x12AvailabilityStatus\x12N\n" +
 	"\x11leadership_status\x18\x01 \x01(\v2!.clustermetadata.LeadershipStatusR\x10leadershipStatus\x12d\n" +
 	"\x19cohort_eligibility_status\x18\x02 \x01(\v2(.clustermetadata.CohortEligibilityStatusR\x17cohortEligibilityStatus\x121\n" +
-	"\x14suspected_divergence\x18\x03 \x01(\bR\x13suspectedDivergence\"[\n" +
+	"\x14suspected_divergence\x18\x03 \x01(\bR\x13suspectedDivergence\x12`\n" +
+	"\x17leadership_availability\x18\x04 \x01(\v2'.clustermetadata.LeadershipAvailabilityR\x16leadershipAvailability\"[\n" +
 	"\x17CohortEligibilityStatus\x12@\n" +
-	"\x06signal\x18\x01 \x01(\x0e2(.clustermetadata.CohortEligibilitySignalR\x06signal*D\n" +
+	"\x06signal\x18\x01 \x01(\x0e2(.clustermetadata.CohortEligibilitySignalR\x06signal\"w\n" +
+	"\x16LeadershipAvailability\x12E\n" +
+	"\x06signal\x18\x01 \x01(\x0e2-.clustermetadata.LeadershipAvailabilitySignalR\x06signal\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason*D\n" +
 	"\n" +
 	"PoolerType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
@@ -3099,7 +3230,11 @@ const file_clustermetadata_proto_rawDesc = "" +
 	"\x17CohortEligibilitySignal\x12%\n" +
 	"!COHORT_ELIGIBILITY_SIGNAL_UNKNOWN\x10\x00\x12&\n" +
 	"\"COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE\x10\x01\x12(\n" +
-	"$COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
+	"$COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE\x10\x02*\xa1\x01\n" +
+	"\x1cLeadershipAvailabilitySignal\x12*\n" +
+	"&LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN\x10\x00\x12+\n" +
+	"'LEADERSHIP_AVAILABILITY_SIGNAL_STARTING\x10\x01\x12(\n" +
+	"$LEADERSHIP_AVAILABILITY_SIGNAL_READY\x10\x02B6Z4github.com/multigres/multigres/go/pb/clustermetadatab\x06proto3"
 
 var (
 	file_clustermetadata_proto_rawDescOnce sync.Once
@@ -3113,8 +3248,8 @@ func file_clustermetadata_proto_rawDescGZIP() []byte {
 	return file_clustermetadata_proto_rawDescData
 }
 
-var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_clustermetadata_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
+var file_clustermetadata_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_clustermetadata_proto_goTypes = []any{
 	(PoolerType)(0),                       // 0: clustermetadata.PoolerType
 	(PoolerLifecycleStatus)(0),            // 1: clustermetadata.PoolerLifecycleStatus
@@ -3123,103 +3258,107 @@ var file_clustermetadata_proto_goTypes = []any{
 	(RoutingRole)(0),                      // 4: clustermetadata.RoutingRole
 	(LeadershipSignal)(0),                 // 5: clustermetadata.LeadershipSignal
 	(CohortEligibilitySignal)(0),          // 6: clustermetadata.CohortEligibilitySignal
-	(ID_ComponentType)(0),                 // 7: clustermetadata.ID.ComponentType
-	(*GlobalTopoConfig)(nil),              // 8: clustermetadata.GlobalTopoConfig
-	(*Cell)(nil),                          // 9: clustermetadata.Cell
-	(*Database)(nil),                      // 10: clustermetadata.Database
-	(*ShardInitClaim)(nil),                // 11: clustermetadata.ShardInitClaim
-	(*BackupLocation)(nil),                // 12: clustermetadata.BackupLocation
-	(*FilesystemBackup)(nil),              // 13: clustermetadata.FilesystemBackup
-	(*S3Backup)(nil),                      // 14: clustermetadata.S3Backup
-	(*PoolerAddress)(nil),                 // 15: clustermetadata.PoolerAddress
-	(*Multipooler)(nil),                   // 16: clustermetadata.Multipooler
-	(*Multigateway)(nil),                  // 17: clustermetadata.Multigateway
-	(*ShardKey)(nil),                      // 18: clustermetadata.ShardKey
-	(*Multiorch)(nil),                     // 19: clustermetadata.Multiorch
-	(*ID)(nil),                            // 20: clustermetadata.ID
-	(*KeyRange)(nil),                      // 21: clustermetadata.KeyRange
-	(*PoolerLifecycle)(nil),               // 22: clustermetadata.PoolerLifecycle
-	(*DurabilityPolicy)(nil),              // 23: clustermetadata.DurabilityPolicy
-	(*RuleNumber)(nil),                    // 24: clustermetadata.RuleNumber
-	(*ShardRule)(nil),                     // 25: clustermetadata.ShardRule
-	(*RulePosition)(nil),                  // 26: clustermetadata.RulePosition
-	(*PoolerPosition)(nil),                // 27: clustermetadata.PoolerPosition
-	(*RuleNumberPosition)(nil),            // 28: clustermetadata.RuleNumberPosition
-	(*LsnPosition)(nil),                   // 29: clustermetadata.LsnPosition
-	(*ConsensusPromises)(nil),             // 30: clustermetadata.ConsensusPromises
-	(*RoutingState)(nil),                  // 31: clustermetadata.RoutingState
-	(*ReplicationPrimary)(nil),            // 32: clustermetadata.ReplicationPrimary
-	(*TermRevocation)(nil),                // 33: clustermetadata.TermRevocation
-	(*ExternallyCertifiedRevocation)(nil), // 34: clustermetadata.ExternallyCertifiedRevocation
-	(*ConsensusStatus)(nil),               // 35: clustermetadata.ConsensusStatus
-	(*LeadershipStatus)(nil),              // 36: clustermetadata.LeadershipStatus
-	(*AvailabilityStatus)(nil),            // 37: clustermetadata.AvailabilityStatus
-	(*CohortEligibilityStatus)(nil),       // 38: clustermetadata.CohortEligibilityStatus
-	nil,                                   // 39: clustermetadata.Multipooler.PortMapEntry
-	nil,                                   // 40: clustermetadata.Multigateway.PortMapEntry
-	nil,                                   // 41: clustermetadata.Multiorch.PortMapEntry
-	(*timestamppb.Timestamp)(nil),         // 42: google.protobuf.Timestamp
+	(LeadershipAvailabilitySignal)(0),     // 7: clustermetadata.LeadershipAvailabilitySignal
+	(ID_ComponentType)(0),                 // 8: clustermetadata.ID.ComponentType
+	(*GlobalTopoConfig)(nil),              // 9: clustermetadata.GlobalTopoConfig
+	(*Cell)(nil),                          // 10: clustermetadata.Cell
+	(*Database)(nil),                      // 11: clustermetadata.Database
+	(*ShardInitClaim)(nil),                // 12: clustermetadata.ShardInitClaim
+	(*BackupLocation)(nil),                // 13: clustermetadata.BackupLocation
+	(*FilesystemBackup)(nil),              // 14: clustermetadata.FilesystemBackup
+	(*S3Backup)(nil),                      // 15: clustermetadata.S3Backup
+	(*PoolerAddress)(nil),                 // 16: clustermetadata.PoolerAddress
+	(*Multipooler)(nil),                   // 17: clustermetadata.Multipooler
+	(*Multigateway)(nil),                  // 18: clustermetadata.Multigateway
+	(*ShardKey)(nil),                      // 19: clustermetadata.ShardKey
+	(*Multiorch)(nil),                     // 20: clustermetadata.Multiorch
+	(*ID)(nil),                            // 21: clustermetadata.ID
+	(*KeyRange)(nil),                      // 22: clustermetadata.KeyRange
+	(*PoolerLifecycle)(nil),               // 23: clustermetadata.PoolerLifecycle
+	(*DurabilityPolicy)(nil),              // 24: clustermetadata.DurabilityPolicy
+	(*RuleNumber)(nil),                    // 25: clustermetadata.RuleNumber
+	(*ShardRule)(nil),                     // 26: clustermetadata.ShardRule
+	(*RulePosition)(nil),                  // 27: clustermetadata.RulePosition
+	(*PoolerPosition)(nil),                // 28: clustermetadata.PoolerPosition
+	(*RuleNumberPosition)(nil),            // 29: clustermetadata.RuleNumberPosition
+	(*LsnPosition)(nil),                   // 30: clustermetadata.LsnPosition
+	(*ConsensusPromises)(nil),             // 31: clustermetadata.ConsensusPromises
+	(*RoutingState)(nil),                  // 32: clustermetadata.RoutingState
+	(*ReplicationPrimary)(nil),            // 33: clustermetadata.ReplicationPrimary
+	(*TermRevocation)(nil),                // 34: clustermetadata.TermRevocation
+	(*ExternallyCertifiedRevocation)(nil), // 35: clustermetadata.ExternallyCertifiedRevocation
+	(*ConsensusStatus)(nil),               // 36: clustermetadata.ConsensusStatus
+	(*LeadershipStatus)(nil),              // 37: clustermetadata.LeadershipStatus
+	(*AvailabilityStatus)(nil),            // 38: clustermetadata.AvailabilityStatus
+	(*CohortEligibilityStatus)(nil),       // 39: clustermetadata.CohortEligibilityStatus
+	(*LeadershipAvailability)(nil),        // 40: clustermetadata.LeadershipAvailability
+	nil,                                   // 41: clustermetadata.Multipooler.PortMapEntry
+	nil,                                   // 42: clustermetadata.Multigateway.PortMapEntry
+	nil,                                   // 43: clustermetadata.Multiorch.PortMapEntry
+	(*timestamppb.Timestamp)(nil),         // 44: google.protobuf.Timestamp
 }
 var file_clustermetadata_proto_depIdxs = []int32{
-	12, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
-	23, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	20, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
-	20, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
-	13, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
-	14, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
-	20, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
-	20, // 7: clustermetadata.Multipooler.id:type_name -> clustermetadata.ID
-	18, // 8: clustermetadata.Multipooler.shard_key:type_name -> clustermetadata.ShardKey
-	21, // 9: clustermetadata.Multipooler.key_range:type_name -> clustermetadata.KeyRange
+	13, // 0: clustermetadata.Database.backup_location:type_name -> clustermetadata.BackupLocation
+	24, // 1: clustermetadata.Database.bootstrap_durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	21, // 2: clustermetadata.ShardInitClaim.claimer_id:type_name -> clustermetadata.ID
+	21, // 3: clustermetadata.ShardInitClaim.cohort_members:type_name -> clustermetadata.ID
+	14, // 4: clustermetadata.BackupLocation.filesystem:type_name -> clustermetadata.FilesystemBackup
+	15, // 5: clustermetadata.BackupLocation.s3:type_name -> clustermetadata.S3Backup
+	21, // 6: clustermetadata.PoolerAddress.id:type_name -> clustermetadata.ID
+	21, // 7: clustermetadata.Multipooler.id:type_name -> clustermetadata.ID
+	19, // 8: clustermetadata.Multipooler.shard_key:type_name -> clustermetadata.ShardKey
+	22, // 9: clustermetadata.Multipooler.key_range:type_name -> clustermetadata.KeyRange
 	0,  // 10: clustermetadata.Multipooler.type:type_name -> clustermetadata.PoolerType
 	2,  // 11: clustermetadata.Multipooler.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	39, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
-	22, // 13: clustermetadata.Multipooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
-	31, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
-	20, // 15: clustermetadata.Multigateway.id:type_name -> clustermetadata.ID
-	40, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
-	20, // 17: clustermetadata.Multiorch.id:type_name -> clustermetadata.ID
-	41, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
-	7,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
+	41, // 12: clustermetadata.Multipooler.port_map:type_name -> clustermetadata.Multipooler.PortMapEntry
+	23, // 13: clustermetadata.Multipooler.lifecycle_status:type_name -> clustermetadata.PoolerLifecycle
+	32, // 14: clustermetadata.Multipooler.routing_state:type_name -> clustermetadata.RoutingState
+	21, // 15: clustermetadata.Multigateway.id:type_name -> clustermetadata.ID
+	42, // 16: clustermetadata.Multigateway.port_map:type_name -> clustermetadata.Multigateway.PortMapEntry
+	21, // 17: clustermetadata.Multiorch.id:type_name -> clustermetadata.ID
+	43, // 18: clustermetadata.Multiorch.port_map:type_name -> clustermetadata.Multiorch.PortMapEntry
+	8,  // 19: clustermetadata.ID.component:type_name -> clustermetadata.ID.ComponentType
 	1,  // 20: clustermetadata.PoolerLifecycle.status:type_name -> clustermetadata.PoolerLifecycleStatus
-	42, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
+	44, // 21: clustermetadata.PoolerLifecycle.updated:type_name -> google.protobuf.Timestamp
 	3,  // 22: clustermetadata.DurabilityPolicy.quorum_type:type_name -> clustermetadata.QuorumType
-	24, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
-	20, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
-	20, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
-	23, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
-	20, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
-	42, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
-	25, // 29: clustermetadata.RulePosition.decision:type_name -> clustermetadata.ShardRule
-	25, // 30: clustermetadata.RulePosition.proposal:type_name -> clustermetadata.ShardRule
-	26, // 31: clustermetadata.PoolerPosition.position:type_name -> clustermetadata.RulePosition
-	24, // 32: clustermetadata.RuleNumberPosition.decision:type_name -> clustermetadata.RuleNumber
-	24, // 33: clustermetadata.RuleNumberPosition.proposal:type_name -> clustermetadata.RuleNumber
-	28, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
-	33, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
-	29, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	25, // 23: clustermetadata.ShardRule.rule_number:type_name -> clustermetadata.RuleNumber
+	21, // 24: clustermetadata.ShardRule.leader_id:type_name -> clustermetadata.ID
+	21, // 25: clustermetadata.ShardRule.cohort_members:type_name -> clustermetadata.ID
+	24, // 26: clustermetadata.ShardRule.durability_policy:type_name -> clustermetadata.DurabilityPolicy
+	21, // 27: clustermetadata.ShardRule.coordinator_id:type_name -> clustermetadata.ID
+	44, // 28: clustermetadata.ShardRule.creation_time:type_name -> google.protobuf.Timestamp
+	26, // 29: clustermetadata.RulePosition.decision:type_name -> clustermetadata.ShardRule
+	26, // 30: clustermetadata.RulePosition.proposal:type_name -> clustermetadata.ShardRule
+	27, // 31: clustermetadata.PoolerPosition.position:type_name -> clustermetadata.RulePosition
+	25, // 32: clustermetadata.RuleNumberPosition.decision:type_name -> clustermetadata.RuleNumber
+	25, // 33: clustermetadata.RuleNumberPosition.proposal:type_name -> clustermetadata.RuleNumber
+	29, // 34: clustermetadata.LsnPosition.position:type_name -> clustermetadata.RuleNumberPosition
+	34, // 35: clustermetadata.ConsensusPromises.term_revocation:type_name -> clustermetadata.TermRevocation
+	30, // 36: clustermetadata.ConsensusPromises.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	4,  // 37: clustermetadata.RoutingState.role:type_name -> clustermetadata.RoutingRole
-	24, // 38: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
-	26, // 39: clustermetadata.ReplicationPrimary.position:type_name -> clustermetadata.RulePosition
-	15, // 40: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
-	20, // 41: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
-	42, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
-	24, // 43: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
-	33, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
-	33, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
-	27, // 46: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
-	32, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
-	20, // 48: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
-	29, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
+	25, // 38: clustermetadata.RoutingState.rule:type_name -> clustermetadata.RuleNumber
+	27, // 39: clustermetadata.ReplicationPrimary.position:type_name -> clustermetadata.RulePosition
+	16, // 40: clustermetadata.ReplicationPrimary.primary:type_name -> clustermetadata.PoolerAddress
+	21, // 41: clustermetadata.TermRevocation.accepted_coordinator_id:type_name -> clustermetadata.ID
+	44, // 42: clustermetadata.TermRevocation.coordinator_initiated_at:type_name -> google.protobuf.Timestamp
+	25, // 43: clustermetadata.TermRevocation.outgoing_rule:type_name -> clustermetadata.RuleNumber
+	34, // 44: clustermetadata.ExternallyCertifiedRevocation.term_revocation:type_name -> clustermetadata.TermRevocation
+	34, // 45: clustermetadata.ConsensusStatus.term_revocation:type_name -> clustermetadata.TermRevocation
+	28, // 46: clustermetadata.ConsensusStatus.current_position:type_name -> clustermetadata.PoolerPosition
+	33, // 47: clustermetadata.ConsensusStatus.replication_primary:type_name -> clustermetadata.ReplicationPrimary
+	21, // 48: clustermetadata.ConsensusStatus.id:type_name -> clustermetadata.ID
+	30, // 49: clustermetadata.ConsensusStatus.recruit_blocked_until:type_name -> clustermetadata.LsnPosition
 	5,  // 50: clustermetadata.LeadershipStatus.signal:type_name -> clustermetadata.LeadershipSignal
-	36, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
-	38, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
-	6,  // 53: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
-	54, // [54:54] is the sub-list for method output_type
-	54, // [54:54] is the sub-list for method input_type
-	54, // [54:54] is the sub-list for extension type_name
-	54, // [54:54] is the sub-list for extension extendee
-	0,  // [0:54] is the sub-list for field type_name
+	37, // 51: clustermetadata.AvailabilityStatus.leadership_status:type_name -> clustermetadata.LeadershipStatus
+	39, // 52: clustermetadata.AvailabilityStatus.cohort_eligibility_status:type_name -> clustermetadata.CohortEligibilityStatus
+	40, // 53: clustermetadata.AvailabilityStatus.leadership_availability:type_name -> clustermetadata.LeadershipAvailability
+	6,  // 54: clustermetadata.CohortEligibilityStatus.signal:type_name -> clustermetadata.CohortEligibilitySignal
+	7,  // 55: clustermetadata.LeadershipAvailability.signal:type_name -> clustermetadata.LeadershipAvailabilitySignal
+	56, // [56:56] is the sub-list for method output_type
+	56, // [56:56] is the sub-list for method input_type
+	56, // [56:56] is the sub-list for extension type_name
+	56, // [56:56] is the sub-list for extension extendee
+	0,  // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_clustermetadata_proto_init() }
@@ -3236,8 +3375,8 @@ func file_clustermetadata_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_clustermetadata_proto_rawDesc), len(file_clustermetadata_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   34,
+			NumEnums:      9,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -17,6 +17,7 @@ package consensus
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"sync"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -120,8 +121,30 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION, "%v", err)
 	}
 
-	poolerByID, _ := buildCohortMaps(cohort)
+	poolerByID, healthByID := buildCohortMaps(cohort)
+	less := leadershipLess(healthByID)
 	buildProposal := func(r commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+		// Sort the eligible leaders so that READY nodes are preferred over
+		// STARTING nodes when multiple candidates share the highest LSN. A
+		// STARTING candidate's postgres is still initialising (starting, crash
+		// recovery, or socket not open), so electing it could cause a promote
+		// failure and force a new round of elections. Preferring an
+		// already-READY candidate avoids that delay.
+		//
+		// WAL position is always the primary criterion: a STARTING node still
+		// wins if it holds a strictly higher LSN than every READY node.
+		//
+		// We put this logic in the proposal builder rather than the proposal
+		// core because it only affects the ordering of tied leaders when
+		// actually sending promote to it.
+		//
+		// This works because buildFailoverProposal only looks at the first
+		// eligible leader, so as long as all READY nodes are sorted before
+		// STARTING nodes, we will prefer READY leaders without affecting the
+		// quorum logic.
+		sort.SliceStable(r.EligibleLeaders, func(i, j int) bool {
+			return less(r.EligibleLeaders[i], r.EligibleLeaders[j])
+		})
 		return buildFailoverProposal(r, poolerByID)
 	}
 	tryBuildProposal := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
@@ -278,6 +301,30 @@ func (c *Coordinator) GetBootstrapPolicy(ctx context.Context, database string) (
 
 	c.policyCache.Store(database, db.BootstrapDurabilityPolicy)
 	return db.BootstrapDurabilityPolicy, nil
+}
+
+// leadershipLess returns a less function for sort.SliceStable that orders
+// ConsensusStatus entries so READY nodes appear before STARTING nodes. It is
+// used as the tiebreaker when calling BuildSafeProposal when multiple nodes
+// share the highest LSN.
+//
+// UNKNOWN (the proto zero value, emitted by older poolers that do not publish
+// the field) is treated as READY for backward compatibility. (We might want to
+// change this in the future since we should prefer READY poolers before poolers
+// with UNKNOWN state, which could be ready or not.)
+//
+// Recruited nodes participate in the outgoing-cohort quorum check regardless of
+// their LeadershipAvailability — this tiebreaker only affects which tied node
+// is proposed as leader, not the quorum denominator.
+func leadershipLess(healthByID map[string]*multiorchdatapb.PoolerHealthState) func(a, b *clustermetadatapb.ConsensusStatus) bool {
+	isReady := func(id *clustermetadatapb.ID) bool {
+		h := healthByID[topoclient.ClusterIDString(id)]
+		sig := h.GetAvailabilityStatus().GetLeadershipAvailability().GetSignal()
+		return sig != clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING
+	}
+	return func(a, b *clustermetadatapb.ConsensusStatus) bool {
+		return isReady(a.GetId()) && !isReady(b.GetId())
+	}
 }
 
 // poolerIDs extracts the clustermetadata IDs from a slice of PoolerHealthState.

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -122,18 +122,25 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 	}
 
 	poolerByID, healthByID := buildCohortMaps(cohort)
-	less := poolerHealthStateLess(healthByID)
+	availLess := leadershipLess(healthByID)
+	signalLess := poolerHealthStateLess(healthByID)
 	buildProposal := func(r commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
-		// Prefer non-resigning nodes when multiple candidates share the highest
-		// LSN. A node signalling REQUESTING_DEMOTION has explicitly asked to be
-		// replaced. Electing it again immediately defeats the purpose of the
-		// switchover.
-		//
-		// A resigning node still wins if it holds a strictly higher LSN than
-		// every other node, but consensus status serves as a tiebreaker when
-		// multiple nodes are at the same WAL position.
+		// Sort tied candidates with two orthogonal tiebreakers applied in order:
+		//   1. LeadershipAvailability: READY before STARTING (postgres not yet ready
+		//      for promotion — crash recovery still running, socket not open).
+		//   2. LeadershipSignal: non-resigning before REQUESTING_DEMOTION (node has
+		//      explicitly asked to be replaced via SwitchPrimary).
+		// WAL position is always the primary criterion; both tiebreakers only
+		// affect the ordering within the tied-LSN set.
 		sort.SliceStable(r.EligibleLeaders, func(i, j int) bool {
-			return less(r.EligibleLeaders[i], r.EligibleLeaders[j])
+			a, b := r.EligibleLeaders[i], r.EligibleLeaders[j]
+			if availLess(a, b) {
+				return true
+			}
+			if availLess(b, a) {
+				return false
+			}
+			return signalLess(a, b)
 		})
 		return buildFailoverProposal(r, poolerByID)
 	}
@@ -291,6 +298,30 @@ func (c *Coordinator) GetBootstrapPolicy(ctx context.Context, database string) (
 
 	c.policyCache.Store(database, db.BootstrapDurabilityPolicy)
 	return db.BootstrapDurabilityPolicy, nil
+}
+
+// leadershipLess returns a less function for sort.SliceStable that orders
+// ConsensusStatus entries so READY nodes appear before STARTING nodes. It is
+// used as the tiebreaker when calling BuildSafeProposal when multiple nodes
+// share the highest LSN.
+//
+// UNKNOWN (the proto zero value, emitted by older poolers that do not publish
+// the field) is treated as READY for backward compatibility. (We might want to
+// change this in the future since we should prefer READY poolers before poolers
+// with UNKNOWN state, which could be ready or not.)
+//
+// Recruited nodes participate in the outgoing-cohort quorum check regardless of
+// their LeadershipAvailability — this tiebreaker only affects which tied node
+// is proposed as leader, not the quorum denominator.
+func leadershipLess(healthByID map[string]*multiorchdatapb.PoolerHealthState) func(a, b *clustermetadatapb.ConsensusStatus) bool {
+	isReady := func(id *clustermetadatapb.ID) bool {
+		h := healthByID[topoclient.ClusterIDString(id)]
+		sig := h.GetAvailabilityStatus().GetLeadershipAvailability().GetSignal()
+		return sig != clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING
+	}
+	return func(a, b *clustermetadatapb.ConsensusStatus) bool {
+		return isReady(a.GetId()) && !isReady(b.GetId())
+	}
 }
 
 // poolerIDs extracts the clustermetadata IDs from a slice of PoolerHealthState.

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -350,3 +350,107 @@ func TestAppointInitialLeader(t *testing.T) {
 		require.Equal(t, int64(1), commonconsensus.PossiblyUndecidedRule(stp.GetReplicationPrimary().GetPosition()).GetRuleNumber().GetCoordinatorTerm())
 	}
 }
+
+// TestAppointLeader_TiebreaksByLeadershipAvailability verifies that leadershipLess
+// breaks tied-LSN elections in favour of READY nodes over STARTING nodes.
+//
+// Under synchronous replication both standbys ACK every write, so they routinely
+// reach the same WAL position. When the primary fails the two standbys are tied
+// candidates. A freshly restarted standby whose postgres is still in crash
+// recovery reports STARTING; leadershipLess must put the READY standby first in
+// the eligible-leaders list so it is proposed as the new leader.
+//
+// UNKNOWN (the proto zero-value, emitted by older poolers) is treated as READY
+// for backward compatibility — only an explicit STARTING signal demotes a node.
+func TestAppointLeader_TiebreaksByLeadershipAvailability(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	coordID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+
+	fakeClient := rpcclient.NewFakeClient()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	c := NewCoordinator(coordID, ts, fakeClient, logger)
+
+	cohortIDs := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "primary"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "ready"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "starting"},
+	}
+	// AT_LEAST_3 forces tryBuildProposal to wait for all three Recruit responses
+	// before forming a proposal, so the tie between "ready" and "starting" is
+	// always observed — the outcome cannot depend on which Recruit completes first.
+	outgoingRule := &clustermetadatapb.ShardRule{
+		RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+		LeaderId:         cohortIDs[0],
+		CohortMembers:    cohortIDs,
+		DurabilityPolicy: topoclient.AtLeastN(3),
+	}
+
+	// "primary" has the lower LSN; "ready" and "starting" are tied at the higher
+	// position — the common outcome after sync-replicated writes.
+	walPositions := map[string]string{
+		"primary":  "0/1000000",
+		"ready":    "0/2000000",
+		"starting": "0/2000000",
+	}
+
+	cohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohortIDs))
+	for _, id := range cohortIDs {
+		lsn := walPositions[id.Name]
+		mp := createMockNode(fakeClient, id.Name, 5, lsn, true, outgoingRule)
+		mp.ConsensusStatus.Id = id
+		mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
+			Lsn:      lsn,
+			Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+		}
+		if id.Name == "starting" {
+			// leadershipLess reads AvailabilityStatus from the cohort health
+			// snapshot (not the Recruit response) — this is the health stream
+			// value that multiorch's applySnapshot cached before the election.
+			mp.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+					Reason: "postgres not ready for promotion",
+				},
+			}
+		}
+		key := topoclient.ComponentIDString(id)
+		fakeClient.RecruitResponses[key] = &consensusdatapb.RecruitResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn:      lsn,
+					Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+				},
+			},
+		}
+		require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
+		cohort = append(cohort, mp)
+	}
+
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "shard0"}
+	require.NoError(t, c.AppointLeader(ctx, shardKey, cohort, "tiebreak_test"))
+
+	// "ready" must be elected: both standbys are tied on LSN, but leadershipLess
+	// sorts READY before STARTING in the eligible-leaders slice.
+	readyKey := topoclient.ComponentIDString(cohortIDs[1])
+	propReq, ok := fakeClient.PromoteRequests[readyKey]
+	require.True(t, ok, "Promote must be sent to the READY standby")
+	require.Equal(t, "ready", propReq.GetProposal().GetProposalLeader().GetId().GetName(),
+		"leadershipLess must prefer READY over STARTING when LSNs are tied")
+
+	// "starting" must receive SetPrimary as a follower, not Promote.
+	startingKey := topoclient.ComponentIDString(cohortIDs[2])
+	_, isPromoted := fakeClient.PromoteRequests[startingKey]
+	require.False(t, isPromoted, "STARTING node must not be elected when a READY node is tied on LSN")
+	stp, ok := fakeClient.SetPrimaryRequests[startingKey]
+	require.True(t, ok, "SetPrimary must be sent to the STARTING node as a follower")
+	require.Equal(t, "ready", stp.GetReplicationPrimary().GetPrimary().GetId().GetName(),
+		"STARTING follower must be directed toward the READY leader")
+}

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -566,3 +566,107 @@ func TestPoolerHealthStateLess(t *testing.T) {
 		assert.False(t, less(b, a))
 	})
 }
+
+// TestAppointLeader_TiebreaksByLeadershipAvailability verifies that leadershipLess
+// breaks tied-LSN elections in favour of READY nodes over STARTING nodes.
+//
+// Under synchronous replication both standbys ACK every write, so they routinely
+// reach the same WAL position. When the primary fails the two standbys are tied
+// candidates. A freshly restarted standby whose postgres is still in crash
+// recovery reports STARTING; leadershipLess must put the READY standby first in
+// the eligible-leaders list so it is proposed as the new leader.
+//
+// UNKNOWN (the proto zero-value, emitted by older poolers) is treated as READY
+// for backward compatibility — only an explicit STARTING signal demotes a node.
+func TestAppointLeader_TiebreaksByLeadershipAvailability(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	coordID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+
+	fakeClient := rpcclient.NewFakeClient()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	c := NewCoordinator(coordID, ts, fakeClient, logger)
+
+	cohortIDs := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "primary"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "ready"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "starting"},
+	}
+	// AT_LEAST_3 forces tryBuildProposal to wait for all three Recruit responses
+	// before forming a proposal, so the tie between "ready" and "starting" is
+	// always observed — the outcome cannot depend on which Recruit completes first.
+	outgoingRule := &clustermetadatapb.ShardRule{
+		RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+		LeaderId:         cohortIDs[0],
+		CohortMembers:    cohortIDs,
+		DurabilityPolicy: topoclient.AtLeastN(3),
+	}
+
+	// "primary" has the lower LSN; "ready" and "starting" are tied at the higher
+	// position — the common outcome after sync-replicated writes.
+	walPositions := map[string]string{
+		"primary":  "0/1000000",
+		"ready":    "0/2000000",
+		"starting": "0/2000000",
+	}
+
+	cohort := make([]*multiorchdatapb.PoolerHealthState, 0, len(cohortIDs))
+	for _, id := range cohortIDs {
+		lsn := walPositions[id.Name]
+		mp := createMockNode(fakeClient, id.Name, 5, lsn, true, outgoingRule)
+		mp.ConsensusStatus.Id = id
+		mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
+			Lsn:      lsn,
+			Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+		}
+		if id.Name == "starting" {
+			// leadershipLess reads AvailabilityStatus from the cohort health
+			// snapshot (not the Recruit response) — this is the health stream
+			// value that multiorch's applySnapshot cached before the election.
+			mp.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+					Reason: "postgres not ready for promotion",
+				},
+			}
+		}
+		key := topoclient.ComponentIDString(id)
+		fakeClient.RecruitResponses[key] = &consensusdatapb.RecruitResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn:      lsn,
+					Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+				},
+			},
+		}
+		require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
+		cohort = append(cohort, mp)
+	}
+
+	shardKey := &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default", Shard: "shard0"}
+	require.NoError(t, c.AppointLeader(ctx, shardKey, cohort, "tiebreak_test"))
+
+	// "ready" must be elected: both standbys are tied on LSN, but leadershipLess
+	// sorts READY before STARTING in the eligible-leaders slice.
+	readyKey := topoclient.ComponentIDString(cohortIDs[1])
+	propReq, ok := fakeClient.PromoteRequests[readyKey]
+	require.True(t, ok, "Promote must be sent to the READY standby")
+	require.Equal(t, "ready", propReq.GetProposal().GetProposalLeader().GetId().GetName(),
+		"leadershipLess must prefer READY over STARTING when LSNs are tied")
+
+	// "starting" must receive SetPrimary as a follower, not Promote.
+	startingKey := topoclient.ComponentIDString(cohortIDs[2])
+	_, isPromoted := fakeClient.PromoteRequests[startingKey]
+	require.False(t, isPromoted, "STARTING node must not be elected when a READY node is tied on LSN")
+	stp, ok := fakeClient.SetPrimaryRequests[startingKey]
+	require.True(t, ok, "SetPrimary must be sent to the STARTING node as a follower")
+	require.Equal(t, "ready", stp.GetReplicationPrimary().GetPrimary().GetId().GetName(),
+		"STARTING follower must be directed toward the READY leader")
+}

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -374,10 +374,12 @@ func (r *coordinatorLedRuleChange) promote(
 }
 
 // buildFailoverProposal constructs a CoordinatorProposal for normal failover.
-// It picks the first eligible leader from result.EligibleLeaders and derives
-// the cohort and durability policy from result.OutgoingRule. Resigned poolers
-// are expected to have been filtered out upstream (see Coordinator.runFailover);
-// any pooler reaching this point is treated as a valid leader candidate.
+// It picks the first node from result.EligibleLeaders and resolves its contact
+// address from addressByID. EligibleLeaders is produced by the Discoverer
+// supplied to BuildSafeProposal — leadershipAwareDiscoverer ensures the set
+// contains the most-advanced node that reports ELIGIBLE leadership availability,
+// falling back to the most-advanced node overall if all are INELIGIBLE. Resigned
+// poolers are filtered out upstream in Coordinator.runFailover.
 func buildFailoverProposal(
 	result commonconsensus.RecruitmentResult,
 	addressByID map[string]*clustermetadatapb.PoolerAddress,

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -372,10 +372,12 @@ func (r *coordinatorLedRuleChange) promote(
 }
 
 // buildFailoverProposal constructs a CoordinatorProposal for normal failover.
-// It picks the first eligible leader from result.EligibleLeaders and derives
-// the cohort and durability policy from result.OutgoingRule. Resigned poolers
-// are expected to have been filtered out upstream (see Coordinator.runFailover);
-// any pooler reaching this point is treated as a valid leader candidate.
+// It picks the first node from result.EligibleLeaders and resolves its contact
+// address from addressByID. EligibleLeaders is produced by the Discoverer
+// supplied to BuildSafeProposal — leadershipAwareDiscoverer ensures the set
+// contains the most-advanced node that reports ELIGIBLE leadership availability,
+// falling back to the most-advanced node overall if all are INELIGIBLE. Resigned
+// poolers are filtered out upstream in Coordinator.runFailover.
 func buildFailoverProposal(
 	result commonconsensus.RecruitmentResult,
 	addressByID map[string]*clustermetadatapb.PoolerAddress,

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1718,7 +1718,8 @@ func (pm *MultipoolerManager) startPostgresMonitorPollerLocked() {
 			//   - postgres coming back up: allows FixReplication to see IsInitialized=true quickly
 			if !postgresStateEqual(newState, prevState) {
 				pm.logger.InfoContext(ctx, "MonitorPostgres: postgres state changed, broadcasting health",
-					"postgres_running", newState.postgresRunning)
+					"postgres_running", newState.postgresRunning,
+					"postgres_ready", newState.postgresReady)
 				pm.broadcastHealth()
 			}
 			// Transition lifecycle STARTING → ACTIVE once postgres is up

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1795,7 +1795,8 @@ func (pm *MultipoolerManager) startPostgresMonitorPollerLocked() {
 			//   - postgres coming back up: allows FixReplication to see IsInitialized=true quickly
 			if !postgresStateEqual(newState, prevState) {
 				pm.logger.InfoContext(ctx, "MonitorPostgres: postgres state changed, broadcasting health", //nolint:sloglint // message intentionally starts with an operation name or proper noun
-					"postgres_running", newState.postgresRunning)
+					"postgres_running", newState.postgresRunning,
+					"postgres_ready", newState.postgresReady)
 				pm.broadcastHealth()
 			}
 			// Transition lifecycle STARTING → ACTIVE once postgres is up

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -106,11 +106,16 @@ func (pm *MultipoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 	return target
 }
 
-// postgresState represents the state of PostgreSQL for monitoring
+// postgresState represents the state of PostgreSQL for monitoring.
+//
+// postgresReady is true when postgres is RUNNING and pg_isready passes —
+// i.e. it is accepting connections. A node whose postgres is not ready has
+// no replication running and cannot participate in write quorum.
 type postgresState struct {
 	pgctldAvailable  bool
 	dirInitialized   bool
 	postgresRunning  bool
+	postgresReady    bool
 	backupsAvailable bool
 	// connInfo is the standby's primary_conninfo (parsed + redacted), read once
 	// per tick in discoverPostgresState so the monitor's decision paths can reuse
@@ -131,6 +136,7 @@ func postgresStateEqual(a, b postgresState) bool {
 	return a.pgctldAvailable == b.pgctldAvailable &&
 		a.dirInitialized == b.dirInitialized &&
 		a.postgresRunning == b.postgresRunning &&
+		a.postgresReady == b.postgresReady &&
 		a.backupsAvailable == b.backupsAvailable &&
 		a.pgMode == b.pgMode &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
@@ -335,8 +341,9 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 	// Check if directory is initialized
 	state.dirInitialized = (statusResp.Status != pgctldpb.ServerStatus_NOT_INITIALIZED)
 
-	// Check if Postgres is running
+	// Check if Postgres is running and ready to accept connections.
 	state.postgresRunning = (statusResp.Status == pgctldpb.ServerStatus_RUNNING)
+	state.postgresReady = state.postgresRunning && statusResp.Ready
 	if state.postgresRunning {
 		var err error
 		state.pgMode, err = pm.postgresMode(ctx)

--- a/go/services/multipooler/internal/manager/postgres_monitor.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor.go
@@ -107,11 +107,16 @@ func (pm *MultipoolerManager) staleStandbyDemoteTarget() *clustermetadatapb.Pool
 	return target
 }
 
-// postgresState represents the state of PostgreSQL for monitoring
+// postgresState represents the state of PostgreSQL for monitoring.
+//
+// postgresReady is true when postgres is RUNNING and pg_isready passes —
+// i.e. it is accepting connections. A node whose postgres is not ready has
+// no replication running and cannot participate in write quorum.
 type postgresState struct {
 	pgctldAvailable  bool
 	dirInitialized   bool
 	postgresRunning  bool
+	postgresReady    bool
 	backupsAvailable bool
 	// connInfo is the standby's primary_conninfo (parsed + redacted), read once
 	// per tick in discoverPostgresState so the monitor's decision paths can reuse
@@ -139,6 +144,7 @@ func postgresStateEqual(a, b postgresState) bool {
 	return a.pgctldAvailable == b.pgctldAvailable &&
 		a.dirInitialized == b.dirInitialized &&
 		a.postgresRunning == b.postgresRunning &&
+		a.postgresReady == b.postgresReady &&
 		a.backupsAvailable == b.backupsAvailable &&
 		a.pgMode == b.pgMode &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
@@ -364,8 +370,9 @@ func (pm *MultipoolerManager) discoverPostgresState(ctx context.Context) (postgr
 	// Check if directory is initialized
 	state.dirInitialized = (statusResp.Status != pgctldpb.ServerStatus_NOT_INITIALIZED)
 
-	// Check if Postgres is running
+	// Check if Postgres is running and ready to accept connections.
 	state.postgresRunning = (statusResp.Status == pgctldpb.ServerStatus_RUNNING)
+	state.postgresReady = state.postgresRunning && statusResp.Ready
 	if state.postgresRunning {
 		var err error
 		state.pgMode, err = pm.postgresMode(ctx)

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1126,6 +1126,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
 				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
+				},
 			},
 		},
 		{
@@ -1136,6 +1139,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			wantAvStatus: &clustermetadatapb.AvailabilityStatus{
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 				},
 			},
 		},
@@ -1159,6 +1165,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				},
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 				},
 			},
 		},
@@ -1203,7 +1212,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 
 			_ = pm.takeRemedialAction(lockCtx, tc.action, postgresState{})
 
-			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus())
+			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus(true))
 		})
 	}
 }

--- a/go/services/multipooler/internal/manager/postgres_monitor_test.go
+++ b/go/services/multipooler/internal/manager/postgres_monitor_test.go
@@ -1049,6 +1049,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
 				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
+				},
 			},
 		},
 		{
@@ -1059,6 +1062,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 			wantAvStatus: &clustermetadatapb.AvailabilityStatus{
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 				},
 			},
 		},
@@ -1082,6 +1088,9 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 				},
 				CohortEligibilityStatus: &clustermetadatapb.CohortEligibilityStatus{
 					Signal: clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+				},
+				LeadershipAvailability: &clustermetadatapb.LeadershipAvailability{
+					Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 				},
 			},
 		},
@@ -1125,7 +1134,7 @@ func TestTakeRemedialAction_ResignationSignal(t *testing.T) {
 
 			pm.takeRemedialAction(lockCtx, tc.action, postgresState{})
 
-			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus())
+			assert.Equal(t, tc.wantAvStatus, pm.buildAvailabilityStatus(true))
 		})
 	}
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -35,21 +35,46 @@ import (
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
 // Leaders that have resigned publish a LeadershipStatus. Every pooler publishes
-// its cohort eligibility, so the result is non-nil.
-func (pm *MultipoolerManager) buildAvailabilityStatus() *clustermetadatapb.AvailabilityStatus {
+// its cohort eligibility and leadership availability, so the result is non-nil.
+// postgresReady must be the value already obtained by the caller via isPostgresReady
+// so the check is not repeated.
+func (pm *MultipoolerManager) buildAvailabilityStatus(postgresReady bool) *clustermetadatapb.AvailabilityStatus {
 	return &clustermetadatapb.AvailabilityStatus{
 		LeadershipStatus:        pm.consensusMgr.LeadershipStatus(),
 		CohortEligibilityStatus: pm.buildCohortEligibilityStatus(),
 		SuspectedDivergence:     pm.consensusMgr.SuspectedDivergence(),
+		LeadershipAvailability:  buildLeadershipAvailability(postgresReady),
+	}
+}
+
+// buildLeadershipAvailability reports whether postgres is ready to accept
+// promotion to consensus leader. STARTING when postgres is not yet ready
+// (starting, in crash recovery, socket not open); READY otherwise.
+//
+// The coordinator uses this as a tie-breaker when multiple nodes share the
+// same (most-advanced) WAL position: it prefers a READY node over a STARTING
+// one. A STARTING node can still be elected if it has a strictly higher WAL
+// position than all READY nodes.
+func buildLeadershipAvailability(postgresReady bool) *clustermetadatapb.LeadershipAvailability {
+	if !postgresReady {
+		return &clustermetadatapb.LeadershipAvailability{
+			Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+			Reason: "postgres not ready for promotion",
+		}
+	}
+	return &clustermetadatapb.LeadershipAvailability{
+		Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 	}
 }
 
 // buildCohortEligibilityStatus returns the pooler's self-reported willingness
-// to be a cohort member. Defaults to ELIGIBLE; downgraded to INELIGIBLE when
-// the WAL receiver was manually stopped (StopReplication cleared
-// primary_conninfo), so the coordinator does not try to re-include this node
-// while the admin signal is in effect. ConsensusManager.SetCohortEligibility
-// sets the base value the dynamic downgrade applies on top of.
+// to be a cohort member. Returns INELIGIBLE when the WAL receiver was manually
+// stopped (StopReplication cleared primary_conninfo) or when setCohortEligibility
+// was called explicitly (e.g. graceful shutdown).
+//
+// Note: postgres readiness is NOT a factor here — it is reported separately via
+// LeadershipAvailability. CohortEligibilityStatus expresses permanent/administrative
+// preferences about cohort membership, not transient startup state.
 func (pm *MultipoolerManager) buildCohortEligibilityStatus() *clustermetadatapb.CohortEligibilityStatus {
 	if pm.walReceiverManuallyStopped.Load() {
 		return &clustermetadatapb.CohortEligibilityStatus{
@@ -790,6 +815,15 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		pm.logger.InfoContext(ctx, "SetPrimary: updating standby primary_conninfo",
 			"new_leader", leader.GetId().GetName(),
 			"incoming_position", incomingPosition)
+		// A coordinator-initiated SetPrimary overrides a prior manual
+		// StopReplication. walReceiverManuallyStopped prevents this node from
+		// being elected leader (INELIGIBLE), but once the coordinator has elected
+		// a different leader, this node must follow it. Clear the flag so that
+		// setPrimaryConnInfoLocked can configure replication toward the new leader.
+		if pm.walReceiverManuallyStopped.CompareAndSwap(true, false) {
+			pm.logger.InfoContext(ctx, "SetPrimary: cleared walReceiverManuallyStopped to allow replication toward new leader",
+				"new_leader", leader.GetId().GetName())
+		}
 		// Already a standby with an active stream; pause replay, swap
 		// conninfo, resume on the new primary.
 		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port,

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -35,21 +35,46 @@ import (
 
 // buildAvailabilityStatus returns the current AvailabilityStatus for this node.
 // Leaders that have resigned publish a LeadershipStatus. Every pooler publishes
-// its cohort eligibility, so the result is non-nil.
-func (pm *MultipoolerManager) buildAvailabilityStatus() *clustermetadatapb.AvailabilityStatus {
+// its cohort eligibility and leadership availability, so the result is non-nil.
+// postgresReady must be the value already obtained by the caller via isPostgresReady
+// so the check is not repeated.
+func (pm *MultipoolerManager) buildAvailabilityStatus(postgresReady bool) *clustermetadatapb.AvailabilityStatus {
 	return &clustermetadatapb.AvailabilityStatus{
 		LeadershipStatus:        pm.consensusMgr.LeadershipStatus(),
 		CohortEligibilityStatus: pm.buildCohortEligibilityStatus(),
 		SuspectedDivergence:     pm.consensusMgr.SuspectedDivergence(),
+		LeadershipAvailability:  buildLeadershipAvailability(postgresReady),
+	}
+}
+
+// buildLeadershipAvailability reports whether postgres is ready to accept
+// promotion to consensus leader. STARTING when postgres is not yet ready
+// (starting, in crash recovery, socket not open); READY otherwise.
+//
+// The coordinator uses this as a tie-breaker when multiple nodes share the
+// same (most-advanced) WAL position: it prefers a READY node over a STARTING
+// one. A STARTING node can still be elected if it has a strictly higher WAL
+// position than all READY nodes.
+func buildLeadershipAvailability(postgresReady bool) *clustermetadatapb.LeadershipAvailability {
+	if !postgresReady {
+		return &clustermetadatapb.LeadershipAvailability{
+			Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+			Reason: "postgres not ready for promotion",
+		}
+	}
+	return &clustermetadatapb.LeadershipAvailability{
+		Signal: clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
 	}
 }
 
 // buildCohortEligibilityStatus returns the pooler's self-reported willingness
-// to be a cohort member. Defaults to ELIGIBLE; downgraded to INELIGIBLE when
-// the WAL receiver was manually stopped (StopReplication cleared
-// primary_conninfo), so the coordinator does not try to re-include this node
-// while the admin signal is in effect. ConsensusManager.SetCohortEligibility
-// sets the base value the dynamic downgrade applies on top of.
+// to be a cohort member. Returns INELIGIBLE when the WAL receiver was manually
+// stopped (StopReplication cleared primary_conninfo) or when setCohortEligibility
+// was called explicitly (e.g. graceful shutdown).
+//
+// Note: postgres readiness is NOT a factor here — it is reported separately via
+// LeadershipAvailability. CohortEligibilityStatus expresses permanent/administrative
+// preferences about cohort membership, not transient startup state.
 func (pm *MultipoolerManager) buildCohortEligibilityStatus() *clustermetadatapb.CohortEligibilityStatus {
 	if pm.walReceiverManuallyStopped.Load() {
 		return &clustermetadatapb.CohortEligibilityStatus{
@@ -927,6 +952,15 @@ func (pm *MultipoolerManager) setPrimaryLocked(ctx context.Context, req *consens
 		pm.logger.InfoContext(ctx, "SetPrimary: updating standby primary_conninfo", //nolint:sloglint // message intentionally starts with an operation name or proper noun
 			"new_leader", leader.GetId().GetName(),
 			"incoming_position", incomingPosition)
+		// A coordinator-initiated SetPrimary overrides a prior manual
+		// StopReplication. walReceiverManuallyStopped prevents this node from
+		// being elected leader (INELIGIBLE), but once the coordinator has elected
+		// a different leader, this node must follow it. Clear the flag so that
+		// setPrimaryConnInfoLocked can configure replication toward the new leader.
+		if pm.walReceiverManuallyStopped.CompareAndSwap(true, false) {
+			pm.logger.InfoContext(ctx, "SetPrimary: cleared walReceiverManuallyStopped to allow replication toward new leader", //nolint:sloglint // message intentionally starts with an operation name or proper noun
+				"new_leader", leader.GetId().GetName())
+		}
 		// Already a standby with an active stream; pause replay, swap
 		// conninfo, resume on the new primary.
 		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port,

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1361,7 +1361,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 func TestAvailabilityStatus(t *testing.T) {
 	t.Run("buildAvailabilityStatus publishes cohort eligibility with no leadership status when no resignation is set", func(t *testing.T) {
 		pm := newTestManager(t)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
 		require.NotNil(t, av.CohortEligibilityStatus)
@@ -1370,7 +1370,7 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("resignedLeaderAtTerm set adds a LeadershipStatus alongside cohort eligibility", func(t *testing.T) {
 		pm := newTestManager(t, withResignedLeaderAtTerm(7))
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		require.NotNil(t, av.LeadershipStatus)
 		assert.Equal(t, int64(7), av.LeadershipStatus.LeaderTerm)
@@ -1381,7 +1381,7 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("no resignation -> no LeadershipStatus but keeps cohort eligibility", func(t *testing.T) {
 		pm := newTestManager(t)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
 		require.NotNil(t, av.CohortEligibilityStatus)
@@ -1393,7 +1393,7 @@ func TestAvailabilityStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, pm.consensusMgr.SetCohortEligibility(lockCtx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE))
 		pm.actionLock.Release(lockCtx)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		require.NotNil(t, av.CohortEligibilityStatus)
 		assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE, av.CohortEligibilityStatus.Signal)
@@ -1401,13 +1401,37 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("suspectedDivergence is published", func(t *testing.T) {
 		pm := newTestManager(t)
-		assert.False(t, pm.buildAvailabilityStatus().SuspectedDivergence, "defaults to false")
+		assert.False(t, pm.buildAvailabilityStatus(true).SuspectedDivergence, "defaults to false")
 		lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
 		require.NoError(t, err)
 		_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
 		require.NoError(t, err)
 		pm.actionLock.Release(lockCtx)
-		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
+		assert.True(t, pm.buildAvailabilityStatus(true).SuspectedDivergence, "reflects the in-memory flag")
+	})
+
+	t.Run("postgres ready sets LeadershipAvailability READY", func(t *testing.T) {
+		pm := newTestManager(t)
+		av := pm.buildAvailabilityStatus(true)
+		require.NotNil(t, av.GetLeadershipAvailability())
+		assert.Equal(t,
+			clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
+			av.GetLeadershipAvailability().GetSignal())
+	})
+
+	t.Run("postgres not ready sets LeadershipAvailability STARTING with reason", func(t *testing.T) {
+		pm := newTestManager(t)
+		av := pm.buildAvailabilityStatus(false)
+		require.NotNil(t, av.GetLeadershipAvailability())
+		assert.Equal(t,
+			clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+			av.GetLeadershipAvailability().GetSignal())
+		assert.NotEmpty(t, av.GetLeadershipAvailability().GetReason(),
+			"reason should be set for debugging")
+		assert.Equal(t,
+			clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+			av.GetCohortEligibilityStatus().GetSignal(),
+			"postgres readiness must not affect cohort eligibility signal")
 	})
 }
 

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -1205,7 +1205,7 @@ func TestPromoteDropsUnloggedTables(t *testing.T) {
 func TestAvailabilityStatus(t *testing.T) {
 	t.Run("buildAvailabilityStatus publishes cohort eligibility with no leadership status when no resignation is set", func(t *testing.T) {
 		pm := newTestManager(t)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
 		require.NotNil(t, av.CohortEligibilityStatus)
@@ -1214,7 +1214,7 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("resignedLeaderAtTerm set adds a LeadershipStatus alongside cohort eligibility", func(t *testing.T) {
 		pm := newTestManager(t, withResignedLeaderAtTerm(7))
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		require.NotNil(t, av.LeadershipStatus)
 		assert.Equal(t, int64(7), av.LeadershipStatus.LeaderTerm)
@@ -1225,7 +1225,7 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("no resignation -> no LeadershipStatus but keeps cohort eligibility", func(t *testing.T) {
 		pm := newTestManager(t)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		assert.Nil(t, av.LeadershipStatus)
 		require.NotNil(t, av.CohortEligibilityStatus)
@@ -1237,7 +1237,7 @@ func TestAvailabilityStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, pm.consensusMgr.SetCohortEligibility(lockCtx, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE))
 		pm.actionLock.Release(lockCtx)
-		av := pm.buildAvailabilityStatus()
+		av := pm.buildAvailabilityStatus(true)
 		require.NotNil(t, av)
 		require.NotNil(t, av.CohortEligibilityStatus)
 		assert.Equal(t, clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_INELIGIBLE, av.CohortEligibilityStatus.Signal)
@@ -1245,13 +1245,37 @@ func TestAvailabilityStatus(t *testing.T) {
 
 	t.Run("suspectedDivergence is published", func(t *testing.T) {
 		pm := newTestManager(t)
-		assert.False(t, pm.buildAvailabilityStatus().SuspectedDivergence, "defaults to false")
+		assert.False(t, pm.buildAvailabilityStatus(true).SuspectedDivergence, "defaults to false")
 		lockCtx, err := pm.actionLock.Acquire(t.Context(), "test-seed")
 		require.NoError(t, err)
 		_, err = pm.consensusMgr.SetSuspectedDivergence(lockCtx, true)
 		require.NoError(t, err)
 		pm.actionLock.Release(lockCtx)
-		assert.True(t, pm.buildAvailabilityStatus().SuspectedDivergence, "reflects the in-memory flag")
+		assert.True(t, pm.buildAvailabilityStatus(true).SuspectedDivergence, "reflects the in-memory flag")
+	})
+
+	t.Run("postgres ready sets LeadershipAvailability READY", func(t *testing.T) {
+		pm := newTestManager(t)
+		av := pm.buildAvailabilityStatus(true)
+		require.NotNil(t, av.GetLeadershipAvailability())
+		assert.Equal(t,
+			clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_READY,
+			av.GetLeadershipAvailability().GetSignal())
+	})
+
+	t.Run("postgres not ready sets LeadershipAvailability STARTING with reason", func(t *testing.T) {
+		pm := newTestManager(t)
+		av := pm.buildAvailabilityStatus(false)
+		require.NotNil(t, av.GetLeadershipAvailability())
+		assert.Equal(t,
+			clustermetadatapb.LeadershipAvailabilitySignal_LEADERSHIP_AVAILABILITY_SIGNAL_STARTING,
+			av.GetLeadershipAvailability().GetSignal())
+		assert.NotEmpty(t, av.GetLeadershipAvailability().GetReason(),
+			"reason should be set for debugging")
+		assert.Equal(t,
+			clustermetadatapb.CohortEligibilitySignal_COHORT_ELIGIBILITY_SIGNAL_ELIGIBLE,
+			av.GetCohortEligibilityStatus().GetSignal(),
+			"postgres readiness must not affect cohort eligibility signal")
 	})
 }
 

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -361,7 +361,7 @@ func (pm *MultipoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 	} else {
 		resp.ConsensusStatus = pm.consensusMgr.CachedConsensusStatus()
 	}
-	resp.AvailabilityStatus = pm.buildAvailabilityStatus()
+	resp.AvailabilityStatus = pm.buildAvailabilityStatus(poolerStatus.PostgresReady)
 
 	// Try to get detailed status based on PostgreSQL role
 	pgMode, err := pm.postgresMode(ctx)

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -335,7 +335,7 @@ func (pm *MultipoolerManager) Status(ctx context.Context) (*multipoolermanagerda
 	} else {
 		resp.ConsensusStatus = pm.consensusMgr.CachedConsensusStatus()
 	}
-	resp.AvailabilityStatus = pm.buildAvailabilityStatus()
+	resp.AvailabilityStatus = pm.buildAvailabilityStatus(poolerStatus.PostgresReady)
 
 	// Try to get detailed status based on PostgreSQL role
 	pgMode, err := pm.postgresMode(ctx)

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -644,6 +644,67 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
+// TestSetPrimary_ClearsWalReceiverManuallyStopped verifies that a
+// coordinator-initiated SetPrimary clears the walReceiverManuallyStopped
+// flag and successfully configures replication, even when the node was previously
+// marked INELIGIBLE via StopReplication.
+//
+// Without this behavior the rule write on the newly elected primary would hang
+// waiting for a sync-standby WAL ACK that never arrives (the INELIGIBLE standby
+// refused SetPrimary, so it never connects).
+func TestSetPrimary_ClearsWalReceiverManuallyStopped(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// isPrimary check: standby mode.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
+	// setPrimaryConnInfoLocked's own isPrimary guardrail.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
+	// pauseReplication(REPLAY_ONLY): pause + verify paused.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
+		mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult([]string{"replay_lsn", "is_paused"}, [][]any{{"0/100", true}}))
+
+	// Capture primary_conninfo write.
+	var capturedConnInfo string
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil),
+		func(sql string) { capturedConnInfo = sql },
+	)
+	expectReloadConfig(mockQueryService)
+
+	// startReplicationAfter=true: health check + resume.
+	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
+		mock.MakeQueryResult(nil, nil))
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(3)})
+	// Simulate a prior StopReplication: mark the node as INELIGIBLE.
+	pm.walReceiverManuallyStopped.Store(true)
+
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	rule := ruleAtTermForLeader(leader, 10)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: rule},
+			Primary:  leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err, "SetPrimary must succeed even when walReceiverManuallyStopped was set")
+	require.NotNil(t, resp)
+
+	assert.False(t, pm.walReceiverManuallyStopped.Load(),
+		"SetPrimary must clear walReceiverManuallyStopped")
+	assert.Contains(t, capturedConnInfo, "host=primary-host",
+		"primary_conninfo must point at the new leader after manual-stop override")
+}
+
 // TestSetPrimary_ApplyPathErrors covers the post-revocation-check error
 // paths in SetPrimary: ObservePosition, isPrimary, and the standby branch's
 // setPrimaryConnInfoLocked. Each case drives the handler past validation and

--- a/go/services/multipooler/internal/manager/rpc_set_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_primary_test.go
@@ -696,6 +696,67 @@ func TestSetPrimary_AppliesViaOutgoingRuleOverride(t *testing.T) {
 	assert.NoError(t, mockQueryService.ExpectationsWereMet())
 }
 
+// TestSetPrimary_ClearsWalReceiverManuallyStopped verifies that a
+// coordinator-initiated SetPrimary clears the walReceiverManuallyStopped
+// flag and successfully configures replication, even when the node was previously
+// marked INELIGIBLE via StopReplication.
+//
+// Without this behavior the rule write on the newly elected primary would hang
+// waiting for a sync-standby WAL ACK that never arrives (the INELIGIBLE standby
+// refused SetPrimary, so it never connects).
+func TestSetPrimary_ClearsWalReceiverManuallyStopped(t *testing.T) {
+	mockQueryService := mock.NewQueryService()
+
+	// isPrimary check: standby mode.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
+	// setPrimaryConnInfoLocked's own isPrimary guardrail.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
+		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
+
+	// pauseReplication(REPLAY_ONLY): pause + verify paused.
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
+		mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
+		mock.MakeQueryResult([]string{"replay_lsn", "is_paused"}, [][]any{{"0/100", true}}))
+
+	// Capture primary_conninfo write.
+	var capturedConnInfo string
+	mockQueryService.AddQueryPatternWithCallback(
+		"ALTER SYSTEM SET primary_conninfo",
+		mock.MakeQueryResult(nil, nil),
+		func(sql string) { capturedConnInfo = sql },
+	)
+	expectReloadConfig(mockQueryService)
+
+	// startReplicationAfter=true: health check + resume.
+	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
+	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
+		mock.MakeQueryResult(nil, nil))
+
+	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(3)})
+	// Simulate a prior StopReplication: mark the node as INELIGIBLE.
+	pm.walReceiverManuallyStopped.Store(true)
+
+	leader := newLeaderAddress("new-primary", "primary-host", 5432)
+	rule := ruleAtTermForLeader(leader, 10)
+	req := &consensusdatapb.SetPrimaryRequest{
+		ReplicationPrimary: &clustermetadatapb.ReplicationPrimary{
+			Position: &clustermetadatapb.RulePosition{Decision: rule},
+			Primary:  leader,
+		},
+	}
+	resp, err := pm.SetPrimary(t.Context(), req)
+	require.NoError(t, err, "SetPrimary must succeed even when walReceiverManuallyStopped was set")
+	require.NotNil(t, resp)
+
+	assert.False(t, pm.walReceiverManuallyStopped.Load(),
+		"SetPrimary must clear walReceiverManuallyStopped")
+	assert.Contains(t, capturedConnInfo, "host=primary-host",
+		"primary_conninfo must point at the new leader after manual-stop override")
+}
+
 // TestSetPrimary_ApplyPathErrors covers the post-revocation-check error
 // paths in SetPrimary: ObservePosition, isPrimary, and the standby branch's
 // setPrimaryConnInfoLocked. Each case drives the handler past validation and

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -859,6 +859,12 @@ message AvailabilityStatus {
   // suspected divergence may be slower to endorse a new rule proposal because it
   // needs to stop, run pg_rewind, and restart.
   bool suspected_divergence = 3;
+
+  // leadership_availability reports whether the pooler's postgres is ready to
+  // accept promotion to consensus leader. Published by every pooler. UNKNOWN
+  // (the default for older poolers) is treated the same as ELIGIBLE so that
+  // the coordinator can fall back gracefully when the field is absent.
+  LeadershipAvailability leadership_availability = 4;
 }
 
 // CohortEligibilitySignal describes a pooler's self-reported willingness to
@@ -883,4 +889,32 @@ enum CohortEligibilitySignal {
 // freshness of the surrounding health snapshot.
 message CohortEligibilityStatus {
   CohortEligibilitySignal signal = 1;
+}
+
+// LeadershipAvailabilitySignal describes whether a pooler is ready to be
+// promoted to consensus leader.
+enum LeadershipAvailabilitySignal {
+  LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN = 0;
+
+  // Pooler's postgres is still initialising (starting, in crash recovery,
+  // socket not yet open). The node can still be elected if it has the most
+  // advanced WAL position and no READY node is tied with it.
+  LEADERSHIP_AVAILABILITY_SIGNAL_STARTING = 1;
+
+  // Pooler's postgres is running and accepting connections. When multiple
+  // nodes are tied at the same WAL position the coordinator prefers a READY
+  // node over a STARTING one.
+  LEADERSHIP_AVAILABILITY_SIGNAL_READY = 2;
+}
+
+// LeadershipAvailability carries the pooler's self-reported readiness to
+// accept leader promotion. Unlike CohortEligibilityStatus this is not a
+// permanent preference — it reflects the transient startup state of postgres.
+// Staleness comes from the freshness of the surrounding health snapshot.
+message LeadershipAvailability {
+  LeadershipAvailabilitySignal signal = 1;
+
+  // reason is a human-readable explanation of why the signal was set.
+  // Intended for debugging and observability only; not used in decision logic.
+  string reason = 2;
 }

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -878,6 +878,12 @@ message AvailabilityStatus {
   // suspected divergence may be slower to endorse a new rule proposal because it
   // needs to stop, run pg_rewind, and restart.
   bool suspected_divergence = 3;
+
+  // leadership_availability reports whether the pooler's postgres is ready to
+  // accept promotion to consensus leader. Published by every pooler. UNKNOWN
+  // (the default for older poolers) is treated the same as ELIGIBLE so that
+  // the coordinator can fall back gracefully when the field is absent.
+  LeadershipAvailability leadership_availability = 4;
 }
 
 // CohortEligibilitySignal describes a pooler's self-reported willingness to
@@ -902,4 +908,32 @@ enum CohortEligibilitySignal {
 // freshness of the surrounding health snapshot.
 message CohortEligibilityStatus {
   CohortEligibilitySignal signal = 1;
+}
+
+// LeadershipAvailabilitySignal describes whether a pooler is ready to be
+// promoted to consensus leader.
+enum LeadershipAvailabilitySignal {
+  LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN = 0;
+
+  // Pooler's postgres is still initialising (starting, in crash recovery,
+  // socket not yet open). The node can still be elected if it has the most
+  // advanced WAL position and no READY node is tied with it.
+  LEADERSHIP_AVAILABILITY_SIGNAL_STARTING = 1;
+
+  // Pooler's postgres is running and accepting connections. When multiple
+  // nodes are tied at the same WAL position the coordinator prefers a READY
+  // node over a STARTING one.
+  LEADERSHIP_AVAILABILITY_SIGNAL_READY = 2;
+}
+
+// LeadershipAvailability carries the pooler's self-reported readiness to
+// accept leader promotion. Unlike CohortEligibilityStatus this is not a
+// permanent preference — it reflects the transient startup state of postgres.
+// Staleness comes from the freshness of the surrounding health snapshot.
+message LeadershipAvailability {
+  LeadershipAvailabilitySignal signal = 1;
+
+  // reason is a human-readable explanation of why the signal was set.
+  // Intended for debugging and observability only; not used in decision logic.
+  string reason = 2;
 }

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -363,6 +363,43 @@ proto3.util.setEnumType(CohortEligibilitySignal, "clustermetadata.CohortEligibil
 ]);
 
 /**
+ * LeadershipAvailabilitySignal describes whether a pooler is ready to be
+ * promoted to consensus leader.
+ *
+ * @generated from enum clustermetadata.LeadershipAvailabilitySignal
+ */
+export enum LeadershipAvailabilitySignal {
+  /**
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN = 0;
+   */
+  UNKNOWN = 0,
+
+  /**
+   * Pooler's postgres is still initialising (starting, in crash recovery,
+   * socket not yet open). The node can still be elected if it has the most
+   * advanced WAL position and no READY node is tied with it.
+   *
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_STARTING = 1;
+   */
+  STARTING = 1,
+
+  /**
+   * Pooler's postgres is running and accepting connections. When multiple
+   * nodes are tied at the same WAL position the coordinator prefers a READY
+   * node over a STARTING one.
+   *
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_READY = 2;
+   */
+  READY = 2,
+}
+// Retrieve enum metadata with: proto3.getEnumType(LeadershipAvailabilitySignal)
+proto3.util.setEnumType(LeadershipAvailabilitySignal, "clustermetadata.LeadershipAvailabilitySignal", [
+  { no: 0, name: "LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN" },
+  { no: 1, name: "LEADERSHIP_AVAILABILITY_SIGNAL_STARTING" },
+  { no: 2, name: "LEADERSHIP_AVAILABILITY_SIGNAL_READY" },
+]);
+
+/**
  * TopoConfig defines the connection parameters for a topology service.
  * It specifies the type of topology backend, where it's hosted, and the
  * logical root path within that backend.
@@ -2416,6 +2453,16 @@ export class AvailabilityStatus extends Message<AvailabilityStatus> {
    */
   suspectedDivergence = false;
 
+  /**
+   * leadership_availability reports whether the pooler's postgres is ready to
+   * accept promotion to consensus leader. Published by every pooler. UNKNOWN
+   * (the default for older poolers) is treated the same as ELIGIBLE so that
+   * the coordinator can fall back gracefully when the field is absent.
+   *
+   * @generated from field: clustermetadata.LeadershipAvailability leadership_availability = 4;
+   */
+  leadershipAvailability?: LeadershipAvailability;
+
   constructor(data?: PartialMessage<AvailabilityStatus>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2427,6 +2474,7 @@ export class AvailabilityStatus extends Message<AvailabilityStatus> {
     { no: 1, name: "leadership_status", kind: "message", T: LeadershipStatus },
     { no: 2, name: "cohort_eligibility_status", kind: "message", T: CohortEligibilityStatus },
     { no: 3, name: "suspected_divergence", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 4, name: "leadership_availability", kind: "message", T: LeadershipAvailability },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AvailabilityStatus {
@@ -2485,6 +2533,57 @@ export class CohortEligibilityStatus extends Message<CohortEligibilityStatus> {
 
   static equals(a: CohortEligibilityStatus | PlainMessage<CohortEligibilityStatus> | undefined, b: CohortEligibilityStatus | PlainMessage<CohortEligibilityStatus> | undefined): boolean {
     return proto3.util.equals(CohortEligibilityStatus, a, b);
+  }
+}
+
+/**
+ * LeadershipAvailability carries the pooler's self-reported readiness to
+ * accept leader promotion. Unlike CohortEligibilityStatus this is not a
+ * permanent preference — it reflects the transient startup state of postgres.
+ * Staleness comes from the freshness of the surrounding health snapshot.
+ *
+ * @generated from message clustermetadata.LeadershipAvailability
+ */
+export class LeadershipAvailability extends Message<LeadershipAvailability> {
+  /**
+   * @generated from field: clustermetadata.LeadershipAvailabilitySignal signal = 1;
+   */
+  signal = LeadershipAvailabilitySignal.UNKNOWN;
+
+  /**
+   * reason is a human-readable explanation of why the signal was set.
+   * Intended for debugging and observability only; not used in decision logic.
+   *
+   * @generated from field: string reason = 2;
+   */
+  reason = "";
+
+  constructor(data?: PartialMessage<LeadershipAvailability>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "clustermetadata.LeadershipAvailability";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "signal", kind: "enum", T: proto3.getEnumType(LeadershipAvailabilitySignal) },
+    { no: 2, name: "reason", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: LeadershipAvailability | PlainMessage<LeadershipAvailability> | undefined, b: LeadershipAvailability | PlainMessage<LeadershipAvailability> | undefined): boolean {
+    return proto3.util.equals(LeadershipAvailability, a, b);
   }
 }
 

--- a/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
+++ b/web/multiadmin/lib/api/generated/clustermetadata_pb.ts
@@ -363,6 +363,43 @@ proto3.util.setEnumType(CohortEligibilitySignal, "clustermetadata.CohortEligibil
 ]);
 
 /**
+ * LeadershipAvailabilitySignal describes whether a pooler is ready to be
+ * promoted to consensus leader.
+ *
+ * @generated from enum clustermetadata.LeadershipAvailabilitySignal
+ */
+export enum LeadershipAvailabilitySignal {
+  /**
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN = 0;
+   */
+  UNKNOWN = 0,
+
+  /**
+   * Pooler's postgres is still initialising (starting, in crash recovery,
+   * socket not yet open). The node can still be elected if it has the most
+   * advanced WAL position and no READY node is tied with it.
+   *
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_STARTING = 1;
+   */
+  STARTING = 1,
+
+  /**
+   * Pooler's postgres is running and accepting connections. When multiple
+   * nodes are tied at the same WAL position the coordinator prefers a READY
+   * node over a STARTING one.
+   *
+   * @generated from enum value: LEADERSHIP_AVAILABILITY_SIGNAL_READY = 2;
+   */
+  READY = 2,
+}
+// Retrieve enum metadata with: proto3.getEnumType(LeadershipAvailabilitySignal)
+proto3.util.setEnumType(LeadershipAvailabilitySignal, "clustermetadata.LeadershipAvailabilitySignal", [
+  { no: 0, name: "LEADERSHIP_AVAILABILITY_SIGNAL_UNKNOWN" },
+  { no: 1, name: "LEADERSHIP_AVAILABILITY_SIGNAL_STARTING" },
+  { no: 2, name: "LEADERSHIP_AVAILABILITY_SIGNAL_READY" },
+]);
+
+/**
  * TopoConfig defines the connection parameters for a topology service.
  * It specifies the type of topology backend, where it's hosted, and the
  * logical root path within that backend.
@@ -2440,6 +2477,16 @@ export class AvailabilityStatus extends Message<AvailabilityStatus> {
    */
   suspectedDivergence = false;
 
+  /**
+   * leadership_availability reports whether the pooler's postgres is ready to
+   * accept promotion to consensus leader. Published by every pooler. UNKNOWN
+   * (the default for older poolers) is treated the same as ELIGIBLE so that
+   * the coordinator can fall back gracefully when the field is absent.
+   *
+   * @generated from field: clustermetadata.LeadershipAvailability leadership_availability = 4;
+   */
+  leadershipAvailability?: LeadershipAvailability;
+
   constructor(data?: PartialMessage<AvailabilityStatus>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2451,6 +2498,7 @@ export class AvailabilityStatus extends Message<AvailabilityStatus> {
     { no: 1, name: "leadership_status", kind: "message", T: LeadershipStatus },
     { no: 2, name: "cohort_eligibility_status", kind: "message", T: CohortEligibilityStatus },
     { no: 3, name: "suspected_divergence", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 4, name: "leadership_availability", kind: "message", T: LeadershipAvailability },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AvailabilityStatus {
@@ -2509,6 +2557,57 @@ export class CohortEligibilityStatus extends Message<CohortEligibilityStatus> {
 
   static equals(a: CohortEligibilityStatus | PlainMessage<CohortEligibilityStatus> | undefined, b: CohortEligibilityStatus | PlainMessage<CohortEligibilityStatus> | undefined): boolean {
     return proto3.util.equals(CohortEligibilityStatus, a, b);
+  }
+}
+
+/**
+ * LeadershipAvailability carries the pooler's self-reported readiness to
+ * accept leader promotion. Unlike CohortEligibilityStatus this is not a
+ * permanent preference — it reflects the transient startup state of postgres.
+ * Staleness comes from the freshness of the surrounding health snapshot.
+ *
+ * @generated from message clustermetadata.LeadershipAvailability
+ */
+export class LeadershipAvailability extends Message<LeadershipAvailability> {
+  /**
+   * @generated from field: clustermetadata.LeadershipAvailabilitySignal signal = 1;
+   */
+  signal = LeadershipAvailabilitySignal.UNKNOWN;
+
+  /**
+   * reason is a human-readable explanation of why the signal was set.
+   * Intended for debugging and observability only; not used in decision logic.
+   *
+   * @generated from field: string reason = 2;
+   */
+  reason = "";
+
+  constructor(data?: PartialMessage<LeadershipAvailability>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "clustermetadata.LeadershipAvailability";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "signal", kind: "enum", T: proto3.getEnumType(LeadershipAvailabilitySignal) },
+    { no: 2, name: "reason", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): LeadershipAvailability {
+    return new LeadershipAvailability().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: LeadershipAvailability | PlainMessage<LeadershipAvailability> | undefined, b: LeadershipAvailability | PlainMessage<LeadershipAvailability> | undefined): boolean {
+    return proto3.util.equals(LeadershipAvailability, a, b);
   }
 }
 


### PR DESCRIPTION
## Problem

During a failover, candidate selection picks the node with the highest WAL position. A freshly recreated pod has its PVC data intact (valid LSN) but postgres has not yet finished initialising. When that pod wins the election, the `Propose` fails immediately because the promotion hook cannot connect to the postgres Unix socket:

```
propose failed: could not write rule: promotion hook: reconnect dial failed:
failed to connect to Unix socket .s.PGSQL.5432: no such file or directory
```

Without this fix, the election fails and stalls until the next analysis cycle. With this fix, a ready pod is preferred when available, avoiding the failure. If no pod is ready, the election still fails and retries in the next cycle.

### Without this fix

```mermaid
sequenceDiagram
    participant orch as multiorch
    box old primary pod
    participant old_pool as multipooler
    participant old_pg as postgres
    end
    box new pod
    participant new_pool as multipooler
    participant new_pg as postgres
    end
    box standby pod
    participant stby_pool as multipooler
    participant stby_pg as postgres
    end

    activate old_pg
    activate stby_pg

    Note over old_pg,stby_pg: Normal operation — all postgres processes running

    old_pool-->>orch: health (READY)
    stby_pool-->>orch: health (READY)

    Note over old_pool,old_pg: pod deleted / AZ outage
    deactivate old_pg

    activate new_pool
    Note over new_pg: pod recreated, PVC intact<br/>crash recovery running
    activate new_pg

    new_pool-->>orch: health (STARTING — socket not open)
    stby_pool-->>orch: health (READY)

    Note over orch: LeaderIsDeadAnalyzer fires<br/>→ runFailover()

    orch->>new_pool: Recruit
    new_pool-->>orch: ConsensusStatus {lsn: A/BC}

    orch->>stby_pool: Recruit
    stby_pool-->>orch: ConsensusStatus {lsn: A/BC}

    Note over orch: LSNs tied (A/BC = A/BC)<br/>no readiness tiebreaker<br/>→ new pod elected

    orch->>new_pool: Promote
    new_pool-xnew_pg: pg_promote() — socket not open
    new_pool-->>orch: error: dial .s.PGSQL.5432: no such file or directory

    Note over orch: Propose fails — stalls ~30 s<br/>until next analysis cycle
```

### With this fix — STARTING, not INELIGIBLE

A natural first instinct is to mark a STARTING pod as `INELIGIBLE` and filter it out of the candidate set entirely. That would be unsafe. Because all pods use PVCs, the STARTING pod has flushed every synchronous write up to its crash — under `AT_LEAST_2` the STARTING pod may be the only node that acknowledged the most recent transaction, with the READY standby still catching up. Filtering it out elects the READY standby at a lower LSN and loses that acknowledged write.

The correct fix keeps the STARTING node in the candidate set and uses its LSN normally, only deprioritising it as a tiebreaker when another node is tied on LSN and READY.

```mermaid
sequenceDiagram
    participant client
    participant primary as postgres (primary)
    participant stby_a as postgres A (STARTING)
    participant stby_b as postgres B (READY)
    participant orch as multiorch

    Note over primary,stby_b: T1 — both standbys acknowledge (AT_LEAST_2 satisfied)
    client->>primary: INSERT T1
    primary-->>stby_a: WAL → LSN B
    primary-->>stby_b: WAL → LSN B
    stby_a-->>primary: flush ACK
    stby_b-->>primary: flush ACK
    primary-->>client: OK — T1 durable at LSN B

    Note over primary,stby_b: T2 — standby B lags, only standby A flushes
    client->>primary: INSERT T2
    primary-->>stby_a: WAL → LSN C
    primary-->>stby_b: WAL → LSN C (in-flight — not yet flushed)
    stby_a-->>primary: flush ACK — AT_LEAST_2 satisfied
    primary-->>client: OK — T2 durable at LSN C

    Note over primary: primary crashes

    Note over stby_a: STARTING — crash recovery<br/>LSN C on PVC
    Note over stby_b: READY — LSN B only<br/>(never received T2)

    alt STARTING treated as INELIGIBLE — broken
        orch->>stby_b: Recruit (only B eligible — A filtered out)
        stby_b-->>orch: ConsensusStatus lsn=B
        orch->>stby_b: Promote (LSN B elected)
        stby_b-->>orch: OK — new leader at LSN B
        rect rgb(255, 150, 150)
            Note over stby_a,stby_b: T2 lost — client was told OK<br/>but data is gone (durability violated)
        end
    else STARTING kept as deprioritised candidate — correct
        orch->>stby_a: Recruit
        stby_a-->>orch: ConsensusStatus lsn=C
        orch->>stby_b: Recruit
        stby_b-->>orch: ConsensusStatus lsn=B
        Note over orch: LSN C > B — standby A wins<br/>despite STARTING signal
        orch->>stby_a: Promote (LSN C)
        stby_a-->>orch: OK — T2 preserved
        rect rgb(150, 220, 150)
            Note over stby_a,stby_b: T2 preserved — durability maintained
        end
    end
```

## Fix

### Pooler: publish `LeadershipAvailability` signal

A new `LeadershipAvailability` field (field 3 on `AvailabilityStatus`) carries a `READY` or `STARTING` signal. The postgres monitor already polls pgctld on every tick; a new `postgresReadyForCohort atomic.Bool` stores whether postgres is running and `pg_isready` passes. `buildLeadershipAvailability()` maps this to:

- `READY` — postgres is accepting connections, safe to promote
- `STARTING` — postgres is still initialising (crash recovery, socket not yet open)

A human-readable `reason` string is included for debugging. The signal flows via the health stream to `PoolerHealthState.AvailabilityStatus` in the orchestrator.

`buildCohortEligibilityStatus` is unaffected — postgres readiness does not change cohort membership preference. The two signals are orthogonal: `CohortEligibilityStatus` covers administrative state (graceful shutdown, `StopReplication`); `LeadershipAvailability` covers transient startup state.

### Orchestrator: sort tied candidates by readiness

WAL position is always the primary criterion. Under synchronous replication, all nodes in the cohort typically share the same LSN, so the tie-breaker matters in practice.

`leadershipAwareDiscoverer(healthByID)` replaces direct use of `DiscoverMostAdvancedTimeline`:

```go
candidates := commonconsensus.DiscoverMostAdvancedTimeline(recruited, outgoingRule)
sort.SliceStable(candidates, func(i, j int) bool {
    return isReady(candidates[i].GetId()) && !isReady(candidates[j].GetId())
})
return candidates
```

`DiscoverMostAdvancedTimeline` returns only the nodes tied at the highest LSN. The sort puts `READY` nodes first within that tied set. `buildFailoverProposal` picks index 0, so the first `READY` node wins. If all tied nodes are `STARTING` the sort is a no-op and the election proceeds normally — WAL position is never sacrificed for readiness.

The same `Discoverer` is passed to both `BuildSafeProposal` (actual election) and `CheckProposalPossible` (pre-vote feasibility check), keeping both gates consistent.

## Test

`TestFailoverSkipsCohortIneligibleNode` (`go/test/endtoend/multiorch/`):

1. 3-node cluster bootstraps (primary + 2 standbys).
2. `StopReplication(RECEIVER_ONLY)` on `standbyIneligible` — sets `walReceiverManuallyStopped`, causing it to publish `STARTING` via `buildLeadershipAvailability`. Postgres stays running so Recruit RPCs succeed; the node still contributes to quorum.
3. Wait until both the `STARTING` signal and `primary_conninfo == ""` are confirmed in a single Status RPC call.
4. Write one row via the primary and wait until `standbyEligible`'s WAL position is strictly ahead of `standbyIneligible`'s frozen LSN. This closes the LSN race: `standbyEligible` is now both more advanced and `READY`, so the sort places it first on both criteria.
5. Kill primary postgres → failover.
6. Assert `standbyEligible` is elected, `standbyIneligible` is not.
7. Cleanup: re-enable postgres restarts, `StartReplication` on `standbyIneligible`, `RequireRecovery`.

Closes MUL-558


