### PR TITLE
fix(multipooler): wait out reopen window instead of surfacing transient pool-close

### DIFF
--- a/go/services/multipooler/connpoolmanager/config.go
+++ b/go/services/multipooler/connpoolmanager/config.go
@@ -606,6 +606,6 @@ func (c *Config) NewManager(logger *slog.Logger) *Manager {
 		logger:  logger,
 		metrics: metrics,
 	}
-	mgr.closed.Store(true) // Manager is closed until Open() is called
+	mgr.setLifecycle(lifecycleClosed) // Manager is closed until Open() is called
 	return mgr
 }

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -43,8 +43,15 @@ type PoolManager interface {
 	// while credentials are managed internally via viper flags.
 	Open(ctx context.Context, connConfig *ConnectionConfig)
 
-	// Close shuts down all connection pools.
+	// Close shuts down all connection pools. This is a terminal close.
 	Close()
+
+	// CloseForReopen closes all pools as the first half of a reopen (a Close
+	// immediately followed by an Open, e.g. to refresh stale file descriptors
+	// after a PostgreSQL restart). It must be paired with a subsequent Open.
+	// Unlike Close, it marks the close as transient so connection requests
+	// racing the reopen wait for the Open and retry, rather than failing.
+	CloseForReopen()
 
 	// PgUser returns the configured PostgreSQL user for system queries.
 	PgUser() string

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -51,6 +51,26 @@ const (
 // otherwise.
 var ErrManagerClosed = errors.New("manager is closed")
 
+// managerLifecycle is the manager's phase. It is the single source of truth for
+// retry decisions in withReopenRetry: only lifecycleRunning permits new pool
+// creation, lifecycleReopening is a transient close that callers wait out, and
+// lifecycleClosed is terminal.
+type managerLifecycle uint32
+
+const (
+	// lifecycleRunning is the normal serving state. It is the zero value, so a
+	// freshly-allocated Manager must be explicitly stored as lifecycleClosed
+	// until Open() runs (see NewManager).
+	lifecycleRunning managerLifecycle = iota
+	// lifecycleReopening marks a CloseForReopen->Open window. Pool creation is
+	// refused (the pools are torn down) but the close is transient: callers
+	// block on reopenDone and retry once the paired Open completes.
+	lifecycleReopening
+	// lifecycleClosed is a terminal shutdown. Pool creation is refused and
+	// callers surface the close instead of retrying.
+	lifecycleClosed
+)
+
 // Manager orchestrates per-user connection pools with a shared admin pool.
 // Each user gets their own RegularPool and ReservedPool that connect directly
 // as that user via trust/peer authentication.
@@ -91,19 +111,19 @@ type Manager struct {
 	// This mutex is only acquired when a new user pool needs to be created.
 	createMu sync.Mutex
 
-	// closed indicates whether the manager has been closed. It is set by both
-	// Close (terminal) and CloseForReopen (transient); the reopen bookkeeping
-	// below is what distinguishes the two for retry decisions.
-	closed atomic.Bool
+	// lifecycle is the manager's phase (running/reopening/closed) and the single
+	// source of truth for retry decisions. It is read lock-free on the hot path
+	// and distinguishes a transient reopen from a terminal shutdown without a
+	// second flag. See managerLifecycle.
+	lifecycle atomic.Uint32
 
-	// Reopen bookkeeping, guarded by reopenMu. CloseForReopen opens a reopen
-	// window (reopening=true, reopenDone=fresh channel) before tearing the
-	// pools down; the paired Open closes the window via endReopen. While a
-	// window is open, withReopenRetry waits on reopenDone before retrying a
-	// closed-pool error instead of surfacing the transient failure to the
-	// client.
+	// reopenDone is the wait handle for a reopen window, guarded by reopenMu.
+	// CloseForReopen creates it (and moves lifecycle to reopening) before tearing
+	// the pools down; the paired Open — or a terminal Close that interrupts the
+	// reopen — closes it via endReopen. While lifecycle is reopening,
+	// withReopenRetry blocks on this channel before retrying a closed-pool error
+	// instead of surfacing the transient failure to the client.
 	reopenMu   sync.Mutex
-	reopening  bool
 	reopenDone chan struct{}
 
 	// Rebalancer goroutine management
@@ -153,7 +173,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	close(zeroCh)
 	m.zeroCh = zeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
-	m.closed.Store(false)
+	m.setLifecycle(lifecycleRunning)
 
 	// Build admin client config. pwSourceNone signals that ResolvePgPassword
 	// was never called — production startup in services/multipooler/init.go
@@ -300,8 +320,11 @@ func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) 
 		}
 	}
 
-	// Check if closed before attempting to create
-	if m.closed.Load() {
+	// Refuse to create a pool unless the manager is running. Reopening counts as
+	// closed here: the pools (and admin pool) are torn down mid-reopen, so a pool
+	// built now would be wired to a nil admin pool. withReopenRetry waits the
+	// reopen window out and retries against the fresh pools.
+	if m.lifecycleState() != lifecycleRunning {
 		return nil, ErrManagerClosed
 	}
 
@@ -325,8 +348,8 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 		}
 	}
 
