### PR TITLE
test(shardsetup): extend timing table with failover and recovery events

### DIFF
--- a/.github/scripts/timing-summary.py
+++ b/.github/scripts/timing-summary.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 # Reads integration-test-results.jsonl (go test -json output), extracts
-# startup timing rows emitted by shardsetup.TimingCollector, and writes a
-# mean±95%CI / p50/p95/p99 markdown table to $GITHUB_STEP_SUMMARY.
+# timing rows emitted by shardsetup.TimingCollector, and writes a
+# mean±99.9%CI / p50/p95/p99 markdown table to $GITHUB_STEP_SUMMARY.
 #
-# Usage: python3 .github/scripts/startup-timing-summary.py
-"""Summarise startup timing stats from integration test output into a markdown table."""
+# Usage: python3 .github/scripts/timing-summary.py
+"""Summarise timing stats from integration test output into a markdown table."""
 
 # pylint: disable=invalid-name  # script filename uses hyphens (conventional for CLI scripts)
 
@@ -30,47 +30,47 @@ import sys
 from collections import defaultdict
 from typing import IO
 
-# t-distribution critical values at the 97.5th percentile (for a 95% two-sided
+# t-distribution critical values at the 99.95th percentile (for a 99.9% two-sided
 # CI on the mean), keyed by degrees of freedom (n-1).  Values are taken from
-# standard t-tables.  For df > 120 the normal approximation 1.960 is used.
-_T_CRIT_97_5: dict[int, float] = {
-    1: 12.706,
-    2: 4.303,
-    3: 3.182,
-    4: 2.776,
-    5: 2.571,
-    6: 2.447,
-    7: 2.365,
-    8: 2.306,
-    9: 2.262,
-    10: 2.228,
-    12: 2.179,
-    15: 2.131,
-    20: 2.086,
-    25: 2.060,
-    30: 2.042,
-    40: 2.021,
-    60: 2.000,
-    120: 1.980,
+# standard t-tables.  For df > 120 the normal approximation 3.291 is used.
+_T_CRIT_99_95: dict[int, float] = {
+    1: 636.619,
+    2: 31.598,
+    3: 12.924,
+    4: 8.610,
+    5: 6.869,
+    6: 5.959,
+    7: 5.408,
+    8: 5.041,
+    9: 4.781,
+    10: 4.587,
+    12: 4.318,
+    15: 4.073,
+    20: 3.850,
+    25: 3.725,
+    30: 3.646,
+    40: 3.551,
+    60: 3.460,
+    120: 3.373,
 }
 
 
-def t_crit_95(df: int) -> float:
-    """Return the 97.5th-percentile t critical value for the given degrees of freedom.
+def t_crit_999(df: int) -> float:
+    """Return the 99.95th-percentile t critical value for the given degrees of freedom.
 
     Uses the nearest entry with df' ≤ df (conservative — slightly widens the
-    interval).  Falls back to the normal-distribution value 1.960 for df > 120.
+    interval).  Falls back to the normal-distribution value 3.291 for df > 120.
     """
     if df >= 120:
-        return 1.960
-    for k in sorted(_T_CRIT_97_5, reverse=True):
+        return 3.291
+    for k in sorted(_T_CRIT_99_95, reverse=True):
         if df >= k:
-            return _T_CRIT_97_5[k]
-    return _T_CRIT_97_5[1]
+            return _T_CRIT_99_95[k]
+    return _T_CRIT_99_95[1]
 
 
-def mean_ci_95(values: list[float]) -> tuple[float, float]:
-    """Return (mean, half_width) for a 95% CI on the mean, assuming normality.
+def mean_ci_999(values: list[float]) -> tuple[float, float]:
+    """Return (mean, half_width) for a 99.9% CI on the mean, assuming normality.
 
     For n=1 the half-width is 0.0 (a CI cannot be computed from a single sample).
     """
@@ -79,16 +79,19 @@ def mean_ci_95(values: list[float]) -> tuple[float, float]:
     if n < 2:
         return mean, 0.0
     variance = sum((x - mean) ** 2 for x in values) / (n - 1)
-    margin = t_crit_95(n - 1) * math.sqrt(variance) / math.sqrt(n)
+    margin = t_crit_999(n - 1) * math.sqrt(variance) / math.sqrt(n)
     return mean, margin
 
 
 def clean_label(label: str) -> str:
     """Normalise labels that vary by pooler instance.
 
-    "manager ready: pooler-N" → "manager ready"
+    "manager ready: pooler-N"          → "manager ready"
+    "failover: pooler-N → new primary" → "failover"
     """
