### PR TITLE
feat(consensus): structured observability events for recruit and propose rounds

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -16,6 +16,8 @@
 package consensus
 
 import (
+	"fmt"
+
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	"github.com/multigres/multigres/go/tools/pgutil"
 )
@@ -51,6 +53,17 @@ func CompareRuleNumbers(a, b *clustermetadatapb.RuleNumber) int {
 		return 1
 	}
 	return 0
+}
+
+// FormatRuleNumber renders a RuleNumber for human-readable logs as
+// "coordinator_term.leader_subterm" (e.g. "7.2"). The proto's default string
+// form is verbose and not log-friendly, so prefer this helper wherever a rule
+// number is logged. A nil RuleNumber renders as "none".
+func FormatRuleNumber(rn *clustermetadatapb.RuleNumber) string {
+	if rn == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%d.%d", rn.GetCoordinatorTerm(), rn.GetLeaderSubterm())
 }
 
 // MostAdvancedPosition returns the highest-ranked PoolerPosition among the

--- a/go/common/eventlog/events.go
+++ b/go/common/eventlog/events.go
@@ -121,17 +121,44 @@ func (e BackupLeaseLost) LogAttrs() []slog.Attr {
 	return []slog.Attr{slog.String("holder", e.Holder)}
 }
 
-type TermBegin struct {
-	NewTerm      int64
+type ConsensusRecruit struct {
+	Rule         string
 	PreviousTerm int64
 	RevokedRole  string // "primary" | "standby" | "" (empty = no revoke)
 }
 
-func (TermBegin) EventType() string { return "term.begin" }
-func (e TermBegin) LogAttrs() []slog.Attr {
+func (ConsensusRecruit) EventType() string { return "consensus.recruit" }
+func (e ConsensusRecruit) LogAttrs() []slog.Attr {
 	return []slog.Attr{
-		slog.Int64("new_term", e.NewTerm),
+		slog.String("rule", e.Rule),
 		slog.Int64("previous_term", e.PreviousTerm),
 		slog.String("revoked_role", e.RevokedRole),
 	}
+}
+
+// ConsensusPromote is emitted by a multipooler node when it executes the leader
+// path of the Propose phase: it calls pg_promote and writes the new rule entry.
+// Together with consensus.recruit events from Recruit, these events let operators
+// reconstruct the full lifecycle of a term election and correlate Propose-phase
+// failures with postgres state changes.
+type ConsensusPromote struct {
+	Rule string
+}
+
+func (ConsensusPromote) EventType() string { return "consensus.promote" }
+func (e ConsensusPromote) LogAttrs() []slog.Attr {
+	return []slog.Attr{slog.String("rule", e.Rule)}
+}
+
+// ConsensusSetPrimary is emitted by a multipooler node when it executes the
+// standby path of the Propose phase: it configures primary_conninfo to replicate
+// from the new leader. Together with consensus.recruit and consensus.promote
+// events, these events cover the full Propose round across all participating nodes.
+type ConsensusSetPrimary struct {
+	Rule string
+}
+
+func (ConsensusSetPrimary) EventType() string { return "consensus.set_primary" }
+func (e ConsensusSetPrimary) LogAttrs() []slog.Attr {
+	return []slog.Attr{slog.String("rule", e.Rule)}
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -333,7 +333,9 @@ func (pm *MultiPoolerManager) Recruit(ctx context.Context, req *consensusdatapb.
 		return nil, mterrors.Wrap(err, "failed to determine role for recruit")
 	}
 
-	termEvent := eventlog.TermBegin{NewTerm: revokedBelowTerm}
+	termEvent := eventlog.ConsensusRecruit{
+		Rule: commonconsensus.FormatRuleNumber(revocation.GetOutgoingRule()),
+	}
 	eventlog.Emit(ctx, pm.logger, eventlog.Started, termEvent)
 
 	// Stop replication participation.
@@ -483,6 +485,34 @@ func (pm *MultiPoolerManager) Propose(ctx context.Context, req *consensusdatapb.
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT,
 			"proposal.proposed_rule.creation_time is required")
 	}
+	// Propose is only valid for the designated leader. Non-leaders should
+	// receive the leader's identity via SetTermPrimary, which handles
+	// replication setup without requiring a prior Recruit.
+	if !proto.Equal(pm.serviceID, proposalLeader.GetId()) {
+		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
+			"Propose received on %s but proposal_leader is %s; non-leaders should be told via SetTermPrimary",
+			pm.serviceID.GetName(), proposalLeader.GetId().GetName())
+	}
+
+	proposeEvent := eventlog.ConsensusPromote{
+		Rule: commonconsensus.FormatRuleNumber(proposedRule.GetRuleNumber()),
+	}
+	eventlog.Emit(ctx, pm.logger, eventlog.Started, proposeEvent)
+
+	resp, err := pm.proposeLocked(ctx, req)
+	if err != nil {
+		eventlog.Emit(ctx, pm.logger, eventlog.Failed, proposeEvent, "error", err)
+	} else {
+		eventlog.Emit(ctx, pm.logger, eventlog.Success, proposeEvent)
+	}
+	return resp, err
+}
+
+func (pm *MultiPoolerManager) proposeLocked(ctx context.Context, req *consensusdatapb.ProposeRequest) (*consensusdatapb.ProposeResponse, error) {
+	proposal := req.GetProposal()
+	revocation := proposal.GetTermRevocation()
+	proposalLeader := proposal.GetProposalLeader()
+	proposedRule := proposal.GetProposedRule()
 
 	revokedBelowTerm := revocation.GetRevokedBelowTerm()
 	coordinatorID := revocation.GetAcceptedCoordinatorId()
@@ -536,15 +566,6 @@ func (pm *MultiPoolerManager) Propose(ctx context.Context, req *consensusdatapb.
 	if connInfo != "" {
 		return nil, mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION,
 			"primary_conninfo is set (%q); call Recruit before Propose to stop replication", connInfo)
-	}
-
-	// Propose is only valid for the designated leader. Non-leaders should
-	// receive the leader's identity via SetTermPrimary, which handles
-	// replication setup without requiring a prior Recruit.
-	if !proto.Equal(pm.serviceID, proposalLeader.GetId()) {
-		return nil, mterrors.Errorf(mtrpcpb.Code_INVALID_ARGUMENT,
-			"Propose received on %s but proposal_leader is %s; non-leaders should be told via SetTermPrimary",
-			pm.serviceID.GetName(), proposalLeader.GetId().GetName())
 	}
 
 	// Leader path: promote postgres, write rule, enable query service.
@@ -732,6 +753,26 @@ func (pm *MultiPoolerManager) SetTermPrimary(ctx context.Context, req *consensus
 		}
 		return &consensusdatapb.SetTermPrimaryResponse{ConsensusStatus: cs}, nil
 	}