-	// Check if closed (with lock held)
-	if m.closed.Load() {
+	// Re-check lifecycle with the lock held (see getOrCreateUserPool).
+	if m.lifecycleState() != lifecycleRunning {
 		return nil, ErrManagerClosed
 	}
 
@@ -402,7 +425,15 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 func (m *Manager) Close() {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
-	m.closeLocked()
+	if m.lifecycleState() == lifecycleClosed {
+		return
+	}
+	m.setLifecycle(lifecycleClosed)
+	// If a reopen was in progress, this terminal close pre-empts it: wake any
+	// withReopenRetry waiters so they observe lifecycleClosed and surface the
+	// error instead of blocking on a paired Open that will never come.
+	m.endReopen()
+	m.teardownLocked()
 }
 
 // CloseForReopen closes all pools as the first half of a reopen — a Close
@@ -415,22 +446,23 @@ func (m *Manager) Close() {
 func (m *Manager) CloseForReopen() {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
+	// beginReopen moves lifecycle to reopening (and arms reopenDone) before the
+	// teardown, so a racing acquisition sees "reopening" rather than a torn-down
+	// "running" manager.
 	m.beginReopen()
-	m.closeLocked()
+	m.teardownLocked()
 }
 
-// closeLocked tears down all pools and marks the manager closed. The caller
-// must hold createMu.
-func (m *Manager) closeLocked() {
-	if m.closed.Load() {
-		return
-	}
-	m.closed.Store(true)
-
+// teardownLocked tears down all pools and shared resources. It does NOT touch
+// lifecycle — the caller sets that (Close -> closed, CloseForReopen -> reopening)
+// before calling. It is idempotent: each resource is guarded so a repeated or
+// post-reopen call is a cheap no-op. The caller must hold createMu.
+func (m *Manager) teardownLocked() {
 	// Stop the rebalancer goroutine first
 	if m.rebalancerCancel != nil {
 		m.rebalancerCancel()
 		m.rebalancerWg.Wait()
+		m.rebalancerCancel = nil
 	}
 
 	// Close all user pools
@@ -451,7 +483,7 @@ func (m *Manager) closeLocked() {
 	}
 
 	// Unregister observable metric callbacks so the OTel SDK stops invoking
-	// them against closed pool state.
+	// them against closed pool state. Metrics.Close is safe to call repeatedly.
 	if err := m.metrics.Close(); err != nil {
 		m.logger.Warn("failed to unregister pool metrics callbacks", "error", err)
 	}
@@ -673,65 +705,84 @@ func withReopenRetry[T any](ctx context.Context, m *Manager, user string, client
 }
 
 // handleClosed decides how withReopenRetry should react to a closed-pool
-// failure (ErrPoolClosed from an op, or ErrManagerClosed from the lookup). If a
-// reopen is in progress it blocks for the paired Open to finish, honoring ctx,
-// then reports retry=true. A terminal close with no reopen pending reports
-// retry=false. It returns a non-nil error only when ctx is cancelled while
-// waiting. Retry bounding is the caller's responsibility.
+// failure (ErrPoolClosed from an op, or ErrManagerClosed from the lookup),
+// switching on the manager's lifecycle:
+//
+//   - reopening: a CloseForReopen->Open window is in progress. Block on the
+//     reopen channel (honoring ctx) for the paired Open to finish, then retry
+//     against the fresh pools.
+//   - closed: terminal shutdown. Report retry=false so the caller surfaces the
+//     error unchanged.
+//   - running: the reopen already completed, or a pool was evicted/swapped
+//     while the manager stayed up. Retry against the current snapshot.
+//
+// It returns a non-nil error only when ctx is cancelled while waiting. Retry
+// bounding is the caller's responsibility.
 func (m *Manager) handleClosed(ctx context.Context) (retry bool, err error) {
-	reopening, done := m.reopenState()
-	switch {
-	case reopening:
-		// Wait for the paired Open to finish, then retry against fresh pools.
-		// done is non-nil whenever reopening is true; the guard is defensive.
-		if done != nil {
+	switch m.lifecycleState() {
+	case lifecycleReopening:
+		// done is non-nil whenever lifecycle is reopening; reopenWaitCh may
+		// still return nil if the window closed between the load above and the
+		// lock below, in which case the reopen is done and we just retry.
+		if done := m.reopenWaitCh(); done != nil {
 			select {
 			case <-done:
 			case <-ctx.Done():
 				return false, ctx.Err()
 			}
 		}
-	case m.closed.Load():
-		// Terminal shutdown with no reopen pending: nothing to retry.
+		return true, nil
+	case lifecycleClosed:
 		return false, nil
+	default: // lifecycleRunning
+		return true, nil
 	}
-
-	// Either the reopen completed (manager is back up), or a pool was closed
-	// (evicted/swapped) while the manager stayed up. Retry against the current
-	// snapshot.
-	return true, nil
 }
 
-// beginReopen opens a reopen window. The caller must hold createMu.
+// lifecycleState returns the manager's current phase.
+func (m *Manager) lifecycleState() managerLifecycle {
+	return managerLifecycle(m.lifecycle.Load())
+}
+
+// setLifecycle stores the manager's phase.
+func (m *Manager) setLifecycle(s managerLifecycle) {
+	m.lifecycle.Store(uint32(s))
+}
+
+// beginReopen arms the reopen wait handle and moves lifecycle to reopening. The
+// channel is created before the lifecycle store so any reader that observes
+// "reopening" is guaranteed a non-nil channel to wait on. The caller must hold
+// createMu.
 func (m *Manager) beginReopen() {
 	m.reopenMu.Lock()
-	defer m.reopenMu.Unlock()
 	if m.reopenDone == nil {
 		m.reopenDone = make(chan struct{})
 	}
-	m.reopening = true
+	m.reopenMu.Unlock()
+	m.setLifecycle(lifecycleReopening)
 }
 
-// endReopen closes the current reopen window, if any, waking withReopenRetry
-// waiters so they retry against the freshly reopened pools. It is a no-op when
-// no window is open (e.g. a plain startup Open).
+// endReopen closes the current reopen wait handle, if any, waking withReopenRetry
+// waiters so they re-check lifecycle and retry (against the freshly reopened
+// pools after Open, or surface the error after a terminal Close). It is a no-op
+// when no window is armed (e.g. a plain startup Open). It does not change
+// lifecycle — the caller sets that first.
 func (m *Manager) endReopen() {
 	m.reopenMu.Lock()
 	done := m.reopenDone
 	m.reopenDone = nil
-	m.reopening = false
 	m.reopenMu.Unlock()
 	if done != nil {
 		close(done)
 	}
 }
 
-// reopenState reports whether a reopen window is currently open and returns the
-// channel that endReopen will close when it completes.
-func (m *Manager) reopenState() (bool, <-chan struct{}) {
+// reopenWaitCh returns the channel endReopen will close when the current reopen
+// window completes, or nil if no window is armed.
+func (m *Manager) reopenWaitCh() <-chan struct{} {
 	m.reopenMu.Lock()
 	defer m.reopenMu.Unlock()
-	return m.reopening, m.reopenDone
+	return m.reopenDone
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.
@@ -856,9 +907,10 @@ func (m *Manager) CloseReservedConnections(ctx context.Context) int {
 	return total
 }
 
-// IsClosed returns whether the manager has been closed.
+// IsClosed reports whether the manager is terminally closed. It returns false
+// during a reopen window: the manager is mid-refresh, not shut down.
 func (m *Manager) IsClosed() bool {
-	return m.closed.Load()
+	return m.lifecycleState() == lifecycleClosed
 }
 
 // UserPoolCount returns the number of user pools currently managed.

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -37,7 +37,19 @@ const (
 	// initialUserPoolCapacity is the initial capacity for new user pools.
 	// The rebalancer will adjust this based on demand.
 	initialUserPoolCapacity int64 = 10
+
+	// maxPoolClosedRetries bounds how many times withReopenRetry retries a
+	// transient closed-pool failure (a reopen swap or a stale-credentials
+	// eviction) before surfacing it. It protects callers from unbounded retry
+	// loops if closes keep racing acquisition.
+	maxPoolClosedRetries = 4
 )
+
+// ErrManagerClosed is returned by connection-acquisition paths when the
+// manager is closed. withReopenRetry treats it as transient (waits for the
+// paired Open, then retries) while a reopen window is open, and as terminal
+// otherwise.
+var ErrManagerClosed = errors.New("manager is closed")
 
 // Manager orchestrates per-user connection pools with a shared admin pool.
 // Each user gets their own RegularPool and ReservedPool that connect directly
@@ -79,15 +91,20 @@ type Manager struct {
 	// This mutex is only acquired when a new user pool needs to be created.
 	createMu sync.Mutex
 
-	// closed indicates whether the manager has been closed.
+	// closed indicates whether the manager has been closed. It is set by both
+	// Close (terminal) and CloseForReopen (transient); the reopen bookkeeping
+	// below is what distinguishes the two for retry decisions.
 	closed atomic.Bool
 
-	// generation is incremented on every Open(). Callers that get
-	// ErrPoolClosed from an in-flight pool operation can compare the
-	// pre-call generation against the current one: if it advanced, a
-	// reopen swapped the pools underneath them and the call is safe to
-	// retry against the fresh snapshot.
-	generation atomic.Uint64
+	// Reopen bookkeeping, guarded by reopenMu. CloseForReopen opens a reopen
+	// window (reopening=true, reopenDone=fresh channel) before tearing the
+	// pools down; the paired Open closes the window via endReopen. While a
+	// window is open, withReopenRetry waits on reopenDone before retrying a
+	// closed-pool error instead of surfacing the transient failure to the
+	// client.
+	reopenMu   sync.Mutex
+	reopening  bool
+	reopenDone chan struct{}
 
 	// Rebalancer goroutine management
 	rebalancerCtx    context.Context
@@ -137,7 +154,6 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	m.zeroCh = zeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
 	m.closed.Store(false)
-	m.generation.Add(1)
 
 	// Build admin client config. pwSourceNone signals that ResolvePgPassword
 	// was never called — production startup in services/multipooler/init.go
@@ -199,6 +215,10 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 		"reserved_allocation", reservedCapacity,
 		"rebalance_interval", m.config.RebalanceInterval(),
 	)
+
+	// If this Open is the second half of a reopen, end the window now that the
+	// fresh pools are ready, waking any withReopenRetry waiters so they retry.
+	m.endReopen()
 }
 
 // buildClientConfig creates a client.Config with the specified user and password.
@@ -282,7 +302,7 @@ func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) 
 
 	// Check if closed before attempting to create
 	if m.closed.Load() {
-		return nil, errors.New("manager is closed")
+		return nil, ErrManagerClosed
 	}
 
 	// Cold path: need to create a new user pool.
@@ -307,7 +327,7 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 
 	// Check if closed (with lock held)
 	if m.closed.Load() {
-		return nil, errors.New("manager is closed")
+		return nil, ErrManagerClosed
 	}
 
 	currentPools := *pools
@@ -377,11 +397,31 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 	return pool, nil
 }
 
-// Close shuts down all connection pools.
+// Close shuts down all connection pools. This is a terminal close: callers
+// acquiring connections afterward receive ErrManagerClosed until a fresh Open.
 func (m *Manager) Close() {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
+	m.closeLocked()
+}
 
+// CloseForReopen closes all pools as the first half of a reopen — a Close
+// immediately followed by an Open, e.g. to refresh stale file descriptors
+// after PostgreSQL restarts. It opens a reopen window so that connection
+// requests racing the close wait for the matching Open and retry against the
+// fresh pools, rather than receiving the transient ErrManagerClosed /
+// ErrPoolClosed error. It MUST be paired with a subsequent Open, which closes
+// the window. See withReopenRetry.
+func (m *Manager) CloseForReopen() {
+	m.createMu.Lock()
+	defer m.createMu.Unlock()
+	m.beginReopen()
+	m.closeLocked()
+}
+
+// closeLocked tears down all pools and marks the manager closed. The caller
+// must hold createMu.
+func (m *Manager) closeLocked() {
 	if m.closed.Load() {
 		return
 	}
@@ -467,7 +507,7 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 // pool regardless of the keys they pass. The caller must call Recycle() on
 // the returned connection to return it to the pool.
 func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConn(ctx)
 	})
 }
@@ -477,7 +517,7 @@ func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, se
 // for consistent bucket assignment.
 func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConnWithSettings(ctx, s)
 	})
 }
