### PR TITLE
feat(multipooler): raise and surface max_wal_senders for multi-cell clusters

### DIFF
--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -1078,8 +1078,13 @@ type PrimaryStatus struct {
 	ConnectedFollowers []*clustermetadata.ID `protobuf:"bytes,3,rep,name=connected_followers,json=connectedFollowers,proto3" json:"connected_followers,omitempty"`
 	// Synchronous replication configuration (parsed from synchronous_standby_names and synchronous_commit)
 	SyncReplicationConfig *SynchronousReplicationConfiguration `protobuf:"bytes,4,opt,name=sync_replication_config,json=syncReplicationConfig,proto3" json:"sync_replication_config,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Maximum number of WAL sender processes the primary allows (the
+	// max_wal_senders setting). Surfacing this alongside connected_followers makes
+	// wal-sender capacity exhaustion visible: once connected_followers reaches
+	// max_wal_senders, additional standbys cannot stream.
+	MaxWalSenders int32 `protobuf:"varint,5,opt,name=max_wal_senders,json=maxWalSenders,proto3" json:"max_wal_senders,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PrimaryStatus) Reset() {
@@ -1138,6 +1143,13 @@ func (x *PrimaryStatus) GetSyncReplicationConfig() *SynchronousReplicationConfig
 		return x.SyncReplicationConfig
 	}
 	return nil
+}
+
+func (x *PrimaryStatus) GetMaxWalSenders() int32 {
+	if x != nil {
+		return x.MaxWalSenders
+	}
+	return 0
 }
 
 // Status provides unified status information that works for both PRIMARY and REPLICA poolers.
