### PR TITLE
fix(multipooler): return honest 40001 instead of MTF01 for transactions aborted by failover

### DIFF
--- a/docs/query_serving/graceful_drain_design.md
+++ b/docs/query_serving/graceful_drain_design.md
@@ -119,11 +119,29 @@ logical lend tracked by `OnReserve`/`OnRelease`.
 admission gate called by every gRPC handler before acquiring an
 executor:
 
-| State                      | `allowOnShutdown=false`    | `allowOnShutdown=true`   |
-| -------------------------- | -------------------------- | ------------------------ |
-| SERVING, not shutting down | Allow                      | Allow                    |
-| SERVING, shutting down     | Reject (`ErrShuttingDown`) | Allow                    |
-| NOT_SERVING                | Reject (`ErrNotServing`)   | Reject (`ErrNotServing`) |
+| State                            | `allowOnShutdown=false` | `allowOnShutdown=true` |
+| -------------------------------- | ----------------------- | ---------------------- |
+| SERVING, not shutting down       | Allow                   | Allow                  |
+| SERVING, shutting down (drain)   | Reject (`MTF01`)        | Allow                  |
+| NOT_SERVING / demoted to REPLICA | Reject (`MTF01`)        | Allow                  |
+
+`allowOnShutdown=true` marks an in-flight operation on an **existing
+reserved connection**, so it is admitted regardless of serving status
+or demotion: the reserved connection itself is the real gate, not the
+pooler's serving state. Tablegroup/shard mismatches (`MTD01`) are still
+rejected. Once admitted, two outcomes are possible:
+
+- **Connection still alive** (the normal in-drain case): the operation
+  runs on the live backend. PostgreSQL is demoted only _after_ the
+  drain finishes, so a surviving reserved connection is still on the
+  primary and the transaction concludes cleanly.
+- **Connection already force-closed** (the drain exceeded its grace
+  period while the client sat idle-in-transaction): the executor
+  returns SQLSTATE `40001` (`serialization_failure`, _"transaction
+  aborted: connection terminated during a planned failover"_) so the
+  client retries the whole transaction. This is deliberately **not**
+  `MTF01` — the transaction no longer exists, so there is nothing for
+  the gateway to buffer or auto-retry; only the client can replay it.
 
 Each gRPC method sets `allowOnShutdown` based on whether it operates
 on an existing reserved connection:
@@ -137,6 +155,7 @@ on an existing reserved connection:
 | `CopyBidiExecute`           | `reservedConnId > 0` | Same                                     |
 | `ReserveStreamExecute`      | `false`              | Always a new reservation                 |
 | `ConcludeTransaction`       | `true`               | Always on existing reserved conn         |
+| `DiscardTempTables`         | `true`               | Always on existing reserved conn         |
 | `ReleaseReservedConnection` | `true`               | Always on existing reserved conn         |
 | `GetAuthCredentials`        | `false`              | Admin operation, not query path          |
 | `StreamPoolerHealth`        | No gate              | Health streaming is independent          |
@@ -162,6 +181,12 @@ reserved connections are forcibly killed via
 connections survive into a non-serving state where they could execute
 queries against a demoted replica. The force-close kills the backend
 PostgreSQL processes and returns the connections to the pool.
+
+A late operation (e.g. a `COMMIT`) that arrives after its reserved
+connection was force-closed is admitted by the gate (`allowOnShutdown`)
+but finds the connection gone, and the executor returns SQLSTATE
+`40001` so the client retries the whole transaction. See the Admission
+Control section above.
 
 When `OnStateChange` receives `SERVING`, the transition is immediate:
 set `servingStatus=SERVING` and `shuttingDown=false`.

--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -41,6 +41,7 @@ const (
 	PgSSQueryCanceled           = "57014" // query_canceled
 	PgSSInternalError           = "XX000" // internal_error
 	PgSSReadOnlyTransaction     = "25006" // read_only_sql_transaction
+	PgSSSerializationFailure    = "40001" // serialization_failure
 )
 
 // NewQueryCanceled creates a PgDiagnostic for an explicit cancel request
@@ -55,6 +56,21 @@ func NewQueryCanceled() *PgDiagnostic {
 func NewStatementTimeout() *PgDiagnostic {
 	return NewPgError("ERROR", PgSSQueryCanceled,
 		"canceling statement due to statement timeout", "")
+}
+
+// NewTransactionAborted creates a PgDiagnostic for a transaction whose reserved
+// connection was terminated before it could continue or be concluded — e.g.
+// force-closed when a planned failover drain exceeded its grace period while the
+// client sat idle-in-transaction. SQLSTATE 40001 (serialization_failure) so
+// clients and ORMs retry the whole transaction; the data was rolled back, so a
+// retry is the correct recovery.
+//
+// This is deliberately NOT MTF01: the transaction is gone, so there is nothing
+// to buffer or auto-retry inside the cluster — only the client can replay it.
+func NewTransactionAborted(reservedConnID uint64) *PgDiagnostic {
+	return NewPgError("ERROR", PgSSSerializationFailure,
+		"transaction aborted: connection terminated during a planned failover; please retry the transaction",
+		fmt.Sprintf("reserved connection %d was terminated", reservedConnID))
 }
 
 // NewAuthenticationTimeout creates a PgDiagnostic for an authentication_timeout

--- a/go/common/mterrors/code.go
+++ b/go/common/mterrors/code.go
@@ -58,18 +58,21 @@ func NewStatementTimeout() *PgDiagnostic {
 		"canceling statement due to statement timeout", "")
 }
 
-// NewTransactionAborted creates a PgDiagnostic for a transaction whose reserved
-// connection was terminated before it could continue or be concluded — e.g.
-// force-closed when a planned failover drain exceeded its grace period while the
-// client sat idle-in-transaction. SQLSTATE 40001 (serialization_failure) so
-// clients and ORMs retry the whole transaction; the data was rolled back, so a
-// retry is the correct recovery.
+// NewReservedConnectionTerminated creates a PgDiagnostic for a reserved
+// connection that was terminated before its in-flight work could continue or
+// be concluded — e.g. force-closed when a planned failover drain exceeded its
+// grace period while the client sat idle. The message is deliberately not
+// transaction-specific: a reserved connection may hold a transaction or only
+// non-transactional session state (temp tables, portals, COPY, LISTEN), and
+// the same termination applies to all of them. SQLSTATE 40001
+// (serialization_failure) so clients and ORMs retry their in-flight work; the
+// connection's state was rolled back, so a retry is the correct recovery.
 //
-// This is deliberately NOT MTF01: the transaction is gone, so there is nothing
+// This is deliberately NOT MTF01: the connection is gone, so there is nothing
 // to buffer or auto-retry inside the cluster — only the client can replay it.
-func NewTransactionAborted(reservedConnID uint64) *PgDiagnostic {
+func NewReservedConnectionTerminated(reservedConnID uint64) *PgDiagnostic {
 	return NewPgError("ERROR", PgSSSerializationFailure,
-		"transaction aborted: connection terminated during a planned failover; please retry the transaction",
+		"reserved connection terminated during a planned failover; please retry",
 		fmt.Sprintf("reserved connection %d was terminated", reservedConnID))
 }
 

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -169,7 +169,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
-			return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 
 		// Apply settings if they changed (e.g., SET inside a transaction).
@@ -280,7 +280,7 @@ func (e *Executor) StreamExecute(
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
-			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 
 		// Apply settings if they changed (e.g., SET inside a transaction).
@@ -650,7 +650,7 @@ func (e *Executor) portalExecuteWithReserved(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 	} else {
 		// Create a new reserved connection. Wire ensurePrepared as the
@@ -800,7 +800,7 @@ func (e *Executor) Describe(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 
 		if options.SessionSettings != nil {
@@ -950,7 +950,7 @@ func (e *Executor) CopyReady(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return 0, nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return 0, nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 
 		// Existing reserved conns are actively held (never idle in the
@@ -1062,7 +1062,7 @@ func (e *Executor) CopySendData(
 	// Get the reserved connection
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return mterrors.NewTransactionAborted(options.ReservedConnectionId)
+		return mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 	}
 
 	e.logger.DebugContext(ctx, "sending COPY data",
@@ -1103,7 +1103,7 @@ func (e *Executor) CopyFinalize(
 	// Get the reserved connection
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+		return nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 	}
 
 	e.logger.DebugContext(ctx, "finalizing COPY",
@@ -1308,7 +1308,7 @@ func (e *Executor) CopyOutReady(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return 0, nil, nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+			return 0, nil, nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 		}
 		e.stampVpidOnReserved(ctx, reservedConn, options)
 		format, columnFormats, notices, err = reservedConn.Conn().InitiateCopyToStdout(ctx, copyQuery)
@@ -1393,7 +1393,7 @@ func (e *Executor) CopyOutStream(
 	user := e.getUserFromOptions(options)
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+		return nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 	}
 
 	conn := reservedConn.Conn()
@@ -1559,7 +1559,7 @@ func (e *Executor) ConcludeTransaction(
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
-		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+		return nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 	}
 
 	// Execute COMMIT or ROLLBACK using the reserved connection's methods,
@@ -1646,7 +1646,7 @@ func (e *Executor) DiscardTempTables(
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
-		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
+		return nil, nil, mterrors.NewReservedConnectionTerminated(options.ReservedConnectionId)
 	}
 
 	// Send DISCARD TEMP to PostgreSQL to drop all temp tables on this backend.

--- a/go/services/multipooler/executor/executor.go
+++ b/go/services/multipooler/executor/executor.go
@@ -169,7 +169,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
-			return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 
 		// Apply settings if they changed (e.g., SET inside a transaction).
@@ -280,7 +280,7 @@ func (e *Executor) StreamExecute(
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
 			// Connection destroyed — return zero state so gateway clears its tracking
-			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 
 		// Apply settings if they changed (e.g., SET inside a transaction).
@@ -650,7 +650,7 @@ func (e *Executor) portalExecuteWithReserved(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 	} else {
 		// Create a new reserved connection. Wire ensurePrepared as the
@@ -800,7 +800,7 @@ func (e *Executor) Describe(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 
 		if options.SessionSettings != nil {
@@ -950,7 +950,7 @@ func (e *Executor) CopyReady(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return 0, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return 0, nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 
 		// Existing reserved conns are actively held (never idle in the
@@ -1062,7 +1062,7 @@ func (e *Executor) CopySendData(
 	// Get the reserved connection
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+		return mterrors.NewTransactionAborted(options.ReservedConnectionId)
 	}
 
 	e.logger.DebugContext(ctx, "sending COPY data",
@@ -1103,7 +1103,7 @@ func (e *Executor) CopyFinalize(
 	// Get the reserved connection
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 	}
 
 	e.logger.DebugContext(ctx, "finalizing COPY",
@@ -1308,7 +1308,7 @@ func (e *Executor) CopyOutReady(
 	if options != nil && options.ReservedConnectionId > 0 {
 		reservedConn, _ = e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 		if reservedConn == nil {
-			return 0, nil, nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+			return 0, nil, nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 		}
 		e.stampVpidOnReserved(ctx, reservedConn, options)
 		format, columnFormats, notices, err = reservedConn.Conn().InitiateCopyToStdout(ctx, copyQuery)
@@ -1393,7 +1393,7 @@ func (e *Executor) CopyOutStream(
 	user := e.getUserFromOptions(options)
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok || reservedConn == nil {
-		return nil, nil, fmt.Errorf("reserved connection %d not found for user %s", options.ReservedConnectionId, user)
+		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 	}
 
 	conn := reservedConn.Conn()
@@ -1559,7 +1559,7 @@ func (e *Executor) ConcludeTransaction(
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
-		return nil, nil, fmt.Errorf("reserved connection %d not found", options.ReservedConnectionId)
+		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 	}
 
 	// Execute COMMIT or ROLLBACK using the reserved connection's methods,
@@ -1646,7 +1646,7 @@ func (e *Executor) DiscardTempTables(
 	reservedConn, ok := e.poolManager.GetReservedConn(int64(options.ReservedConnectionId), user)
 	if !ok {
 		// Connection destroyed — return zero state so gateway clears its tracking
-		return nil, nil, fmt.Errorf("reserved connection %d not found", options.ReservedConnectionId)
+		return nil, nil, mterrors.NewTransactionAborted(options.ReservedConnectionId)
 	}
 
 	// Send DISCARD TEMP to PostgreSQL to drop all temp tables on this backend.

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -692,7 +692,7 @@ func TestCopyOutReady_ReservedConnectionNotFound(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
-	require.Contains(t, err.Error(), "transaction aborted")
+	require.Contains(t, err.Error(), "terminated during a planned failover")
 }
 
 // TestConcludeTransaction_ReservedConnTerminated covers the failover-leak fix:
@@ -716,7 +716,7 @@ func TestConcludeTransaction_ReservedConnTerminated(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
 	assert.False(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "must not surface MTF01: %v", err)
-	require.Contains(t, err.Error(), "transaction aborted")
+	require.Contains(t, err.Error(), "terminated during a planned failover")
 }
 
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
@@ -743,7 +743,7 @@ func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
-		require.Contains(t, err.Error(), "transaction aborted")
+		require.Contains(t, err.Error(), "terminated during a planned failover")
 	})
 }
 

--- a/go/services/multipooler/executor/executor_test.go
+++ b/go/services/multipooler/executor/executor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/fakepgserver"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -690,7 +691,32 @@ func TestCopyOutReady_ReservedConnectionNotFound(t *testing.T) {
 		nil,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "reserved connection 42 not found for user alice")
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+	require.Contains(t, err.Error(), "transaction aborted")
+}
+
+// TestConcludeTransaction_ReservedConnTerminated covers the failover-leak fix:
+// when a COMMIT/ROLLBACK arrives for a reserved connection that was already
+// force-closed (e.g. the planned-failover drain exceeded its grace period while
+// the client sat idle-in-transaction), the executor must return an honest 40001
+// (transaction aborted) rather than a bare error or the misleading MTF01 — so
+// the client retries the whole transaction.
+func TestConcludeTransaction_ReservedConnTerminated(t *testing.T) {
+	e := newTestExecutor()
+	e.poolManager = &stubPoolManager{reservedConnOK: false}
+
+	_, _, err := e.ConcludeTransaction(
+		context.Background(),
+		&query.Target{TableGroup: "tg"},
+		&query.ExecuteOptions{User: "alice", ReservedConnectionId: 42},
+		0, // TRANSACTION_CONCLUSION_UNSPECIFIED — unused on the not-found path
+		nil,
+		false,
+	)
+	require.Error(t, err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+	assert.False(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "must not surface MTF01: %v", err)
+	require.Contains(t, err.Error(), "transaction aborted")
 }
 
 func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
@@ -716,7 +742,8 @@ func TestCopyOutStream_ValidationAndNotFound(t *testing.T) {
 			func(client.CopyOutMessage) error { return nil },
 		)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "reserved connection 99 not found for user alice")
+		assert.True(t, mterrors.IsErrorCode(err, mterrors.PgSSSerializationFailure), "expected 40001, got: %v", err)
+		require.Contains(t, err.Error(), "transaction aborted")
 	})
 }
 

--- a/go/services/multipooler/poolerserver/controller.go
+++ b/go/services/multipooler/poolerserver/controller.go
@@ -52,10 +52,14 @@ type PoolerController interface {
 	OnStateChange(ctx context.Context, poolerType clustermetadatapb.PoolerType, servingStatus clustermetadatapb.PoolerServingStatus) error
 
 	// StartRequest checks whether a new request should be admitted.
-	// It validates that the target's pooler type matches this pooler's actual type
-	// (returning MTF01 on mismatch to trigger gateway buffering), and checks
-	// serving status. During graceful shutdown, allowOnShutdown=true permits
-	// requests on existing reserved connections so in-flight transactions can complete.
+	// For fresh requests (allowOnShutdown=false) it validates that the target's
+	// pooler type matches this pooler's actual type (returning MTF01 on mismatch
+	// to trigger gateway buffering) and checks serving status. allowOnShutdown=true
+	// marks an in-flight operation on an existing reserved connection: it is
+	// admitted regardless of serving status or demotion (the reserved connection
+	// is the real gate), so in-flight transactions can complete on the live backend
+	// — or surface an honest 40001 from the executor if the connection was already
+	// force-closed during the drain.
 	StartRequest(target *query.Target, allowOnShutdown bool) error
 
 	// AwaitStateChange blocks until the pooler's type and serving status match

--- a/go/services/multipooler/poolerserver/pooler.go
+++ b/go/services/multipooler/poolerserver/pooler.go
@@ -183,25 +183,45 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 // Returns nil if the request is allowed, or an error if it should be rejected.
 //
 // It validates the target against this pooler's identity (tablegroup, shard, type)
-// via checkTarget, then checks serving status. A target mismatch returns MTF01,
-// which causes the gateway to buffer the request until the correct pooler is available.
+// via checkTargetLocked, then checks serving status. A PRIMARY-to-REPLICA target
+// mismatch or a non-serving status returns MTF01, which causes the gateway to
+// buffer the request until the correct pooler is available.
 //
-// During graceful shutdown (shuttingDown=true), requests on existing reserved
-// connections (allowOnShutdown=true) are still admitted so that in-flight
-// transactions can complete. New reservations and fresh queries are rejected.
+// allowOnShutdown=true marks an in-flight operation on an existing reserved
+// connection (COMMIT/ROLLBACK, temp-table cleanup, a mid-transaction statement).
+// These are admitted regardless of serving status or demotion — the reserved
+// connection is the real gate. During the graceful drain the connection is still
+// alive and the operation completes; if the drain exceeded its grace period and
+// force-closed the connection, the executor returns an honest 40001
+// (transaction aborted) so the client retries the whole transaction. New
+// reservations and fresh queries (allowOnShutdown=false) are rejected with MTF01
+// once the pooler stops serving.
 func (s *QueryPoolerServer) StartRequest(target *query.Target, allowOnShutdown bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.checkTargetLocked(target); err != nil {
+	if err := s.checkTargetLocked(target, allowOnShutdown); err != nil {
 		return err
+	}
+
+	// In-flight operations on an existing reserved connection (allowOnShutdown)
+	// are admitted regardless of serving status or demotion. The reserved
+	// connection itself is the real gate: if it still exists the operation
+	// completes on the live backend (postgres is demoted only after the drain
+	// finishes); if it was force-closed because the drain exceeded its grace
+	// period, the executor returns an honest "transaction aborted" error (40001)
+	// so the client retries the whole transaction — rather than the misleading
+	// MTF01 "failover in progress, will be retried automatically" signal, which
+	// is neither buffered nor retryable for a transaction that no longer exists.
+	if allowOnShutdown {
+		return nil
 	}
 
 	if s.servingStatus != clustermetadatapb.PoolerServingStatus_SERVING && !s.shuttingDown {
 		return mterrors.MTF01.New()
 	}
 
-	if s.shuttingDown && !allowOnShutdown {
+	if s.shuttingDown {
 		return mterrors.MTF01.New()
 	}
 
@@ -217,8 +237,16 @@ func (s *QueryPoolerServer) StartRequest(target *query.Target, allowOnShutdown b
 //     buffering until the new primary is discovered. All other type combinations
 //     are allowed (PRIMARY serves both PRIMARY and REPLICA traffic).
 //
+// allowOnShutdown signals an in-flight operation on an existing reserved
+// connection. Such operations bypass the demotion (PRIMARY→REPLICA) check: the
+// reserved connection's existence is the real gate (see StartRequest), so a
+// demoted pooler whose reserved connection survived the drain can still conclude
+// its transaction, and one whose connection was force-closed surfaces an honest
+// 40001 from the executor rather than MTF01. Tablegroup/shard mismatches (real
+// routing bugs) are still rejected.
+//
 // Caller must hold s.mu.
-func (s *QueryPoolerServer) checkTargetLocked(target *query.Target) error {
+func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, allowOnShutdown bool) error {
 	if target == nil {
 		return nil
 	}
@@ -229,6 +257,10 @@ func (s *QueryPoolerServer) checkTargetLocked(target *query.Target) error {
 
 	if s.shard != "" && target.Shard != "" && target.Shard != s.shard {
 		return mterrors.MTD01.New("target shard %q does not match pooler shard %q", target.Shard, s.shard)
+	}
+
+	if allowOnShutdown {
+		return nil
 	}
 
 	// A PRIMARY request hitting a REPLICA means the gateway thinks this pooler is

--- a/go/services/multipooler/poolerserver/pooler_test.go
+++ b/go/services/multipooler/poolerserver/pooler_test.go
@@ -104,14 +104,37 @@ func TestStartRequest_NotServing(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
 
-	// Both should fail when not serving with MTF01 (triggers gateway buffering)
+	// Fresh requests (allowOnShutdown=false) fail with MTF01 (triggers gateway buffering).
 	err := s.StartRequest(nil, false)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
 
+	// In-flight ops on an existing reserved connection (allowOnShutdown=true) are
+	// admitted regardless of serving status — the reserved connection is the real
+	// gate. If it was force-closed, the executor (not StartRequest) surfaces an
+	// honest 40001 instead of the misleading MTF01.
 	err = s.StartRequest(nil, true)
+	require.NoError(t, err)
+}
+
+func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
+	s.poolerType = clustermetadatapb.PoolerType_REPLICA
+
+	// A PRIMARY-targeted op on a demoted (REPLICA) pooler is rejected with MTF01
+	// when it's a fresh request...
+	target := &query.Target{PoolerType: clustermetadatapb.PoolerType_PRIMARY}
+	err := s.StartRequest(target, false)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
+
+	// ...but admitted when it's an in-flight op on an existing reserved connection
+	// (e.g. a COMMIT after a planned demotion). This lets the executor conclude the
+	// transaction on the live backend, or return an honest 40001 if the connection
+	// was force-closed during the drain.
+	err = s.StartRequest(target, true)
+	require.NoError(t, err)
 }
 
 func TestStartRequest_ShuttingDown_NewRequestRejected(t *testing.T) {

--- a/go/test/endtoend/queryserving/transaction_failover_test.go
+++ b/go/test/endtoend/queryserving/transaction_failover_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestTransactionAbortedOnFailoverGraceExpiry is a regression test for an MTF01
+// leak. When a client holds a transaction open (idle-in-transaction) across a
+// planned failover for longer than the pooler's connection-drain grace period,
+// the old primary force-closes the reserved connection (rolling the transaction
+// back) and then demotes to REPLICA. A subsequent statement on that transaction
+// used to surface MTF01 ("planned failover in progress, will be retried
+// automatically") — which is wrong on two counts: the transaction no longer
+// exists, and nothing retries it.
+//
+// After the fix the pooler admits the in-flight reserved-connection operation
+// (the connection's existence is the real gate) and the executor returns an
+// honest 40001 (serialization_failure) so the client retries the whole
+// transaction.
+//
+// Before the fix this test FAILS: the post-failover statement returns SQLSTATE
+// "MTF01" instead of "40001".
+func TestTransactionAbortedOnFailoverGraceExpiry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping transaction-failover test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping transaction-failover test")
+	}
+
+	// A short drain grace period guarantees the idle-in-transaction reserved
+	// connection is force-closed quickly once failover demotes its pooler. It must
+	// be > 0 — a 0 grace period means an unbounded drain that would wait for our
+	// COMMIT and never reproduce the bug.
+	setup, cleanup := newFailoverTxnTestCluster(t, "--connpool-drain-grace-period=1s")
+	defer cleanup()
+
+	// Create the test table up front via a throwaway connection.
+	gatewayDB := openGatewayDB(t, setup)
+	_, err := gatewayDB.Exec("CREATE TABLE IF NOT EXISTS txn_failover_test (id INT PRIMARY KEY, val TEXT)")
+	require.NoError(t, err)
+	gatewayDB.Close()
+
+	// Dedicated single connection so the whole transaction stays pinned to one
+	// reserved backend on the current primary.
+	ctx := context.Background()
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(context.Background())
+
+	// Open a transaction and run a statement. This reserves a backend on the
+	// primary and leaves it idle-in-transaction.
+	_, err = conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "INSERT INTO txn_failover_test (id, val) VALUES (1, 'before-failover')")
+	require.NoError(t, err)
+
+	t.Logf("transaction open and idle on primary %s; triggering failover", setup.PrimaryName)
+
+	// Fail over away from the current primary. The old primary drains for its (1s)
+	// grace period; because our connection sits idle-in-transaction it keeps the
+	// drain blocked until the grace period expires, then the connection is
+	// force-closed and the transaction rolled back. triggerFailover's recovery
+	// wait is far longer than the grace period, so by the time it returns the
+	// reserved connection is gone and the old pooler is a demoted REPLICA.
+	triggerFailover(t, setup)
+
+	// Belt-and-suspenders: ensure the grace period has elapsed (it already has,
+	// given the recovery wait above) before probing the dead transaction.
+	time.Sleep(2 * time.Second)
+
+	// The next statement on the now-dead transaction must surface an honest,
+	// retryable error — 40001, not MTF01.
+	_, err = conn.Exec(ctx, "INSERT INTO txn_failover_test (id, val) VALUES (2, 'after-failover')")
+	require.Error(t, err, "a statement on a transaction killed by failover must return an error")
+
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected pgconn.PgError, got %T: %v", err, err)
+	t.Logf("post-failover error: SQLSTATE=%s severity=%s message=%q", pgErr.Code, pgErr.Severity, pgErr.Message)
+
+	assert.NotEqual(t, mterrors.MTF01.ID, pgErr.Code,
+		"MTF01 must not leak to the client for a transaction aborted by failover (regression)")
+	assert.Equal(t, mterrors.PgSSSerializationFailure, pgErr.Code,
+		"transaction aborted by failover should surface 40001 serialization_failure so the client retries")
+}
+
+// newFailoverTxnTestCluster creates a 3-node cluster with buffering enabled on
+// the gateway and custom flags applied to every multipooler (e.g. a short
+// connpool-drain-grace-period). Buffering is enabled to demonstrate that it does
+// NOT hide this error — reserved-connection operations bypass the gateway buffer.
+func newFailoverTxnTestCluster(t *testing.T, poolerArgs ...string) (*shardsetup.ShardSetup, func()) {
+	t.Helper()
+	bufferArgs := []string{
+		"--buffer-enabled",
+		"--buffer-window", "10s",
+		"--buffer-size", "1000",
+		"--buffer-max-failover-duration", "20s",
+		"--buffer-min-time-between-failovers", "0s",
+		"--buffer-drain-concurrency", "5",
+	}
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(3),
+		shardsetup.WithMultiOrchCount(3),
+		shardsetup.WithMultigateway(),
+		func(c *shardsetup.SetupConfig) {
+			c.MultigatewayExtraArgs = append(c.MultigatewayExtraArgs, bufferArgs...)
+		},
+		shardsetup.WithMultipoolerExtraArgs(poolerArgs...),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+		shardsetup.WithLeaderFailoverGracePeriod("0s", "0s"),
+	)
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	require.NotNil(t, setup.GetPrimary(t), "primary should exist after bootstrap")
+	t.Logf("Initial primary: %s", setup.PrimaryName)
+
+	return setup, cleanup
+}


### PR DESCRIPTION
## Summary

- A client holding a transaction open across a planned failover for longer than the connection-drain grace period (`--connpool-drain-grace-period`, default 3s) would get `MTF01` ("planned failover in progress, will be retried automatically") leaked to the client. The error is misleading: the transaction was already rolled back, nothing buffers or retries it, and to the app the query had "seemed to succeed."
- The fix makes the pooler return an honest, retryable `40001` (`serialization_failure`) instead, so clients/ORMs retry the whole transaction.

## Problem

`MTF01` is a pre-execution admission gate (`StartRequest`). For an in-flight op on an existing reserved connection (a COMMIT/ROLLBACK or a mid-transaction statement), the gateway routes it back to the specific pooler that holds the connection. If a planned failover demoted that pooler and the drain grace period expired while the client sat idle-in-transaction, the reserved connection was force-closed (transaction rolled back) and the pooler demoted to REPLICA. The late op then hit `StartRequest`'s serving-status / demotion checks and returned `MTF01` — un-buffered, straight to the client. `MTF01`'s contract ("will be retried automatically") is wrong here: the transaction no longer exists, so only the client can replay it.

This only affects transactions / multi-statement batches. Plain autocommit statements are buffered and unaffected.

## Solution

`StartRequest`'s `allowOnShutdown` flag is already set exactly for in-flight ops on an existing reserved connection (`ConcludeTransaction`, `DiscardTempTables`, `ReleaseReservedConnection`, and mid-transaction statements). It now also bypasses the serving-status and demotion checks — not just the `shuttingDown` check — so the reserved connection's existence becomes the real gate:

- Connection survived the drain → the op completes on the live backend (postgres is demoted only after the drain finishes).
- Connection was force-closed → the executor returns the new `40001` (`serialization_failure`) so the client retries.

Adds `mterrors.NewTransactionAborted` and updates the graceful-drain design doc + `StartRequest` comments.

Tests: unit coverage for the gate (`pooler_test.go`) and the executor's connection-gone path (`executor_test.go`), plus an e2e regression test (`transaction_failover_test.go`) that holds a transaction across a real failover. Verified it fails before this change (leaks `MTF01`) and passes after (returns `40001`).