### PR TITLE
ci: benchmark postgres target in weekly pgbench so overhead summary is non-empty

### DIFF
--- a/.github/workflows/test-pgbench.yml
+++ b/.github/workflows/test-pgbench.yml
@@ -266,7 +266,10 @@ jobs:
             "$SLACK_WEBHOOK_URL"
 
       - name: Prepare baseline for cache save
-        if: ${{ !cancelled() && steps.results.outputs.path != '' }}
+        if: >-
+          !cancelled() &&
+          github.event_name != 'pull_request' &&
+          steps.results.outputs.path != ''
         env:
           RESULTS_PATH: ${{ steps.results.outputs.path }}
         run: |
@@ -274,7 +277,10 @@ jobs:
           cp "$RESULTS_PATH" /tmp/pgbench-baseline/results.json
 
       - name: Save current results as new baseline
-        if: ${{ !cancelled() && steps.results.outputs.path != '' }}
+        if: >-
+          !cancelled() &&
+          github.event_name != 'pull_request' &&
+          steps.results.outputs.path != ''
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: /tmp/pgbench-baseline/results.json

--- a/.github/workflows/test-pgbench.yml
+++ b/.github/workflows/test-pgbench.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run pgbench benchmarks
         env:
           RUN_BENCHMARKS: "1"
+          PGBENCH_TARGETS: "postgres,multigateway"
           PGBENCH_DURATION: "30"
           PGBENCH_CLIENTS: "1,10,50"
           TEST_PRINT_LOGS: "1"
@@ -211,14 +212,27 @@ jobs:
               "| \(.scenario) | \(.pg_tps) | \(.mgw_tps) | \(.overhead)% |"
             ) | join("\n")) as $table_rows |
 
-            {blocks: [
-              {type: "header", text: {type: "plain_text",
-                text: ("Weekly pgbench: multigateway overhead " + ($avg_overhead | tostring) + "% avg")}},
-              {type: "section", text: {type: "mrkdwn",
-                text: ("*Sustained Load Results*\n| Scenario | PG TPS | MGW TPS | Overhead |\n|---|---|---|---|\n" + $table_rows)}},
-              {type: "section", text: {type: "mrkdwn",
-                text: ("<" + $url + "|View CI run>")}}
-            ]}
+            # Detect which targets the run actually produced, so a misconfigured
+            # target matrix surfaces loudly instead of posting a silent "0% avg".
+            ([$sustained[].target] | unique) as $targets |
+
+            {blocks: (
+              if ($comparisons | length) > 0 then [
+                {type: "header", text: {type: "plain_text",
+                  text: ("Weekly pgbench: multigateway overhead " + ($avg_overhead | tostring) + "% avg")}},
+                {type: "section", text: {type: "mrkdwn",
+                  text: ("*Sustained Load Results*\n| Scenario | PG TPS | MGW TPS | Overhead |\n|---|---|---|---|\n" + $table_rows)}},
+                {type: "section", text: {type: "mrkdwn",
+                  text: ("<" + $url + "|View CI run>")}}
+              ] else [
+                {type: "header", text: {type: "plain_text",
+                  text: ":warning: Weekly pgbench: no overhead comparison produced"}},
+                {type: "section", text: {type: "mrkdwn",
+                  text: ("No postgres-vs-multigateway comparison could be built — the run is missing a `postgres` baseline.\nTargets present in results: `" + ($targets | join(", ")) + "`\nCheck `PGBENCH_TARGETS` in the workflow.")}},
+                {type: "section", text: {type: "mrkdwn",
+                  text: ("<" + $url + "|View CI run>")}}
+              ] end
+            )}
             ')
 
           curl -sf -X POST -H 'Content-type: application/json' \


### PR DESCRIPTION
## Summary

- The weekly pgbench Slack summary builds a postgres-vs-multigateway overhead comparison, but the workflow never set `PGBENCH_TARGETS`, so `parseTargets()` defaulted to multigateway-only. With no `postgres` rows the comparison was always empty — every run posted "multigateway overhead 0% avg" with a header-only table.
- Set `PGBENCH_TARGETS: "postgres,multigateway"` so both targets are benchmarked and the overhead table has data.
- Harden the summary `jq`: when no comparison can be built it now posts a `:warning:` message naming the targets actually present, instead of silently posting 0%.
- Stop PR-labeled runs from overwriting the baseline, so one-off checks don't pollute the week-over-week regression comparison.

## Problem

Confirmed against the latest scheduled run's artifact: `results.json` contained 10 rows, all `target: "multigateway"`, zero `postgres`. The summary `jq` builds `$pg_tps` from `select(.target == "postgres")` → empty, so `$comparisons` is empty and it falls into the `else 0` branch. The job still succeeds, which is why the breakage went unnoticed — the data was simply missing a baseline.

## Solution

Provide the postgres target explicitly via env, and make the missing-baseline case loud rather than silent. Both `jq` branches were verified locally against the real artifact (multigateway-only → warning; synthetic two-target → proper table).

Baseline-save is now gated on `github.event_name != 'pull_request'` (matching the Slack summary step), so `Run Benchmarks` PR runs are safe throwaway checks while scheduled and `workflow_dispatch` runs still update the baseline.

Note: the regression-detection script only ever compares `multigateway` rows, so it keeps working across the one-run baseline transition from single- to two-target results.