### PR TITLE
test(pgregresstest): run pg_partman's pgTAP suite through multigateway

### DIFF
--- a/go/test/endtoend/pgregresstest/README.md
+++ b/go/test/endtoend/pgregresstest/README.md
@@ -213,13 +213,15 @@ on `ExternalExtension` (`extensions.go`):
   partitioned queues via pg_partman's `create_parent`, so pgmq `DependsOn`
   `pg_partman` (which itself ships only a pgTAP suite). `ExternalBuildList` orders
   dependencies before their dependents.
-- **`CreateExtension`** — whether the harness pre-creates the extension through
-  multigateway (and passes `--load-extension`) before the run. pgvector's
-  fixtures assume it already exists (they open with a bare
-  `CREATE TABLE ... vector(3)`), so `true`. pg_cron's fixtures create and drop
-  the extension themselves (`CREATE EXTENSION pg_cron VERSION '1.0'` is the first
-  statement), so `false` — preloading would make that statement fail with
-  "already exists".
+- **`PreCreateExtensions`** — extensions the harness `CREATE`s through multigateway
+  (each optionally into a specific schema) before the run, for fixtures that assume
+  an extension already exists. pgvector's fixtures open with a bare
+  `CREATE TABLE ... vector(3)`, so it lists `{Name: "vector"}`. pg_partman's pgTAP
+  tests expect pgtap in `public` and pg_partman in `partman` (its control file pins
+  no schema, so a bare `CREATE EXTENSION` would land it in `public` and break every
+  `partman.*` reference), so it lists both with the schema set. Left empty for
+  fixtures that manage the extension themselves (pg_cron's first statement is
+  `CREATE EXTENSION pg_cron VERSION '1.0'`; pgmq each `DROP`s and re-`CREATE`s it).
 - **`ServerConfigFile`** — a `postgresql.conf` snippet under
   `testdata/pg17/external/` the cluster must apply before postgres starts, for
   extensions needing server-level config the pooled query path can't set.

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -91,7 +91,7 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"pg_graphql", KindExternal, StatusCovered, "Supabase pg_graphql; Rust/pgrx crate built with cargo-pgrx; loads test/fixtures.sql before its pg_regress suite"},
 	{"pg_jsonschema", KindExternal, StatusExternal, "Rust"},
 	{"pg_net", KindExternal, StatusExternal, "background worker"},
-	{"pg_partman", KindExternal, StatusUnsupported, "ships a pgTAP suite, not pg_regress; built and installed as a build dependency of pgmq (create_partitioned → create_parent)"},
+	{"pg_partman", KindExternal, StatusCovered, "pgTAP suite run via psql (not pg_regress); needs pgtap + max_locks_per_transaction>=128 (see testdata/pg17/external/pg_partman.conf). Runs the transaction-wrapped tests only (top-level + test_pg17plus/ + test_no_search_path/); autocommit/procedure subfolders can't run through a transaction pooler — see runExternalPgTAP. Also pgmq's build dependency (pgmq.create_partitioned → create_parent)."},
 	{"pg_stat_statements", KindContrib, StatusUnsupported, "NO_INSTALLCHECK; records query text the gateway rewrites"},
 	{"pg_trgm", KindContrib, StatusCovered, ""},
 	{"pgaudit", KindExternal, StatusExternal, ""},
@@ -99,7 +99,7 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"pgjwt", KindExternal, StatusExternal, "depends on pgcrypto"},
 	{"pgmq", KindExternal, StatusCovered, "tembo-io/pgmq; pure-SQL queue built as a PGXS module from pgmq-extension/; partitioned-queue tests depend on pg_partman"},
 	{"pgsodium", KindExternal, StatusExternal, "libsodium"},
-	{"pgtap", KindExternal, StatusExternal, ""},
+	{"pgtap", KindExternal, StatusExternal, "test dependency of pg_partman; built from externalSpecs but not run as its own suite"},
 	{"plpgsql", KindContrib, StatusUnsupported, "built-in PL; exercised by the core regression suite, not contrib"},
 	{"plpgsql_check", KindExternal, StatusExternal, ""},
 	{"postgis", KindExternal, StatusExternal, ""},
@@ -110,6 +110,32 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"uuid-ossp", KindContrib, StatusCovered, "needs --with-uuid"},
 	{"vector", KindExternal, StatusCovered, "pgvector; built as a PGXS module from externalSpecs"},
 	{"wrappers", KindExternal, StatusExternal, "Rust"},
+}
+
+// TestHarness selects how an external extension's shipped test suite is
+// executed. The zero value (HarnessPgRegress) drives the pg_regress binary and
+// diffs each test's output against expected/*.out — the model the contrib suite
+// and pgvector/pg_cron use. HarnessPgTAP instead feeds each test .sql to psql and
+// parses the TAP stream the pgTAP assertions emit server-side; correctness is
+// decided in-database (no expected-output files, no patch pipeline). Extensions
+// like pg_partman ship pgTAP suites.
+type TestHarness string
+
+const (
+	// HarnessPgRegress runs the extension's tests through pg_regress (default).
+	HarnessPgRegress TestHarness = ""
+	// HarnessPgTAP runs the extension's pgTAP tests through psql and parses TAP.
+	HarnessPgTAP TestHarness = "pgtap"
+)
+
+// ExtensionInstall names an extension to CREATE before a pgTAP suite, with an
+// optional target schema. When Schema is non-empty the harness creates that
+// schema first and installs the extension into it (CREATE EXTENSION ... SCHEMA
+// <Schema>); when empty the extension lands in the current schema (public). See
+// ExternalExtension.PreCreateExtensions.
+type ExtensionInstall struct {
+	Name   string
+	Schema string
 }
 
 // ExternalExtension describes one external (non-contrib) extension wired into
