### PR TITLE
feat(multipooler): database-aware connection pooling + CREATE DATABASE (prototype)

### DIFF
--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1111,8 +1111,14 @@ type ExecuteOptions struct {
 	// functions can map virtual PIDs (visible to clients) back to real
 	// backend PIDs via pg_stat_activity.
 	ClientConnectionId uint32 `protobuf:"varint,8,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// database is the PostgreSQL database the client connected to (from the
+	// startup packet). A single multipooler serves many logical databases on
+	// the same PostgreSQL instance; this selects which (database, user)
+	// connection pool the query runs on. When empty, the multipooler falls
+	// back to its configured default database.
+	Database      string `protobuf:"bytes,9,opt,name=database,proto3" json:"database,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1192,6 +1198,13 @@ func (x *ExecuteOptions) GetClientConnectionId() uint32 {
 		return x.ClientConnectionId
 	}
 	return 0
+}
+
+func (x *ExecuteOptions) GetDatabase() string {
+	if x != nil {
+		return x.Database
+	}
+	return ""
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM
@@ -1442,7 +1455,7 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
 	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\x12,\n" +
-	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xb9\x03\n" +
+	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xd5\x03\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
@@ -1450,7 +1463,8 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12G\n" +
 	"\x12prepared_statement\x18\x06 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x12,\n" +
 	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
-	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x1aB\n" +
+	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x12\x1a\n" +
+	"\bdatabase\x18\t \x01(\tR\bdatabase\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +

--- a/go/services/multigateway/planner/unsafe_stmt.go
+++ b/go/services/multigateway/planner/unsafe_stmt.go
@@ -21,11 +21,19 @@ import (
 
 // planUnsupportedStmt rejects Tier 2 statements — server-level operations
 // that should not be available through a shared connection pooler in a
-// hosted environment: LOAD, ALTER SYSTEM, CREATE/DROP DATABASE, CREATE
-// LANGUAGE, CREATE SUBSCRIPTION, CREATE FOREIGN DATA WRAPPER, CREATE SERVER.
-// These change the server itself, affect tenant isolation, or open outbound
-// connections to external hosts, and there is no "inspect the body"
-// mitigation that could make them safe.
+// hosted environment: LOAD, ALTER SYSTEM, CREATE LANGUAGE, CREATE
+// SUBSCRIPTION, CREATE FOREIGN DATA WRAPPER, CREATE SERVER. These change the
+// server itself, affect tenant isolation, or open outbound connections to
+// external hosts, and there is no "inspect the body" mitigation that could
+// make them safe.
+//
+// CREATE DATABASE / DROP DATABASE are NOT rejected: the multipooler is
+// database-aware (it holds connection pools keyed by (database, user) on a
+// single PostgreSQL instance), so a newly created database is immediately
+// reachable by reconnecting with that dbname. CREATE/DROP DATABASE run on a
+// regular pooled connection like any other statement; PostgreSQL enforces
+// the usual constraints (not inside a transaction block, not while connected
+// to the database being dropped).
 //
 // Tier 1 statements (DO, CREATE FUNCTION / PROCEDURE, CREATE TRIGGER,
 // CREATE RULE, CREATE EVENT TRIGGER) embed procedural-language code. They
@@ -48,14 +56,6 @@ func planUnsupportedStmt(stmt ast.Stmt) error {
 	case ast.T_AlterSystemStmt:
 		return mterrors.NewFeatureNotSupported(
 			"ALTER SYSTEM is not supported: modifying server configuration is not permitted through the connection pooler")
-
-	case ast.T_CreatedbStmt:
-		return mterrors.NewFeatureNotSupported(
-			"CREATE DATABASE is not supported through the connection pooler")
-
-	case ast.T_DropdbStmt:
-		return mterrors.NewFeatureNotSupported(
-			"DROP DATABASE is not supported through the connection pooler")
 
 	case ast.T_CreatePLangStmt:
 		return mterrors.NewFeatureNotSupported(

--- a/go/services/multigateway/planner/unsafe_stmt_test.go
+++ b/go/services/multigateway/planner/unsafe_stmt_test.go
@@ -49,16 +49,14 @@ func TestPlanUnsupportedStmt(t *testing.T) {
 			wantMessage: "ALTER SYSTEM is not supported",
 		},
 		{
-			name:        "CREATE DATABASE",
-			stmt:        &ast.CreatedbStmt{BaseNode: ast.BaseNode{Tag: ast.T_CreatedbStmt}, Dbname: "test"},
-			wantErr:     true,
-			wantMessage: "CREATE DATABASE is not supported",
+			name:    "CREATE DATABASE is allowed",
+			stmt:    &ast.CreatedbStmt{BaseNode: ast.BaseNode{Tag: ast.T_CreatedbStmt}, Dbname: "test"},
+			wantErr: false,
 		},
 		{
-			name:        "DROP DATABASE",
-			stmt:        &ast.DropdbStmt{BaseNode: ast.BaseNode{Tag: ast.T_DropdbStmt}, Dbname: "test"},
-			wantErr:     true,
-			wantMessage: "DROP DATABASE is not supported",
+			name:    "DROP DATABASE is allowed",
+			stmt:    &ast.DropdbStmt{BaseNode: ast.BaseNode{Tag: ast.T_DropdbStmt}, Dbname: "test"},
+			wantErr: false,
 		},
 		{
 			name:        "CREATE LANGUAGE",
@@ -287,11 +285,6 @@ func TestPlanRejectsUnsafeStatements(t *testing.T) {
 			name: "ALTER SYSTEM rejected through Plan",
 			sql:  "ALTER SYSTEM SET max_connections = 200",
 			stmt: &ast.AlterSystemStmt{BaseNode: ast.BaseNode{Tag: ast.T_AlterSystemStmt}},
-		},
-		{
-			name: "CREATE DATABASE rejected through Plan",
-			sql:  "CREATE DATABASE foo",
-			stmt: &ast.CreatedbStmt{BaseNode: ast.BaseNode{Tag: ast.T_CreatedbStmt}, Dbname: "foo"},
 		},
 	}
 

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -94,6 +94,25 @@ func userAuthFrom(conn *server.Conn) *querypb.UserAuth {
 	}
 }
 
+// newExecuteOptions builds the ExecuteOptions fields common to every outbound
+// query RPC from the session connection and state: SCRAM passthrough keys, the
+// PostgreSQL user, the target database, the virtual PID, and session settings.
+//
+// Forwarding Database on every path is load-bearing: the multipooler keys its
+// connection pools by (database, user), so a request that omitted it would fall
+// back to the pooler's default database and could run against the wrong logical
+// database. Callers set request-specific fields (MaxRows, ReservedConnectionId,
+// PreparedStatement) on the returned value.
+func newExecuteOptions(conn *server.Conn, state *handler.MultiGatewayConnectionState) *querypb.ExecuteOptions {
+	return &querypb.ExecuteOptions{
+		UserAuth:           userAuthFrom(conn),
+		User:               conn.User(),
+		Database:           conn.Database(),
+		ClientConnectionId: conn.ConnectionID(),
+		SessionSettings:    state.GetSessionSettings(),
+	}
+}
+
 // buildTarget constructs a routing target from the given tableGroup and shard.
 // When the connection arrived on the replica-reads port (state.TargetReplica()),
 // the target's PoolerType is set to REPLICA; otherwise PRIMARY.
@@ -178,13 +197,8 @@ func (sc *ScatterConn) StreamExecute(
 
 	target := sc.buildTarget(tableGroup, shard, state)
 
-	eo := &querypb.ExecuteOptions{
-		UserAuth:           userAuthFrom(conn),
-		User:               conn.User(),
-		ClientConnectionId: conn.ConnectionID(),
-		SessionSettings:    state.GetSessionSettings(),
-		PreparedStatement:  preparedStatement,
-	}
+	eo := newExecuteOptions(conn, state)
+	eo.PreparedStatement = preparedStatement
 
 	ss := state.GetMatchingShardState(target)
 
@@ -364,13 +378,8 @@ func (sc *ScatterConn) PortalStreamExecute(
 	// Create target for routing
 	target := sc.buildTarget(tableGroup, shard, state)
 
-	eo := &querypb.ExecuteOptions{
-		UserAuth:           userAuthFrom(conn),
-		User:               conn.User(),
-		ClientConnectionId: conn.ConnectionID(),
-		MaxRows:            uint64(maxRows),
-		SessionSettings:    state.GetSessionSettings(),
-	}
+	eo := newExecuteOptions(conn, state)
+	eo.MaxRows = uint64(maxRows)
 
 	// When the protocol layer folded a Describe('P') into this Execute, ask
 	// the multipooler to fuse Bind+Describe(P)+Execute+Sync into one
@@ -412,12 +421,7 @@ func (sc *ScatterConn) PortalStreamExecute(
 		sc.logger.DebugContext(ctx, "creating reserved connection for portal",
 			"reasons", protoutil.ReasonsString(reasons))
 
-		noopEo := &querypb.ExecuteOptions{
-			UserAuth:           userAuthFrom(conn),
-			User:               conn.User(),
-			ClientConnectionId: conn.ConnectionID(),
-			SessionSettings:    state.GetSessionSettings(),
-		}
+		noopEo := newExecuteOptions(conn, state)
 		reservationOpts := &querypb.ReservationOptions{Reasons: reasons}
 		if state.PendingBeginQuery != "" {
 			reservationOpts.BeginQuery = state.PendingBeginQuery
@@ -489,12 +493,7 @@ func (sc *ScatterConn) Describe(
 	// Create target for routing
 	target := sc.buildTarget(tableGroup, shard, state)
 
-	eo := &querypb.ExecuteOptions{
-		UserAuth:           userAuthFrom(conn),
-		User:               conn.User(),
-		ClientConnectionId: conn.ConnectionID(),
-		SessionSettings:    state.GetSessionSettings(),
-	}
+	eo := newExecuteOptions(conn, state)
 	var preparedStatement *querypb.PreparedStatement
 	var portal *querypb.Portal
 	if portalInfo != nil {
@@ -598,13 +597,8 @@ func (sc *ScatterConn) ConcludeTransaction(
 			continue
 		}
 
-		eo := &querypb.ExecuteOptions{
-			UserAuth:             userAuthFrom(conn),
-			User:                 conn.User(),
-			ClientConnectionId:   conn.ConnectionID(),
-			SessionSettings:      state.GetSessionSettings(),
-			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-		}
+		eo := newExecuteOptions(conn, state)
+		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 		qs, err := sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), ss.Target)
 		if err != nil {
@@ -704,13 +698,8 @@ func (sc *ScatterConn) DiscardTempTables(
 			continue
 		}
 
-		eo := &querypb.ExecuteOptions{
-			UserAuth:             userAuthFrom(conn),
-			User:                 conn.User(),
-			ClientConnectionId:   conn.ConnectionID(),
-			SessionSettings:      state.GetSessionSettings(),
-			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-		}
+		eo := newExecuteOptions(conn, state)
+		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 		qs, err := sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), ss.Target)
 		if err != nil {
@@ -797,12 +786,7 @@ func (sc *ScatterConn) CopyOutInitiate(
 		Shard:      shard,
 	}
 
-	execOptions := &querypb.ExecuteOptions{
-		UserAuth:           userAuthFrom(conn),
-		User:               conn.User(),
-		ClientConnectionId: conn.ConnectionID(),
-		SessionSettings:    state.GetSessionSettings(),
-	}
+	execOptions := newExecuteOptions(conn, state)
 
 	// Reuse an existing reserved connection (e.g. one already held by a
 	// transaction or temp-table reservation) so the COPY runs on the same
@@ -870,13 +854,8 @@ func (sc *ScatterConn) CopyOutStream(
 		return nil, errors.New("no active COPY connection")
 	}
 
-	copyOptions := &querypb.ExecuteOptions{
-		UserAuth:             userAuthFrom(conn),
-		User:                 conn.User(),
-		ClientConnectionId:   conn.ConnectionID(),
-		SessionSettings:      state.GetSessionSettings(),
-		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-	}
+	copyOptions := newExecuteOptions(conn, state)
+	copyOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 	result, reservedState, err := sc.gateway.CopyOutStream(ctx, target, copyOptions, onMessage)
 	sc.applyReservedState(conn, state, target, reservedState)
@@ -922,12 +901,7 @@ func (sc *ScatterConn) CopyInitiate(
 	}
 
 	// Create execute options
-	execOptions := &querypb.ExecuteOptions{
-		UserAuth:           userAuthFrom(conn),
-		User:               conn.User(),
-		ClientConnectionId: conn.ConnectionID(),
-		SessionSettings:    state.GetSessionSettings(),
-	}
+	execOptions := newExecuteOptions(conn, state)
 
 	// If there's already a reserved connection for this target (e.g., in a transaction),
 	// pass its ID so CopyReady reuses it instead of creating a new one.
@@ -1008,13 +982,8 @@ func (sc *ScatterConn) CopySendData(
 	}
 
 	// Build options with reserved connection ID
-	copyOptions := &querypb.ExecuteOptions{
-		UserAuth:             userAuthFrom(conn),
-		User:                 conn.User(),
-		ClientConnectionId:   conn.ConnectionID(),
-		SessionSettings:      state.GetSessionSettings(),
-		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-	}
+	copyOptions := newExecuteOptions(conn, state)
+	copyOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 	// Send data via gateway
 	if err := sc.gateway.CopySendData(ctx, target, data, copyOptions); err != nil {
@@ -1066,13 +1035,8 @@ func (sc *ScatterConn) CopyFinalize(
 	}
 
 	// Build options with reserved connection ID
-	copyOptions := &querypb.ExecuteOptions{
-		UserAuth:             userAuthFrom(conn),
-		User:                 conn.User(),
-		ClientConnectionId:   conn.ConnectionID(),
-		SessionSettings:      state.GetSessionSettings(),
-		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-	}
+	copyOptions := newExecuteOptions(conn, state)
+	copyOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 	// Finalize the COPY operation via gateway
 	result, reservedState, err := sc.gateway.CopyFinalize(ctx, target, finalData, copyOptions)
@@ -1135,13 +1099,8 @@ func (sc *ScatterConn) CopyAbort(
 	}
 
 	// Build options with reserved connection ID
-	copyOptions := &querypb.ExecuteOptions{
-		UserAuth:             userAuthFrom(conn),
-		User:                 conn.User(),
-		ClientConnectionId:   conn.ConnectionID(),
-		SessionSettings:      state.GetSessionSettings(),
-		ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-	}
+	copyOptions := newExecuteOptions(conn, state)
+	copyOptions.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 	// Abort the COPY operation via gateway
 	reservedState, err := sc.gateway.CopyAbort(ctx, target, "operation aborted by client", copyOptions)
@@ -1172,13 +1131,8 @@ func (sc *ScatterConn) ReleaseAllReservedConnections(
 			continue
 		}
 
-		eo := &querypb.ExecuteOptions{
-			UserAuth:             userAuthFrom(conn),
-			User:                 conn.User(),
-			ClientConnectionId:   conn.ConnectionID(),
-			SessionSettings:      state.GetSessionSettings(),
-			ReservedConnectionId: ss.ReservedState.GetReservedConnectionId(),
-		}
+		eo := newExecuteOptions(conn, state)
+		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 
 		qs, err := sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), ss.Target)
 		if err != nil {

--- a/go/services/multipooler/connpoolmanager/config_test.go
+++ b/go/services/multipooler/connpoolmanager/config_test.go
@@ -175,16 +175,18 @@ func TestConnectionConfig_TCPOnly(t *testing.T) {
 
 func TestManagerStats(t *testing.T) {
 	stats := ManagerStats{
-		UserPools: make(map[string]UserPoolStats),
+		UserPools: make(map[poolKey]UserPoolStats),
 	}
 
 	// Add some user pool stats.
-	stats.UserPools["user1"] = UserPoolStats{Username: "user1"}
-	stats.UserPools["user2"] = UserPoolStats{Username: "user2"}
+	key1 := poolKey{database: "db", user: "user1"}
+	key2 := poolKey{database: "db", user: "user2"}
+	stats.UserPools[key1] = UserPoolStats{Username: "user1"}
+	stats.UserPools[key2] = UserPoolStats{Username: "user2"}
 
 	assert.Len(t, stats.UserPools, 2)
-	assert.Contains(t, stats.UserPools, "user1")
-	assert.Contains(t, stats.UserPools, "user2")
+	assert.Contains(t, stats.UserPools, key1)
+	assert.Contains(t, stats.UserPools, key2)
 }
 
 func TestUserPoolStats(t *testing.T) {

--- a/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
+++ b/go/services/multipooler/connpoolmanager/dynamic_allocation_integration_test.go
@@ -134,7 +134,7 @@ func TestDynamicAllocation_DifferentWorkloadPatterns(t *testing.T) {
 				defer wg.Done()
 				<-ready // Wait for signal to start
 
-				conn, err := manager.GetRegularConn(ctx, user, nil, nil)
+				conn, err := manager.GetRegularConn(ctx, "", user, nil, nil)
 				if err == nil {
 					mu.Lock()
 					connsByUser[user] = append(connsByUser[user], conn)
@@ -155,9 +155,9 @@ func TestDynamicAllocation_DifferentWorkloadPatterns(t *testing.T) {
 		if len(stats.UserPools) != 3 {
 			return false
 		}
-		capA = stats.UserPools["userA"].Regular.Capacity
-		capB = stats.UserPools["userB"].Regular.Capacity
-		capC = stats.UserPools["userC"].Regular.Capacity
+		capA = stats.UserPools[poolKey{database: server.ClientConfig().Database, user: "userA"}].Regular.Capacity
+		capB = stats.UserPools[poolKey{database: server.ClientConfig().Database, user: "userB"}].Regular.Capacity
+		capC = stats.UserPools[poolKey{database: server.ClientConfig().Database, user: "userC"}].Regular.Capacity
 		totalCap := capA + capB + capC
 		return totalCap == 9
 	}, 5*time.Second, 50*time.Millisecond, "rebalancer should converge on total capacity = 9")
@@ -213,7 +213,7 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 			go func(u string, shouldRelease bool) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
+				conn, err := manager.GetRegularConn(ctx, "", u, nil, nil)
 				if err == nil {
 					if !shouldRelease {
 						mu.Lock()
@@ -250,7 +250,7 @@ func TestDynamicAllocation_UserArrivalDuringLoad(t *testing.T) {
 	// Now add a 3rd user during load
 	for range 4 {
 		wg.Go(func() {
-			conn, err := manager.GetRegularConn(ctx, "user3", nil, nil)
+			conn, err := manager.GetRegularConn(ctx, "", "user3", nil, nil)
 			if err == nil {
 				mu.Lock()
 				conns["user3"] = append(conns["user3"], conn)
@@ -316,15 +316,15 @@ func TestDynamicAllocation_UserDepartureDuringLoad(t *testing.T) {
 	ctx := context.Background()
 
 	// Create 3 users
-	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
+	conn1, err := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
+	conn2, err := manager.GetRegularConn(ctx, "", "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
-	conn3, err := manager.GetRegularConn(ctx, "user3", nil, nil)
+	conn3, err := manager.GetRegularConn(ctx, "", "user3", nil, nil)
 	require.NoError(t, err)
 	conn3.Recycle()
 
@@ -339,11 +339,11 @@ func TestDynamicAllocation_UserDepartureDuringLoad(t *testing.T) {
 			case <-done:
 				return
 			default:
-				conn, _ := manager.GetRegularConn(ctx, "user1", nil, nil)
+				conn, _ := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 				if conn != nil {
 					conn.Recycle()
 				}
-				conn, _ = manager.GetRegularConn(ctx, "user2", nil, nil)
+				conn, _ = manager.GetRegularConn(ctx, "", "user2", nil, nil)
 				if conn != nil {
 					conn.Recycle()
 				}
@@ -358,9 +358,9 @@ func TestDynamicAllocation_UserDepartureDuringLoad(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond, "user3 should be garbage collected")
 	close(done)
 
-	assert.True(t, manager.HasUserPool("user1"))
-	assert.True(t, manager.HasUserPool("user2"))
-	assert.False(t, manager.HasUserPool("user3"))
+	assert.True(t, manager.HasUserPool("", "user1"))
+	assert.True(t, manager.HasUserPool("", "user2"))
+	assert.False(t, manager.HasUserPool("", "user3"))
 }
 
 // TestDynamicAllocation_CapacityExhaustion tests fair distribution
@@ -395,7 +395,7 @@ func TestDynamicAllocation_CapacityExhaustion(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
+				conn, err := manager.GetRegularConn(ctx, "", u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)
@@ -474,7 +474,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 				case <-done:
 					return
 				default:
-					conn, _ := manager.GetRegularConn(ctx, "user1", nil, nil)
+					conn, _ := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 					if conn != nil {
 						time.Sleep(50 * time.Millisecond) // Hold connection briefly
 						conn.Recycle()
@@ -500,7 +500,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
+				conn, err := manager.GetRegularConn(ctx, "", u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)
@@ -519,7 +519,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 	require.Eventually(t, func() bool {
 		stats := manager.Stats()
 		capacityMu.Lock()
-		user1Capacity = stats.UserPools["user1"].Regular.Capacity
+		user1Capacity = stats.UserPools[poolKey{database: server.ClientConfig().Database, user: "user1"}].Regular.Capacity
 		capacityMu.Unlock()
 		return user1Capacity < 16
 	}, 5*time.Second, 50*time.Millisecond, "user1 capacity should decrease when shared with other users")
@@ -544,7 +544,7 @@ func TestDynamicAllocation_CapacityRecovery(t *testing.T) {
 	var finalUser1Capacity int64
 	require.Eventually(t, func() bool {
 		stats := manager.Stats()
-		finalUser1Capacity = stats.UserPools["user1"].Regular.Capacity
+		finalUser1Capacity = stats.UserPools[poolKey{database: server.ClientConfig().Database, user: "user1"}].Regular.Capacity
 		return finalUser1Capacity > user1Capacity
 	}, 5*time.Second, 50*time.Millisecond, "remaining user should get more capacity after others leave")
 	t.Logf("user1 capacity alone: %d (was %d with 4 users)", finalUser1Capacity, user1Capacity)
@@ -590,7 +590,7 @@ func TestDynamicAllocation_GracefulDegradation(t *testing.T) {
 			go func(u string) {
 				defer wg.Done()
 				<-ready
-				conn, err := manager.GetRegularConn(ctx, u, nil, nil)
+				conn, err := manager.GetRegularConn(ctx, "", u, nil, nil)
 				if err == nil {
 					mu.Lock()
 					conns[u] = append(conns[u], conn)

--- a/go/services/multipooler/connpoolmanager/interface.go
+++ b/go/services/multipooler/connpoolmanager/interface.go
@@ -70,31 +70,33 @@ type PoolManager interface {
 
 	// --- Regular Pool Operations ---
 
-	// GetRegularConn acquires a regular connection for the specified user,
-	// optionally carrying SCRAM passthrough keys from the caller's session.
-	// Keys may be nil for admin/internal callers that dial via the
-	// local-trust line in pg_hba.conf. When non-nil, keys are consumed only
-	// when this call triggers first-time user-pool creation; subsequent
-	// calls reuse the existing pool regardless of the keys they pass.
-	GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
+	// GetRegularConn acquires a regular connection for the specified
+	// (database, user), optionally carrying SCRAM passthrough keys from the
+	// caller's session. Keys may be nil for admin/internal callers that dial
+	// via the local-trust line in pg_hba.conf. When non-nil, keys are consumed
+	// only when this call triggers first-time pool creation; subsequent calls
+	// reuse the existing pool regardless of the keys they pass. An empty
+	// database resolves to the multipooler's configured default database.
+	GetRegularConn(ctx context.Context, database, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
 
 	// GetRegularConnWithSettings is GetRegularConn that additionally applies
 	// per-session settings. Settings are provided as a map and internally
 	// converted via the shared SettingsCache.
-	GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
+	GetRegularConnWithSettings(ctx context.Context, settings map[string]string, database, user string, clientKey, serverKey []byte) (regular.PooledConn, error)
 
 	// --- Reserved Pool Operations ---
 
 	// NewReservedConn creates a new reserved connection for the specified
-	// user, optionally carrying SCRAM passthrough keys. Settings are
-	// provided as a map and internally converted via the shared
+	// (database, user), optionally carrying SCRAM passthrough keys. Settings
+	// are provided as a map and internally converted via the shared
 	// SettingsCache. Optional ReservedConnOption values configure
 	// validate-with-retry behavior. Key-consumption semantics match
 	// GetRegularConn.
-	NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
+	NewReservedConn(ctx context.Context, settings map[string]string, database, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error)
 
-	// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
-	GetReservedConn(connID int64, user string) (*reserved.Conn, bool)
+	// GetReservedConn retrieves an existing reserved connection by ID for the
+	// specified (database, user) pool.
+	GetReservedConn(connID int64, database, user string) (*reserved.Conn, bool)
 
 	// ApplySettingsToConn ensures the connection's settings match the given
 	// session settings. If they differ, executes SET commands on the connection

--- a/go/services/multipooler/connpoolmanager/manager.go
+++ b/go/services/multipooler/connpoolmanager/manager.go
@@ -45,6 +45,23 @@ const (
 	maxPoolClosedRetries = 4
 )
 
+// poolKey identifies a connection pool by the (database, user) pair it serves.
+// A single multipooler process holds pools for many logical databases on the
+// same PostgreSQL instance (CREATE DATABASE plus clients connecting to a
+// database other than the configured default), so the database is part of the
+// pool identity, not just the user.
+type poolKey struct {
+	database string
+	user     string
+}
+
+// String renders the key for use as a flat map key (demand/allocation maps in
+// the rebalancer) and for log lines. The NUL separator cannot appear in a
+// PostgreSQL identifier, so the encoding is unambiguous.
+func (k poolKey) String() string {
+	return k.database + "\x00" + k.user
+}
+
 // ErrManagerClosed is returned by connection-acquisition paths when the
 // manager is closed. withReopenRetry treats it as transient (waits for the
 // paired Open, then retries) while a reopen window is open, and as terminal
@@ -102,10 +119,11 @@ type Manager struct {
 	settingsCache *connstate.SettingsCache // Shared settings cache for all users
 	metrics       *Metrics                 // OpenTelemetry metrics
 
-	// userPoolsSnapshot holds an atomic pointer to an immutable map of user pools.
-	// This enables lock-free reads on the hot path (existing users).
-	// The map is replaced atomically via copy-on-write when new users are added.
-	userPoolsSnapshot atomic.Pointer[map[string]*UserPool]
+	// userPoolsSnapshot holds an atomic pointer to an immutable map of pools
+	// keyed by (database, user). This enables lock-free reads on the hot path
+	// (existing pools). The map is replaced atomically via copy-on-write when a
+	// new (database, user) pool is added.
+	userPoolsSnapshot atomic.Pointer[map[poolKey]*UserPool]
 
 	// createMu serializes user pool creation (cold path only).
 	// This mutex is only acquired when a new user pool needs to be created.
@@ -165,7 +183,7 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 
 	m.ctx = ctx
 	m.connConfig = connConfig
-	emptyPools := make(map[string]*UserPool)
+	emptyPools := make(map[poolKey]*UserPool)
 	m.userPoolsSnapshot.Store(&emptyPools)
 
 	// Initialize zeroCh as closed: starts at zero lent connections (drained).
@@ -183,7 +201,10 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	if source == pwSourceNone {
 		panic("connpoolmanager: Open called before ResolvePgPassword; no password source configured")
 	}
-	adminClientConfig := m.buildClientConfig(m.config.PgUser(), adminPassword)
+	// The admin pool connects to the configured default database. It is used
+	// for instance-wide maintenance (kill/cancel backend, credential queries),
+	// none of which are database-specific.
+	adminClientConfig := m.buildClientConfig(m.connConfig.Database, m.config.PgUser(), adminPassword)
 
 	// Build admin pool config
 	connectTimeout := 2 * m.config.DialTimeout()
@@ -247,12 +268,12 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 // SSLMode/TLSConfig from the ConnectionConfig propagate to every dial built by
 // this manager. They are honored only on TCP connections (libpq parity); the
 // client startup code skips SSLRequest when SocketFile is set.
-func (m *Manager) buildClientConfig(user, password string) *client.Config {
+func (m *Manager) buildClientConfig(database, user, password string) *client.Config {
 	return &client.Config{
 		SocketFile:  m.connConfig.SocketFile,
 		Host:        m.connConfig.Host,
 		Port:        m.connConfig.Port,
-		Database:    m.connConfig.Database,
+		Database:    database,
 		User:        user,
 		Password:    password,
 		SSLMode:     m.connConfig.SSLMode,
@@ -267,7 +288,7 @@ func (m *Manager) buildClientConfig(user, password string) *client.Config {
 // using those keys. Absent keys fall back to the empty-password path, which
 // only succeeds against a pg_hba.conf that still trusts the local socket for
 // the dialing user — the template's narrow admin-user trust exception.
-func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte) *client.Config {
+func (m *Manager) buildUserClientConfig(database, user string, clientKey, serverKey []byte) *client.Config {
 	// If SCRAM passthrough keys are present, use them — no password needed.
 	// Otherwise we need a password to authenticate. When the requested user
 	// matches the configured admin user, fall back to the admin password
@@ -287,12 +308,24 @@ func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte
 			password = pw
 		}
 	}
-	cfg := m.buildClientConfig(user, password)
+	cfg := m.buildClientConfig(database, user, password)
 	if len(clientKey) > 0 && len(serverKey) > 0 {
 		cfg.ScramClientKey = clientKey
 		cfg.ScramServerKey = serverKey
 	}
 	return cfg
+}
+
+// resolveDatabase maps an empty database request to the multipooler's
+// configured default database. Internal callers (heartbeat reads, the logical
+// replication listener) pass "" because they are not tied to any client
+// session; they should land on the default-database pool rather than create a
+// distinct "" pool.
+func (m *Manager) resolveDatabase(database string) string {
+	if database == "" {
+		return m.connConfig.Database
+	}
+	return database
 }
 
 // getOrCreateUserPool returns the pool for the given user, creating it if needed.
@@ -308,14 +341,15 @@ func (m *Manager) buildUserClientConfig(user string, clientKey, serverKey []byte
 // (user, password) in PostgreSQL's SCRAM scheme, so cached keys stay valid
 // until the user's password rotates; password rotation is surfaced via SCRAM
 // auth failure on the next dial.
-func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) (*UserPool, error) {
+func (m *Manager) getOrCreateUserPool(database, user string, clientKey, serverKey []byte) (*UserPool, error) {
 	if user == "" {
 		return nil, errors.New("user cannot be empty")
 	}
+	key := poolKey{database: m.resolveDatabase(database), user: user}
 
 	// Hot path: atomic load + map lookup (no lock)
 	if pools := m.userPoolsSnapshot.Load(); pools != nil {
-		if pool, ok := (*pools)[user]; ok {
+		if pool, ok := (*pools)[key]; ok {
 			return pool, nil
 		}
 	}
@@ -331,19 +365,19 @@ func (m *Manager) getOrCreateUserPool(user string, clientKey, serverKey []byte) 
 	// Cold path: need to create a new user pool.
 	// Use the manager's lifecycle context so the pool is tied to the manager's
 	// lifetime, not the caller's request context.
-	return m.createUserPoolSlow(m.ctx, user, clientKey, serverKey)
+	return m.createUserPoolSlow(m.ctx, key, clientKey, serverKey)
 }
 
 // createUserPoolSlow creates a new user pool. This is the cold path that requires
 // acquiring the createMu mutex.
-func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey, serverKey []byte) (*UserPool, error) {
+func (m *Manager) createUserPoolSlow(ctx context.Context, key poolKey, clientKey, serverKey []byte) (*UserPool, error) {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
 
 	// Double-check after acquiring lock
 	pools := m.userPoolsSnapshot.Load()
 	if pools != nil {
-		if pool, ok := (*pools)[user]; ok {
+		if pool, ok := (*pools)[key]; ok {
 			return pool, nil
 		}
 	}
@@ -368,17 +402,18 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 	onReserve := func() { m.lentAdd(1) }
 	onRelease := func() { m.lentAdd(-1) }
 
-	// Create new user pool with per-user pool names for metric cardinality.
-	// Note: Including username in pool names enables per-user monitoring but increases
-	// metric cardinality. If this becomes an issue with many users, we can make it configurable.
-	// Create new user pool with initial capacity. The rebalancer will adjust
-	// the capacity based on demand within a few seconds.
+	// Create new pool with per-(database, user) pool names for metric
+	// cardinality. Including both in the name keeps pools for the same user on
+	// different databases distinct in monitoring. If cardinality becomes an
+	// issue with many databases/users, we can make it configurable.
+	// The rebalancer adjusts capacity based on demand within a few seconds.
 	userConnectTimeout := 2 * m.config.DialTimeout()
+	nameSuffix := key.user + "@" + key.database
 	pool, err := NewUserPool(ctx, &UserPoolConfig{
-		ClientConfig: m.buildUserClientConfig(user, clientKey, serverKey),
+		ClientConfig: m.buildUserClientConfig(key.database, key.user, clientKey, serverKey),
 		AdminPool:    m.adminPool,
 		RegularPoolConfig: &connpool.Config{
-			Name:            "regular:" + user,
+			Name:            "regular:" + nameSuffix,
 			Capacity:        initialRegularCap,
 			IdleTimeout:     m.config.UserRegularIdleTimeout(),
 			MaxLifetime:     m.config.UserRegularMaxLifetime(),
@@ -387,7 +422,7 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 			Logger:          m.logger,
 		},
 		ReservedPoolConfig: &connpool.Config{
-			Name:            "reserved:" + user,
+			Name:            "reserved:" + nameSuffix,
 			Capacity:        initialReservedCap,
 			IdleTimeout:     m.config.UserReservedIdleTimeout(),
 			MaxLifetime:     m.config.UserReservedMaxLifetime(),
@@ -405,17 +440,17 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 		OnRelease:                 onRelease,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create user pool for %q: %w", user, err)
+		return nil, fmt.Errorf("create user pool for %q on %q: %w", key.user, key.database, err)
 	}
 
 	// Copy-on-write: create new map with the new pool
-	newPools := make(map[string]*UserPool, len(currentPools)+1)
+	newPools := make(map[poolKey]*UserPool, len(currentPools)+1)
 	maps.Copy(newPools, currentPools)
-	newPools[user] = pool
+	newPools[key] = pool
 
 	// Atomic publish
 	m.userPoolsSnapshot.Store(&newPools)
-	m.logger.InfoContext(ctx, "created user pool", "user", user, "total_users", len(newPools))
+	m.logger.InfoContext(ctx, "created user pool", "user", key.user, "database", key.database, "total_pools", len(newPools))
 
 	return pool, nil
 }
@@ -467,13 +502,13 @@ func (m *Manager) teardownLocked() {
 
 	// Close all user pools
 	if pools := m.userPoolsSnapshot.Load(); pools != nil {
-		for user, pool := range *pools {
+		for key, pool := range *pools {
 			pool.Close()
-			m.logger.Debug("closed user pool", "user", user)
+			m.logger.Debug("closed user pool", "user", key.user, "database", key.database)
 		}
 	}
 	// Clear the snapshot
-	emptyPools := make(map[string]*UserPool)
+	emptyPools := make(map[poolKey]*UserPool)
 	m.userPoolsSnapshot.Store(&emptyPools)
 
 	// Close shared admin pool last
@@ -538,8 +573,8 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 // first-time pool creation for the user; subsequent calls reuse the existing
 // pool regardless of the keys they pass. The caller must call Recycle() on
 // the returned connection to return it to the pool.
-func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
-	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+func (m *Manager) GetRegularConn(ctx context.Context, database, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, database, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConn(ctx)
 	})
 }
@@ -547,9 +582,9 @@ func (m *Manager) GetRegularConn(ctx context.Context, user string, clientKey, se
 // GetRegularConnWithSettings is GetRegularConn that additionally applies
 // per-session settings. Settings are converted via the shared SettingsCache
 // for consistent bucket assignment.
-func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
+func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[string]string, database, user string, clientKey, serverKey []byte) (regular.PooledConn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
+	return withReopenRetry(ctx, m, database, user, clientKey, serverKey, func(pool *UserPool) (regular.PooledConn, error) {
 		return pool.GetRegularConnWithSettings(ctx, s)
 	})
 }
@@ -563,9 +598,9 @@ func (m *Manager) GetRegularConnWithSettings(ctx context.Context, settings map[s
 // values configure validate-with-retry behavior. Key-consumption semantics
 // match GetRegularConn. The caller must call Release() when done with the
 // connection.
-func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]string, database, user string, clientKey, serverKey []byte, opts ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	s := m.settingsCache.GetOrCreate(settings)
-	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, database, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewReservedConn(ctx, s, opts...)
 	})
 }
@@ -574,8 +609,8 @@ func (m *Manager) NewReservedConn(ctx context.Context, settings map[string]strin
 // replication mode (replication=database) and tagged with
 // ReasonLogicalReplication, on the specified user's reserved pool. SCRAM
 // passthrough key semantics match NewReservedConn.
-func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
-	return withReopenRetry(ctx, m, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
+func (m *Manager) NewLogicalReplicationConn(ctx context.Context, database, user string, clientKey, serverKey []byte) (*reserved.Conn, error) {
+	return withReopenRetry(ctx, m, database, user, clientKey, serverKey, func(pool *UserPool) (*reserved.Conn, error) {
 		return pool.NewLogicalReplicationConn(ctx)
 	})
 }
@@ -590,7 +625,7 @@ func (m *Manager) NewLogicalReplicationConn(ctx context.Context, user string, cl
 // Callers should still retry against whatever the snapshot now holds: the
 // racing caller's fresh pool is the right target, and if the entry is gone
 // getOrCreateUserPool creates a new one.
-func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
+func (m *Manager) evictUserPool(key poolKey, stale *UserPool) bool {
 	m.createMu.Lock()
 	defer m.createMu.Unlock()
 
@@ -598,17 +633,17 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 	if pools == nil {
 		return false
 	}
-	current, ok := (*pools)[user]
+	current, ok := (*pools)[key]
 	if !ok || current != stale {
 		return false
 	}
 
-	newPools := make(map[string]*UserPool, len(*pools)-1)
-	for u, p := range *pools {
-		if u == user {
+	newPools := make(map[poolKey]*UserPool, len(*pools)-1)
+	for k, p := range *pools {
+		if k == key {
 			continue
 		}
-		newPools[u] = p
+		newPools[k] = p
 	}
 	m.userPoolsSnapshot.Store(&newPools)
 
@@ -616,7 +651,7 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 	// but Close is cheap and racing creators already passed the double-check
 	// by now, so finishing synchronously keeps invariants simple.
 	stale.Close()
-	m.logger.InfoContext(m.ctx, "evicted user pool after stale credentials detected", "user", user)
+	m.logger.InfoContext(m.ctx, "evicted user pool after stale credentials detected", "user", key.user, "database", key.database)
 	return true
 }
 
@@ -650,13 +685,14 @@ func (m *Manager) evictUserPool(user string, stale *UserPool) bool {
 // getOrCreateUserPool so that a first-time pool creation triggered during
 // this call (including after an eviction or reopen swap) gets the session's
 // keys.
-func withReopenRetry[T any](ctx context.Context, m *Manager, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
+func withReopenRetry[T any](ctx context.Context, m *Manager, database, user string, clientKey, serverKey []byte, op func(*UserPool) (T, error)) (T, error) {
 	var zero T
 	authRetried := false
+	key := poolKey{database: m.resolveDatabase(database), user: user}
 
 	for closedAttempts := 0; ; {
 		var err error
-		pool, lookupErr := m.getOrCreateUserPool(user, clientKey, serverKey)
+		pool, lookupErr := m.getOrCreateUserPool(database, user, clientKey, serverKey)
 		if lookupErr != nil {
 			err = lookupErr
 		} else {
@@ -675,7 +711,7 @@ func withReopenRetry[T any](ctx context.Context, m *Manager, user string, client
 					return zero, opErr
 				}
 				authRetried = true
-				m.evictUserPool(user, pool)
+				m.evictUserPool(key, pool)
 				continue
 			}
 			err = opErr
@@ -785,16 +821,17 @@ func (m *Manager) reopenWaitCh() <-chan struct{} {
 	return m.reopenDone
 }
 
-// GetReservedConn retrieves an existing reserved connection by ID for the specified user.
-// Returns nil, false if the user pool doesn't exist, the connection is not found, or has timed out.
-func (m *Manager) GetReservedConn(connID int64, user string) (*reserved.Conn, bool) {
+// GetReservedConn retrieves an existing reserved connection by ID for the
+// specified (database, user) pool. Returns nil, false if the pool doesn't
+// exist, the connection is not found, or has timed out.
+func (m *Manager) GetReservedConn(connID int64, database, user string) (*reserved.Conn, bool) {
 	// Lock-free read via atomic snapshot
 	pools := m.userPoolsSnapshot.Load()
 	if pools == nil {
 		return nil, false
 	}
 
-	pool, ok := (*pools)[user]
+	pool, ok := (*pools)[poolKey{database: m.resolveDatabase(database), user: user}]
 	if !ok {
 		return nil, false
 	}
@@ -825,14 +862,14 @@ func (m *Manager) ApplySettingsToConn(ctx context.Context, conn *regular.Conn, s
 func (m *Manager) Stats() ManagerStats {
 	pools := m.userPoolsSnapshot.Load()
 
-	var userPoolStats map[string]UserPoolStats
+	var userPoolStats map[poolKey]UserPoolStats
 	if pools != nil {
-		userPoolStats = make(map[string]UserPoolStats, len(*pools))
-		for user, pool := range *pools {
-			userPoolStats[user] = pool.Stats()
+		userPoolStats = make(map[poolKey]UserPoolStats, len(*pools))
+		for key, pool := range *pools {
+			userPoolStats[key] = pool.Stats()
 		}
 	} else {
-		userPoolStats = make(map[string]UserPoolStats)
+		userPoolStats = make(map[poolKey]UserPoolStats)
 	}
 
 	return ManagerStats{
@@ -843,8 +880,8 @@ func (m *Manager) Stats() ManagerStats {
 
 // ManagerStats holds statistics for all managed pools.
 type ManagerStats struct {
-	Admin     connpool.PoolStats       // Shared admin pool stats
-	UserPools map[string]UserPoolStats // Per-user pool stats
+	Admin     connpool.PoolStats        // Shared admin pool stats
+	UserPools map[poolKey]UserPoolStats // Per-(database, user) pool stats
 }
 
 // lentAdd adjusts the lent connection count by n.
@@ -922,12 +959,12 @@ func (m *Manager) UserPoolCount() int {
 	return len(*pools)
 }
 
-// HasUserPool returns whether a pool exists for the given user.
-func (m *Manager) HasUserPool(user string) bool {
+// HasUserPool returns whether a pool exists for the given (database, user).
+func (m *Manager) HasUserPool(database, user string) bool {
 	pools := m.userPoolsSnapshot.Load()
 	if pools == nil {
 		return false
 	}
-	_, ok := (*pools)[user]
+	_, ok := (*pools)[poolKey{database: m.resolveDatabase(database), user: user}]
 	return ok
 }

--- a/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_logical_replication_test.go
@@ -50,7 +50,7 @@ func TestManagerNewLogicalReplicationConn(t *testing.T) {
 	defer mgr.Close()
 
 	const user = "test_user"
-	conn, err := mgr.NewLogicalReplicationConn(context.Background(), user, nil, nil)
+	conn, err := mgr.NewLogicalReplicationConn(context.Background(), "", user, nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseError)
 
@@ -61,7 +61,7 @@ func TestManagerNewLogicalReplicationConn(t *testing.T) {
 
 	// The factory must create a per-user pool, not place the replication conn
 	// on the shared admin pool.
-	assert.True(t, mgr.HasUserPool(user),
+	assert.True(t, mgr.HasUserPool("", user),
 		"replication conn must be checked out from the user's pool, not the admin pool")
 }
 
@@ -84,16 +84,16 @@ func TestManager_LogicalReplicationSharesReservedCap(t *testing.T) {
 
 	// Force the per-user pool into existence and pin its reserved cap to 2
 	// so the test is deterministic regardless of the default reservedRatio.
-	pool, err := mgr.getOrCreateUserPool(user, nil, nil)
+	pool, err := mgr.getOrCreateUserPool("", user, nil, nil)
 	require.NoError(t, err)
 	// Pin reserved cap to 2. Regular cap is irrelevant for this test —
 	// reserved conns and replication conns share the reserved pool only.
 	require.NoError(t, pool.SetCapacity(ctx, 4, 2))
 
 	// Fill the reserved cap with transactional reserved conns.
-	r1, err := mgr.NewReservedConn(ctx, nil, user, nil, nil)
+	r1, err := mgr.NewReservedConn(ctx, nil, "", user, nil, nil)
 	require.NoError(t, err)
-	r2, err := mgr.NewReservedConn(ctx, nil, user, nil, nil)
+	r2, err := mgr.NewReservedConn(ctx, nil, "", user, nil, nil)
 	require.NoError(t, err)
 
 	// Sanity-check that the rebalancer hasn't moved the reserved cap out
@@ -106,7 +106,7 @@ func TestManager_LogicalReplicationSharesReservedCap(t *testing.T) {
 	// the test fails fast rather than hanging if cap-sharing is broken.
 	shortCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 	defer cancel()
-	blocked, err := mgr.NewLogicalReplicationConn(shortCtx, user, nil, nil)
+	blocked, err := mgr.NewLogicalReplicationConn(shortCtx, "", user, nil, nil)
 	require.Error(t, err, "replication conn must not be created while the user's reserved cap is full")
 	// Pin the failure mode to the cap-acquire timeout path. The underlying
 	// connpool returns ErrTimeout when waitForConn() exits due to ctx
@@ -119,7 +119,7 @@ func TestManager_LogicalReplicationSharesReservedCap(t *testing.T) {
 	// Releasing one reserved conn must free a slot and unblock replication.
 	r1.Release(reserved.ReleaseCommit)
 
-	rl, err := mgr.NewLogicalReplicationConn(ctx, user, nil, nil)
+	rl, err := mgr.NewLogicalReplicationConn(ctx, "", user, nil, nil)
 	require.NoError(t, err, "releasing a reserved conn must let a replication conn through")
 	require.NotNil(t, rl)
 	defer rl.Release(reserved.ReleaseError)

--- a/go/services/multipooler/connpoolmanager/manager_test.go
+++ b/go/services/multipooler/connpoolmanager/manager_test.go
@@ -90,7 +90,7 @@ func TestManager_Close(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a connection to create a user pool.
-	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -152,7 +152,7 @@ func TestManager_GetRegularConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Get a regular connection for a user.
-	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -162,7 +162,7 @@ func TestManager_GetRegularConn(t *testing.T) {
 	conn.Recycle()
 
 	// Verify user pool was created.
-	assert.True(t, manager.HasUserPool("testuser"))
+	assert.True(t, manager.HasUserPool("", "testuser"))
 }
 
 func TestManager_GetRegularConn_EmptyUser(t *testing.T) {
@@ -176,7 +176,7 @@ func TestManager_GetRegularConn_EmptyUser(t *testing.T) {
 	ctx := context.Background()
 
 	// Empty user should error.
-	_, err := manager.GetRegularConn(ctx, "", nil, nil)
+	_, err := manager.GetRegularConn(ctx, "", "", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "user cannot be empty")
 }
@@ -192,7 +192,7 @@ func TestManager_GetRegularConn_ClosedManager(t *testing.T) {
 	ctx := context.Background()
 
 	// Closed manager should error.
-	_, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	_, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "manager is closed")
 }
@@ -215,7 +215,7 @@ func TestManager_GetRegularConnWithSettings(t *testing.T) {
 	}
 
 	// Get a connection with settings.
-	conn, err := manager.GetRegularConnWithSettings(ctx, settings, "testuser", nil, nil)
+	conn, err := manager.GetRegularConnWithSettings(ctx, settings, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -239,7 +239,7 @@ func TestManager_NewReservedConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a reserved connection.
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, nil, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -266,7 +266,7 @@ func TestManager_NewReservedConn_WithSettings(t *testing.T) {
 	}
 
 	// Create a reserved connection with settings.
-	conn, err := manager.NewReservedConn(ctx, settings, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, settings, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
@@ -304,7 +304,7 @@ func TestWithReopenRetry_RetriesOnReopen(t *testing.T) {
 	ctx := context.Background()
 
 	calls := 0
-	result, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	result, err := withReopenRetry(ctx, manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		if calls == 1 {
 			// Simulate reopenConnections running mid-flight: close the pools as
@@ -345,7 +345,7 @@ func TestWithReopenRetry_WaitsForReopenThenRetries(t *testing.T) {
 	}()
 
 	calls := 0
-	result, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	result, err := withReopenRetry(ctx, manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 99, nil
 	})
@@ -367,7 +367,7 @@ func TestWithReopenRetry_SurfacesGenuineClose(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		// Genuine shutdown racing the op: terminal Close, no reopen window.
 		manager.Close()
@@ -393,7 +393,7 @@ func TestWithReopenRetry_FailsFastOnPreClosedManager(t *testing.T) {
 	manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, nil
 	})
@@ -415,7 +415,7 @@ func TestWithReopenRetry_RetriesErrPoolClosedUpToCap(t *testing.T) {
 	defer manager.Close()
 
 	calls := 0
-	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, connpool.ErrPoolClosed
 	})
@@ -442,7 +442,7 @@ func TestWithReopenRetry_ReopenWaitHonorsContextCancellation(t *testing.T) {
 	defer cancel()
 
 	calls := 0
-	_, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(ctx, manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, connpool.ErrPoolClosed
 	})
@@ -480,7 +480,7 @@ func TestWithReopenRetry_TerminalCloseDuringReopenWakesWaiter(t *testing.T) {
 		// Close below, well before this would fire.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_, err := withReopenRetry(ctx, manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+		_, err := withReopenRetry(ctx, manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 			calls++
 			return 0, nil
 		})
@@ -518,7 +518,7 @@ func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
 
 	var seenPools []*UserPool
 	calls := 0
-	result, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(pool *UserPool) (int, error) {
+	result, err := withReopenRetry(context.Background(), manager, "", "testuser", nil, nil, func(pool *UserPool) (int, error) {
 		calls++
 		seenPools = append(seenPools, pool)
 		if calls == 1 {
@@ -535,8 +535,8 @@ func TestWithReopenRetry_EvictsStalePoolOnAuthError(t *testing.T) {
 
 	snap := manager.userPoolsSnapshot.Load()
 	require.NotNil(t, snap, "snapshot must be loaded after retry")
-	assert.True(t, manager.HasUserPool("testuser"), "user pool must be present in fresh snapshot")
-	assert.NotSame(t, seenPools[0], (*snap)["testuser"], "the original stale pool must no longer be in the snapshot")
+	assert.True(t, manager.HasUserPool("", "testuser"), "user pool must be present in fresh snapshot")
+	assert.NotSame(t, seenPools[0], (*snap)[poolKey{database: manager.resolveDatabase(""), user: "testuser"}], "the original stale pool must no longer be in the snapshot")
 }
 
 // TestWithReopenRetry_SurfacesPersistentAuthError ensures that if the retry
@@ -554,7 +554,7 @@ func TestWithReopenRetry_SurfacesPersistentAuthError(t *testing.T) {
 	authErr := &mterrors.PgDiagnostic{MessageType: 'E', Severity: "FATAL", Code: "28P01", Message: "password authentication failed"}
 
 	calls := 0
-	_, err := withReopenRetry(context.Background(), manager, "testuser", nil, nil, func(_ *UserPool) (int, error) {
+	_, err := withReopenRetry(context.Background(), manager, "", "testuser", nil, nil, func(_ *UserPool) (int, error) {
 		calls++
 		return 0, fmt.Errorf("dial failed: %w", authErr)
 	})
@@ -578,21 +578,21 @@ func TestEvictUserPool_RemovesFromSnapshotAndCloses(t *testing.T) {
 	ctx := context.Background()
 
 	// Warm up: create a user pool.
-	stale, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	stale, err := manager.getOrCreateUserPool("", "testuser", nil, nil)
 	require.NoError(t, err)
-	require.True(t, manager.HasUserPool("testuser"))
+	require.True(t, manager.HasUserPool("", "testuser"))
 
-	evicted := manager.evictUserPool("testuser", stale)
+	evicted := manager.evictUserPool(poolKey{database: manager.resolveDatabase(""), user: "testuser"}, stale)
 	assert.True(t, evicted, "eviction of the current pool should return true")
-	assert.False(t, manager.HasUserPool("testuser"), "pool must be removed from snapshot")
+	assert.False(t, manager.HasUserPool("", "testuser"), "pool must be removed from snapshot")
 
 	// Subsequent acquire must produce a different pool instance.
-	fresh, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	fresh, err := manager.getOrCreateUserPool("", "testuser", nil, nil)
 	require.NoError(t, err)
 	assert.NotSame(t, stale, fresh, "post-eviction acquire must build a fresh pool")
 
 	// Real acquisition must still work against the fresh pool.
-	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 }
@@ -609,18 +609,18 @@ func TestEvictUserPool_NoOpOnRacingEviction(t *testing.T) {
 	manager := newTestManager(t, server)
 	defer manager.Close()
 
-	stale, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	stale, err := manager.getOrCreateUserPool("", "testuser", nil, nil)
 	require.NoError(t, err)
 
 	// Racing goroutine already evicted + recreated.
-	require.True(t, manager.evictUserPool("testuser", stale))
-	fresh, err := manager.getOrCreateUserPool("testuser", nil, nil)
+	require.True(t, manager.evictUserPool(poolKey{database: manager.resolveDatabase(""), user: "testuser"}, stale))
+	fresh, err := manager.getOrCreateUserPool("", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotSame(t, stale, fresh)
 
 	// Late caller still holding the stale reference must not clobber fresh.
-	assert.False(t, manager.evictUserPool("testuser", stale), "stale reference must not evict the fresh pool")
-	assert.True(t, manager.HasUserPool("testuser"), "fresh pool must remain in the snapshot")
+	assert.False(t, manager.evictUserPool(poolKey{database: manager.resolveDatabase(""), user: "testuser"}, stale), "stale reference must not evict the fresh pool")
+	assert.True(t, manager.HasUserPool("", "testuser"), "fresh pool must remain in the snapshot")
 }
 
 // TestManager_NewReservedConn_SurvivesReopen exercises the end-to-end path:
@@ -638,7 +638,7 @@ func TestManager_NewReservedConn_SurvivesReopen(t *testing.T) {
 	ctx := context.Background()
 
 	// Warm up: create a user pool.
-	c1, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	c1, err := manager.NewReservedConn(ctx, nil, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	c1.Release(reserved.ReleaseCommit)
 
@@ -652,7 +652,7 @@ func TestManager_NewReservedConn_SurvivesReopen(t *testing.T) {
 	})
 
 	// Reserved-conn acquisition must succeed against the fresh pool.
-	c2, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	c2, err := manager.NewReservedConn(ctx, nil, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, c2)
 	c2.Release(reserved.ReleaseCommit)
@@ -669,12 +669,12 @@ func TestManager_GetReservedConn(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a reserved connection.
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, nil, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	connID := conn.ConnID()
 
 	// Retrieve by ID.
-	retrieved, ok := manager.GetReservedConn(connID, "testuser")
+	retrieved, ok := manager.GetReservedConn(connID, "", "testuser")
 	require.True(t, ok)
 	assert.Equal(t, connID, retrieved.ConnID())
 
@@ -690,7 +690,7 @@ func TestManager_GetReservedConn_NotFound(t *testing.T) {
 	defer manager.Close()
 
 	// Non-existent connection ID.
-	_, ok := manager.GetReservedConn(999999, "testuser")
+	_, ok := manager.GetReservedConn(999999, "", "testuser")
 	assert.False(t, ok)
 }
 
@@ -703,7 +703,7 @@ func TestManager_GetReservedConn_UserNotFound(t *testing.T) {
 	defer manager.Close()
 
 	// No user pools exist yet.
-	_, ok := manager.GetReservedConn(1, "unknownuser")
+	_, ok := manager.GetReservedConn(1, "", "unknownuser")
 	assert.False(t, ok)
 }
 
@@ -723,19 +723,19 @@ func TestManager_Stats(t *testing.T) {
 	assert.Empty(t, stats.UserPools)
 
 	// Create some user pools.
-	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
+	conn1, err := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
+	conn2, err := manager.GetRegularConn(ctx, "", "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
 	// Verify stats include user pools.
 	stats = manager.Stats()
 	assert.Len(t, stats.UserPools, 2)
-	assert.Contains(t, stats.UserPools, "user1")
-	assert.Contains(t, stats.UserPools, "user2")
+	assert.Contains(t, stats.UserPools, poolKey{database: manager.resolveDatabase(""), user: "user1"})
+	assert.Contains(t, stats.UserPools, poolKey{database: manager.resolveDatabase(""), user: "user2"})
 }
 
 func TestManager_UserPoolReuse(t *testing.T) {
@@ -749,15 +749,15 @@ func TestManager_UserPoolReuse(t *testing.T) {
 	ctx := context.Background()
 
 	// Get connections for the same user multiple times.
-	conn1, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn1, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn2, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
-	conn3, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn3, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn3.Recycle()
 
@@ -782,7 +782,7 @@ func TestManager_ConcurrentUserPoolCreation(t *testing.T) {
 	// Concurrently create connections for the same user.
 	for range numGoroutines {
 		wg.Go(func() {
-			conn, err := manager.GetRegularConn(ctx, "concurrent-user", nil, nil)
+			conn, err := manager.GetRegularConn(ctx, "", "concurrent-user", nil, nil)
 			if err != nil {
 				errs <- err
 				return
@@ -822,7 +822,7 @@ func TestManager_ConcurrentDifferentUsers(t *testing.T) {
 		go func(userNum int) {
 			defer wg.Done()
 			user := "user" + string(rune('A'+userNum))
-			conn, err := manager.GetRegularConn(ctx, user, nil, nil)
+			conn, err := manager.GetRegularConn(ctx, "", user, nil, nil)
 			if err != nil {
 				t.Errorf("unexpected error for %s: %v", user, err)
 				return
@@ -854,12 +854,12 @@ func TestManager_SettingsCacheIntegration(t *testing.T) {
 	}
 
 	// Get connections with the same settings multiple times.
-	conn1, err := manager.GetRegularConnWithSettings(ctx, settings, "user1", nil, nil)
+	conn1, err := manager.GetRegularConnWithSettings(ctx, settings, "", "user1", nil, nil)
 	require.NoError(t, err)
 	settings1 := conn1.Conn.Settings()
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConnWithSettings(ctx, settings, "user2", nil, nil)
+	conn2, err := manager.GetRegularConnWithSettings(ctx, settings, "", "user2", nil, nil)
 	require.NoError(t, err)
 	settings2 := conn2.Conn.Settings()
 	conn2.Recycle()
@@ -884,7 +884,7 @@ func TestManager_ApplySettingsToConn(t *testing.T) {
 
 	// Create a reserved connection with initial settings.
 	initialSettings := map[string]string{"search_path": "public"}
-	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -914,7 +914,7 @@ func TestManager_ApplySettingsToConn_SameSettings(t *testing.T) {
 	ctx := context.Background()
 
 	settings := map[string]string{"search_path": "public"}
-	conn, err := manager.NewReservedConn(ctx, settings, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, settings, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -939,7 +939,7 @@ func TestManager_ApplySettingsToConn_NilSettings(t *testing.T) {
 
 	ctx := context.Background()
 
-	conn, err := manager.NewReservedConn(ctx, nil, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, nil, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -964,7 +964,7 @@ func TestManager_ApplySettingsToConn_RemovedSettings(t *testing.T) {
 
 	// Create a reserved connection with two settings.
 	initialSettings := map[string]string{"search_path": "public", "work_mem": "256MB"}
-	conn, err := manager.NewReservedConn(ctx, initialSettings, "testuser", nil, nil)
+	conn, err := manager.NewReservedConn(ctx, initialSettings, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	defer conn.Release(reserved.ReleaseCommit)
 
@@ -1002,7 +1002,7 @@ func BenchmarkManager_GetUserPool_HotPath(b *testing.B) {
 	defer manager.Close()
 
 	// Create the user pool first (cold path)
-	conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "benchuser", nil, nil)
 	if err != nil {
 		b.Fatalf("failed to create user pool: %v", err)
 	}
@@ -1013,7 +1013,7 @@ func BenchmarkManager_GetUserPool_HotPath(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			// This should only do: atomic load + map lookup
-			if !manager.HasUserPool("benchuser") {
+			if !manager.HasUserPool("", "benchuser") {
 				b.Fatal("user pool should exist")
 			}
 		}
@@ -1041,7 +1041,7 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 	defer manager.Close()
 
 	// Create the user pool first
-	conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "benchuser", nil, nil)
 	if err != nil {
 		b.Fatalf("failed to create user pool: %v", err)
 	}
@@ -1050,7 +1050,7 @@ func BenchmarkManager_GetRegularConn_ExistingUser(b *testing.B) {
 	// Benchmark getting connections for existing user
 	b.ResetTimer()
 	for b.Loop() {
-		conn, err := manager.GetRegularConn(ctx, "benchuser", nil, nil)
+		conn, err := manager.GetRegularConn(ctx, "", "benchuser", nil, nil)
 		if err != nil {
 			b.Fatalf("failed to get connection: %v", err)
 		}
@@ -1071,7 +1071,7 @@ func TestBuildUserClientConfig_KeysApplied(t *testing.T) {
 	defer manager.Close()
 
 	ck, sk := bytes32(1), bytes32(2)
-	cfg := manager.buildUserClientConfig("alice", ck, sk)
+	cfg := manager.buildUserClientConfig("", "alice", ck, sk)
 
 	assert.Equal(t, ck, cfg.ScramClientKey)
 	assert.Equal(t, sk, cfg.ScramServerKey)
@@ -1094,7 +1094,7 @@ func TestBuildUserClientConfig_NilKeys_FallsBack(t *testing.T) {
 	manager.Open(context.Background(), &ConnectionConfig{Database: "db"})
 	defer manager.Close()
 
-	cfg := manager.buildUserClientConfig("alice", nil, nil)
+	cfg := manager.buildUserClientConfig("", "alice", nil, nil)
 
 	assert.Nil(t, cfg.ScramClientKey)
 	assert.Nil(t, cfg.ScramServerKey)

--- a/go/services/multipooler/connpoolmanager/metrics.go
+++ b/go/services/multipooler/connpoolmanager/metrics.go
@@ -388,7 +388,7 @@ func (m *Metrics) RegisterManagerCallbacks(
 			var totalWaitTime float64
 			var totalGetCount int64
 
-			for user, userStats := range stats.UserPools {
+			for key, userStats := range stats.UserPools {
 				// Regular pool: server connections
 				totalActive += userStats.Regular.Borrowed
 				totalIdle += userStats.Regular.Idle
@@ -405,8 +405,11 @@ func (m *Metrics) RegisterManagerCallbacks(
 				totalWaitTime += userStats.WaitTime.Seconds()
 				totalGetCount += userStats.GetCount
 
-				// Per-user pool capacity and current connections.
-				userAttr := metric.WithAttributes(attribute.String("user", user))
+				// Per-(database, user) pool capacity and current connections.
+				userAttr := metric.WithAttributes(
+					attribute.String("user", key.user),
+					attribute.String("database", key.database),
+				)
 
 				if m.poolCapacity != nil {
 					capacity := userStats.Regular.Capacity + userStats.Reserved.RegularPool.Capacity

--- a/go/services/multipooler/connpoolmanager/rebalancer.go
+++ b/go/services/multipooler/connpoolmanager/rebalancer.go
@@ -60,12 +60,13 @@ func (m *Manager) rebalance(ctx context.Context) {
 		return
 	}
 
-	// 1. Collect demands from all user pools
+	// 1. Collect demands from all pools. The FairShareAllocator keys by a flat
+	// string, so encode each (database, user) key via poolKey.String().
 	regularDemands := make(map[string]int64, len(*pools))
 	reservedDemands := make(map[string]int64, len(*pools))
-	for user, pool := range *pools {
-		regularDemands[user] = pool.RegularDemand()
-		reservedDemands[user] = pool.ReservedDemand()
+	for key, pool := range *pools {
+		regularDemands[key.String()] = pool.RegularDemand()
+		reservedDemands[key.String()] = pool.ReservedDemand()
 	}
 
 	// 2. Compute fair allocations
@@ -73,20 +74,22 @@ func (m *Manager) rebalance(ctx context.Context) {
 	reservedAllocs := m.reservedAllocator.Allocate(reservedDemands)
 
 	// 3. Apply new capacities to each pool
-	for user, pool := range *pools {
-		regularCap := regularAllocs[user]
-		reservedCap := reservedAllocs[user]
+	for key, pool := range *pools {
+		regularCap := regularAllocs[key.String()]
+		reservedCap := reservedAllocs[key.String()]
 
 		m.logger.DebugContext(ctx, "rebalance user",
-			"user", user,
-			"regular_demand", regularDemands[user],
-			"reserved_demand", reservedDemands[user],
+			"user", key.user,
+			"database", key.database,
+			"regular_demand", regularDemands[key.String()],
+			"reserved_demand", reservedDemands[key.String()],
 			"regular_cap", regularCap,
 			"reserved_cap", reservedCap)
 
 		if err := pool.SetCapacity(ctx, regularCap, reservedCap); err != nil {
 			m.logger.WarnContext(ctx, "failed to set capacity",
-				"user", user,
+				"user", key.user,
+				"database", key.database,
 				"regular_cap", regularCap,
 				"reserved_cap", reservedCap,
 				"error", err)
@@ -114,14 +117,14 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	cutoff := now - inactiveTimeout.Nanoseconds()
 
 	// Find inactive pools
-	var inactiveUsers []string
-	for user, pool := range *pools {
+	var inactiveKeys []poolKey
+	for key, pool := range *pools {
 		if pool.LastActivity() < cutoff {
-			inactiveUsers = append(inactiveUsers, user)
+			inactiveKeys = append(inactiveKeys, key)
 		}
 	}
 
-	if len(inactiveUsers) == 0 {
+	if len(inactiveKeys) == 0 {
 		return
 	}
 
@@ -136,12 +139,12 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 	}
 
 	// Create new map without inactive pools
-	newPools := make(map[string]*UserPool, len(*pools)-len(inactiveUsers))
+	newPools := make(map[poolKey]*UserPool, len(*pools)-len(inactiveKeys))
 	maps.Copy(newPools, *pools)
 
 	var closedCount int
-	for _, user := range inactiveUsers {
-		pool, ok := newPools[user]
+	for _, key := range inactiveKeys {
+		pool, ok := newPools[key]
 		if !ok {
 			continue
 		}
@@ -153,11 +156,12 @@ func (m *Manager) garbageCollectInactivePools(ctx context.Context) {
 
 		// Close and remove the pool
 		pool.Close()
-		delete(newPools, user)
+		delete(newPools, key)
 		closedCount++
 
 		m.logger.InfoContext(ctx, "garbage collected inactive user pool",
-			"user", user,
+			"user", key.user,
+			"database", key.database,
 			"inactive_duration", time.Duration(now-pool.LastActivity()))
 	}
 

--- a/go/services/multipooler/connpoolmanager/rebalancer_test.go
+++ b/go/services/multipooler/connpoolmanager/rebalancer_test.go
@@ -92,11 +92,11 @@ func TestManager_RebalanceWithUsers(t *testing.T) {
 	ctx := context.Background()
 
 	// Create some user pools
-	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
+	conn1, err := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
+	conn2, err := manager.GetRegularConn(ctx, "", "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
@@ -105,8 +105,8 @@ func TestManager_RebalanceWithUsers(t *testing.T) {
 
 	// Verify both users still have pools
 	assert.Equal(t, 2, manager.UserPoolCount())
-	assert.True(t, manager.HasUserPool("user1"))
-	assert.True(t, manager.HasUserPool("user2"))
+	assert.True(t, manager.HasUserPool("", "user1"))
+	assert.True(t, manager.HasUserPool("", "user2"))
 }
 
 func TestManager_GarbageCollectInactivePools_ManualTest(t *testing.T) {
@@ -122,7 +122,7 @@ func TestManager_GarbageCollectInactivePools_ManualTest(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "inactive-user", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "inactive-user", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -131,7 +131,7 @@ func TestManager_GarbageCollectInactivePools_ManualTest(t *testing.T) {
 	// Manually set lastActivity to a time far in the past
 	// Default inactive timeout is 5 minutes
 	pools := manager.userPoolsSnapshot.Load()
-	pool := (*pools)["inactive-user"]
+	pool := (*pools)[poolKey{database: manager.resolveDatabase(""), user: "inactive-user"}]
 	// Set activity to 10 minutes ago
 	pool.lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
 
@@ -140,7 +140,7 @@ func TestManager_GarbageCollectInactivePools_ManualTest(t *testing.T) {
 
 	// Pool should have been removed
 	assert.Equal(t, 0, manager.UserPoolCount())
-	assert.False(t, manager.HasUserPool("inactive-user"))
+	assert.False(t, manager.HasUserPool("", "inactive-user"))
 }
 
 func TestManager_GarbageCollectPreservesActivePool(t *testing.T) {
@@ -154,7 +154,7 @@ func TestManager_GarbageCollectPreservesActivePool(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "active-user", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "active-user", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -163,7 +163,7 @@ func TestManager_GarbageCollectPreservesActivePool(t *testing.T) {
 
 	// Pool should still exist (activity is recent)
 	assert.Equal(t, 1, manager.UserPoolCount())
-	assert.True(t, manager.HasUserPool("active-user"))
+	assert.True(t, manager.HasUserPool("", "active-user"))
 }
 
 func TestManager_GarbageCollectMixedPools(t *testing.T) {
@@ -177,11 +177,11 @@ func TestManager_GarbageCollectMixedPools(t *testing.T) {
 	ctx := context.Background()
 
 	// Create two user pools
-	conn1, err := manager.GetRegularConn(ctx, "user1", nil, nil)
+	conn1, err := manager.GetRegularConn(ctx, "", "user1", nil, nil)
 	require.NoError(t, err)
 	conn1.Recycle()
 
-	conn2, err := manager.GetRegularConn(ctx, "user2", nil, nil)
+	conn2, err := manager.GetRegularConn(ctx, "", "user2", nil, nil)
 	require.NoError(t, err)
 	conn2.Recycle()
 
@@ -189,18 +189,18 @@ func TestManager_GarbageCollectMixedPools(t *testing.T) {
 
 	// Set user2 as inactive (10 minutes ago)
 	pools := manager.userPoolsSnapshot.Load()
-	(*pools)["user2"].lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
+	(*pools)[poolKey{database: manager.resolveDatabase(""), user: "user2"}].lastActivity.Store(time.Now().Add(-10 * time.Minute).UnixNano())
 
 	// Keep user1 active
-	(*pools)["user1"].lastActivity.Store(time.Now().UnixNano())
+	(*pools)[poolKey{database: manager.resolveDatabase(""), user: "user1"}].lastActivity.Store(time.Now().UnixNano())
 
 	// Trigger garbage collection
 	manager.garbageCollectInactivePools(ctx)
 
 	// Only user1 should remain
 	assert.Equal(t, 1, manager.UserPoolCount())
-	assert.True(t, manager.HasUserPool("user1"))
-	assert.False(t, manager.HasUserPool("user2"))
+	assert.True(t, manager.HasUserPool("", "user1"))
+	assert.False(t, manager.HasUserPool("", "user2"))
 }
 
 func TestManager_RebalancerLoop(t *testing.T) {
@@ -214,7 +214,7 @@ func TestManager_RebalancerLoop(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
@@ -252,13 +252,13 @@ func TestManager_DemandTrackersCreated(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a user pool
-	conn, err := manager.GetRegularConn(ctx, "testuser", nil, nil)
+	conn, err := manager.GetRegularConn(ctx, "", "testuser", nil, nil)
 	require.NoError(t, err)
 	conn.Recycle()
 
 	// Get the pool and verify stats include demand fields
 	pools := manager.userPoolsSnapshot.Load()
-	pool := (*pools)["testuser"]
+	pool := (*pools)[poolKey{database: manager.resolveDatabase(""), user: "testuser"}]
 	require.NotNil(t, pool)
 
 	// Demand trackers should be created since default config has valid durations

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -157,6 +157,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	e.logger.DebugContext(ctx, "executing query",
 		"tablegroup", target.TableGroup,
 		"shard", target.Shard,
@@ -166,7 +167,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 
 	// Check if we should use an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
 			return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
@@ -209,7 +210,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 
 	// Get a connection from the pool for this user
 	clientKey, serverKey := scramKeysFromOptions(options)
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, database, user, clientKey, serverKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -265,6 +266,7 @@ func (e *Executor) StreamExecute(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	reasons := protoutil.GetReasons(reservationOptions)
 	e.logger.DebugContext(ctx, "stream executing query",
 		"tablegroup", target.TableGroup,
@@ -277,7 +279,7 @@ func (e *Executor) StreamExecute(
 
 	// Case 1: Use an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
@@ -326,7 +328,7 @@ func (e *Executor) StreamExecute(
 
 	// Get a connection from the pool for this user
 	clientKey, serverKey := scramKeysFromOptions(options)
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, database, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -369,6 +371,7 @@ func (e *Executor) reserveAndStreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	var settings map[string]string
 	if options != nil {
 		settings = e.sessionSettingsForPool(options.SessionSettings)
@@ -403,7 +406,7 @@ func (e *Executor) reserveAndStreamExecute(
 
 	// Create a reserved connection
 	clientKey, serverKey := scramKeysFromOptions(options)
-	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reservedOpts...)
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, settings, database, user, clientKey, serverKey, reservedOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
@@ -594,6 +597,7 @@ func (e *Executor) PortalStreamExecute(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	var settings map[string]string
 	if options != nil {
 		settings = e.sessionSettingsForPool(options.SessionSettings)
@@ -622,12 +626,12 @@ func (e *Executor) PortalStreamExecute(
 	// 1. ReservedConnectionId is already set (e.g., from transaction or previous portal)
 	// 2. MaxRows > 0 (portal may be suspended and need resumption)
 	if (options != nil && options.ReservedConnectionId > 0) || maxRows > 0 {
-		return e.portalExecuteWithReserved(ctx, preparedStatement, portal, options, settings, user, maxRows, includeDescribe, paramFormats, resultFormats, callback)
+		return e.portalExecuteWithReserved(ctx, preparedStatement, portal, options, settings, user, database, maxRows, includeDescribe, paramFormats, resultFormats, callback)
 	}
 
 	// Use regular connection for non-suspended execution with no existing reservation
 	clientKey, serverKey := scramKeysFromOptions(options)
-	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, includeDescribe, clientKey, serverKey, paramFormats, resultFormats, options, callback)
+	return e.portalExecuteWithRegular(ctx, preparedStatement, portal, settings, user, database, includeDescribe, clientKey, serverKey, paramFormats, resultFormats, options, callback)
 }
 
 // portalExecuteWithReserved executes a portal using a reserved connection.
@@ -638,6 +642,7 @@ func (e *Executor) portalExecuteWithReserved(
 	options *query.ExecuteOptions,
 	settings map[string]string,
 	user string,
+	database string,
 	maxRows int32,
 	includeDescribe bool,
 	paramFormats, resultFormats []int16,
@@ -648,7 +653,7 @@ func (e *Executor) portalExecuteWithReserved(
 
 	// Check if we should use an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
@@ -661,7 +666,7 @@ func (e *Executor) portalExecuteWithReserved(
 		// below is a no-op for the new-conn path because connState
 		// dedupes by canonical name.
 		clientKey, serverKey := scramKeysFromOptions(options)
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, database, user, clientKey, serverKey, reserved.WithValidate(func(ctx context.Context, conn *regular.Conn) error {
 			_, err := e.ensurePrepared(ctx, conn, preparedStatement)
 			return err
 		}))
@@ -726,13 +731,14 @@ func (e *Executor) portalExecuteWithRegular(
 	portal *query.Portal,
 	settings map[string]string,
 	user string,
+	database string,
 	includeDescribe bool,
 	clientKey, serverKey []byte,
 	paramFormats, resultFormats []int16,
 	options *query.ExecuteOptions,
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
-	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
+	conn, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, database, user, clientKey, serverKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 	}
@@ -782,6 +788,7 @@ func (e *Executor) Describe(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	var settings map[string]string
 	if options != nil {
 		settings = e.sessionSettingsForPool(options.SessionSettings)
@@ -798,7 +805,7 @@ func (e *Executor) Describe(
 	// Acquire the connection: reserved (transactional) or regular (pooled).
 	var conn *regular.Conn
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
@@ -812,7 +819,7 @@ func (e *Executor) Describe(
 		conn = reservedConn.Conn()
 	} else {
 		clientKey, serverKey := scramKeysFromOptions(options)
-		pooled, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, user, clientKey, serverKey)
+		pooled, err := e.poolManager.GetRegularConnWithSettings(ctx, settings, database, user, clientKey, serverKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get connection for user %s: %w", user, err)
 		}
@@ -930,6 +937,7 @@ func (e *Executor) CopyReady(
 	reservationOptions *query.ReservationOptions,
 ) (int16, []int16, *query.ReservedState, error) {
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	var settings map[string]string
 	if options != nil {
 		settings = e.sessionSettingsForPool(options.SessionSettings)
@@ -948,7 +956,7 @@ func (e *Executor) CopyReady(
 
 	// Check if we should use an existing reserved connection
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			return 0, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
@@ -1018,7 +1026,7 @@ func (e *Executor) CopyReady(
 		}
 
 		clientKey, serverKey := scramKeysFromOptions(options)
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, database, user, clientKey, serverKey, reserved.WithValidate(validate))
 		if err != nil {
 			return 0, nil, nil, fmt.Errorf("failed to create reserved connection for COPY: %w", err)
 		}
@@ -1058,9 +1066,10 @@ func (e *Executor) CopySendData(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
 	// Get the reserved connection
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok || reservedConn == nil {
 		return fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 	}
@@ -1099,9 +1108,10 @@ func (e *Executor) CopyFinalize(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
 	// Get the reserved connection
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok || reservedConn == nil {
 		return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 	}
@@ -1202,9 +1212,10 @@ func (e *Executor) CopyAbort(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
 	// Get the reserved connection
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok || reservedConn == nil {
 		// Already cleaned up — return zero state
 		e.logger.DebugContext(ctx, "COPY connection already cleaned up",
@@ -1288,6 +1299,7 @@ func (e *Executor) CopyOutReady(
 	reservationOptions *query.ReservationOptions,
 ) (int16, []int16, []*mterrors.PgDiagnostic, *query.ReservedState, error) {
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 	var settings map[string]string
 	if options != nil {
 		settings = e.sessionSettingsForPool(options.SessionSettings)
@@ -1306,7 +1318,7 @@ func (e *Executor) CopyOutReady(
 	)
 
 	if options != nil && options.ReservedConnectionId > 0 {
-		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 		if reservedConn == nil {
 			return 0, nil, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 		}
@@ -1345,7 +1357,7 @@ func (e *Executor) CopyOutReady(
 		}
 
 		clientKey, serverKey := scramKeysFromOptions(options)
-		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, user, clientKey, serverKey, reserved.WithValidate(validate))
+		reservedConn, err = e.poolManager.NewReservedConn(ctx, settings, database, user, clientKey, serverKey, reserved.WithValidate(validate))
 		if err != nil {
 			return 0, nil, notices, nil, err
 		}
@@ -1391,7 +1403,8 @@ func (e *Executor) CopyOutStream(
 	}
 
 	user := e.getUserFromOptions(options)
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	database := e.getDatabaseFromOptions(options)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok || reservedConn == nil {
 		return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
 	}
@@ -1485,6 +1498,17 @@ func (e *Executor) getUserFromOptions(options *query.ExecuteOptions) string {
 	return "postgres"
 }
 
+// getDatabaseFromOptions extracts the target database from ExecuteOptions. It
+// selects which (database, user) connection pool the query runs on. An empty
+// value (older gateways, internal requests) is passed through to the pool
+// manager, which resolves it to the multipooler's configured default database.
+func (e *Executor) getDatabaseFromOptions(options *query.ExecuteOptions) string {
+	if options != nil {
+		return options.GetDatabase()
+	}
+	return ""
+}
+
 // scramKeysFromOptions returns the SCRAM passthrough keys carried on the
 // request, or (nil, nil) if no keys were forwarded. The connpoolmanager
 // consults the passthrough flag before consuming them, so it is always safe
@@ -1549,6 +1573,7 @@ func (e *Executor) ConcludeTransaction(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
 	e.logger.DebugContext(ctx, "conclude transaction",
 		"user", user,
@@ -1556,7 +1581,7 @@ func (e *Executor) ConcludeTransaction(
 		"conclusion", conclusion.String())
 
 	// Get the reserved connection
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
 		return nil, nil, fmt.Errorf("reserved connection %d not found", options.ReservedConnectionId)
@@ -1637,13 +1662,14 @@ func (e *Executor) DiscardTempTables(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
 	e.logger.DebugContext(ctx, "discard temp tables",
 		"user", user,
 		"reserved_conn_id", options.ReservedConnectionId)
 
 	// Get the reserved connection
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
 		return nil, nil, fmt.Errorf("reserved connection %d not found", options.ReservedConnectionId)
@@ -1690,8 +1716,9 @@ func (e *Executor) ReleaseReservedConnection(
 	}
 
 	user := e.getUserFromOptions(options)
+	database := e.getDatabaseFromOptions(options)
 
-	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
+	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), database, user)
 	if !ok || reservedConn == nil {
 		// Already cleaned up or timed out
 		return nil

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -133,19 +133,19 @@ func (m *stubPoolManager) CloseForReopen()                                      
 func (m *stubPoolManager) PgUser() string                                          { return "postgres" }
 func (m *stubPoolManager) PgPassword() (string, bool)                              { return "", true }
 func (m *stubPoolManager) GetAdminConn(context.Context) (admin.PooledConn, error)  { return nil, nil }
-func (m *stubPoolManager) GetRegularConn(context.Context, string, []byte, []byte) (regular.PooledConn, error) {
+func (m *stubPoolManager) GetRegularConn(context.Context, string, string, []byte, []byte) (regular.PooledConn, error) {
 	return nil, nil
 }
 
-func (m *stubPoolManager) GetRegularConnWithSettings(context.Context, map[string]string, string, []byte, []byte) (regular.PooledConn, error) {
+func (m *stubPoolManager) GetRegularConnWithSettings(context.Context, map[string]string, string, string, []byte, []byte) (regular.PooledConn, error) {
 	return nil, nil
 }
 
-func (m *stubPoolManager) NewReservedConn(context.Context, map[string]string, string, []byte, []byte, ...reserved.ReservedConnOption) (*reserved.Conn, error) {
+func (m *stubPoolManager) NewReservedConn(context.Context, map[string]string, string, string, []byte, []byte, ...reserved.ReservedConnOption) (*reserved.Conn, error) {
 	return nil, errors.New("not implemented in test stub")
 }
 
-func (m *stubPoolManager) GetReservedConn(int64, string) (*reserved.Conn, bool) {
+func (m *stubPoolManager) GetReservedConn(int64, string, string) (*reserved.Conn, bool) {
 	return m.reservedConn, m.reservedConnOK
 }
 

--- a/go/services/multipooler/executor/internal_query.go
+++ b/go/services/multipooler/executor/internal_query.go
@@ -114,7 +114,7 @@ func (e *Executor) Query(ctx context.Context, queryStr string) (*sqltypes.Result
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
+	conn, err := e.poolManager.GetRegularConn(ctx, "", e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (e *Executor) QueryMultiStatement(ctx context.Context, queryStr string) err
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
+	conn, err := e.poolManager.GetRegularConn(ctx, "", e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func (e *Executor) QueryArgs(ctx context.Context, sql string, args ...any) (*sql
 		IncludeQueryText: true,
 	})
 
-	conn, err := e.poolManager.GetRegularConn(ctx, e.poolManager.PgUser(), nil, nil)
+	conn, err := e.poolManager.GetRegularConn(ctx, "", e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (e *Executor) Begin(ctx context.Context) (InternalTx, error) {
 
 	// Internal callers connect as the configured superuser and need no session
 	// settings or SCRAM passthrough keys.
-	reservedConn, err := e.poolManager.NewReservedConn(ctx, nil, e.poolManager.PgUser(), nil, nil)
+	reservedConn, err := e.poolManager.NewReservedConn(ctx, nil, "", e.poolManager.PgUser(), nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}

--- a/go/services/multipooler/pubsub/listener.go
+++ b/go/services/multipooler/pubsub/listener.go
@@ -229,7 +229,7 @@ func (l *Listener) run(ctx context.Context) {
 	connect := func() {
 		releaseConn(reserved.ReleaseError)
 		var err error
-		conn, err = l.poolManager.NewReservedConn(ctx, nil, l.poolManager.PgUser(), nil, nil)
+		conn, err = l.poolManager.NewReservedConn(ctx, nil, "", l.poolManager.PgUser(), nil, nil)
 		if err != nil {
 			l.logger.ErrorContext(ctx, "pubsub: failed to acquire reserved connection", "error", err)
 			conn = nil

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -325,6 +325,13 @@ message ExecuteOptions {
   // functions can map virtual PIDs (visible to clients) back to real
   // backend PIDs via pg_stat_activity.
   uint32 client_connection_id = 8;
+
+  // database is the PostgreSQL database the client connected to (from the
+  // startup packet). A single multipooler serves many logical databases on
+  // the same PostgreSQL instance; this selects which (database, user)
+  // connection pool the query runs on. When empty, the multipooler falls
+  // back to its configured default database.
+  string database = 9;
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM


### PR DESCRIPTION
> **Prototype — not for merge.** This is an exploratory prototype to see what it takes to support multiple logical databases and `CREATE DATABASE` through the pooler. It builds, vets, and passes unit tests for the touched packages, but has not had live end-to-end validation.

## Summary

- A single multipooler can now serve **many logical databases** on the same PostgreSQL instance: connection pools are keyed by `(database, user)` instead of just `user`.
- The client's startup `database` is plumbed end-to-end (gateway → pooler) via a new `ExecuteOptions.database` field, instead of being ignored in favor of the pooler's one configured DB.
- `CREATE DATABASE` / `DROP DATABASE` are no longer rejected — they run as ordinary statements, so a freshly created database is immediately reachable by reconnecting with that dbname.

## Description

Today the gateway reads the client's requested database but only uses it for plan-cache keys, metrics, and tracing — routing always lands on the one database each multipooler is configured for. And the connection pool manager dials a single `connConfig.Database` for every pool. So regardless of the `dbname` a client sends, it effectively talks to `postgres`.

This prototype takes the **multipooler-serves-many-databases** approach (one Postgres instance, many logical DBs):

- **`proto/query.proto`** — adds `string database = 9` to `ExecuteOptions`.
- **Gateway (`scatterconn`)** — a `newExecuteOptions(conn, state)` helper stamps `Database: conn.Database()` on every outbound query RPC. All 13 inline construction sites now go through it so no path can silently omit the database (which would route to the wrong pool).
- **`connpoolmanager`** — pools are keyed by a new `poolKey{database, user}`. Public methods take a `database` arg, per-pool dials override the dbname, and the rebalancer, GC, metrics, and stats all key by `(database, user)`. An empty database resolves to the pooler's configured default, so internal machinery (heartbeat, logical-replication listener) and the admin/maintenance pool stay on the default DB and the multigres internal schema is untouched.
- **`executor`** — extracts the database from options and threads it into every pool acquisition.
- **`planner/unsafe_stmt.go`** — drops the `CREATE DATABASE` / `DROP DATABASE` rejections (other Tier-2 guards remain). PostgreSQL still enforces its own constraints (can't run inside a transaction block, can't drop the DB you're connected to).

## Behavior change worth flagging

Previously the gateway ignored the client's `dbname`, so every connection landed on the configured database. Now `dbname` is honored: connecting to a database that doesn't exist in PostgreSQL surfaces a real "database does not exist" error instead of silently using `postgres`. That's the intended multi-DB semantics, but it's a visible change for clients that relied on the old pass-through.

## Not done yet

- Live end-to-end validation (spin a cluster, `CREATE DATABASE foo`, reconnect with `dbname=foo`).
- The `TestRuleStorePG_*` failures in `multipooler/manager` are pre-existing (they fail on `main` too), unrelated to this change.