### PR TITLE
fix(multiorch): eliminate blocking recruit drain; propose to full cohort after quorum

### DIFF
--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -80,6 +80,17 @@ type FakeClient struct {
 	// Errors to return - keyed by pooler ID
 	Errors map[string]error
 
+	// RecruitDelays maps pooler IDs to artificial delays for Recruit calls.
+	// Use this to simulate slow or unresponsive nodes for testing timeout behavior.
+	// If the context is cancelled during the delay, the context error is returned.
+	RecruitDelays map[string]time.Duration
+
+	// RecruitGates maps pooler IDs to gate channels. Recruit blocks until the
+	// channel is closed. Use this to precisely control when a Recruit call
+	// completes relative to other goroutines, e.g. to sequence Phase 1 and
+	// Phase 2 in rule-change tests.
+	RecruitGates map[string]chan struct{}
+
 	// CallLog tracks which methods were called for verification in tests
 	CallLog []string
 
@@ -110,6 +121,8 @@ func NewFakeClient() *FakeClient {
 		RewindToSourceResponses:             make(map[string]*multipoolermanagerdatapb.RewindToSourceResponse),
 		SetPostgresRestartsEnabledResponses: make(map[string]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		Errors:                              make(map[string]error),
+		RecruitDelays:                       make(map[string]time.Duration),
+		RecruitGates:                        make(map[string]chan struct{}),
 		CallLog:                             make([]string, 0),
 		PromoteRequests:                     make(map[string]*consensusdatapb.PromoteRequest),
 		SetPrimaryRequests:                  make(map[string]*consensusdatapb.SetPrimaryRequest),
@@ -194,6 +207,28 @@ func (f *FakeClient) Recruit(ctx context.Context, pooler *clustermetadatapb.Mult
 
 	if err := f.checkError(poolerID); err != nil {
 		return nil, err
+	}
+
+	f.mu.RLock()
+	delay := f.RecruitDelays[poolerID]
+	f.mu.RUnlock()
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	f.mu.RLock()
+	gate := f.RecruitGates[poolerID]
+	f.mu.RUnlock()
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	f.mu.RLock()

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -116,16 +116,26 @@ func (r *coordinatorLedRuleChange) Run(
 	// selected → commit). Monotonic, so unaffected by wall-clock adjustments.
 	start := time.Now()
 	var selectedAt time.Time
-	eventlog.Emit(ctx, r.coordinator.logger, eventlog.Started, eventlog.PrimaryPromotion{
+	primaryPromotion := eventlog.PrimaryPromotion{
 		ProposedTerm: proposedTerm,
 		Reason:       r.reason,
-	})
+	}
+	eventlog.Emit(ctx, r.coordinator.logger, eventlog.Started, primaryPromotion)
 
-	// Recruit all nodes concurrently.
+	// Phase 1: Recruit all nodes concurrently.
+	//
+	// Each recruit returns a ConsensusStatus that reflects the node's current WAL
+	// position and durability commitments. The coordinator accumulates these and
+	// tries to build a proposal after each arrival, until one succeeds. This
+	// lets the coordinator select the most advanced node that can still satisfy
+	// the durability policy, without waiting for the slowest nodes in the
+	// cohort to respond.
+
 	type recruitResult struct {
 		pooler *multiorchdatapb.PoolerHealthState
 		cs     *clustermetadatapb.ConsensusStatus // nil if recruit failed
 	}
+
 	recruited := make(chan recruitResult, len(cohort))
 	for _, p := range cohort {
 		go func() {
@@ -135,29 +145,12 @@ func (r *coordinatorLedRuleChange) Run(
 
 	var (
 		statuses  []*clustermetadatapb.ConsensusStatus
-		recruits  []*multiorchdatapb.PoolerHealthState
 		propReq   *consensusdatapb.PromoteRequest
 		leaderKey string
 	)
 
-	type promoteResult struct {
-		poolerName string
-		isLeader   bool
-		err        error
-	}
-	promoteResults := make(chan promoteResult, len(cohort))
-
-	// dispatchProposal sends Promote to the designated leader and SetPrimary
-	// to every other cohort member. r.promote handles the dispatch internally.
-	dispatchProposal := func(p *multiorchdatapb.PoolerHealthState) {
-		isLeader := topoclient.ClusterIDString(p.MultiPooler.Id) == leaderKey
-		go func() {
-			err := r.promote(ctx, p, propReq, isLeader)
-			promoteResults <- promoteResult{poolerName: p.MultiPooler.Id.Name, isLeader: isLeader, err: err}
-		}()
-	}
-
-	// Phase 1: collect recruits until tryBuildProposal succeeds (or we run out).
+	// Phase 2: collect recruits until tryBuildProposal succeeds, or all nodes
+	// have responded without reaching quorum.
 	//
 	// We commit to the leader at the FIRST successful tryBuildProposal and stream
 	// Proposes from there — recruits arriving after that point don't change
@@ -181,7 +174,6 @@ func (r *coordinatorLedRuleChange) Run(
 			continue
 		}
 		statuses = append(statuses, rr.cs)
-		recruits = append(recruits, rr.pooler)
 		p, err := r.tryBuildProposal(revocation, statuses)
 		if err != nil {
 			continue
@@ -214,23 +206,39 @@ func (r *coordinatorLedRuleChange) Run(
 		}, "error", err)
 		return mterrors.Wrap(err, "recruitment failed")
 	}
-	for _, p := range recruits {
-		dispatchProposal(p)
+
+	// Phase 3: Propose to all nodes concurrently.
+	//
+	// Note that we send proposals to all nodes, including those that didn't
+	// respond to recruit or whose recruits arrived after the proposal was
+	// selected. This is important for safety: if a node didn't respond to
+	// recruit, it may have been partitioned or slow, and thus may not have
+	// received the proposal's term revocation. Sending it SetPrimary
+	// ensures it learns about the new term. The same applies to late recruits
+	// that arrived after the proposal was selected — they may have been too
+	// slow to factor into leader selection, but they still need to learn about
+	// the new term.
+
+	type promoteResult struct {
+		poolerName string
+		isLeader   bool
+		err        error
 	}
 
-	// Phase 2: drain remaining recruits, proposing to each as it arrives.
-	for range remaining {
-		if rr := <-recruited; rr.cs != nil {
-			dispatchProposal(rr.pooler)
-			recruits = append(recruits, rr.pooler)
-		}
+	promoteResults := make(chan promoteResult, len(cohort))
+	for _, p := range cohort {
+		isLeader := topoclient.ClusterIDString(p.MultiPooler.Id) == leaderKey
+		go func() {
+			err := r.promote(ctx, p, propReq, isLeader)
+			promoteResults <- promoteResult{poolerName: p.MultiPooler.Id.Name, isLeader: isLeader, err: err}
+		}()
 	}
 
-	// Wait for every Promote to return, not just the leader's. The rule
+	// Phase 4: Wait for every Promote to return, not just the leader's. The rule
 	// change is committed when the leader's Promote succeeds — which can
 	// only happen because enough followers endorsed the proposal first to
 	// satisfy the cohort's durability quorum. Returning early here would
-	// let Run's context cancel the in-flight non-leader Proposes. The shard
+	// let Run's context cancel the in-flight non-leader Promotes. The shard
 	// is already safe at that point, but any pooler whose Promote was
 	// cancelled wouldn't learn the new primary on this round and would
 	// need to be re-wired before it could route correctly. Waiting avoids
@@ -240,7 +248,7 @@ func (r *coordinatorLedRuleChange) Run(
 	// non-leaders to learn about, so there is nothing to gain by waiting
 	// — return as soon as we see the leader's failure.
 	var leaderErr error
-	for range len(recruits) {
+	for range len(cohort) {
 		pr := <-promoteResults
 		if pr.err != nil {
 			if pr.isLeader {

--- a/go/services/multiorch/consensus/rule_change_test.go
+++ b/go/services/multiorch/consensus/rule_change_test.go
@@ -483,6 +483,134 @@ func TestRun_LeaderPromoteFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to accept proposal")
 }
 
+func TestRun_SlowRecruitDoesNotBlockAfterQuorum(t *testing.T) {
+	// Phase 2 must not block on recruit goroutines still in flight after quorum
+	// is reached. Recruit is sent to every cohort member regardless of health
+	// status — node health can change during the recruit phase — but once Phase 1
+	// has a viable proposal, Run should proceed without waiting for stragglers.
+	//
+	// Setup: mp1 responds immediately and satisfies quorum on its own. mp2's
+	// Recruit is configured to block for 20 s. Without the non-blocking Phase 2,
+	// Run would stall for 20 s waiting for mp2; with it, Run completes quickly
+	// and mp2's goroutine finishes in the background.
+	ctx := context.Background()
+	fc := rpcclient.NewFakeClient()
+	c := newRuleChangeCoordinator(t, fc)
+
+	mp1 := makePoolerState("zone1", "mp1")
+	mp2 := makePoolerState("zone1", "mp2")
+
+	cohort := []*multiorchdatapb.PoolerHealthState{mp1, mp2}
+	setRecruitOK(fc, mp1)
+
+	mp2Key := topoclient.MultiPoolerIDString(mp2.MultiPooler.Id)
+	fc.RecruitDelays[mp2Key] = 20 * time.Second
+
+	leaderID := mp1.MultiPooler.Id
+	proposal := &consensusdatapb.CoordinatorProposal{
+		TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+		ProposalLeader: &clustermetadatapb.PoolerAddress{
+			Id:           leaderID,
+			Host:         "localhost",
+			PostgresPort: 5432,
+		},
+		ProposedRule: &clustermetadatapb.ShardRule{
+			LeaderId:      leaderID,
+			CohortMembers: []*clustermetadatapb.ID{mp1.MultiPooler.Id},
+			DurabilityPolicy: &clustermetadatapb.DurabilityPolicy{
+				QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+				RequiredCount: 1,
+			},
+		},
+	}
+
+	rc := c.newRuleChange("test", fixedProposal(1, proposal), nopCheckProposalPossible)
+
+	start := time.Now()
+	err := rc.Run(ctx, cohort, newTestRevocation(t, c, cohort))
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 2*time.Second,
+		"Run blocked waiting for slow recruit; Phase 2 should not wait for in-flight goroutines after quorum")
+	// mp2's Recruit RPC was issued (no pre-filtering on health), but its slow
+	// response did not delay Run.
+	assert.Contains(t, fc.GetCallLog(), fmt.Sprintf("Recruit(%s)", mp2Key),
+		"Recruit should be issued to all cohort members regardless of health status")
+}
+
+func TestRun_StragglersGetSetTermPrimary(t *testing.T) {
+	// When a node's Recruit response arrives after Phase 1 has committed to a
+	// proposal, Phase 2's non-blocking select should catch it and dispatch
+	// SetTermPrimary so the node learns the new leader immediately rather than
+	// waiting for a follow-up re-wiring round.
+	//
+	// Sequencing: mp2's Recruit is gated so it cannot complete until
+	// tryBuildProposal releases it. tryBuildProposal runs on the Run() goroutine
+	// synchronously inside Phase 1, so releasing the gate there and sleeping
+	// briefly guarantees mp2's goroutine writes to the buffered channel before
+	// Phase 2's select runs.
+	ctx := context.Background()
+	fc := rpcclient.NewFakeClient()
+	c := newRuleChangeCoordinator(t, fc)
+
+	mp1 := makePoolerState("zone1", "mp1") // leader, responds during Phase 1
+	mp2 := makePoolerState("zone1", "mp2") // straggler, responds during Phase 2
+	cohort := []*multiorchdatapb.PoolerHealthState{mp1, mp2}
+	setRecruitOK(fc, mp1)
+	setRecruitOK(fc, mp2)
+
+	mp1Key := topoclient.MultiPoolerIDString(mp1.MultiPooler.Id)
+	mp2Key := topoclient.MultiPoolerIDString(mp2.MultiPooler.Id)
+
+	// Gate mp2: its Recruit blocks until the gate is closed.
+	mp2Gate := make(chan struct{})
+	fc.RecruitGates[mp2Key] = mp2Gate
+
+	leaderID := mp1.MultiPooler.Id
+	proposal := &consensusdatapb.CoordinatorProposal{
+		TermRevocation: &clustermetadatapb.TermRevocation{RevokedBelowTerm: 1},
+		ProposalLeader: &clustermetadatapb.PoolerAddress{
+			Id:           leaderID,
+			Host:         "localhost",
+			PostgresPort: 5432,
+		},
+		ProposedRule: &clustermetadatapb.ShardRule{
+			LeaderId:      leaderID,
+			CohortMembers: []*clustermetadatapb.ID{mp1.MultiPooler.Id, mp2.MultiPooler.Id},
+			DurabilityPolicy: &clustermetadatapb.DurabilityPolicy{
+				QuorumType:    clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N,
+				RequiredCount: 1,
+			},
+		},
+	}
+
+	// Phase 1 succeeds as soon as mp1 responds (mp2 is still gated at this point).
+	// Close the gate here — inside tryBuildProposal on the Run() goroutine — then
+	// sleep briefly so mp2's goroutine has time to pass the gate, complete Recruit,
+	// and write its result to the buffered channel before Phase 2's select runs.
+	gateOpened := false
+	tryBuildProposal := func(_ *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {
+		if len(statuses) < 1 {
+			return nil, errors.New("need at least 1 node")
+		}
+		if !gateOpened {
+			gateOpened = true
+			close(mp2Gate)
+			time.Sleep(5 * time.Millisecond)
+		}
+		return proposal, nil
+	}
+
+	rc := c.newRuleChange("test", tryBuildProposal, nopCheckProposalPossible)
+	require.NoError(t, rc.Run(ctx, cohort, newTestRevocation(t, c, cohort)))
+
+	assert.NotNil(t, fc.PromoteRequests[mp1Key],
+		"leader (mp1) should receive Promote")
+	assert.NotNil(t, fc.SetPrimaryRequests[mp2Key],
+		"straggler (mp2) should receive SetPrimary")
+}
+
 func TestRun_NonLeaderPromoteFails(t *testing.T) {
 	// Promote fails for a non-leader — Run should succeed (non-leader failures are non-fatal).
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

`coordinatorLedRuleChange.Run()` launches one Recruit goroutine per cohort member. Phase 2 collected Recruit responses with a **blocking drain**: it called `<-recruited` for every remaining goroutine and waited for each to complete before dispatching Promote results. Any node whose Recruit RPC was slow or timed out would stall `Run()` for the full RPC duration, even though quorum was already satisfied in Phase 1 and the leader's Promote was ready to go.

## Fix

Remove the blocking drain entirely. As soon as Phase 1 elects a leader, dispatch Promote/SetPrimary to every cohort member unconditionally — including nodes whose Recruit goroutines are still in flight or have failed. Recruit goroutines still in flight run to completion on their own without blocking the proposal phase. Node health can change during the recruit phase, so Recruit is sent to every cohort member unconditionally and the response race determines leader selection.

Also adds latency instrumentation to the eventlog calls: `recruit_ms` (time to quorum) and `promote_ms` (proposal phase duration) are now emitted on the terminal Success/Failed events, and a Started event is emitted before any RPCs go out so the full appointment can be traced end-to-end.

## Tests

- **`TestRun_SlowRecruitDoesNotBlockAfterQuorum`** — mp2's Recruit is configured with a 20 s blocking delay; mp1 alone satisfies quorum. Asserts that `Run()` completes in under 2 s and that mp2's Recruit RPC was still issued (no pre-filtering on health status).
- **`TestRun_StragglersGetSetTermPrimary`** — mp2's Recruit is gated and released from inside `tryBuildProposal` after Phase 1 commits. Asserts that mp1 receives `Promote` (as leader) and mp2 receives `SetPrimary`.
- **`RecruitDelays` and `RecruitGates`** added to `FakeClient` to support delay injection and precise goroutine sequencing in tests.

Fixes MUL-555