@@ -127,22 +153,63 @@ type ExternalExtension struct {
 	// pgmq-extension/, so it uses "pgmq-extension". Empty means the repo root.
 	BuildSubdir string
 
+	// Harness selects the test runner (see TestHarness). The zero value runs the
+	// pg_regress path; HarnessPgTAP runs the psql+TAP path. Fields below tagged
+	// "(pgTAP)" apply only to the HarnessPgTAP path; the patch pipeline applies only
+	// to the pg_regress path; PreCreateExtensions is used by both.
+	Harness TestHarness
+
+	// TestGlobs (pgTAP) are the filename globs, relative to TestSubdir, selecting
+	// the test files to run (their union, deduped). pgTAP suites ship flat *.sql
+	// files rather than the pg_regress sql/+expected/ layout, so listRegressTests
+	// does not apply. Defaults to ["*.sql"] when empty.
+	//
+	// pg_partman is restricted to its self-contained, transaction-wrapped tests:
+	// the top-level test-*.sql plus the rolled-back tests under test_pg17plus/ and
+	// test_no_search_path/. The OTHER subfolders are deliberately excluded, and the
+	// reason is a hard limit of running pgTAP through a transaction pooler, not a
+	// scoping whim — see the long note on runExternalPgTAP. In short: pgTAP keeps
+	// its plan/results in session-temp tables that plan() creates *inside* a
+	// function body, so the gateway can't observe them. Inside a BEGIN…ROLLBACK the
+	// visible BEGIN pins the backend and the ROLLBACK discards that temp state, so
+	// these tests are clean. The excluded folders run pgTAP in autocommit (their
+	// procedures COMMIT, so they can't be wrapped): plan()'s temp table is then
+	// created on an unpinned pooled backend and never discarded, leaking into the
+	// next file as "You tried to plan twice!". They also need infrastructure the
+	// pooled path can't provide — background workers (test_bgw/), tablespaces
+	// (test_tablespace/), non-superuser roles (test_nonsuperuser/), or manual
+	// multi-stage orchestration with out-of-band commits (test_procedure/).
+	TestGlobs []string
+
+	// ExcludeGlobs (pgTAP) removes files that TestGlobs would otherwise select,
+	// matched against the path relative to TestSubdir. Use it for
+	// a test that runs cleanly but isn't a reliable signal — e.g. a date-calibrated
+	// expectation that drifts with the calendar (see pg_partman below).
+	ExcludeGlobs []string
+
+	// PreCreateExtensions lists extensions to CREATE EXTENSION through multigateway,
+	// in order, before the suite runs — each optionally into a specific schema. Used
+	// by both harnesses for fixtures that assume an extension already exists:
+	//   - pg_regress: pgvector's fixtures open with a bare CREATE TABLE ...
+	//     vector(3) and never CREATE EXTENSION, so it lists {Name: "vector"}.
+	//   - pgTAP: pg_partman's test files never CREATE EXTENSION; they expect pgtap
+	//     in public and pg_partman in the `partman` schema, referencing partman.*
+	//     explicitly.
+	// The Schema field matters because pg_partman's control file is
+	// relocatable=false with no `schema=` default, so CREATE EXTENSION without a
+	// SCHEMA clause lands it in public (first in search_path) and every
+	// schema-qualified partman.* reference then fails with "schema partman does not
+	// exist". The pgTAP path tears these down after its suite (see runExternalPgTAP);
+	// the pg_regress path relies on resetContribState clearing public before the
+	// next extension.
+	PreCreateExtensions []ExtensionInstall
+
 	// TestSubdir is the directory within the checkout that holds the shipped
 	// pg_regress fixtures (sql/ + expected/), relative to the clone root.
 	// pgvector keeps them under test/; pg_cron keeps them at the repo root, so
 	// it uses "." (filepath.Join collapses it back to the clone root). pgmq keeps
 	// them under pgmq-extension/test, alongside its BuildSubdir.
 	TestSubdir string
-
-	// CreateExtension controls whether the harness pre-creates the extension
-	// through multigateway (and passes pg_regress --load-extension) before the
-	// suite runs. pgvector's fixtures assume it already exists (they open with a
-	// bare CREATE TABLE ... vector(3) and never CREATE EXTENSION), so it needs
-	// the preload. pg_cron's fixtures manage the extension themselves
-	// (CREATE EXTENSION pg_cron VERSION '1.0' is the first statement, then they
-	// DROP and recreate it at a newer version), so preloading would make that
-	// first statement fail with "extension already exists" — it must be false.
-	CreateExtension bool
 
 	// ScratchDatabases names databases the harness creates directly on the
 	// primary (bypassing multigateway, like the public-schema reset) before the
@@ -218,7 +285,9 @@ type ExternalExtension struct {
 var externalSpecs = map[string]ExternalExtension{
 	"vector": {
 		Name: "vector", Repo: "https://github.com/pgvector/pgvector", Tag: "v0.8.1",
-		TestSubdir: "test", CreateExtension: true,
+		// pgvector's fixtures assume the extension already exists (they open with a
+		// bare CREATE TABLE ... vector(3) and never CREATE EXTENSION), so preload it.
+		TestSubdir: "test", PreCreateExtensions: []ExtensionInstall{{Name: "vector"}},
 	},
 	"pg_graphql": {
 		Name: "pg_graphql", Repo: "https://github.com/supabase/pg_graphql", Tag: "v1.6.1",
@@ -228,9 +297,9 @@ var externalSpecs = map[string]ExternalExtension{
 		BuildSystem: "pgrx", PgrxVersion: "0.16.1", TestSubdir: "test",
 		// test/fixtures.sql opens with `drop extension if exists pg_graphql;
 		// create extension pg_graphql cascade;` and sets the graphql schema
-		// comment, so the harness loads it first and must not also preload the
-		// extension itself.
-		CreateExtension: false, FixturesFile: "fixtures.sql",
+		// comment, so the harness loads it first (FixturesFile) and must not also
+		// preload the extension itself (PreCreateExtensions left empty).
+		FixturesFile: "fixtures.sql",
 		// Several tests `create extension citext` — install it first (see
 		// ContribDeps), or they fail with "extension citext is not available".
 		ContribDeps: []string{"citext"},
@@ -241,20 +310,49 @@ var externalSpecs = map[string]ExternalExtension{
 	},
 	"pg_cron": {
 		Name: "pg_cron", Repo: "https://github.com/citusdata/pg_cron", Tag: "v1.6.4",
-		TestSubdir: ".", CreateExtension: false, ServerConfigFile: "pg_cron.conf",
+		// pg_cron's fixtures manage the extension themselves (CREATE EXTENSION pg_cron
+		// VERSION '1.0' is the first statement, then they DROP and recreate it at a
+		// newer version), so PreCreateExtensions is left empty to avoid colliding.
+		TestSubdir: ".", ServerConfigFile: "pg_cron.conf",
 		// pg_cron-test.sql references pgcron_dbno/pgcron_dbyes by name (it REVOKEs
 		// CONNECT on one and schedules/alters jobs targeting both) but never
 		// connects to them; front-load them on the primary so those metadata and
 		// CONNECT-privilege checks run for real. See ScratchDatabases.
 		ScratchDatabases: []string{"pgcron_dbno", "pgcron_dbyes"},
 	},
-	// pg_partman is a build-only dependency of pgmq, never tested on its own (it
-	// ships a pgTAP suite, not pg_regress — see its StatusUnsupported catalog
-	// entry). pgmq.create_partitioned calls partman's create_parent, which works
-	// without the background worker, so no ServerConfigFile is needed; the PGXS
-	// Makefile is at the repo root, so BuildSubdir stays empty.
+	// pgtap is a build dependency only: pg_partman's pgTAP tests need the pgtap
+	// extension installed. The harness clones/builds/installs it (via pg_partman's
+	// DependsOn) but never runs its own suite, so it carries no test fields and is
+	// not StatusCovered in the catalog.
+	"pgtap": {
+		Name: "pgtap", Repo: "https://github.com/theory/pgtap", Tag: "v1.3.4",
+	},
 	"pg_partman": {
 		Name: "pg_partman", Repo: "https://github.com/pgpartman/pg_partman", Tag: "v5.4.3",
+		Harness:    HarnessPgTAP,
+		TestSubdir: "test",
+		// The self-contained, transaction-wrapped tests only: the top-level
+		// test-*.sql plus the rolled-back tests under test_pg17plus/ and
+		// test_no_search_path/. The other subfolders are excluded — see TestGlobs.
+		TestGlobs: []string{"test-*.sql", "test_pg17plus/*.sql", "test_no_search_path/*.sql"},
+		// test-time-monthly-source-generated asserts an exact post-undo_partition
+		// row count (ARRAY[91]) calibrated to a specific run date: the data spans a
+		// fixed now()-relative 12-month window, but the monthly partition boundaries
+		// and premake shift with the calendar, so undo_partition(p_loop_count=>20)
+		// moves a date-dependent number of rows. It fails identically with and
+		// without the gateway (74≠91 on 2026-06-08) — the test's own date assumption,
+		// not a multigres behavior — so it's excluded from the deterministic set.
+		ExcludeGlobs: []string{"test_pg17plus/test-time-monthly-source-generated.sql"},
+		// pgtap (public) and pg_partman (partman schema) must both exist before any
+		// test file runs — the files assume them and never CREATE EXTENSION. pgtap
+		// goes in public; pg_partman MUST go in the `partman` schema (its tests
+		// reference partman.* explicitly), so it carries an explicit Schema.
+		DependsOn:           []string{"pgtap"},
+		PreCreateExtensions: []ExtensionInstall{{Name: "pgtap"}, {Name: "pg_partman", Schema: "partman"}},
+		// Subpartition tests create/drop several hundred tables in one transaction;
+		// the default max_locks_per_transaction (64) risks a cluster crash. pgmq,
+		// which DependsOn pg_partman, runs fine with this raised too.
+		ServerConfigFile: "pg_partman.conf",
 	},
 	"pgmq": {
 		Name: "pgmq", Repo: "https://github.com/tembo-io/pgmq", Tag: "v1.11.1",
@@ -263,8 +361,8 @@ var externalSpecs = map[string]ExternalExtension{
 		BuildSubdir: "pgmq-extension", TestSubdir: "pgmq-extension/test",
 		// Every test file CREATEs the extension itself (the topic/fifo files open
 		// with DROP EXTENSION IF EXISTS pgmq CASCADE; CREATE EXTENSION pgmq), so the
-		// harness must not preload it.
-		CreateExtension: false,
+		// harness must not preload it (PreCreateExtensions left empty).
+		//
 		// base.sql creates partitioned queues via pg_partman's create_parent and
 		// CREATEs pg_partman directly; install it first. (base.sql also calls
 		// pgmq.create_unlogged, whose CREATE UNLOGGED TABLE runs as dynamic SQL

--- a/go/test/endtoend/pgregresstest/isolation.go
+++ b/go/test/endtoend/pgregresstest/isolation.go
@@ -1,0 +1,480 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// patchIsolationtester rewrites two pieces of
+// src/test/isolation/isolationtester.c so the harness works against
+// multigateway:
+//
+//  1. Per-session application_name setup. Upstream sends
+//     PQexecParams("SELECT set_config('application_name',
+//     current_setting('application_name') || '/' || $1, false)", ...),
+//     which the multigateway planner rejects (the value must be a literal
+//     constant for is_local=false set_config so the pooler can track it).
+//     The replacement reads PGAPPNAME (set by isolation_main.c per test),
+//     concatenates the session name client-side, escapes via
+//     PQescapeLiteral, and sends a simple-protocol PQexec.
+//
+//  2. Lock-wait probe function name. Upstream prepares
+//     `pg_catalog.pg_isolation_test_session_is_blocked(...)`. Replacing
+//     that builtin C function with a PL/pgSQL shim via CREATE OR REPLACE
+//     proved unreliable (fresh backends were observed to still bind the
+//     C entry, returning false for every probe and hanging every
+//     blocking spec at max_step_wait). We point the harness at our own
+//     function `public.multigres_test_session_is_blocked` (installed by
+//     installPIDMappingFunction) with explicit arg casts so PG resolves
+//     it under extended-protocol Parse with paramTypes=NULL.
+//
+// Idempotent: source is reset via `git checkout` before patching, so
+// repeat invocations against the cached checkout produce the same
+// result.
+func (pb *PostgresBuilder) patchIsolationtester(t *testing.T, ctx context.Context) error {
+	t.Helper()
+	rel := filepath.Join("src", "test", "isolation", "isolationtester.c")
+	abs := filepath.Join(pb.SourceDir, rel)
+
+	reset := executil.Command(ctx, "git", "-C", pb.SourceDir, "checkout", "--", rel)
+	if out, err := reset.CombinedOutput(); err != nil {
+		return fmt.Errorf("reset %s: %w\n%s", rel, err, out)
+	}
+
+	src, err := os.ReadFile(abs)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", abs, err)
+	}
+
+	appNameOrig := "\t\tres = PQexecParams(conns[i].conn,\n" +
+		"\t\t\t\t\t\t   \"SELECT set_config('application_name',\\n\"\n" +
+		"\t\t\t\t\t\t   \"  current_setting('application_name') || '/' || $1,\\n\"\n" +
+		"\t\t\t\t\t\t   \"  false)\",\n" +
+		"\t\t\t\t\t\t   1, NULL,\n" +
+		"\t\t\t\t\t\t   &sessionname,\n" +
+		"\t\t\t\t\t\t   NULL, NULL, 0);"
+
+	appNameReplacement := "\t\t/*\n" +
+		"\t\t * multigres patch: build the application_name literal client-side\n" +
+		"\t\t * and send it via the simple protocol. The multigateway planner\n" +
+		"\t\t * rejects set_config() when the value is a non-literal expression\n" +
+		"\t\t * or bound parameter (the pooler tracks the literal value), so we\n" +
+		"\t\t * cannot use PQexecParams + current_setting() here.\n" +
+		"\t\t */\n" +
+		"\t\t{\n" +
+		"\t\t\tconst char *appname_prefix = getenv(\"PGAPPNAME\");\n" +
+		"\t\t\tchar\t   *combined;\n" +
+		"\t\t\tchar\t   *escaped;\n" +
+		"\t\t\tchar\t   *appname_query;\n" +
+		"\n" +
+		"\t\t\tif (appname_prefix == NULL)\n" +
+		"\t\t\t\tappname_prefix = \"\";\n" +
+		"\t\t\tcombined = psprintf(\"%s/%s\", appname_prefix, sessionname);\n" +
+		"\t\t\tescaped = PQescapeLiteral(conns[i].conn, combined, strlen(combined));\n" +
+		"\t\t\tfree(combined);\n" +
+		"\t\t\tif (escaped == NULL)\n" +
+		"\t\t\t{\n" +
+		"\t\t\t\tfprintf(stderr, \"PQescapeLiteral failed: %s\",\n" +
+		"\t\t\t\t\t\tPQerrorMessage(conns[i].conn));\n" +
+		"\t\t\t\texit(1);\n" +
+		"\t\t\t}\n" +
+		"\t\t\tappname_query = psprintf(\n" +
+		"\t\t\t\t\"SELECT set_config('application_name', %s, false)\", escaped);\n" +
+		"\t\t\tPQfreemem(escaped);\n" +
+		"\t\t\tres = PQexec(conns[i].conn, appname_query);\n" +
+		"\t\t\tfree(appname_query);\n" +
+		"\t\t}"
+
+	if !bytes.Contains(src, []byte(appNameOrig)) {
+		return fmt.Errorf("%s: original set_config block not found (PG version drift?)", rel)
+	}
+	patched := bytes.Replace(src, []byte(appNameOrig), []byte(appNameReplacement), 1)
+
+	// Add explicit type casts on both args. isolationtester PQprepares the
+	// wait-query with paramTypes=NULL so $1 enters parse as UNKNOWN, and the
+	// '{...}' literal is also UNKNOWN. PG resolves this for the pg_catalog
+	// C builtin via implicit catalog priority but fails for a public
+	// PL/pgSQL function with "function public.X(unknown, unknown) does not
+	// exist". Casting to int4 / int4[] removes the ambiguity.
+	waitFnOrig := "\"SELECT pg_catalog.pg_isolation_test_session_is_blocked($1, '{\""
+	waitFnReplacement := "\"SELECT public.multigres_test_session_is_blocked($1::int4, '{\""
+	if !bytes.Contains(patched, []byte(waitFnOrig)) {
+		return fmt.Errorf("%s: wait-query function reference not found (PG version drift?)", rel)
+	}
+	patched = bytes.Replace(patched, []byte(waitFnOrig), []byte(waitFnReplacement), 1)
+
+	waitFnSuffixOrig := "appendPQExpBufferStr(&wait_query, \"}')\");"
+	waitFnSuffixReplacement := "appendPQExpBufferStr(&wait_query, \"}'::int4[])\");"
+	if !bytes.Contains(patched, []byte(waitFnSuffixOrig)) {
+		return fmt.Errorf("%s: wait-query suffix not found (PG version drift?)", rel)
+	}
+	patched = bytes.Replace(patched, []byte(waitFnSuffixOrig), []byte(waitFnSuffixReplacement), 1)
+
+	if err := os.WriteFile(abs, patched, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", abs, err)
+	}
+	t.Logf("Patched %s: literal application_name + public.multigres_test_session_is_blocked", rel)
+	return nil
+}
+
+// BuildIsolation builds the PostgreSQL isolation test tools (isolationtester and
+// pg_isolation_regress). Must be called after Build().
+func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) error {
+	t.Helper()
+
+	if err := pb.patchIsolationtester(t, ctx); err != nil {
+		return fmt.Errorf("patch isolationtester: %w", err)
+	}
+
+	isolationDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")
+
+	t.Logf("Building isolation test tools in %s...", isolationDir)
+	cmd := executil.Command(ctx, "make", "-C", isolationDir, "all")
+	cmd.Cmd.Stdout = os.Stdout
+	cmd.Cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("make isolation tools failed: %w", err)
+	}
+
+	t.Logf("Isolation test tools built successfully")
+	return nil
+}
+
+// installPIDMappingFunction creates public.multigres_test_session_is_blocked
+// in the target database so the patched isolationtester (see
+// patchIsolationtester) can probe lock waits through the multigateway →
+// multipooler → PostgreSQL hop.
+//
+// Multipooler is configured with --database=postgres and routes every
+// query to a pooled connection against the postgres DB regardless of the
+// dbname in the client startup packet, so the shim must live in postgres.
+// Both isolation invocation paths (selective via PGISOLATION_TESTS and
+// full-suite via the make installcheck target) force --dbname=postgres on
+// pg_isolation_regress, so postgres is also the dbname the harness opens.
+//
+// The shim mirrors the upstream builtin: returns true if check_pid is
+// waiting on any pid in blocked_by, considering both heavyweight lock
+// waits (pg_blocking_pids) and SSI safe-snapshot waits
+// (pg_safe_snapshot_blocking_pids — required for SERIALIZABLE READ ONLY
+// DEFERRABLE specs such as read-only-anomaly-3). Both inputs are
+// multigateway virtual pids; we map them to real PostgreSQL backend pids
+// via pg_stat_activity.application_name (the multipooler stamps each
+// backend with `multigres_vpid:<id>` per query). A given vpid can map to
+// multiple PG backends in flight (a leftover stamp on a pool conn after
+// a regular query, plus the live reserved conn) so the wait-check
+// aggregates over every matching backend rather than picking one
+// non-deterministically.
+func (pb *PostgresBuilder) installPIDMappingFunction(t *testing.T, pgPort int, password string) error {
+	t.Helper()
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		pgPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	stmts := []string{
+		// Debug table: every shim invocation logs its inputs/outputs and a
+		// snapshot of every backend in this DB so failures can be diagnosed
+		// post-hoc by querying isolation_debug_log (see
+		// dumpIsolationDebugLog).
+		`CREATE TABLE IF NOT EXISTS public.isolation_debug_log (
+			id serial PRIMARY KEY,
+			ts timestamptz DEFAULT now(),
+			check_pid int4,
+			blocked_by int4[],
+			real_check_pid int4,
+			real_blocked_by int4[],
+			blocking_pids int4[],
+			vpid_entries text[],
+			all_pg_backends text[],
+			result boolean
+		)`,
+		// Non-destructive add for runs against a pre-existing table from an
+		// earlier shim version that lacked all_pg_backends.
+		`ALTER TABLE public.isolation_debug_log
+		   ADD COLUMN IF NOT EXISTS all_pg_backends text[]`,
+		`TRUNCATE public.isolation_debug_log`,
+		`DROP FUNCTION IF EXISTS public.multigres_test_session_is_blocked(int4, int4[])`,
+		`CREATE FUNCTION public.multigres_test_session_is_blocked(check_pid int4, blocked_by int4[])
+RETURNS boolean
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+<<fn>>
+DECLARE
+    v_log_id int4;
+    v_real_check_pid int4;
+    v_real_blocked_by int4[];
+    v_blocking_pids int4[];
+    v_vpid_entries text[];
+    v_all_backends text[];
+    v_stamp_found boolean;
+    v_result boolean;
+BEGIN
+    -- Capture the inserted id directly so the later UPDATE targets THIS
+    -- invocation's row even under concurrent shim calls (parallel groups
+    -- in the isolation schedule, or multiple sessions polling at once).
+    -- max(id) would race against any concurrent INSERT in between.
+    INSERT INTO public.isolation_debug_log
+        (check_pid, blocked_by, result)
+    VALUES
+        (check_pid, blocked_by, NULL)
+    RETURNING id INTO v_log_id;
+
+    SELECT array_agg(sa.application_name || '=' || sa.pid)
+    INTO v_vpid_entries
+    FROM pg_stat_activity sa
+    WHERE sa.application_name LIKE 'multigres_vpid:%';
+
+    SELECT array_agg(sa.pid || ':' || COALESCE(sa.application_name,'<null>') || ':' || COALESCE(sa.state,'<null>'))
+    INTO v_all_backends
+    FROM pg_stat_activity sa
+    WHERE sa.datname = current_database();
+
+    -- A client vpid can map to multiple PG backends (a leftover stamp on
+    -- a pool conn after the client ran a regular query, plus the live
+    -- reserved conn). Picking one non-deterministically risks probing the
+    -- idle one and missing the wait. real_check_pid is kept for
+    -- diagnostic display only; the actual block check below aggregates
+    -- over every matching backend.
+    SELECT sa.pid INTO v_real_check_pid
+    FROM pg_stat_activity sa
+    WHERE sa.application_name = 'multigres_vpid:' || check_pid
+    LIMIT 1;
+
+    SELECT array_agg(sa.pid) INTO v_real_blocked_by
+    FROM pg_stat_activity sa
+    WHERE sa.application_name = ANY(
+        SELECT 'multigres_vpid:' || unnest(blocked_by)
+    );
+
+    -- Direct connections (no multigateway) hand us real pids; preserve them.
+    v_stamp_found := v_real_check_pid IS NOT NULL;
+    v_real_check_pid := COALESCE(v_real_check_pid, check_pid);
+    v_real_blocked_by := COALESCE(v_real_blocked_by, blocked_by);
+
+    -- Aggregate heavyweight lock blockers and SSI safe-snapshot blockers
+    -- across every PG backend currently stamped for this vpid. SSI
+    -- safe-snapshot wait is required for SERIALIZABLE READ ONLY
+    -- DEFERRABLE specs (e.g. read-only-anomaly-3). Aggregation handles
+    -- the duplicate-stamp case where one backend is the live reserved
+    -- conn (potentially blocked) and another is a leaked pool conn
+    -- (idle).
+    --
+    -- The direct-pid fallback only fires when no stamp was found for
+    -- check_pid. vpids occupy the full 31-bit signed int32 space, so a
+    -- vpid value can coincidentally equal an unrelated real PG backend
+    -- PID; probing check_pid as a real pid unconditionally would surface
+    -- that unrelated backend's blockers and risk a false positive.
+    SELECT COALESCE(array_agg(DISTINCT b), '{}'::int4[]) INTO v_blocking_pids
+    FROM (
+        SELECT unnest(pg_blocking_pids(sa.pid)) AS b
+        FROM pg_stat_activity sa
+        WHERE sa.application_name = 'multigres_vpid:' || check_pid
+        UNION ALL
+        SELECT unnest(pg_safe_snapshot_blocking_pids(sa.pid)) AS b
+        FROM pg_stat_activity sa
+        WHERE sa.application_name = 'multigres_vpid:' || check_pid
+        UNION ALL
+        SELECT unnest(pg_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
+        UNION ALL
+        SELECT unnest(pg_safe_snapshot_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
+    ) sub
+    WHERE b IS NOT NULL;
+
+    v_result := v_blocking_pids && v_real_blocked_by;
+
+    UPDATE public.isolation_debug_log
+    SET real_check_pid = v_real_check_pid,
+        real_blocked_by = v_real_blocked_by,
+        blocking_pids = v_blocking_pids,
+        vpid_entries = v_vpid_entries,
+        all_pg_backends = v_all_backends,
+        result = v_result
+    WHERE id = v_log_id;
+
+    RETURN v_result;
+END fn;
+$$`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("failed to execute statement [%s]: %w", truncateForLog(stmt, 80), err)
+		}
+	}
+
+	// Sanity check: the function exists and is plpgsql.
+	var lang string
+	if err := db.QueryRow(`
+		SELECT l.lanname
+		FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid
+		WHERE p.proname = 'multigres_test_session_is_blocked'
+		  AND p.pronamespace = 'public'::regnamespace`).Scan(&lang); err != nil {
+		return fmt.Errorf("verify multigres_test_session_is_blocked: %w", err)
+	}
+	if lang != "plpgsql" {
+		return fmt.Errorf("multigres_test_session_is_blocked installed with lanname=%q (expected plpgsql)", lang)
+	}
+
+	t.Logf("Installed public.multigres_test_session_is_blocked on database \"postgres\"")
+	return nil
+}
+
+// dumpIsolationDebugLog prints recent entries from
+// public.isolation_debug_log so investigators can see the inputs/outputs
+// of every shim invocation during the isolation run. Best-effort;
+// failures are logged and ignored.
+func (pb *PostgresBuilder) dumpIsolationDebugLog(t *testing.T, pgPort int, password string) {
+	t.Helper()
+	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
+		pgPort, password)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		t.Logf("isolation_debug_log dump: connect failed: %v", err)
+		return
+	}
+	defer db.Close()
+
+	var total int
+	if err := db.QueryRow(`SELECT count(*) FROM public.isolation_debug_log WHERE check_pid > 0`).Scan(&total); err != nil {
+		t.Logf("isolation_debug_log dump: count failed: %v", err)
+		return
+	}
+	t.Logf("isolation_debug_log: %d shim invocations recorded during run", total)
+	if total == 0 {
+		t.Logf("isolation_debug_log: shim never executed — wait-query is not reaching public.multigres_test_session_is_blocked")
+		return
+	}
+
+	rows, err := db.Query(`
+		SELECT id, check_pid, blocked_by, real_check_pid, real_blocked_by,
+		       blocking_pids, vpid_entries, all_pg_backends, result
+		FROM public.isolation_debug_log
+		WHERE check_pid > 0
+		ORDER BY id DESC
+		LIMIT 30`)
+	if err != nil {
+		t.Logf("isolation_debug_log dump: select failed: %v", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, checkPid int
+		var blockedBy, realBlockedBy, blockingPids, vpidEntries, allBackends sql.NullString
+		var realCheckPid sql.NullInt32
+		var result sql.NullBool
+		if err := rows.Scan(&id, &checkPid, &blockedBy, &realCheckPid, &realBlockedBy, &blockingPids, &vpidEntries, &allBackends, &result); err != nil {
+			t.Logf("isolation_debug_log dump: scan failed: %v", err)
+			continue
+		}
+		t.Logf("isolation_debug_log id=%d check_pid=%d blocked_by=%s real_check=%v real_blocked=%s blocking=%s vpids=%s all=%s result=%v",
+			id, checkPid, blockedBy.String, realCheckPid, realBlockedBy.String, blockingPids.String, vpidEntries.String, allBackends.String, result)
+	}
+}
+
+// RunIsolationTests runs PostgreSQL isolation tests against multigateway.
+// Isolation tests exercise multi-connection concurrency (deadlocks, serialization
+// anomalies, lock contention, concurrent DDL) using isolationtester.
+//
+// directPgPort is the primary's direct PostgreSQL port; it's used to install
+// the public.multigres_test_session_is_blocked shim that the patched
+// isolationtester binary calls (see patchIsolationtester for the source-side
+// rewrite that retargets the wait query at the public function).
+//
+// The isolation Makefile has no installcheck-tests target, so for selective tests
+// we invoke pg_isolation_regress directly with test names as positional args.
+func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d (harness db=postgres)...", multigatewayPort)
+
+	// Install the lock-detection shim on PostgreSQL directly (bypassing
+	// multigateway). Both the selective (PGISOLATION_TESTS) and full-suite
+	// paths force --dbname=postgres on pg_isolation_regress (see the cmd
+	// construction below), and multipooler routes every query to the
+	// postgres DB anyway, so the shim only needs to live there.
+	if err := pb.installPIDMappingFunction(t, directPgPort, password); err != nil {
+		t.Logf("Warning: Failed to install PID mapping function: %v", err)
+		t.Logf("Isolation tests that rely on lock detection (deadlock, etc.) may fail")
+	}
+
+	isolationBuildDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")
+	isolationSourceDir := filepath.Join(pb.SourceDir, "src", "test", "isolation")
+	outputIsoDir := filepath.Join(isolationBuildDir, "output_iso")
+
+	if err := os.MkdirAll(outputIsoDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create output_iso directory: %w", err)
+	}
+
+	pgIsoRegress := filepath.Join(isolationBuildDir, "pg_isolation_regress")
+	if _, err := os.Stat(pgIsoRegress); os.IsNotExist(err) {
+		t.Logf("Building pg_isolation_regress...")
+		buildCmd := executil.Command(ctx, "make", "-C", isolationBuildDir, "all")
+		if out, err := buildCmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to build pg_isolation_regress: %w\n%s", err, out)
+		}
+	}
+
+	var cmd *executil.Cmd
+	if testsEnv := os.Getenv("PGISOLATION_TESTS"); testsEnv != "" {
+		args := []string{
+			"--inputdir=" + isolationSourceDir,
+			"--outputdir=" + outputIsoDir,
+			"--host=localhost",
+			fmt.Sprintf("--port=%d", multigatewayPort),
+			"--user=postgres",
+			"--dbname=postgres",
+			"--use-existing",
+			"--dlpath=" + isolationBuildDir,
+		}
+		args = append(args, strings.Fields(testsEnv)...)
+		cmd = executil.Command(ctx, pgIsoRegress, args...).WithProcessGroup()
+		t.Logf("Running selective isolation tests: %s", testsEnv)
+	} else {
+		cmd = executil.Command(ctx, "make", "-C", isolationBuildDir, "installcheck",
+			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
+		t.Logf("Running full PostgreSQL isolation test suite (installcheck)")
+	}
+
+	results, runErr := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+		suiteName: "Isolation",
+		outputDir: filepath.Join(pb.OutputDir, "isolation"),
+		srcOutDir: outputIsoDir,
+	}, multigatewayPort, password)
+
+	// Post-suite diagnostic: dump the last entries of isolation_debug_log
+	// so investigators can see what the shim observed (or didn't) for
+	// hung specs. The table lives in the postgres DB on the primary;
+	// query it directly to bypass any multigateway routing that a
+	// failing wait-query would have used.
+	pb.dumpIsolationDebugLog(t, directPgPort, password)
+
+	return results, runErr
+}