-    return re.sub(r": pooler-\d+$", "", label).strip()
+    label = re.sub(r": pooler-\d+$", "", label)
+    label = re.sub(r": pooler-\d+ →.*$", "", label)
+    return label.strip()
 
 
 def percentile(values: list[float], p: float) -> float:
@@ -135,7 +138,7 @@ def format_cell(elapsed_seconds: float, limit_seconds: float) -> str:
 def format_ci_cell(mean_s: float, margin_s: float, limit_s: float, n: int) -> str:
     """Format a mean±CI cell as 'Xs ±Ys (P%, n=N)'.
 
-    Shows the mean elapsed time, the 95% CI half-width, the mean as a
+    Shows the mean elapsed time, the 99.9% CI half-width, the mean as a
     percentage of the timeout, and the sample size so the reliability of the
     interval is immediately visible.
     """
@@ -215,15 +218,15 @@ def main() -> None:
         )  # pylint: disable=consider-using-with
 
     try:
-        out.write("## Startup Timing\n\n")
+        out.write("## Timing Summary\n\n")
         out.write(
-            "| Operation | Timeout | mean ±95%CI | min | p50 | p95 | p99 | max |\n"
+            "| Operation | Timeout | mean ±99.9%CI | min | p50 | p95 | p99 | max |\n"
         )
         out.write("|---|---|---|---|---|---|---|---|\n")
         for label in sorted(data):
             vals = data[label]
             limit_s = parse_duration_seconds(limits[label])
-            mean_s, margin_s = mean_ci_95(vals)
+            mean_s, margin_s = mean_ci_999(vals)
             p50v = percentile(vals, 50)
             p95v = percentile(vals, 95)
             p99v = percentile(vals, 99)

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Stop port pool server
         run: kill "$PORT_POOL_PID" || true
 
+      - name: Write timing summary
+        if: ${{ !cancelled() }}
+        run: |
+          sudo apt-get install -y python3-scipy
+          python3 .github/scripts/timing-summary.py
+
       - name: Upload test results to Trunk
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-results
@@ -85,12 +91,6 @@ jobs:
           junit-paths: integration-test-results.xml
           previous-step-outcome: ${{ steps.integration-tests.outcome }}
           allow-quarantine: "true"
-
-      - name: Write timing summary
-        if: ${{ !cancelled() }}
-        run: |
-          sudo apt-get install -y python3-scipy
-          python3 .github/scripts/timing-summary.py
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -86,9 +86,11 @@ jobs:
           previous-step-outcome: ${{ steps.integration-tests.outcome }}
           allow-quarantine: "true"
 
-      - name: Write startup timing to summary
+      - name: Write timing summary
         if: ${{ !cancelled() }}
