### PR TITLE
fix(multipooler): wait for postgres socket before calling pg_promote()

### DIFF
--- a/go/cmd/pgctld/testutil/grpc_helpers.go
+++ b/go/cmd/pgctld/testutil/grpc_helpers.go
@@ -52,6 +52,13 @@ type MockPgCtldService struct {
 	InitDirResponse  *pb.InitDataDirResponse
 	PgRewindResponse *pb.PgRewindResponse
 
+	// StatusResponseQueue allows tests to return different responses on successive
+	// Status calls. Each call pops the first element from the queue. When the queue
+	// is empty the call falls through to StatusResponse or the default RUNNING+Ready
+	// response. Useful for simulating postgres starting up: queue a few not-ready
+	// responses followed by a ready one.
+	StatusResponseQueue []*pb.StatusResponse
+
 	// Error configurations
 	StartError    error
 	StopError     error
@@ -115,12 +122,24 @@ func (m *MockPgCtldService) ReloadConfig(ctx context.Context, req *pb.ReloadConf
 	return &pb.ReloadConfigResponse{Message: "Mock config reloaded"}, nil
 }
 
+// StatusCallCount returns the number of Status RPC calls received so far.
+func (m *MockPgCtldService) StatusCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.StatusCalls)
+}
+
 func (m *MockPgCtldService) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.StatusCalls = append(m.StatusCalls, req)
 	if m.StatusError != nil {
 		return nil, m.StatusError
+	}
+	if len(m.StatusResponseQueue) > 0 {
+		resp := m.StatusResponseQueue[0]
+		m.StatusResponseQueue = m.StatusResponseQueue[1:]
+		return resp, nil
 	}
 	if m.StatusResponse != nil {
 		return m.StatusResponse, nil

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -1335,6 +1335,17 @@ func (pm *MultiPoolerManager) promoteStandbyToPrimary(ctx context.Context, state
 		return nil
 	}
 
+	// Wait for postgres to be ready before attempting promotion. A freshly
+	// recreated pod may have valid WAL data on its PVC (giving it a valid
+	// LSN in the Recruit response) but postgres may still be initialising —
+	// the socket may not yet exist or pg_isready may not yet pass. Without
+	// this wait the connection attempt inside pg_promote() fails immediately
+	// with "no such file or directory". We block here rather than failing and
+	// waiting for the next analysis cycle.
+	if err := pm.waitForPostgresReady(ctx); err != nil {
+		return mterrors.Wrap(err, "postgres not ready for promotion")
+	}
+
 	// Call pg_promote() to promote standby to primary
 	pm.logger.InfoContext(ctx, "PostgreSQL promotion needed")
 	pm.logger.InfoContext(ctx, "Calling pg_promote() to promote standby to primary")
@@ -1425,6 +1436,32 @@ func (pm *MultiPoolerManager) waitForPromotionComplete(ctx context.Context) erro
 
 			if promotedFromRecovery && pm.isPostgresReady(promotionCtx) {
 				pm.logger.InfoContext(ctx, "Promotion completed successfully - node is now primary and accepting connections")
+				return nil
+			}
+		}
+	}
+}
+
+// waitForPostgresReady polls isPostgresReady until postgres is accepting
+// connections or the context deadline is reached. It returns immediately if
+// postgres is already ready. Used by promoteStandbyToPrimary to handle the
+// window where a freshly (re)started postgres has not yet opened its socket
+// or not yet passed pg_isready, which would otherwise cause the pg_promote()
+// connection attempt to fail with "no such file or directory".
+func (pm *MultiPoolerManager) waitForPostgresReady(ctx context.Context) error {
+	if pm.isPostgresReady(ctx) {
+		return nil
+	}
+	pm.logger.InfoContext(ctx, "Waiting for postgres to become ready before promotion")
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("postgres did not become ready before context deadline: %w", ctx.Err())
+		case <-ticker.C:
+			if pm.isPostgresReady(ctx) {
+				pm.logger.InfoContext(ctx, "Postgres is now ready, proceeding with promotion")
 				return nil
 			}
 		}