--- a/go/test/endtoend/pgregresstest/pg_regress.go
+++ b/go/test/endtoend/pgregresstest/pg_regress.go
@@ -1,0 +1,572 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// RunRegressionTests runs PostgreSQL regression tests against multigateway.
+//
+// Uses make installcheck-tests with TESTS variable to run specific regression tests
+// against the existing PostgreSQL server (multigateway).
+//
+// The installcheck-tests target runs specific tests against an already-running
+// PostgreSQL server, unlike installcheck which runs the entire parallel_schedule.
+//
+// From PostgreSQL's src/test/regress/GNUmakefile:
+//
+//	installcheck: runs --schedule=parallel_schedule (all tests)
+//	installcheck-tests: runs $(TESTS) (specific tests only)
+//
+// Environment variables that pg_regress reads:
+//
+//	PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE - connection params
+//
+// Reference: https://github.com/postgres/postgres/blob/master/src/test/regress/GNUmakefile
+func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context, multigatewayPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	t.Logf("Running PostgreSQL regression tests against multigateway on port %d...", multigatewayPort)
+
+	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
+	makeArgs := []string{"-C", regressDir}
+
+	// --use-existing: skip pg_regress's automatic DROP + CREATE of the
+	// "regression" database. Multigateway rejects DROP DATABASE (see the
+	// unsafe-statement list in go/services/multigateway/planner/unsafe_stmt.go),
+	// so we can't let pg_regress manage the database. Instead we run against
+	// the existing "postgres" database for the whole suite.
+	//
+	// --dbname=postgres: point pg_regress at that existing database. pg_regress
+	// will create/drop the expected schema objects per test; cross-test state
+	// leakage is still possible but has not surfaced in practice.
+	makeArgs = append(makeArgs, "EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres")
+
+	if testsEnv := os.Getenv("PGREGRESS_TESTS"); testsEnv != "" {
+		makeArgs = append(makeArgs, "installcheck-tests", "TESTS="+testsEnv)
+		t.Logf("Running selective regression tests: %s", testsEnv)
+	} else {
+		makeArgs = append(makeArgs, "installcheck")
+		t.Logf("Running full PostgreSQL regression test suite (installcheck)")
+	}
+
+	cmd := executil.Command(ctx, "make", makeArgs...).WithProcessGroup()
+
+	return pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+		suiteName: "Regression",
+		outputDir: pb.OutputDir,
+		srcOutDir: regressDir,
+	}, multigatewayPort, password)
+}
+
+// DefaultContribModules is the core-contrib extension test set run through
+// multigateway by default. Each entry is a directory under contrib/ whose
+// sql/ + expected/ fixtures pg_regress drives via the module's installcheck
+// target.
+//
+// It is derived from ExtensionCatalog (every StatusCovered entry), which is the
+// single source of truth for coverage state and the rationale behind each
+// extension's status (covered / pending / unsupported / external). uuid-ossp
+// and pgcrypto need extra ./configure features enabled by the harness when the
+// contrib suite runs (--with-uuid and --with-ssl=openssl; see
+// TestPostgreSQLRegression). See extensions.go.
+var DefaultContribModules = CoveredContribModules()
+
+// ContribModules returns the contrib module directories to test. PGCONTRIB_TESTS
+// (space-separated directory names) overrides the default set when set.
+func ContribModules() []string {
+	if v := os.Getenv("PGCONTRIB_TESTS"); v != "" {
+		return strings.Fields(v)
+	}
+	return DefaultContribModules
+}
+
+// RunContribTests runs each contrib module's installcheck suite against
+// multigateway and returns one merged TestResults across all modules.
+//
+// Each module is a separate pg_regress invocation (make -C contrib/<mod>
+// installcheck). As with the core regression suite we pass
+// --use-existing --dbname=postgres because multigateway rejects DROP/CREATE
+// DATABASE. Per-test names are prefixed with the module directory
+// ("citext/citext") so they stay unique in the merged report.
+//
+// All modules share the single postgres database (multigateway can't isolate
+// per-DB), so before each module we reset the public schema directly on the
+// primary (directPgPort) to clear objects/extensions a previous module left
+// behind — otherwise a module's CREATE TYPE/EXTENSION collides with leftovers
+// and its expected output diverges. The reset bypasses multigateway because
+// the gateway rejects schema DDL; the standby picks it up via WAL.
+//
+// A module that produces no parseable output (e.g. a module with no REGRESS
+// tests) is logged and skipped — one module must not abort the rest of the set.
+func (pb *PostgresBuilder) RunContribTests(t *testing.T, ctx context.Context, modules []string, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	// contrib installcheck targets invoke $(top_builddir)/src/test/regress/pg_regress.
+	// Build it up front so a contrib-only run (RUN_PGCONTRIB without RUN_PGREGRESS)
+	// does not fail for a missing pg_regress binary.
+	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
+	if out, err := executil.Command(ctx, "make", "-C", regressDir, "all").CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to build pg_regress: %w\n%s", err, truncateForLog(string(out), 2000))
+	}
+
+	merged := &TestResults{
+		FailureDetails: []TestFailure{},
+		Tests:          []IndividualTestResult{},
+	}
+
+	// Replace pg_regress's strict text diff with the patch-based pipeline, which
+	// whitespace-normalizes both sides (so error-cursor caret-position shifts
+	// from multigateway query rewriting are not diffs) and applies per-test
+	// patches for genuine multigres-specific output differences.
+	mode := GetPatchMode()
+
+	for _, mod := range modules {
+		moduleDir := filepath.Join(pb.BuildDir, "contrib", mod)
+		if !suiteutil.FileExists(filepath.Join(moduleDir, "Makefile")) {
+			t.Logf("contrib/%s: no Makefile in build tree, skipping", mod)
+			continue
+		}
+
+		// Clean slate for this module: drop anything a prior module left in
+		// public. Best-effort — log and proceed if it fails, since the run is
+		// still useful (the failure will show up as a diff).
+		if err := resetContribState(directPgPort, password); err != nil {
+			t.Logf("contrib/%s: warning: public schema reset failed: %v", mod, err)
+		}
+
+		t.Logf("Running contrib/%s installcheck against multigateway...", mod)
+		cmd := executil.Command(ctx, "make", "-C", moduleDir, "installcheck",
+			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
+
+		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+			suiteName: "Contrib/" + mod,
+			outputDir: filepath.Join(pb.OutputDir, "contrib", mod),
+			srcOutDir: moduleDir,
+		}, multigatewayPort, password)
+		if res == nil {
+			// No TAP output: module has no REGRESS tests or the harness failed
+			// to execute. Log and continue so one module can't abort the set.
+			t.Logf("contrib/%s: no test results (%v)", mod, err)
+			continue
+		}
+
+		// Re-evaluate each test's verdict via the patch pipeline (bare names,
+		// before the module prefix is applied below).
+		pb.verifyContribModule(ctx, mod, res, mode)
+
+		for _, tr := range res.Tests {
+			tr.Name = mod + "/" + tr.Name
+			merged.Tests = append(merged.Tests, tr)
+			switch tr.Status {
+			case "fail":
+				merged.FailedTests++
+				detail := tr.FailReason
+				if detail == "" {
+					detail = "see contrib/" + mod + "/regression.diffs"
+				}
+				merged.FailureDetails = append(merged.FailureDetails, TestFailure{
+					TestName: tr.Name,
+					Error:    detail,
+				})
+			case "skip":
+				merged.SkippedTests++
+			default:
+				merged.PassedTests++
+			}
+		}
+		merged.TimedOut = merged.TimedOut || res.TimedOut
+	}
+
+	merged.TotalTests = merged.PassedTests + merged.FailedTests + merged.SkippedTests
+	return merged, nil
+}
+
+// listRegressTests returns the regression test names for an external extension,
+// derived from the .sql files under <testDir>/sql. This mirrors the PGXS
+// convention REGRESS = $(patsubst test/sql/%.sql,%,$(wildcard test/sql/*.sql)).
+// Names are sorted so the run order is deterministic and matches make's sorted
+// $(wildcard).
+func listRegressTests(testDir string) []string {
+	matches, err := filepath.Glob(filepath.Join(testDir, "sql", "*.sql"))
+	if err != nil {
+		return nil
+	}
+	sort.Strings(matches)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, strings.TrimSuffix(filepath.Base(m), ".sql"))
+	}
+	return names
+}
+
+// runExternalRegress runs one external extension's shipped pg_regress suite
+// against multigateway (the pgvector/pg_cron model) and re-evaluates each test
+// through the patch pipeline. Returns nil when the checkout has no sql/ fixtures.
+//
+// Unlike contrib we cannot use `make installcheck`: under PGXS that target runs
+// $(top_builddir)/src/test/regress/pg_regress, and PGXS resolves top_builddir
+// into the install tree, where pg_regress is not installed. We instead invoke
+// the pg_regress we built directly, passing the same flags the contrib suite
+// relies on (--use-existing --dbname=postgres, because multigateway rejects
+// DROP/CREATE DATABASE) plus the extension's --inputdir. Fixtures that assume the
+// extension exists are preloaded via PreCreateExtensions, since --use-existing
+// skips pg_regress's own --load-extension step.
+func (pb *PostgresBuilder) runExternalRegress(t *testing.T, ctx context.Context, ext ExternalExtension, cloneDir, testDir, pgBinDir string, multigatewayPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	if !suiteutil.FileExists(filepath.Join(testDir, "sql")) {
+		t.Logf("external/%s: no %s/sql in checkout, skipping", ext.Name, ext.TestSubdir)
+		return nil, nil
+	}
+	tests := listRegressTests(testDir)
+	if len(tests) == 0 {
+		t.Logf("external/%s: no .sql tests found, skipping", ext.Name)
+		return nil, nil
+	}
+
+	// Load the extension's fixtures through multigateway before the suite, the way
+	// its own runner does (pg_graphql's bin/installcheck runs `psql -f
+	// test/fixtures.sql` first; those fixtures CREATE the extension and set its
+	// schema config). Same pooled path the test queries take.
+	if ext.FixturesFile != "" {
+		fixturesPath := filepath.Join(testDir, ext.FixturesFile)
+		if err := loadFixturesViaGateway(ctx, filepath.Join(pgBinDir, "psql"), fixturesPath, multigatewayPort, password); err != nil {
+			t.Logf("external/%s: warning: load fixtures %q failed: %v", ext.Name, ext.FixturesFile, err)
+		}
+	}
+
+	// Preload extensions whose fixtures assume they already exist (pgvector's
+	// fixtures open with a bare CREATE TABLE ... vector(3) and never CREATE
+	// EXTENSION). Extensions whose fixtures manage the extension themselves (pg_cron
+	// CREATEs it as their first statement) leave PreCreateExtensions empty so we
+	// don't collide with that. resetContribState clears these (all in public) before
+	// the next extension, so no teardown is needed here.
+	for _, e := range ext.PreCreateExtensions {
+		if err := createExtensionWithSchema(multigatewayPort, password, e.Name, e.Schema); err != nil {
+			t.Logf("external/%s: warning: CREATE EXTENSION %s failed: %v", ext.Name, e.Name, err)
+		}
+	}
+
+	t.Logf("Running external/%s pg_regress (%d tests) against multigateway...", ext.Name, len(tests))
+	pgRegress := filepath.Join(pb.BuildDir, "src", "test", "regress", "pg_regress")
+	args := []string{
+		"--inputdir=" + testDir,
+		"--outputdir=" + cloneDir,
+		"--bindir=" + pgBinDir,
+		"--use-existing",
+		"--dbname=postgres",
+	}
+	args = append(args, tests...)
+	// Run from the clone root so psql's client-side \copy resolves the relative
+	// paths the fixtures use (e.g. pgvector's copy test does \copy t TO
+	// 'results/vector.bin'); pg_regress writes its results/ dir under
+	// --outputdir=cloneDir, which is this same directory.
+	cmd := executil.Command(ctx, pgRegress, args...).WithProcessGroup().SetDir(cloneDir)
+
+	res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
+		suiteName: "External/" + ext.Name,
+		outputDir: filepath.Join(pb.OutputDir, "external", ext.Name),
+		srcOutDir: cloneDir,
+	}, multigatewayPort, password)
+	if res == nil {
+		return nil, err
+	}
+
+	// Re-evaluate each test via the patch pipeline. pg_regress wrote results to
+	// <cloneDir>/results (--outputdir); expected lives in <testDir>/expected, and
+	// patches are per-extension under patches/external/<ext>.
+	patchDir := filepath.Join(PatchesDir(), "external", ext.Name)
+	pb.verifyModuleResults(ctx, testDir, filepath.Join(cloneDir, "results"), patchDir, res, GetPatchMode())
+	return res, err
+}
+
+// verifyContribModule re-evaluates each test in a contrib module's results
+// using the patch-based pipeline (see patch_verify.go), replacing pg_regress's
+// strict text verdict. Expected output lives in the source tree
+// (contrib/<mod>/expected); actual output is written by pg_regress into the
+// build tree (contrib/<mod>/results). Patches are per-module
+// (testdata/pg<major>/patches/contrib/<mod>/<test>.patch) so test names that
+// collide across modules (e.g. "init") do not clash.
+//
+// res.Tests carry bare test names here (the module prefix is applied by the
+// caller afterwards). Statuses are updated in place.
+func (pb *PostgresBuilder) verifyContribModule(ctx context.Context, mod string, res *TestResults, mode PatchMode) {
+	moduleSrcDir := filepath.Join(pb.SourceDir, "contrib", mod)
+	moduleResultsDir := filepath.Join(pb.BuildDir, "contrib", mod, "results")
+	patchDir := filepath.Join(PatchesDir(), "contrib", mod)
+	pb.verifyModuleResults(ctx, moduleSrcDir, moduleResultsDir, patchDir, res, mode)
+}
+
+// verifyModuleResults is the shared per-test verification loop behind both the
+// contrib and external suites. expectedDir is the directory whose expected/
+// subdirectory holds the upstream .out files (and numbered variants); resultsDir
+// holds the .out files pg_regress wrote for this run; patchDir holds the
+// per-test patches for genuine multigres-specific differences. Statuses in
+// res.Tests are updated in place; skipped tests are left untouched.
+func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir, resultsDir, patchDir string, res *TestResults, mode PatchMode) {
+	repoRoot := findRepoRoot()
+
+	for i := range res.Tests {
+		test := &res.Tests[i]
+		if test.Status == "skip" {
+			continue
+		}
+
+		// PostgreSQL ships alternate expected files (name_1.out, name_2.out, …)
+		// for output that legitimately varies by platform/build — e.g.
+		// citext_utf8_1.out for a C-locale run, or pgcrypto blowfish_1.out for an
+		// OpenSSL build without the legacy cipher provider. pg_regress passes if
+		// actual matches ANY variant; mirror that here before falling back to
+		// patch-based verification, otherwise a canonical-only comparison
+		// manufactures diffs that aren't multigres behavior at all.
+		variants := expectedVariants(expectedDir, test.Name)
+		actPath := filepath.Join(resultsDir, test.Name+".out")
+		if len(variants) == 0 || !suiteutil.FileExists(actPath) {
+			// Test didn't run or expected missing; keep the TAP verdict.
+			test.FailReason = "expected or actual output missing; kept TAP verdict"
+			continue
+		}
+
+		if actualMatchesAnyVariant(actPath, variants) {
+			test.Status = "pass"
+			test.PatchApplied = false
+			test.PatchPath = ""
+			test.FailReason = ""
+			// A patch is unnecessary once a stock variant matches; drop a stale one.
+			if mode == PatchModeGenerate {
+				_ = os.Remove(filepath.Join(patchDir, test.Name+".patch"))
+			}
+			continue
+		}
+
+		// No variant matches: apply (verify) or write (generate) a patch against
+		// the canonical expected file for genuine multigres-specific differences.
+		outcome, err := VerifyTest(ctx, VerifyInput{
+			Name:         test.Name,
+			ExpectedPath: variants[0],
+			ActualPath:   actPath,
+			PatchDir:     patchDir,
+			RepoRoot:     repoRoot,
+		}, mode)
+		if err != nil {
+			test.Status = "fail"
+			test.FailReason = err.Error()
+			continue
+		}
+
+		test.Status = outcome.Status
+		test.PatchApplied = outcome.PatchApplied
+		test.PatchPath = outcome.PatchPath
+		test.FailReason = outcome.Reason
+	}
+}
+
+// expectedVariants returns the expected-output files pg_regress would accept for
+// a test: the canonical <name>.out first, then numbered variants
+// <name>_1.out … <name>_9.out that exist. Mirrors findExpectedFile's search but
+// returns every match rather than only the first.
+func expectedVariants(regressDir, name string) []string {
+	var out []string
+	canonical := filepath.Join(regressDir, "expected", name+".out")
+	if suiteutil.FileExists(canonical) {
+		out = append(out, canonical)
+	}
+	for i := 1; i < 10; i++ {
+		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
+		if suiteutil.FileExists(p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// actualMatchesAnyVariant reports whether the actual output equals any expected
+// variant after whitespace normalization (the same canonicalization the patch
+// pipeline uses, so error-cursor caret shifts are not treated as differences).
+func actualMatchesAnyVariant(actPath string, variants []string) bool {
+	actRaw, err := os.ReadFile(actPath)
+	if err != nil {
+		return false
+	}
+	act := normalizeWhitespace(actRaw)
+	for _, v := range variants {
+		expRaw, err := os.ReadFile(v)
+		if err != nil {
+			continue
+		}
+		if bytes.Equal(normalizeWhitespace(expRaw), act) {
+			return true
+		}
+	}
+	return false
+}
+
+// findExpectedFile locates the expected-output file pg_regress would use for
+// the given test name. PostgreSQL ships variant files (name_1.out, name_2.out,
+// …) for platform-dependent output. We try the canonical name first, then
+// numbered variants in order. Returns the empty string if none exist.
+func findExpectedFile(regressDir, name string) string {
+	canonical := filepath.Join(regressDir, "expected", name+".out")
+	if suiteutil.FileExists(canonical) {
+		return canonical
+	}
+	for i := 1; i < 10; i++ {
+		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
+		if suiteutil.FileExists(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// VerifyWithPatches re-evaluates each test's pass/fail status using the
+// patch-based pipeline (see patch_verify.go). After pg_regress runs, this
+// ignores pg_regress's own pass/fail verdict (which is a strict text diff)
+// and replaces it with: does the actual output match the (patched) expected
+// output? Results are updated in-place, including aggregate counters.
+//
+// In generate mode, any residual diffs are absorbed by (re)writing patches.
+//
+// Expected output lives in the source tree (prep_buildtree does not symlink
+// .out files into the build tree). Actual output is written by pg_regress
+// into the build tree's results/ directory.
+func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, results *TestResults, buildRegressDir, outputDir string) error {
+	t.Helper()
+	mode := GetPatchMode()
+	patchDir := PatchesDir()
+	repoRoot := findRepoRoot()
+	sourceRegressDir := filepath.Join(pb.SourceDir, "src", "test", "regress")
+
+	// Ensure patch dir exists in generate mode so writes don't fail.
+	if mode == PatchModeGenerate {
+		if err := os.MkdirAll(patchDir, 0o755); err != nil {
+			return fmt.Errorf("mkdir patches: %w", err)
+		}
+	}
+
+	t.Logf("Patch-based verification: mode=%s patches=%s", mode, patchDir)
+	t.Logf("  expected source: %s", sourceRegressDir)
+	t.Logf("  actual source:   %s", buildRegressDir)
+
+	// Per-test residual diffs are written under outputDir/diffs/ for inclusion
+	// in the CI artifact. Concatenated failures.diffs is written at the end.
+	diffsDir := ""
+	if outputDir != "" {
+		diffsDir = filepath.Join(outputDir, "diffs")
+	}
+	var aggregated bytes.Buffer
+
+	// Recompute aggregates from the per-test results after verification.
+	// We intentionally discard pg_regress's TAP-derived aggregates because
+	// patch-based verification is authoritative.
+	var passed, failed int
+	failures := results.FailureDetails[:0]
+
+	for i := range results.Tests {
+		test := &results.Tests[i]
+		if test.Status == "skip" {
+			// Leave skipped tests alone.
+			continue
+		}
+
+		expPath := findExpectedFile(sourceRegressDir, test.Name)
+		actPath := filepath.Join(buildRegressDir, "results", test.Name+".out")
+		if expPath == "" || !suiteutil.FileExists(actPath) {
+			// Infrastructure problem (test didn't run, expected missing).
+			// Preserve TAP verdict, count accordingly.
+			test.FailReason = "expected or actual output missing; kept TAP verdict"
+			if test.Status == "pass" {
+				passed++
+			} else {
+				failed++
+				failures = append(failures, TestFailure{
+					TestName: test.Name,
+					Error:    test.FailReason,
+				})
+			}
+			continue
+		}
+
+		outcome, err := VerifyTest(ctx, VerifyInput{
+			Name:         test.Name,
+			ExpectedPath: expPath,
+			ActualPath:   actPath,
+			PatchDir:     patchDir,
+			RepoRoot:     repoRoot,
+		}, mode)
+		if err != nil {
+			return fmt.Errorf("verify %s: %w", test.Name, err)
+		}
+
+		test.Status = outcome.Status
+		test.PatchApplied = outcome.PatchApplied
+		test.PatchPath = outcome.PatchPath
+		test.FailReason = outcome.Reason
+
+		if outcome.Status == "pass" {
+			passed++
+			continue
+		}
+		failed++
+		failures = append(failures, TestFailure{
+			TestName: test.Name,
+			Error:    outcome.Reason,
+		})
+
+		if outcome.Diff == "" || diffsDir == "" {
+			continue
+		}
+		if err := os.MkdirAll(diffsDir, 0o755); err != nil {
+			t.Logf("Warning: mkdir %s: %v", diffsDir, err)
+			continue
+		}
+		diffPath := filepath.Join(diffsDir, test.Name+".diff")
+		if err := os.WriteFile(diffPath, []byte(outcome.Diff), 0o644); err != nil {
+			t.Logf("Warning: write %s: %v", diffPath, err)
+			continue
+		}
+		fmt.Fprintf(&aggregated, "=== %s ===\n%s\n", test.Name, outcome.Diff)
+	}
+
+	if outputDir != "" && aggregated.Len() > 0 {
+		aggPath := filepath.Join(outputDir, "failures.diffs")
+		if err := os.WriteFile(aggPath, aggregated.Bytes(), 0o644); err != nil {
+			t.Logf("Warning: write %s: %v", aggPath, err)
+		} else {
+			t.Logf("Residual failure diffs: %s (per-test files in %s)", aggPath, diffsDir)
+		}
+	}
+
+	results.PassedTests = passed
+	results.FailedTests = failed
+	// Preserve SkippedTests + any pre-existing total if it exceeds ran.
+	if results.TotalTests < passed+failed+results.SkippedTests {
+		results.TotalTests = passed + failed + results.SkippedTests
+	}
+	results.FailureDetails = failures
+	return nil
+}

--- a/go/test/endtoend/pgregresstest/pg_tap.go
+++ b/go/test/endtoend/pgregresstest/pg_tap.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// runExternalPgTAP runs one external extension's pgTAP suite against multigateway.
+// Unlike the pg_regress path there are no expected-output files: each test .sql is
+// fed to psql and the TAP stream its pgTAP assertions emit server-side is parsed
+// for ok/not ok. A file passes when psql exits cleanly, no assertion reports
+// "not ok", and the number of assertions run matches the declared plan ("1..N").
+//
+// Each file is one psql process running the file's single BEGIN…ROLLBACK
+// transaction. The dependency extensions (PreCreateExtensions) are created up
+// front because the test files assume they already exist and never CREATE
+// EXTENSION themselves.
+//
+// # Why only transaction-wrapped tests are runnable
+//
+// pgTAP keeps its plan and results in SESSION-temp tables (__tcache__,
+// __tresults__) that plan() creates with `EXECUTE 'CREATE TEMP TABLE …'` *inside
+// the plan() function body*. The gateway pins ("reserves") a backend for session
+// affinity by parsing the CLIENT statement — it reserves on a visible BEGIN, or a
+// visible top-level CREATE TEMP TABLE (planner.go classifies CreateStmt with
+// RELPERSISTENCE_TEMP). It never sees DDL executed inside a function, so it does
+// not know plan() created a temp table.
+//
+// That distinction decides everything:
+//
+//   - Inside BEGIN…ROLLBACK, the visible BEGIN pins the whole file to one backend,
+//     so __tcache__ is consistent for the file, and ROLLBACK discards it. Clean.
+//   - In AUTOCOMMIT (pgTAP suites whose procedures COMMIT, so they can't be
+//     wrapped), each statement is its own transaction on an unpinned, pooled
+//     backend. plan()'s temp table is created on whatever backend served that
+//     statement and is NOT discarded on release (only *reserved* temp tables get
+//     DISCARD TEMP — and this one was never reserved, being invisible). It leaks
+//     onto the pooled backend and the next client that lands there sees a stale
+//     plan row → pgTAP raises "You tried to plan twice!".
+//
+// This is a fundamental limit of pgTAP-via-pooler, not a bug we can fix in the
+// harness: you cannot know what a procedure does to a session without executing
+// it, so the pooler can neither pin nor discard. It was confirmed empirically —
+// running the autocommit suites through the gateway produced many "plan twice"
+// failures that all vanished when the same files were run directly against
+// PostgreSQL (no pooler). So we run only the suites that wrap each test in
+// BEGIN…ROLLBACK (see ExternalExtension.TestGlobs); the rest also need
+// infrastructure the pooled path can't provide (background workers, tablespaces,
+// non-superuser roles, manual multi-stage commits).
+//
+// Returns nil when the checkout has no matching test files.
+func (pb *PostgresBuilder) runExternalPgTAP(t *testing.T, ctx context.Context, ext ExternalExtension, testDir, pgBinDir string, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
+	t.Helper()
+
+	// Run the committed TestGlobs (the union of patterns) minus ExcludeGlobs — for
+	// pg_partman the self-contained transaction-wrapped set.
+	matches, err := selectPgTAPFiles(testDir, ext.TestGlobs, ext.ExcludeGlobs)
+	if err != nil {
+		return nil, fmt.Errorf("external/%s: %w", ext.Name, err)
+	}
+	if len(matches) == 0 {
+		t.Logf("external/%s: no test files found, skipping", ext.Name)
+		return nil, nil
+	}
+
+	// pgTAP suites assume their dependencies already exist; create them in order
+	// (pgtap before pg_partman), each in its target schema, through the gateway.
+	// Best-effort — a failure here surfaces as the per-file assertions failing,
+	// which is more informative than aborting.
+	for _, e := range ext.PreCreateExtensions {
+		if err := createExtensionWithSchema(multigatewayPort, password, e.Name, e.Schema); err != nil {
+			t.Logf("external/%s: warning: CREATE EXTENSION %s failed: %v", ext.Name, e.Name, err)
+		}
+	}
+
+	outputDir := filepath.Join(pb.OutputDir, "external", ext.Name)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("external/%s: create output dir: %w", ext.Name, err)
+	}
+
+	psqlBin := filepath.Join(pgBinDir, "psql")
+	res := &TestResults{
+		FailureDetails: []TestFailure{},
+		Tests:          []IndividualTestResult{},
+	}
+
+	t.Logf("Running external/%s pgTAP suite (%d files) against multigateway...", ext.Name, len(matches))
+	for _, f := range matches {
+		// Name by path relative to the test dir so subfolder files (e.g. under
+		// test_pg17plus/) stay unique and self-describing; for the top-level set
+		// this is just the bare file stem.
+		rel, relErr := filepath.Rel(testDir, f)
+		if relErr != nil {
+			rel = filepath.Base(f)
+		}
+		name := strings.TrimSuffix(rel, ".sql")
+
+		// Drop the throwaway schemas a pg_partman test file creates, on the primary,
+		// before each file. The rolled-back tests never leave these behind, so this
+		// is normally a no-op; it keeps the run order-independent and re-runnable
+		// after a crash that left a half-applied test's schema committed.
+		cleanupPgTAPScratch(directPgPort, password)
+
+		// Drive psql the way pg_prove does: unaligned + tuples-only so each pgTAP
+		// row is a bare TAP line, no psqlrc, and stop on a genuine SQL error
+		// (assertion "not ok" rows are result data, not errors, so they don't trip
+		// ON_ERROR_STOP — only real failures abort the file).
+		args := []string{
+			"--no-psqlrc",
+			"--no-align",
+			"--quiet",
+			"--pset", "pager=off",
+			"--tuples-only",
+			"--set", "ON_ERROR_STOP=1",
+			"--file", f,
+		}
+		cmd := executil.Command(ctx, psqlBin, args...).WithProcessGroup().SetDir(testDir)
+		cmd.AddEnv(
+			"PGHOST=localhost",
+			fmt.Sprintf("PGPORT=%d", multigatewayPort),
+			"PGUSER=postgres",
+			"PGPASSWORD="+password,
+			"PGDATABASE=postgres",
+			"PGCONNECT_TIMEOUT=10",
+		)
+		cmd.SetWaitDelay(10 * time.Second)
+
+		// Assertion rows and pgTAP diagnostics arrive on stdout; NOTICE/error text
+		// goes to stderr. Parse stdout only; tee both to the terminal for visibility.
+		var tap bytes.Buffer
+		cmd.Stdout = io.MultiWriter(os.Stdout, &tap)
+		cmd.Stderr = os.Stderr
+
+		start := time.Now()
+		runErr := cmd.Run()
+		dur := time.Since(start)
+
+		// Persist the raw TAP for debugging (the pgTAP analog of regression.out).
+		// Flatten any subfolder separators in the name so the file lands directly
+		// under outputDir (a subfolder name like "test_pg17plus/foo" would otherwise
+		// need its parent dir created first).
+		tapFile := strings.ReplaceAll(name, "/", "__") + ".tap"
+		if werr := os.WriteFile(filepath.Join(outputDir, tapFile), tap.Bytes(), 0o644); werr != nil {
+			t.Logf("external/%s/%s: warning: could not save .tap output: %v", ext.Name, name, werr)
+		}
+
+		planned, passed, failed := parsePgTAPOutput(tap.String())
+
+		status, reason := "pass", ""
+		switch {
+		case ctx.Err() == context.DeadlineExceeded:
+			status, reason = "fail", "suite timed out"
+		case len(failed) > 0:
+			status, reason = "fail", summarizePgTAPFailures(failed)
+		case planned >= 0 && planned != passed:
+			status, reason = "fail", fmt.Sprintf("plan mismatch: declared %d, ran %d", planned, passed)
+		case planned < 0:
+			// No plan line means the file errored out before SELECT plan(N) — e.g.
+			// a setup statement the gateway/pooler couldn't handle.
+			reason = "no TAP plan line emitted"
+			if runErr != nil {
+				reason += fmt.Sprintf("; psql exited: %v", runErr)
+			}
+			status = "fail"
+		}
+
+		res.Tests = append(res.Tests, IndividualTestResult{
+			Name:       name,
+			Status:     status,
+			Duration:   fmt.Sprintf("%dms", dur.Milliseconds()),
+			FailReason: reason,
+		})
+		res.TimedOut = res.TimedOut || ctx.Err() == context.DeadlineExceeded
+
+		emoji := "✅"
+		if status == "fail" {
+			emoji = "❌"
+		}
+		t.Logf("  %s external/%s/%s (plan=%d ran=%d fail=%d) %v", emoji, ext.Name, name, planned, passed, len(failed), dur.Round(time.Millisecond))
+	}
+
+	// Tear down what we pre-created so the next extension's suite starts from the
+	// state its expected output assumes. resetContribState (run before each
+	// extension) only drops public, so an extension we installed into its own
+	// schema — pg_partman in `partman` — would otherwise persist and change a
+	// later suite's output: pgmq DependsOn pg_partman and its base.sql runs
+	// `CREATE EXTENSION IF NOT EXISTS pg_partman`, which would then emit an
+	// unexpected "already exists" NOTICE and diff against pgmq's base.out. Drop in
+	// reverse so dependents go before dependencies; best-effort.
+	for i := len(ext.PreCreateExtensions) - 1; i >= 0; i-- {
+		e := ext.PreCreateExtensions[i]
+		_ = execOnPrimary(directPgPort, password, fmt.Sprintf("DROP EXTENSION IF EXISTS %q CASCADE", e.Name))
+		if e.Schema != "" {
+			_ = execOnPrimary(directPgPort, password, fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", e.Schema))
+		}
+	}
+
+	return res, nil
+}
+
+// selectPgTAPFiles returns the absolute paths of the .sql files under testDir to
+// run, sorted and deduped: the union of globs (defaulting to ["*.sql"]), each
+// matched relative to testDir, minus any file whose path relative to testDir
+// matches an entry in excludes. globs and excludes use "/"-separated relative
+// patterns (e.g. "test_pg17plus/*.sql"), matched with filepath.Match.
+func selectPgTAPFiles(testDir string, globs, excludes []string) ([]string, error) {
+	seen := map[string]bool{}
+	var matches []string
+	add := func(f string) {
+		if !seen[f] {
+			seen[f] = true
+			matches = append(matches, f)
+		}
+	}
+
+	if len(globs) == 0 {
+		globs = []string{"*.sql"}
+	}
+	for _, g := range globs {
+		m, err := filepath.Glob(filepath.Join(testDir, g))
+		if err != nil {
+			return nil, fmt.Errorf("bad test glob %q: %w", g, err)
+		}
+		for _, f := range m {
+			add(f)
+		}
+	}
+
+	if len(excludes) > 0 {
+		kept := matches[:0]
+		for _, f := range matches {
+			rel, err := filepath.Rel(testDir, f)
+			if err != nil {
+				rel = filepath.Base(f)
+			}
+			drop := false
+			for _, ex := range excludes {
+				if ok, _ := filepath.Match(ex, rel); ok {
+					drop = true
+					break
+				}
+			}
+			if !drop {
+				kept = append(kept, f)
+			}
+		}
+		matches = kept
+	}
+
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// parsePgTAPOutput parses a TAP stream emitted by a pgTAP test file run through
+// psql. pgTAP prints a plan line ("1..N") and one "ok <n> - desc" / "not ok <n> -
+// desc" line per assertion (diagnostics are "#"-prefixed and ignored; non-TAP
+// command tags and result rows don't match the ok/not-ok prefixes). Returns the
+// declared plan count (-1 when absent), the number of passing assertions, and the
+// descriptions of the failing ones. "not ok" is checked before "ok" so a failing
+// assertion is never miscounted as a pass.
+func parsePgTAPOutput(output string) (planned, passed int, failed []string) {
+	planned = -1
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimRight(line, "\r")
+		switch {
+		case strings.HasPrefix(line, "1.."):
+			// "1..134" → 134. A "1..0 # SKIP" form leaves planned at -1.
+			if n, err := strconv.Atoi(strings.TrimSpace(line[len("1.."):])); err == nil {
+				planned = n
+			}
+		case strings.HasPrefix(line, "not ok"):
+			failed = append(failed, strings.TrimSpace(strings.TrimPrefix(line, "not ok")))
+		case strings.HasPrefix(line, "ok"):
+			passed++
+		}
+	}
+	return planned, passed, failed
+}
+
+// summarizePgTAPFailures renders failing pgTAP assertion descriptions into a
+// short, bounded FailReason (the full TAP is saved alongside as <name>.tap).
+func summarizePgTAPFailures(failed []string) string {
+	const max = 5
+	shown := failed
+	if len(shown) > max {
+		shown = shown[:max]
+	}
+	s := fmt.Sprintf("%d assertion(s) failed: %s", len(failed), strings.Join(shown, " | "))
+	if len(failed) > max {
+		s += fmt.Sprintf(" … (+%d more)", len(failed)-max)
+	}
+	return s
+}
+
+// pgTAPScratchSchemas are the throwaway schemas pg_partman's test files create
+// (CREATE SCHEMA partman_test; some also use partman_retention_test). They live
+// outside the partman/pgtap/public extension schemas, so dropping them never
+// touches installed state.
+var pgTAPScratchSchemas = []string{"partman_test", "partman_retention_test"}
+
+// cleanupPgTAPScratch best-effort drops the per-test scratch schemas on the
+// primary (directly, bypassing the gateway like resetContribState), so a file
+// that committed instead of rolling back can't poison the next one. The supported
+// rolled-back suite never leaves these behind — this just keeps the run
+// order-independent and re-runnable. It does NOT attempt the fuller cleanup the
+// excluded autocommit/procedure suites would need (test roles, leaked pgTAP temp
+// tables on pooled backends); those aren't run by default for the reasons in
+// runExternalPgTAP's doc comment.
+func cleanupPgTAPScratch(directPgPort int, password string) {
+	for _, s := range pgTAPScratchSchemas {
+		_ = execOnPrimary(directPgPort, password, fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", s))
+	}
+}

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -155,8 +155,8 @@ func TestPostgreSQLRegression(t *testing.T) {
 	// suite will run). Each is a PGXS module living outside the PostgreSQL source
 	// tree (e.g. pgvector); it is built against the just-installed PostgreSQL so
 	// its .so matches the running server's ABI. ExternalBuildList includes the
-	// covered extensions plus their build-only dependencies (e.g. pg_partman for
-	// pgmq), ordered so dependencies install first.
+	// covered extensions plus their build-only dependencies (e.g. pgtap for
+	// pg_partman, and pg_partman for pgmq), ordered so dependencies install first.
 	if runExternal {
 		t.Logf("Phase 2d: Installing external extensions...")
 		// Install contrib modules the external extensions depend on (e.g.

--- a/go/test/endtoend/pgregresstest/pgtap_test.go
+++ b/go/test/endtoend/pgregresstest/pgtap_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePgTAPOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		wantPlanned int
+		wantPassed  int
+		wantFailed  []string
+	}{
+		{
+			name: "all pass with plan",
+			output: "1..3\n" +
+				"ok 1 - table partman_test.foo exists\n" +
+				"ok 2 - column id is pk\n" +
+				"ok 3 - has 4 partitions\n",
+			wantPlanned: 3,
+			wantPassed:  3,
+			wantFailed:  nil,
+		},
+		{
+			name: "some fail",
+			output: "1..3\n" +
+				"ok 1 - first\n" +
+				"not ok 2 - second should match\n" +
+				"ok 3 - third\n",
+			wantPlanned: 3,
+			wantPassed:  2,
+			wantFailed:  []string{"2 - second should match"},
+		},
+		{
+			name: "not ok never miscounted as ok",
+			output: "1..1\n" +
+				"not ok 1 - boom\n",
+			wantPlanned: 1,
+			wantPassed:  0,
+			wantFailed:  []string{"1 - boom"},
+		},
+		{
+			name: "diagnostics and command tags ignored",
+			output: "BEGIN\n" +
+				"CREATE SCHEMA\n" +
+				"1..2\n" +
+				"ok 1 - one\n" +
+				"# a diagnostic line about a failure\n" +
+				"not ok 2 - two\n" +
+				"# Looks like you failed 1 test of 2\n",
+			wantPlanned: 2,
+			wantPassed:  1,
+			wantFailed:  []string{"2 - two"},
+		},
+		{
+			name:        "no plan line",
+			output:      "ERROR:  relation does not exist\n",
+			wantPlanned: -1,
+			wantPassed:  0,
+			wantFailed:  nil,
+		},
+		{
+			name:        "plan present but no assertions ran (plan mismatch)",
+			output:      "1..5\n",
+			wantPlanned: 5,
+			wantPassed:  0,
+			wantFailed:  nil,
+		},
+		{
+			name: "carriage returns trimmed",
+			output: "1..1\r\n" +
+				"ok 1 - crlf\r\n",
+			wantPlanned: 1,
+			wantPassed:  1,
+			wantFailed:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			planned, passed, failed := parsePgTAPOutput(tc.output)
+			assert.Equal(t, tc.wantPlanned, planned, "planned")
+			assert.Equal(t, tc.wantPassed, passed, "passed")
+			assert.Equal(t, tc.wantFailed, failed, "failed")
+		})
+	}
+}
+
+func TestSummarizePgTAPFailures(t *testing.T) {
+	t.Run("under cap lists all", func(t *testing.T) {
+		got := summarizePgTAPFailures([]string{"a", "b"})
+		assert.Equal(t, "2 assertion(s) failed: a | b", got)
+	})
+	t.Run("over cap truncates with count", func(t *testing.T) {
+		got := summarizePgTAPFailures([]string{"a", "b", "c", "d", "e", "f", "g"})
+		assert.Equal(t, "7 assertion(s) failed: a | b | c | d | e … (+2 more)", got)
+	})
+}
+
+// TestExternalBuildList_IncludesPgTAPDependency asserts that pg_partman pulls in
+// its pgtap build dependency, dependencies-first, when selected via PGEXTERNAL_TESTS.
+func TestExternalBuildList_IncludesPgTAPDependency(t *testing.T) {
+	t.Setenv("PGEXTERNAL_TESTS", "pg_partman")
+
+	specs := ExternalBuildList()
+	names := make([]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.Name
+	}
+	require.Equal(t, []string{"pgtap", "pg_partman"}, names,
+		"pgtap must be installed before pg_partman")
+}
+
+// TestSelectPgTAPFiles covers glob-union, subfolder patterns, exclude filtering,
+// and the default glob, against a temp tree mirroring pg_partman's layout.
+func TestSelectPgTAPFiles(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"test-a.sql", "test-b.sql", "helper.txt",
+		"test_pg17plus/keep.sql", "test_pg17plus/drop-me.sql",
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("-- test"), 0o644))
+	}
+	rel := func(paths []string) []string {
+		out := make([]string, len(paths))
+		for i, p := range paths {
+			r, _ := filepath.Rel(dir, p)
+			out[i] = r
+		}
+		return out
+	}
+
+	t.Run("globs union, excludes applied, non-.sql ignored", func(t *testing.T) {
+		got, err := selectPgTAPFiles(dir,
+			[]string{"test-*.sql", "test_pg17plus/*.sql"},
+			[]string{"test_pg17plus/drop-me.sql"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-a.sql", "test-b.sql", "test_pg17plus/keep.sql"}, rel(got))
+	})
+
+	t.Run("default glob when none given", func(t *testing.T) {
+		got, err := selectPgTAPFiles(dir, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-a.sql", "test-b.sql"}, rel(got)) // top-level *.sql only
+	})
+}
+
+// TestPgPartmanSpec_IsPgTAP guards the wiring that selects the pgTAP harness and
+// the dependency/preload setup pg_partman needs.
+func TestPgPartmanSpec_IsPgTAP(t *testing.T) {
+	spec, ok := externalSpecs["pg_partman"]
+	require.True(t, ok, "pg_partman must have a build spec")
+	assert.Equal(t, HarnessPgTAP, spec.Harness)
+	assert.Equal(t, []string{"test-*.sql", "test_pg17plus/*.sql", "test_no_search_path/*.sql"}, spec.TestGlobs)
+	assert.Equal(t, []string{"pgtap"}, spec.DependsOn)
+	assert.Equal(t, []ExtensionInstall{{Name: "pgtap"}, {Name: "pg_partman", Schema: "partman"}}, spec.PreCreateExtensions)
+	assert.Equal(t, []string{"test_pg17plus/test-time-monthly-source-generated.sql"}, spec.ExcludeGlobs)
+	assert.Equal(t, "pg_partman.conf", spec.ServerConfigFile)
+
+	// pg_partman must be marked covered so the suite actually runs it.
+	var covered bool
+	for _, e := range ExtensionCatalog {
+		if e.Name == "pg_partman" {
+			covered = e.Status == StatusCovered
+		}
+	}
+	assert.True(t, covered, "pg_partman must be StatusCovered in the catalog")
+}

--- a/go/test/endtoend/pgregresstest/postgres_builder.go
+++ b/go/test/endtoend/pgregresstest/postgres_builder.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -234,183 +233,6 @@ func (pb *PostgresBuilder) runTestSuite(t *testing.T, ctx context.Context, cmd *
 	return results, nil
 }
 
-// RunRegressionTests runs PostgreSQL regression tests against multigateway.
-//
-// Uses make installcheck-tests with TESTS variable to run specific regression tests
-// against the existing PostgreSQL server (multigateway).
-//
-// The installcheck-tests target runs specific tests against an already-running
-// PostgreSQL server, unlike installcheck which runs the entire parallel_schedule.
-//
-// From PostgreSQL's src/test/regress/GNUmakefile:
-//
-//	installcheck: runs --schedule=parallel_schedule (all tests)
-//	installcheck-tests: runs $(TESTS) (specific tests only)
-//
-// Environment variables that pg_regress reads:
-//
-//	PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE - connection params
-//
-// Reference: https://github.com/postgres/postgres/blob/master/src/test/regress/GNUmakefile
-func (pb *PostgresBuilder) RunRegressionTests(t *testing.T, ctx context.Context, multigatewayPort int, password string) (*TestResults, error) {
-	t.Helper()
-
-	t.Logf("Running PostgreSQL regression tests against multigateway on port %d...", multigatewayPort)
-
-	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
-	makeArgs := []string{"-C", regressDir}
-
-	// --use-existing: skip pg_regress's automatic DROP + CREATE of the
-	// "regression" database. Multigateway rejects DROP DATABASE (see the
-	// unsafe-statement list in go/services/multigateway/planner/unsafe_stmt.go),
-	// so we can't let pg_regress manage the database. Instead we run against
-	// the existing "postgres" database for the whole suite.
-	//
-	// --dbname=postgres: point pg_regress at that existing database. pg_regress
-	// will create/drop the expected schema objects per test; cross-test state
-	// leakage is still possible but has not surfaced in practice.
-	makeArgs = append(makeArgs, "EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres")
-
-	if testsEnv := os.Getenv("PGREGRESS_TESTS"); testsEnv != "" {
-		makeArgs = append(makeArgs, "installcheck-tests", "TESTS="+testsEnv)
-		t.Logf("Running selective regression tests: %s", testsEnv)
-	} else {
-		makeArgs = append(makeArgs, "installcheck")
-		t.Logf("Running full PostgreSQL regression test suite (installcheck)")
-	}
-
-	cmd := executil.Command(ctx, "make", makeArgs...).WithProcessGroup()
-
-	return pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
-		suiteName: "Regression",
-		outputDir: pb.OutputDir,
-		srcOutDir: regressDir,
-	}, multigatewayPort, password)
-}
-
-// DefaultContribModules is the core-contrib extension test set run through
-// multigateway by default. Each entry is a directory under contrib/ whose
-// sql/ + expected/ fixtures pg_regress drives via the module's installcheck
-// target.
-//
-// It is derived from ExtensionCatalog (every StatusCovered entry), which is the
-// single source of truth for coverage state and the rationale behind each
-// extension's status (covered / pending / unsupported / external). uuid-ossp
-// and pgcrypto need extra ./configure features enabled by the harness when the
-// contrib suite runs (--with-uuid and --with-ssl=openssl; see
-// TestPostgreSQLRegression). See extensions.go.
-var DefaultContribModules = CoveredContribModules()
-
-// ContribModules returns the contrib module directories to test. PGCONTRIB_TESTS
-// (space-separated directory names) overrides the default set when set.
-func ContribModules() []string {
-	if v := os.Getenv("PGCONTRIB_TESTS"); v != "" {
-		return strings.Fields(v)
-	}
-	return DefaultContribModules
-}
-
-// RunContribTests runs each contrib module's installcheck suite against
-// multigateway and returns one merged TestResults across all modules.
-//
-// Each module is a separate pg_regress invocation (make -C contrib/<mod>
-// installcheck). As with the core regression suite we pass
-// --use-existing --dbname=postgres because multigateway rejects DROP/CREATE
-// DATABASE. Per-test names are prefixed with the module directory
-// ("citext/citext") so they stay unique in the merged report.
-//
-// All modules share the single postgres database (multigateway can't isolate
-// per-DB), so before each module we reset the public schema directly on the
-// primary (directPgPort) to clear objects/extensions a previous module left
-// behind — otherwise a module's CREATE TYPE/EXTENSION collides with leftovers
-// and its expected output diverges. The reset bypasses multigateway because
-// the gateway rejects schema DDL; the standby picks it up via WAL.
-//
-// A module that produces no parseable output (e.g. a module with no REGRESS
-// tests) is logged and skipped — one module must not abort the rest of the set.
-func (pb *PostgresBuilder) RunContribTests(t *testing.T, ctx context.Context, modules []string, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
-	t.Helper()
-
-	// contrib installcheck targets invoke $(top_builddir)/src/test/regress/pg_regress.
-	// Build it up front so a contrib-only run (RUN_PGCONTRIB without RUN_PGREGRESS)
-	// does not fail for a missing pg_regress binary.
-	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
-	if out, err := executil.Command(ctx, "make", "-C", regressDir, "all").CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("failed to build pg_regress: %w\n%s", err, truncateForLog(string(out), 2000))
-	}
-
-	merged := &TestResults{
-		FailureDetails: []TestFailure{},
-		Tests:          []IndividualTestResult{},
-	}
-
-	// Replace pg_regress's strict text diff with the patch-based pipeline, which
-	// whitespace-normalizes both sides (so error-cursor caret-position shifts
-	// from multigateway query rewriting are not diffs) and applies per-test
-	// patches for genuine multigres-specific output differences.
-	mode := GetPatchMode()
-
-	for _, mod := range modules {
-		moduleDir := filepath.Join(pb.BuildDir, "contrib", mod)
-		if !suiteutil.FileExists(filepath.Join(moduleDir, "Makefile")) {
-			t.Logf("contrib/%s: no Makefile in build tree, skipping", mod)
-			continue
-		}
-
-		// Clean slate for this module: drop anything a prior module left in
-		// public. Best-effort — log and proceed if it fails, since the run is
-		// still useful (the failure will show up as a diff).
-		if err := resetContribState(directPgPort, password); err != nil {
-			t.Logf("contrib/%s: warning: public schema reset failed: %v", mod, err)
-		}
-
-		t.Logf("Running contrib/%s installcheck against multigateway...", mod)
-		cmd := executil.Command(ctx, "make", "-C", moduleDir, "installcheck",
-			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
-
-		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
-			suiteName: "Contrib/" + mod,
-			outputDir: filepath.Join(pb.OutputDir, "contrib", mod),
-			srcOutDir: moduleDir,
-		}, multigatewayPort, password)
-		if res == nil {
-			// No TAP output: module has no REGRESS tests or the harness failed
-			// to execute. Log and continue so one module can't abort the set.
-			t.Logf("contrib/%s: no test results (%v)", mod, err)
-			continue
-		}
-
-		// Re-evaluate each test's verdict via the patch pipeline (bare names,
-		// before the module prefix is applied below).
-		pb.verifyContribModule(ctx, mod, res, mode)
-
-		for _, tr := range res.Tests {
-			tr.Name = mod + "/" + tr.Name
-			merged.Tests = append(merged.Tests, tr)
-			switch tr.Status {
-			case "fail":
-				merged.FailedTests++
-				detail := tr.FailReason
-				if detail == "" {
-					detail = "see contrib/" + mod + "/regression.diffs"
-				}
-				merged.FailureDetails = append(merged.FailureDetails, TestFailure{
-					TestName: tr.Name,
-					Error:    detail,
-				})
-			case "skip":
-				merged.SkippedTests++
-			default:
-				merged.PassedTests++
-			}
-		}
-		merged.TimedOut = merged.TimedOut || res.TimedOut
-	}
-
-	merged.TotalTests = merged.PassedTests + merged.FailedTests + merged.SkippedTests
-	return merged, nil
-}
-
 // ExternalModules returns the external extensions to test, defaulting to the
 // covered set (CoveredExternalExtensions). PGEXTERNAL_TESTS (space-separated
 // catalog names, e.g. "vector") selects a subset for local iteration.
@@ -433,55 +255,51 @@ func ExternalModules() []ExternalExtension {
 	return out
 }
 
-// listRegressTests returns the regression test names for an external extension,
-// derived from the .sql files under <testDir>/sql. This mirrors the PGXS
-// convention REGRESS = $(patsubst test/sql/%.sql,%,$(wildcard test/sql/*.sql)).
-// Names are sorted so the run order is deterministic and matches make's sorted
-// $(wildcard).
-func listRegressTests(testDir string) []string {
-	matches, err := filepath.Glob(filepath.Join(testDir, "sql", "*.sql"))
-	if err != nil {
-		return nil
-	}
-	sort.Strings(matches)
-	names := make([]string, 0, len(matches))
-	for _, m := range matches {
-		names = append(names, strings.TrimSuffix(filepath.Base(m), ".sql"))
-	}
-	return names
-}
-
-// RunExternalTests runs each external extension's shipped pg_regress suite
-// against multigateway and returns one merged TestResults across all of them.
+// RunExternalTests runs each external extension's shipped test suite against
+// multigateway and returns one merged TestResults across all of them.
 //
 // External (KindExternal) extensions are PGXS modules that live outside the
-// PostgreSQL source tree (see Builder.InstallExternalExtension, which has
-// already cloned and installed each one before this is called). They ship the
-// same sql/ + expected/ fixture layout as contrib, so verification reuses the
-// shared pipeline (verifyModuleResults). Per-test names are prefixed with the
-// extension name ("vector/btree") to stay unique in the merged report.
+// PostgreSQL source tree (see Builder.InstallExternalExtension, which has already
+// cloned and installed each one — and any DependsOn build dependencies — before
+// this is called). Two test harnesses are supported, selected per extension by
+// ExternalExtension.Harness:
 //
-// Unlike contrib we cannot use `make installcheck`: under PGXS that target runs
-// $(top_builddir)/src/test/regress/pg_regress, and PGXS resolves top_builddir
-// into the install tree, where pg_regress is not installed. We instead invoke
-// the pg_regress we built directly, passing the same flags the contrib suite
-// relies on (--use-existing --dbname=postgres, because multigateway rejects
-// DROP/CREATE DATABASE) plus the extension's --inputdir/--load-extension.
+//   - pg_regress (default, e.g. pgvector/pg_cron): drives the pg_regress binary
+//     and diffs against expected/*.out via the patch pipeline. See
+//     runExternalRegress.
+//   - pgTAP (HarnessPgTAP, e.g. pg_partman): feeds each test .sql to psql and
+//     parses the TAP stream the assertions emit server-side; no expected-output
+//     files, no patch pipeline. See runExternalPgTAP.
 //
-// As with contrib, all extensions share the single postgres database, so before
-// each one we reset the public schema directly on the primary (directPgPort,
-// bypassing the gateway's DDL block) to clear objects a prior extension left
-// behind; pg_regress's --load-extension re-creates the extension per test.
+// Per-test names are prefixed with the extension name ("vector/btree",
+// "pg_partman/test-id-10") to stay unique in the merged report.
+//
+// All extensions share the single postgres database (multigateway can't isolate
+// per-DB), so before each one we reset the public schema directly on the primary
+// (directPgPort, bypassing the gateway's DDL block) to clear objects a prior
+// extension left behind, and front-load/drop any ScratchDatabases. Those shared
+// setup steps live here; only the run-and-verify step differs per harness.
 func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, exts []ExternalExtension, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
 	t.Helper()
 
-	// Ensure the pg_regress we drive directly is built (a contrib/regression run
-	// would have built it already; an external-only run must build it here).
-	regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
-	pgRegress := filepath.Join(regressDir, "pg_regress")
-	if !suiteutil.FileExists(pgRegress) {
-		if out, err := executil.Command(ctx, "make", "-C", regressDir, "all").CombinedOutput(); err != nil {
-			return nil, fmt.Errorf("failed to build pg_regress: %w\n%s", err, truncateForLog(string(out), 2000))
+	pgBinDir := pb.BinDir()
+
+	// Ensure the pg_regress we drive directly is built — but only if a
+	// regress-harness extension will actually use it. A pgTAP-only run (e.g.
+	// PGEXTERNAL_TESTS=pg_partman) drives psql directly and needs no pg_regress.
+	needRegress := false
+	for _, ext := range exts {
+		if ext.Harness == HarnessPgRegress {
+			needRegress = true
+			break
+		}
+	}
+	if needRegress {
+		regressDir := filepath.Join(pb.BuildDir, "src", "test", "regress")
+		if !suiteutil.FileExists(filepath.Join(regressDir, "pg_regress")) {
+			if out, err := executil.Command(ctx, "make", "-C", regressDir, "all").CombinedOutput(); err != nil {
+				return nil, fmt.Errorf("failed to build pg_regress: %w\n%s", err, truncateForLog(string(out), 2000))
+			}
 		}
 	}
 
@@ -489,25 +307,13 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 		FailureDetails: []TestFailure{},
 		Tests:          []IndividualTestResult{},
 	}
-	mode := GetPatchMode()
-	pgBinDir := pb.BinDir()
 
 	for _, ext := range exts {
 		cloneDir := filepath.Join(pb.ExternalDir, ext.Name)
 		// Fixtures live under ext.TestSubdir within the checkout (pgvector: test/;
-		// pg_cron: the repo root, i.e. "."). filepath.Join collapses "." back to
-		// the clone root.
+		// pg_cron: the repo root, i.e. "."; pg_partman: test/). filepath.Join
+		// collapses "." back to the clone root.
 		testDir := filepath.Join(cloneDir, ext.TestSubdir)
-		if !suiteutil.FileExists(filepath.Join(testDir, "sql")) {
-			t.Logf("external/%s: no %s/sql in checkout, skipping", ext.Name, ext.TestSubdir)
-			continue
-		}
-
-		tests := listRegressTests(testDir)
-		if len(tests) == 0 {
-			t.Logf("external/%s: no .sql tests found, skipping", ext.Name)
-			continue
-		}
 
 		// Clean slate for this extension: drop anything a prior extension left in
 		// public. Best-effort — log and proceed if it fails.
@@ -526,59 +332,22 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			}
 		}
 
-		// Load the extension's fixtures through multigateway before the suite, the
-		// way its own runner does (pg_graphql's bin/installcheck runs
-		// `psql -f test/fixtures.sql` first; those fixtures CREATE the extension and
-		// set its schema config). Same pooled path the test queries take.
-		if ext.FixturesFile != "" {
-			fixturesPath := filepath.Join(testDir, ext.FixturesFile)
-			if err := loadFixturesViaGateway(ctx, filepath.Join(pgBinDir, "psql"), fixturesPath, multigatewayPort, password); err != nil {
-				t.Logf("external/%s: warning: load fixtures %q failed: %v", ext.Name, ext.FixturesFile, err)
-			}
+		var (
+			res *TestResults
+			err error
+		)
+		switch ext.Harness {
+		case HarnessPgTAP:
+			res, err = pb.runExternalPgTAP(t, ctx, ext, testDir, pgBinDir, multigatewayPort, directPgPort, password)
+		case HarnessPgRegress:
+			res, err = pb.runExternalRegress(t, ctx, ext, cloneDir, testDir, pgBinDir, multigatewayPort, password)
+		default:
+			err = fmt.Errorf("external/%s: unknown test harness %q", ext.Name, ext.Harness)
 		}
-
-		// Preload the extension when its fixtures assume it already exists:
-		// --use-existing skips pg_regress's own --load-extension step, and
-		// pgvector's fixtures open with a bare CREATE TABLE ... vector(3) (see
-		// createExtensionViaGateway). Extensions whose fixtures manage the
-		// extension themselves (pg_cron CREATEs it as their first statement) set
-		// CreateExtension=false so we don't collide with that.
-		if ext.CreateExtension {
-			if err := createExtensionViaGateway(multigatewayPort, password, ext.Name); err != nil {
-				t.Logf("external/%s: warning: CREATE EXTENSION failed: %v", ext.Name, err)
-			}
-		}
-
-		t.Logf("Running external/%s pg_regress (%d tests) against multigateway...", ext.Name, len(tests))
-		args := []string{
-			"--inputdir=" + testDir,
-			"--outputdir=" + cloneDir,
-			"--bindir=" + pgBinDir,
-			"--use-existing",
-			"--dbname=postgres",
-		}
-		// --load-extension only fires inside create_database(), which pg_regress
-		// skips under --use-existing, so it is a no-op here; pass it only for the
-		// preloaded extensions to keep intent clear.
-		if ext.CreateExtension {
-			args = append(args, "--load-extension="+ext.Name)
-		}
-		args = append(args, tests...)
-		// Run from the clone root so psql's client-side \copy resolves the
-		// relative paths the fixtures use (e.g. pgvector's copy test does
-		// \copy t TO 'results/vector.bin'); pg_regress writes its results/ dir
-		// under --outputdir=cloneDir, which is this same directory.
-		cmd := executil.Command(ctx, pgRegress, args...).WithProcessGroup().SetDir(cloneDir)
-
-		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
-			suiteName: "External/" + ext.Name,
-			outputDir: filepath.Join(pb.OutputDir, "external", ext.Name),
-			srcOutDir: cloneDir,
-		}, multigatewayPort, password)
 
 		// Drop the scratch databases now the suite has run (verification reads
