### PR TITLE
fix(multigateway): validate SET against PostgreSQL at SET time

### DIFF
--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -28,24 +28,24 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// ApplySessionState handles SET/RESET commands by updating local session state only.
+// ApplySessionState records a SET/RESET in the gateway's local session-settings
+// tracker. The pool propagates the tracked settings to a backend on the next
+// query via ApplySettings, so the change survives pool rotation.
 //
-// Neither SET nor RESET is routed to PostgreSQL. Both are applied locally and
-// return a synthetic CommandComplete response. The pool propagates these settings
-// to the backend connection on the next query via ApplySettings.
+// This primitive does NOT validate against PostgreSQL — it only records state.
+// Validation is the planner's job: a real `SET var = value` is planned as
+// Sequence[ValidateSetting, ApplySessionState] (see planner.planVariableSetStmt).
+// The ValidateSetting step runs set_config(..., is_local := true) on a backend so
+// an invalid name/value errors at SET time (but leaves no backend state behind),
+// and this primitive runs only if that succeeded — recording the setting and
+// emitting CommandComplete("SET"). A silent variant of this primitive is also
+// used for `SELECT set_config(...)` (see planner.planSelectStmt), where a
+// trailing Route owns the client response.
 //
-// Behaviour deviation from PostgreSQL:
-// SET commands are NOT validated against PostgreSQL. This means a client can SET
-// an invalid variable name or value without receiving an immediate error. The error
-// will surface on the next query when the pool tries to apply the setting to a
-// backend connection. The client must RESET the bad variable to recover. This
-// trade-off was chosen intentionally to keep the SET/RESET path simple. It may
-// be revisited in the future if stricter validation is needed.
-//
-// For RESET/RESET ALL:
-// The variable is removed from SessionSettings. On the next query, the merged
-// settings (SessionSettings overlaid on StartupParams) will fall back to the
-// startup parameter value, and the pool will apply the correct SET commands.
+// RESET/RESET ALL run through this primitive directly (no backend round-trip):
+// the variable is removed from SessionSettings, and on the next query the merged
+// settings (SessionSettings overlaid on StartupParams) fall back to the
+// startup/default value.
 type ApplySessionState struct {
 	// VariableStmt is the SET/RESET statement from the AST.
 	VariableStmt *ast.VariableSetStmt

--- a/go/services/multigateway/engine/validate_setting.go
+++ b/go/services/multigateway/engine/validate_setting.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// ValidateSetting validates a SET's value against PostgreSQL without persisting
+// it on the pooled backend.
+//
+// It runs `SELECT pg_catalog.set_config(name, value, true)` on a backend. The
+// is_local := true argument scopes the change to the statement's own implicit
+// transaction, so it reverts the instant the statement completes — leaving the
+// backend's session state (and therefore multipooler's per-backend connstate)
+// exactly as it was. multipooler must remain the sole authority on backend
+// session GUCs; routing a raw `SET name = value` here would mutate the backend
+// behind its back and break a later RESET (the pooler wouldn't know to reset
+// the orphaned value). set_config still validates the value, so an invalid name
+// or out-of-range value raises the same error a real SET would, surfacing it at
+// SET time rather than on a later unrelated query.
+//
+// The result row is discarded; this primitive emits nothing to the client. It
+// is the first step of Sequence[ValidateSetting, ApplySessionState]: the
+// trailing ApplySessionState records the setting for pool-rotation replay and
+// emits the synthetic CommandComplete("SET"), and runs only if validation
+// succeeded because the Sequence stops on the first child's error.
+type ValidateSetting struct {
+	TableGroup string
+	Shard      string
+	// Name and Value are the SET's variable name and value (already unquoted by
+	// the parser); they are re-quoted as SQL string literals in validateSQL.
+	Name  string
+	Value string
+	// Query is the original SQL string, for debug output.
+	Query string
+}
+
+// NewValidateSetting creates a ValidateSetting primitive.
+func NewValidateSetting(tableGroup, shard, name, value, sql string) *ValidateSetting {
+	return &ValidateSetting{
+		TableGroup: tableGroup,
+		Shard:      shard,
+		Name:       name,
+		Value:      value,
+		Query:      sql,
+	}
+}
+
+// validateSQL deparses `SELECT pg_catalog.set_config('<name>', '<value>', true)`
+// from an AST rather than formatting a string. Building the tree and letting the
+// deparser render it means the name and value are quoted/escaped by the
+// canonical path (ast.QuoteStringLiteral), so a single quote in either — a
+// hostile variable name or value — cannot break out of the string literal.
+// is_local is true so the validation reverts when the statement completes.
+func (v *ValidateSetting) validateSQL() string {
+	funcname := ast.NewNodeList(ast.NewString("pg_catalog"), ast.NewString("set_config"))
+	args := ast.NewNodeList(
+		ast.NewA_Const(ast.NewString(v.Name), 0),
+		ast.NewA_Const(ast.NewString(v.Value), 0),
+		ast.NewA_Const(ast.NewBoolean(true), 0),
+	)
+	sel := ast.NewSelectStmt()
+	sel.TargetList.Append(ast.NewResTarget("", ast.NewFuncCall(funcname, args, 0)))
+	return sel.SqlString()
+}
+
+// discardResults swallows result chunks: only an execution error matters here.
+func discardResults(context.Context, *sqltypes.Result) error { return nil }
+
+// StreamExecute runs the validation query on a backend and propagates any error,
+// discarding the result row. bindVars/callback are unused: the validation SQL is
+// fully formed from the literal name/value, and this step is silent.
+func (v *ValidateSetting) StreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	_ []*ast.A_Const,
+	_ func(context.Context, *sqltypes.Result) error,
+) error {
+	return exec.StreamExecute(ctx, conn, v.TableGroup, v.Shard, v.validateSQL(), nil, state, discardResults)
+}
+
+// PortalStreamExecute mirrors StreamExecute. The validation SQL carries no
+// parameters, so the portal's binds are irrelevant.
+func (v *ValidateSetting) PortalStreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	_ *preparedstatement.PortalInfo,
+	_ int32,
+	_ bool,
+	_ func(context.Context, *sqltypes.Result) error,
+) error {
+	return exec.StreamExecute(ctx, conn, v.TableGroup, v.Shard, v.validateSQL(), nil, state, discardResults)
+}
+
+// GetTableGroup returns the target tablegroup.
+func (v *ValidateSetting) GetTableGroup() string { return v.TableGroup }
+
+// GetQuery returns the original SQL string.
+func (v *ValidateSetting) GetQuery() string { return v.Query }
+
+// String returns a description for debugging.
+func (v *ValidateSetting) String() string {
+	return fmt.Sprintf("ValidateSetting(%s=%s)", v.Name, v.Value)
+}
+
+// Ensure ValidateSetting implements Primitive.
+var _ Primitive = (*ValidateSetting)(nil)