+
+	// Both no-op gates passed — this call will actually reconfigure replication.
+	setTermEvent := eventlog.ConsensusSetPrimary{
+		Rule: commonconsensus.FormatRuleNumber(rule.GetRuleNumber()),
+	}
+	eventlog.Emit(ctx, pm.logger, eventlog.Started, setTermEvent)
+
+	resp, err := pm.setTermPrimaryLocked(ctx, req)
+	if err != nil {
+		eventlog.Emit(ctx, pm.logger, eventlog.Failed, setTermEvent, "error", err)
+	} else {
+		eventlog.Emit(ctx, pm.logger, eventlog.Success, setTermEvent)
+	}
+	return resp, err
+}
+
+func (pm *MultiPoolerManager) setTermPrimaryLocked(ctx context.Context, req *consensusdatapb.SetTermPrimaryRequest) (*consensusdatapb.SetTermPrimaryResponse, error) {
+	leader := req.GetLeader()
+	rule := req.GetRule()
+	port := leader.GetPostgresPort()
 
 	// Decide between "standby update" and "stale-primary demote" based on
 	// actual postgres recovery state rather than topology — a node mid-promote

--- a/go/services/multipooler/internal/manager/rpc_consensus_test.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus_test.go
@@ -788,14 +788,13 @@ func TestPropose(t *testing.T) {
 		{
 			// proposal_leader is some other pooler: Propose is leader-only, so
 			// it must reject this and direct the coordinator to use
-			// SetTermPrimary for followers.
-			name:        "RejectedWhenNotDesignatedLeader",
-			initialTerm: recruitedTerm,
-			ruleStore:   &fakeRuleStore{pos: makeRulePosition(0)},
-			req:         makeReplicaReq(),
-			setupMocks: func(m *mock.QueryService) {
-				expectStandbyReadyMocks(m)
-			},
+			// SetTermPrimary for followers. The identity check runs before any
+			// postgres queries, so no mocks are needed.
+			name:              "RejectedWhenNotDesignatedLeader",
+			initialTerm:       recruitedTerm,
+			ruleStore:         &fakeRuleStore{pos: makeRulePosition(0)},
+			req:               makeReplicaReq(),
+			setupMocks:        func(_ *mock.QueryService) {},
 			expectError:       true,
 			expectErrContains: "non-leaders should be told via SetTermPrimary",
 		},

--- a/go/test/endtoend/multiorch/demote_stale_primary_test.go
+++ b/go/test/endtoend/multiorch/demote_stale_primary_test.go
@@ -140,13 +140,13 @@ func TestDemoteStalePrimary_SIGKILL(t *testing.T) {
 	shardsetup.WaitForEvent(t, mo.LogFile, "primary.demotion", "success", 5*time.Second)
 	t.Log("Verified primary.demotion event in multiorch log")
 
-	// Step 9: Verify term.begin event was emitted during failover.
+	// Step 9: Verify consensus.recruit event was emitted during failover.
 	// Recruit is sent by AppointLeaderAction to all nodes during failover; the new primary is selected from the recruited set.
-	t.Log("Verifying term.begin event in new primary's multipooler log...")
+	t.Log("Verifying consensus.recruit event in new primary's multipooler log...")
 	newPrimary := setup.GetMultipoolerInstance(newPrimaryName)
 	require.NotNil(t, newPrimary, "new primary instance should exist")
-	shardsetup.WaitForEvent(t, newPrimary.Multipooler.LogFile, "term.begin", "success", 5*time.Second)
-	t.Log("Verified term.begin event in new primary's multipooler log")
+	shardsetup.WaitForEvent(t, newPrimary.Multipooler.LogFile, "consensus.recruit", "success", 5*time.Second)
+	t.Log("Verified consensus.recruit event in new primary's multipooler log")
 
 	t.Log("TestDemoteStalePrimary_SIGKILL completed successfully")
 }


### PR DESCRIPTION
## Problem

When a Propose round fails — because postgres became unavailable between Recruit and Propose, or because a standby's SetTermPrimary failed — there was no structured signal in the event log. The only evidence was unstructured log lines scattered across multipooler and multiorch. Correlating a failing Propose round with postgres state changes (socket gone, postgres restarting) required manual grep across multiple services.

## Changes

### Three new consensus events (multipooler)

| Event                   | Handler          | Emitted when                                           |
| ----------------------- | ---------------- | ------------------------------------------------------ |
| `consensus.recruit`     | `Recruit`        | A Recruit attempt starts / succeeds / fails            |
| `consensus.promote`     | `Propose`        | The designated leader attempts pg_promote + rule write |
| `consensus.set_primary` | `SetTermPrimary` | A standby reconfigures primary_conninfo                |

All three carry a `rule_number` field formatted as `"coordinator_term.leader_subterm"` (e.g. `"6.0"`), which is the correlation key tying the three events together across nodes in the same election round. Each event emits Started before the work begins, then Failed (with `error`) or Success on completion.

`consensus.recruit` is a rename of the pre-existing `term.begin` event; the field name changes from `new_term` (int) to `rule_number` (string).

For `consensus.promote`, input validation and the non-leader identity check run before the Started event so routing mistakes do not generate spurious started+failed pairs.

For `consensus.set_primary`, the event is only emitted after both no-op gates pass (rule not revoked, incoming rule strictly higher than local position), so idempotent retries do not generate events.

### FormatRuleNumber helper

`commonconsensus.FormatRuleNumber(rn)` renders a `*RuleNumber` as `"coordinator_term.leader_subterm"` for logs. Nil renders as `"none"`. Used by all three new event types.

## Files changed

| File                                                        | Change                                                                                                             |
| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| `go/common/consensus/compare.go`                            | Add `FormatRuleNumber`                                                                                             |
| `go/common/eventlog/events.go`                              | Rename `TermBegin` → `ConsensusRecruit`; replace `TermPromotion` with `ConsensusPromote` and `ConsensusSetPrimary` |
| `go/services/multipooler/internal/manager/rpc_consensus.go` | Emit events in `Recruit`, `Propose`, `SetTermPrimary`; move validation before event setup in `Propose`             |
| `go/test/endtoend/multiorch/demote_stale_primary_test.go`   | Update `WaitForEvent` assertion from `term.begin` to `consensus.recruit`                                           |