--- a/go/services/multipooler/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/manager/rpc_consensus_test.go
@@ -37,6 +37,7 @@ import (
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	consensusdatapb "github.com/multigres/multigres/go/pb/consensusdata"
+	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
 )
 
 // recruitTS is a fixed coordinator_initiated_at timestamp used in Recruit test cases.
@@ -47,16 +48,19 @@ var recruitTS = timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 // path reads one field but stores the other, the assertion catches it.
 var ruleCreatedTS = timestamppb.New(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
 
-func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, rules ruleStorer) (*MultiPoolerManager, string) {
+// setupManagerWithPgctld is like setupManagerWithMockDB but accepts a custom
+// pgctld mock. Use it when a test needs to control the sequence of pgctld
+// Status responses (e.g. to simulate postgres starting up).
+func setupManagerWithPgctld(t *testing.T, mockQueryService *mock.QueryService, pgctld *testutil.MockPgCtldService, rules ruleStorer) (*MultiPoolerManager, string) {
+	t.Helper()
 	ctx := t.Context()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
 	t.Cleanup(func() { ts.Close() })
 
-	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, &testutil.MockPgCtldService{})
+	pgctldAddr, cleanupPgctld := testutil.StartMockPgctldServer(t, pgctld)
 	t.Cleanup(cleanupPgctld)
 
-	// Create the database in topology with backup location
 	database := "testdb"
 	addDatabaseToTopo(t, ts, database)
 
@@ -89,8 +93,6 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	require.NoError(t, err)
 	t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
 
-	// Assign mock pooler controller and rule store BEFORE starting the manager
-	// to avoid race conditions.
 	pm.qsc = &mockPoolerController{queryService: mockQueryService}
 	pm.rules = rules
 
@@ -101,13 +103,9 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 		return pm.GetState() == ManagerStateReady
 	}, 5*time.Second, 100*time.Millisecond, "Manager should reach Ready state")
 
-	// Create the pg_data directory to simulate initialized data directory
 	pgDataDir := tmpDir + "/pg_data"
-	err = os.MkdirAll(pgDataDir, 0o755)
-	require.NoError(t, err)
-	// Create PG_VERSION file to mark it as initialized
-	err = os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644)
-	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(pgDataDir, 0o755))
+	require.NoError(t, os.WriteFile(pgDataDir+"/PG_VERSION", []byte("18\n"), 0o644))
 	t.Setenv(constants.PgDataDirEnvVar, pgDataDir)
 
 	// Initialize consensus state
@@ -116,6 +114,11 @@ func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, r
 	pm.mu.Unlock()
 
 	return pm, tmpDir
+}
+
+func setupManagerWithMockDB(t *testing.T, mockQueryService *mock.QueryService, rules ruleStorer) (*MultiPoolerManager, string) {
+	t.Helper()
+	return setupManagerWithPgctld(t, mockQueryService, &testutil.MockPgCtldService{}, rules)
 }
 
 // ============================================================================
