### PR TITLE
test(pgregresstest): run pg_cron's regression suite through multigateway

### DIFF
--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -143,8 +143,8 @@ as catalog entries move to `covered` and their suites run.
 
 The external suite runs the pg_regress suites of extensions that live **outside**
 the PostgreSQL source tree (separate repositories), executed through
-multigateway. pgvector is the first: catalog name `vector`, pinned to a tag in
-`externalSpecs` (`extensions.go`).
+multigateway. The covered set lives in `externalSpecs` (`extensions.go`), each
+pinned to a tag: `vector` (pgvector) and `pg_cron` (Citus pg_cron).
 
 How it works, and how it differs from the contrib suite:
 
@@ -153,28 +153,69 @@ How it works, and how it differs from the contrib suite:
   the per-run build root, then runs `make && make install` with
   `PG_CONFIG` pointed at the from-source PostgreSQL so the extension `.so` links
   against the exact server ABI the cluster runs (the same guarantee the suite
-  gives `regress.so`). pgvector needs only a C compiler — no extra system libs.
+  gives `regress.so`). Both pgvector and pg_cron need only a C compiler — no
+  extra system libs.
 - **Test execution**: unlike contrib we cannot use `make installcheck`. Under
   PGXS that target invokes `$(top_builddir)/src/test/regress/pg_regress`, and
   PGXS resolves `top_builddir` into the **install** tree, where `pg_regress` is
   not installed. The harness instead invokes the `pg_regress` it built directly,
   with the same flags the contrib suite relies on
   (`--use-existing --dbname=postgres`, because multigateway rejects DROP/CREATE
-  DATABASE) plus the extension's `--inputdir`/`--load-extension`. The test list
-  is derived from `test/sql/*.sql`, mirroring the extension's
-  `REGRESS = $(patsubst test/sql/%.sql,%,$(wildcard test/sql/*.sql))`.
+  DATABASE) plus the extension's `--inputdir`. The test list is derived from
+  `<TestSubdir>/sql/*.sql`, mirroring the extension's
+  `REGRESS = $(patsubst sql/%.sql,%,$(wildcard sql/*.sql))`.
 - **Per-extension isolation** and **verification** work exactly like contrib:
   the `public` schema is reset on the primary between extensions, and results go
   through the same patch pipeline (`PGREGRESS_PATCH_MODE`). Genuine
   multigres-specific output differences are captured under
   `testdata/pg17/patches/external/<ext>/`.
 