@@ -493,7 +533,7 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // connection.
 func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewReservedConn(ctx, s, opts...)
 	})
 }
@@ -503,7 +543,7 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 // ReasonLogicalReplication, on the specified user's reserved pool. SCRAM
 // passthrough key semantics match NewReservedConn.
 func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
-	return withReopenRetry(m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewLogicalReplicationConn(ctx)
 	})
 }
@@ -548,65 +588,150 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 	return true
 }
 
-// withReopenRetry runs op against the current user pool with two single-shot
-// retry paths for transient, self-healable failures:
+// withReopenRetry runs op against the current user pool, retrying transient,
+// self-healable failures:
 //
-//  1. ErrPoolClosed after a generation bump: reopenConnections() swapped the
-//     pools mid-flight (PostgreSQL auto-restart recovery). Retry against the
-//     fresh pool. A closed-pool error with no generation bump means the
-//     manager is genuinely shutting down — surface it unchanged.
+//  1. Closed pool while the manager is being reopened: reopenConnections()
+//     runs Close (via CloseForReopen) immediately followed by Open to refresh
+//     pools (PostgreSQL auto-restart recovery). A request racing that window
+//     sees ErrManagerClosed from getOrCreateUserPool or ErrPoolClosed from the
+//     op. Because CloseForReopen marked a reopen window, we wait for the paired
+//     Open to finish (honoring ctx) and retry against the fresh pools instead
+//     of surfacing the transient error. A closed pool with no reopen window
+//     means the manager is genuinely shutting down — surface it unchanged.
 //