@@ -2787,12 +2799,13 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\bnum_sync\x18\x03 \x01(\x05R\anumSync\x124\n" +
 	"\vstandby_ids\x18\x04 \x03(\v2\x13.clustermetadata.IDR\n" +
 	"standbyIds\x12:\n" +
-	"\x19standby_application_names\x18\x05 \x03(\tR\x17standbyApplicationNames\"\xf2\x01\n" +
+	"\x19standby_application_names\x18\x05 \x03(\tR\x17standbyApplicationNames\"\x9a\x02\n" +
 	"\rPrimaryStatus\x12\x10\n" +
 	"\x03lsn\x18\x01 \x01(\tR\x03lsn\x12\x14\n" +
 	"\x05ready\x18\x02 \x01(\bR\x05ready\x12D\n" +
 	"\x13connected_followers\x18\x03 \x03(\v2\x13.clustermetadata.IDR\x12connectedFollowers\x12s\n" +
-	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\"\x8d\x06\n" +
+	"\x17sync_replication_config\x18\x04 \x01(\v2;.multipoolermanagerdata.SynchronousReplicationConfigurationR\x15syncReplicationConfig\x12&\n" +
+	"\x0fmax_wal_senders\x18\x05 \x01(\x05R\rmaxWalSenders\"\x8d\x06\n" +
 	"\x06Status\x12<\n" +
 	"\vpooler_type\x18\x01 \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
 	"poolerType\x12L\n" +

--- a/go/services/multipooler/manager/pg_replication.go
+++ b/go/services/multipooler/manager/pg_replication.go
@@ -939,28 +939,17 @@ func (pm *MultiPoolerManager) setSynchronousStandbyNames(ctx context.Context, sy
 	return pm.applySynchronousStandbyNames(ctx, standbyNamesValue)
 }
 
-// getSynchronousReplicationConfig retrieves and parses the current synchronous replication configuration
-func (pm *MultiPoolerManager) getSynchronousReplicationConfig(ctx context.Context) (*multipoolermanagerdatapb.SynchronousReplicationConfiguration, error) {
+// parseSyncReplicationConfig builds the synchronous replication configuration
+// from the raw synchronous_standby_names and synchronous_commit GUC values. It
+// is a pure function (no query) so the parsing rules are unit-testable directly;
+// the caller (getPrimaryStatusInternal) reads the GUCs.
+func parseSyncReplicationConfig(syncStandbyNames, syncCommit string) (*multipoolermanagerdatapb.SynchronousReplicationConfiguration, error) {
 	config := &multipoolermanagerdatapb.SynchronousReplicationConfiguration{}
 
-	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-
-	// Query synchronous_standby_names
-	result, err := pm.query(queryCtx, "SHOW synchronous_standby_names")
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to query synchronous_standby_names")
-	}
-
-	var syncStandbyNamesStr string
-	if err := executor.ScanSingleRow(result, &syncStandbyNamesStr); err != nil {
-		return nil, mterrors.Wrap(err, "failed to scan synchronous_standby_names")
-	}
-
 	// Only parse standby names if not empty
-	syncStandbyNamesStr = strings.TrimSpace(syncStandbyNamesStr)
-	if syncStandbyNamesStr != "" {
-		syncConfig, err := parseSynchronousStandbyNames(syncStandbyNamesStr)
+	syncStandbyNames = strings.TrimSpace(syncStandbyNames)
+	if syncStandbyNames != "" {
+		syncConfig, err := parseSynchronousStandbyNames(syncStandbyNames)
 		if err != nil {
 			return nil, err
 		}
@@ -974,20 +963,9 @@ func (pm *MultiPoolerManager) getSynchronousReplicationConfig(ctx context.Contex
 		config.StandbyApplicationNames = poolerIDsToAppNames(appNames)
 	}
 
-	// Query synchronous_commit
-	result, err = pm.query(queryCtx, "SHOW synchronous_commit")
-	if err != nil {
-		return nil, mterrors.Wrap(err, "failed to query synchronous_commit")
-	}
-
-	var syncCommitStr string
-	if err := executor.ScanSingleRow(result, &syncCommitStr); err != nil {
-		return nil, mterrors.Wrap(err, "failed to scan synchronous_commit")
-	}
-
-	// Map string to enum
+	// Map synchronous_commit string to enum
 	var syncCommitLevel multipoolermanagerdatapb.SynchronousCommitLevel
-	switch strings.ToLower(syncCommitStr) {
+	switch strings.ToLower(syncCommit) {
 	case "off":
 		syncCommitLevel = multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_OFF
 	case "local":
@@ -1000,7 +978,7 @@ func (pm *MultiPoolerManager) getSynchronousReplicationConfig(ctx context.Contex
 		syncCommitLevel = multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_APPLY
 	default:
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT,
-			fmt.Sprintf("unknown synchronous_commit value: %q", syncCommitStr))
+			fmt.Sprintf("unknown synchronous_commit value: %q", syncCommit))
 	}
 	config.SynchronousCommit = syncCommitLevel
 

--- a/go/services/multipooler/manager/pg_replication_test.go
+++ b/go/services/multipooler/manager/pg_replication_test.go
@@ -769,23 +769,18 @@ func TestGetStandbyReplayLSN(t *testing.T) {
 	}
 }
 
-func TestGetSynchronousReplicationConfig(t *testing.T) {
+func TestParseSyncReplicationConfig(t *testing.T) {
 	tests := []struct {
 		name           string
-		setupMock      func(*mock.QueryService)
+		standbyNames   string
+		syncCommit     string
 		expectError    bool
 		validateResult func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration)
 	}{
 		{
-			name: "FIRST method with multiple standbys",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"},
-					[][]any{{`FIRST 2 ("zone1_replica-1", "zone2_replica-2", "zone3_replica-3")`}}))
-				m.AddQueryPatternOnce("SHOW synchronous_commit", mock.MakeQueryResult(
-					[]string{"synchronous_commit"}, [][]any{{"on"}}))
-			},
-			expectError: false,
+			name:         "FIRST method with multiple standbys",
+			standbyNames: `FIRST 2 ("zone1_replica-1", "zone2_replica-2", "zone3_replica-3")`,
+			syncCommit:   "on",
 			validateResult: func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration) {
 				assert.Equal(t, multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_FIRST, config.SynchronousMethod)
 				assert.Equal(t, int32(2), config.NumSync)
@@ -794,15 +789,9 @@ func TestGetSynchronousReplicationConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "ANY method with single standby",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"},
-					[][]any{{`ANY 1 ("zone1_replica-1")`}}))
-				m.AddQueryPatternOnce("SHOW synchronous_commit", mock.MakeQueryResult(
-					[]string{"synchronous_commit"}, [][]any{{"remote_apply"}}))
-			},
-			expectError: false,
+			name:         "ANY method with single standby",
+			standbyNames: `ANY 1 ("zone1_replica-1")`,
+			syncCommit:   "remote_apply",
 			validateResult: func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration) {
 				assert.Equal(t, multipoolermanagerdatapb.SynchronousMethod_SYNCHRONOUS_METHOD_ANY, config.SynchronousMethod)
 				assert.Equal(t, int32(1), config.NumSync)
@@ -813,71 +802,41 @@ func TestGetSynchronousReplicationConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "empty synchronous_standby_names",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"}, [][]any{{""}}))
-				m.AddQueryPatternOnce("SHOW synchronous_commit", mock.MakeQueryResult(
-					[]string{"synchronous_commit"}, [][]any{{"local"}}))
-			},
-			expectError: false,
+			name:         "empty synchronous_standby_names",
+			standbyNames: "",
+			syncCommit:   "local",
 			validateResult: func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration) {
 				assert.Equal(t, 0, len(config.StandbyIds))
 				assert.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_LOCAL, config.SynchronousCommit)
 			},
 		},
 		{
-			name: "synchronous_commit off",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"}, [][]any{{""}}))
-				m.AddQueryPatternOnce("SHOW synchronous_commit", mock.MakeQueryResult(
-					[]string{"synchronous_commit"}, [][]any{{"off"}}))
-			},
-			expectError: false,
+			name:         "synchronous_commit off",
+			standbyNames: "",
+			syncCommit:   "off",
 			validateResult: func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration) {
 				assert.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_OFF, config.SynchronousCommit)
 			},
 		},
 		{
-			name: "synchronous_commit remote_write",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"}, [][]any{{""}}))
-				m.AddQueryPatternOnce("SHOW synchronous_commit", mock.MakeQueryResult(
-					[]string{"synchronous_commit"}, [][]any{{"remote_write"}}))
-			},
-			expectError: false,
+			name:         "synchronous_commit remote_write",
+			standbyNames: "",
+			syncCommit:   "remote_write",
 			validateResult: func(t *testing.T, config *multipoolermanagerdatapb.SynchronousReplicationConfiguration) {
 				assert.Equal(t, multipoolermanagerdatapb.SynchronousCommitLevel_SYNCHRONOUS_COMMIT_REMOTE_WRITE, config.SynchronousCommit)
 			},
 		},
 		{
-			name: "query error on synchronous_standby_names",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnceWithError("SHOW synchronous_standby_names", errors.New("connection done"))
-			},
-			expectError: true,
-		},
-		{
-			name: "query error on synchronous_commit",
-			setupMock: func(m *mock.QueryService) {
-				m.AddQueryPatternOnce("SHOW synchronous_standby_names", mock.MakeQueryResult(
-					[]string{"synchronous_standby_names"}, [][]any{{""}}))
-				m.AddQueryPatternOnceWithError("SHOW synchronous_commit", errors.New("connection done"))
-			},
-			expectError: true,
+			name:         "unknown synchronous_commit value",
+			standbyNames: "",
+			syncCommit:   "bogus",
+			expectError:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pm, mockQueryService := newTestManagerWithMock("default", "0-inf")
-
-			tt.setupMock(mockQueryService)
-
-			ctx := context.Background()
-			result, err := pm.getSynchronousReplicationConfig(ctx)
+			result, err := parseSyncReplicationConfig(tt.standbyNames, tt.syncCommit)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -889,7 +848,6 @@ func TestGetSynchronousReplicationConfig(t *testing.T) {
 					tt.validateResult(t, result)
 				}
 			}
