### PR TITLE
feat(multiorch): record and assert leader appointment latency

### DIFF
--- a/go/common/eventlog/eventlog_test.go
+++ b/go/common/eventlog/eventlog_test.go
@@ -36,6 +36,8 @@ func (h *testHandler) Handle(_ context.Context, r slog.Record) error {
 func (h *testHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
 func (h *testHandler) WithGroup(string) slog.Handler      { return h }
 
+func ptr[T any](v T) *T { return &v }
+
 // recordAttrs extracts all attributes from a slog.Record into a map.
 func recordAttrs(r slog.Record) map[string]any {
 	attrs := make(map[string]any)
@@ -55,14 +57,33 @@ func TestEmit(t *testing.T) {
 		wantLevel     slog.Level
 		wantEventType string
 		wantAttrs     map[string]any
+		wantAbsent    []string
 	}{
 		{
-			name:          "event with fields",
+			name:          "terminal promotion carries new_primary, proposed_term and phase timings",
 			outcome:       Success,
-			event:         PrimaryPromotion{NewPrimary: "pg-1", Reason: "ShardInit"},
+			event:         PrimaryPromotion{NewPrimary: "pg-1", ProposedTerm: 7, Reason: "ShardInit", RecruitMs: ptr(int64(120)), ProposeMs: ptr(int64(680))},
 			wantLevel:     slog.LevelInfo,
 			wantEventType: "primary.promotion",
-			wantAttrs:     map[string]any{"outcome": "success", "new_primary": "pg-1", "reason": "ShardInit"},
+			wantAttrs:     map[string]any{"outcome": "success", "new_primary": "pg-1", "proposed_term": int64(7), "reason": "ShardInit", "recruit_ms": int64(120), "propose_ms": int64(680)},
+		},
+		{
+			name:          "recruitment failure records recruit_ms but no propose_ms",
+			outcome:       Failed,
+			event:         PrimaryPromotion{ProposedTerm: 7, Reason: "LeaderIsDead", RecruitMs: ptr(int64(4200))},
+			wantLevel:     slog.LevelError,
+			wantEventType: "primary.promotion",
+			wantAttrs:     map[string]any{"outcome": "failed", "proposed_term": int64(7), "reason": "LeaderIsDead", "recruit_ms": int64(4200)},
+			wantAbsent:    []string{"new_primary", "propose_ms"},
+		},
+		{
+			name:          "started promotion omits new_primary and phase timings",
+			outcome:       Started,
+			event:         PrimaryPromotion{ProposedTerm: 7, Reason: "LeaderIsDead"},
+			wantLevel:     slog.LevelInfo,
+			wantEventType: "primary.promotion",
+			wantAttrs:     map[string]any{"outcome": "started", "proposed_term": int64(7), "reason": "LeaderIsDead"},
+			wantAbsent:    []string{"new_primary", "recruit_ms", "propose_ms"},
 		},
 	}
 
@@ -82,6 +103,9 @@ func TestEmit(t *testing.T) {
 			assert.Equal(t, tt.wantEventType, attrs["event_type"])
 			for k, v := range tt.wantAttrs {
 				assert.Equal(t, v, attrs[k], "attr %s", k)
+			}
+			for _, k := range tt.wantAbsent {
+				assert.NotContains(t, attrs, k, "attr %s should be absent", k)
 			}
 		})
 	}

--- a/go/common/eventlog/events.go
+++ b/go/common/eventlog/events.go
@@ -22,16 +22,49 @@ func (NodeJoin) EventType() string       { return "node.join" }
 func (e NodeJoin) LogAttrs() []slog.Attr { return []slog.Attr{slog.String("node_name", e.NodeName)} }
 
 type PrimaryPromotion struct {
+	// NewPrimary is the elected leader. It is empty on the Started event because
+	// the leader is not chosen until recruitment completes; it is set on the
+	// terminal Success/Failed event.
 	NewPrimary string
-	Reason     string // why the promotion was initiated, e.g. "ShardInit" or a failover trigger
+	// ProposedTerm is the term the coordinator is driving the cohort to. Known
+	// before any RPC and stable through completion, it correlates a promotion's
+	// Started and terminal events (and the term.begin event and rule-history row).
+	ProposedTerm int64
+	Reason       string // why the promotion was initiated, e.g. "ShardInit" or a failover trigger
+	// RecruitMs and ProposeMs split the appointment latency (milliseconds,
+	// monotonic clock) into its two phases: RecruitMs from Run start until a
+	// leader is selected (recruiting a quorum), ProposeMs from leader selection
+	// until the proposal commits. They are set only on terminal events and nil
+	// where not applicable — both on Started, and ProposeMs on a recruitment
+	// failure that never reached the propose phase. Draining late recruits
+	// overlaps the propose phase but is off the commit critical path, so the
+	// split reflects time-to-select-leader vs. time-to-commit.
+	RecruitMs *int64
+	ProposeMs *int64
 }
+
+const (
+	attrRecruitMs = "recruit_ms"
+	attrProposeMs = "propose_ms"
+)
 
 func (PrimaryPromotion) EventType() string { return "primary.promotion" }
 func (e PrimaryPromotion) LogAttrs() []slog.Attr {
-	return []slog.Attr{
-		slog.String("new_primary", e.NewPrimary),
+	attrs := []slog.Attr{
+		slog.Int64("proposed_term", e.ProposedTerm),
 		slog.String("reason", e.Reason),
 	}
+	// Omitted on Started, where the leader is not yet known.
+	if e.NewPrimary != "" {
+		attrs = append(attrs, slog.String("new_primary", e.NewPrimary))
+	}
+	if e.RecruitMs != nil {
+		attrs = append(attrs, slog.Int64(attrRecruitMs, *e.RecruitMs))
+	}
+	if e.ProposeMs != nil {
+		attrs = append(attrs, slog.Int64(attrProposeMs, *e.ProposeMs))
+	}
+	return attrs
 }
 
 type BackupAttempt struct{ BackupName string }

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -78,6 +78,7 @@ func (r *coordinatorLedRuleChange) Run(
 	if revocation == nil {
 		return mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "Run: revocation is required")
 	}
+	proposedTerm := revocation.GetRevokedBelowTerm()
 
 	// Extract cached consensus statuses for the pre-vote feasibility check.
 	var initialStatuses []*clustermetadatapb.ConsensusStatus
@@ -88,11 +89,12 @@ func (r *coordinatorLedRuleChange) Run(
 	}
 
 	r.coordinator.logger.InfoContext(ctx, "Starting rule change",
-		"proposed_term", revocation.GetRevokedBelowTerm(),
+		"proposed_term", proposedTerm,
 		"cohort_size", len(cohort))
 
 	// Back off if any node recently accepted a revocation — another coordinator
-	// may be running an election.
+	// may be running an election. A backoff is a decision not to start this
+	// appointment, so it precedes the Started event below rather than failing one.
 	if err := checkRecentAcceptance(ctx, r.coordinator.logger, cohort); err != nil {
 		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "%v", err)
 	}
@@ -102,6 +104,21 @@ func (r *coordinatorLedRuleChange) Run(
 	if err := r.checkProposalPossible(revocation, initialStatuses); err != nil {
 		return mterrors.Errorf(mtrpcpb.Code_UNAVAILABLE, "pre-vote failed: %v", err)
 	}
+
+	// Mark the start of the appointment before any RPCs go out. The leader is not
+	// chosen until recruitment completes, so new_primary is omitted here; the
+	// terminal Success/Failed event below carries it. proposed_term correlates
+	// this Started event with its terminal event for tracing.
+	//
+	// start and selectedAt bracket the two latency phases reported on the
+	// terminal event: recruit (start → leader selected) and propose (leader
+	// selected → commit). Monotonic, so unaffected by wall-clock adjustments.
+	start := time.Now()
+	var selectedAt time.Time
+	eventlog.Emit(ctx, r.coordinator.logger, eventlog.Started, eventlog.PrimaryPromotion{
+		ProposedTerm: proposedTerm,
+		Reason:       r.reason,
+	})
 
 	// Recruit all nodes concurrently.
 	type recruitResult struct {
@@ -178,14 +195,22 @@ func (r *coordinatorLedRuleChange) Run(
 			Reason:          r.reason,
 			AcceptedNodeIds: ids,
 		}
-		eventlog.Emit(ctx, r.coordinator.logger, eventlog.Started, eventlog.PrimaryPromotion{
-			NewPrimary: p.GetProposalLeader().GetId().GetName(),
-			Reason:     r.reason,
-		})
+		selectedAt = time.Now()
 	}
 
 	if propReq == nil {
 		_, err := r.tryBuildProposal(revocation, statuses)
+		// Recruitment never assembled a viable proposal: no leader was chosen,
+		// so the appointment failed before commit. Emit the terminal event that
+		// closes out the Started above (new_primary unknown). All elapsed time
+		// was spent recruiting; the propose phase never began, so ProposeMs is
+		// left nil.
+		recruitMs := time.Since(start).Milliseconds()
+		eventlog.Emit(ctx, r.coordinator.logger, eventlog.Failed, eventlog.PrimaryPromotion{
+			ProposedTerm: proposedTerm,
+			Reason:       r.reason,
+			RecruitMs:    &recruitMs,
+		}, "error", err)
 		return mterrors.Wrap(err, "recruitment failed")
 	}
 	for _, p := range recruits {
@@ -230,16 +255,24 @@ func (r *coordinatorLedRuleChange) Run(
 	}
 
 	newPrimary := propReq.GetProposal().GetProposalLeader().GetId().GetName()
+	recruitMs := selectedAt.Sub(start).Milliseconds()
+	proposeMs := time.Since(selectedAt).Milliseconds()
 	if leaderErr != nil {
 		eventlog.Emit(ctx, r.coordinator.logger, eventlog.Failed, eventlog.PrimaryPromotion{
-			NewPrimary: newPrimary,
-			Reason:     r.reason,
+			NewPrimary:   newPrimary,
+			ProposedTerm: proposedTerm,
+			Reason:       r.reason,
+			RecruitMs:    &recruitMs,
+			ProposeMs:    &proposeMs,
 		}, "error", leaderErr)
 		return mterrors.Wrapf(leaderErr, "leader %s failed to accept proposal", newPrimary)
 	}
 	eventlog.Emit(ctx, r.coordinator.logger, eventlog.Success, eventlog.PrimaryPromotion{
-		NewPrimary: newPrimary,
-		Reason:     r.reason,
+		NewPrimary:   newPrimary,
+		ProposedTerm: proposedTerm,
+		Reason:       r.reason,
+		RecruitMs:    &recruitMs,
+		ProposeMs:    &proposeMs,
 	})
 	return nil
 }

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -353,45 +353,93 @@ func (pm *MultiPoolerManager) queryReplicationStatus(ctx context.Context) (*mult
 	return status, nil
 }
 
-// waitForReplicationPause polls until WAL replay is paused and returns the status at that moment.
-// This ensures the LSN returned represents the exact point at which replication stopped.
-func (pm *MultiPoolerManager) waitForReplicationPause(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
-	// Create a context with timeout for the polling loop
+// pollForReplicationStatus polls poll on a 10s budget until it reports done,
+// returning the accompanying status. The first attempt runs immediately and
+// subsequent attempts back off exponentially from a small base: a state that
+// settles within milliseconds (the common case for these replication waits)
+// returns promptly instead of paying a fixed poll interval on the failover
+// critical path, while the backoff avoids hammering postgres when it takes
+// longer.
+//
+// poll returns (status, done, err): done==true stops the loop and returns
+// status; a non-nil err aborts immediately, except that an err observed after
+// the context expired mid-poll is reported as the canonical timeout. On
+// budget/context exhaustion, onTimeout (if non-nil) is invoked for diagnostics
+// and a canonical DEADLINE_EXCEEDED (timeoutMsg) or wrapped cancellation
+// (cancelMsg) is returned.
+func (pm *MultiPoolerManager) pollForReplicationStatus(
+	ctx context.Context,
+	timeoutMsg, cancelMsg string,
+	onTimeout func(cause error),
+	poll func(ctx context.Context) (status *multipoolermanagerdatapb.StandbyReplicationStatus, done bool, err error),
+) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	fail := func(cause error) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
+		if onTimeout != nil {
+			onTimeout(cause)
+		}
+		if errors.Is(cause, context.DeadlineExceeded) {
+			return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, timeoutMsg)
+		}
+		return nil, mterrors.Wrap(cause, cancelMsg)
+	}
 
-	for {
-		select {
-		case <-waitCtx.Done():
-			if waitCtx.Err() == context.DeadlineExceeded {
-				pm.logger.ErrorContext(ctx, "Timeout waiting for WAL replay to pause")
-				return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL replay to pause")
+	r := retry.New(5*time.Millisecond, 500*time.Millisecond)
+	for _, err := range r.Attempts(waitCtx) {
+		if err != nil {
+			return fail(err)
+		}
+		status, done, pErr := poll(waitCtx)
+		if pErr != nil {
+			// Surface the cleaner timeout cause if waitCtx expired mid-poll
+			// instead of an opaque "pool ctx expired" wrapper.
+			if waitErr := waitCtx.Err(); waitErr != nil {
+				return fail(waitErr)
 			}
-			pm.logger.ErrorContext(ctx, "Context cancelled while waiting for WAL replay to pause")
-			return nil, mterrors.Wrap(waitCtx.Err(), "context cancelled while waiting for WAL replay to pause")
+			return nil, pErr
+		}
+		if done {
+			return status, nil
+		}
+	}
 
-		case <-ticker.C:
-			// Query all replication status fields
+	// Attempts only stops yielding when waitCtx is done, which is handled by the
+	// err branch above; this is unreachable but required for the compiler.
+	return fail(waitCtx.Err())
+}
+
+// waitForReplicationPause polls until WAL replay is paused and returns the status at that moment.
+// This ensures the LSN returned represents the exact point at which replication stopped.
+func (pm *MultiPoolerManager) waitForReplicationPause(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
+	return pm.pollForReplicationStatus(ctx,
+		"timeout waiting for WAL replay to pause",
+		"context cancelled while waiting for WAL replay to pause",
+		func(cause error) {
+			if errors.Is(cause, context.DeadlineExceeded) {
+				pm.logger.ErrorContext(ctx, "Timeout waiting for WAL replay to pause")
+			} else {
+				pm.logger.ErrorContext(ctx, "Context cancelled while waiting for WAL replay to pause")
+			}
+		},
+		func(waitCtx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, bool, error) {
+			// pg_wal_replay_pause() is asynchronous, so poll until it takes effect.
 			status, err := pm.queryReplicationStatus(waitCtx)
 			if err != nil {
 				pm.logger.ErrorContext(ctx, "Failed to get replication status", "error", err)
-				return nil, err
+				return nil, false, err
 			}
-
-			// Once paused, we have the exact state at the moment replication stopped
-			if status.IsWalReplayPaused {
-				pm.logger.InfoContext(ctx, "WAL replay is now paused",
-					"last_replay_lsn", status.LastReplayLsn,
-					"last_receive_lsn", status.LastReceiveLsn,
-					"pause_state", status.WalReplayPauseState)
-
-				return status, nil
+			if !status.IsWalReplayPaused {
+				return nil, false, nil
 			}
-		}
-	}
+			// Once paused, we have the exact state at the moment replication stopped.
+			pm.logger.InfoContext(ctx, "WAL replay is now paused",
+				"last_replay_lsn", status.LastReplayLsn,
+				"last_receive_lsn", status.LastReceiveLsn,
+				"pause_state", status.WalReplayPauseState)
+			return status, true, nil
+		})
 }
 
 // readPrimaryConnInfo returns the current primary_conninfo setting as a raw string.
@@ -457,6 +505,13 @@ func (pm *MultiPoolerManager) waitForReplayStabilize(ctx context.Context) (*mult
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 
+	// TODO: short-circuit when replay has provably caught up. On the recruit path
+	// the receiver is stopped before this runs, so the received LSN is fixed; if
+	// pg_last_wal_replay_lsn() == pg_last_wal_receive_lsn() we are maximally
+	// applied and can return immediately instead of waiting out requiredStablePolls.
+	// That needs queryReplayState to also return the receive LSN. Until then the
+	// stability heuristic below is a safe (if slightly slower) fallback.
+	//
 	// requiredStablePolls: number of consecutive polls showing the same replay_lsn
 	// before we declare stability. At 10ms per tick, 3 polls = 30ms of stability.
 	const requiredStablePolls = 3
@@ -527,13 +582,6 @@ func (pm *MultiPoolerManager) queryReplayState(ctx context.Context) (replayLsn s
 // waitForReceiverDisconnect waits for the WAL receiver to fully disconnect after clearing primary_conninfo.
 // It polls pg_stat_wal_receiver to confirm the receiver has stopped.
 func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
-	// Create a context with timeout for the polling loop
-	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
 	// Track the latest poll snapshot so a timeout has diagnostic detail without
 	// needing another query after the ctx has already expired.
 	var (
@@ -542,32 +590,17 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 		lastConnInfo string
 	)
 
-	timedOut := func(cause error) (*multipoolermanagerdatapb.StandbyReplicationStatus, error) {
-		pm.logger.ErrorContext(ctx, "WAL receiver did not disconnect",
-			"cause", cause,
-			"last_receiver_count", lastCount,
-			"last_walreceiver_status", lastStatus,
-			"last_primary_conninfo", lastConnInfo)
-		if errors.Is(cause, context.DeadlineExceeded) {
-			return nil, mterrors.New(mtrpcpb.Code_DEADLINE_EXCEEDED, "timeout waiting for WAL receiver to disconnect")
-		}
-		return nil, mterrors.Wrap(cause, "context cancelled while waiting for WAL receiver to disconnect")
-	}
-
-	for {
-		select {
-		case <-waitCtx.Done():
-			return timedOut(waitCtx.Err())
-
-		case <-ticker.C:
-			// Re-check waitCtx before issuing a query: when waitCtx expires at the
-			// same tick boundary, select may pick this branch and the subsequent
-			// pm.query would surface an opaque "pool ctx expired" instead of the
-			// real timeout cause.
-			if err := waitCtx.Err(); err != nil {
-				return timedOut(err)
-			}
-
+	return pm.pollForReplicationStatus(ctx,
+		"timeout waiting for WAL receiver to disconnect",
+		"context cancelled while waiting for WAL receiver to disconnect",
+		func(cause error) {
+			pm.logger.ErrorContext(ctx, "WAL receiver did not disconnect",
+				"cause", cause,
+				"last_receiver_count", lastCount,
+				"last_walreceiver_status", lastStatus,
+				"last_primary_conninfo", lastConnInfo)
+		},
+		func(waitCtx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, bool, error) {
 			// Pull the count, the walreceiver status, and the live primary_conninfo
 			// in a single query so each poll is also a diagnostic snapshot.
 			result, err := pm.query(waitCtx, `SELECT
@@ -575,18 +608,12 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 				coalesce((SELECT status FROM pg_stat_wal_receiver), ''),
 				current_setting('primary_conninfo')`)
 			if err != nil {
-				// If waitCtx expired between the pre-check and the Pool.Get
-				// ctx.Err() check, surface the cleaner timeout cause instead of
-				// an opaque "pool ctx expired" wrapper.
-				if waitErr := waitCtx.Err(); waitErr != nil {
-					return timedOut(waitErr)
-				}
 				pm.logger.ErrorContext(ctx, "Failed to query pg_stat_wal_receiver", "error", err)
-				return nil, mterrors.Wrap(err, "failed to query pg_stat_wal_receiver")
+				return nil, false, mterrors.Wrap(err, "failed to query pg_stat_wal_receiver")
 			}
 			if err := executor.ScanSingleRow(result, &lastCount, &lastStatus, &lastConnInfo); err != nil {
 				pm.logger.ErrorContext(ctx, "Failed to scan pg_stat_wal_receiver row", "error", err)
-				return nil, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver row")
+				return nil, false, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver row")
 			}
 
 			// Done when either the walreceiver slot is gone, OR it's sitting
@@ -606,22 +633,21 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 			//     Treating WAITING+empty as done lets us proceed without
 			//     waiting out that timeout.
 			done := lastCount == 0 || (lastStatus == "waiting" && lastConnInfo == "")
-			if done {
-				pm.logger.InfoContext(ctx, "WAL receiver has disconnected",
-					"last_receiver_count", lastCount,
-					"last_walreceiver_status", lastStatus)
-
-				// Get the final replication status
-				status, err := pm.queryReplicationStatus(waitCtx)
-				if err != nil {
-					pm.logger.ErrorContext(ctx, "Failed to get replication status", "error", err)
-					return nil, err
-				}
-
-				return status, nil
+			if !done {
+				return nil, false, nil
 			}
-		}
-	}
+			pm.logger.InfoContext(ctx, "WAL receiver has disconnected",
+				"last_receiver_count", lastCount,
+				"last_walreceiver_status", lastStatus)
+
+			// Get the final replication status
+			status, err := pm.queryReplicationStatus(waitCtx)
+			if err != nil {
+				pm.logger.ErrorContext(ctx, "Failed to get replication status", "error", err)
+				return nil, false, err
+			}
+			return status, true, nil
+		})
 }
 
 // pauseReplication pauses replication based on the specified mode.

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -1407,9 +1407,12 @@ func TestPauseReplication(t *testing.T) {
 // shrinking the parent context shortens the effective deadline via the
 // min-deadline semantics of context.WithTimeout.
 func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
-	t.Run("deadline expires before first poll", func(t *testing.T) {
+	t.Run("deadline already expired surfaces timeout before polling", func(t *testing.T) {
 		pm, _ := newTestManagerWithMock("default", "0-inf")
-		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		// Deadline already in the past: the first retry attempt observes the
+		// expired context and returns the timeout without ever polling, so no
+		// query mock is needed.
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 		defer cancel()
 
 		status, err := pm.waitForReceiverDisconnect(ctx)
@@ -1419,16 +1422,15 @@ func TestWaitForReceiverDisconnect_Timeout(t *testing.T) {
 		assert.Equal(t, mtrpcpb.Code_DEADLINE_EXCEEDED, mterrors.Code(err))
 	})
 
-	t.Run("deadline expires after one poll returns still-streaming", func(t *testing.T) {
+	t.Run("deadline expires while polls keep returning still-streaming", func(t *testing.T) {
 		pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
-		// Persistent (non-consumeOnce) pattern: the function may poll once or
-		// more before the deadline trips, depending on scheduling.
+		// Persistent (non-consumeOnce) pattern: the function polls repeatedly
+		// (immediately, then with exponential backoff) until the deadline trips.
 		mockQueryService.AddQueryPattern("SELECT COUNT", mock.MakeQueryResult(
 			[]string{"count", "status", "primary_conninfo"},
 			[][]any{{int64(1), "streaming", "host=primary port=5432"}}))
 
-		// 600ms leaves room for at least one 500ms tick before the deadline trips.
-		ctx, cancel := context.WithTimeout(t.Context(), 600*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 		defer cancel()
 
 		status, err := pm.waitForReceiverDisconnect(ctx)

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -20,9 +20,11 @@
 package multiorch
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -421,6 +423,54 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 
 		t.Logf("Rule history verified: term=%d, leader=%s, coordinator=%s, reason=%s",
 			termNumber, leaderID, coordinatorID, reason)
+	})
+
+	// Verify the leader appointments themselves were fast. The coordinator stamps
+	// each successful promotion with recruit_ms (Run start → leader selected) and
+	// propose_ms (leader selected → commit), measuring the appointment itself —
+	// independent of the (much larger) detection + grace-period cost that precedes
+	// it. Tracking the two phases separately matters because they can slow down
+	// for different reasons: a laggy node during recruit vs. a slow postgres
+	// promotion during propose. Any of the multiorchs may have been coordinator
+	// for a given failover, so we aggregate promotion events across all logs.
+	t.Run("verify appointment timing", func(t *testing.T) {
+		var events []map[string]any
+		for name, mo := range setup.MultiOrchInstances {
+			data, err := os.ReadFile(mo.LogFile)
+			require.NoError(t, err, "should be able to read multiorch %s log", name)
+			events = append(events, shardsetup.ParseEvents(t, bytes.NewReader(data))...)
+		}
+
+		promotions := shardsetup.FindEvents(events, "primary.promotion", "success")
+		require.GreaterOrEqual(t, len(promotions), 3,
+			"expected at least 3 successful promotions across multiorch logs after the failovers")
+
+		// Per-phase regression guards, separate because the phases have very
+		// different baselines and failure modes. Both exclude the failure-
+		// detection grace period that dominates the test's overall 30s budget.
+		//
+		// Recruit needs a few round trips + WAL replay stabilizing.
+		// Propose needs pg_promote() to succeed and the rule entry to replicate.
+		// The test bounds are deliberately tight to catch regressions that would
+		// make a simpler failover slow.
+		const (
+			maxRecruit = 500 * time.Millisecond
+			maxPropose = 3 * time.Second
+		)
+		for _, p := range promotions {
+			recruitMs, ok := p["recruit_ms"].(float64)
+			require.True(t, ok, "successful promotion must record recruit_ms: %v", p)
+			proposeMs, ok := p["propose_ms"].(float64)
+			require.True(t, ok, "successful promotion must record propose_ms: %v", p)
+			recruit := time.Duration(recruitMs) * time.Millisecond
+			propose := time.Duration(proposeMs) * time.Millisecond
+			t.Logf("Leader appointment (new_primary=%v, proposed_term=%v): recruit=%v, propose=%v",
+				p["new_primary"], p["proposed_term"], recruit, propose)
+			assert.Less(t, recruit, maxRecruit,
+				"recruit phase for %v should be fast (took %v)", p["new_primary"], recruit)
+			assert.Less(t, propose, maxPropose,
+				"propose phase for %v should be fast (took %v)", p["new_primary"], propose)
+		}
 	})
 
 	// Verify all successful writes are present on all multipoolers (all should be healthy now)

--- a/go/test/endtoend/shardsetup/events.go
+++ b/go/test/endtoend/shardsetup/events.go
@@ -49,12 +49,20 @@ func ParseEvents(t *testing.T, r io.Reader) []map[string]any {
 // HasEvent checks if events contains at least one event with the given
 // event_type and outcome values.
 func HasEvent(events []map[string]any, eventType, outcome string) bool {
+	return len(FindEvents(events, eventType, outcome)) > 0
+}
+
+// FindEvents returns every event with the given event_type and outcome, in the
+// order they appear. Use this when a test needs to inspect an event's own
+// attributes (e.g. a duration field), not just assert that it occurred.
+func FindEvents(events []map[string]any, eventType, outcome string) []map[string]any {
+	var matches []map[string]any
 	for _, e := range events {
 		if e["event_type"] == eventType && e["outcome"] == outcome {
-			return true
+			matches = append(matches, e)
 		}
 	}
-	return false
+	return matches
 }
 
 // WaitForEvent polls logFile until the given event_type+outcome appears or timeout expires.


### PR DESCRIPTION
Two related changes:

1. **Instrument leader appointment latency.** The `primary.promotion` event now records `proposed_term` and the `recruit_ms` / `propose_ms` split (recruit = start → leader selected, propose = leader selected → commit). `Started` now fires before recruitment so it marks the true start, and recruitment failures emit a terminal `Failed` instead of returning silently. The dead-primary e2e asserts each phase stays fast, isolating appointment latency from the much larger detection/grace window.

2. **Poll for replication state with backoff.** `waitForReceiverDisconnect` and `waitForReplicationPause` used fixed-interval tickers whose first tick fires before the first check, adding that interval to every recruit even though the state usually settles in milliseconds. Both now share a `pollForReplicationStatus` helper that checks immediately, then backs off exponentially via the `retry` helper. This change makes recruit a few hundred milliseconds faster.

## Validation

Dead-primary e2e now asserts recruit and propose each stay within per-phase bounds