-//  2. Class-28 SQLSTATE from PostgreSQL: the cached user pool's ClientConfig
+//  2. Closed pool while the manager stays up: evictUserPool() replaced a
+//     stale-credentials pool. Retry against the freshly created pool. Both this
+//     and the reopen path are bounded by maxPoolClosedRetries.
+//
+//  3. Class-28 SQLSTATE from PostgreSQL: the cached user pool's ClientConfig
 //     carries stale SCRAM keys (password rotated in pg_authid). Evict the
 //     pool and recreate from the triggering session's keys, which are
 //     known-current — they were derived moments ago during the session's
 //     SCRAM handshake at MultiGateway against whatever verifier pg_authid
 //     holds right now. If the retry also auth-fails (retrier itself used the
 //     old password at the gateway), we surface the clean 28xxx error and the
-//     client reconnects to re-derive keys against the new verifier.
+//     client reconnects to re-derive keys against the new verifier. This path
+//     performs at most one eviction + retry.
 //
 // clientKey and serverKey forward the SCRAM passthrough material to
 // getOrCreateUserPool so that a first-time pool creation triggered during
 // this call (including after an eviction or reopen swap) gets the session's
 // keys.
-func withReopenRetry[T any](m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
+func withReopenRetry[T any](ctx context.Context, m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
-	startGen := m.generation.Load()
-	pool, err := m.getOrCreateUserPool(user, clientKey, serverKey)
-	if err != nil {
+	authRetried := false
+
+	for closedAttempts := 0; ; {
+		var err error
+		pool, lookupErr := m.getOrCreateUserPool(user, clientKey, serverKey)
+		if lookupErr != nil {
+			err = lookupErr
+		} else {
+			result, opErr := op(pool)
+			if opErr == nil {
+				return result, nil
+			}
+
+			// Stale-key self-heal applies only to op failures, since it needs the
+			// pool to evict. evictUserPool is best-effort; even if it returns
+			// false (racing eviction), getOrCreateUserPool on the next iteration
+			// returns whatever is in the snapshot now — a freshly-created pool
+			// with fresh keys, or absent (and we create one).
+			if mterrors.IsAuthenticationError(opErr) {
+				if authRetried {
+					return zero, opErr
+				}
+				authRetried = true
+				m.evictUserPool(user, pool)
+				continue
+			}
+			err = opErr
+		}
+
+		// A closed manager (ErrManagerClosed from the lookup) and a closed pool
+		// (ErrPoolClosed from the op) are the same situation seen from two sides:
+		// transient while a reopen is in progress — wait it out and retry — and
+		// terminal otherwise. Bound the retries so repeated transient closes
+		// can't loop forever.
+		if errors.Is(err, ErrManagerClosed) || errors.Is(err, connpool.ErrPoolClosed) {
+			if closedAttempts >= maxPoolClosedRetries {
+				return zero, err
+			}
+			closedAttempts++
+			retry, werr := m.handleClosed(ctx)
+			if werr != nil {
+				return zero, werr
+			}
+			if retry {
+				continue
+			}
+		}
+
 		return zero, err
 	}
-	result, err := op(pool)
-	if err == nil {
-		return result, nil
+}
+
+// handleClosed decides how withReopenRetry should react to a closed-pool
+// failure (ErrPoolClosed from an op, or ErrManagerClosed from the lookup). If a
+// reopen is in progress it blocks for the paired Open to finish, honoring ctx,
+// then reports retry=true. A terminal close with no reopen pending reports
+// retry=false. It returns a non-nil error only when ctx is cancelled while
+// waiting. Retry bounding is the caller's responsibility.
+func (m *Manager) handleClosed(ctx context.Context) (retry bool, err error) {
+	reopening, done := m.reopenState()
+	switch {
+	case reopening:
+		// Wait for the paired Open to finish, then retry against fresh pools.
+		// done is non-nil whenever reopening is true; the guard is defensive.
+		if done != nil {
+			select {
+			case <-done:
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
+		}
+	case m.closed.Load():
+		// Terminal shutdown with no reopen pending: nothing to retry.
+		return false, nil
 	}
 
-	// Manager-restart race: reopenConnections swapped pools mid-flight.
-	if errors.Is(err, connpool.ErrPoolClosed) {
-		if m.generation.Load() == startGen {
-			return zero, err
-		}
-		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
-		if err2 != nil {
-			return zero, err2
-		}
-		return op(pool2)
-	}
+	// Either the reopen completed (manager is back up), or a pool was closed
+	// (evicted/swapped) while the manager stayed up. Retry against the current
+	// snapshot.
+	return true, nil
+}
 
-	// Stale-key self-heal. evictUserPool is best-effort; even if it returns
-	// false (racing eviction), getOrCreateUserPool returns whatever is in the
-	// snapshot now, which is either a freshly-created pool with fresh keys
-	// or absent (and we create one).
-	if mterrors.IsAuthenticationError(err) {
-		m.evictUserPool(user, pool)
-		pool2, err2 := m.getOrCreateUserPool(user, clientKey, serverKey)
-		if err2 != nil {
-			return zero, err2
-		}
-		return op(pool2)
+// beginReopen opens a reopen window. The caller must hold createMu.
+func (m *Manager) beginReopen() {
+	m.reopenMu.Lock()
+	defer m.reopenMu.Unlock()
+	if m.reopenDone == nil {
+		m.reopenDone = make(chan struct{})
 	}
+	m.reopening = true
+}
 
-	return zero, err
+// endReopen closes the current reopen window, if any, waking withReopenRetry
+// waiters so they retry against the freshly reopened pools. It is a no-op when
+// no window is open (e.g. a plain startup Open).
+func (m *Manager) endReopen() {
+	m.reopenMu.Lock()
+	done := m.reopenDone
+	m.reopenDone = nil
+	m.reopening = false
+	m.reopenMu.Unlock()
+	if done != nil {
+		close(done)
+	}
+}
+
+// reopenState reports whether a reopen window is currently open and returns the
+// channel that endReopen will close when it completes.
+func (m *Manager) reopenState() (bool, <-chan struct{}) {
+	m.reopenMu.Lock()
+	defer m.reopenMu.Unlock()
+	return m.reopening, m.reopenDone
 }
 
 // GetReservedConn retrieves an existing reserved connection by ID for the specified user.

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -429,7 +429,7 @@ func (m *Manager) Close() {
 		return
 	}
 	m.setLifecycle(lifecycleClosed)
-	// If a reopen was in progress, this terminal close pre-empts it: wake any
+	// If a reopen was in progress, this terminal close preempts it: wake any
 	// withReopenRetry waiters so they observe lifecycleClosed and surface the
 	// error instead of blocking on a paired Open that will never come.
 	m.endReopen()

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -454,6 +454,53 @@ func TestWithReopenRetry_ReopenWaitHonorsContextCancellation(t *testing.T) {
 	assert.Equal(t, 0, calls, "op must not run while waiting for the reopen to complete")
 }
 
+// TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter verifies the
+// pre-emption behavior the single lifecycle enum makes representable: if a
+// terminal Close lands while a caller is blocked on an in-progress reopen
+// window, the caller is woken, observes the now-terminal lifecycle, and
+// surfaces ErrManagerClosed instead of blocking until its context expires.
+func TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	manager.CloseForReopen() // window open; pools torn down, no paired Open coming
+
+	type result struct {
+		calls int
+		err   error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		calls := 0
+		// A generous deadline: the assertion is that we return via the terminal
+		// Close below, well before this would fire.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+			calls++
+			return 0, nil
+		})
+		resCh <- result{calls: calls, err: err}
+	}()
+
+	// Let the caller reach the reopen wait, then pre-empt it with a terminal Close.
+	time.Sleep(20 * time.Millisecond)
+	manager.Close()
+
+	select {
+	case res := <-resCh:
+		require.Error(t, res.err)
+		assert.ErrorIs(t, res.err, ErrManagerClosed)
+		assert.Equal(t, 0, res.calls, "op must not run once the reopen is pre-empted by a terminal close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("withReopenRetry did not wake after a terminal Close pre-empted the reopen")
+	}
+}
+
 // TestWithReopenRetry_EvictsStalePoolOnAuthError verifies the stale-key
 // self-heal path: when op fails with a class-28 SQLSTATE (SCRAM auth
 // failure against stale cached keys), withReopenRetry must evict the

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -455,7 +455,7 @@ func TestWithReopenRetry_ReopenWaitHonorsContextCancellation(t *testing.T) {
 }
 
 // TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter verifies the
-// pre-emption behavior the single lifecycle enum makes representable: if a
+// preemption behavior the single lifecycle enum makes representable: if a
 // terminal Close lands while a caller is blocked on an in-progress reopen
 // window, the caller is woken, observes the now-terminal lifecycle, and
 // surfaces ErrManagerClosed instead of blocking until its context expires.
@@ -487,7 +487,7 @@ func TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter(t *testing.T) {
 		resCh <- result{calls: calls, err: err}
 	}()
 
-	// Let the caller reach the reopen wait, then pre-empt it with a terminal Close.
+	// Let the caller reach the reopen wait, then preempt it with a terminal Close.
 	time.Sleep(20 * time.Millisecond)
 	manager.Close()
 
@@ -495,9 +495,9 @@ func TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter(t *testing.T) {
 	case res := <-resCh:
 		require.Error(t, res.err)
 		assert.ErrorIs(t, res.err, ErrManagerClosed)
-		assert.Equal(t, 0, res.calls, "op must not run once the reopen is pre-empted by a terminal close")
+		assert.Equal(t, 0, res.calls, "op must not run once the reopen is preempted by a terminal close")
 	case <-time.After(2 * time.Second):
-		t.Fatal("withReopenRetry did not wake after a terminal Close pre-empted the reopen")
+		t.Fatal("withReopenRetry did not wake after a terminal Close preempted the reopen")
 	}
 }
 

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -275,11 +276,23 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 	assert.Greater(t, server.GetPatternCalledNum(`SELECT pg_catalog\.set_config\(.+\)`), 0)
 }
 
+// testConnConfig returns a ConnectionConfig pointing at the fake server, used
+// to drive a simulated reopen (the Open half) in these tests.
+func testConnConfig(server *fakepgserver.Server) *ConnectionConfig {
+	return &ConnectionConfig{
+		SocketFile: server.ClientConfig().SocketFile,
+		Host:       server.ClientConfig().Host,
+		Port:       server.ClientConfig().Port,
+		Database:   server.ClientConfig().Database,
+	}
+}
+
 // TestWithReopenRetry_RetriesOnReopen covers the race in which
 // reopenConnections (triggered by MonitorPostgres after a postgres restart)
 // closes the user pool while a connection acquisition is already in-flight.
-// The helper must notice the generation bump and retry against the fresh pool
-// rather than surfacing the transient ErrPoolClosed to the caller.
+// CloseForReopen marks a reopen window; the helper must wait for the paired
+// Open to complete and retry against the fresh pool rather than surfacing the
+// transient ErrPoolClosed to the caller.
 func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -288,14 +301,17 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	manager := newTestManager(t, server)
 	defer manager.Close()
 
+	ctx := context.Background()
+
 	calls := 0
-	result, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	result, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		if calls == 1 {
-			// Simulate reopenConnections running mid-flight: the pool we
-			// were handed has been closed, but a new one has already been
-			// installed with a bumped generation.
-			manager.generation.Add(1)
+			// Simulate reopenConnections running mid-flight: close the pools as
+			// part of a reopen window, then complete the reopen (Open) from a
+			// goroutine. withReopenRetry must wait the window out and retry.
+			manager.CloseForReopen()
+			go manager.Open(ctx, testConnConfig(server))
 			return 0, connpool.ErrPoolClosed
 		}
 		return 42, nil
@@ -303,12 +319,45 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, 42, result)
-	assert.Equal(t, 2, calls, "should have retried once after the reopen")
+	assert.Equal(t, 2, calls, "should have retried once after the reopen completed")
 }
 
