### PR TITLE
feat(multigateway): prevent creation of unlogged tables

### DIFF
--- a/docs/query_serving/unsafe_statement_rejection.md
+++ b/docs/query_serving/unsafe_statement_rejection.md
@@ -3,8 +3,9 @@
 ## Overview
 
 The multigateway inspects every SQL statement at plan time and
-classifies it into one of two statement-level tiers, plus an
-expression-level filter that runs across all tiers:
+classifies it into one of two statement-level tiers, plus a
+replication-safety check and an expression-level filter that run across
+all tiers:
 
 - **Tier 1 — statements embedding procedural code** (DO, CREATE
   FUNCTION / PROCEDURE, CREATE TRIGGER, CREATE RULE, CREATE EVENT
@@ -13,6 +14,11 @@ expression-level filter that runs across all tiers:
   SYSTEM, CREATE/DROP DATABASE, CREATE LANGUAGE, CREATE SUBSCRIPTION,
   CREATE FDW, CREATE SERVER). Risk is modifying the shared server
   process or crossing tenant boundaries.
+- **Replication safety — UNLOGGED tables** (CREATE UNLOGGED TABLE,
+  CREATE UNLOGGED TABLE AS, SELECT INTO UNLOGGED, ALTER TABLE ... SET
+  UNLOGGED). Risk is data that is not replicated to standbys and is
+  silently truncated on crash recovery — incompatible with a replicated,
+  highly-available cluster.
 - **Expression-level filter — dangerous built-in function calls**
   (`set_config`, `dblink*`, `pg_read_file*`, `lo_import/export`,
   `pg_execute_server_program`, `{query,table,cursor}_to_xml*`).
@@ -20,11 +26,12 @@ expression-level filter that runs across all tiers:
   connections, shell, arbitrary SQL) or bypassing the pooler's
   session-state tracker (set_config).
 
