### PR TITLE
test(pgregresstest): run pgmq's regression suite through multigateway

### DIFF
--- a/go/test/endtoend/pgbuilder/builder.go
+++ b/go/test/endtoend/pgbuilder/builder.go
@@ -249,7 +249,13 @@ func (b *Builder) InstallContrib(t *testing.T, ctx context.Context) error {
 // ABI-consistency guarantee Build provides for regress.so). The checkout is
 // per-run, so a shallow clone happens once per invocation; pinning the tag keeps
 // the suite reproducible.
-func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, name, repo, tag string) (string, error) {
+//
+// buildSubdir is the directory within the checkout that holds the PGXS Makefile,
+// relative to the clone root. It is empty for extensions whose Makefile sits at
+// the repo root (pgvector, pg_cron) and set when it lives in a subdirectory
+// (pgmq: "pgmq-extension"). The returned path is always the clone root, so the
+// caller resolves the extension's TestSubdir against it independently.
+func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, name, repo, tag, buildSubdir string) (string, error) {
 	t.Helper()
 
 	if err := os.MkdirAll(b.ExternalDir, 0o755); err != nil {
@@ -270,9 +276,11 @@ func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, na
 	}
 
 	pgConfig := filepath.Join(b.BinDir(), "pg_config")
+	// The PGXS Makefile may live in a subdirectory of the checkout (pgmq).
+	buildDir := filepath.Join(cloneDir, buildSubdir)
 
 	t.Logf("Building external extension %s with PGXS (PG_CONFIG=%s)...", name, pgConfig)
-	makeCmd := executil.Command(ctx, "make", "-C", cloneDir, "-j", "4", "PG_CONFIG="+pgConfig)
+	makeCmd := executil.Command(ctx, "make", "-C", buildDir, "-j", "4", "PG_CONFIG="+pgConfig)
 	makeCmd.Stdout = os.Stdout
 	makeCmd.Stderr = os.Stderr
 	if err := makeCmd.Run(); err != nil {
@@ -280,7 +288,7 @@ func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, na
 	}
 
 	t.Logf("Installing external extension %s into %s...", name, b.InstallDir)
-	installCmd := executil.Command(ctx, "make", "-C", cloneDir, "PG_CONFIG="+pgConfig, "install")
+	installCmd := executil.Command(ctx, "make", "-C", buildDir, "PG_CONFIG="+pgConfig, "install")
 	installCmd.Stdout = os.Stdout
 	installCmd.Stderr = os.Stderr
 	if err := installCmd.Run(); err != nil {

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -144,7 +144,10 @@ as catalog entries move to `covered` and their suites run.
 The external suite runs the pg_regress suites of extensions that live **outside**
 the PostgreSQL source tree (separate repositories), executed through
 multigateway. The covered set lives in `externalSpecs` (`extensions.go`), each
-pinned to a tag: `vector` (pgvector) and `pg_cron` (Citus pg_cron).
+pinned to a tag: `vector` (pgvector), `pg_cron` (Citus pg_cron), and `pgmq`
+(tembo-io message queue). `externalSpecs` also holds build-only dependencies that
+are installed but not tested on their own — `pg_partman`, which pgmq's
+partitioned-queue tests require (see `DependsOn` below).
 
 How it works, and how it differs from the contrib suite:
 
@@ -175,9 +178,18 @@ How it works, and how it differs from the contrib suite:
 Extensions diverge from the pgvector baseline in a few ways, captured as fields
 on `ExternalExtension` (`extensions.go`):
 
+- **`BuildSubdir`** — where the PGXS `Makefile` lives in the checkout. pgvector
+  and pg_cron keep it at the repo root (`""`); pgmq keeps the extension under
+  `pgmq-extension/`, so it builds there.
 - **`TestSubdir`** — where the shipped `sql/` + `expected/` fixtures live in the
   checkout. pgvector keeps them under `test/`; pg_cron keeps them at the repo
-  root (`.`).
+  root (`.`); pgmq keeps them under `pgmq-extension/test`.
+- **`DependsOn`** — other `externalSpecs` the harness clones, builds, and installs
+  first because the suite `CREATE`s them too. They are build-only (not tested on
+  their own, so they need not ship a pg_regress suite). pgmq's `base.sql` creates
+  partitioned queues via pg_partman's `create_parent`, so pgmq `DependsOn`
+  `pg_partman` (which itself ships only a pgTAP suite). `ExternalBuildList` orders
+  dependencies before their dependents.
 - **`CreateExtension`** — whether the harness pre-creates the extension through
   multigateway (and passes `--load-extension`) before the run. pgvector's
   fixtures assume it already exists (they open with a bare

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -91,12 +91,13 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"pg_graphql", KindExternal, StatusExternal, "Rust"},
 	{"pg_jsonschema", KindExternal, StatusExternal, "Rust"},
 	{"pg_net", KindExternal, StatusExternal, "background worker"},
+	{"pg_partman", KindExternal, StatusUnsupported, "ships a pgTAP suite, not pg_regress; built and installed as a build dependency of pgmq (create_partitioned → create_parent)"},
 	{"pg_stat_statements", KindContrib, StatusUnsupported, "NO_INSTALLCHECK; records query text the gateway rewrites"},
 	{"pg_trgm", KindContrib, StatusCovered, ""},
 	{"pgaudit", KindExternal, StatusExternal, ""},
 	{"pgcrypto", KindContrib, StatusCovered, "needs --with-ssl=openssl"},
 	{"pgjwt", KindExternal, StatusExternal, "depends on pgcrypto"},
-	{"pgmq", KindExternal, StatusExternal, ""},
+	{"pgmq", KindExternal, StatusCovered, "tembo-io/pgmq; pure-SQL queue built as a PGXS module from pgmq-extension/; partitioned-queue tests depend on pg_partman"},
 	{"pgsodium", KindExternal, StatusExternal, "libsodium"},
 	{"pgtap", KindExternal, StatusExternal, ""},
 	{"plpgsql", KindContrib, StatusUnsupported, "built-in PL; exercised by the core regression suite, not contrib"},
@@ -120,10 +121,17 @@ type ExternalExtension struct {
 	Repo string
 	Tag  string
 
+	// BuildSubdir is the directory within the checkout that holds the PGXS
+	// Makefile, relative to the clone root. pgvector and pg_cron keep it at the
+	// repo root (""), so the harness builds there; pgmq keeps the extension under
+	// pgmq-extension/, so it uses "pgmq-extension". Empty means the repo root.
+	BuildSubdir string
+
 	// TestSubdir is the directory within the checkout that holds the shipped
 	// pg_regress fixtures (sql/ + expected/), relative to the clone root.
 	// pgvector keeps them under test/; pg_cron keeps them at the repo root, so
-	// it uses "." (filepath.Join collapses it back to the clone root).
+	// it uses "." (filepath.Join collapses it back to the clone root). pgmq keeps
+	// them under pgmq-extension/test, alongside its BuildSubdir.
 	TestSubdir string
 
 	// CreateExtension controls whether the harness pre-creates the extension
@@ -163,6 +171,15 @@ type ExternalExtension struct {
 	// shared_preload_libraries = 'pg_cron' or CREATE EXTENSION errors out. Empty
 	// for extensions that need nothing beyond the stock cluster (pgvector).
 	ServerConfigFile string
+
+	// DependsOn names other externalSpecs the harness must clone, build, and
+	// install before this extension's suite runs, because the suite CREATEs those
+	// extensions too. They are build-only: installed so CREATE EXTENSION resolves,
+	// but not tested on their own (they need not ship a pg_regress suite). pgmq's
+	// base.sql creates partitioned queues via pg_partman's create_parent, so pgmq
+	// DependsOn pg_partman. ExternalBuildList orders dependencies before the
+	// extensions that need them. Empty for self-contained extensions (pgvector).
+	DependsOn []string
 }
 
 // externalSpecs holds the build coordinates (git repo + pinned tag) and the
@@ -184,6 +201,30 @@ var externalSpecs = map[string]ExternalExtension{
 		// CONNECT-privilege checks run for real. See ScratchDatabases.
 		ScratchDatabases: []string{"pgcron_dbno", "pgcron_dbyes"},
 	},
+	// pg_partman is a build-only dependency of pgmq, never tested on its own (it
+	// ships a pgTAP suite, not pg_regress — see its StatusUnsupported catalog
+	// entry). pgmq.create_partitioned calls partman's create_parent, which works
+	// without the background worker, so no ServerConfigFile is needed; the PGXS
+	// Makefile is at the repo root, so BuildSubdir stays empty.
+	"pg_partman": {
+		Name: "pg_partman", Repo: "https://github.com/pgpartman/pg_partman", Tag: "v5.4.3",
+	},
+	"pgmq": {
+		Name: "pgmq", Repo: "https://github.com/tembo-io/pgmq", Tag: "v1.11.1",
+		// The extension lives under pgmq-extension/ (PGXS Makefile + test/), not at
+		// the repo root, so both the build and the fixtures hang off that subdir.
+		BuildSubdir: "pgmq-extension", TestSubdir: "pgmq-extension/test",
+		// Every test file CREATEs the extension itself (the topic/fifo files open
+		// with DROP EXTENSION IF EXISTS pgmq CASCADE; CREATE EXTENSION pgmq), so the
+		// harness must not preload it.
+		CreateExtension: false,
+		// base.sql creates partitioned queues via pg_partman's create_parent and
+		// CREATEs pg_partman directly; install it first. (base.sql also calls
+		// pgmq.create_unlogged, whose CREATE UNLOGGED TABLE runs as dynamic SQL
+		// inside a plpgsql function — the gateway only sees the SELECT, so the
+		// top-level unlogged-table rejection does not fire and it succeeds.)
+		DependsOn: []string{"pg_partman"},
+	},
 }
 
 // CoveredExternalExtensions returns the external extensions the suite builds and
@@ -201,6 +242,35 @@ func CoveredExternalExtensions() []ExternalExtension {
 		}
 	}
 	return exts
+}
+
+// ExternalBuildList returns every external extension the suite must clone, build,
+// and install: the extensions selected for this run (ExternalModules, which
+// honors PGEXTERNAL_TESTS) plus their build-only dependencies (DependsOn), with
+// each dependency ordered before the extension that needs it and every entry
+// deduplicated. Dependencies are resolved through externalSpecs. The build phase
+// iterates this so a narrowed run (e.g. PGEXTERNAL_TESTS="pgmq") builds only the
+// selected extensions and their deps; the test phase iterates ExternalModules
+// (dependencies ship no pg_regress suite we run).
+func ExternalBuildList() []ExternalExtension {
+	var out []ExternalExtension
+	seen := map[string]bool{}
+	add := func(spec ExternalExtension) {
+		if seen[spec.Name] {
+			return
+		}
+		seen[spec.Name] = true
+		out = append(out, spec)
+	}
+	for _, e := range ExternalModules() {
+		for _, dep := range e.DependsOn {
+			if spec, ok := externalSpecs[dep]; ok {
+				add(spec)
+			}
+		}
+		add(e)
+	}
+	return out
 }
 
 // CheckExternalSpecs verifies every covered external extension has a build spec.

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -153,11 +153,13 @@ func TestPostgreSQLRegression(t *testing.T) {
 	// Phase 2d: Clone, build, and install external extensions (only when that
 	// suite will run). Each is a PGXS module living outside the PostgreSQL source
 	// tree (e.g. pgvector); it is built against the just-installed PostgreSQL so
-	// its .so matches the running server's ABI.
+	// its .so matches the running server's ABI. ExternalBuildList includes the
+	// covered extensions plus their build-only dependencies (e.g. pg_partman for
+	// pgmq), ordered so dependencies install first.
 	if runExternal {
 		t.Logf("Phase 2d: Installing external extensions...")
-		for _, ext := range CoveredExternalExtensions() {
-			if _, err := builder.InstallExternalExtension(t, buildCtx, ext.Name, ext.Repo, ext.Tag); err != nil {
+		for _, ext := range ExternalBuildList() {
+			if _, err := builder.InstallExternalExtension(t, buildCtx, ext.Name, ext.Repo, ext.Tag, ext.BuildSubdir); err != nil {
 				t.Fatalf("Failed to install external extension %s: %v", ext.Name, err)
 			}
 		}


### PR DESCRIPTION
## Summary

- Enroll [tembo-io/pgmq](https://github.com/tembo-io/pgmq) (v1.11.1) as a covered external extension, running all five of its shipped pg_regress files (`base`, `fifo_tests`, `fifo_rr_tests`, `fifo_per_group_tests`, `topic_tests`) through multigateway. All pass with **no patches** — pgmq's output matches upstream's expected output exactly.
- Add two reusable knobs to `ExternalExtension`, both first needed by pgmq: `BuildSubdir` (the PGXS Makefile lives under `pgmq-extension/`, not the repo root) and `DependsOn` (build-only prerequisite extensions).
- Build `pg_partman` (v5.4.3) as a build-only dependency of pgmq via `DependsOn`, so `base.sql`'s partitioned-queue tests (`create_partitioned` → partman's `create_parent`) run for real. It is not tested on its own (it ships a pgTAP suite, not pg_regress) and is recorded as `StatusUnsupported` in the catalog.

## Description

`ExternalBuildList` resolves the selected extensions plus their dependencies (dependencies first, deduped) and honors `PGEXTERNAL_TESTS`, so a narrowed run (e.g. `PGEXTERNAL_TESTS="pgmq"`) builds only what it needs. The build phase iterates this list; the test phase still iterates only the covered set.

One behavior worth flagging: `base.sql` calls `pgmq.create_unlogged()`, and it succeeds even though multigres rejects unlogged tables. That rejection is top-level-statement-only, and pgmq issues the `CREATE UNLOGGED TABLE` as dynamic SQL inside a plpgsql function — the gateway only sees `SELECT pgmq.create_unlogged(...)`, so the guard never fires.

Verified locally with `RUN_PGEXTERNAL=1 PGEXTERNAL_TESTS="pgmq"`: pg_partman and pgmq clone/build/install cleanly against the from-source PostgreSQL, and pg_regress reports all 5 tests pass with an empty `regression.diffs`.