### PR TITLE
test(pgbouncertests): pooling & resilience tests ported from PgBouncer

### DIFF
--- a/go/test/endtoend/queryserving/pgbouncertests/README.md
+++ b/go/test/endtoend/queryserving/pgbouncertests/README.md
@@ -1,551 +1,76 @@
-# pgbouncertests — pooling & resilience suite (triage)
-
-> **Status: PORTING COMPLETE — all (A) groups landed.** This document started as
-> Step 1 of the PgBouncer-port effort. It categorizes every PgBouncer test file
-> as **(A) port**, **(B) out of scope**, or **(C) already covered**, and tracks
-> the net-new Go tests to land. The triage has been reviewed; the resolved
-> decisions are recorded in [Review decisions](#review-decisions). The point of
-> the triage is to land only the net-new coverage and avoid re-porting what we
-> already test. All seven (A) groups are **complete** — Group 1 (prepared
-> statements across a pooled-backend swap), Group 2 (continuous-load-under-
-> disruption), Group 3 (pool exhaustion / capacity), Group 4 (reserved-connection
-> lifecycle & timeout), Group 5 (cancel-race under pooling), Group 6 (COPY under
-> fault), and Group 7 (small differential deltas) — see
-> [Implementation status](#implementation-status).
-
-The scenarios in the (A) set are **derived from PgBouncer's own test suite**,
-which is ISC-licensed. The upstream license is reproduced in the `LICENSE` file
-in this directory; see [Attribution and license](#attribution-and-license).
-
-## Mission and framing
-
-We want the behavioral coverage of [PgBouncer's test suite][pgbouncer-test]
-(`~/pgbouncer/test/`, Python/pytest) re-expressed as Go end-to-end tests on the
-`multigateway → multipooler → postgres` path, reusing the existing
-`go/test/endtoend/` harness.
-
-**Multigres is currently a passthrough proxy.** Postgres computes every result;
-multigres does not rewrite or shard queries. So this suite's value is **not
-result correctness** — that is Postgres's job, covered by `sqllogictest` and
-`pgregresstest`. The value is whether the proxy **faithfully relays
-protocol/session state and behaves correctly under pooling and faults**:
-
-- Does session state and prepared statements survive a **pooled-backend swap**?
-- Does the **reserved (pinned) connection** lifecycle behave correctly?
-- Does **pool exhaustion** queue/block correctly instead of corrupting state?
-- Does the proxy **recover** when a backend is killed/restarted mid-load?
-
-Treat PostgreSQL as the oracle wherever a differential comparison makes sense
-(e.g. error SQLSTATEs), exactly as `pgproto`/`sqllogictest` do — but note most of
-the net-new value here is **stateful scenario + fault-injection tests**, not
-statement-result diffs (see [Differential vs. scenario testing](#differential-vs-scenario-testing)).
-
-This is a **triage-and-port** job, not a translation job. PgBouncer's tests are
-wired to PgBouncer's own admin console, INI config files, and `utils.py` fault
-helpers. We re-express only the **proxy-generic** scenarios on top of our
-harness; PgBouncer-specific machinery (admin console, HBA/userlist auth, peering,
-`SO_REUSEPORT`) has no multigres analog and is excluded with rationale below.
-
-## The multigres pooling model (the facts the triage rests on)
-
-These are the proxy behaviors the suite exercises. Verified in-repo:
-
-- **Multigateway does no connection pooling.** It load-balances across
-  multipooler instances and buffers during failover
-  (`go/services/multigateway/poolergateway/pooler_gateway.go`). All backend
-  pooling lives in **multipooler**.
-- **Multipooler pools postgres backends per statement.** A clean backend is
-  borrowed, settings applied, statement executed, then returned to the pool
-  (`go/services/multipooler/pools/connpool/pool.go`). Pooled connections are
-  bucketed by a settings hash so a session's `SET`s are replayed onto whichever
-  backend it next lands on (`pools/regular/regular_conn.go` `ApplySettings`).
-  **This is the "pooled-backend-swap boundary" — where pooling bugs hide.**
-- **Reserved (pinned) connections** keep one physical backend attached to a
-  client session across statements when work is non-poolable. The reasons
-  (`go/common/protoutil/reservation.go`) are: **transaction, temp table, portal
-  (suspended cursor), COPY, LISTEN, logical replication**. There is **no
-  `ReasonPrepared`** — a bare named `Parse` does _not_ pin the connection.
-- **Prepared statements are re-prepared on swap, not pinned.** The executor's
-  `ensurePrepared` / `ensurePreparedWithName`
-  (`go/services/multipooler/executor/executor.go:308,682`) re-parse a client's
-  named statement onto whichever backend a later Bind/Execute lands on. So a
-  statement parsed once and executed after a swap _should_ still work — exactly
-  PgBouncer's `test_prepared.py` scenario, and it exercises real code.
-- **Pool exhaustion blocks, it does not error.** When capacity is reached
-  callers wait on a waitlist until a connection recycles
-  (`connpool/pool.go`); there is no overflow error, no per-db/per-user _client_
-  connection cap. Capacity is `--connpool-global-capacity` (default 100) split
-  by a fair-share rebalancer; reserved gets `--connpool-reserved-ratio` (0.2).
-- **Timeouts that exist:** `--connpool-user-regular-idle-timeout` (5m,
-  ≈ `server_idle_timeout`), `--connpool-user-regular-max-lifetime` (1h,
-  ≈ `server_lifetime`), `--connpool-user-reserved-inactivity-timeout` (30s,
-  ≈ idle-in-transaction killer). `statement_timeout` is enforced at the gateway.
-- **No PgBouncer-style admin console.** Neither multigateway nor multipooler
-  exposes `PAUSE`/`RESUME`/`SUSPEND`/`RECONNECT`/`RELOAD`/`SHOW`. Pool config is
-  fixed at process start via flags; there is no live reconfiguration.
-  (`multiadmin` is a cluster-admin gRPC/HTTP service, not a PG-protocol console.)
-
-## Triage table
-
-`A` = port net-new · `B` = out of scope (no analog) · `C` = already covered.
-"Existing test" names files under `go/test/endtoend/queryserving/`.
-
-| PgBouncer file               | Verdict | Net-new delta to port / why excluded                                                                                                                                                                                                     | Existing coverage                                                             |
-| ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `test_prepared.py`           | **A**   | Prepared statement + session state survive a **pooled-backend swap** (re-prepare via `ensurePrepared`); large Parse/Bind (>4 KB) relay; DISCARD ALL across pooling                                                                       | `prepared_stmt_test.go`, `extended_query_protocol_test.go` (no swap boundary) |
-| `test_operations.py`         | **A**   | **Backend restart/reconnect under continuous load** (the `stress.py` ethos): pool transparently reconnects new statements; in-flight statement sees a clean error. _Admin-command parts → B._                                            | `postgres_crash_recovery_test.go`, `buffer_test.go` (single events, not load) |
-| `test_limits.py`             | **A**   | **Pool exhaustion / capacity**: with `--connpool-global-capacity=N`, the (N+1)th concurrent statement blocks then proceeds; no state corruption. _`max_client_conn`/`min_pool_size`/per-db caps/dynamic reload → B._                     | none                                                                          |
-| `test_timeouts.py`           | **A**   | **Reserved-connection inactivity timeout** (idle-in-txn killer): pinned conn killed after timeout → next statement errors cleanly. **Backend recycle on max-lifetime/idle** → seamless for new statements. _`statement_timeout` → C._    | `statement_timeout_test.go` (query timeout only)                              |
-| `test_cancel.py`             | **A**   | **Cancel-race under pooling**: cancel for client A must not hit a backend just reused by client B; cancel while pool exhausted. _Basic cancel/cross-conn/gRPC-TLS forwarding → C._                                                       | `query_cancel_test.go` (no pooling-reuse race)                                |
-| `test_copy.py`               | **A**   | **COPY interrupted by backend fault** (kill mid-stream → clean error + recovery); COPY in **pipeline/extended** mode. _Formats, TO STDOUT, txn, multi-statement, error recovery → C._                                                    | `copy_test.go` (extensive, no fault path)                                     |
-| `test_no_database.py`        | **A**   | Connect to **nonexistent database** → clean SQLSTATE `3D000`, connection closed cleanly; auth-vs-db error ordering (differential vs PG). _`auto_database`/`auth_user` variants → B._                                                     | none (no explicit nonexistent-db test)                                        |
-| `test_misc.py`               | **A/B** | A: pool **queue-wait** behavior (overlaps `test_limits`). B: `query_wait_notify` (no admin notice), `server_check_query` (no per-conn health check), `fast_close`/`wait_close`/`auto_database`/`host_list` (PgBouncer config).           | `startup_params_test.go` (connect_query/options → C)                          |
-| `test_ssl.py`                | **B/C** | C: full static TLS matrix already covered + multipooler↔PG TLS. B: live TLS toggle / CA change via SIGHUP (no live reconfig).                                                                                                            | `ssl_test.go`, `WithMultipoolerPGTLS`                                         |
-| `test_auth.py`               | **B/C** | C: SCRAM correct/wrong/nonexistent, replication-role rejection. B: `auth_type` matrix, `auth_query`, `auth_dbname`, userlist/HBA file, mock auth, VALID UNTIL — all PgBouncer auth machinery with no analog (auth is passthrough to PG). | `authentication_test.go`                                                      |
-| `test_replication.py`        | **B**   | Replication protocol passthrough is **stubbed** (gateway returns `0A000 feature_not_supported`); porting would test unimplemented features. Existing test already asserts the stub. Revisit when replication lands.                      | `replication_test.go`, `replica_reads_test.go`                                |
-| `test_no_user.py`            | **B/C** | C: nonexistent user → clean auth error. B: mock-auth across trust/plain/md5/scram + forced-user (PgBouncer-specific).                                                                                                                    | `authentication_test.go`                                                      |
-| `test_admin.py`              | **B**   | Admin console `SHOW`/`RELOAD`/config validation — no multigateway analog.                                                                                                                                                                | —                                                                             |
-| `test_load_balance_hosts.py` | **B**   | `load_balance_hosts` over a server host-list — multigres routes by topology, not a static host-list with round-robin/disable.                                                                                                            | (routing covered by `replica_reads_test.go`)                                  |
-| `test_peering.py`            | **B**   | Peering / `SO_REUSEPORT` / rolling restart via peer takeover — gateways coordinate via etcd/topology, not PgBouncer peering. Linux-only.                                                                                                 | —                                                                             |
-
-## (A) Port — the net-new suite
-
-Package name: **`pgbouncertests`** — names the source of the scenarios so the
-provenance (and the ISC attribution) is obvious. The net-new value is stateful
-pooling + fault-resilience, since the protocol basics are already well covered.
-Concrete test groups, in rough priority order:
-
-1. **Prepared statements across a pooled-backend swap (headline).** Open a
-   session, `Parse` a named statement, force the session to land on a _different_
-   backend before `Bind`/`Execute` (e.g. interleave another client to occupy the
-   first backend, or exhaust+recycle), assert the statement still executes and
-   the result matches direct-PG. Probe `ensurePrepared` re-prepare path. Also:
-   `DISCARD ALL` / `DEALLOCATE ALL` semantics across the swap; Parse/Bind > 4 KB
-   relay. _Asserts the boundary, not just the happy path._
-2. **Continuous-load-under-disruption (the `stress.py` ethos).** Drive
-   continuous statements through the gateway while `KillPostgres` /
-   `StopPostgres(...)` / restart the backend; assert new statements reconnect
-   transparently, in-flight statements get a clean error (not a hang or torn
-   packet), and no session-state corruption survives the event. Reuse
-   `postgres_crash_recovery_test.go` primitives; extend to _under load_ + the
-   reconnect/PID-change assertion from `test_operations.py::test_reconnect`.
-3. **Pool exhaustion / capacity.** Configure a small `--connpool-global-capacity`
-   (needs a harness option — see [gaps](#harness-gaps-to-close)); launch N+1
-   concurrent slow statements; assert the (N+1)th **blocks then completes** when a
-   slot frees, and that a context-cancelled waiter is cleaned up. (Multigres
-   blocks rather than erroring — the assertion differs from PgBouncer's reject.)
-4. **Reserved-connection lifecycle & timeout.** Open an explicit transaction
-   (pins a backend), idle past `--connpool-user-reserved-inactivity-timeout`,
-   assert the next statement on the pinned connection errors cleanly and the
-   backend is reclaimed. Verify temp-table / LISTEN / portal reservations pin and
-   release at the right boundaries.
-5. **Cancel-race under pooling.** Issue a cancel for a query whose backend may be
-   released and reused by another client; assert the cancel never disturbs the
-   reusing client (the `test_cancel.py::test_cancel_race` concern).
-6. **COPY under fault.** Kill the backend mid-`COPY FROM STDIN`; assert a clean
-   error and that the connection (or a fresh one) is usable afterward.
-7. **Small differential deltas (PG-as-oracle).** Connect to a nonexistent
-   database → `3D000`; auth-failure-vs-db-error ordering. These _do_ fit the
-   differential model and can reuse `setup.GetComparisonTargets`.
-
-### Implementation status
-
-Groups 1 and 2 are **complete**.
-
-**Group 1 — prepared statements across a pooled-backend swap.** Tests:
-
-- `prepared_swap_test.go` — `TestPreparedStatementAcrossPooledBackends`: prepare
-  once, then execute many times; asserts every execute returns correct results
-  (exercising the multipooler `ensurePrepared` re-prepare path) and that the
-  statement was observed running on ≥2 distinct backends.
-- `large_statement_test.go` — `TestLargePreparedStatementRelay` (differential:
-  16 KB Parse + 64 KB Bind relay, PG-as-oracle) and
-  `TestLargePreparedStatementAcrossPooledBackends` (a 16 KB statement re-prepares
-  correctly on every backend the pool serves it from, literal intact).
-- `prepared_reset_test.go` — `TestPreparedStatementResetSemantics`
-  (differential): both `DEALLOCATE ALL` and `DISCARD ALL` drop the session's
-  prepared statements identically on PG and the gateway. `DISCARD ALL` used to
-  fail here (it surfaced a real bug); it now passes after the fix described in
-  the note below.
-
-**How the swap is exercised — black-box.** Which physical backend an Execute
-lands on is an internal pooling detail; an e2e test treats the proxy as a black
-box, so it does not (and cannot) deterministically force a _specific_ internal
-swap. Instead the tests assert the invariant — _a statement prepared once keeps
-returning correct results no matter which backend serves each Execute_ — under
-conditions that make backends rotate:
-
-- **Churn** (`startPoolChurn`): a handful of ordinary background clients run a
-  cheap query in a tight loop. Because the multipooler pool is LIFO, their
-  constant borrow/return keeps changing which connection is on top, so a
-  foreground session's consecutive Executes are handed different backends instead
-  of its own just-returned one. This is pure wire-protocol load.
-- **Observation**: the foreground client reads `pg_backend_pid()` from its _own_
-  query results through the gateway — a normal result value, not a side channel
-  into the underlying PostgreSQL.
-- **Assertion** (`runAcrossBackends`): run the statement until it has been served
-  by ≥2 distinct backends (and at least `minExecutes` times); every execute must
-  succeed (a missing re-prepare would surface as "prepared statement does not
-  exist"), and seeing ≥2 backends proves the test is not vacuous.
-
-Earlier attempts that depended on proxy internals were rejected as not
-black-box: terminating the backend (`pg_terminate_backend`) leaves a dead socket
-the next streaming Execute hits as a broken pipe; pinning a specific backend with
-holder connections, and reaping via a short idle timeout read through
-`pg_stat_activity`, both coupled the test to pool internals and the heartbeat
-interval.
-
-`shardsetup.WithMultipoolerExtraArgs` was added during this work as a general
-harness option for connpool tuning; group 1 doesn't use it, but groups 3 and 4
-(pool exhaustion, reserved-connection timeout) do.
-
-**Bug found and fixed — `DISCARD ALL` no longer poisons pooled connections.**
-The original `DISCARD ALL` plan forwarded the statement to a pooled backend
-(where it ran `DEALLOCATE ALL`, dropping that backend's server-side prepared
-statements) but invalidated none of the matching bookkeeping: the gateway's
-consolidator stayed populated, so `DISCARD ALL` didn't actually drop the
-client's prepared statements (the next EXECUTE succeeded instead of failing —
-diverging from PostgreSQL); and the multipooler's per-connection tracking
-(`connState.PreparedStatements`) stayed stale on the backend it ran on, so a
-later session reusing that pooled backend skipped re-`Parse` and failed at
-`Bind` with "prepared statement does not exist" (SQLSTATE 26000).
-
-The fix (commit `50417fb0`) handles `DISCARD ALL` **entirely at the gateway and
-never forwards it to a shared pooled backend** — a new `DiscardAllPrimitive`
-(`go/services/multigateway/engine/discard_all_primitive.go`, planned via
-`planDiscardStmt`). In the pooled model the session state `DISCARD ALL` resets
-lives at the gateway, not on any one backend: prepared statements (the
-consolidator), session GUCs (`ResetAllSessionVariables` / `ResetStatementTimeout`),
-and LISTEN subscriptions are all gateway-side. The only backend-resident session
-state is whatever a _reserved_ connection holds (open transaction, temp tables,
-`WITH HOLD` cursors), which the primitive cleans up via
-`ReleaseAllReservedConnections`. The primitive also rejects `DISCARD ALL` inside
-a transaction block (matching PG's `PreventInTransactionBlock`). Already-prepared
-statements on pooled backends are intentionally left in place — they act as a
-pool-wide dedup cache and the multipooler's `connState` stays accurate.
-
-Because the bug is fixed, the test now lives as the `DISCARD ALL` case of the
-differential `TestPreparedStatementResetSemantics` and passes against both PG
-and the gateway. The earlier failing-on-purpose `TestPreparedStatementDiscardAll`
-and its `shardsetup.NewIsolated` cluster are gone — the whole package runs in the
-shared cluster.
-
-**Group 2 — continuous-load-under-disruption (the `stress.py` ethos).** Tests
-in `backend_restart_test.go`, ported from `test_operations.py`'s
-`test_database_restart` and `test_reconnect`. Both inject the fault with
-`KillPostgres` (SIGKILL — a hard crash); the multipooler's postgres monitor then
-auto-restarts the _same_ backend (crash recovery; the primary stays primary —
-there is no failover). Each runs in its own `shardsetup.NewIsolated` cluster so
-the deliberate crash cannot leak into the shared-cluster tests.
-
-- `TestBackendCrashRecoveryUnderLoad` — drives continuous INSERT load through the
-  gateway with a `shardsetup.WriterValidator` (6 workers), hard-kills postgres
-  mid-load, waits for the monitor to restart it, then asserts the load **resumes
-  on its own** (success count climbs past the recovery point with no client
-  reconnect) and that **every acknowledged write survived** crash recovery
-  (`count(*) ≥ successful` — a SIGKILL mid-commit can leave a committed row whose
-  ack never reached the client, so the table may hold a few _extra_ rows).
-- `TestBackendCrashTransparentReconnect` — the `test_reconnect` analog. A single
-  client session reads `pg_backend_pid()`, postgres is hard-killed and restarted,
-  and the **same** session must recover: its next statement lands on a fresh
-  backend (a _different_ pid). The first post-crash statement may error, but
-  cleanly and within a deadline (the "clean error, not a hang or torn packet"
-  property) — never a hang.
-
-**What Group 2 establishes about multigres.** The transparent-reconnect test
-confirms a property stronger than PgBouncer's: a client's gateway connection
-**survives a backend crash**. PgBouncer's `test_database_restart` tolerates
-in-flight `OperationalError`s and then opens a _new_ client connection; in
-multigres the client connection stays up across the crash because backend
-pooling lives in the multipooler, decoupled from client sessions — the gateway
-swaps in a fresh backend underneath the same session.
-
-**Group 3 — pool exhaustion / capacity.** Tests in `pool_exhaustion_test.go`,
-ported from `test_limits.py`. Each runs in its own `NewIsolated` cluster started
-with a deliberately tiny pool via `shardsetup.WithMultipoolerExtraArgs`
-(`--connpool-global-capacity=4 --connpool-reserved-ratio=0.5
---connpool-rebalance-interval=1s`), which settles the lone test user's regular
-sub-pool to 2 backends. Where PgBouncer **rejects** connections on a full pool,
-multigres **blocks** on the waitlist (`connpool/{pool.go,waitlist.go}`) — so the
-assertions are inverted accordingly.
-
-- `TestPoolExhaustionBlocksThenProceeds` — launches 12 concurrent `pg_sleep(1)`
-  statements at a pool that can run only ~2 at once, and asserts **all 12
-  succeed** (queue-and-proceed, no rejection) while the **peak concurrency
-  observed on postgres stays capped below the number launched** (a peak equal to
-  the launch count would mean the pool never limited). Concurrency is measured
-  through a side connection straight to postgres — bypassing the saturated pool —
-  that samples `pg_stat_activity` for active `pg_sleep` backends. Observed peak:
-  exactly 2.
-- `TestPoolExhaustionWaiterCancelledCleanly` — saturates the pool with long
-  holders, then issues one more statement with an 800 ms deadline. That statement
-  must **block on the waitlist and fail on its deadline** (elapsed ≈ the full
-  deadline proves it queued rather than being served or rejected); then, after
-  the holders release, a fresh statement must **succeed** — proving the
-  cancelled waiter was removed from the waitlist cleanly, leaking no slot and
-  causing no deadlock.
-
-**Group 4 — reserved-connection lifecycle & timeout.** Tests in
-`reserved_conn_test.go`, ported from `test_timeouts.py` (the idle-in-transaction
-killer). The timeout tests use `NewIsolated` clusters started with a short
-`--connpool-user-reserved-inactivity-timeout=2s` via
-`shardsetup.WithMultipoolerExtraArgs`. All observe pinning black-box via
-`pg_backend_pid()`.
-
-- `TestReservedConnectionInactivityTimeout` — opens a transaction (pinning a
-  backend), idles past the inactivity timeout so the reaper kills the pinned
-  backend, and asserts the session's next statement **fails cleanly** (a returned
-  error within the deadline, not a hang) — multigres's idle-in-transaction
-  killer. It then asserts the session **recovers**: after a ROLLBACK a fresh
-  statement succeeds on a pooled backend, proving the reaped reservation was
-  reclaimed rather than wedging the session.
-- `TestReservedConnectionSurvivesWithActivity` — the inverse control: a
-  transaction issuing a statement every second (faster than the 2s timeout) is
-  **never reaped**, and because it is pinned every statement runs on the **same
-  backend**. Proves the timeout is inactivity-based (reset by activity).
-- `TestTransactionPinsBackendThenReleases` — the pin/release boundary, on the
-  shared cluster under pool churn: inside the transaction every statement stays
-  on **one backend** despite churn that rotates the pool (the inverse of Group
-  1's pooled rotation); after COMMIT the session rejoins the pool and its
-  statements **rotate across ≥2 backends** again, confirming the reservation
-  ended at COMMIT.
-
-**Group 5 — cancel-race under pooling.** Test in `cancel_race_test.go`, ported
-from `test_cancel.py::test_cancel_race`. PgBouncer's worry is that a
-CancelRequest for client A could cancel a query client B now runs on a backend A
-released — because in raw postgres the cancel key maps to a _backend_. Multigres
-routes cancels by the _client↔gateway connection_ (the gateway's synthetic
-BackendKeyData + per-connection secret; `multigateway/{cancel.go,listener.go}`),
-so the backend a query borrows is never the cancel's addressing unit and the
-reuse race is structurally absent.
-
-- `TestCancelForReleasedBackendDoesNotHitReuser` — runs in a `NewIsolated`
-  cluster with a capacity-1 regular pool (`--connpool-global-capacity=2
---connpool-reserved-ratio=0.5`) so backend reuse is forced. Client A runs a
-  statement then idles (releasing the single backend); client B starts a long
-  statement that **provably reuses A's exact backend** (asserted via equal
-  `pg_backend_pid()`); a stale out-of-band CancelRequest for A is then delivered
-  (raw socket, same machinery as `query_cancel_test.go`). B finishes
-  **uncancelled**, proving A's cancel hit only A's idle connection. A then stays
-  usable (its cancel was a harmless no-op).
-
-The secondary "cancel while pool exhausted" case from the triage is **not**
-ported here: cancelling a pool-blocked waiter is already covered by Group 3's
-`TestPoolExhaustionWaiterCancelledCleanly` (via context cancellation), and
-whether an out-of-band CancelRequest interrupts a query still _queued_ for a slot
-(vs. one executing on a backend) is a separate multigres-cancel-semantics
-question left for its own investigation.
-
-**Group 6 — COPY under fault.** Test in `copy_fault_test.go`, ported from
-`test_copy.py`. COPY's happy paths (formats, TO STDOUT, transactions,
-multi-statement, error recovery) are already covered by `copy_test.go`, so the
-net-new delta is the fault path. Runs in a `NewIsolated` cluster.
-
-- `TestCopyInterruptedByBackendCrash` — streams a large `COPY FROM STDIN` (a
-  reader generating rows on demand, so CopyData keeps flowing), hard-kills
-  postgres mid-stream with `KillPostgres`, and asserts: the COPY **fails cleanly**
-  (a returned error within a deadline, not a hang or torn stream — observed as a
-  closed-connection write error, since a crashed reserved-COPY backend tears down
-  the client connection), the proxy **recovers** so a fresh connection serves
-  queries again after the monitor restarts postgres, and the interrupted COPY
-  **committed nothing** (the durable pre-crash table survives crash recovery with
-  zero rows — COPY FROM is all-or-nothing). Note this differs from Group 2's
-  regular-query case, where the same client connection survived a backend crash;
-  a reserved COPY stream does not.
-
-The triage's "COPY in pipeline/extended mode" sub-item is not ported — extended
-COPY happy-path sequencing is part of the existing `copy_test.go` /
-`extended_query_protocol_test.go` coverage, and the net-new value here is the
-fault path above.
-
-**Group 7 — small differential deltas (PG-as-oracle).** Tests in
-`nonexistent_db_test.go`, ported from `test_no_database.py`. These fit the
-differential model (run against both `GetComparisonTargets`) and use the shared
-cluster (no fault injection).
-
-- `TestNonexistentDatabaseConnectBehavior` — documents and guards a real
-  **divergence**: direct PostgreSQL validates the catalog during startup and
-  rejects a nonexistent database at connect time with `3D000`
-  (invalid_catalog_name), whereas the multigateway authenticates the client and
-  never validates the requested database — so connecting to `no_such_db_xyz`
-  succeeds and `SELECT current_database()` returns the served `postgres`. The
-  multigateway branch asserts that current behavior, so if gateway-side database
-  validation is later added the test flags it for an intended update.
-- `TestAuthErrorPrecedesDatabaseError` — the matching case: with a wrong password
-  **and** a nonexistent database, both targets report the auth failure (`28P01`)
-  at connect time, confirming authentication is checked before the database is
-  resolved on both PostgreSQL and the gateway.
-
-**⚠️ Divergence worth a maintainer's eye:** the gateway accepting an unknown
-connection database and silently serving its backend database (rather than
-rejecting with `3D000`) means a client asking for database `X` can be served
-`postgres`. This may be an artifact of the single-database test topology /
-passthrough routing; it is captured by the test above but may warrant a separate
-look at whether the gateway should validate the connection database.
-
-- **Verified:** all seven groups pass at `go test -count=3` (Group 1 and Group 7
-  differential cases on both the postgres and multigateway targets); pgx sessions
-  rotate across 5–8 backends within the first ~40 executes; killed backends
-  recover and the same client session resumes on a fresh backend pid; a 12-wide
-  load peaks at 2 concurrent backends with all statements succeeding, and a
-  cancelled pool waiter leaves the pool healthy; an idle pinned backend is reaped
-  and the session recovers while an active one stays pinned to a single backend; a
-  reused backend is unaffected by the previous owner's cancel; a COPY hard-killed
-  mid-stream fails cleanly, recovers, and commits nothing; a nonexistent database
-  yields `3D000` on direct PG while the gateway diverges (documented), and auth
-  errors precede database errors on both; `go vet` / golangci-lint clean.
-- **Not started:** none — the (A) suite is complete.
-
-## (B) Out of scope — rationale
-
-- **Admin console** (`test_admin.py`, admin parts of `test_operations.py`): no
-  `PAUSE`/`RESUME`/`SHOW`/`RELOAD` surface on multigateway or multipooler.
-- **Auth machinery** (`test_auth.py`, `test_no_user.py` mock-auth): no
-  userlist/HBA file, `auth_query`, `auth_dbname`, or mock-auth — auth is passed
-  through to postgres.
-- **Replication passthrough** (`test_replication.py`): gateway stubs replication
-  commands with `feature_not_supported`. Revisit when implemented.
-- **Peering / load-balance-hosts** (`test_peering.py`,
-  `test_load_balance_hosts.py`): no `SO_REUSEPORT` peering or static server
-  host-list; routing is topology-driven.
-- **Live reconfiguration** (TLS SIGHUP toggles, `RELOAD`-driven limit changes):
-  config is fixed at process start.
-- **PgBouncer config knobs** (`fast_close`, `wait_close`, `auto_database`,
-  `host_list`, `track_extra_parameters`, `query_wait_notify`): PgBouncer-specific
-  with no multigres setting.
-
-## (C) Already covered — do not duplicate
-
-Mapped above. The existing suite (`go/test/endtoend/queryserving/`) already
-covers, with differential PG-as-oracle where applicable: transactions, prepared
-statements (happy path), query cancel (incl. gRPC-TLS forwarding),
-LISTEN/NOTIFY, COPY (formats/txn/multi-statement/error-recovery), session
-settings, statement timeout, the full SSL matrix, startup params/PGOPTIONS,
-SCRAM auth, error/notice formatting, replica reads, replication stubs, failover
-buffering, postgres crash recovery, and extended-protocol sequencing. Port only
-the **delta** (a new assertion across a swap or under a fault), ideally as added
-cases in the existing file rather than a parallel file.
-
-## Differential vs. scenario testing
-
-Unlike `pgproto`/`sqllogictest`, **most of this suite is not corpus-driven
-differential**. The pooling/resilience scenarios are assertions about proxy
-_behavior under fault_ (reconnect, block-then-proceed, clean error), not
-statement-result diffs — so the `suiteutil` corpus/patch/`results.json` model
-mostly does **not** apply here. Recommendation:
-
-- Use plain Go test assertions (testify) for the scenario + fault tests, built on
-  `shardsetup` + the pgprotocol/pgx/lib-pq clients + the fault helpers.
-- Reserve `suiteutil` differential reporting + `.patch` known-divergence files
-  **only** for the small differential deltas (group 7 above), where PG is a true
-  oracle. If we add no corpus-driven cases, we don't need the patch machinery —
-  and we should say so rather than bolt it on for its own sake.
-
-This is an honest deviation from the original spec's assumption that the suite is
-corpus-driven; flagging it for review.
-
-## Harness reuse (do not reinvent)
-
-- **Cluster:** `shardsetup.New(t, shardsetup.WithMultipoolerCount(2),
-shardsetup.WithMultigateway())`; `NewSharedSetupManager` +
-  `RunTestMain(m)` in `TestMain`; `SetupTest(t)` per test — copy
-  `queryserving/main_test.go`. Use `NewIsolated(t, ...)` for tests that kill the
-  primary/backend so cleanup is clean.
-- **Clients:** `go/common/pgprotocol/client` for adversarial/cancel sequences;
-  `pgx/v5` or `database/sql`+`lib/pq` for SQL-level assertions. Cancellation
-  follows `query_cancel_test.go` (out-of-band CancelRequest).
-- **Faults:** `setup.KillPostgres`, `StopPostgres(...) (resume)`,
-  `ShutdownPostgres`, `ProcessInstance.StopPostgresImmediate` /
-  `TerminateGracefully`, `GetPgctld`/`GetMultipooler`, `StopEtcd`,
-  `DisableRecovery`/`EnableRecovery`/`TriggerRecoveryOnce`. Pattern reference:
-  `postgres_crash_recovery_test.go`.
-- **Differential targets (group 7):** `setup.GetComparisonTargets(t)` →
-  `[]TestTarget{{"postgres",...},{"multigateway",...}}`; creds via
-  `shardsetup.DefaultTestUser`, `TestPostgresPassword`, `GetTestUserDSN`.
-- **Reporting (only if corpus-driven cases land):** `suiteutil` `report.go` /
-  `diffreport.go` / `corpus.go` / `patch.go` and `ResetPublicSchema` /
-  `NewSchemaResetterWithCleanup` / `RunWithTimeout`.
-
-## Harness gaps to close
-
-**Closed.** The connpool-tuning gap is resolved: `shardsetup` now exposes
-`WithMultipoolerExtraArgs(...)`, which appends arbitrary flags to every
-multipooler (mirroring the existing `MultigatewayExtraArgs` plumbing in
-`shardsetup/setup.go`). Group 3 uses it for `--connpool-global-capacity`,
-`--connpool-reserved-ratio`, and `--connpool-rebalance-interval`; group 4 uses
-it for `--connpool-user-reserved-inactivity-timeout`. Targeted convenience
-wrappers (`WithConnpoolCapacity(n)` /
-`WithReservedInactivityTimeout(d)`) were deemed unnecessary — the generic
-extra-args option is enough.
-
-## Gating, CI, and how to run
-
-This suite runs **directly in the standard e2e integration framework**, not
-behind the extended-query-serving label. The package lives under
-`go/test/endtoend/queryserving/pgbouncertests/`, so the
-**`.github/workflows/test-integration.yml`** job — which runs
-`gotestsum --packages="./go/test/endtoend/..."` on every PR and push to `main`
-— picks it up automatically. No `suiteutil.SkipUnlessEnabled` /
-`RUN_EXTENDED_QUERY_SERVING_TESTS` gate, no PR label, and no separate
-pgbouncer-specific workflow. Tests only self-skip in `-short` mode or when the
-PostgreSQL binaries are absent (`utils.ShouldSkipRealPostgres`), matching the
-rest of the e2e suite.
-
-This decision was made because the suite's value is core proxy behavior
-(pooling, prepared-statement relay, fault recovery) that should be exercised on
-every change, not gated behind an opt-in label that only runs on cron or
-demand. The fault-injection groups (2–6) kill/restart backends, so keep using
-`shardsetup.NewIsolated` for those individual tests to keep cleanup contained
-within the shared-cluster package.
-
-Run locally via the project conventions (use the `/mt-dev` skill; integration
-tests build first). Do not run `go test` directly per repo policy.
-
-## Review decisions
-
-The triage was reviewed; the following are settled:
-
-1. **Name/scope:** the suite lives in a new package, **`pgbouncertests`**, to
-   make the provenance and ISC attribution explicit (rather than folding cases
-   into the existing files).
-2. **Differential vs. scenario:** approved — use plain Go assertions for the
-   scenario + fault tests, and reserve the `suiteutil` corpus/patch model only
-   for the small differential deltas (group 7).
-3. **Harness option:** approved — add the
-   `WithMultipoolerExtraArgs`/connpool option to `shardsetup` as part of this
-   work (see [Harness gaps to close](#harness-gaps-to-close)).
-4. **Replication (B):** confirmed — defer all of `test_replication.py` until
-   replication passthrough is implemented; we'll add tests when we add support.
-
-## Attribution and license
-
-The (A) scenarios are ported from [PgBouncer's test suite][pgbouncer-test],
-which is distributed under the **ISC License** (Copyright © 2007-2009 Marko
-Kreen, Skype Technologies OÜ). We re-implement the scenarios in Go rather than
-copying code, but because they are a derivative of an ISC-licensed work we
-reproduce the upstream license, following the same in-repo convention used for
-other vendored third-party code (e.g. `go/common/cache/theine/LICENSE`):
-
-- A `LICENSE` file in this directory holds the verbatim PgBouncer ISC license,
-  which applies to the derived test scenarios.
-- All new code and modifications in this directory (the Go re-implementation and
-  harness) are part of Multigres and licensed under the **Apache License,
-  Version 2.0** — the repository-root `LICENSE`.
-- Each ported `.go` file carries the standard multigres Apache-2.0 header (the
-  `check-license` hook requires a `Copyright … Supabase, Inc.` line) **plus** an
-  upstream-attribution line crediting PgBouncer's ISC copyright — mirroring the
-  multi-copyright header pattern in `theine`'s Go files. For example:
-
-  ```go
-  // Copyright 2026 Supabase, Inc.
-  // Portions derived from PgBouncer (ISC License),
-  // Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
-  //
-  // Licensed under the Apache License, Version 2.0 (the "License");
-  // ... (standard Apache-2.0 header) ...
-  ```
+# pgbouncertests — pooling & resilience e2e tests
+
+End-to-end tests for the `multigateway → multipooler → postgres` path, covering
+connection pooling, session-state handling, and fault recovery. The scenarios
+are derived from [PgBouncer's test suite][pgbouncer-test] (ISC-licensed; see
+[`LICENSE`](./LICENSE)).
+
+Multigres is a passthrough proxy — Postgres computes every result — so these
+tests are **not** about result correctness (that is covered by `sqllogictest`
+and `pgregresstest`). They check that the proxy faithfully relays protocol and
+session state, and behaves correctly under pooling and faults.
+
+## What's covered
+
+Each `*_test.go` mirrors a PgBouncer `test_*.py` scenario; its doc comment
+explains the specific behavior and why it matters.
+
+| Test file                 | Scenario                                                                   |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `prepared_swap_test.go`   | a prepared statement is re-prepared correctly across a pooled-backend swap |
+| `large_statement_test.go` | large (>4 KB) Parse / Bind messages relay intact                           |
+| `prepared_reset_test.go`  | `DEALLOCATE ALL` / `DISCARD ALL` drop the session's prepared statements    |
+| `backend_restart_test.go` | backend crash recovery under load, and transparent reconnect               |
+| `pool_exhaustion_test.go` | a full pool queues and proceeds (multigres blocks; it does not reject)     |
+| `reserved_conn_test.go`   | reserved-connection pin/release boundary and idle-in-transaction timeout   |
+| `cancel_race_test.go`     | a cancel for one client never hits another client reusing its backend      |
+| `copy_fault_test.go`      | `COPY FROM STDIN` interrupted by a backend crash                           |
+| `nonexistent_db_test.go`  | connecting to a nonexistent database (differential vs. PostgreSQL)         |
+
+## Approach
+
+The tests are **black-box**: they speak only the PostgreSQL wire protocol to the
+multigateway and observe only what a client can — query results, errors, and
+`pg_backend_pid()` read from the client's own rows (never a side channel into the
+underlying PostgreSQL, except where a test explicitly samples `pg_stat_activity`
+to measure concurrency).
+
+Which backend a pooled (non-pinned) session lands on is an internal detail, so
+the swap-boundary tests don't force a specific swap. Instead `startPoolChurn`
+drives concurrent load that keeps the pool rotating, and `runAcrossBackends`
+asserts a statement ran on ≥2 distinct backends (so the test isn't vacuous)
+while every execute returns correct results. Fault tests inject crashes with
+`KillPostgres` and run in their own `shardsetup.NewIsolated` cluster so the
+damage can't leak into the shared-cluster tests.
+
+## Running
+
+This suite runs as part of the standard e2e integration job. Each test
+self-skips in `-short` mode or when the PostgreSQL
+binaries are absent. Use the `/mt-dev` skill (integration tests build
+first); don't run `go test` directly.
+
+## Known divergences from PostgreSQL
+
+- **Nonexistent connection database:** the gateway authenticates the client and
+  serves its backend database instead of rejecting with `3D000`
+  (guarded by `nonexistent_db_test.go`).
+- **`DISCARD ALL`** does not run `pg_advisory_unlock_all()` on the backend, so
+  session-level advisory locks are not released (a pre-existing pooling
+  limitation).
+
+## Out of scope
+
+PgBouncer features with no multigres analog are not ported: the admin console
+(`PAUSE`/`RESUME`/`SHOW`/`RELOAD`), HBA/userlist auth, peering / `SO_REUSEPORT`,
+and `load_balance_hosts`.
+
+## Attribution
+
+Scenarios are derived from [PgBouncer][pgbouncer-test] (ISC License, © 2007-2009
+Marko Kreen, Skype Technologies OÜ); the upstream license is in
+[`LICENSE`](./LICENSE). New code is licensed under Apache-2.0 (the repository-root
+`LICENSE`); each `.go` file carries the standard Apache header plus a PgBouncer
+attribution line.
 
 [pgbouncer-test]: https://github.com/pgbouncer/pgbouncer/tree/master/test
-
-</content>
-</invoke>

--- a/go/test/endtoend/queryserving/pgbouncertests/README.md
+++ b/go/test/endtoend/queryserving/pgbouncertests/README.md
@@ -1,0 +1,551 @@
+# pgbouncertests — pooling & resilience suite (triage)
+
+> **Status: PORTING COMPLETE — all (A) groups landed.** This document started as
+> Step 1 of the PgBouncer-port effort. It categorizes every PgBouncer test file
+> as **(A) port**, **(B) out of scope**, or **(C) already covered**, and tracks
+> the net-new Go tests to land. The triage has been reviewed; the resolved
+> decisions are recorded in [Review decisions](#review-decisions). The point of
+> the triage is to land only the net-new coverage and avoid re-porting what we
+> already test. All seven (A) groups are **complete** — Group 1 (prepared
+> statements across a pooled-backend swap), Group 2 (continuous-load-under-
+> disruption), Group 3 (pool exhaustion / capacity), Group 4 (reserved-connection
+> lifecycle & timeout), Group 5 (cancel-race under pooling), Group 6 (COPY under
+> fault), and Group 7 (small differential deltas) — see
+> [Implementation status](#implementation-status).
+
+The scenarios in the (A) set are **derived from PgBouncer's own test suite**,
+which is ISC-licensed. The upstream license is reproduced in the `LICENSE` file
+in this directory; see [Attribution and license](#attribution-and-license).
+
+## Mission and framing
+
+We want the behavioral coverage of [PgBouncer's test suite][pgbouncer-test]
+(`~/pgbouncer/test/`, Python/pytest) re-expressed as Go end-to-end tests on the
+`multigateway → multipooler → postgres` path, reusing the existing
+`go/test/endtoend/` harness.
+
+**Multigres is currently a passthrough proxy.** Postgres computes every result;
+multigres does not rewrite or shard queries. So this suite's value is **not
+result correctness** — that is Postgres's job, covered by `sqllogictest` and
+`pgregresstest`. The value is whether the proxy **faithfully relays
+protocol/session state and behaves correctly under pooling and faults**:
+
+- Does session state and prepared statements survive a **pooled-backend swap**?
+- Does the **reserved (pinned) connection** lifecycle behave correctly?
+- Does **pool exhaustion** queue/block correctly instead of corrupting state?
+- Does the proxy **recover** when a backend is killed/restarted mid-load?
+
+Treat PostgreSQL as the oracle wherever a differential comparison makes sense
+(e.g. error SQLSTATEs), exactly as `pgproto`/`sqllogictest` do — but note most of
+the net-new value here is **stateful scenario + fault-injection tests**, not
+statement-result diffs (see [Differential vs. scenario testing](#differential-vs-scenario-testing)).
+
+This is a **triage-and-port** job, not a translation job. PgBouncer's tests are
+wired to PgBouncer's own admin console, INI config files, and `utils.py` fault
+helpers. We re-express only the **proxy-generic** scenarios on top of our
+harness; PgBouncer-specific machinery (admin console, HBA/userlist auth, peering,
+`SO_REUSEPORT`) has no multigres analog and is excluded with rationale below.
+
+## The multigres pooling model (the facts the triage rests on)
+
+These are the proxy behaviors the suite exercises. Verified in-repo:
+
+- **Multigateway does no connection pooling.** It load-balances across
+  multipooler instances and buffers during failover
+  (`go/services/multigateway/poolergateway/pooler_gateway.go`). All backend
+  pooling lives in **multipooler**.
+- **Multipooler pools postgres backends per statement.** A clean backend is
+  borrowed, settings applied, statement executed, then returned to the pool
+  (`go/services/multipooler/pools/connpool/pool.go`). Pooled connections are
+  bucketed by a settings hash so a session's `SET`s are replayed onto whichever
+  backend it next lands on (`pools/regular/regular_conn.go` `ApplySettings`).
+  **This is the "pooled-backend-swap boundary" — where pooling bugs hide.**
+- **Reserved (pinned) connections** keep one physical backend attached to a
+  client session across statements when work is non-poolable. The reasons
+  (`go/common/protoutil/reservation.go`) are: **transaction, temp table, portal
+  (suspended cursor), COPY, LISTEN, logical replication**. There is **no
+  `ReasonPrepared`** — a bare named `Parse` does _not_ pin the connection.
+- **Prepared statements are re-prepared on swap, not pinned.** The executor's
+  `ensurePrepared` / `ensurePreparedWithName`
+  (`go/services/multipooler/executor/executor.go:308,682`) re-parse a client's
+  named statement onto whichever backend a later Bind/Execute lands on. So a
+  statement parsed once and executed after a swap _should_ still work — exactly
+  PgBouncer's `test_prepared.py` scenario, and it exercises real code.
+- **Pool exhaustion blocks, it does not error.** When capacity is reached
+  callers wait on a waitlist until a connection recycles
+  (`connpool/pool.go`); there is no overflow error, no per-db/per-user _client_
+  connection cap. Capacity is `--connpool-global-capacity` (default 100) split
+  by a fair-share rebalancer; reserved gets `--connpool-reserved-ratio` (0.2).
+- **Timeouts that exist:** `--connpool-user-regular-idle-timeout` (5m,
+  ≈ `server_idle_timeout`), `--connpool-user-regular-max-lifetime` (1h,
+  ≈ `server_lifetime`), `--connpool-user-reserved-inactivity-timeout` (30s,
+  ≈ idle-in-transaction killer). `statement_timeout` is enforced at the gateway.
+- **No PgBouncer-style admin console.** Neither multigateway nor multipooler
+  exposes `PAUSE`/`RESUME`/`SUSPEND`/`RECONNECT`/`RELOAD`/`SHOW`. Pool config is
+  fixed at process start via flags; there is no live reconfiguration.
+  (`multiadmin` is a cluster-admin gRPC/HTTP service, not a PG-protocol console.)
+
+## Triage table
+
+`A` = port net-new · `B` = out of scope (no analog) · `C` = already covered.
+"Existing test" names files under `go/test/endtoend/queryserving/`.
+
+| PgBouncer file               | Verdict | Net-new delta to port / why excluded                                                                                                                                                                                                     | Existing coverage                                                             |
+| ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `test_prepared.py`           | **A**   | Prepared statement + session state survive a **pooled-backend swap** (re-prepare via `ensurePrepared`); large Parse/Bind (>4 KB) relay; DISCARD ALL across pooling                                                                       | `prepared_stmt_test.go`, `extended_query_protocol_test.go` (no swap boundary) |
+| `test_operations.py`         | **A**   | **Backend restart/reconnect under continuous load** (the `stress.py` ethos): pool transparently reconnects new statements; in-flight statement sees a clean error. _Admin-command parts → B._                                            | `postgres_crash_recovery_test.go`, `buffer_test.go` (single events, not load) |
+| `test_limits.py`             | **A**   | **Pool exhaustion / capacity**: with `--connpool-global-capacity=N`, the (N+1)th concurrent statement blocks then proceeds; no state corruption. _`max_client_conn`/`min_pool_size`/per-db caps/dynamic reload → B._                     | none                                                                          |
+| `test_timeouts.py`           | **A**   | **Reserved-connection inactivity timeout** (idle-in-txn killer): pinned conn killed after timeout → next statement errors cleanly. **Backend recycle on max-lifetime/idle** → seamless for new statements. _`statement_timeout` → C._    | `statement_timeout_test.go` (query timeout only)                              |
+| `test_cancel.py`             | **A**   | **Cancel-race under pooling**: cancel for client A must not hit a backend just reused by client B; cancel while pool exhausted. _Basic cancel/cross-conn/gRPC-TLS forwarding → C._                                                       | `query_cancel_test.go` (no pooling-reuse race)                                |
+| `test_copy.py`               | **A**   | **COPY interrupted by backend fault** (kill mid-stream → clean error + recovery); COPY in **pipeline/extended** mode. _Formats, TO STDOUT, txn, multi-statement, error recovery → C._                                                    | `copy_test.go` (extensive, no fault path)                                     |
+| `test_no_database.py`        | **A**   | Connect to **nonexistent database** → clean SQLSTATE `3D000`, connection closed cleanly; auth-vs-db error ordering (differential vs PG). _`auto_database`/`auth_user` variants → B._                                                     | none (no explicit nonexistent-db test)                                        |
+| `test_misc.py`               | **A/B** | A: pool **queue-wait** behavior (overlaps `test_limits`). B: `query_wait_notify` (no admin notice), `server_check_query` (no per-conn health check), `fast_close`/`wait_close`/`auto_database`/`host_list` (PgBouncer config).           | `startup_params_test.go` (connect_query/options → C)                          |
+| `test_ssl.py`                | **B/C** | C: full static TLS matrix already covered + multipooler↔PG TLS. B: live TLS toggle / CA change via SIGHUP (no live reconfig).                                                                                                            | `ssl_test.go`, `WithMultipoolerPGTLS`                                         |
+| `test_auth.py`               | **B/C** | C: SCRAM correct/wrong/nonexistent, replication-role rejection. B: `auth_type` matrix, `auth_query`, `auth_dbname`, userlist/HBA file, mock auth, VALID UNTIL — all PgBouncer auth machinery with no analog (auth is passthrough to PG). | `authentication_test.go`                                                      |
+| `test_replication.py`        | **B**   | Replication protocol passthrough is **stubbed** (gateway returns `0A000 feature_not_supported`); porting would test unimplemented features. Existing test already asserts the stub. Revisit when replication lands.                      | `replication_test.go`, `replica_reads_test.go`                                |
+| `test_no_user.py`            | **B/C** | C: nonexistent user → clean auth error. B: mock-auth across trust/plain/md5/scram + forced-user (PgBouncer-specific).                                                                                                                    | `authentication_test.go`                                                      |
+| `test_admin.py`              | **B**   | Admin console `SHOW`/`RELOAD`/config validation — no multigateway analog.                                                                                                                                                                | —                                                                             |
+| `test_load_balance_hosts.py` | **B**   | `load_balance_hosts` over a server host-list — multigres routes by topology, not a static host-list with round-robin/disable.                                                                                                            | (routing covered by `replica_reads_test.go`)                                  |
+| `test_peering.py`            | **B**   | Peering / `SO_REUSEPORT` / rolling restart via peer takeover — gateways coordinate via etcd/topology, not PgBouncer peering. Linux-only.                                                                                                 | —                                                                             |
+
+## (A) Port — the net-new suite
+
+Package name: **`pgbouncertests`** — names the source of the scenarios so the
+provenance (and the ISC attribution) is obvious. The net-new value is stateful
+pooling + fault-resilience, since the protocol basics are already well covered.
+Concrete test groups, in rough priority order:
+
+1. **Prepared statements across a pooled-backend swap (headline).** Open a
+   session, `Parse` a named statement, force the session to land on a _different_
+   backend before `Bind`/`Execute` (e.g. interleave another client to occupy the
+   first backend, or exhaust+recycle), assert the statement still executes and
+   the result matches direct-PG. Probe `ensurePrepared` re-prepare path. Also:
+   `DISCARD ALL` / `DEALLOCATE ALL` semantics across the swap; Parse/Bind > 4 KB
+   relay. _Asserts the boundary, not just the happy path._
+2. **Continuous-load-under-disruption (the `stress.py` ethos).** Drive
+   continuous statements through the gateway while `KillPostgres` /
+   `StopPostgres(...)` / restart the backend; assert new statements reconnect
+   transparently, in-flight statements get a clean error (not a hang or torn
+   packet), and no session-state corruption survives the event. Reuse
+   `postgres_crash_recovery_test.go` primitives; extend to _under load_ + the
+   reconnect/PID-change assertion from `test_operations.py::test_reconnect`.
+3. **Pool exhaustion / capacity.** Configure a small `--connpool-global-capacity`
+   (needs a harness option — see [gaps](#harness-gaps-to-close)); launch N+1
+   concurrent slow statements; assert the (N+1)th **blocks then completes** when a
+   slot frees, and that a context-cancelled waiter is cleaned up. (Multigres
+   blocks rather than erroring — the assertion differs from PgBouncer's reject.)
+4. **Reserved-connection lifecycle & timeout.** Open an explicit transaction
+   (pins a backend), idle past `--connpool-user-reserved-inactivity-timeout`,
+   assert the next statement on the pinned connection errors cleanly and the
+   backend is reclaimed. Verify temp-table / LISTEN / portal reservations pin and
+   release at the right boundaries.
+5. **Cancel-race under pooling.** Issue a cancel for a query whose backend may be
+   released and reused by another client; assert the cancel never disturbs the
+   reusing client (the `test_cancel.py::test_cancel_race` concern).
+6. **COPY under fault.** Kill the backend mid-`COPY FROM STDIN`; assert a clean
+   error and that the connection (or a fresh one) is usable afterward.
+7. **Small differential deltas (PG-as-oracle).** Connect to a nonexistent
+   database → `3D000`; auth-failure-vs-db-error ordering. These _do_ fit the
+   differential model and can reuse `setup.GetComparisonTargets`.
+
+### Implementation status
+
+Groups 1 and 2 are **complete**.
+
+**Group 1 — prepared statements across a pooled-backend swap.** Tests:
+
+- `prepared_swap_test.go` — `TestPreparedStatementAcrossPooledBackends`: prepare
+  once, then execute many times; asserts every execute returns correct results
+  (exercising the multipooler `ensurePrepared` re-prepare path) and that the
+  statement was observed running on ≥2 distinct backends.
+- `large_statement_test.go` — `TestLargePreparedStatementRelay` (differential:
+  16 KB Parse + 64 KB Bind relay, PG-as-oracle) and
+  `TestLargePreparedStatementAcrossPooledBackends` (a 16 KB statement re-prepares
+  correctly on every backend the pool serves it from, literal intact).
+- `prepared_reset_test.go` — `TestPreparedStatementResetSemantics`
+  (differential): both `DEALLOCATE ALL` and `DISCARD ALL` drop the session's
+  prepared statements identically on PG and the gateway. `DISCARD ALL` used to
+  fail here (it surfaced a real bug); it now passes after the fix described in
+  the note below.
+
+**How the swap is exercised — black-box.** Which physical backend an Execute
+lands on is an internal pooling detail; an e2e test treats the proxy as a black
+box, so it does not (and cannot) deterministically force a _specific_ internal
+swap. Instead the tests assert the invariant — _a statement prepared once keeps
+returning correct results no matter which backend serves each Execute_ — under
+conditions that make backends rotate:
+
+- **Churn** (`startPoolChurn`): a handful of ordinary background clients run a
+  cheap query in a tight loop. Because the multipooler pool is LIFO, their
+  constant borrow/return keeps changing which connection is on top, so a
+  foreground session's consecutive Executes are handed different backends instead
+  of its own just-returned one. This is pure wire-protocol load.
+- **Observation**: the foreground client reads `pg_backend_pid()` from its _own_
+  query results through the gateway — a normal result value, not a side channel
+  into the underlying PostgreSQL.
+- **Assertion** (`runAcrossBackends`): run the statement until it has been served
+  by ≥2 distinct backends (and at least `minExecutes` times); every execute must
+  succeed (a missing re-prepare would surface as "prepared statement does not
+  exist"), and seeing ≥2 backends proves the test is not vacuous.
+
+Earlier attempts that depended on proxy internals were rejected as not
+black-box: terminating the backend (`pg_terminate_backend`) leaves a dead socket
+the next streaming Execute hits as a broken pipe; pinning a specific backend with
+holder connections, and reaping via a short idle timeout read through
+`pg_stat_activity`, both coupled the test to pool internals and the heartbeat
+interval.
+
+`shardsetup.WithMultipoolerExtraArgs` was added during this work as a general
+harness option for connpool tuning; group 1 doesn't use it, but groups 3 and 4
+(pool exhaustion, reserved-connection timeout) do.
+
+**Bug found and fixed — `DISCARD ALL` no longer poisons pooled connections.**
+The original `DISCARD ALL` plan forwarded the statement to a pooled backend
+(where it ran `DEALLOCATE ALL`, dropping that backend's server-side prepared
+statements) but invalidated none of the matching bookkeeping: the gateway's
+consolidator stayed populated, so `DISCARD ALL` didn't actually drop the
+client's prepared statements (the next EXECUTE succeeded instead of failing —
+diverging from PostgreSQL); and the multipooler's per-connection tracking
+(`connState.PreparedStatements`) stayed stale on the backend it ran on, so a
+later session reusing that pooled backend skipped re-`Parse` and failed at
+`Bind` with "prepared statement does not exist" (SQLSTATE 26000).
+
+The fix (commit `50417fb0`) handles `DISCARD ALL` **entirely at the gateway and
+never forwards it to a shared pooled backend** — a new `DiscardAllPrimitive`
+(`go/services/multigateway/engine/discard_all_primitive.go`, planned via
+`planDiscardStmt`). In the pooled model the session state `DISCARD ALL` resets
+lives at the gateway, not on any one backend: prepared statements (the
+consolidator), session GUCs (`ResetAllSessionVariables` / `ResetStatementTimeout`),
+and LISTEN subscriptions are all gateway-side. The only backend-resident session
+state is whatever a _reserved_ connection holds (open transaction, temp tables,
+`WITH HOLD` cursors), which the primitive cleans up via
+`ReleaseAllReservedConnections`. The primitive also rejects `DISCARD ALL` inside
+a transaction block (matching PG's `PreventInTransactionBlock`). Already-prepared
+statements on pooled backends are intentionally left in place — they act as a
+pool-wide dedup cache and the multipooler's `connState` stays accurate.
+
+Because the bug is fixed, the test now lives as the `DISCARD ALL` case of the
+differential `TestPreparedStatementResetSemantics` and passes against both PG
+and the gateway. The earlier failing-on-purpose `TestPreparedStatementDiscardAll`
+and its `shardsetup.NewIsolated` cluster are gone — the whole package runs in the
+shared cluster.
+
+**Group 2 — continuous-load-under-disruption (the `stress.py` ethos).** Tests
+in `backend_restart_test.go`, ported from `test_operations.py`'s
+`test_database_restart` and `test_reconnect`. Both inject the fault with
+`KillPostgres` (SIGKILL — a hard crash); the multipooler's postgres monitor then
+auto-restarts the _same_ backend (crash recovery; the primary stays primary —
+there is no failover). Each runs in its own `shardsetup.NewIsolated` cluster so
+the deliberate crash cannot leak into the shared-cluster tests.
+
+- `TestBackendCrashRecoveryUnderLoad` — drives continuous INSERT load through the
+  gateway with a `shardsetup.WriterValidator` (6 workers), hard-kills postgres
+  mid-load, waits for the monitor to restart it, then asserts the load **resumes
+  on its own** (success count climbs past the recovery point with no client
+  reconnect) and that **every acknowledged write survived** crash recovery
+  (`count(*) ≥ successful` — a SIGKILL mid-commit can leave a committed row whose
+  ack never reached the client, so the table may hold a few _extra_ rows).
+- `TestBackendCrashTransparentReconnect` — the `test_reconnect` analog. A single
+  client session reads `pg_backend_pid()`, postgres is hard-killed and restarted,
+  and the **same** session must recover: its next statement lands on a fresh
+  backend (a _different_ pid). The first post-crash statement may error, but
+  cleanly and within a deadline (the "clean error, not a hang or torn packet"
+  property) — never a hang.
+
+**What Group 2 establishes about multigres.** The transparent-reconnect test
+confirms a property stronger than PgBouncer's: a client's gateway connection
+**survives a backend crash**. PgBouncer's `test_database_restart` tolerates
+in-flight `OperationalError`s and then opens a _new_ client connection; in
+multigres the client connection stays up across the crash because backend
+pooling lives in the multipooler, decoupled from client sessions — the gateway
+swaps in a fresh backend underneath the same session.
+
+**Group 3 — pool exhaustion / capacity.** Tests in `pool_exhaustion_test.go`,
+ported from `test_limits.py`. Each runs in its own `NewIsolated` cluster started
+with a deliberately tiny pool via `shardsetup.WithMultipoolerExtraArgs`
+(`--connpool-global-capacity=4 --connpool-reserved-ratio=0.5
+--connpool-rebalance-interval=1s`), which settles the lone test user's regular
+sub-pool to 2 backends. Where PgBouncer **rejects** connections on a full pool,
+multigres **blocks** on the waitlist (`connpool/{pool.go,waitlist.go}`) — so the
+assertions are inverted accordingly.
+
+- `TestPoolExhaustionBlocksThenProceeds` — launches 12 concurrent `pg_sleep(1)`
+  statements at a pool that can run only ~2 at once, and asserts **all 12
+  succeed** (queue-and-proceed, no rejection) while the **peak concurrency
+  observed on postgres stays capped below the number launched** (a peak equal to
+  the launch count would mean the pool never limited). Concurrency is measured
+  through a side connection straight to postgres — bypassing the saturated pool —
+  that samples `pg_stat_activity` for active `pg_sleep` backends. Observed peak:
+  exactly 2.
+- `TestPoolExhaustionWaiterCancelledCleanly` — saturates the pool with long
+  holders, then issues one more statement with an 800 ms deadline. That statement
+  must **block on the waitlist and fail on its deadline** (elapsed ≈ the full
+  deadline proves it queued rather than being served or rejected); then, after
+  the holders release, a fresh statement must **succeed** — proving the
+  cancelled waiter was removed from the waitlist cleanly, leaking no slot and
+  causing no deadlock.
+
+**Group 4 — reserved-connection lifecycle & timeout.** Tests in
+`reserved_conn_test.go`, ported from `test_timeouts.py` (the idle-in-transaction
+killer). The timeout tests use `NewIsolated` clusters started with a short
+`--connpool-user-reserved-inactivity-timeout=2s` via
+`shardsetup.WithMultipoolerExtraArgs`. All observe pinning black-box via
+`pg_backend_pid()`.
+
+- `TestReservedConnectionInactivityTimeout` — opens a transaction (pinning a
+  backend), idles past the inactivity timeout so the reaper kills the pinned
+  backend, and asserts the session's next statement **fails cleanly** (a returned
+  error within the deadline, not a hang) — multigres's idle-in-transaction
+  killer. It then asserts the session **recovers**: after a ROLLBACK a fresh
+  statement succeeds on a pooled backend, proving the reaped reservation was
+  reclaimed rather than wedging the session.
+- `TestReservedConnectionSurvivesWithActivity` — the inverse control: a
+  transaction issuing a statement every second (faster than the 2s timeout) is
+  **never reaped**, and because it is pinned every statement runs on the **same
+  backend**. Proves the timeout is inactivity-based (reset by activity).
+- `TestTransactionPinsBackendThenReleases` — the pin/release boundary, on the
+  shared cluster under pool churn: inside the transaction every statement stays
+  on **one backend** despite churn that rotates the pool (the inverse of Group
+  1's pooled rotation); after COMMIT the session rejoins the pool and its
+  statements **rotate across ≥2 backends** again, confirming the reservation
+  ended at COMMIT.
+
+**Group 5 — cancel-race under pooling.** Test in `cancel_race_test.go`, ported
+from `test_cancel.py::test_cancel_race`. PgBouncer's worry is that a
+CancelRequest for client A could cancel a query client B now runs on a backend A
+released — because in raw postgres the cancel key maps to a _backend_. Multigres
+routes cancels by the _client↔gateway connection_ (the gateway's synthetic
+BackendKeyData + per-connection secret; `multigateway/{cancel.go,listener.go}`),
+so the backend a query borrows is never the cancel's addressing unit and the
+reuse race is structurally absent.
+
+- `TestCancelForReleasedBackendDoesNotHitReuser` — runs in a `NewIsolated`
+  cluster with a capacity-1 regular pool (`--connpool-global-capacity=2
+--connpool-reserved-ratio=0.5`) so backend reuse is forced. Client A runs a
+  statement then idles (releasing the single backend); client B starts a long
+  statement that **provably reuses A's exact backend** (asserted via equal
+  `pg_backend_pid()`); a stale out-of-band CancelRequest for A is then delivered
+  (raw socket, same machinery as `query_cancel_test.go`). B finishes
+  **uncancelled**, proving A's cancel hit only A's idle connection. A then stays
+  usable (its cancel was a harmless no-op).
+
+The secondary "cancel while pool exhausted" case from the triage is **not**
+ported here: cancelling a pool-blocked waiter is already covered by Group 3's
+`TestPoolExhaustionWaiterCancelledCleanly` (via context cancellation), and
+whether an out-of-band CancelRequest interrupts a query still _queued_ for a slot
+(vs. one executing on a backend) is a separate multigres-cancel-semantics
+question left for its own investigation.
+
+**Group 6 — COPY under fault.** Test in `copy_fault_test.go`, ported from
+`test_copy.py`. COPY's happy paths (formats, TO STDOUT, transactions,
+multi-statement, error recovery) are already covered by `copy_test.go`, so the
+net-new delta is the fault path. Runs in a `NewIsolated` cluster.
+
+- `TestCopyInterruptedByBackendCrash` — streams a large `COPY FROM STDIN` (a
+  reader generating rows on demand, so CopyData keeps flowing), hard-kills
+  postgres mid-stream with `KillPostgres`, and asserts: the COPY **fails cleanly**
+  (a returned error within a deadline, not a hang or torn stream — observed as a
+  closed-connection write error, since a crashed reserved-COPY backend tears down
+  the client connection), the proxy **recovers** so a fresh connection serves
+  queries again after the monitor restarts postgres, and the interrupted COPY
+  **committed nothing** (the durable pre-crash table survives crash recovery with
+  zero rows — COPY FROM is all-or-nothing). Note this differs from Group 2's
+  regular-query case, where the same client connection survived a backend crash;
+  a reserved COPY stream does not.
+
+The triage's "COPY in pipeline/extended mode" sub-item is not ported — extended
+COPY happy-path sequencing is part of the existing `copy_test.go` /
+`extended_query_protocol_test.go` coverage, and the net-new value here is the
+fault path above.
+
+**Group 7 — small differential deltas (PG-as-oracle).** Tests in
+`nonexistent_db_test.go`, ported from `test_no_database.py`. These fit the
+differential model (run against both `GetComparisonTargets`) and use the shared
+cluster (no fault injection).
+
+- `TestNonexistentDatabaseConnectBehavior` — documents and guards a real
+  **divergence**: direct PostgreSQL validates the catalog during startup and
+  rejects a nonexistent database at connect time with `3D000`
+  (invalid_catalog_name), whereas the multigateway authenticates the client and
+  never validates the requested database — so connecting to `no_such_db_xyz`
+  succeeds and `SELECT current_database()` returns the served `postgres`. The
+  multigateway branch asserts that current behavior, so if gateway-side database
+  validation is later added the test flags it for an intended update.
+- `TestAuthErrorPrecedesDatabaseError` — the matching case: with a wrong password
+  **and** a nonexistent database, both targets report the auth failure (`28P01`)
+  at connect time, confirming authentication is checked before the database is
+  resolved on both PostgreSQL and the gateway.
+
+**⚠️ Divergence worth a maintainer's eye:** the gateway accepting an unknown
+connection database and silently serving its backend database (rather than
+rejecting with `3D000`) means a client asking for database `X` can be served
+`postgres`. This may be an artifact of the single-database test topology /
+passthrough routing; it is captured by the test above but may warrant a separate
+look at whether the gateway should validate the connection database.
+
+- **Verified:** all seven groups pass at `go test -count=3` (Group 1 and Group 7
+  differential cases on both the postgres and multigateway targets); pgx sessions
+  rotate across 5–8 backends within the first ~40 executes; killed backends
+  recover and the same client session resumes on a fresh backend pid; a 12-wide
+  load peaks at 2 concurrent backends with all statements succeeding, and a
+  cancelled pool waiter leaves the pool healthy; an idle pinned backend is reaped
+  and the session recovers while an active one stays pinned to a single backend; a
+  reused backend is unaffected by the previous owner's cancel; a COPY hard-killed
+  mid-stream fails cleanly, recovers, and commits nothing; a nonexistent database
+  yields `3D000` on direct PG while the gateway diverges (documented), and auth
+  errors precede database errors on both; `go vet` / golangci-lint clean.
+- **Not started:** none — the (A) suite is complete.
+
+## (B) Out of scope — rationale
+
+- **Admin console** (`test_admin.py`, admin parts of `test_operations.py`): no
+  `PAUSE`/`RESUME`/`SHOW`/`RELOAD` surface on multigateway or multipooler.
+- **Auth machinery** (`test_auth.py`, `test_no_user.py` mock-auth): no
+  userlist/HBA file, `auth_query`, `auth_dbname`, or mock-auth — auth is passed
+  through to postgres.
+- **Replication passthrough** (`test_replication.py`): gateway stubs replication
+  commands with `feature_not_supported`. Revisit when implemented.
+- **Peering / load-balance-hosts** (`test_peering.py`,
+  `test_load_balance_hosts.py`): no `SO_REUSEPORT` peering or static server
+  host-list; routing is topology-driven.
+- **Live reconfiguration** (TLS SIGHUP toggles, `RELOAD`-driven limit changes):
+  config is fixed at process start.
+- **PgBouncer config knobs** (`fast_close`, `wait_close`, `auto_database`,
+  `host_list`, `track_extra_parameters`, `query_wait_notify`): PgBouncer-specific
+  with no multigres setting.
+
+## (C) Already covered — do not duplicate
+
+Mapped above. The existing suite (`go/test/endtoend/queryserving/`) already
+covers, with differential PG-as-oracle where applicable: transactions, prepared
+statements (happy path), query cancel (incl. gRPC-TLS forwarding),
+LISTEN/NOTIFY, COPY (formats/txn/multi-statement/error-recovery), session
+settings, statement timeout, the full SSL matrix, startup params/PGOPTIONS,
+SCRAM auth, error/notice formatting, replica reads, replication stubs, failover
+buffering, postgres crash recovery, and extended-protocol sequencing. Port only
+the **delta** (a new assertion across a swap or under a fault), ideally as added
+cases in the existing file rather than a parallel file.
+
+## Differential vs. scenario testing
+
+Unlike `pgproto`/`sqllogictest`, **most of this suite is not corpus-driven
+differential**. The pooling/resilience scenarios are assertions about proxy
+_behavior under fault_ (reconnect, block-then-proceed, clean error), not
+statement-result diffs — so the `suiteutil` corpus/patch/`results.json` model
+mostly does **not** apply here. Recommendation:
+
+- Use plain Go test assertions (testify) for the scenario + fault tests, built on
+  `shardsetup` + the pgprotocol/pgx/lib-pq clients + the fault helpers.
+- Reserve `suiteutil` differential reporting + `.patch` known-divergence files
+  **only** for the small differential deltas (group 7 above), where PG is a true
+  oracle. If we add no corpus-driven cases, we don't need the patch machinery —
+  and we should say so rather than bolt it on for its own sake.
+
+This is an honest deviation from the original spec's assumption that the suite is
+corpus-driven; flagging it for review.
+
+## Harness reuse (do not reinvent)
+
+- **Cluster:** `shardsetup.New(t, shardsetup.WithMultipoolerCount(2),
+shardsetup.WithMultigateway())`; `NewSharedSetupManager` +
+  `RunTestMain(m)` in `TestMain`; `SetupTest(t)` per test — copy
+  `queryserving/main_test.go`. Use `NewIsolated(t, ...)` for tests that kill the
+  primary/backend so cleanup is clean.
+- **Clients:** `go/common/pgprotocol/client` for adversarial/cancel sequences;
+  `pgx/v5` or `database/sql`+`lib/pq` for SQL-level assertions. Cancellation
+  follows `query_cancel_test.go` (out-of-band CancelRequest).
+- **Faults:** `setup.KillPostgres`, `StopPostgres(...) (resume)`,
+  `ShutdownPostgres`, `ProcessInstance.StopPostgresImmediate` /
+  `TerminateGracefully`, `GetPgctld`/`GetMultipooler`, `StopEtcd`,
+  `DisableRecovery`/`EnableRecovery`/`TriggerRecoveryOnce`. Pattern reference:
+  `postgres_crash_recovery_test.go`.
+- **Differential targets (group 7):** `setup.GetComparisonTargets(t)` →
+  `[]TestTarget{{"postgres",...},{"multigateway",...}}`; creds via
+  `shardsetup.DefaultTestUser`, `TestPostgresPassword`, `GetTestUserDSN`.
+- **Reporting (only if corpus-driven cases land):** `suiteutil` `report.go` /
+  `diffreport.go` / `corpus.go` / `patch.go` and `ResetPublicSchema` /
+  `NewSchemaResetterWithCleanup` / `RunWithTimeout`.
+
+## Harness gaps to close
+
+**Closed.** The connpool-tuning gap is resolved: `shardsetup` now exposes
+`WithMultipoolerExtraArgs(...)`, which appends arbitrary flags to every
+multipooler (mirroring the existing `MultigatewayExtraArgs` plumbing in
+`shardsetup/setup.go`). Group 3 uses it for `--connpool-global-capacity`,
+`--connpool-reserved-ratio`, and `--connpool-rebalance-interval`; group 4 uses
+it for `--connpool-user-reserved-inactivity-timeout`. Targeted convenience
+wrappers (`WithConnpoolCapacity(n)` /
+`WithReservedInactivityTimeout(d)`) were deemed unnecessary — the generic
+extra-args option is enough.
+
+## Gating, CI, and how to run
+
+This suite runs **directly in the standard e2e integration framework**, not
+behind the extended-query-serving label. The package lives under
+`go/test/endtoend/queryserving/pgbouncertests/`, so the
+**`.github/workflows/test-integration.yml`** job — which runs
+`gotestsum --packages="./go/test/endtoend/..."` on every PR and push to `main`
+— picks it up automatically. No `suiteutil.SkipUnlessEnabled` /
+`RUN_EXTENDED_QUERY_SERVING_TESTS` gate, no PR label, and no separate
+pgbouncer-specific workflow. Tests only self-skip in `-short` mode or when the
+PostgreSQL binaries are absent (`utils.ShouldSkipRealPostgres`), matching the
+rest of the e2e suite.
+
+This decision was made because the suite's value is core proxy behavior
+(pooling, prepared-statement relay, fault recovery) that should be exercised on
+every change, not gated behind an opt-in label that only runs on cron or
+demand. The fault-injection groups (2–6) kill/restart backends, so keep using
+`shardsetup.NewIsolated` for those individual tests to keep cleanup contained
+within the shared-cluster package.
+
+Run locally via the project conventions (use the `/mt-dev` skill; integration
+tests build first). Do not run `go test` directly per repo policy.
+
+## Review decisions
+
+The triage was reviewed; the following are settled:
+
+1. **Name/scope:** the suite lives in a new package, **`pgbouncertests`**, to
+   make the provenance and ISC attribution explicit (rather than folding cases
+   into the existing files).
+2. **Differential vs. scenario:** approved — use plain Go assertions for the
+   scenario + fault tests, and reserve the `suiteutil` corpus/patch model only
+   for the small differential deltas (group 7).
+3. **Harness option:** approved — add the
+   `WithMultipoolerExtraArgs`/connpool option to `shardsetup` as part of this
+   work (see [Harness gaps to close](#harness-gaps-to-close)).
+4. **Replication (B):** confirmed — defer all of `test_replication.py` until
+   replication passthrough is implemented; we'll add tests when we add support.
+
+## Attribution and license
+
+The (A) scenarios are ported from [PgBouncer's test suite][pgbouncer-test],
+which is distributed under the **ISC License** (Copyright © 2007-2009 Marko
+Kreen, Skype Technologies OÜ). We re-implement the scenarios in Go rather than
+copying code, but because they are a derivative of an ISC-licensed work we
+reproduce the upstream license, following the same in-repo convention used for
+other vendored third-party code (e.g. `go/common/cache/theine/LICENSE`):
+
+- A `LICENSE` file in this directory holds the verbatim PgBouncer ISC license,
+  which applies to the derived test scenarios.
+- All new code and modifications in this directory (the Go re-implementation and
+  harness) are part of Multigres and licensed under the **Apache License,
+  Version 2.0** — the repository-root `LICENSE`.
+- Each ported `.go` file carries the standard multigres Apache-2.0 header (the
+  `check-license` hook requires a `Copyright … Supabase, Inc.` line) **plus** an
+  upstream-attribution line crediting PgBouncer's ISC copyright — mirroring the
+  multi-copyright header pattern in `theine`'s Go files. For example:
+
+  ```go
+  // Copyright 2026 Supabase, Inc.
+  // Portions derived from PgBouncer (ISC License),
+  // Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+  //
+  // Licensed under the Apache License, Version 2.0 (the "License");
+  // ... (standard Apache-2.0 header) ...
+  ```
+
+[pgbouncer-test]: https://github.com/pgbouncer/pgbouncer/tree/master/test
+
+</content>
+</invoke>

--- a/go/test/endtoend/queryserving/pgbouncertests/backend_restart_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/backend_restart_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// Group 2 of the PgBouncer port — continuous-load-under-disruption (the
+// stress.py ethos), ported from test_operations.py::test_database_restart and
+// ::test_reconnect.
+//
+// PgBouncer's scenario: drive traffic while the backend database is restarted
+// underneath the proxy, and assert that (a) in-flight statements fail cleanly
+// rather than hanging or returning a torn packet, and (b) new statements
+// transparently land on a fresh backend connection once the database is back.
+//
+// These are black-box tests: they speak only the PostgreSQL wire protocol to
+// the multigateway and observe only what a normal client can (query results and
+// errors, plus pg_backend_pid() read from the client's own result rows). The
+// fault is injected with KillPostgres (SIGKILL — a hard crash), after which the
+// multipooler's postgres monitor auto-restarts the same backend (crash
+// recovery; the primary stays the primary — there is no failover here).
+//
+// Each test runs in its own NewIsolated cluster so the deliberate backend crash
+// cannot leak into the shared-cluster tests in this package.
+
+// TestBackendCrashRecoveryUnderLoad drives continuous writes through the gateway
+// while the primary's postgres is hard-killed, then asserts the pool transparently
+// reconnects: writes resume on their own (no client reconnect, no hang) and every
+// acknowledged write survived the crash. This is the stress.py ethos —
+// throughput recovers after the disruption — combined with a durability check.
+func TestBackendCrashRecoveryUnderLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Continuous load: several workers INSERTing through the gateway. database/sql
+	// pools client connections, so a connection broken by the crash is discarded
+	// and a fresh one opened transparently — exactly the recovery we want to see.
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, db,
+		shardsetup.WithWorkerCount(6),
+		shardsetup.WithWriteInterval(5*time.Millisecond),
+		shardsetup.WithQueryTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+	defer validatorCleanup()
+	validator.Start(t)
+
+	// Establish a baseline so we know load is flowing before the crash.
+	waitForSuccessfulWrites(t, validator, 50, 30*time.Second)
+	preCrash, _ := validator.Stats()
+	t.Logf("baseline established: %d successful writes before crash", preCrash)
+
+	// Hard-crash postgres on the primary. Restarts stay enabled, so the
+	// multipooler monitor auto-restarts the same backend.
+	setup.KillPostgres(t, setup.PrimaryName)
+	waitForPostgresReady(t, setup, 60*time.Second)
+	t.Log("postgres auto-restarted by the monitor")
+
+	// Transparent recovery: load must resume on its own. Wait for the success
+	// count to climb well past where it was at recovery time, with no client
+	// reconnect or intervention.
+	atRecovery, _ := validator.Stats()
+	require.Eventually(t, func() bool {
+		s, _ := validator.Stats()
+		return s >= atRecovery+30
+	}, 30*time.Second, 200*time.Millisecond,
+		"writes should resume on their own after the backend is back (transparent reconnect)")
+
+	validator.Stop()
+	successful, failed := validator.Stats()
+	t.Logf("after recovery: %d successful, %d failed writes (failures expected during the outage window)", successful, failed)
+	require.Greater(t, successful, preCrash, "more writes must have succeeded after recovery than before the crash")
+
+	// Durability: every acknowledged write must have survived crash recovery.
+	// A SIGKILL mid-commit can leave a row committed on disk whose ack never
+	// reached the client (counted as failed), so the table may hold a few more
+	// rows than we counted successful — hence GreaterOrEqual, not Equal.
+	var count int
+	require.Eventually(t, func() bool {
+		ctx := utils.WithShortDeadline(t)
+		// #nosec G202 -- tableName comes from test setup, not user input.
+		return db.QueryRowContext(ctx, "SELECT count(*) FROM "+validator.TableName()).Scan(&count) == nil
+	}, 15*time.Second, 500*time.Millisecond, "count(*) should be readable after recovery")
+	assert.GreaterOrEqualf(t, count, successful,
+		"every acknowledged write (%d) must survive crash recovery; table holds %d rows", successful, count)
+}
+
+// TestBackendCrashTransparentReconnect is the test_reconnect analog: a single
+// client session reads its backend pid, the backend is hard-killed and
+// auto-restarted, and the same client session must keep working — its next
+// statement lands on a fresh backend (a different pid), proving the gateway
+// reconnected underneath the client rather than handing back a dead connection.
+func TestBackendCrashTransparentReconnect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	var pid1 int
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid1))
+	t.Logf("client session started on backend pid %d", pid1)
+
+	setup.KillPostgres(t, setup.PrimaryName)
+	waitForPostgresReady(t, setup, 60*time.Second)
+	t.Log("postgres auto-restarted by the monitor")
+
+	// The same client session must recover. The first statement after the crash
+	// may error cleanly (the borrowed backend is gone) — that is the "clean
+	// error, not a hang" property, enforced by the per-attempt deadline. It must
+	// then succeed on a fresh backend.
+	var pid2 int
+	require.Eventually(t, func() bool {
+		attemptCtx := utils.WithShortDeadline(t)
+		err := conn.QueryRow(attemptCtx, "SELECT pg_backend_pid()").Scan(&pid2)
+		if err != nil {
+			t.Logf("post-crash statement still failing (expected during recovery): %v", err)
+			return false
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond,
+		"the same client session must recover and serve queries after the backend restarts")
+
+	assert.NotEqual(t, pid1, pid2,
+		"after a crash the session must land on a fresh backend; got the same pid %d, suggesting a stale pooled connection", pid1)
+	t.Logf("session recovered transparently onto fresh backend pid %d", pid2)
+}
+
+// waitForSuccessfulWrites blocks until the validator has recorded at least min
+// successful writes, or fails the test after timeout.
+func waitForSuccessfulWrites(t *testing.T, v *shardsetup.WriterValidator, minWrites int, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		s, _ := v.Stats()
+		return s >= minWrites
+	}, timeout, 100*time.Millisecond, "expected at least %d successful writes", minWrites)
+}
+
+// waitForPostgresReady polls the primary's multipooler manager until it reports
+// postgres ready again (after the monitor auto-restarts a crashed backend).
+func waitForPostgresReady(t *testing.T, setup *shardsetup.ShardSetup, timeout time.Duration) {
+	t.Helper()
+	client := setup.NewPrimaryClient(t)
+	defer client.Close()
+	require.Eventually(t, func() bool {
+		ctx := utils.WithShortDeadline(t)
+		status, err := client.Manager.Status(ctx, &multipoolermanagerdatapb.StatusRequest{})
+		if err != nil {
+			return false
+		}
+		return status.Status.PostgresReady
+	}, timeout, 500*time.Millisecond, "postgres should be auto-restarted by the monitor")
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/cancel_race_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/cancel_race_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Group 5 of the PgBouncer port — cancel-race under pooling, ported from
+// test_cancel.py::test_cancel_race.
+//
+// PgBouncer's worry: a CancelRequest for client A's query must not cancel a
+// different query that client B is now running on a backend A just released into
+// the pool. In a raw-postgres / PgBouncer world the cancel key maps to a
+// *backend*, so reuse is where the race lives.
+//
+// Multigres routes cancels by the *client↔gateway connection* instead: the
+// gateway hands each client a synthetic BackendKeyData (its own encoded PID + a
+// per-connection random secret) and, on a CancelRequest, looks up that client
+// connection by PID, checks the secret, and cancels only that connection's
+// in-flight query (go/services/multigateway/{cancel.go,listener.go}). The
+// backend a query happens to be borrowing is never the cancel's addressing unit,
+// so the backend-reuse race is structurally absent. This test guards that it
+// stays absent.
+//
+// Black-box throughout: clients read pg_backend_pid() from their own rows and
+// send a standalone CancelRequest over a raw socket (the same machinery as
+// query_cancel_test.go). A capacity-1 pool makes backend reuse deterministic.
+//
+// Group 3's TestPoolExhaustionWaiterCancelledCleanly already covers cancelling a
+// pool-blocked waiter (via context cancellation), so it is not repeated here.
+
+// cancelPoolCapacity sizes the pool so the lone test user's regular sub-pool
+// settles to exactly one backend (global 2 × (1 − 0.5)), making backend reuse
+// deterministic. Pairs with connpoolReservedRatio / connpoolRebalanceFast from
+// pool_exhaustion_test.go.
+const cancelPoolCapacity = "--connpool-global-capacity=2"
+
+// TestCancelForReleasedBackendDoesNotHitReuser is the headline race test. With a
+// 1-backend pool: client A runs a statement (then goes idle, releasing the
+// backend), client B starts a long statement that reuses *that same backend*,
+// and a stale CancelRequest for A is delivered while B runs. B must finish
+// uncancelled — proving A's cancel is scoped to A's (idle) connection, never to
+// the shared backend B inherited.
+func TestCancelForReleasedBackendDoesNotHitReuser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(cancelPoolCapacity, connpoolReservedRatio, connpoolRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	// Settle the user's regular pool down to a single backend so reuse is forced.
+	settleDB := openGatewayDB(t, setup)
+	settleConnpool(t, ctx, settleDB)
+	settleDB.Close()
+
+	// Client A: learn its backend and capture its cancel key, then stay idle so
+	// the backend returns to the pool.
+	connA := connectGateway(t, ctx, gatewayDSN)
+	defer connA.Close(ctx)
+	pidA := queryBackendPid(t, ctx, connA)
+	procA, secretA := backendCancelKey(t, connA)
+	t.Logf("client A used backend %d; captured gateway cancel key pid=%d", pidA, procA)
+
+	// Client B: a long statement that, with capacity 1, must reuse A's backend.
+	connB := connectGateway(t, ctx, gatewayDSN)
+	defer connB.Close(ctx)
+	type result struct {
+		pid int
+		err error
+	}
+	bDone := make(chan result, 1)
+	go func() {
+		var pid int
+		var dummy string
+		err := connB.QueryRow(ctx, "SELECT pg_backend_pid(), pg_sleep(3)::text").Scan(&pid, &dummy)
+		bDone <- result{pid: pid, err: err}
+	}()
+
+	// Let B's statement reach the backend, then deliver A's stale cancel.
+	time.Sleep(750 * time.Millisecond)
+	require.NoError(t, sendCancelRequest("127.0.0.1", setup.MultigatewayPgPort, procA, secretA),
+		"sending client A's CancelRequest")
+
+	select {
+	case r := <-bDone:
+		require.NoErrorf(t, r.err,
+			"client B's query must not be cancelled by a CancelRequest meant for client A (got %v)", r.err)
+		require.Equalf(t, pidA, r.pid,
+			"with a capacity-1 pool B must reuse A's exact backend (A=%d, B=%d) — otherwise the reuse race isn't exercised", pidA, r.pid)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for client B's query")
+	}
+	t.Logf("client B completed uncancelled on the reused backend %d", pidA)
+
+	// A's idle-connection cancel was a harmless no-op; A is still usable.
+	var n int
+	require.NoError(t, connA.QueryRow(ctx, "SELECT 1").Scan(&n))
+	require.Equal(t, 1, n)
+}
+
+// backendCancelKey returns the gateway-issued cancel key (synthetic PID and
+// secret) for a pgx connection, decoding the 4-byte secret the gateway sends in
+// BackendKeyData.
+func backendCancelKey(t *testing.T, conn *pgx.Conn) (procID, secret uint32) {
+	t.Helper()
+	sk := conn.PgConn().SecretKey()
+	require.Lenf(t, sk, 4, "gateway should issue a 4-byte cancel secret, got %d bytes", len(sk))
+	return conn.PgConn().PID(), binary.BigEndian.Uint32(sk)
+}
+
+// sendCancelRequest dials the gateway's PostgreSQL port and sends a standalone
+// CancelRequest for (processID, secretKey) — the out-of-band cancel a real
+// client uses. Mirrors the helper in query_cancel_test.go.
+func sendCancelRequest(host string, port int, processID, secretKey uint32) error {
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial cancel endpoint %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	packet := make([]byte, 16)
+	binary.BigEndian.PutUint32(packet[0:4], 16)
+	binary.BigEndian.PutUint32(packet[4:8], protocol.CancelRequestCode)
+	binary.BigEndian.PutUint32(packet[8:12], processID)
+	binary.BigEndian.PutUint32(packet[12:16], secretKey)
+
+	if _, err := conn.Write(packet); err != nil {
+		return fmt.Errorf("write cancel packet: %w", err)
+	}
+	return nil
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/copy_fault_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"io"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Group 6 of the PgBouncer port — COPY under fault, ported from test_copy.py.
+//
+// COPY FROM STDIN pins a reserved backend (ReasonCopy) for the duration of the
+// stream. test_copy.py already covers the happy paths (formats, TO STDOUT,
+// transactions, multi-statement, error recovery), which the existing
+// copy_test.go mirrors — so the net-new delta here is the fault path: a backend
+// hard-killed mid-stream must surface a clean error to the client (not a hang),
+// the proxy must recover, and the interrupted COPY must commit nothing (COPY
+// FROM is all-or-nothing).
+//
+// Black-box: the client streams real COPY data over the wire and observes only
+// the COPY result and post-recovery queries. The fault is KillPostgres (SIGKILL),
+// after which the multipooler's monitor auto-restarts the same backend. Runs in
+// its own NewIsolated cluster so the crash cannot leak into shared-cluster tests.
+
+// TestCopyInterruptedByBackendCrash streams a large COPY FROM STDIN, hard-kills
+// postgres mid-stream, and asserts: the COPY fails cleanly (a returned error
+// within a deadline, not a hang), the proxy recovers so a fresh connection
+// serves queries again, and the killed COPY left zero rows (clean rollback — no
+// partial/torn data).
+func TestCopyInterruptedByBackendCrash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	_, err := conn.Exec(ctx, "CREATE TABLE copy_fault (id int)")
+	require.NoError(t, err)
+
+	// Stream a COPY that runs long enough to be killed mid-flight. The reader
+	// generates rows continuously, so CopyData keeps flowing to the backend and
+	// the dead socket is noticed promptly once postgres is killed.
+	copyDone := make(chan error, 1)
+	go func() {
+		_, copyErr := conn.PgConn().CopyFrom(ctx, &copyRowReader{max: 500_000_000}, "COPY copy_fault FROM STDIN")
+		copyDone <- copyErr
+	}()
+
+	// Let the COPY get going (rows streaming to the reserved backend), then crash
+	// postgres underneath it.
+	time.Sleep(time.Second)
+	setup.KillPostgres(t, setup.PrimaryName)
+
+	select {
+	case copyErr := <-copyDone:
+		require.Error(t, copyErr, "a COPY interrupted by a backend crash must fail cleanly")
+		t.Logf("COPY failed cleanly on backend crash: %v", copyErr)
+	case <-time.After(30 * time.Second):
+		t.Fatal("COPY did not return after the backend was killed (possible hang or torn stream)")
+	}
+
+	waitForPostgresReady(t, setup, 60*time.Second)
+	t.Log("postgres auto-restarted by the monitor")
+
+	// A fresh connection must serve queries again after recovery.
+	conn2 := connectGateway(t, ctx, gatewayDSN)
+	defer conn2.Close(ctx)
+	require.Eventually(t, func() bool {
+		recoverCtx := utils.WithShortDeadline(t)
+		var n int
+		return conn2.QueryRow(recoverCtx, "SELECT 1").Scan(&n) == nil && n == 1
+	}, 30*time.Second, 250*time.Millisecond, "a fresh connection must work after the COPY-fault recovery")
+
+	// COPY FROM is all-or-nothing: the interrupted stream committed nothing, so
+	// the (durable, pre-crash) table survived crash recovery with zero rows.
+	var rows int
+	require.NoError(t, conn2.QueryRow(ctx, "SELECT count(*) FROM copy_fault").Scan(&rows))
+	require.Zerof(t, rows, "an interrupted COPY must commit nothing; found %d rows", rows)
+}
+
+// copyRowReader streams COPY FROM STDIN text data for a single int column —
+// "0\n1\n2\n…" — generating rows on demand up to max. max is only a runaway
+// guard: the test kills the backend long before it is reached, so CopyFrom
+// errors out mid-stream and stops reading.
+type copyRowReader struct {
+	next int64
+	max  int64
+}
+
+func (r *copyRowReader) Read(p []byte) (int, error) {
+	if r.next >= r.max {
+		return 0, io.EOF
+	}
+	n := 0
+	// Leave headroom for the longest int64 line ("-9223372036854775808\n").
+	for r.next < r.max && len(p)-n >= 24 {
+		line := strconv.AppendInt(p[n:n], r.next, 10)
+		n += len(line)
+		p[n] = '\n'
+		n++
+		r.next++
+	}
+	return n, nil
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/nonexistent_db_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Group 7 of the PgBouncer port — small differential deltas (PG-as-oracle),
+// ported from test_no_database.py.
+//
+// Unlike the rest of the suite, these fit the differential model: run the same
+// connection attempt against direct PostgreSQL and the multigateway (via
+// GetComparisonTargets). The two cases are connecting to a nonexistent database
+// and the auth-vs-database error ordering.
+//
+// The headline finding is a genuine **divergence**, documented and guarded
+// below: direct PostgreSQL validates the database during startup and rejects a
+// nonexistent one at connect time (3D000), whereas the multigateway authenticates
+// the client and routes queries to the database its backend serves *without
+// validating the requested name* — so an unknown database is silently accepted.
+// The auth-ordering case, by contrast, matches between the two.
+
+// nonexistentDB is a database name that is not registered in the test topology
+// nor created in postgres.
+const nonexistentDB = "no_such_db_xyz"
+
+// TestNonexistentDatabaseConnectBehavior documents how the two targets diverge on
+// a nonexistent connection database: PostgreSQL rejects it at connect with
+// invalid_catalog_name (3D000); the multigateway accepts the connection (auth
+// only) and serves queries against its backend database regardless of the
+// requested name. The multigateway branch guards that current behavior — if the
+// gateway later validates the connection database, this test will flag it for an
+// intended update.
+func TestNonexistentDatabaseConnectBehavior(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	targets := setup.GetComparisonTargets(t)
+
+	// Direct PostgreSQL: the catalog is validated during startup, so the
+	// connection is rejected before ReadyForQuery with 3D000.
+	code, stage, err := probeConnect(t, ctx, targetPort(t, targets, "postgres"), nonexistentDB, shardsetup.TestPostgresPassword)
+	require.Error(t, err, "direct postgres must reject a nonexistent database")
+	t.Logf("postgres: failed at %s stage with SQLSTATE %q", stage, code)
+	assert.Equal(t, "3D000", code, "direct postgres should reject a nonexistent database with invalid_catalog_name")
+	assert.Equal(t, "connect", stage, "direct postgres rejects the database at connect time")
+
+	// Multigateway (DIVERGENCE): authentication succeeds and the gateway never
+	// validates the requested database, so the connection comes up and queries
+	// run against the served database (postgres). This guards the current
+	// behavior; it is a known divergence from PostgreSQL, not necessarily the
+	// desired end state.
+	gwDSN := buildDSN(targetPort(t, targets, "multigateway"), nonexistentDB, shardsetup.TestPostgresPassword)
+	gwConn, err := pgx.Connect(ctx, gwDSN)
+	require.NoError(t, err,
+		"DIVERGENCE: the multigateway does not validate the connection database, so a nonexistent name is accepted")
+	defer gwConn.Close(ctx)
+
+	var served string
+	require.NoError(t, gwConn.QueryRow(ctx, "SELECT current_database()").Scan(&served))
+	t.Logf("multigateway accepted database %q and served %q instead", nonexistentDB, served)
+	assert.Equal(t, "postgres", served,
+		"the gateway serves its backend database regardless of the requested (nonexistent) name")
+}
+
+// TestAuthErrorPrecedesDatabaseError asserts that when both the password is wrong
+// AND the database does not exist, both targets report the authentication error
+// (28P01) at connect time — authentication is checked before the database is
+// resolved, so the bad-database error never surfaces. This case matches between
+// PostgreSQL and the multigateway.
+func TestAuthErrorPrecedesDatabaseError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+
+	for _, target := range setup.GetComparisonTargets(t) {
+		t.Run(target.Name, func(t *testing.T) {
+			code, stage, err := probeConnect(t, ctx, target.Port, nonexistentDB, "definitely_the_wrong_password")
+			require.Error(t, err, "a wrong password must fail the connection")
+			t.Logf("%s: failed at %s stage with SQLSTATE %q", target.Name, stage, code)
+			assert.Equalf(t, "28P01", code,
+				"auth failure (28P01) must win over the nonexistent-database error, got %q", code)
+			assert.Equalf(t, "connect", stage,
+				"the auth failure must be reported at connect time, got %s", stage)
+		})
+	}
+}
+
+// buildDSN builds a libpq DSN for the test user against the given port/database.
+func buildDSN(port int, dbname, password string) string {
+	return fmt.Sprintf("host=localhost port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=5",
+		port, shardsetup.DefaultTestUser, password, dbname)
+}
+
+// probeConnect connects to a target with the given database and password, then
+// runs a trivial query, and returns the SQLSTATE and stage ("connect" or
+// "query") of the first error encountered — or ("", "none", nil) on success.
+// This normalizes the connect-time-vs-first-query timing difference between
+// direct PostgreSQL and the multigateway.
+func probeConnect(t *testing.T, ctx context.Context, port int, dbname, password string) (code, stage string, err error) {
+	t.Helper()
+	conn, cerr := pgx.Connect(ctx, buildDSN(port, dbname, password))
+	if cerr != nil {
+		return sqlState(cerr), "connect", cerr
+	}
+	defer conn.Close(ctx)
+
+	var n int
+	if qerr := conn.QueryRow(ctx, "SELECT 1").Scan(&n); qerr != nil {
+		return sqlState(qerr), "query", qerr
+	}
+	return "", "none", nil
+}
+
+// sqlState extracts the PostgreSQL SQLSTATE from an error, or "" if the error is
+// not a PostgreSQL error response.
+func sqlState(err error) string {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code
+	}
+	return ""
+}
+
+// targetPort returns the port of the named comparison target.
+func targetPort(t *testing.T, targets []shardsetup.TestTarget, name string) int {
+	t.Helper()
+	for _, target := range targets {
+		if target.Name == name {
+			return target.Port
+		}
+	}
+	t.Fatalf("comparison target %q not found", name)
+	return 0
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/pool_exhaustion_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/pool_exhaustion_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Group 3 of the PgBouncer port — pool exhaustion / capacity, ported from
+// test_limits.py.
+//
+// PgBouncer rejects connections once a pool is full; multigres instead BLOCKS:
+// when the multipooler's per-user regular pool is at capacity, a borrow waits on
+// a waitlist until a connection is returned (see
+// go/services/multipooler/pools/connpool/{pool.go,waitlist.go}). So the ported
+// assertions differ from PgBouncer's — we prove the proxy queues and proceeds
+// rather than erroring, and that a waiter whose context is cancelled is removed
+// from the waitlist cleanly (no leak, no deadlock).
+//
+// These are black-box tests over the gateway PostgreSQL wire path. Each runs in
+// its own NewIsolated cluster started with a deliberately tiny connpool
+// capacity. The multipooler splits global capacity into a regular and a reserved
+// sub-pool (reserved-ratio) and a fair-share rebalancer (rebalance-interval)
+// settles each user's slice; with --connpool-global-capacity=4
+// --connpool-reserved-ratio=0.5 the single test user's regular pool settles to 2
+// backends. We never assert the exact number though — only that concurrency is
+// capped well below the number of statements launched, which holds for any small
+// capacity and decisively catches a pool that fails to limit at all.
+
+const (
+	// smallPoolArgs starts a multipooler with a tiny connection pool so a
+	// handful of concurrent statements exhausts it. With ratio 0.5 the regular
+	// (non-pinned) sub-pool gets half of 4 = 2 backends for the lone test user;
+	// the short rebalance interval makes that slice settle within a couple of
+	// seconds. Reads default to the primary, so all load lands on one pool.
+	connpoolGlobalCapacity = "--connpool-global-capacity=4"
+	connpoolReservedRatio  = "--connpool-reserved-ratio=0.5"
+	connpoolRebalanceFast  = "--connpool-rebalance-interval=1s"
+
+	// concurrencyCeiling is a loose upper bound on the settled regular-pool
+	// capacity for one user under this config (settles to 2; 6 leaves slack for
+	// the pre-rebalance initial capacity and any internal user split). The point
+	// is that it is far below loadStatements, so a pool that does not limit at
+	// all (peak == loadStatements) fails loudly.
+	concurrencyCeiling = 6
+
+	// loadStatements is how many concurrent slow statements we launch — many
+	// more than the pool can run at once, so most must queue.
+	loadStatements = 12
+
+	// holderStatements saturate the pool for the waiter-cancellation test; more
+	// than any plausible capacity here so the probe is guaranteed to block.
+	holderStatements = 8
+)
+
+// TestPoolExhaustionBlocksThenProceeds launches far more concurrent slow
+// statements than the pool can serve at once and asserts that (a) every one
+// eventually succeeds — multigres queues rather than rejecting — and (b) the
+// number actually executing on postgres at any instant stayed capped well below
+// the number launched, proving the pool serialized them across a limited set of
+// backends. Ported from test_limits.py::test_pool_size.
+func TestPoolExhaustionBlocksThenProceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(connpoolGlobalCapacity, connpoolReservedRatio, connpoolRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	gatewayDB := openGatewayDB(t, setup)
+	defer gatewayDB.Close()
+	monitorDB := openDirectPostgresDB(t, setup)
+	defer monitorDB.Close()
+
+	settleConnpool(t, ctx, gatewayDB)
+
+	// Sample, via a connection that bypasses the pool entirely, how many of our
+	// slow statements run on postgres concurrently.
+	peak := newSleepConcurrencyMonitor(ctx, monitorDB)
+
+	var wg sync.WaitGroup
+	errs := make([]error, loadStatements)
+	for i := range loadStatements {
+		wg.Go(func() {
+			_, errs[i] = gatewayDB.ExecContext(ctx, "SELECT pg_sleep(1)")
+		})
+	}
+	wg.Wait()
+	observedPeak := peak.stop()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "statement %d must succeed — multigres queues on a full pool, it does not reject", i)
+	}
+	t.Logf("peak concurrent backends running pg_sleep: %d (launched %d concurrently)", observedPeak, loadStatements)
+
+	require.GreaterOrEqual(t, observedPeak, 1, "monitor should have observed at least one statement executing")
+	require.Less(t, observedPeak, loadStatements,
+		"the pool must cap concurrency below the number launched; peak==launched means the pool did not limit at all")
+	assert.LessOrEqualf(t, observedPeak, concurrencyCeiling,
+		"concurrency (%d) should settle near the tiny configured capacity, not balloon", observedPeak)
+}
+
+// TestPoolExhaustionWaiterCancelledCleanly saturates the pool, then issues one
+// more statement with a short deadline. That statement must BLOCK on the
+// waitlist (not be rejected) and then fail when its context expires; the elapsed
+// time proves it waited the full deadline rather than running immediately.
+// Finally, after the holders release, a fresh statement must succeed — proving
+// the cancelled waiter was removed from the waitlist cleanly, leaking no slot and
+// causing no deadlock. Ported from test_limits.py (pool-full waiter behavior).
+func TestPoolExhaustionWaiterCancelledCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(connpoolGlobalCapacity, connpoolReservedRatio, connpoolRebalanceFast),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	gatewayDB := openGatewayDB(t, setup)
+	defer gatewayDB.Close()
+	monitorDB := openDirectPostgresDB(t, setup)
+	defer monitorDB.Close()
+
+	settleConnpool(t, ctx, gatewayDB)
+
+	// Saturate the pool with long-running holders. More than any plausible
+	// capacity here, so some run and the rest queue — the pool is full.
+	holderCtx, cancelHolders := context.WithCancel(ctx)
+	var holders sync.WaitGroup
+	for range holderStatements {
+		holders.Go(func() {
+			_, _ = gatewayDB.ExecContext(holderCtx, "SELECT pg_sleep(30)")
+		})
+	}
+	// Wait until statements are actually executing on postgres, then give the
+	// remaining holders a moment to pile onto the waitlist.
+	waitForActiveSleeps(t, ctx, monitorDB, 1)
+	time.Sleep(time.Second)
+
+	// The probe must block on the full pool, then be cancelled by its deadline.
+	const probeDeadline = 800 * time.Millisecond
+	probeCtx, probeCancel := context.WithTimeout(ctx, probeDeadline)
+	start := time.Now()
+	_, probeErr := gatewayDB.ExecContext(probeCtx, "SELECT 1")
+	elapsed := time.Since(start)
+	probeCancel()
+
+	require.Error(t, probeErr, "a statement against a saturated pool must block then fail on its deadline, not return early")
+	assert.GreaterOrEqualf(t, elapsed, probeDeadline-200*time.Millisecond,
+		"probe should have blocked ~%s waiting for a slot, but returned after %s — suggests it was rejected/served, not queued", probeDeadline, elapsed)
+	t.Logf("probe against saturated pool blocked for %s then failed: %v", elapsed, probeErr)
+
+	// Release the holders; the pool must recover and serve the cancelled-waiter's
+	// successor cleanly — proof the timed-out waiter was removed from the waitlist.
+	cancelHolders()
+	holders.Wait()
+
+	require.Eventually(t, func() bool {
+		recoverCtx := utils.WithShortDeadline(t)
+		_, err := gatewayDB.ExecContext(recoverCtx, "SELECT 1")
+		return err == nil
+	}, 20*time.Second, 250*time.Millisecond,
+		"after the holders release, the pool must serve again — a leaked or deadlocked waiter would block this forever")
+}
+
+// --- shared helpers for the pool-exhaustion tests ---
+
+// openGatewayDB opens a database/sql pool against the gateway (primary path).
+// database/sql multiplexes many client connections, so the multipooler's pool —
+// not the client — is the concurrency limiter under test.
+func openGatewayDB(t *testing.T, setup *shardsetup.ShardSetup) *sql.DB {
+	t.Helper()
+	dsn := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(50)
+	db.SetMaxIdleConns(50)
+	return db
+}
+
+// openDirectPostgresDB opens a small database/sql pool straight to the primary's
+// postgres, bypassing the gateway and its connection pool. Used as a side channel
+// to observe execution concurrency even while the pool under test is saturated.
+func openDirectPostgresDB(t *testing.T, setup *shardsetup.ShardSetup) *sql.DB {
+	t.Helper()
+	dsn := shardsetup.GetTestUserDSN("localhost", setup.GetPrimary(t).Pgctld.PgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(3)
+	db.SetMaxIdleConns(3)
+	return db
+}
+
+// settleConnpool creates the test user's pool with a warmup query, then waits for
+// the fair-share rebalancer (1s interval) to clamp the user's regular slice down
+// to its small global allocation before the test measures capacity.
+func settleConnpool(t *testing.T, ctx context.Context, gatewayDB *sql.DB) {
+	t.Helper()
+	_, err := gatewayDB.ExecContext(ctx, "SELECT 1")
+	require.NoError(t, err, "warmup query should succeed")
+	time.Sleep(5 * time.Second)
+}
+
+// activeSleepQuery counts backends on postgres currently executing one of our
+// pg_sleep statements (excluding the monitor's own counting query).
+const activeSleepQuery = `SELECT count(*) FROM pg_stat_activity ` +
+	`WHERE state = 'active' AND query LIKE '%pg_sleep%' AND query NOT LIKE '%pg_stat_activity%'`
+
+// waitForActiveSleeps blocks until at least min of our slow statements are
+// executing on postgres, confirming load has reached the backend.
+func waitForActiveSleeps(t *testing.T, ctx context.Context, monitorDB *sql.DB, min int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var n int
+		sctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		if err := monitorDB.QueryRowContext(sctx, activeSleepQuery).Scan(&n); err != nil {
+			return false
+		}
+		return n >= min
+	}, 15*time.Second, 100*time.Millisecond, "expected at least %d statements executing on postgres", min)
+}
+
+// sleepConcurrencyMonitor polls the direct-postgres connection and records the
+// peak number of concurrently executing pg_sleep statements.
+type sleepConcurrencyMonitor struct {
+	done chan struct{}
+	wg   sync.WaitGroup
+	peak atomic.Int64
+}
+
+// newSleepConcurrencyMonitor starts sampling immediately; call stop() to end
+// sampling and read the peak.
+func newSleepConcurrencyMonitor(ctx context.Context, monitorDB *sql.DB) *sleepConcurrencyMonitor {
+	m := &sleepConcurrencyMonitor{done: make(chan struct{})}
+	m.wg.Go(func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-m.done:
+				return
+			case <-ticker.C:
+				var n int64
+				sctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+				err := monitorDB.QueryRowContext(sctx, activeSleepQuery).Scan(&n)
+				cancel()
+				if err == nil && n > m.peak.Load() {
+					m.peak.Store(n)
+				}
+			}
+		}
+	})
+	return m
+}
+
+// stop ends sampling and returns the peak concurrency observed.
+func (m *sleepConcurrencyMonitor) stop() int {
+	close(m.done)
+	m.wg.Wait()
+	return int(m.peak.Load())
+}

--- a/go/test/endtoend/queryserving/pgbouncertests/reserved_conn_test.go
+++ b/go/test/endtoend/queryserving/pgbouncertests/reserved_conn_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Supabase, Inc.
+// Portions derived from PgBouncer (ISC License),
+// Copyright (c) 2007-2009 Marko Kreen, Skype Technologies OÜ.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgbouncertests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Group 4 of the PgBouncer port — reserved-connection lifecycle & timeout,
+// ported from test_timeouts.py (the idle-in-transaction killer).
+//
+// A "reserved" (pinned) connection keeps one physical backend attached to a
+// client session across statements when the work is non-poolable — an open
+// transaction, a temp table, a WITH HOLD cursor, COPY, or LISTEN
+// (go/common/protoutil/reservation.go). There is no "prepared" reason: a bare
+// named Parse does not pin (that is Group 1's concern).
+//
+// Two behaviors are exercised here:
+//   - The reserved-inactivity timeout (--connpool-user-reserved-inactivity-timeout,
+//     multigres's idle-in-transaction killer): an idle pinned backend is reaped,
+//     and the session's next statement fails cleanly rather than hanging. Client
+//     activity resets the timer, so an active session is never reaped.
+//   - The pin/release boundary: while pinned, every statement in the session runs
+//     on the SAME backend even under pool churn that would otherwise rotate it;
+//     once the reservation ends (COMMIT), the session returns to the pool and its
+//     statements rotate across backends again.
+//
+// All assertions are black-box: the session reads pg_backend_pid() from its own
+// result rows (a normal value, not a side channel) and observes only query
+// success/failure. The timeout tests use NewIsolated clusters started with a
+// short inactivity timeout via WithMultipoolerExtraArgs.
+
+// shortReservedInactivityTimeout reaps an idle pinned backend after ~2s (the
+// reaper ticks at timeout/10). Short enough to keep the test quick, long enough
+// that a sub-second statement cadence comfortably keeps a session alive.
+const shortReservedInactivityTimeout = "--connpool-user-reserved-inactivity-timeout=2s"
+
+// TestReservedConnectionInactivityTimeout opens a transaction (pinning a
+// backend), lets it sit idle past the inactivity timeout, and asserts the next
+// statement fails cleanly — the multigres equivalent of PostgreSQL's
+// idle_in_transaction_session_timeout killing an abandoned transaction. It then
+// asserts the session recovers: a fresh statement succeeds on a pooled backend,
+// proving the reaped reservation was reclaimed rather than wedging the session.
+func TestReservedConnectionInactivityTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(shortReservedInactivityTimeout),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	// Pin a backend: BEGIN, then a statement inside the transaction reserves it.
+	_, err := conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+	pinnedPid := queryBackendPid(t, ctx, conn)
+	t.Logf("transaction pinned backend pid %d", pinnedPid)
+
+	// Idle past the inactivity timeout so the reaper kills the pinned backend.
+	time.Sleep(4 * time.Second)
+
+	// The next statement on the reaped reservation must fail cleanly (a returned
+	// error within the deadline), not hang.
+	stmtCtx := utils.WithShortDeadline(t)
+	_, err = conn.Exec(stmtCtx, "SELECT 1")
+	require.Error(t, err, "a statement on a reservation reaped for inactivity must fail, not succeed or hang")
+	t.Logf("statement after inactivity-reap failed cleanly: %v", err)
+
+	// The session must recover. Roll back the dead transaction (best effort) and
+	// confirm a fresh statement succeeds — proving the backend was reclaimed.
+	_, _ = conn.Exec(ctx, "ROLLBACK")
+	require.Eventually(t, func() bool {
+		recoverCtx := utils.WithShortDeadline(t)
+		var n int
+		return conn.QueryRow(recoverCtx, "SELECT 1").Scan(&n) == nil && n == 1
+	}, 15*time.Second, 250*time.Millisecond,
+		"after the reserved backend is reaped the session must serve again on a pooled connection")
+}
+
+// TestReservedConnectionSurvivesWithActivity is the inverse control: a
+// transaction that keeps issuing statements faster than the inactivity timeout
+// is never reaped, and — because it is pinned — every statement runs on the same
+// backend. Proves the timeout is inactivity-based (reset by activity) and that a
+// reservation pins one backend for the session's duration.
+func TestReservedConnectionSurvivesWithActivity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2), // primary + standby (bootstrap needs 2)
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultipoolerExtraArgs(shortReservedInactivityTimeout),
+	)
+	defer cleanup()
+	setup.WaitForMultigatewayQueryServing(t)
+
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	_, err := conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+	pinnedPid := queryBackendPid(t, ctx, conn)
+
+	// Six statements at a 1s cadence spans 5s — well past the 2s timeout in
+	// aggregate, but no single gap reaches it, so the pinned backend survives and
+	// stays the same throughout.
+	for i := range 6 {
+		time.Sleep(time.Second)
+		stmtCtx := utils.WithShortDeadline(t)
+		var n int
+		require.NoErrorf(t, conn.QueryRow(stmtCtx, "SELECT 1").Scan(&n),
+			"statement %d should keep the pinned backend alive (activity resets the inactivity timer)", i)
+		require.Equalf(t, pinnedPid, queryBackendPid(t, ctx, conn),
+			"a pinned transaction must stay on backend %d across statements", pinnedPid)
+	}
+
+	_, err = conn.Exec(ctx, "COMMIT")
+	require.NoError(t, err)
+}
+
+// TestTransactionPinsBackendThenReleases proves the reservation boundary: inside
+// a transaction every statement runs on the same backend even under pool churn
+// that would otherwise rotate it (Group 1 shows non-pinned sessions DO rotate);
+// after COMMIT the session rejoins the pool and its statements rotate across
+// backends again. Uses the shared cluster (no fault injection, default timeouts).
+func TestTransactionPinsBackendThenReleases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping")
+	}
+
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 90*time.Second)
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	conn := connectGateway(t, ctx, gatewayDSN)
+	defer conn.Close(ctx)
+
+	stopChurn := startPoolChurn(t, ctx, gatewayDSN, churnClients)
+	defer stopChurn()
+
+	// Pinned: every statement in the transaction must hit the same backend,
+	// despite the churn rotating the pool underneath.
+	_, err := conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+	pinnedPid := queryBackendPid(t, ctx, conn)
+	for i := range minExecutes {
+		require.Equalf(t, pinnedPid, queryBackendPid(t, ctx, conn),
+			"statement %d inside the transaction must stay pinned to backend %d", i, pinnedPid)
+	}
+	t.Logf("transaction stayed pinned to backend %d across %d statements under churn", pinnedPid, minExecutes)
+
+	_, err = conn.Exec(ctx, "COMMIT")
+	require.NoError(t, err)
+
+	// Released: back in the pool, the session's statements rotate across backends
+	// again (>=2 distinct), confirming the reservation ended at COMMIT.
+	runAcrossBackends(t, ctx, func(ctx context.Context, _ int) int {
+		return queryBackendPid(t, ctx, conn)
+	})
+}
+
+// queryBackendPid reads the backend pid serving the connection's current
+// statement, via the connection's own result row.
+func queryBackendPid(t *testing.T, ctx context.Context, conn *pgx.Conn) int {
+	t.Helper()
+	var pid int
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid))
+	return pid
+}


### PR DESCRIPTION
## Summary

- Adds the `pgbouncertests` end-to-end suite — pooling, session-state, and fault-recovery behavior on the `multigateway → multipooler → postgres` path, with scenarios ported from [PgBouncer's test suite](https://github.com/pgbouncer/pgbouncer/tree/master/test) (ISC-licensed).
- Covers backend crash recovery under load + transparent reconnect, pool exhaustion (multigres queues rather than rejecting), reserved-connection pin/release + idle-in-transaction timeout, cancel-race, `COPY` interrupted by a backend crash, and connecting to a nonexistent database (differential vs. PostgreSQL).
- Test-only: no product or proto changes. Builds on #1087, which landed the `DISCARD ALL` gateway fix, the Group 1 prepared-statement tests, and the `shardsetup.WithMultipoolerExtraArgs` harness option.

## Description

The tests are **black-box**: they speak only the PostgreSQL wire protocol to the multigateway and observe only what a client can — query results, errors, and `pg_backend_pid()` read from the client's own rows. Pooled-backend rotation is induced with concurrent churn (`startPoolChurn`) and asserted via distinct `pg_backend_pid()` values rather than forcing a specific internal swap, so a test is never green-by-luck. Fault tests inject crashes with `KillPostgres`, and each runs in its own `shardsetup.NewIsolated` cluster so the damage can't leak into the shared-cluster tests.

The suite runs in the standard e2e integration job (no opt-in label); tests self-skip in `-short` or when the PostgreSQL binaries are absent. See the package `README.md` for the file→scenario map, the approach, and known divergences from PostgreSQL — notably that the gateway serves its backend database for an unknown requested database instead of rejecting with `3D000` (guarded by `nonexistent_db_test.go`).