@@ -1057,4 +1060,67 @@ func TestSetResignedLeaderAtTerm_BroadcastsOnChange(t *testing.T) {
 
 	require.NoError(t, pm.setResignedLeaderAtTerm(lockCtx, 0))
 	assert.Equal(t, 1, drain(), "clearing the term is also a change and should broadcast")
+}
+
+// ============================================================================
+// TestWaitForPostgresReady
+// ============================================================================
+
+// notReady/ready helpers for StatusResponseQueue construction.
+func pgctldNotReady() *pgctldpb.StatusResponse {
+	return &pgctldpb.StatusResponse{Status: pgctldpb.ServerStatus_RUNNING, Ready: false}
+}
+
+func pgctldReady() *pgctldpb.StatusResponse {
+	return &pgctldpb.StatusResponse{Status: pgctldpb.ServerStatus_RUNNING, Ready: true}
+}
+
+// TestWaitForPostgresReady exercises the three code paths in
+// waitForPostgresReady:
+//
+//  1. Fast path  — postgres is already ready on the first check; returns
+//     immediately without entering the polling loop.
+//  2. Polling    — postgres is not ready initially but becomes ready after a
+//     few polling ticks; returns nil once ready.
+//  3. Timeout    — postgres never becomes ready before the context deadline;
+//     returns an error wrapping ctx.Err().
+func TestWaitForPostgresReady(t *testing.T) {
+	t.Run("already ready returns immediately", func(t *testing.T) {
+		// Default MockPgCtldService returns RUNNING+Ready=true — fast path.
+		pm, _ := setupManagerWithMockDB(t, mock.NewQueryService(), &fakeRuleStore{pos: makeRulePosition(0)})
+		err := pm.waitForPostgresReady(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("polls until postgres becomes ready", func(t *testing.T) {
+		// Queue: two not-ready responses, then one ready response.
+		// waitForPostgresReady should poll twice and succeed on the third call.
+		pgctld := &testutil.MockPgCtldService{
+			StatusResponseQueue: []*pgctldpb.StatusResponse{
+				pgctldNotReady(),
+				pgctldNotReady(),
+				pgctldReady(),
+			},
+		}
+		pm, _ := setupManagerWithPgctld(t, mock.NewQueryService(), pgctld, &fakeRuleStore{pos: makeRulePosition(0)})
+		err := pm.waitForPostgresReady(t.Context())
+		require.NoError(t, err, "should succeed once postgres becomes ready")
+		// All three queued responses should have been consumed (checked via the
+		// Status call counter which is protected by the mock's internal mutex).
+		assert.Equal(t, 3, pgctld.StatusCallCount(),
+			"waitForPostgresReady should have called Status exactly 3 times")
+	})
+
+	t.Run("returns error when context deadline exceeded", func(t *testing.T) {
+		// Never becomes ready: every Status call returns Ready=false.
+		pgctld := &testutil.MockPgCtldService{
+			StatusResponse: pgctldNotReady(),
+		}
+		pm, _ := setupManagerWithPgctld(t, mock.NewQueryService(), pgctld, &fakeRuleStore{pos: makeRulePosition(0)})
+		ctx, cancel := context.WithTimeout(t.Context(), 350*time.Millisecond)
+		defer cancel()
+		err := pm.waitForPostgresReady(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
 }


### PR DESCRIPTION
When a pod is recreated with PVC data intact, the multipooler can successfully respond to a Recruit RPC (postgres is running and answers SQL) but by the time the Propose RPC arrives the socket may no longer exist. The connection pool tries to reconnect for pg_promote() and fails:

    propose failed: could not write rule: promotion hook: reconnect dial
    failed: failed to connect to Unix socket .s.PGSQL.5432: no such file
    or directory

Add waitForPostgresReady, which polls isPostgresReady at 200ms intervals until postgres is accepting connections or the context deadline (the Propose RPC timeout) is reached. Call it at the start of promoteStandbyToPrimary, after the already-promoted early-exit, so the wait only runs when pg_promote() is actually about to be called.

If postgres becomes ready within the Propose timeout the promotion proceeds without waiting for the next analysis cycle. If postgres is already ready the fast path returns immediately with no polling overhead.

Change is confined to go/services/multipooler/manager/manager.go.

Tests (rpc_consensus_test.go):

  - already ready returns immediately: fast path, no polling loop entered
  - polls until postgres becomes ready: queue of 2 not-ready + 1 ready pgctld responses; StatusCallCount confirms exactly 3 calls were made
  - context deadline exceeded: permanently not-ready; error wraps context.DeadlineExceeded at 350ms

Test infrastructure (go/cmd/pgctld/testutil/grpc_helpers.go):

  - MockPgCtldService.StatusResponseQueue: dequeues one response per Status call to enable sequenced mock responses
  - MockPgCtldService.StatusCallCount(): call count accessor under the internal mutex
  - setupManagerWithPgctld helper: variant of setupManagerWithMockDB that accepts a custom pgctld mock

Part of MUL-558