-Enrolling another external extension is a two-line change: add its
-`externalSpecs` entry (repo + pinned tag) and flip its `ExtensionCatalog` row to
-`StatusCovered`. The catalog and report update automatically. Extensions that
-need toolchains the harness doesn't provision (Rust: `pg_graphql`, `wrappers`)
-or that the pooler blocks by design (outbound connections) stay `StatusExternal`
-/ `StatusUnsupported`.
+### Per-extension knobs
+
+Extensions diverge from the pgvector baseline in a few ways, captured as fields
+on `ExternalExtension` (`extensions.go`):
+
+- **`TestSubdir`** — where the shipped `sql/` + `expected/` fixtures live in the
+  checkout. pgvector keeps them under `test/`; pg_cron keeps them at the repo
+  root (`.`).
+- **`CreateExtension`** — whether the harness pre-creates the extension through
+  multigateway (and passes `--load-extension`) before the run. pgvector's
+  fixtures assume it already exists (they open with a bare
+  `CREATE TABLE ... vector(3)`), so `true`. pg_cron's fixtures create and drop
+  the extension themselves (`CREATE EXTENSION pg_cron VERSION '1.0'` is the first
+  statement), so `false` — preloading would make that statement fail with
+  "already exists".
+- **`ServerConfigFile`** — a `postgresql.conf` snippet under
+  `testdata/pg17/external/` the cluster must apply before postgres starts, for
+  extensions needing server-level config the pooled query path can't set.
+  pg_cron's background worker requires `shared_preload_libraries = 'pg_cron'`
+  (`pg_cron.conf`), or `CREATE EXTENSION pg_cron` errors out. The snippet is
+  appended at initdb time and only when the external suite runs (the library it
+  loads is only installed then), so regression/isolation-only runs are
+  unaffected. Note: with the shared cluster, a `ServerConfigFile` applied for a
+  combined `RUN_EXTENDED_QUERY_SERVING_TESTS` run is in effect for the other
+  suites too; pg_cron's launcher is idle with no scheduled jobs.
+- **`ScratchDatabases`** — databases the harness creates directly on the primary
+  (bypassing the gateway) before the suite and drops afterward. This is a
+  **test-only** accommodation, not a product capability: multigres is
+  one-database-per-instance and the gateway blocks `CREATE`/`DROP DATABASE` by
+  design (adding a database is a provisioning operation, see
+  `docs/query_serving/unsafe_statement_rejection.md`). It exists because some
+  suites reference other databases purely as _metadata_ — pg_cron passes a DB
+  name to `cron.schedule_in_database` / `alter_job(database := ...)` and reads
+  its ACL from the shared `pg_database` catalog, all over the same `postgres`
+  connection, never opening a session against it. Creating the physical database
+  is enough to make those catalog/privilege checks run for real; the suite's own
+  `CREATE`/`DROP DATABASE` statements still hit the gateway block (the only lines
+  left in pg_cron's patch). Don't use this to fake reachability of a feature
+  multigres genuinely blocks — only for name/metadata references like the above.
+
+Enrolling another external extension is a small catalog edit: add its
+`externalSpecs` entry (repo, pinned tag, and the knobs above) and flip its
+`ExtensionCatalog` row to `StatusCovered`. The catalog and report update
+automatically. Extensions that need toolchains the harness doesn't provision
+(Rust: `pg_graphql`, `wrappers`) or that the pooler blocks by design (outbound
+connections) stay `StatusExternal` / `StatusUnsupported`.
 
 Regenerate the patches after an output change with:
 

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -87,7 +87,7 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"index_advisor", KindExternal, StatusExternal, "depends on hypopg"},
 	{"ltree", KindContrib, StatusCovered, ""},
 	{"moddatetime", KindContrib, StatusUnsupported, "contrib/spi ships no pg_regress suite"},
-	{"pg_cron", KindExternal, StatusExternal, ""},
+	{"pg_cron", KindExternal, StatusCovered, "Citus pg_cron; built as a PGXS module from externalSpecs; needs shared_preload_libraries (see testdata/pg17/external/pg_cron.conf)"},
 	{"pg_graphql", KindExternal, StatusExternal, "Rust"},
 	{"pg_jsonschema", KindExternal, StatusExternal, "Rust"},
 	{"pg_net", KindExternal, StatusExternal, "background worker"},
@@ -112,21 +112,78 @@ var ExtensionCatalog = []ExtensionInfo{
 }
 
 // ExternalExtension describes one external (non-contrib) extension wired into
-// the external suite: its catalog name plus the git coordinates the harness
-// clones and builds it from.
+// the external suite: its catalog name, the git coordinates the harness clones
+// and builds it from, and a few knobs for the places extensions diverge from
+// the pgvector baseline (test layout, extension lifecycle, server config).
 type ExternalExtension struct {
 	Name string
 	Repo string
 	Tag  string
+
+	// TestSubdir is the directory within the checkout that holds the shipped
+	// pg_regress fixtures (sql/ + expected/), relative to the clone root.
+	// pgvector keeps them under test/; pg_cron keeps them at the repo root, so
+	// it uses "." (filepath.Join collapses it back to the clone root).
+	TestSubdir string
+
+	// CreateExtension controls whether the harness pre-creates the extension
+	// through multigateway (and passes pg_regress --load-extension) before the
+	// suite runs. pgvector's fixtures assume it already exists (they open with a
+	// bare CREATE TABLE ... vector(3) and never CREATE EXTENSION), so it needs
+	// the preload. pg_cron's fixtures manage the extension themselves
+	// (CREATE EXTENSION pg_cron VERSION '1.0' is the first statement, then they
+	// DROP and recreate it at a newer version), so preloading would make that
+	// first statement fail with "extension already exists" — it must be false.
+	CreateExtension bool
+
+	// ScratchDatabases names databases the harness creates directly on the
+	// primary (bypassing multigateway, like the public-schema reset) before the
+	// suite runs and drops afterward. This is a TEST-ONLY accommodation, NOT a
+	// product capability: multigres is one-database-per-postgres-instance by
+	// design (multigateway blocks CREATE/DROP DATABASE as Tier 2 statements;
+	// adding a database is a provisioning operation that brings up a new
+	// cluster, see docs/query_serving/unsafe_statement_rejection.md). pg_cron's
+	// test, though, uses other databases purely as *metadata*: it passes their
+	// names to cron.schedule_in_database / cron.alter_job(database := ...) and
+	// reads their ACLs from the shared pg_database catalog, all over the same
+	// `postgres` connection — it never opens a session against them (nothing in
+	// the multigres stack does; only pg_cron's in-process launcher would, and
+	// the test doesn't wait for it). So creating the physical databases here is
+	// enough to make those catalog/privilege checks run for real, while the
+	// test's own CREATE/DROP DATABASE statements still hit the gateway block
+	// (the only lines left in the patch). Reusable for any extension whose suite
+	// references databases by name without connecting to them.
+	ScratchDatabases []string
+
+	// ServerConfigFile, when non-empty, names a postgresql.conf snippet under
+	// testdata/pg<major>/external/ that the cluster must apply before postgres
+	// starts (appended at initdb time, last-write-wins over the template). Use
+	// it for extensions that need server-level configuration the pooled query
+	// path can't set, e.g. pg_cron's background worker requires
+	// shared_preload_libraries = 'pg_cron' or CREATE EXTENSION errors out. Empty
+	// for extensions that need nothing beyond the stock cluster (pgvector).
+	ServerConfigFile string
 }
 
