### PR TITLE
test(queryserving): cover SET and SET LOCAL inside transactions

### DIFF
--- a/go/test/endtoend/queryserving/session_settings_test.go
+++ b/go/test/endtoend/queryserving/session_settings_test.go
@@ -387,10 +387,129 @@ func TestMultiGateway_SessionSettings(t *testing.T) {
 		}
 	})
 
-	// Test 11: SET LOCAL behavior (Phase 2 placeholder)
+	// Test 11: SET and SET LOCAL behavior inside transactions.
+	//
+	// Exercises the full client → gateway → multipooler → PostgreSQL flow for
+	// SET commands issued inside an explicit transaction:
+	//   - a regular SET inside a txn is discarded on ROLLBACK, kept on COMMIT
+	//   - SET LOCAL on a gateway-managed variable (statement_timeout) applies
+	//     within the txn and reverts at COMMIT — it must not survive the boundary
+	//   - SET LOCAL on a non-managed variable (search_path) is passed through to
+	//     PostgreSQL and likewise does not leak past COMMIT
+	//
+	// Session state is per gateway connection, so all statements run on a single
+	// pinned *sql.Conn. The follow-up SHOW loops still route through the pool, so
+	// they also verify the gateway re-applies the post-txn state to fresh backends.
 	t.Run("SET LOCAL behavior", func(t *testing.T) {
-		t.Skip("SET LOCAL requires transaction support (Phase 2)")
-		// TODO Phase 2: Implement transaction-scoped settings tracking
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err, "failed to pin connection")
+		defer conn.Close()
+
+		// Start from a clean, known session state.
+		_, err = conn.ExecContext(ctx, "RESET ALL")
+		require.NoError(t, err, "failed to RESET ALL")
+
+		t.Run("regular SET inside txn is discarded on ROLLBACK", func(t *testing.T) {
+			_, err := conn.ExecContext(ctx, "SET search_path = 'before_txn'")
+			require.NoError(t, err, "failed to SET pre-txn search_path")
+
+			tx, err := conn.BeginTx(ctx, nil)
+			require.NoError(t, err, "failed to BEGIN")
+
+			_, err = tx.ExecContext(ctx, "SET search_path = 'inside_txn'")
+			require.NoError(t, err, "failed to SET inside txn")
+
+			var inside string
+			err = tx.QueryRowContext(ctx, "SHOW search_path").Scan(&inside)
+			require.NoError(t, err, "failed to SHOW inside txn")
+			assert.Equal(t, "inside_txn", inside, "SET inside txn should be visible within the txn")
+
+			require.NoError(t, tx.Rollback(), "failed to ROLLBACK")
+
+			// ROLLBACK discards the in-txn SET; search_path reverts to the
+			// pre-txn value.
+			for i := range 10 {
+				var after string
+				err = conn.QueryRowContext(ctx, "SHOW search_path").Scan(&after)
+				require.NoError(t, err, "iteration %d: failed to SHOW after rollback", i)
+				require.Equal(t, "before_txn", after, "iteration %d: ROLLBACK should discard in-txn SET", i)
+			}
+		})
+
+		t.Run("regular SET inside txn persists on COMMIT", func(t *testing.T) {
+			_, err := conn.ExecContext(ctx, "SET search_path = 'before_commit'")
+			require.NoError(t, err, "failed to SET pre-commit search_path")
+
+			tx, err := conn.BeginTx(ctx, nil)
+			require.NoError(t, err, "failed to BEGIN")
+
+			_, err = tx.ExecContext(ctx, "SET search_path = 'after_commit'")
+			require.NoError(t, err, "failed to SET inside txn")
+			require.NoError(t, tx.Commit(), "failed to COMMIT")
+
+			// COMMIT makes the in-txn SET the persistent session value.
+			for i := range 10 {
+				var after string
+				err = conn.QueryRowContext(ctx, "SHOW search_path").Scan(&after)
+				require.NoError(t, err, "iteration %d: failed to SHOW after commit", i)
+				require.Equal(t, "after_commit", after, "iteration %d: COMMIT should persist in-txn SET", i)
+			}
+		})
+
+		t.Run("SET LOCAL statement_timeout reverts at COMMIT", func(t *testing.T) {
+			// Establish a session-level value the LOCAL override masks.
+			_, err := conn.ExecContext(ctx, "SET statement_timeout = '30s'")
+			require.NoError(t, err, "failed to SET session statement_timeout")
+
+			tx, err := conn.BeginTx(ctx, nil)
+			require.NoError(t, err, "failed to BEGIN")
+
+			_, err = tx.ExecContext(ctx, "SET LOCAL statement_timeout = '5s'")
+			require.NoError(t, err, "failed to SET LOCAL statement_timeout")
+
+			var inside string
+			err = tx.QueryRowContext(ctx, "SHOW statement_timeout").Scan(&inside)
+			require.NoError(t, err, "failed to SHOW inside txn")
+			assert.Equal(t, "5s", inside, "SET LOCAL should apply within the txn")
+
+			require.NoError(t, tx.Commit(), "failed to COMMIT")
+
+			// SET LOCAL does not survive the transaction; the session value is restored.
+			for i := range 10 {
+				var after string
+				err = conn.QueryRowContext(ctx, "SHOW statement_timeout").Scan(&after)
+				require.NoError(t, err, "iteration %d: failed to SHOW after commit", i)
+				require.Equal(t, "30s", after, "iteration %d: SET LOCAL must not persist past COMMIT", i)
+			}
+		})
+
+		t.Run("SET LOCAL on non-managed variable does not leak past COMMIT", func(t *testing.T) {
+			// search_path is not gateway-managed: SET LOCAL is passed through to
+			// PostgreSQL, which scopes it to the transaction.
+			_, err := conn.ExecContext(ctx, "SET search_path = 'session_path'")
+			require.NoError(t, err, "failed to SET session search_path")
+
+			tx, err := conn.BeginTx(ctx, nil)
+			require.NoError(t, err, "failed to BEGIN")
+
+			_, err = tx.ExecContext(ctx, "SET LOCAL search_path = 'local_path'")
+			require.NoError(t, err, "failed to SET LOCAL search_path")
+
+			var inside string
+			err = tx.QueryRowContext(ctx, "SHOW search_path").Scan(&inside)
+			require.NoError(t, err, "failed to SHOW inside txn")
+			assert.Equal(t, "local_path", inside, "SET LOCAL should apply within the txn")
+
+			require.NoError(t, tx.Commit(), "failed to COMMIT")
+
+			// The LOCAL value is gone after COMMIT; the session value remains.
+			for i := range 10 {
+				var after string
+				err = conn.QueryRowContext(ctx, "SHOW search_path").Scan(&after)
+				require.NoError(t, err, "iteration %d: failed to SHOW after commit", i)
+				require.Equal(t, "session_path", after, "iteration %d: SET LOCAL must not persist past COMMIT", i)
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds an end-to-end test for SET / SET LOCAL behavior inside explicit transactions, replacing a long-standing skipped "Phase 2 placeholder" in `session_settings_test.go`.
- The transaction-staged SET and gateway-managed SET LOCAL logic was already implemented; this fills the one remaining gap so the behavior is covered end-to-end through the full client → gateway → multipooler → PostgreSQL flow.

## Description

The new `SET LOCAL behavior` subtest pins a single `*sql.Conn` (session state is per gateway connection, so `database/sql` would otherwise route follow-up queries to a different backing session) and covers four cases:

- **regular SET inside txn is discarded on ROLLBACK** — the in-txn value is visible during the transaction and reverts to the pre-txn value after ROLLBACK.
- **regular SET inside txn persists on COMMIT** — the in-txn value becomes the persistent session value after COMMIT.
- **SET LOCAL statement_timeout reverts at COMMIT** — SET LOCAL on a gateway-managed variable applies within the transaction and does not survive the boundary, restoring the session-level value.
- **SET LOCAL on a non-managed variable does not leak past COMMIT** — `SET LOCAL search_path` is passed through to PostgreSQL, scoped to the transaction, and the session value remains afterward.

Each post-transaction assertion loops so the SHOW queries route back through the pool, confirming the gateway re-applies the correct post-txn state to fresh pooled backends rather than only its own in-memory tracking.