-			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}
 }

--- a/go/services/multipooler/manager/rpc_manager.go
+++ b/go/services/multipooler/manager/rpc_manager.go
@@ -31,6 +31,7 @@ import (
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
 	pgctldpb "github.com/multigres/multigres/go/pb/pgctldservice"
+	"github.com/multigres/multigres/go/services/multipooler/executor"
 )
 
 // broadcastHealth broadcasts the current health state to all subscribers.
@@ -546,12 +547,32 @@ func (pm *MultiPoolerManager) getPrimaryStatusInternal(ctx context.Context) (*mu
 	}
 	status.ConnectedFollowers = followers
 
-	// Get synchronous replication configuration
-	syncConfig, err := pm.getSynchronousReplicationConfig(ctx)
+	// Read the replication GUCs in a single query. synchronous_standby_names and
+	// synchronous_commit build the synchronous replication config; max_wal_senders
+	// is the server-wide WAL-sender cap, reported alongside connected followers so
+	// capacity exhaustion (connected followers == max_wal_senders) is visible.
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	result, err := pm.query(queryCtx,
+		"SELECT current_setting('synchronous_standby_names'), current_setting('synchronous_commit'), current_setting('max_wal_senders')")
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to query replication settings")
+	}
+	var (
+		syncStandbyNames string
+		syncCommit       string
+		maxWalSenders    int32
+	)
+	if err := executor.ScanSingleRow(result, &syncStandbyNames, &syncCommit, &maxWalSenders); err != nil {
+		return nil, mterrors.Wrap(err, "failed to scan replication settings")
+	}
+
+	syncConfig, err := parseSyncReplicationConfig(syncStandbyNames, syncCommit)
 	if err != nil {
 		return nil, err
 	}
 	status.SyncReplicationConfig = syncConfig