-// externalSpecs holds the build coordinates (git repo + pinned tag) for every
-// external extension the harness can build. An ExtensionCatalog entry with
-// Kind==KindExternal can only be StatusCovered if it also has a spec here; the
-// pinned tag keeps the suite reproducible (and matches the pgvector ABI the
-// from-source PostgreSQL was built against). Keyed by catalog Name.
+// externalSpecs holds the build coordinates (git repo + pinned tag) and the
+// per-extension knobs for every external extension the harness can build. An
+// ExtensionCatalog entry with Kind==KindExternal can only be StatusCovered if it
+// also has a spec here; the pinned tag keeps the suite reproducible (and matches
+// the ABI the from-source PostgreSQL was built against). Keyed by catalog Name.
 var externalSpecs = map[string]ExternalExtension{
-	"vector": {Name: "vector", Repo: "https://github.com/pgvector/pgvector", Tag: "v0.8.1"},
+	"vector": {
+		Name: "vector", Repo: "https://github.com/pgvector/pgvector", Tag: "v0.8.1",
+		TestSubdir: "test", CreateExtension: true,
+	},
+	"pg_cron": {
+		Name: "pg_cron", Repo: "https://github.com/citusdata/pg_cron", Tag: "v1.6.4",
+		TestSubdir: ".", CreateExtension: false, ServerConfigFile: "pg_cron.conf",
+		// pg_cron-test.sql references pgcron_dbno/pgcron_dbyes by name (it REVOKEs
+		// CONNECT on one and schedules/alters jobs targeting both) but never
+		// connects to them; front-load them on the primary so those metadata and
+		// CONNECT-privilege checks run for real. See ScratchDatabases.
+		ScratchDatabases: []string{"pgcron_dbno", "pgcron_dbyes"},
+	},
 }
 
 // CoveredExternalExtensions returns the external extensions the suite builds and

--- a/go/test/endtoend/pgregresstest/main_test.go
+++ b/go/test/endtoend/pgregresstest/main_test.go
@@ -21,22 +21,50 @@ import (
 	"testing"
 
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 )
 
