### PR TITLE
test(pgregresstest): support pgrx extensions and enroll pg_graphql

### DIFF
--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -63,6 +63,15 @@ jobs:
           # Both are enabled only when the contrib extension suite runs.
           sudo apt-get install -y build-essential bison flex libreadline-dev zlib1g-dev uuid-dev libssl-dev
 
+      # Rust toolchain for the external extension suite's pgrx-based extensions
+      # (pg_graphql is a Rust crate built with cargo-pgrx). The harness installs
+      # the pinned cargo-pgrx version itself (see ensureCargoPgrx); this step only
+      # needs to put a recent stable cargo/rustc on PATH.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
       - name: Build
         run: make build
 

--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -63,15 +63,6 @@ jobs:
           # Both are enabled only when the contrib extension suite runs.
           sudo apt-get install -y build-essential bison flex libreadline-dev zlib1g-dev uuid-dev libssl-dev
 
-      # Rust toolchain for the external extension suite's pgrx-based extensions
-      # (pg_graphql is a Rust crate built with cargo-pgrx). The harness installs
-      # the pinned cargo-pgrx version itself (see ensureCargoPgrx); this step only
-      # needs to put a recent stable cargo/rustc on PATH.
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-
       - name: Build
         run: make build
 

--- a/go/test/endtoend/pgbuilder/builder.go
+++ b/go/test/endtoend/pgbuilder/builder.go
@@ -23,6 +23,7 @@ package pgbuilder
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -238,53 +239,118 @@ func (b *Builder) InstallContrib(t *testing.T, ctx context.Context) error {
 	return nil
 }
 