-		// result files, not the live DB). WITH (FORCE) in case pg_cron's launcher
-		// opened a connection. Best-effort; the cluster is torn down after anyway.
+		// result files, not the live DB). WITH (FORCE) in case a launcher opened a
+		// connection. Best-effort; the cluster is torn down after anyway.
 		for _, db := range ext.ScratchDatabases {
 			if err := execOnPrimary(directPgPort, password, fmt.Sprintf("DROP DATABASE IF EXISTS %q WITH (FORCE)", db)); err != nil {
 				t.Logf("external/%s: warning: drop scratch db %q failed: %v", ext.Name, db, err)
@@ -589,12 +358,6 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 			t.Logf("external/%s: no test results (%v)", ext.Name, err)
 			continue
 		}
-
-		// Re-evaluate each test via the patch pipeline. pg_regress wrote results
-		// to <cloneDir>/results (--outputdir); expected lives in <cloneDir>/test
-		// (--inputdir), and patches are per-extension under patches/external/<ext>.
-		patchDir := filepath.Join(PatchesDir(), "external", ext.Name)
-		pb.verifyModuleResults(ctx, testDir, filepath.Join(cloneDir, "results"), patchDir, res, mode)
 
 		for _, tr := range res.Tests {
 			tr.Name = ext.Name + "/" + tr.Name
@@ -621,127 +384,6 @@ func (pb *PostgresBuilder) RunExternalTests(t *testing.T, ctx context.Context, e
 
 	merged.TotalTests = merged.PassedTests + merged.FailedTests + merged.SkippedTests
 	return merged, nil
-}
-
-// verifyContribModule re-evaluates each test in a contrib module's results
-// using the patch-based pipeline (see patch_verify.go), replacing pg_regress's
-// strict text verdict. Expected output lives in the source tree
-// (contrib/<mod>/expected); actual output is written by pg_regress into the
-// build tree (contrib/<mod>/results). Patches are per-module
-// (testdata/pg<major>/patches/contrib/<mod>/<test>.patch) so test names that
-// collide across modules (e.g. "init") do not clash.
-//
-// res.Tests carry bare test names here (the module prefix is applied by the
-// caller afterwards). Statuses are updated in place.
-func (pb *PostgresBuilder) verifyContribModule(ctx context.Context, mod string, res *TestResults, mode PatchMode) {
-	moduleSrcDir := filepath.Join(pb.SourceDir, "contrib", mod)
-	moduleResultsDir := filepath.Join(pb.BuildDir, "contrib", mod, "results")
-	patchDir := filepath.Join(PatchesDir(), "contrib", mod)
-	pb.verifyModuleResults(ctx, moduleSrcDir, moduleResultsDir, patchDir, res, mode)
-}
-
-// verifyModuleResults is the shared per-test verification loop behind both the
-// contrib and external suites. expectedDir is the directory whose expected/
-// subdirectory holds the upstream .out files (and numbered variants); resultsDir
-// holds the .out files pg_regress wrote for this run; patchDir holds the
-// per-test patches for genuine multigres-specific differences. Statuses in
-// res.Tests are updated in place; skipped tests are left untouched.
-func (pb *PostgresBuilder) verifyModuleResults(ctx context.Context, expectedDir, resultsDir, patchDir string, res *TestResults, mode PatchMode) {
-	repoRoot := findRepoRoot()
-
-	for i := range res.Tests {
-		test := &res.Tests[i]
-		if test.Status == "skip" {
-			continue
-		}
-
-		// PostgreSQL ships alternate expected files (name_1.out, name_2.out, …)
-		// for output that legitimately varies by platform/build — e.g.
-		// citext_utf8_1.out for a C-locale run, or pgcrypto blowfish_1.out for an
-		// OpenSSL build without the legacy cipher provider. pg_regress passes if
-		// actual matches ANY variant; mirror that here before falling back to
-		// patch-based verification, otherwise a canonical-only comparison
-		// manufactures diffs that aren't multigres behavior at all.
-		variants := expectedVariants(expectedDir, test.Name)
-		actPath := filepath.Join(resultsDir, test.Name+".out")
-		if len(variants) == 0 || !suiteutil.FileExists(actPath) {
-			// Test didn't run or expected missing; keep the TAP verdict.
-			test.FailReason = "expected or actual output missing; kept TAP verdict"
-			continue
-		}
-
-		if actualMatchesAnyVariant(actPath, variants) {
-			test.Status = "pass"
-			test.PatchApplied = false
-			test.PatchPath = ""
-			test.FailReason = ""
-			// A patch is unnecessary once a stock variant matches; drop a stale one.
-			if mode == PatchModeGenerate {
-				_ = os.Remove(filepath.Join(patchDir, test.Name+".patch"))
-			}
-			continue
-		}
-
-		// No variant matches: apply (verify) or write (generate) a patch against
-		// the canonical expected file for genuine multigres-specific differences.
-		outcome, err := VerifyTest(ctx, VerifyInput{
-			Name:         test.Name,
-			ExpectedPath: variants[0],
-			ActualPath:   actPath,
-			PatchDir:     patchDir,
-			RepoRoot:     repoRoot,
-		}, mode)
-		if err != nil {
-			test.Status = "fail"
-			test.FailReason = err.Error()
-			continue
-		}
-
-		test.Status = outcome.Status
-		test.PatchApplied = outcome.PatchApplied
-		test.PatchPath = outcome.PatchPath
-		test.FailReason = outcome.Reason
-	}
-}
-
-// expectedVariants returns the expected-output files pg_regress would accept for
-// a test: the canonical <name>.out first, then numbered variants
-// <name>_1.out … <name>_9.out that exist. Mirrors findExpectedFile's search but
-// returns every match rather than only the first.
-func expectedVariants(regressDir, name string) []string {
-	var out []string
-	canonical := filepath.Join(regressDir, "expected", name+".out")
-	if suiteutil.FileExists(canonical) {
-		out = append(out, canonical)
-	}
-	for i := 1; i < 10; i++ {
-		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
-		if suiteutil.FileExists(p) {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
-// actualMatchesAnyVariant reports whether the actual output equals any expected
-// variant after whitespace normalization (the same canonicalization the patch
-// pipeline uses, so error-cursor caret shifts are not treated as differences).
-func actualMatchesAnyVariant(actPath string, variants []string) bool {
-	actRaw, err := os.ReadFile(actPath)
-	if err != nil {
-		return false
-	}
-	act := normalizeWhitespace(actRaw)
-	for _, v := range variants {
-		expRaw, err := os.ReadFile(v)
-		if err != nil {
-			continue
-		}
-		if bytes.Equal(normalizeWhitespace(expRaw), act) {
-			return true
-		}
-	}
-	return false
 }
 
 // resetContribState drops and recreates the public schema on the primary's
@@ -793,33 +435,40 @@ func execOnPrimary(directPgPort int, password, stmt string) error {
 	return nil
 }
 
-// createExtensionViaGateway runs CREATE EXTENSION IF NOT EXISTS through
-// multigateway — the same path the test queries take, so there's no
-// create-on-primary-then-read-from-standby replication race, and it doubles as
-// real coverage that CREATE EXTENSION works over the pooled path (CREATE
-// EXTENSION is not on the gateway's blocked-DDL list; contrib tests create their
-// own extensions through the gateway too).
+// createExtensionWithSchema creates an extension on the given port, optionally
+// into a target schema (which it creates first). With an empty schema it emits a
+// plain CREATE EXTENSION IF NOT EXISTS; with a schema it adds SCHEMA <schema> —
+// needed for extensions whose control file pins no schema (relocatable=false, no
+// `schema=`) but whose tests expect a specific one: pg_partman must live in
+// `partman` or its tests' schema-qualified partman.* references fail with "schema
+// partman does not exist". Names come from the controlled extension catalog, not
+// user input, but are quoted as identifiers defensively all the same.
 //
-// This is needed because pg_regress applies its --load-extension flag only
-// inside create_database(), which it calls solely when !use_existing (see
-// pg_regress.c). The external suite must pass --use-existing (multigateway
-// rejects CREATE/DROP DATABASE), so that load step never fires. Extensions whose
-// test fixtures assume the extension is preloaded (e.g. pgvector — its tests
-// open with a bare CREATE TABLE t (val vector(3)) and never CREATE EXTENSION
-// themselves) would otherwise fail every statement with "type ... does not
-// exist". Creating it here reproduces what create_database would have done.
-func createExtensionViaGateway(multigatewayPort int, password, ext string) error {
+// Both the pg_regress and pgTAP preload paths (ExternalExtension.PreCreateExtensions)
+// use this. Routing CREATE EXTENSION through multigateway (rather than the primary)
+// keeps setup on the same pooled path the test queries take — no
+// create-on-primary-then-read-from-standby replication race — and doubles as real
+// coverage that CREATE EXTENSION works over the gateway. It is the preload the
+// external suite needs because pg_regress's own --load-extension only fires inside
+// create_database(), which it skips under --use-existing (multigateway rejects
+// CREATE/DROP DATABASE); fixtures that assume the extension exists (pgvector opens
+// with a bare CREATE TABLE t (val vector(3))) would otherwise fail.
+func createExtensionWithSchema(port int, password, ext, schema string) error {
 	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		multigatewayPort, password)
+		port, password)
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
 	defer db.Close()
 
-	// ext comes from the controlled extension catalog, not user input; quote it
-	// as an identifier defensively all the same.
-	stmt := fmt.Sprintf(`CREATE EXTENSION IF NOT EXISTS "%s"`, ext)
+	stmt := fmt.Sprintf(`CREATE EXTENSION IF NOT EXISTS %q`, ext)
+	if schema != "" {
+		if _, err := db.Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %q`, schema)); err != nil {
+			return fmt.Errorf("create schema %q: %w", schema, err)
+		}
+		stmt = fmt.Sprintf(`CREATE EXTENSION IF NOT EXISTS %q SCHEMA %q`, ext, schema)
+	}
 	if _, err := db.Exec(stmt); err != nil {
 		return fmt.Errorf("exec [%s]: %w", stmt, err)
 	}
@@ -953,152 +602,6 @@ func findRepoRoot() string {
 	}
 }
 
-// findExpectedFile locates the expected-output file pg_regress would use for
-// the given test name. PostgreSQL ships variant files (name_1.out, name_2.out,
-// …) for platform-dependent output. We try the canonical name first, then
-// numbered variants in order. Returns the empty string if none exist.
-func findExpectedFile(regressDir, name string) string {
-	canonical := filepath.Join(regressDir, "expected", name+".out")
-	if suiteutil.FileExists(canonical) {
-		return canonical
-	}
-	for i := 1; i < 10; i++ {
-		p := filepath.Join(regressDir, "expected", fmt.Sprintf("%s_%d.out", name, i))
-		if suiteutil.FileExists(p) {
-			return p
-		}
-	}
-	return ""
-}
-
-// VerifyWithPatches re-evaluates each test's pass/fail status using the
-// patch-based pipeline (see patch_verify.go). After pg_regress runs, this
-// ignores pg_regress's own pass/fail verdict (which is a strict text diff)
-// and replaces it with: does the actual output match the (patched) expected
-// output? Results are updated in-place, including aggregate counters.
-//
-// In generate mode, any residual diffs are absorbed by (re)writing patches.
-//
-// Expected output lives in the source tree (prep_buildtree does not symlink
-// .out files into the build tree). Actual output is written by pg_regress
-// into the build tree's results/ directory.
-func (pb *PostgresBuilder) VerifyWithPatches(t *testing.T, ctx context.Context, results *TestResults, buildRegressDir, outputDir string) error {
-	t.Helper()
-	mode := GetPatchMode()
-	patchDir := PatchesDir()
-	repoRoot := findRepoRoot()
-	sourceRegressDir := filepath.Join(pb.SourceDir, "src", "test", "regress")
-
-	// Ensure patch dir exists in generate mode so writes don't fail.
-	if mode == PatchModeGenerate {
-		if err := os.MkdirAll(patchDir, 0o755); err != nil {
-			return fmt.Errorf("mkdir patches: %w", err)
-		}
-	}
-
-	t.Logf("Patch-based verification: mode=%s patches=%s", mode, patchDir)
-	t.Logf("  expected source: %s", sourceRegressDir)
-	t.Logf("  actual source:   %s", buildRegressDir)
-
-	// Per-test residual diffs are written under outputDir/diffs/ for inclusion
-	// in the CI artifact. Concatenated failures.diffs is written at the end.
-	diffsDir := ""
-	if outputDir != "" {
-		diffsDir = filepath.Join(outputDir, "diffs")
-	}
-	var aggregated bytes.Buffer
-
-	// Recompute aggregates from the per-test results after verification.
-	// We intentionally discard pg_regress's TAP-derived aggregates because
-	// patch-based verification is authoritative.
-	var passed, failed int
-	failures := results.FailureDetails[:0]
-
-	for i := range results.Tests {
-		test := &results.Tests[i]
-		if test.Status == "skip" {
-			// Leave skipped tests alone.
-			continue
-		}
-
-		expPath := findExpectedFile(sourceRegressDir, test.Name)
-		actPath := filepath.Join(buildRegressDir, "results", test.Name+".out")
-		if expPath == "" || !suiteutil.FileExists(actPath) {
-			// Infrastructure problem (test didn't run, expected missing).
-			// Preserve TAP verdict, count accordingly.
-			test.FailReason = "expected or actual output missing; kept TAP verdict"
-			if test.Status == "pass" {
-				passed++
-			} else {
-				failed++
-				failures = append(failures, TestFailure{
-					TestName: test.Name,
-					Error:    test.FailReason,
-				})
-			}
-			continue
-		}
-
-		outcome, err := VerifyTest(ctx, VerifyInput{
-			Name:         test.Name,
-			ExpectedPath: expPath,
-			ActualPath:   actPath,
-			PatchDir:     patchDir,
-			RepoRoot:     repoRoot,
-		}, mode)
-		if err != nil {
-			return fmt.Errorf("verify %s: %w", test.Name, err)
-		}
-
-		test.Status = outcome.Status
-		test.PatchApplied = outcome.PatchApplied
-		test.PatchPath = outcome.PatchPath
-		test.FailReason = outcome.Reason
-
-		if outcome.Status == "pass" {
-			passed++
-			continue
-		}
-		failed++
-		failures = append(failures, TestFailure{
-			TestName: test.Name,
-			Error:    outcome.Reason,
-		})
-
-		if outcome.Diff == "" || diffsDir == "" {
-			continue
-		}
-		if err := os.MkdirAll(diffsDir, 0o755); err != nil {
-			t.Logf("Warning: mkdir %s: %v", diffsDir, err)
-			continue
-		}
-		diffPath := filepath.Join(diffsDir, test.Name+".diff")
-		if err := os.WriteFile(diffPath, []byte(outcome.Diff), 0o644); err != nil {
-			t.Logf("Warning: write %s: %v", diffPath, err)
-			continue
-		}
-		fmt.Fprintf(&aggregated, "=== %s ===\n%s\n", test.Name, outcome.Diff)
-	}
-
-	if outputDir != "" && aggregated.Len() > 0 {
-		aggPath := filepath.Join(outputDir, "failures.diffs")
-		if err := os.WriteFile(aggPath, aggregated.Bytes(), 0o644); err != nil {
-			t.Logf("Warning: write %s: %v", aggPath, err)
-		} else {
-			t.Logf("Residual failure diffs: %s (per-test files in %s)", aggPath, diffsDir)
-		}
-	}
-
-	results.PassedTests = passed
-	results.FailedTests = failed
-	// Preserve SkippedTests + any pre-existing total if it exceeds ran.
-	if results.TotalTests < passed+failed+results.SkippedTests {
-		results.TotalTests = passed + failed + results.SkippedTests
-	}
-	results.FailureDetails = failures
-	return nil
-}
-
 // CountScheduleTests parses a PostgreSQL schedule file and returns the number
 // of tests listed. Each line starting with "test:" contains space-separated
 // test names (parallel groups have multiple tests per line).
@@ -1117,337 +620,6 @@ func CountScheduleTests(scheduleFile string) (int, error) {
 	return count, nil
 }
 
-// SuiteResult holds results for one test suite.
-type SuiteResult struct {
-	Name          string       // e.g. "Regression Tests", "Isolation Tests"
-	Results       *TestResults // parsed TAP results
-	ExpectedTests int          // total tests from schedule file (0 = unknown)
-}
-
-// githubBlobURLPrefix returns an absolute URL prefix of the form
-// "https://github.com/<owner>/<repo>/blob/<sha>/" when running inside a
-// GitHub Actions job, or an empty string otherwise. Repo-relative paths
-// concatenated onto this prefix resolve to the blob view of that file at
-// the exact commit the job is executing against.
-func githubBlobURLPrefix() string {
-	serverURL := os.Getenv("GITHUB_SERVER_URL")
-	repo := os.Getenv("GITHUB_REPOSITORY")
-	sha := os.Getenv("GITHUB_SHA")
-	if serverURL == "" || repo == "" || sha == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s/blob/%s/", serverURL, repo, sha)
-}
-
-// WriteMarkdownSummary generates a unified markdown report covering one or more
-// test suites. It writes the report to pb.OutputDir/compatibility-report.md and
-// appends it to GITHUB_STEP_SUMMARY when running in CI.
-//
-// Each suite gets its own badge showing pass rate and timeout status. Full diffs
-// are available in the CI artifact (regression.diffs).
-func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResult) (string, error) {
-	t.Helper()
-
-	var sb strings.Builder
-
-	sb.WriteString("## PostgreSQL Compatibility Report\n\n")
-
-	for _, s := range suites {
-		label := strings.TrimSuffix(s.Name, " Tests")
-		sb.WriteString(suiteutil.BadgeMarkdown(
-			label,
-			s.Results.PassedTests,
-			s.Results.TotalTests,
-			s.ExpectedTests,
-			s.Results.TimedOut,
-		))
-		sb.WriteString(" ")
-	}
-	sb.WriteString("\n\n")
-
-	fmt.Fprintf(&sb, "**PostgreSQL Version:** `%s`\n", PostgresVersion)
-	fmt.Fprintf(&sb, "**Timestamp:** %s\n\n", time.Now().UTC().Format(time.RFC3339))
-
-	// Build an absolute URL prefix for patch links when running in CI.
-	// Without this, markdown like [patch](go/test/.../foo.patch) is resolved
-	// relative to the step-summary page (/actions/runs/<id>/) and produces a
-	// 404 URL like .../actions/runs/go/test/.../foo.patch. Falls back to a
-	// relative link when the GitHub Actions env vars aren't set (local runs).
-	patchURLPrefix := githubBlobURLPrefix()
-
-	for _, s := range suites {
-		// The contrib and external suites' per-test detail is rendered by the
-		// richer Extension Coverage table below (it carries the same per-test
-		// results plus catalog context), so skip the generic per-test section
-		// here. Their badges above are still shown.
-		if s.Name == "Contrib Extension Tests" || s.Name == "External Extension Tests" {
-			continue
-		}
-
-		fmt.Fprintf(&sb, "### %s\n\n", s.Name)
-
-		if s.Results.TimedOut {
-			ran := s.Results.TotalTests
-			if s.ExpectedTests > 0 {
-				fmt.Fprintf(&sb, "> **Timed out** — %d of %d scheduled tests executed before the deadline.\n\n", ran, s.ExpectedTests)
-			} else {
-				fmt.Fprintf(&sb, "> **Timed out** — %d tests executed before the deadline.\n\n", ran)
-			}
-		}
-
-		sb.WriteString("| # | Test | Status | Patch | Duration |\n")
-		sb.WriteString("|---|------|--------|-------|----------|\n")
-
-		for i, test := range s.Results.Tests {
-			status := "✅ ok"
-			switch test.Status {
-			case "fail":
-				status = "❌ FAIL"
-			case "skip":
-				status = "⏭️ skip"
-			}
-			duration := test.Duration
-			if duration == "" {
-				duration = "-"
-			}
-			patchCell := "-"
-			if test.PatchApplied {
-				if test.PatchPath != "" {
-					patchCell = fmt.Sprintf("📎 [patch](%s%s)", patchURLPrefix, test.PatchPath)
-				} else {
-					patchCell = "📎 applied"
-				}
-			}
-			fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s |\n", i+1, test.Name, status, patchCell, duration)
-		}
-		sb.WriteString("\n")
-	}
-
-	// Extension coverage map: the full catalog (covered / pending / unsupported
-	// / external) merged with this run's per-test results from both the contrib
-	// and external suites. Rendered whenever either ran so the report doubles as
-	// the living coverage tracker (see extensions.go).
-	var contribResults, externalResults *TestResults
-	for _, s := range suites {
-		switch s.Name {
-		case "Contrib Extension Tests":
-			contribResults = s.Results
-		case "External Extension Tests":
-			externalResults = s.Results
-		}
-	}
-	if contribResults != nil || externalResults != nil {
-		sb.WriteString(ExtensionCoverageMarkdown(contribResults, externalResults))
-	}
-
-	summary := sb.String()
-	summaryPath, err := suiteutil.WriteMarkdown(pb.OutputDir, "compatibility-report.md", summary)
-	if err != nil {
-		return summary, err
-	}
-	t.Logf("Markdown summary written to: %s", summaryPath)
-	return summary, nil
-}
-
-// jsonSuiteResult is the JSON-serializable representation of a single test suite's results.
-type jsonSuiteResult struct {
-	Name  string                 `json:"name"`
-	Tests []IndividualTestResult `json:"tests"`
-}
-
-// WriteJSONResults serializes suite results to pb.OutputDir/results.json.
-// This file is consumed by CI scripts that compare runs to detect regressions.
-func (pb *PostgresBuilder) WriteJSONResults(t *testing.T, suites []SuiteResult) (string, error) {
-	t.Helper()
-
-	var out []jsonSuiteResult
-	for _, s := range suites {
-		out = append(out, jsonSuiteResult{
-			Name:  s.Name,
-			Tests: s.Results.Tests,
-		})
-	}
-
-	resultsPath, err := suiteutil.WriteJSON(pb.OutputDir, "results.json", out)
-	if err != nil {
-		return "", err
-	}
-	t.Logf("JSON results written to: %s", resultsPath)
-	return resultsPath, nil
-}
-
-// WriteBadgeEndpoints writes one shields.io endpoint JSON per suite plus a
-// combined "overall.json" into pb.OutputDir/badges. CI publishes this directory
-// to GitHub Pages so the README and blog badges render the live pass count
-// (republishing the JSON updates the badge with no markdown edits).
-//
-// Filenames are the suite label slug: regression.json, isolation.json,
-// contrib-extension.json, and overall.json. These names are part of the public
-// badge URL, so keep them stable.
-func (pb *PostgresBuilder) WriteBadgeEndpoints(t *testing.T, suites []SuiteResult) error {
-	t.Helper()
-
-	badgeDir := filepath.Join(pb.OutputDir, "badges")
-
-	var totalPassed, totalTests, totalExpected int
-	var anyTimedOut bool
-	for _, s := range suites {
-		label := strings.TrimSuffix(s.Name, " Tests")
-		endpoint := suiteutil.NewBadgeEndpoint(label, s.Results.PassedTests, s.Results.TotalTests, s.ExpectedTests, s.Results.TimedOut)
-		if _, err := suiteutil.WriteJSON(badgeDir, suiteutil.BadgeSlug(label)+".json", endpoint); err != nil {
-			return err
-		}
-		totalPassed += s.Results.PassedTests
-		totalTests += s.Results.TotalTests
-		totalExpected += s.ExpectedTests
-		anyTimedOut = anyTimedOut || s.Results.TimedOut
-	}
-
-	overall := suiteutil.NewBadgeEndpoint("Overall", totalPassed, totalTests, totalExpected, anyTimedOut)
-	if _, err := suiteutil.WriteJSON(badgeDir, "overall.json", overall); err != nil {
-		return err
-	}
-
-	t.Logf("Badge endpoints written to: %s", badgeDir)
-	return nil
-}
-
-// patchIsolationtester rewrites two pieces of
-// src/test/isolation/isolationtester.c so the harness works against
-// multigateway:
-//
-//  1. Per-session application_name setup. Upstream sends
-//     PQexecParams("SELECT set_config('application_name',
-//     current_setting('application_name') || '/' || $1, false)", ...),
-//     which the multigateway planner rejects (the value must be a literal
-//     constant for is_local=false set_config so the pooler can track it).
-//     The replacement reads PGAPPNAME (set by isolation_main.c per test),
-//     concatenates the session name client-side, escapes via
-//     PQescapeLiteral, and sends a simple-protocol PQexec.
-//
-//  2. Lock-wait probe function name. Upstream prepares
-//     `pg_catalog.pg_isolation_test_session_is_blocked(...)`. Replacing
-//     that builtin C function with a PL/pgSQL shim via CREATE OR REPLACE
-//     proved unreliable (fresh backends were observed to still bind the
-//     C entry, returning false for every probe and hanging every
-//     blocking spec at max_step_wait). We point the harness at our own
-//     function `public.multigres_test_session_is_blocked` (installed by
-//     installPIDMappingFunction) with explicit arg casts so PG resolves
-//     it under extended-protocol Parse with paramTypes=NULL.
-//
-// Idempotent: source is reset via `git checkout` before patching, so
-// repeat invocations against the cached checkout produce the same
-// result.
-func (pb *PostgresBuilder) patchIsolationtester(t *testing.T, ctx context.Context) error {
-	t.Helper()
-	rel := filepath.Join("src", "test", "isolation", "isolationtester.c")
-	abs := filepath.Join(pb.SourceDir, rel)
-
-	reset := executil.Command(ctx, "git", "-C", pb.SourceDir, "checkout", "--", rel)
-	if out, err := reset.CombinedOutput(); err != nil {
-		return fmt.Errorf("reset %s: %w\n%s", rel, err, out)
-	}
-
-	src, err := os.ReadFile(abs)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", abs, err)
-	}
-
-	appNameOrig := "\t\tres = PQexecParams(conns[i].conn,\n" +
-		"\t\t\t\t\t\t   \"SELECT set_config('application_name',\\n\"\n" +
-		"\t\t\t\t\t\t   \"  current_setting('application_name') || '/' || $1,\\n\"\n" +
-		"\t\t\t\t\t\t   \"  false)\",\n" +
-		"\t\t\t\t\t\t   1, NULL,\n" +
-		"\t\t\t\t\t\t   &sessionname,\n" +
-		"\t\t\t\t\t\t   NULL, NULL, 0);"
-
-	appNameReplacement := "\t\t/*\n" +
-		"\t\t * multigres patch: build the application_name literal client-side\n" +
-		"\t\t * and send it via the simple protocol. The multigateway planner\n" +
-		"\t\t * rejects set_config() when the value is a non-literal expression\n" +
-		"\t\t * or bound parameter (the pooler tracks the literal value), so we\n" +
-		"\t\t * cannot use PQexecParams + current_setting() here.\n" +
-		"\t\t */\n" +
-		"\t\t{\n" +
-		"\t\t\tconst char *appname_prefix = getenv(\"PGAPPNAME\");\n" +
-		"\t\t\tchar\t   *combined;\n" +
-		"\t\t\tchar\t   *escaped;\n" +
-		"\t\t\tchar\t   *appname_query;\n" +
-		"\n" +
-		"\t\t\tif (appname_prefix == NULL)\n" +
-		"\t\t\t\tappname_prefix = \"\";\n" +
-		"\t\t\tcombined = psprintf(\"%s/%s\", appname_prefix, sessionname);\n" +
-		"\t\t\tescaped = PQescapeLiteral(conns[i].conn, combined, strlen(combined));\n" +
-		"\t\t\tfree(combined);\n" +
-		"\t\t\tif (escaped == NULL)\n" +
-		"\t\t\t{\n" +
-		"\t\t\t\tfprintf(stderr, \"PQescapeLiteral failed: %s\",\n" +
-		"\t\t\t\t\t\tPQerrorMessage(conns[i].conn));\n" +
-		"\t\t\t\texit(1);\n" +
-		"\t\t\t}\n" +
-		"\t\t\tappname_query = psprintf(\n" +
-		"\t\t\t\t\"SELECT set_config('application_name', %s, false)\", escaped);\n" +
-		"\t\t\tPQfreemem(escaped);\n" +
-		"\t\t\tres = PQexec(conns[i].conn, appname_query);\n" +
-		"\t\t\tfree(appname_query);\n" +
-		"\t\t}"
-
-	if !bytes.Contains(src, []byte(appNameOrig)) {
-		return fmt.Errorf("%s: original set_config block not found (PG version drift?)", rel)
-	}
-	patched := bytes.Replace(src, []byte(appNameOrig), []byte(appNameReplacement), 1)
-
-	// Add explicit type casts on both args. isolationtester PQprepares the
-	// wait-query with paramTypes=NULL so $1 enters parse as UNKNOWN, and the
-	// '{...}' literal is also UNKNOWN. PG resolves this for the pg_catalog
-	// C builtin via implicit catalog priority but fails for a public
-	// PL/pgSQL function with "function public.X(unknown, unknown) does not
-	// exist". Casting to int4 / int4[] removes the ambiguity.
-	waitFnOrig := "\"SELECT pg_catalog.pg_isolation_test_session_is_blocked($1, '{\""
-	waitFnReplacement := "\"SELECT public.multigres_test_session_is_blocked($1::int4, '{\""
-	if !bytes.Contains(patched, []byte(waitFnOrig)) {
-		return fmt.Errorf("%s: wait-query function reference not found (PG version drift?)", rel)
-	}
-	patched = bytes.Replace(patched, []byte(waitFnOrig), []byte(waitFnReplacement), 1)
-
-	waitFnSuffixOrig := "appendPQExpBufferStr(&wait_query, \"}')\");"
-	waitFnSuffixReplacement := "appendPQExpBufferStr(&wait_query, \"}'::int4[])\");"
-	if !bytes.Contains(patched, []byte(waitFnSuffixOrig)) {
-		return fmt.Errorf("%s: wait-query suffix not found (PG version drift?)", rel)
-	}
-	patched = bytes.Replace(patched, []byte(waitFnSuffixOrig), []byte(waitFnSuffixReplacement), 1)
-
-	if err := os.WriteFile(abs, patched, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", abs, err)
-	}
-	t.Logf("Patched %s: literal application_name + public.multigres_test_session_is_blocked", rel)
-	return nil
-}
-
-// BuildIsolation builds the PostgreSQL isolation test tools (isolationtester and
-// pg_isolation_regress). Must be called after Build().
-func (pb *PostgresBuilder) BuildIsolation(t *testing.T, ctx context.Context) error {
-	t.Helper()
-
-	if err := pb.patchIsolationtester(t, ctx); err != nil {
-		return fmt.Errorf("patch isolationtester: %w", err)
-	}
-
-	isolationDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")
-
-	t.Logf("Building isolation test tools in %s...", isolationDir)
-	cmd := executil.Command(ctx, "make", "-C", isolationDir, "all")
-	cmd.Cmd.Stdout = os.Stdout
-	cmd.Cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("make isolation tools failed: %w", err)
-	}
-
-	t.Logf("Isolation test tools built successfully")
-	return nil
-}
-
 // truncateForLog clips s to at most n characters (with an ellipsis suffix when
 // truncation occurs). Used for compact log/error messages.
 func truncateForLog(s string, n int) string {
@@ -1455,320 +627,4 @@ func truncateForLog(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
-}
-
-// installPIDMappingFunction creates public.multigres_test_session_is_blocked
-// in the target database so the patched isolationtester (see
-// patchIsolationtester) can probe lock waits through the multigateway →
-// multipooler → PostgreSQL hop.
-//
-// Multipooler is configured with --database=postgres and routes every
-// query to a pooled connection against the postgres DB regardless of the
-// dbname in the client startup packet, so the shim must live in postgres.
-// Both isolation invocation paths (selective via PGISOLATION_TESTS and
-// full-suite via the make installcheck target) force --dbname=postgres on
-// pg_isolation_regress, so postgres is also the dbname the harness opens.
-//
-// The shim mirrors the upstream builtin: returns true if check_pid is
-// waiting on any pid in blocked_by, considering both heavyweight lock
-// waits (pg_blocking_pids) and SSI safe-snapshot waits
-// (pg_safe_snapshot_blocking_pids — required for SERIALIZABLE READ ONLY
-// DEFERRABLE specs such as read-only-anomaly-3). Both inputs are
-// multigateway virtual pids; we map them to real PostgreSQL backend pids
-// via pg_stat_activity.application_name (the multipooler stamps each
-// backend with `multigres_vpid:<id>` per query). A given vpid can map to
-// multiple PG backends in flight (a leftover stamp on a pool conn after
-// a regular query, plus the live reserved conn) so the wait-check
-// aggregates over every matching backend rather than picking one
-// non-deterministically.
-func (pb *PostgresBuilder) installPIDMappingFunction(t *testing.T, pgPort int, password string) error {
-	t.Helper()
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		pgPort, password)
-	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		return fmt.Errorf("failed to connect: %w", err)
-	}
-	defer db.Close()
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-
-	stmts := []string{
-		// Debug table: every shim invocation logs its inputs/outputs and a
-		// snapshot of every backend in this DB so failures can be diagnosed
-		// post-hoc by querying isolation_debug_log (see
-		// dumpIsolationDebugLog).
-		`CREATE TABLE IF NOT EXISTS public.isolation_debug_log (
-			id serial PRIMARY KEY,
-			ts timestamptz DEFAULT now(),
-			check_pid int4,
-			blocked_by int4[],
-			real_check_pid int4,
-			real_blocked_by int4[],
-			blocking_pids int4[],
-			vpid_entries text[],
-			all_pg_backends text[],
-			result boolean
-		)`,
-		// Non-destructive add for runs against a pre-existing table from an
-		// earlier shim version that lacked all_pg_backends.
-		`ALTER TABLE public.isolation_debug_log
-		   ADD COLUMN IF NOT EXISTS all_pg_backends text[]`,
-		`TRUNCATE public.isolation_debug_log`,
-		`DROP FUNCTION IF EXISTS public.multigres_test_session_is_blocked(int4, int4[])`,
-		`CREATE FUNCTION public.multigres_test_session_is_blocked(check_pid int4, blocked_by int4[])
-RETURNS boolean
-LANGUAGE plpgsql
-SET search_path = pg_catalog, public
-AS $$
-<<fn>>
-DECLARE
-    v_log_id int4;
-    v_real_check_pid int4;
-    v_real_blocked_by int4[];
-    v_blocking_pids int4[];
-    v_vpid_entries text[];
-    v_all_backends text[];
-    v_stamp_found boolean;
-    v_result boolean;
-BEGIN
-    -- Capture the inserted id directly so the later UPDATE targets THIS
-    -- invocation's row even under concurrent shim calls (parallel groups
-    -- in the isolation schedule, or multiple sessions polling at once).
-    -- max(id) would race against any concurrent INSERT in between.
-    INSERT INTO public.isolation_debug_log
-        (check_pid, blocked_by, result)
-    VALUES
-        (check_pid, blocked_by, NULL)
-    RETURNING id INTO v_log_id;
-
-    SELECT array_agg(sa.application_name || '=' || sa.pid)
-    INTO v_vpid_entries
-    FROM pg_stat_activity sa
-    WHERE sa.application_name LIKE 'multigres_vpid:%';
-
-    SELECT array_agg(sa.pid || ':' || COALESCE(sa.application_name,'<null>') || ':' || COALESCE(sa.state,'<null>'))
-    INTO v_all_backends
-    FROM pg_stat_activity sa
-    WHERE sa.datname = current_database();
-
-    -- A client vpid can map to multiple PG backends (a leftover stamp on
-    -- a pool conn after the client ran a regular query, plus the live
-    -- reserved conn). Picking one non-deterministically risks probing the
-    -- idle one and missing the wait. real_check_pid is kept for
-    -- diagnostic display only; the actual block check below aggregates
-    -- over every matching backend.
-    SELECT sa.pid INTO v_real_check_pid
-    FROM pg_stat_activity sa
-    WHERE sa.application_name = 'multigres_vpid:' || check_pid
-    LIMIT 1;
-
-    SELECT array_agg(sa.pid) INTO v_real_blocked_by
-    FROM pg_stat_activity sa
-    WHERE sa.application_name = ANY(
-        SELECT 'multigres_vpid:' || unnest(blocked_by)
-    );
-
-    -- Direct connections (no multigateway) hand us real pids; preserve them.
-    v_stamp_found := v_real_check_pid IS NOT NULL;
-    v_real_check_pid := COALESCE(v_real_check_pid, check_pid);
-    v_real_blocked_by := COALESCE(v_real_blocked_by, blocked_by);
-
-    -- Aggregate heavyweight lock blockers and SSI safe-snapshot blockers
-    -- across every PG backend currently stamped for this vpid. SSI
-    -- safe-snapshot wait is required for SERIALIZABLE READ ONLY
-    -- DEFERRABLE specs (e.g. read-only-anomaly-3). Aggregation handles
-    -- the duplicate-stamp case where one backend is the live reserved
-    -- conn (potentially blocked) and another is a leaked pool conn
-    -- (idle).
-    --
-    -- The direct-pid fallback only fires when no stamp was found for
-    -- check_pid. vpids occupy the full 31-bit signed int32 space, so a
-    -- vpid value can coincidentally equal an unrelated real PG backend
-    -- PID; probing check_pid as a real pid unconditionally would surface
-    -- that unrelated backend's blockers and risk a false positive.
-    SELECT COALESCE(array_agg(DISTINCT b), '{}'::int4[]) INTO v_blocking_pids
-    FROM (
-        SELECT unnest(pg_blocking_pids(sa.pid)) AS b
-        FROM pg_stat_activity sa
-        WHERE sa.application_name = 'multigres_vpid:' || check_pid
-        UNION ALL
-        SELECT unnest(pg_safe_snapshot_blocking_pids(sa.pid)) AS b
-        FROM pg_stat_activity sa
-        WHERE sa.application_name = 'multigres_vpid:' || check_pid
-        UNION ALL
-        SELECT unnest(pg_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
-        UNION ALL
-        SELECT unnest(pg_safe_snapshot_blocking_pids(check_pid)) AS b WHERE NOT v_stamp_found
-    ) sub
-    WHERE b IS NOT NULL;
-
-    v_result := v_blocking_pids && v_real_blocked_by;
-
-    UPDATE public.isolation_debug_log
-    SET real_check_pid = v_real_check_pid,
-        real_blocked_by = v_real_blocked_by,
-        blocking_pids = v_blocking_pids,
-        vpid_entries = v_vpid_entries,
-        all_pg_backends = v_all_backends,
-        result = v_result
-    WHERE id = v_log_id;
-
-    RETURN v_result;
-END fn;
-$$`,
-	}
-	for _, stmt := range stmts {
-		if _, err := db.Exec(stmt); err != nil {
-			return fmt.Errorf("failed to execute statement [%s]: %w", truncateForLog(stmt, 80), err)
-		}
-	}
-
-	// Sanity check: the function exists and is plpgsql.
-	var lang string
-	if err := db.QueryRow(`
-		SELECT l.lanname
-		FROM pg_proc p JOIN pg_language l ON p.prolang = l.oid
-		WHERE p.proname = 'multigres_test_session_is_blocked'
-		  AND p.pronamespace = 'public'::regnamespace`).Scan(&lang); err != nil {
-		return fmt.Errorf("verify multigres_test_session_is_blocked: %w", err)
-	}
-	if lang != "plpgsql" {
-		return fmt.Errorf("multigres_test_session_is_blocked installed with lanname=%q (expected plpgsql)", lang)
-	}
-
-	t.Logf("Installed public.multigres_test_session_is_blocked on database \"postgres\"")
-	return nil
-}
-
-// dumpIsolationDebugLog prints recent entries from
-// public.isolation_debug_log so investigators can see the inputs/outputs
-// of every shim invocation during the isolation run. Best-effort;
-// failures are logged and ignored.
-func (pb *PostgresBuilder) dumpIsolationDebugLog(t *testing.T, pgPort int, password string) {
-	t.Helper()
-	connStr := fmt.Sprintf("host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=disable",
-		pgPort, password)
-	db, err := sql.Open("postgres", connStr)
-	if err != nil {
-		t.Logf("isolation_debug_log dump: connect failed: %v", err)
-		return
-	}
-	defer db.Close()
-
-	var total int
-	if err := db.QueryRow(`SELECT count(*) FROM public.isolation_debug_log WHERE check_pid > 0`).Scan(&total); err != nil {
-		t.Logf("isolation_debug_log dump: count failed: %v", err)
-		return
-	}
-	t.Logf("isolation_debug_log: %d shim invocations recorded during run", total)
-	if total == 0 {
-		t.Logf("isolation_debug_log: shim never executed — wait-query is not reaching public.multigres_test_session_is_blocked")
-		return
-	}
-
-	rows, err := db.Query(`
-		SELECT id, check_pid, blocked_by, real_check_pid, real_blocked_by,
-		       blocking_pids, vpid_entries, all_pg_backends, result
-		FROM public.isolation_debug_log
-		WHERE check_pid > 0
-		ORDER BY id DESC
-		LIMIT 30`)
-	if err != nil {
-		t.Logf("isolation_debug_log dump: select failed: %v", err)
-		return
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id, checkPid int
-		var blockedBy, realBlockedBy, blockingPids, vpidEntries, allBackends sql.NullString
-		var realCheckPid sql.NullInt32
-		var result sql.NullBool
-		if err := rows.Scan(&id, &checkPid, &blockedBy, &realCheckPid, &realBlockedBy, &blockingPids, &vpidEntries, &allBackends, &result); err != nil {
-			t.Logf("isolation_debug_log dump: scan failed: %v", err)
-			continue
-		}
-		t.Logf("isolation_debug_log id=%d check_pid=%d blocked_by=%s real_check=%v real_blocked=%s blocking=%s vpids=%s all=%s result=%v",
-			id, checkPid, blockedBy.String, realCheckPid, realBlockedBy.String, blockingPids.String, vpidEntries.String, allBackends.String, result)
-	}
-}
-
-// RunIsolationTests runs PostgreSQL isolation tests against multigateway.
-// Isolation tests exercise multi-connection concurrency (deadlocks, serialization
-// anomalies, lock contention, concurrent DDL) using isolationtester.
-//
-// directPgPort is the primary's direct PostgreSQL port; it's used to install
-// the public.multigres_test_session_is_blocked shim that the patched
-// isolationtester binary calls (see patchIsolationtester for the source-side
-// rewrite that retargets the wait query at the public function).
-//
-// The isolation Makefile has no installcheck-tests target, so for selective tests
-// we invoke pg_isolation_regress directly with test names as positional args.
-func (pb *PostgresBuilder) RunIsolationTests(t *testing.T, ctx context.Context, multigatewayPort, directPgPort int, password string) (*TestResults, error) {
-	t.Helper()
-
-	t.Logf("Running PostgreSQL isolation tests against multigateway on port %d (harness db=postgres)...", multigatewayPort)
-
-	// Install the lock-detection shim on PostgreSQL directly (bypassing
-	// multigateway). Both the selective (PGISOLATION_TESTS) and full-suite
-	// paths force --dbname=postgres on pg_isolation_regress (see the cmd
-	// construction below), and multipooler routes every query to the
-	// postgres DB anyway, so the shim only needs to live there.
-	if err := pb.installPIDMappingFunction(t, directPgPort, password); err != nil {
-		t.Logf("Warning: Failed to install PID mapping function: %v", err)
-		t.Logf("Isolation tests that rely on lock detection (deadlock, etc.) may fail")
-	}
-
-	isolationBuildDir := filepath.Join(pb.BuildDir, "src", "test", "isolation")
-	isolationSourceDir := filepath.Join(pb.SourceDir, "src", "test", "isolation")
-	outputIsoDir := filepath.Join(isolationBuildDir, "output_iso")
-
-	if err := os.MkdirAll(outputIsoDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create output_iso directory: %w", err)
-	}
-
-	pgIsoRegress := filepath.Join(isolationBuildDir, "pg_isolation_regress")
-	if _, err := os.Stat(pgIsoRegress); os.IsNotExist(err) {
-		t.Logf("Building pg_isolation_regress...")
-		buildCmd := executil.Command(ctx, "make", "-C", isolationBuildDir, "all")
-		if out, err := buildCmd.CombinedOutput(); err != nil {
-			return nil, fmt.Errorf("failed to build pg_isolation_regress: %w\n%s", err, out)
-		}
-	}
-
-	var cmd *executil.Cmd
-	if testsEnv := os.Getenv("PGISOLATION_TESTS"); testsEnv != "" {
-		args := []string{
-			"--inputdir=" + isolationSourceDir,
-			"--outputdir=" + outputIsoDir,
-			"--host=localhost",
-			fmt.Sprintf("--port=%d", multigatewayPort),
-			"--user=postgres",
-			"--dbname=postgres",
-			"--use-existing",
-			"--dlpath=" + isolationBuildDir,
-		}
-		args = append(args, strings.Fields(testsEnv)...)
-		cmd = executil.Command(ctx, pgIsoRegress, args...).WithProcessGroup()
-		t.Logf("Running selective isolation tests: %s", testsEnv)
-	} else {
-		cmd = executil.Command(ctx, "make", "-C", isolationBuildDir, "installcheck",
-			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
-		t.Logf("Running full PostgreSQL isolation test suite (installcheck)")
-	}
-
-	results, runErr := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
-		suiteName: "Isolation",
-		outputDir: filepath.Join(pb.OutputDir, "isolation"),
-		srcOutDir: outputIsoDir,
-	}, multigatewayPort, password)
-
-	// Post-suite diagnostic: dump the last entries of isolation_debug_log
-	// so investigators can see what the shim observed (or didn't) for
-	// hung specs. The table lives in the postgres DB on the primary;
-	// query it directly to bypass any multigateway routing that a
-	// failing wait-query would have used.
-	pb.dumpIsolationDebugLog(t, directPgPort, password)
-
-	return results, runErr
 }

--- a/go/test/endtoend/pgregresstest/report.go
+++ b/go/test/endtoend/pgregresstest/report.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/test/endtoend/suiteutil"
+)
+
+// SuiteResult holds results for one test suite.
+type SuiteResult struct {
+	Name          string       // e.g. "Regression Tests", "Isolation Tests"
+	Results       *TestResults // parsed TAP results
+	ExpectedTests int          // total tests from schedule file (0 = unknown)
+}
+
+// githubBlobURLPrefix returns an absolute URL prefix of the form
+// "https://github.com/<owner>/<repo>/blob/<sha>/" when running inside a
+// GitHub Actions job, or an empty string otherwise. Repo-relative paths
+// concatenated onto this prefix resolve to the blob view of that file at
+// the exact commit the job is executing against.
+func githubBlobURLPrefix() string {
+	serverURL := os.Getenv("GITHUB_SERVER_URL")
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	sha := os.Getenv("GITHUB_SHA")
+	if serverURL == "" || repo == "" || sha == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/blob/%s/", serverURL, repo, sha)
+}
+
+// WriteMarkdownSummary generates a unified markdown report covering one or more
+// test suites. It writes the report to pb.OutputDir/compatibility-report.md and
+// appends it to GITHUB_STEP_SUMMARY when running in CI.
+//
+// Each suite gets its own badge showing pass rate and timeout status. Full diffs
+// are available in the CI artifact (regression.diffs).
+func (pb *PostgresBuilder) WriteMarkdownSummary(t *testing.T, suites []SuiteResult) (string, error) {
+	t.Helper()
+
+	var sb strings.Builder
+
+	sb.WriteString("## PostgreSQL Compatibility Report\n\n")
+
+	for _, s := range suites {
+		label := strings.TrimSuffix(s.Name, " Tests")
+		sb.WriteString(suiteutil.BadgeMarkdown(
+			label,
+			s.Results.PassedTests,
+			s.Results.TotalTests,
+			s.ExpectedTests,
+			s.Results.TimedOut,
+		))
+		sb.WriteString(" ")
+	}
+	sb.WriteString("\n\n")
+
+	fmt.Fprintf(&sb, "**PostgreSQL Version:** `%s`\n", PostgresVersion)
+	fmt.Fprintf(&sb, "**Timestamp:** %s\n\n", time.Now().UTC().Format(time.RFC3339))
+
+	// Build an absolute URL prefix for patch links when running in CI.
+	// Without this, markdown like [patch](go/test/.../foo.patch) is resolved
+	// relative to the step-summary page (/actions/runs/<id>/) and produces a
+	// 404 URL like .../actions/runs/go/test/.../foo.patch. Falls back to a
+	// relative link when the GitHub Actions env vars aren't set (local runs).
+	patchURLPrefix := githubBlobURLPrefix()
+
+	for _, s := range suites {
+		// The contrib and external suites' per-test detail is rendered by the
+		// richer Extension Coverage table below (it carries the same per-test
+		// results plus catalog context), so skip the generic per-test section
+		// here. Their badges above are still shown.
+		if s.Name == "Contrib Extension Tests" || s.Name == "External Extension Tests" {
+			continue
+		}
+
+		fmt.Fprintf(&sb, "### %s\n\n", s.Name)
+
+		if s.Results.TimedOut {
+			ran := s.Results.TotalTests
+			if s.ExpectedTests > 0 {
+				fmt.Fprintf(&sb, "> **Timed out** — %d of %d scheduled tests executed before the deadline.\n\n", ran, s.ExpectedTests)
+			} else {
+				fmt.Fprintf(&sb, "> **Timed out** — %d tests executed before the deadline.\n\n", ran)
+			}
+		}
+
+		sb.WriteString("| # | Test | Status | Patch | Duration |\n")
+		sb.WriteString("|---|------|--------|-------|----------|\n")
+
+		for i, test := range s.Results.Tests {
+			status := "✅ ok"
+			switch test.Status {
+			case "fail":
+				status = "❌ FAIL"
+			case "skip":
+				status = "⏭️ skip"
+			}
+			duration := test.Duration
+			if duration == "" {
+				duration = "-"
+			}
+			patchCell := "-"
+			if test.PatchApplied {
+				if test.PatchPath != "" {
+					patchCell = fmt.Sprintf("📎 [patch](%s%s)", patchURLPrefix, test.PatchPath)
+				} else {
+					patchCell = "📎 applied"
+				}
+			}
+			fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s |\n", i+1, test.Name, status, patchCell, duration)
+		}
+		sb.WriteString("\n")
+	}
+
+	// Extension coverage map: the full catalog (covered / pending / unsupported
+	// / external) merged with this run's per-test results from both the contrib
+	// and external suites. Rendered whenever either ran so the report doubles as
+	// the living coverage tracker (see extensions.go).
+	var contribResults, externalResults *TestResults
+	for _, s := range suites {
+		switch s.Name {
+		case "Contrib Extension Tests":
+			contribResults = s.Results
+		case "External Extension Tests":
+			externalResults = s.Results
+		}
+	}
+	if contribResults != nil || externalResults != nil {
+		sb.WriteString(ExtensionCoverageMarkdown(contribResults, externalResults))
+	}
+
+	summary := sb.String()
+	summaryPath, err := suiteutil.WriteMarkdown(pb.OutputDir, "compatibility-report.md", summary)
+	if err != nil {
+		return summary, err
+	}
+	t.Logf("Markdown summary written to: %s", summaryPath)
+	return summary, nil
+}
+
+// jsonSuiteResult is the JSON-serializable representation of a single test suite's results.
+type jsonSuiteResult struct {
+	Name  string                 `json:"name"`
+	Tests []IndividualTestResult `json:"tests"`
+}
+
+// WriteJSONResults serializes suite results to pb.OutputDir/results.json.
+// This file is consumed by CI scripts that compare runs to detect regressions.
+func (pb *PostgresBuilder) WriteJSONResults(t *testing.T, suites []SuiteResult) (string, error) {
+	t.Helper()
+
+	var out []jsonSuiteResult
+	for _, s := range suites {
+		out = append(out, jsonSuiteResult{
+			Name:  s.Name,
+			Tests: s.Results.Tests,
+		})
+	}
+
+	resultsPath, err := suiteutil.WriteJSON(pb.OutputDir, "results.json", out)
+	if err != nil {
+		return "", err
+	}
+	t.Logf("JSON results written to: %s", resultsPath)
+	return resultsPath, nil
+}
+
+// WriteBadgeEndpoints writes one shields.io endpoint JSON per suite plus a
+// combined "overall.json" into pb.OutputDir/badges. CI publishes this directory
+// to GitHub Pages so the README and blog badges render the live pass count
+// (republishing the JSON updates the badge with no markdown edits).
+//
+// Filenames are the suite label slug: regression.json, isolation.json,
+// contrib-extension.json, and overall.json. These names are part of the public
+// badge URL, so keep them stable.
+func (pb *PostgresBuilder) WriteBadgeEndpoints(t *testing.T, suites []SuiteResult) error {
+	t.Helper()
+
+	badgeDir := filepath.Join(pb.OutputDir, "badges")
+
+	var totalPassed, totalTests, totalExpected int
+	var anyTimedOut bool
+	for _, s := range suites {
+		label := strings.TrimSuffix(s.Name, " Tests")
+		endpoint := suiteutil.NewBadgeEndpoint(label, s.Results.PassedTests, s.Results.TotalTests, s.ExpectedTests, s.Results.TimedOut)
+		if _, err := suiteutil.WriteJSON(badgeDir, suiteutil.BadgeSlug(label)+".json", endpoint); err != nil {
+			return err
+		}
+		totalPassed += s.Results.PassedTests
+		totalTests += s.Results.TotalTests
+		totalExpected += s.ExpectedTests
+		anyTimedOut = anyTimedOut || s.Results.TimedOut
+	}
+
+	overall := suiteutil.NewBadgeEndpoint("Overall", totalPassed, totalTests, totalExpected, anyTimedOut)
+	if _, err := suiteutil.WriteJSON(badgeDir, "overall.json", overall); err != nil {
+		return err
+	}
+
+	t.Logf("Badge endpoints written to: %s", badgeDir)
+	return nil
+}

--- a/go/test/endtoend/pgregresstest/testdata/pg17/external/pg_partman.conf
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/external/pg_partman.conf
@@ -1,0 +1,15 @@
+# pg_partman server configuration, appended at initdb time when the external
+# suite runs pg_partman (ExternalExtension.ServerConfigFile in extensions.go).
+#
+# pg_partman's pgTAP suite includes subpartitioning tests that create and drop
+# several hundred tables inside a single rolled-back transaction. The default
+# max_locks_per_transaction (64) is too small for that many relation locks in
+# one transaction and risks exhausting the shared lock table and crashing the
+# cluster, so pg_partman's own test README requires raising it; 128 is the value
+# its docs recommend. Appended after the pgctld template, so this wins.
+#
+# Note: pg_partman's background worker (pg_partman_bgw) is NOT loaded here. It is
+# only needed for automated maintenance and the test_bgw/ subfolder, which this
+# harness excludes (TestGlob = "test-*.sql"); CREATE EXTENSION pg_partman and all
+# top-level tests work without it.
+max_locks_per_transaction = 128


### PR DESCRIPTION
## Summary

- Adds a pgTAP test harness alongside the existing pg_regress one, so extensions that ship pgTAP suites (pg_partman) run through multigateway. Each test `.sql` is fed to `psql` and graded from the server-side TAP stream — no expected-output files, no patch pipeline.
- Covers pg_partman's transaction-wrapped tests (34 files: top-level `test-*.sql` plus `test_pg17plus/` and `test_no_search_path/`).
- Unifies the pg_regress `CreateExtension` bool into a schema-aware `PreCreateExtensions` list shared by both harnesses (`CreateExtension: true` was just the special case `{Name: ext.Name}`).
- Splits the ~2k-line `postgres_builder.go` into `pg_regress.go`, `pg_tap.go`, `isolation.go`, and `report.go` (pure code motion).

## Description

pgTAP decides correctness server-side (each `SELECT ok(...)` returns a TAP row), so the runner just parses the `ok`/`not ok` stream rather than diffing `expected/*.out`. pg_partman is scoped to its self-contained `BEGIN…ROLLBACK` tests; the autocommit/procedure subfolders are excluded and documented.

That exclusion is a hard limit of pgTAP-through-a-transaction-pooler, not a scoping whim: pgTAP's `plan()` creates its state in a temp table *inside a function body*, which the gateway can't observe (it only parses the client statement), so it can't pin the session. Inside `BEGIN…ROLLBACK` the visible `BEGIN` pins the backend and `ROLLBACK` discards that temp state; in autocommit (procedure suites that `COMMIT`) the temp table leaks onto a pooled backend and the next file hits "you tried to plan twice". This was confirmed empirically — the failures vanish when the same files run directly against Postgres.

pg_partman + pgmq run together at 39/39 (pgmq depends on pg_partman); the pgTAP path tears its extensions down after the suite so pgmq's `base.sql` starts from the clean state its expected output assumes.