-// regressionOverridesConfPath returns the absolute path to the
-// testdata/pg<major>/regression_overrides.conf snippet that forces lc_* GUCs
-// to 'C' on each pgctld. Resolved via runtime.Caller so the path is correct
-// regardless of the test's working directory at run time.
-func regressionOverridesConfPath() string {
+// testdataConfPath returns the absolute path to a postgresql.conf snippet under
+// this package's testdata/pg<major>/<parts...>. Resolved via runtime.Caller so
+// the path is correct regardless of the test's working directory at run time.
+func testdataConfPath(parts ...string) string {
 	_, file, _, _ := runtime.Caller(0)
 	pkgDir := filepath.Dir(file)
-	return filepath.Join(pkgDir, "testdata", "pg17", "regression_overrides.conf")
+	return filepath.Join(append([]string{pkgDir, "testdata", "pg17"}, parts...)...)
+}
+
+// regressionOverridesConfPath returns the snippet that forces lc_* GUCs to 'C'
+// on each pgctld so locale-sensitive expected outputs reproduce upstream.
+func regressionOverridesConfPath() string {
+	return testdataConfPath("regression_overrides.conf")
+}
+
+// externalServerConfPaths returns the postgresql.conf snippets the external
+// extensions selected for this run need applied to the cluster before postgres
+// starts (ExternalExtension.ServerConfigFile, e.g. pg_cron's
+// shared_preload_libraries). It is gated on the external suite actually running:
+// the snippet would load a library (pg_cron) that is only installed when the
+// external suite runs, so applying it otherwise would make postgres fail to
+// start. PGEXTERNAL_TESTS narrowing is honored via ExternalModules.
+func externalServerConfPaths() []string {
+	extendedGate := os.Getenv(suiteutil.EnvRunExtendedQueryServingTests) == "1"
+	runExternal := extendedGate || os.Getenv("RUN_PGEXTERNAL") == "1"
+	if !runExternal {
+		return nil
+	}
+	var paths []string
+	for _, ext := range ExternalModules() {
+		if ext.ServerConfigFile == "" {
+			continue
+		}
+		paths = append(paths, testdataConfPath("external", ext.ServerConfigFile))
+	}
+	return paths
 }
 
 // setupManager manages the shared test setup for tests in this package.
 var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardsetup.ShardSetup {
-	// Create a 2-node cluster with multigateway for PostgreSQL regression tests
-	return shardsetup.New(t,
+	opts := []shardsetup.SetupOption{
 		shardsetup.WithMultipoolerCount(2), // primary + standby
 		shardsetup.WithMultigateway(),      // enable multigateway for PostgreSQL connections
 		// Stamp multigres_vpid:<id> on every PG backend so the isolation
@@ -56,7 +84,14 @@ var setupManager = shardsetup.NewSharedSetupManager(func(t *testing.T) *shardset
 		// that resets lc_* to 'C' so currency/number/time/message formatting
 		// matches upstream expected fixtures.
 		shardsetup.WithPgInitdbExtraConfFiles(regressionOverridesConfPath()),
-	)
+	}
+	// Some external extensions need server-level config the pooled query path
+	// can't set (pg_cron's background worker needs shared_preload_libraries).
+	// Apply their snippets to the shared cluster when the external suite runs.
+	if confs := externalServerConfPaths(); len(confs) > 0 {
+		opts = append(opts, shardsetup.WithPgInitdbExtraConfFiles(confs...))
+	}
+	return shardsetup.New(t, opts...)
 })
 
 // TestMain sets the path and cleans up after all tests.

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -494,9 +494,12 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 
 	for _, ext := range exts {
 		cloneDir := filepath.Join(pb.ExternalDir, ext.Name)
-		testDir := filepath.Join(cloneDir, "test")
+		// Fixtures live under ext.TestSubdir within the checkout (pgvector: test/;
+		// pg_cron: the repo root, i.e. "."). filepath.Join collapses "." back to
+		// the clone root.
+		testDir := filepath.Join(cloneDir, ext.TestSubdir)
 		if !suiteutil.FileExists(filepath.Join(testDir, "sql")) {
-			t.Logf("external/%s: no test/sql in checkout, skipping", ext.Name)
+			t.Logf("external/%s: no %s/sql in checkout, skipping", ext.Name, ext.TestSubdir)
 			continue
 		}
 
@@ -512,11 +515,27 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			t.Logf("external/%s: warning: public schema reset failed: %v", ext.Name, err)
 		}
 
-		// Preload the extension: --use-existing skips pg_regress's own
-		// --load-extension step, and pgvector's fixtures assume it is already
-		// installed (see createExtensionViaGateway).
-		if err := createExtensionViaGateway(multigatewayPort, password, ext.Name); err != nil {
-			t.Logf("external/%s: warning: CREATE EXTENSION failed: %v", ext.Name, err)
+		// Front-load the extension's scratch databases directly on the primary.
+		// multigateway blocks CREATE DATABASE by design (one-DB-per-instance; see
+		// ExternalExtension.ScratchDatabases), but the suite only needs them to
+		// exist in the catalog, not to be connectable, so create them here.
+		// Best-effort. They are dropped after the suite runs (below).
+		for _, db := range ext.ScratchDatabases {
+			if err := execOnPrimary(directPgPort, password, fmt.Sprintf("CREATE DATABASE %q", db)); err != nil {
+				t.Logf("external/%s: warning: create scratch db %q failed: %v", ext.Name, db, err)
+			}
+		}
+
+		// Preload the extension when its fixtures assume it already exists:
+		// --use-existing skips pg_regress's own --load-extension step, and
+		// pgvector's fixtures open with a bare CREATE TABLE ... vector(3) (see
+		// createExtensionViaGateway). Extensions whose fixtures manage the
+		// extension themselves (pg_cron CREATEs it as their first statement) set
+		// CreateExtension=false so we don't collide with that.
+		if ext.CreateExtension {
+			if err := createExtensionViaGateway(multigatewayPort, password, ext.Name); err != nil {
+				t.Logf("external/%s: warning: CREATE EXTENSION failed: %v", ext.Name, err)
+			}
 		}
 
 		t.Logf("Running external/%s pg_regress (%d tests) against multigateway...", ext.Name, len(tests))
@@ -526,7 +545,12 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			"--bindir=" + pgBinDir,
 			"--use-existing",
 			"--dbname=postgres",
-			"--load-extension=" + ext.Name,
+		}
+		// --load-extension only fires inside create_database(), which pg_regress
+		// skips under --use-existing, so it is a no-op here; pass it only for the
+		// preloaded extensions to keep intent clear.
+		if ext.CreateExtension {
+			args = append(args, "--load-extension="+ext.Name)
 		}
 		args = append(args, tests...)
 		// Run from the clone root so psql's client-side \copy resolves the
@@ -540,6 +564,16 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			outputDir: filepath.Join(pb.OutputDir, "external", ext.Name),
 			srcOutDir: cloneDir,
 		}, multigatewayPort, password)