-// TestWithReopenRetry_SurfacesGenuineClose covers the non-reopen case: the
-// manager is actually shutting down, so ErrPoolClosed must be returned to the
-// caller instead of being retried into an infinite loop.
+// TestWithReopenRetry_WaitsForReopenThenRetries covers the close-but-not-yet-open
+// window from the lookup side: getOrCreateUserPool sees a closed manager and
+// returns ErrManagerClosed (op never runs, so no pool is created against a
+// half-open manager). Because a reopen window is open, the helper waits for the
+// Open to finish and then succeeds.
+func TestWithReopenRetry_WaitsForReopenThenRetries(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	ctx := context.Background()
+	manager.CloseForReopen() // window open, pools closed
+
+	go func() {
+		// Let withReopenRetry block on the reopen window before completing it.
+		time.Sleep(20 * time.Millisecond)
+		manager.Open(ctx, testConnConfig(server))
+	}()
+
+	calls := 0
+	result, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 99, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 99, result)
+	assert.Equal(t, 1, calls, "op runs once, only after the reopen completes")
+}
+
+// TestWithReopenRetry_SurfacesGenuineClose covers the terminal-shutdown case:
+// the manager is closed mid-flight with no reopen window, so the original
+// ErrPoolClosed must be surfaced rather than retried into a closed manager.
 func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