-The tiers are handled differently because the mitigations are
+The categories are handled differently because the mitigations are
 different (see [Handling](#handling) below). In the current
-implementation, **Tier 2 and the expression-level filter block at plan
-time; Tier 1 is allowed through pending deeper analysis**; the tiers
-will continue to diverge as follow-up layers land.
+implementation, **Tier 2, the UNLOGGED check, and the expression-level
+filter block at plan time; Tier 1 is allowed through pending deeper
+analysis**; the categories will continue to diverge as follow-up layers
+land.
 
 Blocked statements return a PostgreSQL `feature_not_supported` error
 (SQLSTATE `0A000`) with a descriptive message.
@@ -129,6 +136,43 @@ environment the control plane owns these, not tenant users.
 change is a configurable allowlist for self-hosted deployments where
 the operator explicitly opts into these.
 
+### Replication safety — UNLOGGED tables (blocked at plan time)
+
+UNLOGGED tables skip the write-ahead log. That has two consequences
+that make them unsafe in a Multigres cluster: their contents are **not
+streamed to standbys** (the table exists on the primary but is empty on
+every replica), and they are **truncated on crash recovery**. An
+application that writes to an UNLOGGED table and then reads it back
+after a failover — or from a replica — silently sees no rows. Blocking
+at creation time is the only place we can catch this before data loss.
+
+| Statement                      | AST Node              | Persistence / subcommand carried on                 | Example                               |
+| ------------------------------ | --------------------- | --------------------------------------------------- | ------------------------------------- |
+| `CREATE UNLOGGED TABLE`        | `T_CreateStmt`        | `CreateStmt.Relation.RelPersistence == 'u'`         | `CREATE UNLOGGED TABLE t (id int)`    |
+| `CREATE UNLOGGED TABLE AS`     | `T_CreateTableAsStmt` | `CreateTableAsStmt.Into.Rel.RelPersistence`         | `CREATE UNLOGGED TABLE t AS SELECT 1` |
+| `SELECT ... INTO UNLOGGED`     | `T_SelectStmt`        | `SelectStmt.IntoClause.Rel.RelPersistence`          | `SELECT 1 AS id INTO UNLOGGED t`      |
+| `ALTER TABLE ... SET UNLOGGED` | `T_AlterTableStmt`    | an `AlterTableCmd` with `Subtype == AT_SetUnLogged` | `ALTER TABLE t SET UNLOGGED`          |
+
+Two parser subtleties worth noting:
+
+- **`SELECT ... INTO` is a `SelectStmt`, not a `CreateTableAsStmt`, at
+  plan time.** PostgreSQL only rewrites it into a `CreateTableAsStmt`
+  during later parse analysis, which the gateway does not run — so the
+  persistence flag lives on `SelectStmt.IntoClause.Rel` here. (This is
+  exactly the form the unit tests missed and the end-to-end test caught.)
+- **An `ALTER TABLE` may carry several subcommands** (e.g.
+  `ADD COLUMN x int, SET UNLOGGED`), so the check scans every
+  `AlterTableCmd` for `AT_SetUnLogged`.
+
+The check is **field/subcommand-conditional**, not a blanket
+statement-type rejection like Tier 2: only the UNLOGGED persistence flag
+(or the `SET UNLOGGED` subcommand) is rejected. Ordinary
+(`RELPERSISTENCE_PERMANENT`) and temporary (`RELPERSISTENCE_TEMP`)
+tables, plain `ALTER TABLE` subcommands, and `ALTER TABLE ... SET LOGGED`
+(the harmless inverse, restoring WAL logging) all pass straight through.
+It is enforced inside `planUnsupportedStmt()` alongside the Tier 2 switch
+cases.
+
 ### Expression-level filter — dangerous built-in function calls
 
 The statement-level tiers above block whole statements. A second layer
@@ -137,16 +181,16 @@ list, WHERE, JOIN, INSERT values, DEFAULT expressions, CTEs, subqueries)
 and enforces rules on specific built-ins. Schema-qualified variants
 (`pg_catalog.dblink`, etc.) resolve to the same entry.
 
-| Function(s)                                                        | Category                                | Action                                                                                                                                                                           |
-| ------------------------------------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `set_config(name, value, is_local)`                                | Session state                           | Bare `SELECT set_config(lit, lit, false)` rewrites to `SET`. Non-literal args rejected. `is_local=true` passes through (transaction-scoped). Embedded `is_local=false` rejected. |
-| `dblink`, `dblink_exec`, `dblink_connect`, `dblink_connect_u`      | Outbound connections                    | Reject                                                                                                                                                                           |
-| `pg_read_file`, `pg_read_binary_file`, `pg_ls_dir`, `pg_stat_file` | Filesystem read                         | Reject                                                                                                                                                                           |
-| `lo_import`, `lo_export`                                           | Filesystem read/write via large objects | Reject                                                                                                                                                                           |
-| `pg_execute_server_program`                                        | Shell execution                         | Reject                                                                                                                                                                           |
-| `query_to_xml`, `query_to_xmlschema`, `query_to_xml_and_xmlschema` | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                           |
-| `table_to_xml`, `table_to_xmlschema`, `table_to_xml_and_xmlschema` | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                           |
-| `cursor_to_xml`, `cursor_to_xmlschema`                             | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                           |
+| Function(s)                                                                                                     | Category                                | Action                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `set_config(name, value, is_local)`                                                                             | Session state                           | Tracked as a `SET`, but only as a top-level SELECT target-list entry; args may be literal or bound. Other positions and `is_local` handled specially — see prose below. |
+| `dblink*` (sync entry points + async-cursor surface: `_open`, `_fetch`, `_close`, `_send_query`, `_get_result`) | Outbound connections                    | Reject                                                                                                                                                                  |
+| `pg_read_file`, `pg_read_binary_file`, `pg_ls_dir`, `pg_stat_file`                                              | Filesystem read                         | Reject                                                                                                                                                                  |
+| `lo_import`, `lo_export`                                                                                        | Filesystem read/write via large objects | Reject                                                                                                                                                                  |
+| `pg_execute_server_program`                                                                                     | Shell execution                         | Reject                                                                                                                                                                  |
+| `query_to_xml`, `query_to_xmlschema`, `query_to_xml_and_xmlschema`                                              | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                  |
+| `table_to_xml`, `table_to_xmlschema`, `table_to_xml_and_xmlschema`                                              | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                  |
+| `cursor_to_xml`, `cursor_to_xmlschema`                                                                          | Arbitrary SQL via XML helpers           | Reject                                                                                                                                                                  |
 
 **Why these specific functions:** each one is a callable equivalent of
 a Tier 2 operation or a session-state bypass. `dblink` opens outbound
@@ -159,10 +203,10 @@ so the gateway's `SessionSettings` tracker never sees it — on the next
 query the pool picks a different backend connection and the state is
 gone.
 
-**How `set_config` is handled.** The walker accepts
-`set_config(literal, literal, false)` only when it sits directly as a
-top-level SELECT target-list entry (possibly alongside other entries
-or a FROM). Every accepted shape plans the same way:
+**How `set_config` is handled.** The walker accepts a `set_config` call
+only when it sits directly as a top-level SELECT target-list entry
+(possibly alongside other entries or a FROM). Every accepted shape plans
+the same way:
 
 ```text
 Sequence[silent ApplySessionState per call, Route(original SQL)]
@@ -175,24 +219,48 @@ any sibling target-list entries and table rows). This costs one PG
 round-trip even for bare `SELECT set_config(...)`, which is a deliberate
 simplicity choice over a fast-path that would bypass PG.
 
+**Literal and bound arguments.** Each of the three slots (`name`,
+`value`, `is_local`) may be a literal constant **or** a bound parameter
+(`$1`), e.g. `SELECT set_config('search_path', $1, false)`. When any
+slot is bound, the tracking primitive is built via
+`NewApplySessionStateFromBind`, which records the `ParamRef`s and defers
+per-slot resolution to execute time — `executeSetWithBinds` decodes the
+actual values from the portal's wire-protocol Bind values before
+updating `SessionSettings`. All-literal calls use the simpler
+`NewApplySessionStateSilent`. (An earlier iteration rejected non-literal
+args outright; bound parameters are now supported because PostgREST and
+ORMs routinely parameterize the value.)
+
 `set_config(..., true)` — transaction-scoped — is accepted in any
 position but never tracked: it doesn't outlive the transaction, so
-there's nothing for the pool to carry forward.
+there's nothing for the pool to carry forward. (A _bound_ `is_local`
+can't be short-circuited at plan time; the track-or-not decision is
+deferred to `executeSetWithBinds`.)
 
 Anything else is rejected: `set_config` in a WHERE clause, nested inside
 another function's arguments, inside a CTE, in a DEFAULT expression, in
 INSERT/UPDATE — evaluation semantics in those positions (conditional,
 per-row, or hidden in a subquery) can't be faithfully represented by a
-SessionSettings update. Non-literal arguments are always rejected,
-because the value we would need to track is unknown at plan time.
+SessionSettings update. Expression-shaped arguments that are neither a
+literal nor a bound parameter (a column reference, a nested function
+call, a cast of a non-constant) are also rejected, because the value we
+would need to track is unknown at plan time. `SELECT ... INTO` is
+excluded as an allowed position too: that shape dispatches to the
+reserved temp-table route, which would drop the tracked set_config and
+leave the gateway's tracker stale relative to the backend.
 
-**Where it runs.** Inside the planner, in a single walk at the top of
-`Plan()` that also covers the statement-level Tier 2 check. Running here
-means the plan cache short-circuits the walk: a cached plan is by
-construction safe. The normalizer is configured to preserve literals
-inside `set_config(...)` calls (see `go/common/parser/ast/normalizer.go`)
-so the walker still sees the original A_Const arguments despite
-normalization happening earlier in the pipeline for caching.
+**Where it runs.** Inside the planner, in a single walk that runs as
+part of `planUnsupportedConstructs()` — the orchestrator that pairs the
+statement-level check (`planUnsupportedStmt`, covering Tier 2 and the
+UNLOGGED rejection) with this expression-level walk
+(`inspectExpressionFuncCalls`). Both the simple-protocol `Plan()` and
+the extended-protocol `PlanPortal()` call `planUnsupportedConstructs()`,
+so neither path can skip a check. Running in the planner means the plan
+cache short-circuits the walk: a cached plan is by construction safe.
+The normalizer is configured to preserve literals inside
+`set_config(...)` calls (see `go/common/parser/ast/normalizer.go`) so the
+walker still sees the original A_Const arguments despite normalization
+happening earlier in the pipeline for caching.
 
 **Out of scope for this layer.**
 
@@ -217,10 +285,13 @@ execute opaque server-side code and cannot be usefully blocked.
 
 ### Architecture
 
-Both the statement-level Tier 2 filter and the expression-level walker
-run at the top of `Planner.Plan()`, before dispatch. Running in the
-planner (rather than in the executor) means a plan cache hit
-short-circuits both checks: a cached plan is by construction safe.
+Both the statement-level filter (Tier 2 + UNLOGGED) and the
+expression-level walker run before dispatch, bundled behind
+`planUnsupportedConstructs()`. Both `Planner.Plan()` (simple protocol)
+and `Planner.PlanPortal()` (extended protocol) call that orchestrator,
+so neither query path can bypass a check. Running in the planner (rather
+than in the executor) means a plan cache hit short-circuits both checks:
+a cached plan is by construction safe.
 
 ```text
 Client SQL
@@ -236,17 +307,17 @@ Executor normalizes literals (A_Const -> $N) for plan cache
   (skips inside set_config() calls so the planner still sees its literals)
   |
   v
-Planner.Plan()
+Planner.Plan() / Planner.PlanPortal()
   |
-  +-- planUnsupportedStmt(stmt)          <-- Tier 2 rejection check
+  +-- planUnsupportedConstructs(stmt)    <-- orchestrates both checks
   |     |
-  |     +-- blocked? --> return feature_not_supported error
-  |
-  +-- inspectExpressionFuncCalls(stmt)   <-- expression-level filter
+  |     +-- planUnsupportedStmt(stmt)         <-- Tier 2 + UNLOGGED check
+  |     |     +-- blocked? --> return feature_not_supported error
   |     |
-  |     +-- blocklisted func?            --> return feature_not_supported
-  |     +-- rogue set_config?            --> return feature_not_supported
-  |     +-- tracked set_configs found    --> returned to dispatch
+  |     +-- inspectExpressionFuncCalls(stmt)  <-- expression-level filter
+  |           +-- blocklisted func?       --> return feature_not_supported
+  |           +-- rogue set_config?       --> return feature_not_supported
+  |           +-- tracked set_configs found --> returned to dispatch (Plan only)
   |
   v
 Statement-specific planning (switch on NodeTag)
@@ -265,17 +336,18 @@ alongside `planUnsupportedStmt()` and run its own body walker.
 
 ### Key Files
 
-| File                                                       | Purpose                                                                                                     |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `go/services/multigateway/planner/unsafe_stmt.go`          | `planUnsupportedStmt()` — switch on `NodeTag`, returns `feature_not_supported` for Tier 2 statements        |
-| `go/services/multigateway/planner/unsafe_funccall.go`      | `inspectExpressionFuncCalls()` — single walk that rejects blocklist and collects accepted set_config calls  |
-| `go/services/multigateway/planner/select_stmt.go`          | `planSelectStmt()` — dispatches SELECT based on set_config metadata (bare / mixed / plain)                  |
-| `go/services/multigateway/planner/planner.go`              | Runs both checks at the top of `Plan()` before dispatch                                                     |
-| `go/common/parser/ast/normalizer.go`                       | Skips normalization inside `set_config(...)` so the planner still sees literal args under plan caching      |
-| `go/services/multigateway/engine/apply_session_state.go`   | `NewApplySessionStateSilent()` — the tracker-only variant used inside a Sequence                            |
-| `go/services/multigateway/engine/sequence.go`              | Sequence primitive used for mixed `SELECT set_config(...), * FROM t` — tracking step + route                |
-| `go/services/multigateway/planner/unsafe_stmt_test.go`     | Tests for blocked (Tier 2) and allowed (Tier 1 + regular) statement types                                   |
-| `go/services/multigateway/planner/unsafe_funccall_test.go` | Tests for expression-level blocklist, set_config accept / reject positions, bare vs mixed plan construction |
+| File                                                       | Purpose                                                                                                                                                                    |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `go/services/multigateway/planner/unsafe_stmt.go`          | `planUnsupportedStmt()` — switch on `NodeTag`, returns `feature_not_supported` for Tier 2 statements and UNLOGGED tables                                                   |
+| `go/services/multigateway/planner/unsafe_funccall.go`      | `planUnsupportedConstructs()` orchestrator + `inspectExpressionFuncCalls()` — single walk that rejects blocklist and collects accepted (literal or bound) set_config calls |
+| `go/services/multigateway/planner/select_stmt.go`          | `planSelectStmt()` — dispatches SELECT based on set_config metadata; picks silent vs from-bind ApplySessionState                                                           |
+| `go/services/multigateway/planner/planner.go`              | Calls `planUnsupportedConstructs()` at the top of both `Plan()` and `PlanPortal()` before dispatch                                                                         |
+| `go/common/parser/ast/normalizer.go`                       | Skips normalization inside `set_config(...)` so the planner still sees literal args under plan caching                                                                     |
+| `go/services/multigateway/engine/apply_session_state.go`   | `NewApplySessionStateSilent()` (literal) and `NewApplySessionStateFromBind()` (`executeSetWithBinds` defers slot resolution to portal Bind values)                         |
+| `go/services/multigateway/engine/sequence.go`              | Sequence primitive used for mixed `SELECT set_config(...), * FROM t` — tracking step + route                                                                               |
+| `go/services/multigateway/planner/unsafe_stmt_test.go`     | Tests for blocked (Tier 2, UNLOGGED) and allowed (Tier 1 + regular) statement types                                                                                        |
+| `go/services/multigateway/planner/unsafe_funccall_test.go` | Tests for expression-level blocklist, set_config accept / reject positions, literal + bound args, bare vs mixed plan construction                                          |
+| `go/test/endtoend/queryserving/unsafe_stmt_test.go`        | End-to-end coverage through a real multigateway → PostgreSQL: Tier 2, UNLOGGED, simple + extended protocol, in-transaction                                                 |
 
 ### Error Format
 
@@ -295,13 +367,16 @@ The SQLSTATE `0A000` (`feature_not_supported`) was chosen because:
 
 ### Protocol Coverage
 
-Both query protocols are covered:
+Both query protocols are covered, and both call the same
+`planUnsupportedConstructs()` orchestrator (statement-level check +
+expression walk) so the statement-level and expression-level rejections
+apply identically:
 
 - **Simple query protocol** (`Query` message / `'Q'`): `Plan()` calls
-  `planUnsupportedStmt()` before the main dispatch switch.
+  `planUnsupportedConstructs()` before the main dispatch switch.
 - **Extended query protocol** (`Parse`/`Bind`/`Execute`): `PlanPortal()`
-  calls `planUnsupportedStmt()` before checking whether the statement
-  needs local handling.
+  calls `planUnsupportedConstructs()` before checking whether the
+  statement needs local handling.
 
 ## Future Work
 

--- a/go/services/multigateway/planner/unsafe_stmt.go
+++ b/go/services/multigateway/planner/unsafe_stmt.go
@@ -73,6 +73,56 @@ func planUnsupportedStmt(stmt ast.Stmt) error {
 		return mterrors.NewFeatureNotSupported(
 			"CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler")
 
+	// UNLOGGED tables skip the WAL, so their contents are not replicated to
+	// standbys and are truncated on crash recovery — incompatible with a
+	// replicated, highly-available deployment. Reject CREATE UNLOGGED TABLE
+	// and CREATE UNLOGGED TABLE AS / SELECT INTO UNLOGGED; ordinary tables
+	// are unaffected.
+	case ast.T_CreateStmt:
+		if s, ok := stmt.(*ast.CreateStmt); ok &&
+			s.Relation != nil && s.Relation.RelPersistence == ast.RELPERSISTENCE_UNLOGGED {
+			return mterrors.NewFeatureNotSupported(
+				"UNLOGGED tables are not supported: their contents are not replicated and are lost on crash recovery")
+		}
+		return nil
+
+	case ast.T_CreateTableAsStmt:
+		if s, ok := stmt.(*ast.CreateTableAsStmt); ok &&
+			s.Into != nil && s.Into.Rel != nil && s.Into.Rel.RelPersistence == ast.RELPERSISTENCE_UNLOGGED {
+			return mterrors.NewFeatureNotSupported(
+				"UNLOGGED tables are not supported: their contents are not replicated and are lost on crash recovery")
+		}
+		return nil
+
+	// SELECT ... INTO UNLOGGED parses as a SelectStmt carrying an IntoClause —
+	// it only becomes a CreateTableAsStmt during later parse analysis, which
+	// does not run at plan time. The persistence flag therefore lives on
+	// SelectStmt.IntoClause.Rel here, not on a CreateTableAsStmt. Plain
+	// SELECTs (IntoClause == nil) fall straight through.
+	case ast.T_SelectStmt:
+		if s, ok := stmt.(*ast.SelectStmt); ok &&
+			s.IntoClause != nil && s.IntoClause.Rel != nil && s.IntoClause.Rel.RelPersistence == ast.RELPERSISTENCE_UNLOGGED {
+			return mterrors.NewFeatureNotSupported(
+				"UNLOGGED tables are not supported: their contents are not replicated and are lost on crash recovery")
+		}
+		return nil
+
+	// ALTER TABLE ... SET UNLOGGED converts an existing permanent table to
+	// UNLOGGED in place — same replication / crash-recovery hazard as creating
+	// one. A single ALTER may carry several subcommands (e.g. ADD COLUMN, SET
+	// UNLOGGED), so scan every command for the SET UNLOGGED subtype. SET LOGGED
+	// (the inverse, restoring WAL logging) is harmless and passes through.
+	case ast.T_AlterTableStmt:
+		if s, ok := stmt.(*ast.AlterTableStmt); ok && s.Cmds != nil {
+			for _, item := range s.Cmds.Items {
+				if cmd, ok := item.(*ast.AlterTableCmd); ok && cmd.Subtype == ast.AT_SetUnLogged {
+					return mterrors.NewFeatureNotSupported(
+						"ALTER TABLE ... SET UNLOGGED is not supported: UNLOGGED tables are not replicated and are lost on crash recovery")
+				}
+			}
+		}
+		return nil
+
 	default:
 		return nil
 	}

--- a/go/services/multigateway/planner/unsafe_stmt_test.go
+++ b/go/services/multigateway/planner/unsafe_stmt_test.go
@@ -85,6 +85,111 @@ func TestPlanUnsupportedStmt(t *testing.T) {
 			wantMessage: "CREATE SERVER is not supported",
 		},
 
+		// -- UNLOGGED tables: blocked — not replicated, lost on crash --
+		{
+			name: "CREATE UNLOGGED TABLE",
+			stmt: &ast.CreateStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_CreateStmt},
+				Relation: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_UNLOGGED},
+			},
+			wantErr:     true,
+			wantMessage: "UNLOGGED tables are not supported",
+		},
+		{
+			name: "CREATE UNLOGGED TABLE AS",
+			stmt: &ast.CreateTableAsStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_CreateTableAsStmt},
+				Into:     &ast.IntoClause{Rel: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_UNLOGGED}},
+			},
+			wantErr:     true,
+			wantMessage: "UNLOGGED tables are not supported",
+		},
+		{
+			name: "CREATE TABLE (permanent) is allowed",
+			stmt: &ast.CreateStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_CreateStmt},
+				Relation: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_PERMANENT},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CREATE TEMP TABLE is allowed",
+			stmt: &ast.CreateStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_CreateStmt},
+				Relation: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_TEMP},
+			},
+			wantErr: false,
+		},
+		{
+			name: "CREATE TABLE AS (permanent) is allowed",
+			stmt: &ast.CreateTableAsStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_CreateTableAsStmt},
+				Into:     &ast.IntoClause{Rel: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_PERMANENT}},
+			},
+			wantErr: false,
+		},
+		{
+			// SELECT ... INTO UNLOGGED parses as a SelectStmt with an
+			// IntoClause, not a CreateTableAsStmt, at plan time.
+			name: "SELECT INTO UNLOGGED",
+			stmt: &ast.SelectStmt{
+				BaseNode:   ast.BaseNode{Tag: ast.T_SelectStmt},
+				IntoClause: &ast.IntoClause{Rel: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_UNLOGGED}},
+			},
+			wantErr:     true,
+			wantMessage: "UNLOGGED tables are not supported",
+		},
+		{
+			name: "SELECT INTO (permanent) is allowed",
+			stmt: &ast.SelectStmt{
+				BaseNode:   ast.BaseNode{Tag: ast.T_SelectStmt},
+				IntoClause: &ast.IntoClause{Rel: &ast.RangeVar{RelName: "t", RelPersistence: ast.RELPERSISTENCE_PERMANENT}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ALTER TABLE SET UNLOGGED",
+			stmt: &ast.AlterTableStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_AlterTableStmt},
+				Relation: &ast.RangeVar{RelName: "t"},
+				Cmds:     ast.NewNodeList(&ast.AlterTableCmd{Subtype: ast.AT_SetUnLogged}),
+			},
+			wantErr:     true,
+			wantMessage: "ALTER TABLE ... SET UNLOGGED is not supported",
+		},
+		{
+			// SET UNLOGGED may ride alongside other subcommands; all are scanned.
+			name: "ALTER TABLE ADD COLUMN then SET UNLOGGED",
+			stmt: &ast.AlterTableStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_AlterTableStmt},
+				Relation: &ast.RangeVar{RelName: "t"},
+				Cmds: ast.NewNodeList(
+					&ast.AlterTableCmd{Subtype: ast.AT_AddColumn},
+					&ast.AlterTableCmd{Subtype: ast.AT_SetUnLogged},
+				),
+			},
+			wantErr:     true,
+			wantMessage: "ALTER TABLE ... SET UNLOGGED is not supported",
+		},
+		{
+			name: "ALTER TABLE SET LOGGED is allowed",
+			stmt: &ast.AlterTableStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_AlterTableStmt},
+				Relation: &ast.RangeVar{RelName: "t"},
+				Cmds:     ast.NewNodeList(&ast.AlterTableCmd{Subtype: ast.AT_SetLogged}),
+			},
+			wantErr: false,
+		},
+		{
+			name: "ALTER TABLE ADD COLUMN is allowed",
+			stmt: &ast.AlterTableStmt{
+				BaseNode: ast.BaseNode{Tag: ast.T_AlterTableStmt},
+				Relation: &ast.RangeVar{RelName: "t"},
+				Cmds:     ast.NewNodeList(&ast.AlterTableCmd{Subtype: ast.AT_AddColumn}),
+			},
+			wantErr: false,
+		},
+
 		// -- Tier 1: currently allowed pending body analysis.
 		// Blocking outright breaks real workloads and does not close the
 		// session-state leak (reachable via SELECT set_config(...)).

