### PR TITLE
feat(cluster): pre-install pgvector in the cluster image

### DIFF
--- a/.github/workflows/docker-compose-ci.yml
+++ b/.github/workflows/docker-compose-ci.yml
@@ -93,6 +93,18 @@ jobs:
           SELECT label FROM compat_check WHERE id = 1;
           DROP TABLE compat_check;
           SQL
+          echo "== pgvector extension =="
+          # The vector(3) column type and the <-> distance operator only resolve
+          # if pgvector is installed in the image, so ON_ERROR_STOP=1 turns a
+          # missing extension into a hard failure of this step.
+          run_sql <<'SQL'
+          CREATE EXTENSION vector;
+          CREATE TABLE vec_check (id int primary key, embedding vector(3));
+          INSERT INTO vec_check (id, embedding) VALUES (1, '[1,2,3]'), (2, '[4,5,6]');
+          SELECT id FROM vec_check ORDER BY embedding <-> '[3,2,1]' LIMIT 1;
+          DROP TABLE vec_check;
+          DROP EXTENSION vector;
+          SQL
 
       - name: Dump cluster logs on failure
         if: failure()

--- a/Dockerfile.cluster
+++ b/Dockerfile.cluster
@@ -72,8 +72,10 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install pgBackRest from the PostgreSQL APT repository plus procps (pgrep is
-# used by the entrypoint to detect if the gateway dies).
+# Install pgBackRest and pgvector from the PostgreSQL APT repository plus procps
+# (pgrep is used by the entrypoint to detect if the gateway dies). pgvector is
+# preinstalled so compatibility suites can CREATE EXTENSION vector against the
+# bundled PostgreSQL; the PGDG package is built for these exact pg17 binaries.
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -86,6 +88,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     pgbackrest \
+    postgresql-17-pgvector \
     procps && \
     pgbackrest version && \
     apt-get remove -y gnupg lsb-release && \


### PR DESCRIPTION
## Summary

- Pre-install pgvector in the all-in-one `multigres-cluster` image so compatibility suites can `CREATE EXTENSION vector` against the bundled PostgreSQL without building it at runtime.
- Install it from the PostgreSQL APT repo (`postgresql-17-pgvector`) that the Dockerfile already wires up for pgBackRest — the PGDG package is built for these exact pg17 binaries, so no build toolchain is added to the image.
- Extend the existing docker-compose smoke test to verify pgvector is actually usable through multigateway, failing loudly if it's missing.

## Description

The cluster image is Debian-based (`postgres:17.7`), so unlike the Alpine source-build approach used elsewhere, pgvector is available as a prebuilt PGDG package. It's folded into the same apt install that already pulls in pgBackRest and procps, keeping it to a single layer with no extra build dependencies.

The smoke-test step in `docker-compose-ci.yml` now runs a small pgvector round-trip through the gateway. The `vector(3)` column type and the `<->` distance operator only resolve when the extension is installed, so with `ON_ERROR_STOP=1` already set, a missing pgvector turns into a hard failure of the step. Verified locally end-to-end: built the image, brought up the compose cluster, and ran the SQL through multigateway (`CREATE EXTENSION` / insert / nearest-neighbor / drop) — all green.