+// InstallContribModules builds and installs specific contrib modules by
+// directory name (e.g. "citext"), rather than all of contrib. The external
+// suite uses it to satisfy an extension's contrib dependencies — pg_graphql's
+// tests CREATE EXTENSION citext — so an external-only run works without building
+// all of contrib. Idempotent: re-running `make install` for a module is a no-op,
+// so it is safe even when a full InstallContrib already ran.
+func (b *Builder) InstallContribModules(t *testing.T, ctx context.Context, names []string) error {
+	t.Helper()
+
+	for _, name := range names {
+		dir := filepath.Join(b.BuildDir, "contrib", name)
+		t.Logf("Building and installing contrib module %s from %s...", name, dir)
+		cmd := executil.Command(ctx, "make", "-C", dir, "-j", "4", "install")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("make -C contrib/%s install failed: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// ExtensionBuildSpec describes how to clone and build one external extension.
+// It is pgbuilder's view of pgregresstest's ExternalExtension, defined here
+// (rather than imported) because pgbuilder must not depend on pgregresstest.
+type ExtensionBuildSpec struct {
+	Name string
+	Repo string
+	Tag  string
+	// BuildSubdir is the directory within the checkout holding the build entry
+	// point (the PGXS Makefile, or the pgrx crate root), relative to the clone
+	// root. Empty means the repo root (pgvector, pg_cron); set when it lives in a
+	// subdirectory (pgmq: "pgmq-extension").
+	BuildSubdir string
+	// BuildSystem selects the toolchain: "" or "pgxs" builds with make against
+	// PGXS; "pgrx" builds a Rust/pgrx crate with cargo-pgrx.
+	BuildSystem string
+	// PgrxVersion pins the cargo-pgrx CLI version for BuildSystem=="pgrx"; it must
+	// match the crate's pinned pgrx dependency. Ignored for pgxs.
+	PgrxVersion string
+}
+
+// PgMajorVersion returns the PostgreSQL major version as a string ("17"),
+// derived from PostgresVersion (e.g. "REL_17_6"). pgrx uses it to form the
+// per-version feature/init flag ("pg17").
+func PgMajorVersion() string {
+	v := strings.TrimPrefix(PostgresVersion, "REL_")
+	major, _, _ := strings.Cut(v, "_")
+	return major
+}
+
 // InstallExternalExtension clones an external extension's repo at a pinned tag
-// into b.ExternalDir/<name>, builds it as a PGXS module against this builder's
-// from-source PostgreSQL, and installs it into b.InstallDir. It returns the
-// checkout directory so the caller can drive the extension's shipped pg_regress
-// suite (sql/ + expected/) from there. Must be called after Build().
+// into b.ExternalDir/<name>, builds it against this builder's from-source
+// PostgreSQL, and installs it into b.InstallDir. It returns the checkout
+// directory so the caller can drive the extension's shipped pg_regress suite
+// (sql/ + expected/) from there. Must be called after Build().
 //
-// The build is pointed at the per-run install tree via PG_CONFIG so the
-// extension's .so links against the exact PostgreSQL the cluster runs (the same
-// ABI-consistency guarantee Build provides for regress.so). The checkout is
-// per-run, so a shallow clone happens once per invocation; pinning the tag keeps
-// the suite reproducible.
-//
-// buildSubdir is the directory within the checkout that holds the PGXS Makefile,
-// relative to the clone root. It is empty for extensions whose Makefile sits at
-// the repo root (pgvector, pg_cron) and set when it lives in a subdirectory
-// (pgmq: "pgmq-extension"). The returned path is always the clone root, so the
-// caller resolves the extension's TestSubdir against it independently.
-func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, name, repo, tag, buildSubdir string) (string, error) {
+// The build is pointed at the per-run install tree (via PG_CONFIG for PGXS, or
+// --pg-config for pgrx) so the extension's .so links against the exact
+// PostgreSQL the cluster runs — the same ABI-consistency guarantee Build
+// provides for regress.so. The checkout is per-run, so a shallow clone happens
+// once per invocation; pinning the tag keeps the suite reproducible.
+func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, spec ExtensionBuildSpec) (string, error) {
 	t.Helper()
 
 	if err := os.MkdirAll(b.ExternalDir, 0o755); err != nil {
 		return "", fmt.Errorf("failed to create external dir: %w", err)
 	}
-	cloneDir := filepath.Join(b.ExternalDir, name)
+	cloneDir := filepath.Join(b.ExternalDir, spec.Name)
 
-	t.Logf("Cloning external extension %s (%s) from %s...", name, tag, repo)
+	t.Logf("Cloning external extension %s (%s) from %s...", spec.Name, spec.Tag, spec.Repo)
 	clone := executil.Command(ctx, "git", "clone",
 		"--depth=1",
-		"--branch", tag,
-		repo,
+		"--branch", spec.Tag,
+		spec.Repo,
 		cloneDir)
 	var stderr bytes.Buffer
 	clone.Stderr = &stderr
 	if err := clone.Run(); err != nil {
-		return "", fmt.Errorf("failed to clone %s: %w (stderr: %s)", name, err, stderr.String())
+		return "", fmt.Errorf("failed to clone %s: %w (stderr: %s)", spec.Name, err, stderr.String())
 	}
 
 	pgConfig := filepath.Join(b.BinDir(), "pg_config")
-	// The PGXS Makefile may live in a subdirectory of the checkout (pgmq).
-	buildDir := filepath.Join(cloneDir, buildSubdir)
+	// The build entry point may live in a subdirectory of the checkout (pgmq).
+	buildDir := filepath.Join(cloneDir, spec.BuildSubdir)
 
+	switch spec.BuildSystem {
+	case "", "pgxs":
+		if err := b.installPGXSExtension(t, ctx, spec.Name, buildDir, pgConfig); err != nil {
+			return "", err
+		}
+	case "pgrx":
+		if err := b.installPgrxExtension(t, ctx, spec, buildDir, pgConfig); err != nil {
+			return "", err
+		}
+	default:
+		return "", fmt.Errorf("external extension %s: unknown build system %q", spec.Name, spec.BuildSystem)
+	}
+
+	t.Logf("External extension %s installed", spec.Name)
+	return cloneDir, nil
+}
+
+// installPGXSExtension builds and installs a standard PGXS (make) extension into
+// the install tree pgConfig points at.
+func (b *Builder) installPGXSExtension(t *testing.T, ctx context.Context, name, buildDir, pgConfig string) error {
 	t.Logf("Building external extension %s with PGXS (PG_CONFIG=%s)...", name, pgConfig)
 	makeCmd := executil.Command(ctx, "make", "-C", buildDir, "-j", "4", "PG_CONFIG="+pgConfig)
 	makeCmd.Stdout = os.Stdout
 	makeCmd.Stderr = os.Stderr
 	if err := makeCmd.Run(); err != nil {
-		return "", fmt.Errorf("make %s failed: %w", name, err)
+		return fmt.Errorf("make %s failed: %w", name, err)
 	}
 
 	t.Logf("Installing external extension %s into %s...", name, b.InstallDir)
@@ -292,11 +358,73 @@ func (b *Builder) InstallExternalExtension(t *testing.T, ctx context.Context, na
 	installCmd.Stdout = os.Stdout
 	installCmd.Stderr = os.Stderr
 	if err := installCmd.Run(); err != nil {
-		return "", fmt.Errorf("make %s install failed: %w", name, err)
+		return fmt.Errorf("make %s install failed: %w", name, err)
+	}
+	return nil
+}
+
+// installPgrxExtension builds and installs a Rust/pgrx extension with cargo-pgrx
+// against this builder's from-source PostgreSQL. Unlike PGXS there is no make:
+// cargo-pgrx compiles the crate and copies the .so/.control/.sql into the tree
+// pgConfig points at (it also substitutes control-file placeholders like
+// @CARGO_VERSION@, so the files must be produced by cargo-pgrx, not copied).
+func (b *Builder) installPgrxExtension(t *testing.T, ctx context.Context, spec ExtensionBuildSpec, buildDir, pgConfig string) error {
+	// pgrx selects the target server with a per-major-version feature/flag.
+	feature := "pg" + PgMajorVersion()
+
+	if err := b.ensureCargoPgrx(t, ctx, spec.PgrxVersion); err != nil {
+		return err
 	}
 
-	t.Logf("External extension %s installed", name)
-	return cloneDir, nil
+	// Register our from-source PostgreSQL with pgrx. Passing the pg_config path
+	// (rather than "download") makes init adopt the existing install instead of
+	// fetching and building its own, so it is fast and uses the exact server ABI.
+	t.Logf("Registering PostgreSQL with pgrx (cargo pgrx init --%s %s)...", feature, pgConfig)
+	initCmd := executil.Command(ctx, "cargo", "pgrx", "init", "--"+feature, pgConfig)
+	initCmd.Stdout = os.Stdout
+	initCmd.Stderr = os.Stderr
+	if err := initCmd.Run(); err != nil {
+		return fmt.Errorf("cargo pgrx init %s failed: %w", spec.Name, err)
+	}
+
+	// Build and install. --no-default-features --features <pgNN> overrides the
+	// crate's default (often the latest major) so it builds against our server;
+	// --pg-config installs into that server's pkglibdir/sharedir.
+	t.Logf("Building external extension %s with cargo-pgrx (--features %s, --pg-config %s)...", spec.Name, feature, pgConfig)
+	installCmd := executil.Command(ctx, "cargo", "pgrx", "install",
+		"--release",
+		"--no-default-features",
+		"--features", feature,
+		"--pg-config", pgConfig).SetDir(buildDir)
+	installCmd.Stdout = os.Stdout
+	installCmd.Stderr = os.Stderr
+	if err := installCmd.Run(); err != nil {
+		return fmt.Errorf("cargo pgrx install %s failed: %w", spec.Name, err)
+	}
+	return nil
+}
+
+// ensureCargoPgrx installs the cargo-pgrx CLI at the pinned version unless it is
+// already present, so the build matches the crate's pgrx dependency exactly.
+// Installing it compiles the CLI (minutes), so the already-installed fast path
+// matters for repeated local runs.
+func (b *Builder) ensureCargoPgrx(t *testing.T, ctx context.Context, version string) error {
+	if version == "" {
+		return errors.New("pgrx build requires a pinned PgrxVersion")
+	}
+	if out, err := executil.Command(ctx, "cargo", "pgrx", "--version").CombinedOutput(); err == nil &&
+		strings.Contains(string(out), "cargo-pgrx "+version) {
+		t.Logf("cargo-pgrx %s already installed", version)
+		return nil
+	}
+	t.Logf("Installing cargo-pgrx %s (compiles the CLI, may take several minutes)...", version)
+	cmd := executil.Command(ctx, "cargo", "install", "cargo-pgrx", "--version", version, "--locked")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cargo install cargo-pgrx %s failed: %w", version, err)
+	}
+	return nil
 }
 
 // Cleanup removes per-invocation build and install artifacts but leaves the

--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -144,20 +144,27 @@ as catalog entries move to `covered` and their suites run.
 The external suite runs the pg_regress suites of extensions that live **outside**
 the PostgreSQL source tree (separate repositories), executed through
 multigateway. The covered set lives in `externalSpecs` (`extensions.go`), each
-pinned to a tag: `vector` (pgvector), `pg_cron` (Citus pg_cron), and `pgmq`
-(tembo-io message queue). `externalSpecs` also holds build-only dependencies that
-are installed but not tested on their own — `pg_partman`, which pgmq's
-partitioned-queue tests require (see `DependsOn` below).
+pinned to a tag: `vector` (pgvector), `pg_cron` (Citus pg_cron), `pgmq` (tembo-io
+message queue), and `pg_graphql` (Supabase GraphQL). `externalSpecs` also holds
+build-only dependencies that are installed but not tested on their own —
+`pg_partman`, which pgmq's partitioned-queue tests require (see `DependsOn`
+below).
 
 How it works, and how it differs from the contrib suite:
 
-- **Build**: each external extension is a [PGXS](https://www.postgresql.org/docs/current/extend-pgxs.html)
-  module. `Builder.InstallExternalExtension` shallow-clones the pinned tag into
+- **Build**: most external extensions are [PGXS](https://www.postgresql.org/docs/current/extend-pgxs.html)
+  modules. `Builder.InstallExternalExtension` shallow-clones the pinned tag into
   the per-run build root, then runs `make && make install` with
   `PG_CONFIG` pointed at the from-source PostgreSQL so the extension `.so` links
   against the exact server ABI the cluster runs (the same guarantee the suite
-  gives `regress.so`). Both pgvector and pg_cron need only a C compiler — no
-  extra system libs.
+  gives `regress.so`). pgvector, pg_cron, and pgmq need only a C compiler — no
+  extra system libs. Rust extensions (`BuildSystem: "pgrx"`, e.g. pg_graphql) are
+  built with [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) instead:
+  the harness installs the pinned `cargo-pgrx` (it must match the crate's `pgrx`
+  dependency), then `cargo pgrx init --pgNN <pg_config>` adopts the from-source
+  server and `cargo pgrx install --pg-config <pg_config>` builds and installs the
+  extension into it. CI provisions the Rust toolchain; the from-source server
+  guarantees the same ABI as the PGXS path.
 - **Test execution**: unlike contrib we cannot use `make installcheck`. Under
   PGXS that target invokes `$(top_builddir)/src/test/regress/pg_regress`, and
   PGXS resolves `top_builddir` into the **install** tree, where `pg_regress` is
@@ -178,9 +185,25 @@ How it works, and how it differs from the contrib suite:
 Extensions diverge from the pgvector baseline in a few ways, captured as fields
 on `ExternalExtension` (`extensions.go`):
 
-- **`BuildSubdir`** — where the PGXS `Makefile` lives in the checkout. pgvector
-  and pg_cron keep it at the repo root (`""`); pgmq keeps the extension under
-  `pgmq-extension/`, so it builds there.
+- **`BuildSystem`** — the build toolchain: `""`/`"pgxs"` (make) or `"pgrx"`
+  (cargo-pgrx, Rust). pg_graphql is `pgrx`; everything else is PGXS.
+- **`PgrxVersion`** — for `pgrx` extensions, the pinned `cargo-pgrx` CLI version.
+  It must equal the crate's `pgrx` dependency (pg_graphql 1.6.1 → `0.16.1`) or the
+  build is refused. Ignored for PGXS.
+- **`BuildSubdir`** — where the build entry point (PGXS `Makefile` or pgrx crate)
+  lives in the checkout. pgvector and pg_cron keep it at the repo root (`""`);
+  pgmq keeps the extension under `pgmq-extension/`, so it builds there.
+- **`FixturesFile`** — a SQL file (relative to `TestSubdir`) the harness loads
+  through multigateway with `psql` before the suite, mirroring the extension's own
+  runner. pg_graphql's `bin/installcheck` runs `psql -f test/fixtures.sql` first
+  (it `CREATE`s the extension and sets the `graphql` schema comment), so the
+  harness does too. Empty for extensions whose `.sql` files are self-contained.
+- **`ContribDeps`** — contrib modules (by directory name) the harness installs
+  with `InstallContribModules` before the suite, because the suite `CREATE`s them.
+  pg_graphql's tests `create extension citext`, so it sets
+  `ContribDeps: {"citext"}`; without it an external-only run fails those tests
+  with "extension citext is not available". A full run has already installed all
+  of contrib, so the targeted install is a no-op.
 - **`TestSubdir`** — where the shipped `sql/` + `expected/` fixtures live in the
   checkout. pgvector keeps them under `test/`; pg_cron keeps them at the repo
   root (`.`); pgmq keeps them under `pgmq-extension/test`.
@@ -225,8 +248,9 @@ on `ExternalExtension` (`extensions.go`):
 Enrolling another external extension is a small catalog edit: add its
 `externalSpecs` entry (repo, pinned tag, and the knobs above) and flip its
 `ExtensionCatalog` row to `StatusCovered`. The catalog and report update
-automatically. Extensions that need toolchains the harness doesn't provision
-(Rust: `pg_graphql`, `wrappers`) or that the pooler blocks by design (outbound
+automatically. PGXS and Rust/pgrx extensions are both supported (CI provisions
+the Rust toolchain); extensions that need other toolchains the harness doesn't
+provision (e.g. `wrappers`) or that the pooler blocks by design (outbound
 connections) stay `StatusExternal` / `StatusUnsupported`.
 
 Regenerate the patches after an output change with:

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -88,7 +88,7 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"ltree", KindContrib, StatusCovered, ""},
 	{"moddatetime", KindContrib, StatusUnsupported, "contrib/spi ships no pg_regress suite"},
 	{"pg_cron", KindExternal, StatusCovered, "Citus pg_cron; built as a PGXS module from externalSpecs; needs shared_preload_libraries (see testdata/pg17/external/pg_cron.conf)"},
-	{"pg_graphql", KindExternal, StatusExternal, "Rust"},
+	{"pg_graphql", KindExternal, StatusCovered, "Supabase pg_graphql; Rust/pgrx crate built with cargo-pgrx; loads test/fixtures.sql before its pg_regress suite"},
 	{"pg_jsonschema", KindExternal, StatusExternal, "Rust"},
 	{"pg_net", KindExternal, StatusExternal, "background worker"},
 	{"pg_partman", KindExternal, StatusUnsupported, "ships a pgTAP suite, not pg_regress; built and installed as a build dependency of pgmq (create_partitioned → create_parent)"},
@@ -180,6 +180,34 @@ type ExternalExtension struct {
 	// DependsOn pg_partman. ExternalBuildList orders dependencies before the
 	// extensions that need them. Empty for self-contained extensions (pgvector).
 	DependsOn []string
+
+	// BuildSystem selects the build toolchain: "" (or "pgxs") builds a PGXS
+	// module with make; "pgrx" builds a Rust crate with cargo-pgrx. pgvector,
+	// pg_cron, and pgmq are PGXS; pg_graphql is pgrx.
+	BuildSystem string
+
+	// PgrxVersion pins the cargo-pgrx CLI version for BuildSystem=="pgrx". It must
+	// equal the crate's pinned pgrx dependency (pg_graphql 1.6.1 → pgrx 0.16.1),
+	// or cargo-pgrx refuses to build. Empty (and ignored) for PGXS extensions.
+	PgrxVersion string
+
+	// ContribDeps names contrib modules (by directory name) the harness must
+	// install before this extension's suite runs, because the suite CREATEs them.
+	// Unlike DependsOn (external repos), these ship in the PostgreSQL source tree
+	// and are installed with InstallContribModules. pg_graphql's tests
+	// `create extension citext`, so it sets ContribDeps: {"citext"}; without this
+	// an external-only run (no contrib suite) fails those tests with "extension
+	// citext is not available". Harmless in a full run where all contrib is
+	// already installed.
+	ContribDeps []string
+
+	// FixturesFile, when non-empty, names a SQL file (relative to TestSubdir) the
+	// harness loads through multigateway with psql before pg_regress runs, the way
+	// the extension's own runner does. pg_graphql's bin/installcheck loads
+	// test/fixtures.sql (it CREATEs the extension and sets the graphql schema
+	// comment) before the suite, so the fixtures must run first here too. Empty
+	// for extensions whose .sql files are self-contained (pgmq, pgvector).
+	FixturesFile string
 }
 
 // externalSpecs holds the build coordinates (git repo + pinned tag) and the
@@ -191,6 +219,25 @@ var externalSpecs = map[string]ExternalExtension{
 	"vector": {
 		Name: "vector", Repo: "https://github.com/pgvector/pgvector", Tag: "v0.8.1",
 		TestSubdir: "test", CreateExtension: true,
+	},
+	"pg_graphql": {
+		Name: "pg_graphql", Repo: "https://github.com/supabase/pg_graphql", Tag: "v1.6.1",
+		// Rust crate built with cargo-pgrx; the pgrx version must match the crate's
+		// pinned dependency (Cargo.toml: pgrx = "=0.16.1"). Build entry point and
+		// fixtures are at the repo root / test/.
+		BuildSystem: "pgrx", PgrxVersion: "0.16.1", TestSubdir: "test",
+		// test/fixtures.sql opens with `drop extension if exists pg_graphql;
+		// create extension pg_graphql cascade;` and sets the graphql schema
+		// comment, so the harness loads it first and must not also preload the
+		// extension itself.
+		CreateExtension: false, FixturesFile: "fixtures.sql",
+		// Several tests `create extension citext` — install it first (see
+		// ContribDeps), or they fail with "extension citext is not available".
+		ContribDeps: []string{"citext"},
+		// resolve_error_mutation_no_field carries a patch: a pg_graphql
+		// backend-local schema-cache staleness that shows on reused pooled
+		// backends — not a multigres bug. Full rationale is in that patch file's
+		// header comment (testdata/pg17/patches/external/pg_graphql/).
 	},
 	"pg_cron": {
 		Name: "pg_cron", Repo: "https://github.com/citusdata/pg_cron", Tag: "v1.6.4",
@@ -271,6 +318,25 @@ func ExternalBuildList() []ExternalExtension {
 		add(e)
 	}
 	return out
+}
+
+// ExternalContribDeps returns the deduplicated contrib modules the selected
+// external extensions need installed before their suites run (ExternalExtension.
+// ContribDeps), honoring PGEXTERNAL_TESTS via ExternalModules. The build phase
+// installs these so external-only runs work; a full run has already installed
+// all of contrib, which makes the targeted install a harmless no-op.
+func ExternalContribDeps() []string {
+	var deps []string
+	seen := map[string]bool{}
+	for _, e := range ExternalModules() {
+		for _, d := range e.ContribDeps {
+			if !seen[d] {
+				seen[d] = true
+				deps = append(deps, d)
+			}
+		}
+	}
+	return deps
 }
 
 // CheckExternalSpecs verifies every covered external extension has a build spec.

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multigres/multigres/go/test/endtoend/pgbuilder"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
 	"github.com/multigres/multigres/go/test/utils"
@@ -158,8 +159,24 @@ func TestPostgreSQLRegression(t *testing.T) {
 	// pgmq), ordered so dependencies install first.
 	if runExternal {
 		t.Logf("Phase 2d: Installing external extensions...")
+		// Install contrib modules the external extensions depend on (e.g.
+		// pg_graphql's tests `create extension citext`). In a full run contrib is
+		// already installed; this makes external-only runs self-sufficient.
+		if deps := ExternalContribDeps(); len(deps) > 0 {
+			if err := builder.InstallContribModules(t, buildCtx, deps); err != nil {
+				t.Fatalf("Failed to install external contrib deps %v: %v", deps, err)
+			}
+		}
 		for _, ext := range ExternalBuildList() {
-			if _, err := builder.InstallExternalExtension(t, buildCtx, ext.Name, ext.Repo, ext.Tag, ext.BuildSubdir); err != nil {
+			spec := pgbuilder.ExtensionBuildSpec{
+				Name:        ext.Name,
+				Repo:        ext.Repo,
+				Tag:         ext.Tag,
+				BuildSubdir: ext.BuildSubdir,
+				BuildSystem: ext.BuildSystem,
+				PgrxVersion: ext.PgrxVersion,
+			}
+			if _, err := builder.InstallExternalExtension(t, buildCtx, spec); err != nil {
 				t.Fatalf("Failed to install external extension %s: %v", ext.Name, err)
 			}
 		}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -526,6 +526,17 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			}
 		}
 
+		// Load the extension's fixtures through multigateway before the suite, the
+		// way its own runner does (pg_graphql's bin/installcheck runs
+		// `psql -f test/fixtures.sql` first; those fixtures CREATE the extension and
+		// set its schema config). Same pooled path the test queries take.
+		if ext.FixturesFile != "" {
+			fixturesPath := filepath.Join(testDir, ext.FixturesFile)
+			if err := loadFixturesViaGateway(ctx, filepath.Join(pgBinDir, "psql"), fixturesPath, multigatewayPort, password); err != nil {
+				t.Logf("external/%s: warning: load fixtures %q failed: %v", ext.Name, ext.FixturesFile, err)
+			}
+		}
+
 		// Preload the extension when its fixtures assume it already exists:
 		// --use-existing skips pg_regress's own --load-extension step, and
 		// pgvector's fixtures open with a bare CREATE TABLE ... vector(3) (see
@@ -811,6 +822,31 @@ func createExtensionViaGateway(multigatewayPort int, password, ext string) error
 	stmt := fmt.Sprintf(`CREATE EXTENSION IF NOT EXISTS "%s"`, ext)
 	if _, err := db.Exec(stmt); err != nil {
 		return fmt.Errorf("exec [%s]: %w", stmt, err)
+	}
+	return nil
+}
+
+// loadFixturesViaGateway runs an extension's fixtures SQL file through
+// multigateway with psql before its suite, mirroring how the extension's own
+// runner seeds the database (pg_graphql's bin/installcheck runs
+// `psql -v ON_ERROR_STOP=1 -f test/fixtures.sql` first). Routing it through the
+// gateway — not the primary — keeps setup on the same pooled path as the tests
+// and exercises the fixtures' own DDL (pg_graphql's fixtures CREATE the
+// extension and set the graphql schema comment). psql replays the multi-statement
+// file faithfully, including any backslash commands.
+func loadFixturesViaGateway(ctx context.Context, psqlPath, fixturesPath string, multigatewayPort int, password string) error {
+	cmd := executil.Command(ctx, psqlPath,
+		"-v", "ON_ERROR_STOP=1",
+		"-f", fixturesPath,
+		"-d", "postgres")
+	cmd.AddEnv(
+		"PGHOST=localhost",
+		fmt.Sprintf("PGPORT=%d", multigatewayPort),
+		"PGUSER=postgres",
+		"PGPASSWORD="+password,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("psql -f %s: %w\n%s", fixturesPath, err, truncateForLog(string(out), 2000))
 	}
 	return nil
 }

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/pg_graphql/resolve_error_mutation_no_field.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/pg_graphql/resolve_error_mutation_no_field.patch
@@ -1,0 +1,32 @@
+# Known divergence: pg_graphql's backend-local schema cache goes stale on a
+# reused pooled backend. This is NOT a multigres bug.
+#
+# pg_graphql caches the reflected GraphQL schema in backend-process memory and
+# only invalidates that cache on COMMITTED DDL. An earlier test shaped like
+# `begin; create table account(...); graphql.resolve(...); rollback;` builds the
+# cache from the uncommitted table but stamps it with the unchanged committed
+# schema version, leaving the backend holding a schema for a table that no longer
+# exists (so a Mutation type is present).
+#
+# On stock PostgreSQL each pg_regress test runs on a fresh, short-lived backend,
+# so that poisoned cache dies with the test and this test sees an empty schema
+# ("Unknown type Mutation"). multigres pools and REUSES backends, so this test
+# can land on a backend still holding the stale schema and instead reports
+# "Unknown field insertDNE on type Mutation". The transaction was rolled back
+# correctly (the table does not persist) — only pg_graphql's in-memory cache is
+# stale. Same backend-local-state class as hypopg; any backend-reusing pooler
+# (PgBouncer included) would surface it. Narrow: committed schema changes are
+# reflected correctly, so normal pg_graphql usage is unaffected.
+--- a
++++ b
+@@ -9,8 +9,8 @@
+ }
+ $$);
+ resolve
+-------------------------------------------------------------------
+-{"data": null, "errors": [{"message": "Unknown type Mutation"}]}
++-----------------------------------------------------------------------------------------
++{"data": null, "errors": [{"message": "Unknown field \"insertDNE\" on type Mutation"}]}
+ (1 row)
+
+ rollback;


### PR DESCRIPTION
## Summary

- Add a pgrx (Rust/cargo-pgrx) build path to the external extension harness and enroll Supabase [pg_graphql](https://github.com/supabase/pg_graphql) (v1.6.1) as the first covered pgrx extension. Its full pg_regress suite runs through multigateway: **121/121** (120 clean + 1 documented patch).
- New reusable `ExternalExtension` knobs: `BuildSystem` (`pgxs`/`pgrx`) + `PgrxVersion` (pins cargo-pgrx to the crate's pgrx dep), `FixturesFile` (psql-loads a setup file through the gateway before the suite), and `ContribDeps` (installs contrib modules a suite needs, e.g. citext).
- CI provisions the Rust toolchain (`dtolnay/rust-toolchain`, pinned by SHA); the harness installs the matching cargo-pgrx itself.

## Description

For pgrx extensions, `InstallExternalExtension` installs the pinned cargo-pgrx, runs `cargo pgrx init --pgNN <pg_config>` to adopt the from-source PostgreSQL, then `cargo pgrx install --pg-config <pg_config>` so the `.so` links against the exact server ABI (the same guarantee the PGXS path gives). pg_graphql's `bin/installcheck` loads `test/fixtures.sql` first (it creates the extension and sets the graphql schema comment) and its tests `create extension citext`, hence `FixturesFile` and `ContribDeps`.

The one patch (`resolve_error_mutation_no_field`) is **not** a multigres bug — multigres rolls the transaction back correctly and reflects committed DDL correctly. pg_graphql caches the reflected schema in backend-local memory and only invalidates on committed DDL; a `begin; create table; resolve; rollback;` test poisons that backend's cache, and because multigres pools and reuses backends (unlike stock pg_regress, which gets a fresh backend per test), a later test sees the stale schema. It's the same backend-local-state class as hypopg and narrow (rolled-back in-txn DDL only). The full rationale lives in the patch file's header comment.