@@ -318,21 +367,46 @@ func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
-		// No generation bump — manager hasn't been reopened.
+		// Genuine shutdown racing the op: terminal Close, no reopen window.
+		manager.Close()
 		return 0, connpool.ErrPoolClosed
 	})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
-	assert.Equal(t, 1, calls, "should not retry when generation did not advance")
+	assert.Equal(t, 1, calls, "should not retry once the manager is terminally closed")
 }
 
-// TestWithReopenRetry_OnlyRetriesOnce ensures the helper stops after one retry
-// even if the retry also fails with ErrPoolClosed (e.g. if a second reopen
-// races with the retry). Without a cap this could loop forever.
-func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
+// TestWithReopenRetry_FailsFastOnPreClosedManager covers a manager that is
+// already terminally closed before the call: getOrCreateUserPool short-circuits
+// with ErrManagerClosed and op is never invoked.
+func TestWithReopenRetry_FailsFastOnPreClosedManager(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	manager.Close()
+
+	calls := 0
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 0, nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrManagerClosed)
+	assert.Equal(t, 0, calls, "op must not run when the manager is already closed")
+}
+
+// TestWithReopenRetry_RetriesErrPoolClosedUpToCap ensures ErrPoolClosed retries
+// (e.g. repeated eviction/reopen races against a manager that stays up) are
+// bounded by maxPoolClosedRetries instead of looping forever.
+func TestWithReopenRetry_RetriesErrPoolClosedUpToCap(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()
 	server.SetNeverFail(true)
@@ -341,15 +415,43 @@ func TestWithReopenRetry_OnlyRetriesOnce(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
-		manager.generation.Add(1)
 		return 0, connpool.ErrPoolClosed
 	})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connpool.ErrPoolClosed)