-        run: python3 .github/scripts/startup-timing-summary.py
+        run: |
+          sudo apt-get install -y python3-scipy
+          python3 .github/scripts/timing-summary.py
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/go/test/endtoend/multiorch/bootstrap_test.go
+++ b/go/test/endtoend/multiorch/bootstrap_test.go
@@ -355,7 +355,8 @@ func TestBootstrapInitialization(t *testing.T) {
 		// freshly-restored standby that joins via SetTermPrimary/FixReplication never
 		// makes a revocation promise (Recruit isn't called on join), so term=0
 		// is the expected steady state for it.
-		shardsetup.EventuallyPoolerCondition(t, []*shardsetup.MultipoolerInstance{standbyInst}, 90*time.Second, 1*time.Second,
+		shardsetup.TimedEventuallyPoolerCondition(t, setup.Timings, "standby auto-restore",
+			[]*shardsetup.MultipoolerInstance{standbyInst}, 90*time.Second, 1*time.Second,
 			func(r shardsetup.PoolerStatusResult) (bool, string) {
 				if !r.Status.IsInitialized {
 					return false, "not yet initialized"

--- a/go/test/endtoend/multiorch/cohort_rotation_test.go
+++ b/go/test/endtoend/multiorch/cohort_rotation_test.go
@@ -60,7 +60,7 @@ func waitForCohortMembership(t *testing.T, setup *shardsetup.ShardSetup, expecte
 	for _, name := range expected {
 		expectedSet[name] = struct{}{}
 	}
-	require.Eventually(t, func() bool {
+	shardsetup.TimedEventually(t, setup.Timings, "cohort convergence", func() bool {
 		members := fetchLeaderCohort(t, setup)
 		if len(members) != len(expected) {
 			return false

--- a/go/test/endtoend/multiorch/dead_primary_recovery_test.go
+++ b/go/test/endtoend/multiorch/dead_primary_recovery_test.go
@@ -470,6 +470,8 @@ func TestDeadPrimaryRecovery(t *testing.T) {
 				"recruit phase for %v should be fast (took %v)", p["new_primary"], recruit)
 			assert.Less(t, propose, maxPropose,
 				"propose phase for %v should be fast (took %v)", p["new_primary"], propose)
+			setup.Timings.Record("appointment: recruit", recruit, maxRecruit)
+			setup.Timings.Record("appointment: propose", propose, maxPropose)
 		}
 	})
 

--- a/go/test/endtoend/shardsetup/pooler_diagnostics.go
+++ b/go/test/endtoend/shardsetup/pooler_diagnostics.go
@@ -140,6 +140,25 @@ func EventuallyPoolerCondition(
 	}, timeout, tick, msgAndArgs...)
 }
 
+// TimedEventuallyPoolerCondition is EventuallyPoolerCondition that also records elapsed
+// time to tc. tc may be nil, in which case timing is not recorded.
+func TimedEventuallyPoolerCondition(
+	t *testing.T,
+	tc *TimingCollector,
+	label string,
+	poolers []*MultipoolerInstance,
+	timeout, tick time.Duration,
+	condition func(r PoolerStatusResult) (bool, string),
+	msgAndArgs ...any,
+) {
+	t.Helper()
+	start := time.Now()
+	EventuallyPoolerCondition(t, poolers, timeout, tick, condition, msgAndArgs...)
+	if tc != nil {
+		tc.Record(label, time.Since(start), timeout)
+	}
+}
+
 // RequirePoolerCondition fetches status for each pooler once and immediately fails the
 // test if any pooler does not satisfy condition. Diagnostics for all failing poolers are
 // included in the failure message. Use this after RequireRecovery or similar operations
@@ -201,6 +220,7 @@ func WaitForHigherTermPrimary(t *testing.T, setup *ShardSetup, oldTerm int64, mi
 
 // WaitForNewPrimary polls all multipoolers in setup until one other than oldPrimaryName
 // reports IsInitialized + PoolerType_PRIMARY + PostgresReady, then returns its name.
+// Elapsed time is recorded to setup.Timings when non-nil.
 // Fails the test if no new primary is elected within timeout.
 func WaitForNewPrimary(t *testing.T, setup *ShardSetup, oldPrimaryName string, timeout time.Duration) string {
 	t.Helper()
@@ -210,7 +230,8 @@ func WaitForNewPrimary(t *testing.T, setup *ShardSetup, oldPrimaryName string, t
 		poolers = append(poolers, inst)
 	}
 
-	return EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
+	start := time.Now()
+	name := EventuallyPoolersCondition(t, poolers, timeout, 2*time.Second,
 		func(statuses []PoolerStatusResult) (string, bool, string) {
 			for _, r := range statuses {
 				if r.Name == oldPrimaryName || r.Err != nil || r.Status == nil {
@@ -226,6 +247,10 @@ func WaitForNewPrimary(t *testing.T, setup *ShardSetup, oldPrimaryName string, t
 		},
 		"new primary not elected within %v", timeout,
 	)
+	if setup.Timings != nil {
+		setup.Timings.Record(fmt.Sprintf("failover: %s → new primary", oldPrimaryName), time.Since(start), timeout)
+	}
+	return name
 }
 
 // FormatPoolerDiagnostics returns a compact diagnostic string for a pooler status,

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -845,6 +845,7 @@ func (s *ShardSetup) TriggerRecoveryOnce(t *testing.T, orchName string, timeout 
 func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time.Duration) {
 	t.Helper()
 
+	start := time.Now()
 	conn := s.connectToMultiOrch(t, orchName)
 	defer conn.Close()
 
@@ -899,6 +900,9 @@ func (s *ShardSetup) RequireRecovery(t *testing.T, orchName string, timeout time
 		t.Fatalf("RequireRecovery: recovery did not complete within %s", timeout)
 	}
 
+	if s.Timings != nil {
+		s.Timings.Record("recovery: "+orchName, time.Since(start), timeout)
+	}
 	t.Logf("Recovery completed successfully on multiorch '%s' - all problems resolved", orchName)
 }
 


### PR DESCRIPTION
Record elapsed time for WaitForNewPrimary (failover election visible to multipooler) and RequireRecovery (replication fix / rewind) in the TimingCollector summary table. Both functions already hold a *ShardSetup so they can write to setup.Timings / s.Timings directly — no call-site changes required.

Also rename .github/scripts/startup-timing-summary.py to timing-summary.py (the table now covers more than startup) and switch the confidence interval from 95% to 99.9% (t-crit values updated to the 99.95th percentile).