+
+		// Drop the scratch databases now the suite has run (verification reads
+		// result files, not the live DB). WITH (FORCE) in case pg_cron's launcher
+		// opened a connection. Best-effort; the cluster is torn down after anyway.
+		for _, db := range ext.ScratchDatabases {
+			if err := execOnPrimary(directPgPort, password, fmt.Sprintf("DROP DATABASE IF EXISTS %q WITH (FORCE)", db)); err != nil {
+				t.Logf("external/%s: warning: drop scratch db %q failed: %v", ext.Name, db, err)
+			}
+		}
+
 		if res == nil {
 			t.Logf("external/%s: no test results (%v)", ext.Name, err)
 			continue
@@ -723,6 +757,27 @@ func resetContribState(directPgPort int, password string) error {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("exec [%s]: %w", stmt, err)
 		}
+	}
+	return nil
+}
+
+// execOnPrimary runs a single statement directly on the primary's PostgreSQL
+// (bypassing multigateway, which rejects some Tier 2 DDL like CREATE DATABASE).
+// Used to front-load fixture setup an extension's suite needs but the gateway
+// blocks; the standby picks the change up via WAL. Each call is its own
+// autocommit connection so statements that can't run in a transaction block
+// (CREATE DATABASE) work.
+func execOnPrimary(directPgPort int, password, stmt string) error {
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		directPgPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("exec [%s]: %w", stmt, err)
 	}
 	return nil
 }