+	status.MaxWalSenders = maxWalSenders
 
 	return status, nil
 }

--- a/go/services/multipooler/manager/rpc_manager_test.go
+++ b/go/services/multipooler/manager/rpc_manager_test.go
@@ -380,11 +380,11 @@ func TestReplicationStatus(t *testing.T) {
 		// getConnectedFollowerIDs()
 		mockQueryService.AddQueryPattern("SELECT application_name",
 			mock.MakeQueryResult([]string{"application_name"}, nil))
-		// getSynchronousReplicationConfig()
-		mockQueryService.AddQueryPattern("SHOW synchronous_standby_names",
-			mock.MakeQueryResult([]string{"synchronous_standby_names"}, [][]any{{""}}))
-		mockQueryService.AddQueryPattern("SHOW synchronous_commit",
-			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
+		// replication GUCs (synchronous config + max_wal_senders)
+		mockQueryService.AddQueryPattern("SELECT current_setting",
+			mock.MakeQueryResult(
+				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
+				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
 		pm.rules = newRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
@@ -628,10 +628,10 @@ func TestReplicationStatus(t *testing.T) {
 			mock.MakeQueryResult([]string{"pg_current_wal_lsn"}, [][]any{{"0/1000000"}}))
 		mockQueryService.AddQueryPattern("SELECT application_name",
 			mock.MakeQueryResult([]string{"application_name"}, nil))
-		mockQueryService.AddQueryPattern("SHOW synchronous_standby_names",
-			mock.MakeQueryResult([]string{"synchronous_standby_names"}, [][]any{{""}}))
-		mockQueryService.AddQueryPattern("SHOW synchronous_commit",
-			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
+		mockQueryService.AddQueryPattern("SELECT current_setting",
+			mock.MakeQueryResult(
+				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
+				[][]any{{"", "on", "5"}}))
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
 		pm.rules = newRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
 		pm.rules = &fakeRuleStore{
@@ -713,11 +713,11 @@ func TestReplicationStatus(t *testing.T) {
 		// getConnectedFollowerIDs()
 		mockQueryService.AddQueryPattern("SELECT application_name",
 			mock.MakeQueryResult([]string{"application_name"}, nil))
-		// getSynchronousReplicationConfig()
-		mockQueryService.AddQueryPattern("SHOW synchronous_standby_names",
-			mock.MakeQueryResult([]string{"synchronous_standby_names"}, [][]any{{""}}))
-		mockQueryService.AddQueryPattern("SHOW synchronous_commit",
-			mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"on"}}))
+		// replication GUCs (synchronous config + max_wal_senders)
+		mockQueryService.AddQueryPattern("SELECT current_setting",
+			mock.MakeQueryResult(
+				[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
+				[][]any{{"", "on", "5"}}))
 
 		pm.qsc = &mockPoolerController{queryService: mockQueryService}
 		pm.rules = newRuleStore(logger, mockQueryService, noopSyncStandbyManager{})
@@ -834,12 +834,12 @@ func TestUpdateConsensusRule_HistoryFailurePreventsGUCUpdate(t *testing.T) {
 		return manager.GetState() == ManagerStateReady
 	}, 5*time.Second, 100*time.Millisecond)
 
-	// Mock getSynchronousReplicationConfig (called to get current config)
+	// Mock the replication-GUC read (called to get current config)
 	// Returns current config with 2 standbys
-	mockQueryService.AddQueryPattern("SHOW synchronous_standby_names",
-		mock.MakeQueryResult([]string{"synchronous_standby_names"}, [][]any{{"FIRST 1 (zone1_replica-1, zone1_replica-2)"}}))
-	mockQueryService.AddQueryPattern("SHOW synchronous_commit",
-		mock.MakeQueryResult([]string{"synchronous_commit"}, [][]any{{"remote_write"}}))
+	mockQueryService.AddQueryPattern("SELECT current_setting",
+		mock.MakeQueryResult(
+			[]string{"synchronous_standby_names", "synchronous_commit", "max_wal_senders"},
+			[][]any{{"FIRST 1 (zone1_replica-1, zone1_replica-2)", "remote_write", "5"}}))
 
 	// We do NOT add expectations for ALTER SYSTEM SET synchronous_standby_names
 	// If it gets called, ExpectationsWereMet() will fail

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -91,8 +91,8 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 	cnf.MinWalSize = "1GB"
 	cnf.MaxWalSize = "4GB"
 	cnf.CheckpointCompletionTarget = 0.9
-	cnf.MaxWalSenders = 5
-	cnf.MaxReplicationSlots = 5
+	cnf.MaxWalSenders = 25
+	cnf.MaxReplicationSlots = 25
 	cnf.EffectiveCacheSize = "192MB"
 	cnf.RandomPageCost = 1.1
 	cnf.DefaultStatisticsTarget = 100

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -154,6 +154,12 @@ message PrimaryStatus {
 
   // Synchronous replication configuration (parsed from synchronous_standby_names and synchronous_commit)
   SynchronousReplicationConfiguration sync_replication_config = 4;
+
+  // Maximum number of WAL sender processes the primary allows (the
+  // max_wal_senders setting). Surfacing this alongside connected_followers makes
+  // wal-sender capacity exhaustion visible: once connected_followers reaches
+  // max_wal_senders, additional standbys cannot stream.
+  int32 max_wal_senders = 5;
 }
 
 // Status provides unified status information that works for both PRIMARY and REPLICA poolers.

--- a/web/multiadmin/Dockerfile
+++ b/web/multiadmin/Dockerfile
@@ -30,7 +30,7 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy built application
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 

--- a/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
+++ b/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
@@ -187,11 +187,11 @@ function PrimarySection({ primary }: { primary: PrimaryStatus }) {
         />
         <SummaryCard label="num_sync" value={sync?.num_sync ?? "—"} mono />
         <SummaryCard
-          label="Connected followers"
+          label="WAL senders"
           value={
             primary.max_wal_senders != null
-              ? `${primary.connected_followers?.length ?? 0} / ${primary.max_wal_senders} max`
-              : (primary.connected_followers?.length ?? 0)
+              ? `${primary.connected_followers?.length ?? 0} connected / ${primary.max_wal_senders} max`
+              : `${primary.connected_followers?.length ?? 0} connected`
           }
           mono
         />

--- a/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
+++ b/web/multiadmin/app/dashboard/multipoolers/[cell]/[name]/replication/page.tsx
@@ -188,7 +188,11 @@ function PrimarySection({ primary }: { primary: PrimaryStatus }) {
         <SummaryCard label="num_sync" value={sync?.num_sync ?? "—"} mono />
         <SummaryCard
           label="Connected followers"
-          value={primary.connected_followers?.length ?? 0}
+          value={
+            primary.max_wal_senders != null
+              ? `${primary.connected_followers?.length ?? 0} / ${primary.max_wal_senders} max`
+              : (primary.connected_followers?.length ?? 0)
+          }
           mono
         />
       </div>

--- a/web/multiadmin/lib/api/types.ts
+++ b/web/multiadmin/lib/api/types.ts
@@ -208,6 +208,9 @@ export interface PrimaryStatus {
   ready?: boolean;
   connected_followers?: ID[];
   sync_replication_config?: SyncReplicationConfig;
+  // Server-wide cap on WAL sender processes (max_wal_senders). Once
+  // connected_followers reaches this, additional standbys cannot stream.
+  max_wal_senders?: number;
 }
 
 export interface SyncReplicationConfig {


### PR DESCRIPTION
1. **fix(pgctld):** raise default `max_wal_senders`/`max_replication_slots` 5 → 25.
   With 5, a primary can't support more than 5 standbys — extras are refused
   (`number of requested standby connections exceeds "max_wal_senders"`) and
   never stream. Easy to hit in multi-cell (3 cells × 3 poolers → 8 standbys).

2. **feat(multipooler):** surface `max_wal_senders` in `PrimaryStatus`. The
   replication page now shows **"N connected / M max"** on the WAL senders card,
   so capacity exhaustion is obvious ("5 connected / 5 max" explains itself).