--- a/go/services/multigateway/engine/validate_setting_test.go
+++ b/go/services/multigateway/engine/validate_setting_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSetting_ValidateSQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		varName  string
+		varValue string
+		want     string
+	}{
+		{
+			name:     "plain",
+			varName:  "extra_float_digits",
+			varValue: "100",
+			want:     "SELECT pg_catalog.set_config('extra_float_digits', '100', TRUE)",
+		},
+		{
+			name:     "is_local true so the validation reverts after the statement",
+			varName:  "search_path",
+			varValue: "myschema",
+			want:     "SELECT pg_catalog.set_config('search_path', 'myschema', TRUE)",
+		},
+		{
+			name:     "single quote in value is doubled (no breakout)",
+			varName:  "search_path",
+			varValue: "a'); DROP TABLE t; --",
+			want:     "SELECT pg_catalog.set_config('search_path', 'a''); DROP TABLE t; --', TRUE)",
+		},
+		{
+			name:     "single quote in name is doubled too",
+			varName:  "mtinject.it's",
+			varValue: "value",
+			want:     "SELECT pg_catalog.set_config('mtinject.it''s', 'value', TRUE)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewValidateSetting("default", "0-inf", tt.varName, tt.varValue, "SET ...")
+			assert.Equal(t, tt.want, v.validateSQL())
+		})
+	}
+}
+
+// TestValidateSetting_PropagatesError confirms the primitive surfaces the
+// backend's error (e.g. an out-of-range value) up to the caller — this is what
+// makes a bad SET fail at SET time. The Sequence relies on this to stop before
+// the tracking step.
+func TestValidateSetting_PropagatesError(t *testing.T) {
+	wantErr := errors.New("100 is outside the valid range for parameter \"extra_float_digits\" (-15 .. 3)")
+	mockExec := &mockIExecute{streamExecuteErr: wantErr}
+
+	v := NewValidateSetting("default", "0-inf", "extra_float_digits", "100", "SET extra_float_digits = 100")
+	err := v.StreamExecute(context.Background(), mockExec, nil, nil, nil, nil)
+	require.ErrorIs(t, err, wantErr, "validation error must propagate so the SET fails at SET time")
+}
+
+// TestValidateSetting_SuccessReturnsNil confirms a successful validation returns
+// nil (the trailing ApplySessionState then tracks the setting and emits the SET
+// tag). Row discarding itself is exercised end-to-end in the session-settings
+// e2e, where the client sees CommandComplete("SET") rather than a result row.
+func TestValidateSetting_SuccessReturnsNil(t *testing.T) {
+	v := NewValidateSetting("default", "0-inf", "work_mem", "64MB", "SET work_mem = '64MB'")
+	err := v.StreamExecute(context.Background(), &mockIExecute{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+}

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -271,7 +271,18 @@ func (p *Planner) PlanPortal(
 	switch stmt.NodeTag() {
 	case ast.T_VariableSetStmt:
 		setStmt := stmt.(*ast.VariableSetStmt)
-		if isGatewayManagedVariable(setStmt.Name) || setStmt.Kind == ast.VAR_RESET_ALL {
+		// Mirror planVariableSetStmt's local-vs-forward decision so the
+		// extended-protocol path validates and tracks SET exactly like the
+		// simple protocol. Gateway-managed variables and the locally-handled
+		// kinds (plain SET, RESET, RESET ALL, SET TO DEFAULT) are planned here;
+		// only SET LOCAL and SET TRANSACTION / SET ... FROM CURRENT — which the
+		// backend is authoritative for — fall through to a plain portal execute.
+		// Without this, a non-gateway SET over the extended protocol forwarded a
+		// raw SET to the backend: it mutated backend state outside multipooler's
+		// tracking (breaking a later RESET) and never tracked the setting for
+		// pool-rotation replay.
+		if isGatewayManagedVariable(setStmt.Name) ||
+			(!setStmt.IsLocal && setStmt.Kind != ast.VAR_SET_MULTI && setStmt.Kind != ast.VAR_SET_CURRENT) {
 			return p.Plan(portalInfo.PreparedStatementInfo.Query, stmt, conn)
 		}
 		return nil, nil

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
@@ -27,9 +28,16 @@ import (
 )
 
 // planVariableSetStmt plans SET/RESET commands.
-// Creates an ApplySessionState that handles SET and RESET as local state updates
-// with synthetic responses. PG validation is deferred to the next query when
-// the pool applies settings to the backend connection.
+//
+//   - SET var = value (non gateway-managed, non-LOCAL) is planned as
+//     Sequence[ValidateSetting, ApplySessionState]: ValidateSetting runs
+//     set_config(name, value, is_local := true) on a backend so an invalid
+//     name/value errors at SET time (matching PostgreSQL) without persisting on
+//     the pooled backend, and ApplySessionState records it for pool-rotation
+//     replay only if validation succeeded.
+//   - RESET / RESET ALL update local tracking only (no backend round-trip).
+//   - Gateway-managed variables, SET LOCAL, and SET TRANSACTION / FROM CURRENT
+//     are handled by their dedicated paths below.
 func (p *Planner) planVariableSetStmt(
 	sql string,
 	stmt *ast.VariableSetStmt,
@@ -76,8 +84,32 @@ func (p *Planner) planVariableSetStmt(
 	}
 
 	switch stmt.Kind {
-	case ast.VAR_SET_VALUE, ast.VAR_RESET, ast.VAR_RESET_ALL:
-		// These are tracked locally
+	case ast.VAR_SET_VALUE:
+		// Validate the value against PostgreSQL, then track it locally. The
+		// ValidateSetting step runs set_config(name, value, is_local := true),
+		// which validates the value (an invalid name or out-of-range value
+		// errors at SET time, matching PostgreSQL) but reverts immediately, so
+		// no state is left on the pooled backend — multipooler stays the sole
+		// authority on backend session GUCs. The Sequence stops on the first
+		// child's error, so a rejected SET never reaches the tracker. On success
+		// the trailing ApplySessionState records the setting for pool-rotation
+		// replay and emits CommandComplete("SET").
+		value := extractVariableValue(stmt.Args)
+		validate := engine.NewValidateSetting(p.defaultTableGroup, constants.DefaultShard, stmt.Name, value, sql)
+		track := engine.NewApplySessionState(sql, stmt)
+		plan := engine.NewPlan(sql, engine.NewSequence([]engine.Primitive{validate, track}))
+		p.logger.Debug("created validate-then-track SET plan",
+			"variable", stmt.Name, "plan", plan.String())
+		return plan, nil
+
+	case ast.VAR_RESET, ast.VAR_RESET_ALL:
+		// RESET clears local tracking; the merged settings the pool applies on
+		// the next query then fall back to the startup/default value. No
+		// PostgreSQL round-trip is needed.
+		plan := engine.NewPlan(sql, engine.NewApplySessionState(sql, stmt))
+		p.logger.Debug("created RESET plan",
+			"kind", stmt.Kind, "variable", stmt.Name, "plan", plan.String())
+		return plan, nil
 
 	case ast.VAR_SET_MULTI, ast.VAR_SET_CURRENT:
 		// VAR_SET_MULTI: SET TRANSACTION / SET SESSION CHARACTERISTICS — transaction-scoped,
@@ -90,16 +122,6 @@ func (p *Planner) planVariableSetStmt(
 	default:
 		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET kind %d is not yet supported", stmt.Kind))
 	}
-
-	p.logger.Debug("planning SET/RESET command",
-		"kind", stmt.Kind,
-		"variable", stmt.Name)
-
-	primitive := engine.NewApplySessionState(sql, stmt)
-
-	plan := engine.NewPlan(sql, primitive)
-	p.logger.Debug("created SET/RESET plan", "plan", plan.String())
-	return plan, nil
 }
 
 // isGatewayManagedVariable returns true for session variables that are managed

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -42,9 +42,15 @@ func TestPlanVariableSetStmt_SET(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 
-	// The primitive should be an ApplySessionState
-	_, ok := plan.Primitive.(*engine.ApplySessionState)
-	assert.True(t, ok, "expected ApplySessionState primitive")
+	// SET var = value is validated on a backend then tracked locally, so the
+	// plan is Sequence[ValidateSetting, ApplySessionState].
+	seq, ok := plan.Primitive.(*engine.Sequence)
+	require.True(t, ok, "expected Sequence primitive, got %T", plan.Primitive)
+	require.Len(t, seq.Primitives, 2, "expected [ValidateSetting, ApplySessionState]")
+	_, ok = seq.Primitives[0].(*engine.ValidateSetting)
+	assert.True(t, ok, "first primitive should be ValidateSetting (validate on backend), got %T", seq.Primitives[0])
+	_, ok = seq.Primitives[1].(*engine.ApplySessionState)
+	assert.True(t, ok, "second primitive should be ApplySessionState (track + emit SET), got %T", seq.Primitives[1])
 }
 
 func TestPlanVariableSetStmt_RESET(t *testing.T) {

--- a/go/services/multigateway/planner/variable_set_stmt_test.go
+++ b/go/services/multigateway/planner/variable_set_stmt_test.go
@@ -186,3 +186,46 @@ func TestPlanVariableSetStmt_SET_CURRENT_PassesThrough(t *testing.T) {
 	_, ok := plan.Primitive.(*engine.ApplySessionState)
 	assert.False(t, ok, "SET FROM CURRENT should not produce ApplySessionState")
 }
+
+// TestPlanPortal_SET pins that the extended-protocol path plans SET/RESET the
+// same way the simple protocol does: plain SET validates + tracks (Sequence),
+// RESET tracks locally, and only SET LOCAL / SET TRANSACTION fall through to a
+// plain portal execute. A nil plan for a plain SET would forward a raw SET to a
+// pooled backend — mutating it outside multipooler's tracking and skipping
+// pool-rotation replay.
+func TestPlanPortal_SET(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	t.Run("plain SET is planned (validate + track)", func(t *testing.T) {
+		plan, err := p.PlanPortal(newPortalInfoFor(t, "SET work_mem = '256MB'"), testConn.Conn)
+		require.NoError(t, err)
+		require.NotNil(t, plan, "non-gateway SET must be planned, not forwarded raw to a pooled backend")
+		seq, ok := plan.Primitive.(*engine.Sequence)
+		require.True(t, ok, "expected Sequence, got %T", plan.Primitive)
+		require.Len(t, seq.Primitives, 2)
+		_, ok = seq.Primitives[0].(*engine.ValidateSetting)
+		assert.True(t, ok, "first primitive should be ValidateSetting, got %T", seq.Primitives[0])
+	})
+
+	t.Run("RESET is planned", func(t *testing.T) {
+		plan, err := p.PlanPortal(newPortalInfoFor(t, "RESET work_mem"), testConn.Conn)
+		require.NoError(t, err)
+		require.NotNil(t, plan, "RESET must be planned so it clears local tracking")
+		_, ok := plan.Primitive.(*engine.ApplySessionState)
+		assert.True(t, ok, "expected ApplySessionState, got %T", plan.Primitive)
+	})
+
+	t.Run("SET LOCAL falls through to PG", func(t *testing.T) {
+		plan, err := p.PlanPortal(newPortalInfoFor(t, "SET LOCAL work_mem = '256MB'"), testConn.Conn)
+		require.NoError(t, err)
+		assert.Nil(t, plan, "SET LOCAL is forwarded to the backend (authoritative)")
+	})
+
+	t.Run("SET TRANSACTION falls through to PG", func(t *testing.T) {
+		plan, err := p.PlanPortal(newPortalInfoFor(t, "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"), testConn.Conn)
+		require.NoError(t, err)
+		assert.Nil(t, plan, "SET TRANSACTION is forwarded to the backend")
+	})
+}

--- a/go/test/endtoend/queryserving/observability_test.go
+++ b/go/test/endtoend/queryserving/observability_test.go
@@ -165,13 +165,15 @@ func TestGatewayQuerySpanAttributes(t *testing.T) {
 		assert.False(t, found, "Transaction should not have db.tables_used")
 	})
 
-	// ApplySessionState: SET search_path is not gateway-managed, goes to postgres.
-	t.Run("ApplySessionState", func(t *testing.T) {
-		span := findSpanWithPlanType("ApplySessionState")
-		require.NotNil(t, span, "expected an ApplySessionState span")
+	// Sequence: SET search_path is not gateway-managed, so it is validated on a
+	// backend (set_config) and then tracked — planned as
+	// Sequence[ValidateSetting, ApplySessionState].
+	t.Run("Sequence", func(t *testing.T) {
+		span := findSpanWithPlanType("Sequence")
+		require.NotNil(t, span, "expected a Sequence span (SET search_path)")
 
 		_, found := shardsetup.FindSpanAttributeArray(span, "db.tables_used")
-		assert.False(t, found, "ApplySessionState should not have db.tables_used")
+		assert.False(t, found, "Sequence (SET) should not have db.tables_used")
 	})
 
 	// Multi-statement batch: the batch-level span should have no db.plan.type

--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -353,36 +353,32 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 
 	// Test 10: Error handling — invalid SET params
 	//
-	// Behaviour deviation from PostgreSQL: SET commands are applied locally
-	// without validation. Invalid variables are accepted at SET time; errors
-	// surface on the next query when the pool tries to apply the setting.
+	// SET is validated against PostgreSQL at SET time (the gateway runs
+	// set_config(..., is_local := true) before tracking it), so an unrecognized
+	// variable errors immediately and is never tracked — matching PostgreSQL,
+	// and leaving the session uncorrupted (no RESET-to-recover dance).
 	t.Run("error handling", func(t *testing.T) {
 		// Set valid value first
 		_, err := db.ExecContext(ctx, "SET work_mem = '64MB'")
 		require.NoError(t, err, "failed to SET valid value")
 
-		// SET with invalid variable succeeds locally (not validated against PG)
+		// An unrecognized variable now errors at SET time and is not tracked.
 		_, err = db.ExecContext(ctx, "SET invalid_variable_12345 = 'value'")
-		require.NoError(t, err, "invalid SET should succeed locally (behaviour deviation from PG)")
+		require.Error(t, err, "invalid SET should error at SET time (validated against PG)")
+		assert.Contains(t, err.Error(), "unrecognized configuration parameter",
+			"should be PostgreSQL's unrecognized-parameter error")
 
-		// Next query should fail because the pool tries to apply the bad setting
+		// The rejected SET corrupts nothing: the connection stays healthy and the
+		// earlier valid setting is intact.
 		var result string
-		err = db.QueryRowContext(ctx, "SHOW work_mem").Scan(&result)
-		require.Error(t, err, "query after invalid SET should fail when pool applies bad setting")
-
-		// RESET the bad variable to recover
-		_, err = db.ExecContext(ctx, "RESET invalid_variable_12345")
-		require.NoError(t, err, "RESET of invalid variable should succeed")
-
-		// Connection should be usable again with original work_mem intact
 		for i := range 100 {
 			err = db.QueryRowContext(ctx, "SHOW work_mem").Scan(&result)
-			require.NoError(t, err, "iteration %d: should work after RESET of bad variable", i)
+			require.NoError(t, err, "iteration %d: connection should remain usable", i)
 			require.Equal(t, "64MB", result, "iteration %d: work_mem should still be 64MB", i)
 
 			var one int
 			err = db.QueryRowContext(ctx, "SELECT 1").Scan(&one)
-			require.NoError(t, err, "iteration %d: connection should be usable after recovery", i)
+			require.NoError(t, err, "iteration %d: connection should be usable", i)
 			require.Equal(t, 1, one)
 		}
 	})
@@ -621,24 +617,20 @@ func TestMultiGateway_SessionSettingsSQLInjection(t *testing.T) {
 	})
 
 	t.Run("connection survives a single quote in the variable name", func(t *testing.T) {
-		// The GUC name is also embedded in the apply query literal, so it is
-		// escaped too (covered deterministically by the unit test
-		// TestSettingsApplyQuerySingleQuoteInName). Such a custom name is not a
-		// valid GUC, so applying it fails — but it must fail as a clean PostgreSQL
-		// error and leave the pooled connection usable, never as a broken-out
-		// multi-statement apply query.
+		// The GUC name is embedded in the set_config validation literal, so a
+		// single quote in it is escaped (doubled), exactly like the value
+		// (covered deterministically by TestSettingsApplyQuerySingleQuoteInName).
+		// Such a name is not a valid GUC, so validation now fails at SET time —
+		// but it must fail as a clean PostgreSQL error and leave the pooled
+		// connection usable, never as a broken-out multi-statement query.
 		_, err := db.ExecContext(ctx, `SET "mtinject.it's" = 'value'`)
-		require.NoError(t, err, "SET with quote in name should be accepted locally")
+		require.Error(t, err, "SET with an invalid (quoted) name should error, not inject")
 
-		var got string
-		_ = db.QueryRowContext(ctx, `SHOW "mtinject.it's"`).Scan(&got)
-
-		_, err = db.ExecContext(ctx, `RESET "mtinject.it's"`)
-		require.NoError(t, err, "RESET should recover the connection")
-
+		// The quote must not have escaped the literal: the connection stays
+		// usable and the next statement runs normally.
 		var one int
 		err = db.QueryRowContext(ctx, "SELECT 1").Scan(&one)
-		require.NoError(t, err, "connection should be usable after recovery")
+		require.NoError(t, err, "connection should be usable after the rejected SET")
 		require.Equal(t, 1, one)
 	})
 }

--- a/go/test/endtoend/queryserving/set_validation_test.go
+++ b/go/test/endtoend/queryserving/set_validation_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,5 +82,45 @@ func TestMultiGateway_SetValidation(t *testing.T) {
 		var got string
 		require.NoError(t, conn.QueryRow(ctx, "SHOW extra_float_digits").Scan(&got))
 		assert.Equal(t, "2", got, "the valid setting should be applied")
+	})
+
+	// The extended protocol (Parse/Bind/Execute) must validate and track SET
+	// identically. pgx.QueryExecModeExec forces it, the way clients like the
+	// PostgreSQL JDBC driver always send statements — even parameterless ones.
+	// Previously this path forwarded a raw SET to a pooled backend (no
+	// validation, no tracking, and a later RESET could not undo it).
+	t.Run("extended protocol: out-of-range SET errors immediately", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, "SET extra_float_digits = 100", pgx.QueryExecModeExec)
+		require.Error(t, err, "out-of-range SET over the extended protocol should error at SET time")
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected a PgError, got %T: %v", err, err)
+		assert.Equal(t, "22023", pgErr.Code, "should be invalid_parameter_value")
+	})
+
+	// Tracking + RESET over the extended protocol: a valid SET is applied and a
+	// subsequent RESET reverts it. This proves the extended path tracks the
+	// setting (rather than orphaning it on a backend), so RESET works.
+	t.Run("extended protocol: SET tracks and RESET reverts", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+		const m = pgx.QueryExecModeExec
+
+		_, err := conn.Exec(ctx, "SET search_path = 'custom_ext'", m)
+		require.NoError(t, err, "valid SET over the extended protocol should succeed")
+
+		var got string
+		require.NoError(t, conn.QueryRow(ctx, "SHOW search_path", m).Scan(&got))
+		assert.Equal(t, "custom_ext", got, "extended-protocol SET should be tracked and applied")
+
+		_, err = conn.Exec(ctx, "RESET search_path", m)
+		require.NoError(t, err, "RESET over the extended protocol should succeed")
+
+		require.NoError(t, conn.QueryRow(ctx, "SHOW search_path", m).Scan(&got))
+		assert.NotEqual(t, "custom_ext", got, "RESET must revert — the extended SET must not orphan backend state")
+		assert.Contains(t, got, "public", "default search_path contains public")
 	})
 }

--- a/go/test/endtoend/queryserving/set_validation_test.go
+++ b/go/test/endtoend/queryserving/set_validation_test.go
@@ -26,25 +26,23 @@ import (
 	"github.com/multigres/multigres/go/test/utils"
 )
 
-// TestMultiGateway_SetValidationIsDeferred pins down whether the multigateway
-// validates a SET against PostgreSQL at SET time (PG parity) or accepts it
-// locally and lets the error surface later.
+// TestMultiGateway_SetValidation verifies that the multigateway validates a SET
+// against PostgreSQL at SET time (PostgreSQL parity), rather than accepting it
+// locally and letting the error surface later on an unrelated query.
 //
-// Today the gateway defers: SET is applied to local session state with a
-// synthetic CommandComplete and only reaches a backend on the next query (see
-// go/services/multigateway/engine/apply_session_state.go). That deferral is the
-// root cause of the pgvector compatibility failures:
-//   - hnsw_vector / ivfflat_vector: out-of-range SETs of the extension's GUCs
-//     (e.g. SET hnsw.ef_search = 1001) don't raise the range error at SET time.
-//   - ivfflat_bit (downstream): the deferred erroring SET is flushed on the
-//     following statement and aborts a DROP TABLE, leaking a table into the
-//     next test.
+// A `SET var = value` is planned as Sequence[ValidateSetting, ApplySessionState]
+// (see planner.planVariableSetStmt): the ValidateSetting step runs
+// set_config(name, value, is_local := true) on a backend, so an invalid or
+// out-of-range value raises its error immediately — and reverts, leaving the
+// pooled backend untouched — while the setting is tracked only on success. This
+// is what makes pgvector's tuning GUCs behave like vanilla PostgreSQL (e.g.
+// SET hnsw.ef_search = 1001 errors at SET time instead of derailing a later
+// statement and aborting an unrelated DROP TABLE).
 //
-// extra_float_digits is used as a stand-in: it's a plain (non gateway-managed)
-// GUC with a validated integer range of -15..3, so vanilla PostgreSQL rejects
-// an out-of-range SET immediately with SQLSTATE 22023 — exactly the behaviour
-// pgvector's GUCs expect.
-func TestMultiGateway_SetValidationIsDeferred(t *testing.T) {
+// extra_float_digits is the stand-in: a plain (non gateway-managed) GUC with a
+// validated integer range of -15..3, so PostgreSQL rejects an out-of-range SET
+// with SQLSTATE 22023.
+func TestMultiGateway_SetValidation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping SET validation test in short mode")
 	}
@@ -56,44 +54,32 @@ func TestMultiGateway_SetValidationIsDeferred(t *testing.T) {
 	setup.SetupTest(t)
 	ctx := utils.WithTimeout(t, 30*time.Second)
 
-	// Out-of-range for extra_float_digits (valid -15..3). Vanilla PostgreSQL:
-	//   ERROR:  100 is outside the valid range for parameter "extra_float_digits" (-15 .. 3)
-	const badSet = "SET extra_float_digits = 100"
-
-	// Desired behaviour (PostgreSQL parity): the bad SET errors at SET time.
-	// This currently FAILS — the gateway accepts the SET locally without
-	// touching a backend — and documents the gap to close.
+	// An out-of-range value errors at SET time, just like vanilla PostgreSQL —
+	// not on a later, unrelated statement.
 	t.Run("out-of-range SET errors immediately", func(t *testing.T) {
 		conn := connectPgx(t, ctx, setup)
 		defer conn.Close(ctx)
 
-		_, err := conn.Exec(ctx, badSet)
-		require.Error(t, err, "SET with an out-of-range value should error at SET time, like vanilla PostgreSQL")
+		// extra_float_digits valid range is -15..3.
+		_, err := conn.Exec(ctx, "SET extra_float_digits = 100")
+		require.Error(t, err, "out-of-range SET should error at SET time, like vanilla PostgreSQL")
 
 		var pgErr *pgconn.PgError
 		require.True(t, errors.As(err, &pgErr), "expected a PgError, got %T: %v", err, err)
 		assert.Equal(t, "22023", pgErr.Code, "should be invalid_parameter_value")
 	})
 
-	// Characterises the current deferral: a wholly unrelated later statement
-	// carries the SET's validation error. This is the mechanism that aborts the
-	// next pgvector test's DROP TABLE. Once SET is validated eagerly this subtest
-	// self-skips (the SET above already errored), so the test stays meaningful
-	// after the fix.
-	t.Run("deferred error attaches to a later unrelated statement", func(t *testing.T) {
+	// A valid value is accepted and applied: validation does not get in the way
+	// of normal SETs, and the setting is visible to a subsequent SHOW.
+	t.Run("valid SET succeeds and takes effect", func(t *testing.T) {
 		conn := connectPgx(t, ctx, setup)
 		defer conn.Close(ctx)
 
-		if _, err := conn.Exec(ctx, badSet); err != nil {
-			t.Skipf("SET now errors eagerly (deferral fixed); nothing to characterise: %v", err)
-		}
+		_, err := conn.Exec(ctx, "SET extra_float_digits = 2")
+		require.NoError(t, err, "valid SET should succeed")
 
-		_, err := conn.Exec(ctx, "SELECT 1")
-		require.Error(t, err, "the deferred SET error should surface here, on an unrelated statement")
-
-		var pgErr *pgconn.PgError
-		require.True(t, errors.As(err, &pgErr), "expected a PgError, got %T: %v", err, err)
-		assert.Equal(t, "22023", pgErr.Code, "the late error is the SET's range violation")
-		t.Logf("deferred SET error surfaced on a later SELECT 1: %s (SQLSTATE %s)", pgErr.Message, pgErr.Code)
+		var got string
+		require.NoError(t, conn.QueryRow(ctx, "SHOW extra_float_digits").Scan(&got))
+		assert.Equal(t, "2", got, "the valid setting should be applied")
 	})
 }

--- a/go/test/endtoend/queryserving/set_validation_test.go
+++ b/go/test/endtoend/queryserving/set_validation_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMultiGateway_SetValidationIsDeferred pins down whether the multigateway
+// validates a SET against PostgreSQL at SET time (PG parity) or accepts it
+// locally and lets the error surface later.
+//
+// Today the gateway defers: SET is applied to local session state with a
+// synthetic CommandComplete and only reaches a backend on the next query (see
+// go/services/multigateway/engine/apply_session_state.go). That deferral is the
+// root cause of the pgvector compatibility failures:
+//   - hnsw_vector / ivfflat_vector: out-of-range SETs of the extension's GUCs
+//     (e.g. SET hnsw.ef_search = 1001) don't raise the range error at SET time.
+//   - ivfflat_bit (downstream): the deferred erroring SET is flushed on the
+//     following statement and aborts a DROP TABLE, leaking a table into the
+//     next test.
+//
+// extra_float_digits is used as a stand-in: it's a plain (non gateway-managed)
+// GUC with a validated integer range of -15..3, so vanilla PostgreSQL rejects
+// an out-of-range SET immediately with SQLSTATE 22023 — exactly the behaviour
+// pgvector's GUCs expect.
+func TestMultiGateway_SetValidationIsDeferred(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SET validation test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SET validation test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	// Out-of-range for extra_float_digits (valid -15..3). Vanilla PostgreSQL:
+	//   ERROR:  100 is outside the valid range for parameter "extra_float_digits" (-15 .. 3)
+	const badSet = "SET extra_float_digits = 100"
+
+	// Desired behaviour (PostgreSQL parity): the bad SET errors at SET time.
+	// This currently FAILS — the gateway accepts the SET locally without
+	// touching a backend — and documents the gap to close.
+	t.Run("out-of-range SET errors immediately", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		_, err := conn.Exec(ctx, badSet)
+		require.Error(t, err, "SET with an out-of-range value should error at SET time, like vanilla PostgreSQL")
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected a PgError, got %T: %v", err, err)
+		assert.Equal(t, "22023", pgErr.Code, "should be invalid_parameter_value")
+	})
+
+	// Characterises the current deferral: a wholly unrelated later statement
+	// carries the SET's validation error. This is the mechanism that aborts the
+	// next pgvector test's DROP TABLE. Once SET is validated eagerly this subtest
+	// self-skips (the SET above already errored), so the test stays meaningful
+	// after the fix.
+	t.Run("deferred error attaches to a later unrelated statement", func(t *testing.T) {
+		conn := connectPgx(t, ctx, setup)
+		defer conn.Close(ctx)
+
+		if _, err := conn.Exec(ctx, badSet); err != nil {
+			t.Skipf("SET now errors eagerly (deferral fixed); nothing to characterise: %v", err)
+		}
+
+		_, err := conn.Exec(ctx, "SELECT 1")
+		require.Error(t, err, "the deferred SET error should surface here, on an unrelated statement")
+
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "expected a PgError, got %T: %v", err, err)
+		assert.Equal(t, "22023", pgErr.Code, "the late error is the SET's range violation")
+		t.Logf("deferred SET error surfaced on a later SELECT 1: %s (SQLSTATE %s)", pgErr.Message, pgErr.Code)
+	})
+}


### PR DESCRIPTION
## Summary

- The gateway accepted `SET var = value` locally without validation and deferred it to the next query, so an invalid or out-of-range value (e.g. `SET extra_float_digits = 100`) returned success and the error only surfaced later — on an unrelated statement. Fixes #1090.
- A non gateway-managed `SET` is now planned as `Sequence[ValidateSetting, ApplySessionState]`: it is validated against PostgreSQL at SET time and tracked for pool-rotation replay only on success. This applies to both the simple and extended (Parse/Bind/Execute) protocols.

## Problem

`SET` was applied to local session state with a synthetic `CommandComplete`; PostgreSQL never saw it until the next query's `ApplySettings`. An invalid value therefore errored late, attached to a wholly unrelated statement — which (via the pgvector suite) also aborted a following `DROP TABLE` and leaked a table into the next test. On the extended-protocol path the gateway instead forwarded a raw `SET` to a pooled backend, which both skipped tracking and mutated backend state outside multipooler's bookkeeping (so a later `RESET` couldn't undo it).

## Solution

`ValidateSetting` runs `SELECT pg_catalog.set_config(name, value, is_local := true)` on a backend. `set_config` validates the value (out-of-range / unknown errors fire at SET time), and `is_local := true` reverts it the instant the statement completes — so nothing is left on the pooled backend and multipooler stays the sole authority on backend session GUCs. The `Sequence` stops on the validation error, so a rejected `SET` is never tracked; on success `ApplySessionState` records it and emits the `SET` tag. The validation SQL is built as an AST and deparsed, so name/value escaping comes from the canonical quoter rather than hand-rolled string formatting. `planVariableSetStmt` (simple) and `PlanPortal` (extended) share the same local-vs-forward decision, so both protocols behave identically; `RESET`/`RESET ALL`, gateway-managed variables, and `SET LOCAL` / `SET TRANSACTION` / `SET ... FROM CURRENT` are unchanged.

Trade-off: each non gateway-managed `SET` now does one backend round-trip (the prior design deliberately avoided this).

## Verification

End-to-end proof: the pgvector external pg_regress suite now passes **14/14** (previously 11/14 — `hnsw_vector`, `ivfflat_vector`, and `ivfflat_bit` failed on exactly this bug, the last via the aborted `DROP TABLE`). Covered by unit tests (`ValidateSetting`, planner SET/`PlanPortal` routing) and e2e tests (`TestMultiGateway_SetValidation` incl. forced-extended-protocol cases, plus the full session-settings and SQL-injection suites).