--- a/go/test/endtoend/pgregresstest/testdata/pg17/external/pg_cron.conf
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/external/pg_cron.conf
@@ -1,0 +1,15 @@
+# pg_cron server configuration, appended at initdb time when the external suite
+# runs pg_cron (ExternalExtension.ServerConfigFile in extensions.go).
+#
+# pg_cron runs a background worker (the job launcher), so it can only be loaded
+# via shared_preload_libraries — CREATE EXTENSION pg_cron errors out otherwise.
+# The pgctld template leaves shared_preload_libraries commented and a prod list
+# would be far heavier; here we load only pg_cron so the rest of the harness's
+# cluster stays minimal. Appended after the template, so this wins.
+#
+# cron.database_name selects the database the launcher connects to and where the
+# extension's cron.job catalog lives; the suite runs everything in `postgres`.
+# The template already defaults it to 'postgres', but we set it explicitly so
+# the requirement travels with this file.
+shared_preload_libraries = 'pg_cron'
+cron.database_name = 'postgres'

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/pg_cron/pg_cron-test.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/pg_cron/pg_cron-test.patch
@@ -1,0 +1,25 @@
+--- a
++++ b
+@@ -143,6 +143,7 @@
+ ERROR: database "hopedoesnotexist" does not exist
+ -- Create a database that does not allow connection
+ create database pgcron_dbno;
++ERROR: CREATE DATABASE is not supported through the connection pooler
+ revoke connect on database pgcron_dbno from public;
+ -- create a test user
+ create user pgcron_cront with password 'pwd';
+@@ -152,6 +153,7 @@
+ ERROR: User pgcron_cront does not have CONNECT privilege on pgcron_dbno
+ -- Create a database that does allow connections
+ create database pgcron_dbyes;
++ERROR: CREATE DATABASE is not supported through the connection pooler
+ -- Schedule a job on the database that does accept connections for a non existing user
+ SELECT cron.schedule_in_database(job_name:='user does not exist', schedule:='0 11 * * *', command:='VACUUM',database:='pgcron_dbyes',username:='pgcron_useraqwxszedc');
+ ERROR: role "pgcron_useraqwxszedc" does not exist
+@@ -304,4 +306,6 @@
+ DROP EXTENSION pg_cron;
+ drop user pgcron_cront;
+ drop database pgcron_dbno;
++ERROR: DROP DATABASE is not supported through the connection pooler
+ drop database pgcron_dbyes;
++ERROR: DROP DATABASE is not supported through the connection pooler


### PR DESCRIPTION
## Summary

- Enrolls **pg_cron** (Citus, pinned `v1.6.4`) as a covered external extension in the pgregress suite, running its shipped `pg_cron-test` through multigateway — mirroring how pgvector is run.
- Generalizes `ExternalExtension` with four per-extension knobs, since pg_cron diverges from the pgvector baseline: `TestSubdir` (pg_cron ships fixtures at the repo root, not under `test/`), `CreateExtension` (pg_cron's test manages the extension itself, so the harness must not preload it), `ServerConfigFile` (pg_cron's background worker needs `shared_preload_libraries = 'pg_cron'`, applied to the cluster at initdb time only when the external suite runs), and `ScratchDatabases` (see below).
- Adds `testdata/pg17/external/pg_cron.conf` and a captured `pg_cron-test.patch` (just the 4 `CREATE`/`DROP DATABASE` lines).

Verified green in both patch-generate and verify (CI) modes: `pg_cron/pg_cron-test ✅`, 1/1.

## On `CREATE DATABASE` / `DROP DATABASE`

pg_cron's `pg_cron-test.sql` uses `CREATE`/`DROP DATABASE` to set up two scratch databases (`pgcron_dbno`, `pgcron_dbyes`) for its cross-database scheduling tests. multigateway blocks both as Tier 2 statements **by design** — multigres is one-database-per-postgres-instance, and adding a database is a provisioning operation (a new cluster), not a query-path operation (see `docs/query_serving/unsafe_statement_rejection.md`).

Key observation: the test never actually *connects to* those databases. It references them purely as **metadata** — it passes the names to `cron.schedule_in_database` / `cron.alter_job(database := ...)` and reads their ACLs from the shared `pg_database` catalog, all over the same `postgres` connection. The only thing that would open a session against them is pg_cron's in-process launcher (local to postgres, not via the gateway), and the test doesn't wait for it.

So rather than edit upstream's test (which would weaken its assertions), the harness front-loads the two databases **directly on the primary** (bypassing the gateway, via the new `ScratchDatabases` knob) before the suite and drops them after. The catalog/CONNECT-privilege/`alter_job` checks then run for real and match upstream; only the test's own `CREATE`/`DROP DATABASE` statements remain in the patch as the documented gateway block. This is a **test-only** accommodation and is commented as such — it does not represent multi-database support; when `CREATE DATABASE` becomes a real provisioning feature, this hook is revisited.