-	assert.Equal(t, 2, calls, "should retry exactly once, not loop")
+	assert.Equal(t, maxPoolClosedRetries+1, calls, "should retry up to the cap, then surface")
+}
+
+// TestWithReopenRetry_ReopenWaitHonorsContextCancellation verifies callers do
+// not block forever if a reopen never completes: waiting on the reopen window
+// must respect the request context's deadline.
+func TestWithReopenRetry_ReopenWaitHonorsContextCancellation(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetNeverFail(true)
+
+	manager := newTestManager(t, server)
+	defer manager.Close()
+
+	manager.CloseForReopen() // window open and never completed
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	calls := 0
+	_, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		calls++
+		return 0, connpool.ErrPoolClosed
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	// op never runs: getOrCreateUserPool sees the closed manager and we wait on
+	// the reopen window until ctx expires.
+	assert.Equal(t, 0, calls, "op must not run while waiting for the reopen to complete")
 }
 
 // TestWithReopenRetry_EvictsStalePoolOnAuthError verifies the stale-key
@@ -369,7 +471,7 @@ func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
 
 	var seenPools []*UserPool
 	calls := 0
-	result, err := withReopenRetry(manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
+	result, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
 		calls++
 		seenPools = append(seenPools, pool)
 		if calls == 1 {
@@ -405,7 +507,7 @@ func TestWithReopenRetry_SurfacesPersistentAuthError(t *testing.T) {
 	authErr := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01", Message: "password authentication failed"}
 
 	calls := 0
-	_, err := withReopenRetry(manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, fmt.Errorf("dial failed: %w", authErr)
 	})

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -129,6 +129,7 @@ type stubPoolManager struct {
 
 func (m *stubPoolManager) Open(context.Context, *connpoolmanager.ConnectionConfig) {}
 func (m *stubPoolManager) Close()                                                  {}
+func (m *stubPoolManager) CloseForReopen()                                         {}
 func (m *stubPoolManager) PgUser() string                                          { return "postgres" }
 func (m *stubPoolManager) PgPassword() (string, bool)                              { return "", true }
 func (m *stubPoolManager) GetAdminConn(context.Context) (admin.PooledConn, error)  { return nil, nil }

--- a/go/services/multipooler/manager/manager.go
+++ b/go/services/multipooler/manager/manager.go
@@ -559,7 +559,7 @@ func (pm *MultiPoolerManager) closeLocked(ctx context.Context, logMessage string
 	}
 
 	pm.pgMonitor.Stop()
-	pm.closeConnectionsLocked()
+	pm.closeConnectionsLocked(false /* forReopen */)
 	pm.cancel()
 	pm.isOpen = false
 	pm.logger.InfoContext(ctx, "MultiPoolerManager: "+logMessage)
@@ -685,7 +685,12 @@ func (pm *MultiPoolerManager) openConnectionsLocked() {
 // without canceling the main context. Caller must hold pm.mu.
 // This is used by reopenConnections() during auto-restore to avoid canceling
 // the startup context that WaitUntilReady is waiting on.
-func (pm *MultiPoolerManager) closeConnectionsLocked() {
+//
+// When forReopen is true the pool manager is closed via CloseForReopen, which
+// marks the close as transient so connection requests racing the immediately
+// following openConnectionsLocked wait for it and retry instead of failing with
+// a closed-pool error.
+func (pm *MultiPoolerManager) closeConnectionsLocked(forReopen bool) {
 	// Close resources (safe to call even if nil/never opened)
 	if pm.replTracker != nil {
 		pm.replTracker.Close()
@@ -699,7 +704,11 @@ func (pm *MultiPoolerManager) closeConnectionsLocked() {
 
 	// Close connection pool manager
 	if pm.connPoolMgr != nil {
-		pm.connPoolMgr.Close()
+		if forReopen {
+			pm.connPoolMgr.CloseForReopen()
+		} else {
+			pm.connPoolMgr.Close()
+		}
 	}
 }
 
@@ -711,7 +720,10 @@ func (pm *MultiPoolerManager) reopenConnections(_ context.Context) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	pm.closeConnectionsLocked()
+	// forReopen=true: CloseForReopen marks a reopen window so in-flight
+	// connection requests wait for openConnectionsLocked below and retry,
+	// instead of leaking a transient closed-pool error to clients.
+	pm.closeConnectionsLocked(true /* forReopen */)
 	pm.openConnectionsLocked()
 }
 


### PR DESCRIPTION
## Summary

- Stabilizes `TestWrappedPreparedStatementExecution/multigateway` by closing the race in `withReopenRetry` that surfaced a transient closed-pool error to clients during a pool reopen.
- Alternative to #1031 — same bug, simpler model. 
## Problem

`reopenConnections()` runs `Close -> Open` on the conn pool manager to refresh file descriptors after a PostgreSQL restart. A query whose acquisition lands in the close-but-not-yet-open window sees `ErrPoolClosed` (or "manager is closed") and surfaces it to the client: `pq: ... connection pool is closed`. The old generation-counter scheme didn't actually fix this — on the reopen path it made the same retry decision as the plain `closed` flag, so the window stayed open.

## Solution

Distinguish a transient reopen from a terminal shutdown explicitly. `CloseForReopen()` sets `closed=true` — so `getOrCreateUserPool` still refuses to build a pool against a half-open manager, which is what prevents an orphaned pool wired to a nil admin pool — and additionally marks a reopen window with a completion channel that the paired `Open()` closes.

`withReopenRetry` then waits out the window and retries against the fresh pools, honoring the request context. A closed manager with no window in progress stays terminal and surfaces unchanged. Retries are bounded by `maxPoolClosedRetries`. The reopen path in `MultiPoolerManager` calls `CloseForReopen` (vs `Close` for genuine shutdown) via a `forReopen` flag on `closeConnectionsLocked`.

Tests: `TestWithReopenRetry` suite rewritten around `CloseForReopen`/`Open` (op-path retry, lookup-path wait, terminal close, pre-closed fail-fast, retry cap, ctx cancellation); passes `-race -count=5`.