--- a/go/test/endtoend/queryserving/unsafe_stmt_test.go
+++ b/go/test/endtoend/queryserving/unsafe_stmt_test.go
@@ -117,6 +117,76 @@ func TestMultiGateway_UnsafeStatementRejection(t *testing.T) {
 		}
 	})
 
+	// UNLOGGED tables skip the WAL, so their contents are not replicated to
+	// standbys and are truncated on crash recovery — incompatible with a
+	// replicated, highly-available deployment. Ordinary and temp tables are
+	// unaffected.
+	t.Run("unlogged tables rejected", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			sql     string
+			wantMsg string
+		}{
+			{
+				name:    "CREATE UNLOGGED TABLE",
+				sql:     "CREATE UNLOGGED TABLE _test_unlogged (id int)",
+				wantMsg: "UNLOGGED tables are not supported",
+			},
+			{
+				name:    "CREATE UNLOGGED TABLE AS",
+				sql:     "CREATE UNLOGGED TABLE _test_unlogged_as AS SELECT 1 AS id",
+				wantMsg: "UNLOGGED tables are not supported",
+			},
+			{
+				name:    "SELECT INTO UNLOGGED",
+				sql:     "SELECT 1 AS id INTO UNLOGGED _test_unlogged_into",
+				wantMsg: "UNLOGGED tables are not supported",
+			},
+			{
+				// Rejected at plan time, so the table need not exist.
+				name:    "ALTER TABLE SET UNLOGGED",
+				sql:     "ALTER TABLE _test_any SET UNLOGGED",
+				wantMsg: "ALTER TABLE ... SET UNLOGGED is not supported",
+			},
+			{
+				name:    "ALTER TABLE ADD COLUMN then SET UNLOGGED",
+				sql:     "ALTER TABLE _test_any ADD COLUMN c int, SET UNLOGGED",
+				wantMsg: "ALTER TABLE ... SET UNLOGGED is not supported",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := conn.Exec(ctx, tt.sql)
+				require.Error(t, err, "%s should be rejected", tt.name)
+
+				var pgErr *pgconn.PgError
+				require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T", err)
+				assert.Equal(t, "0A000", pgErr.Code, "SQLSTATE should be feature_not_supported")
+				assert.Contains(t, pgErr.Message, tt.wantMsg)
+				t.Logf("rejected %s: %s", tt.name, pgErr.Message)
+			})
+		}
+	})
+
+	// Ordinary CREATE TABLE and non-UNLOGGED ALTER TABLE must still pass
+	// through the pooler — the UNLOGGED checks are field/subcommand-conditional,
+	// not blanket CREATE/ALTER TABLE rejections.
+	t.Run("ordinary CREATE and ALTER TABLE allowed", func(t *testing.T) {
+		_, err := conn.Exec(ctx, "CREATE TABLE _test_logged_tbl (id int)")
+		require.NoError(t, err, "ordinary CREATE TABLE should be allowed")
+
+		_, err = conn.Exec(ctx, "ALTER TABLE _test_logged_tbl ADD COLUMN c int")
+		require.NoError(t, err, "ALTER TABLE ADD COLUMN should be allowed")
+
+		// SET LOGGED is the harmless inverse of SET UNLOGGED — must pass.
+		_, err = conn.Exec(ctx, "ALTER TABLE _test_logged_tbl SET LOGGED")
+		require.NoError(t, err, "ALTER TABLE SET LOGGED should be allowed")
+
+		_, err = conn.Exec(ctx, "DROP TABLE _test_logged_tbl")
+		require.NoError(t, err)
+	})
+
 	// Verify the connection is still healthy after all rejections.
 	// This confirms that rejected statements don't corrupt connection state.
 	t.Run("connection healthy after rejections", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reject UNLOGGED table creation at multigateway plan time with a `feature_not_supported` (SQLSTATE `0A000`) error. UNLOGGED tables skip the WAL, so their contents are never replicated to standbys and are truncated on crash recovery — unsafe in a replicated, highly-available cluster.
- Covers all four ways to land an UNLOGGED relation: `CREATE UNLOGGED TABLE`, `CREATE UNLOGGED TABLE AS`, `SELECT ... INTO UNLOGGED`, and `ALTER TABLE ... SET UNLOGGED`.
- Checks are field/subcommand-conditional — ordinary and `TEMP` tables, plain `ALTER TABLE` subcommands, and `ALTER TABLE ... SET LOGGED` all pass straight through.

## Description

The rejection lives in `planUnsupportedStmt()` alongside the existing Tier 2 checks. Two parser subtleties drove the implementation:

- `SELECT ... INTO UNLOGGED` parses as a `SelectStmt` carrying an `IntoClause`, **not** a `CreateTableAsStmt` — PostgreSQL only rewrites it during later parse analysis, which the gateway does not run. The persistence flag therefore lives on `SelectStmt.IntoClause.Rel`. The end-to-end test caught this case slipping through after the unit tests (built on hand-constructed AST) passed.
- An `ALTER TABLE` can carry several subcommands (e.g. `ADD COLUMN x int, SET UNLOGGED`), so every `AlterTableCmd` is scanned for the `AT_SetUnLogged` subtype.

Coverage is added at both the unit level (`unsafe_stmt_test.go`) and end-to-end through a real multigateway → PostgreSQL cluster (`go/test/endtoend/queryserving/unsafe_stmt_test.go`), including positive pass-through checks for ordinary `CREATE TABLE`, `ALTER TABLE ADD COLUMN`, and `ALTER TABLE SET LOGGED`. The design doc (`docs/query_serving/unsafe_statement_rejection.md`) gains a "Replication safety" category and is brought current with related drift.