### PR TITLE
refactor(multigateway): registry-driven lifecycle for gateway-managed variables

### DIFF
--- a/docs/query_serving/gateway_managed_variables.md
+++ b/docs/query_serving/gateway_managed_variables.md
@@ -1,0 +1,100 @@
+# Gateway-Managed Variables
+
+Gateway-managed variables (GMVs) are session variables whose client-visible
+state is owned by multigateway instead of being replayed to PostgreSQL backend
+connections through `SessionSettings`.
+
+Use this mechanism only for variables whose semantics are implemented at the
+gateway. The currently documented GMV is:
+
+- **`statement_timeout`** — enforced by multigateway with context deadlines
+  rather than PostgreSQL's backend-local timer.
+
+## Why GMVs exist
+
+Regular session settings are stored in `SessionSettings` and applied to pooled
+PostgreSQL connections before queries run. That is appropriate for variables
+PostgreSQL itself owns, such as `search_path`.
+
+Some variables need gateway ownership instead. For example,
+`statement_timeout` must affect the full multigateway → multipooler →
+PostgreSQL request path, so the gateway resolves the effective timeout and
+propagates it as a context deadline. Forwarding that setting to arbitrary pooled
+backends would be redundant and could leave backend-local state unrelated to the
+client session that originally set it.
+
+## Client-visible behavior
+
+For a GMV, multigateway handles the SQL surfaces that it can plan safely:
+
+- `SET <gmv> = ...` updates gateway-local session state.
+- `SET LOCAL <gmv> = ...` updates gateway-local transaction state and is cleared
+  at transaction end.
+- `RESET <gmv>` / `SET <gmv> TO DEFAULT` restore the connection default.
+- `SET LOCAL <gmv> TO DEFAULT` installs a transaction-local default override.
+- `RESET ALL` clears all regular `SessionSettings` and resets every registered
+  GMV.
+- `SHOW <gmv>` reads gateway-local state without a PostgreSQL round trip.
+- Top-level `SELECT set_config('<gmv>', value, false)` updates gateway-local
+  session state before the query is routed to PostgreSQL.
+- Top-level `SELECT set_config('<gmv>', value, true)` updates gateway-local
+  transaction state for known GMV names when an explicit transaction is active,
+  matching `SET LOCAL` behavior.
+
+GMV values are not stored in `SessionSettings` and are not forwarded to backend
+connections as normal session settings.
+
+## `SHOW` vs `current_setting()`
+
+`SHOW <gmv>` is planned explicitly and returns the value from multigateway's
+connection state.
+
+Arbitrary SQL expressions are not rewritten. A query such as:
+
+```sql
+SELECT current_setting('statement_timeout');
+```
+
+runs on PostgreSQL and observes that backend connection's local GUC state, not
+multigateway's GMV state. Clients that need the gateway-owned value should use
+`SHOW <gmv>` or rely on the gateway behavior itself (for `statement_timeout`,
+the enforced request deadline).
+
+## Transaction and savepoint lifecycle
+
+Each GMV is represented by a typed `GatewayManagedVariable[T]` with three value
+layers:
+
+1. default value — initialized once for the connection,
+2. session override — set by non-LOCAL `SET`,
+3. transaction-local override — set by `SET LOCAL` or `set_config(..., true)`.
+
+The effective value resolves as:
+
+```text
+transaction-local > session override > default
+```
+
+GMVs keep a snapshot stack in lockstep with the connection's savepoint stack.
+`BEGIN`, `SAVEPOINT`, `RELEASE`, `ROLLBACK TO`, `COMMIT`, and `ROLLBACK` drive
+that stack through the `gmvLifecycle` interface. This preserves PostgreSQL-like
+GUC behavior across transaction boundaries without each lifecycle method naming
+each variable individually.
+
+## Implementation checklist
+
+When adding or changing a GMV, keep these pieces in sync:
+
+1. Add a typed `GatewayManagedVariable[T]` field to
+   `MultiGatewayConnectionState` and initialize its default at connection setup.
+2. Register the canonical lowercase name in `gatewayManagedVariableNames`.
+3. Return the variable from `gatewayManagedVariablesLocked()` and update that
+   method's fixed-size array length.
+4. Route and validate values in `ApplyGatewayManagedVariable`.
+5. Update the planner and engine switches that create and execute the typed SET,
+   RESET, and SHOW primitives.
+6. Add tests for SET, SET LOCAL, RESET, RESET ALL, SHOW, `set_config`, and
+   transaction/savepoint rollback behavior.
+
+See `docs/query_serving/statement_timeout_design.md` for the concrete
+`statement_timeout` behavior and timeout-enforcement path.

--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -21,18 +21,11 @@ When a variable is `RESET`, its entry is removed from `SessionSettings`, and the
 
 ## Gateway-Managed Variables
 
-A small set of session variables is intercepted by the planner (see `isGatewayManagedVariable` in `planner/variable_set_stmt.go`) and handled entirely by the gateway. These variables are **not** stored in `SessionSettings` and **not** forwarded to PostgreSQL. Instead, the planner emits a `GatewaySessionState` primitive that updates a typed `GatewayManagedVariable[T]` on the connection state.
-
-Today the set is:
-
-- **`statement_timeout`** — enforced by the gateway via context deadlines (see `statement_timeout_design.md`).
-
-Behaviour:
-
-- `SET var = value` parses and validates the value at SET time. Invalid values are rejected immediately with a PostgreSQL-compatible error (unlike regular session settings, which defer validation to the next query).
-- `RESET var` and `SET var TO DEFAULT` revert to the startup-param value (if any) or the flag default.
-- `SHOW var` reports the current gateway-managed value in PostgreSQL-compatible form.
-- `RESET ALL` clears gateway-managed variables alongside `SessionSettings`.
+Some variables are owned by multigateway rather than stored in `SessionSettings`
+or forwarded to PostgreSQL. See
+[`gateway_managed_variables.md`](./gateway_managed_variables.md) for the GMV
+contract and [`statement_timeout_design.md`](./statement_timeout_design.md) for
+the concrete `statement_timeout` behavior.
 
 ## Behaviour Deviations from PostgreSQL
 

--- a/docs/query_serving/statement_timeout_design.md
+++ b/docs/query_serving/statement_timeout_design.md
@@ -13,9 +13,9 @@ backend queries.
 Key capabilities:
 
 - `--statement-timeout` flag sets a server-wide default (default: 30s)
-- `SET statement_timeout` / `RESET statement_timeout` per-session
-  overrides, managed entirely at the gateway (not forwarded to
-  PostgreSQL)
+- `SET statement_timeout` / `SET LOCAL statement_timeout` /
+  `RESET statement_timeout` overrides, managed entirely at the gateway
+  (not forwarded to PostgreSQL)
 - Per-query directives via SQL comments (future:
   `/*mg+ STATEMENT_TIMEOUT_MS=500 */`)
 - Context deadline propagation through gRPC to multipooler
@@ -87,41 +87,17 @@ Multipooler (regular_conn.go)
      - Returns connection to pool or taints on error
 ```
 
-## Gateway-Managed Variables
+## Gateway-Managed Variable Behavior
 
-`statement_timeout` is the first "gateway-managed variable" — a
-session variable that the gateway intercepts and does NOT forward to
-PostgreSQL. This avoids polluting pooled backend connections with
-per-client timeouts and allows the gateway to enforce timeouts via
-context deadlines rather than relying on PostgreSQL's internal timer.
+`statement_timeout` is implemented as a gateway-managed variable (GMV): the
+gateway intercepts its SET/RESET/SHOW surfaces and does not replay it to
+PostgreSQL through `SessionSettings`. This lets the gateway enforce the timeout
+with request context deadlines instead of relying on PostgreSQL's backend-local
+timer.
 
-The `GatewayManagedVariable[T]` generic type holds a default value
-(from the flag) and an optional session override:
-
-```go
-type GatewayManagedVariable[T comparable] struct {
-    defaultValue T
-    currentValue T
-    isSet        bool
-}
-```
-
-`GetEffective()` returns the session override if set, otherwise the
-default. This cleanly handles the priority chain without per-query
-resolution logic.
-
-The planner intercepts gateway-managed variables before the normal
-SET/RESET flow:
-
-```text
-planVariableSetStmt()
-  |
-  +-- isGatewayManagedVariable(name)?
-  |     YES -> planGatewayManagedVariable() -> GatewaySessionState primitive
-  |     NO  -> normal flow: Route + ApplySessionState
-  |
-  +-- SET LOCAL? -> pass through (not intercepted)
-```
+See [`gateway_managed_variables.md`](./gateway_managed_variables.md) for the
+shared GMV contract, including transaction/savepoint behavior and the `SHOW` vs
+`current_setting()` distinction.
 
 ## Startup Parameter Handling
 
@@ -161,8 +137,8 @@ display format.
 | ------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `handler/handler.go`                  | `executeWithTimeout`, `getConnectionState` init                                             |
 | `handler/statement_timeout.go`        | `ResolveStatementTimeout`, `ParsePostgresInterval`, `ParseStatementTimeoutDirective` (stub) |
-| `handler/connection_state.go`         | `GatewayManagedVariable` storage, `Set`/`Reset`/`Get`/`Show`/`Init` methods                 |
-| `handler/gateway_managed_variable.go` | Generic `GatewayManagedVariable[T]` type                                                    |
+| `handler/connection_state.go`         | Connection-level timeout state, `Set`/`Reset`/`Get`/`Show`/`Init` methods                   |
+| `handler/gateway_managed_variable.go` | Generic `GatewayManagedVariable[T]` type and lifecycle interface                            |
 | `planner/variable_set_stmt.go`        | `isGatewayManagedVariable`, `planGatewayManagedVariable`                                    |
 | `planner/variable_show_stmt.go`       | Gateway-managed SHOW interception                                                           |
 | `engine/gateway_session_state.go`     | `GatewaySessionState` SET/RESET primitive                                                   |
@@ -188,4 +164,3 @@ display format.
   multipooler layer as a floor timeout for non-gateway callers.
 - **Transaction timeout**: Separate timeout bounding the time from
   `BEGIN` to `COMMIT`/`ROLLBACK`.
-- **SET LOCAL support**: Transaction-scoped timeout overrides.

--- a/go/common/parser/ast/normalizer.go
+++ b/go/common/parser/ast/normalizer.go
@@ -175,11 +175,13 @@ func funcNamePartEquals(n Node, want string) bool {
 
 // setConfigIsLocalLiteralTrue reports whether fc is a 3-arg call whose
 // third argument is the literal boolean true. The normalizer uses this
-// to allow parameterizing set_config args when is_local=true: those calls
-// aren't tracked or rewritten by the planner, so their literals carry no
-// planning-relevant meaning, and preserving them would churn the plan
-// cache for hot patterns like PostgREST's per-request
-// set_config('request.jwt.claims', '<dynamic JSON>', true).
+// to allow parameterizing set_config's value when is_local=true: the name
+// and is_local literals stay in place — the planner reads them to decide
+// whether the call is tracked (ordinary variables aren't; gateway-managed
+// variables are, as a transaction-local override whose parameterized value
+// is resolved from BindValues at execute time) — while the high-cardinality
+// value would churn the plan cache for hot patterns like PostgREST's
+// per-request set_config('request.jwt.claims', '<dynamic JSON>', true).
 //
 // Anything other than a clean literal-true (false, missing, ParamRef,
 // non-literal expression, TypeCast over a literal) returns false — the

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -62,15 +62,20 @@ type ApplySessionState struct {
 	SilentTracking bool
 
 	// BindRefs, when non-nil, marks this primitive as a deferred-resolution
-	// set_config(): name, value, and/or is_local are decoded from the
-	// portal's wire-protocol Bind values at execute time before
-	// SessionSettings is updated. Nil-valued fields use the literal already
-	// in VariableStmt.Name / Args[0] / LiteralIsLocal.
+	// set_config(): name, value, and/or is_local are resolved at execute
+	// time before SessionSettings is updated. Nil-valued fields use the
+	// literal already in VariableStmt.Name / Args[0] / VariableStmt.IsLocal.
 	//
-	// Reachable only via PortalStreamExecute — StreamExecute is the simple
-	// protocol path, which has no binds and therefore never sets BindRefs.
-	// Set automatically by NewApplySessionStateFromBind for the
-	// extended-protocol `SELECT set_config($1, ...)` shape.
+	// Two resolution sources, one per protocol path:
+	//   - PortalStreamExecute decodes the portal's wire-protocol Bind values
+	//     (extended-protocol `SELECT set_config($1, ...)`).
+	//   - StreamExecute resolves against the normalizer-extracted bindVars
+	//     (simple protocol: ast.Normalize parameterizes the value of a
+	//     set_config(..., true) call, so the cached plan for a gateway-managed
+	//     variable carries a ValueParam that must be re-resolved from each
+	//     execution's literals — never baked into the plan).
+	//
+	// Set automatically by NewApplySessionStateFromBind.
 	BindRefs *BoundSetConfigRefs
 }
 
@@ -80,11 +85,12 @@ type ApplySessionState struct {
 // produced ParamRef for the corresponding set_config slot, or nil when
 // that slot was already a literal in the AST.
 //
-// is_local literals don't need to be carried here: the validator short-
-// circuits literal-true (no tracking, no setConfigCall produced), so any
-// setConfigCall that reaches the execute path with IsLocalParam == nil
-// implies is_local was literal false. executeSetWithBinds defaults to
-// false in that branch.
+// is_local literals don't need to be carried here: they are baked into the
+// synthetic VariableStmt at plan time, so IsLocalParam == nil means "use
+// VariableStmt.IsLocal" — false for a literal-false call, true only for a
+// gateway-managed set_config(..., true), which the planner tracks as a
+// transaction-local override (an ordinary literal-true call produces no
+// setConfigCall at all). Both execute paths fall back to that field.
 type BoundSetConfigRefs struct {
 	NameParam    *ast.ParamRef
 	ValueParam   *ast.ParamRef
@@ -217,17 +223,115 @@ func (s *ApplySessionState) executeSetWithBinds(
 	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)
 }
 
+// executeSetWithNormalizedBinds is StreamExecute's counterpart to
+// executeSetWithBinds: it resolves the bound set_config slots from the
+// normalizer-extracted bindVars instead of a portal's wire-protocol Bind
+// values. Reached on the simple-protocol cacheable path, where ast.Normalize
+// parameterizes the value of a gateway-managed set_config(..., true) call —
+// the plan is cached by its normalized SQL, so every execution must
+// re-resolve the value from that execution's literals.
+//
+// Mirrors executeSetWithBinds' resolution order: is_local first (it decides
+// whether tracking happens at all), then name, then value only if the
+// tracker write will fire. Errors propagate up through the Sequence, which
+// aborts before the trailing Route fires.
+func (s *ApplySessionState) executeSetWithNormalizedBinds(
+	ctx context.Context,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	bindVars []*ast.A_Const,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	// is_local resolves from the normalized literal when bound; otherwise it
+	// falls back to the literal baked into the synthetic VariableStmt (true
+	// only for a gateway-managed set_config(..., true)).
+	isLocal := s.VariableStmt.IsLocal
+	if s.BindRefs.IsLocalParam != nil {
+		c, err := normalizedBindConst(bindVars, s.BindRefs.IsLocalParam, "set_config is_local argument")
+		if err != nil {
+			return err
+		}
+		b, ok := c.Val.(*ast.Boolean)
+		if !ok {
+			return mterrors.NewFeatureNotSupported(fmt.Sprintf(
+				"set_config is_local argument ($%d) must be a boolean literal", s.BindRefs.IsLocalParam.Number))
+		}
+		isLocal = b.BoolVal
+	}
+
+	name := s.VariableStmt.Name
+	if s.BindRefs.NameParam != nil {
+		c, err := normalizedBindConst(bindVars, s.BindRefs.NameParam, "set_config name argument")
+		if err != nil {
+			return err
+		}
+		name = extractConstValue(c)
+	}
+
+	// A transaction-scoped set_config of an ordinary (non-gateway-managed)
+	// variable is owned by PostgreSQL via the trailing Route — the gateway
+	// tracks nothing and can skip resolving the value. Gateway-managed
+	// variables fall through so the transaction-local override is applied to
+	// gateway state (parity with executeSetWithBinds).
+	if isLocal && !handler.IsGatewayManagedVariable(name) {
+		return nil
+	}
+
+	value := extractVariableValue(s.VariableStmt.Args)
+	if s.BindRefs.ValueParam != nil {
+		c, err := normalizedBindConst(bindVars, s.BindRefs.ValueParam, "set_config value argument")
+		if err != nil {
+			return err
+		}
+		value = extractConstValue(c)
+	}
+
+	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)
+}
+
+// normalizedBindConst returns the normalizer-extracted literal that ref
+// points at. ParamRef numbers are 1-based positions into bindVars (the
+// normalizer mints them from a single counter; ast.ReconstructSQL uses the
+// same mapping for the Route's SQL reconstruction). An out-of-range
+// reference means the statement carried a user-typed $N the normalizer
+// never extracted a literal for — invalid in the simple protocol, so fail
+// here, before any gateway state is written (the trailing Route would
+// reject it anyway with "there is no parameter $N").
+func normalizedBindConst(bindVars []*ast.A_Const, ref *ast.ParamRef, what string) (*ast.A_Const, error) {
+	idx := ref.Number - 1 // ParamRef is 1-based
+	if idx < 0 || idx >= len(bindVars) {
+		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf(
+			"%s references parameter $%d but the statement carries %d normalized literal(s)",
+			what, ref.Number, len(bindVars)))
+	}
+	c := bindVars[idx]
+	if c == nil || c.Isnull {
+		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf("%s ($%d) cannot be NULL", what, ref.Number))
+	}
+	return c, nil
+}
+
 // StreamExecute handles the SET/RESET command.
+//
+// bindVars are the literals the normalizer extracted on the simple-protocol
+// cacheable path. A BindRefs primitive must resolve its bound slots from
+// them: the cached plan was minted from the normalized AST, so its synthetic
+// VariableStmt carries `__bind_$N__` placeholders — applying those (or any
+// first-seen literal) would corrupt gateway state on every cache hit that
+// carries different literals.
 func (s *ApplySessionState) StreamExecute(
 	ctx context.Context,
 	_ IExecute,
 	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
-	_ []*ast.A_Const,
+	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	switch s.VariableStmt.Kind {
 	case ast.VAR_SET_VALUE:
+		if s.BindRefs != nil {
+			return s.executeSetWithNormalizedBinds(ctx, conn, state, bindVars, callback)
+		}
 		return s.executeSet(ctx, conn, state, callback)
 	case ast.VAR_RESET, ast.VAR_RESET_ALL:
 		return s.executeReset(ctx, state, callback)

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -162,16 +162,17 @@ func (s *ApplySessionState) PortalStreamExecute(
 	return s.StreamExecute(ctx, exec, conn, state, nil, callback)
 }
 
+// setConfigParamResolver is the small protocol-specific layer for resolving
+// bound set_config(...) arguments. The executeSetWithResolvedParams helper owns
+// the shared is_local -> name -> GMV guard -> value -> applyTracked flow, while
+// each caller supplies how ParamRefs are decoded for its protocol path.
+type setConfigParamResolver struct {
+	resolveBool func(ref *ast.ParamRef, what string) (bool, error)
+	resolveText func(ref *ast.ParamRef, what string) (string, error)
+}
+
 // executeSetWithBinds resolves name/value/is_local from the portal's binds
 // and conditionally updates SessionSettings.
-//
-// is_local is resolved first because it decides whether tracking happens at
-// all: when it resolves true the call is transaction-scoped, PG owns it via
-// the Sequence's trailing Route, and the gateway must NOT write to
-// SessionSettings (otherwise the tracker would outlive the transaction PG
-// scoped the change to). Resolving it first also lets us skip the text
-// decodes for the bound name/value slots — they're only needed for the
-// tracker write.
 //
 // Errors (NULL bind, unsupported OID, out-of-range ParamRef) propagate up
 // through the Sequence, which aborts before the Route fires.
@@ -182,45 +183,14 @@ func (s *ApplySessionState) executeSetWithBinds(
 	portalInfo *preparedstatement.PortalInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// is_local resolves from the bind when bound; otherwise it falls back to the
-	// literal baked into the synthetic VariableStmt (true only for a
-	// gateway-managed set_config(..., true) — see planner.syntheticSetStmt).
-	isLocal := s.VariableStmt.IsLocal
-	if s.BindRefs.IsLocalParam != nil {
-		b, err := preparedstatement.DecodeBindAsBool(portalInfo, s.BindRefs.IsLocalParam, "set_config is_local argument")
-		if err != nil {
-			return err
-		}
-		isLocal = b
-	}
-
-	name := s.VariableStmt.Name
-	if s.BindRefs.NameParam != nil {
-		v, err := preparedstatement.DecodeBindAsText(portalInfo, s.BindRefs.NameParam, "set_config name argument")
-		if err != nil {
-			return err
-		}
-		name = v
-	}
-
-	// A SET LOCAL of an ordinary (non-gateway-managed) variable is owned by
-	// PostgreSQL via the trailing Route — the gateway tracks nothing and can
-	// skip decoding the value. Gateway-managed variables fall through so the
-	// transaction-local override is applied to gateway state.
-	if isLocal && !handler.IsGatewayManagedVariable(name) {
-		return nil
-	}
-
-	value := extractVariableValue(s.VariableStmt.Args)
-	if s.BindRefs.ValueParam != nil {
-		v, err := preparedstatement.DecodeBindAsText(portalInfo, s.BindRefs.ValueParam, "set_config value argument")
-		if err != nil {
-			return err
-		}
-		value = v
-	}
-
-	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)
+	return s.executeSetWithResolvedParams(ctx, conn, state, setConfigParamResolver{
+		resolveBool: func(ref *ast.ParamRef, what string) (bool, error) {
+			return preparedstatement.DecodeBindAsBool(portalInfo, ref, what)
+		},
+		resolveText: func(ref *ast.ParamRef, what string) (string, error) {
+			return preparedstatement.DecodeBindAsText(portalInfo, ref, what)
+		},
+	}, callback)
 }
 
 // executeSetWithNormalizedBinds is StreamExecute's counterpart to
@@ -230,11 +200,6 @@ func (s *ApplySessionState) executeSetWithBinds(
 // parameterizes the value of a gateway-managed set_config(..., true) call —
 // the plan is cached by its normalized SQL, so every execution must
 // re-resolve the value from that execution's literals.
-//
-// Mirrors executeSetWithBinds' resolution order: is_local first (it decides
-// whether tracking happens at all), then name, then value only if the
-// tracker write will fire. Errors propagate up through the Sequence, which
-// aborts before the trailing Route fires.
 func (s *ApplySessionState) executeSetWithNormalizedBinds(
 	ctx context.Context,
 	conn *server.Conn,
@@ -242,48 +207,77 @@ func (s *ApplySessionState) executeSetWithNormalizedBinds(
 	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	// is_local resolves from the normalized literal when bound; otherwise it
-	// falls back to the literal baked into the synthetic VariableStmt (true
-	// only for a gateway-managed set_config(..., true)).
+	return s.executeSetWithResolvedParams(ctx, conn, state, setConfigParamResolver{
+		resolveBool: func(ref *ast.ParamRef, what string) (bool, error) {
+			c, err := normalizedBindConst(bindVars, ref, what)
+			if err != nil {
+				return false, err
+			}
+			b, ok := c.Val.(*ast.Boolean)
+			if !ok {
+				return false, mterrors.NewFeatureNotSupported(fmt.Sprintf(
+					"%s ($%d) must be a boolean literal", what, ref.Number))
+			}
+			return b.BoolVal, nil
+		},
+		resolveText: func(ref *ast.ParamRef, what string) (string, error) {
+			c, err := normalizedBindConst(bindVars, ref, what)
+			if err != nil {
+				return "", err
+			}
+			return extractConstValue(c), nil
+		},
+	}, callback)
+}
+
+// executeSetWithResolvedParams owns the protocol-independent set_config bind
+// flow: resolve is_local first because it decides whether tracking happens at
+// all, resolve name next so the gateway-managed guard can run, and resolve the
+// value only when a tracker write will actually fire.
+func (s *ApplySessionState) executeSetWithResolvedParams(
+	ctx context.Context,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	resolver setConfigParamResolver,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	// is_local resolves from the bound value when present; otherwise it falls
+	// back to the literal baked into the synthetic VariableStmt (true only for a
+	// gateway-managed set_config(..., true) — see planner.syntheticSetStmt).
 	isLocal := s.VariableStmt.IsLocal
 	if s.BindRefs.IsLocalParam != nil {
-		c, err := normalizedBindConst(bindVars, s.BindRefs.IsLocalParam, "set_config is_local argument")
+		b, err := resolver.resolveBool(s.BindRefs.IsLocalParam, "set_config is_local argument")
 		if err != nil {
 			return err
 		}
-		b, ok := c.Val.(*ast.Boolean)
-		if !ok {
-			return mterrors.NewFeatureNotSupported(fmt.Sprintf(
-				"set_config is_local argument ($%d) must be a boolean literal", s.BindRefs.IsLocalParam.Number))
-		}
-		isLocal = b.BoolVal
+		isLocal = b
 	}
 
 	name := s.VariableStmt.Name
 	if s.BindRefs.NameParam != nil {
-		c, err := normalizedBindConst(bindVars, s.BindRefs.NameParam, "set_config name argument")
+		v, err := resolver.resolveText(s.BindRefs.NameParam, "set_config name argument")
 		if err != nil {
 			return err
 		}
-		name = extractConstValue(c)
+		name = v
 	}
 
 	// A transaction-scoped set_config of an ordinary (non-gateway-managed)
 	// variable is owned by PostgreSQL via the trailing Route — the gateway
 	// tracks nothing and can skip resolving the value. Gateway-managed
 	// variables fall through so the transaction-local override is applied to
-	// gateway state (parity with executeSetWithBinds).
+	// gateway state.
 	if isLocal && !handler.IsGatewayManagedVariable(name) {
 		return nil
 	}
 
 	value := extractVariableValue(s.VariableStmt.Args)
 	if s.BindRefs.ValueParam != nil {
-		c, err := normalizedBindConst(bindVars, s.BindRefs.ValueParam, "set_config value argument")
+		v, err := resolver.resolveText(s.BindRefs.ValueParam, "set_config value argument")
 		if err != nil {
 			return err
 		}
-		value = extractConstValue(c)
+		value = v
 	}
 
 	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)

--- a/go/services/multigateway/engine/apply_session_state.go
+++ b/go/services/multigateway/engine/apply_session_state.go
@@ -151,7 +151,7 @@ func (s *ApplySessionState) PortalStreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	if s.BindRefs != nil {
-		return s.executeSetWithBinds(ctx, state, portalInfo, callback)
+		return s.executeSetWithBinds(ctx, conn, state, portalInfo, callback)
 	}
 	return s.StreamExecute(ctx, exec, conn, state, nil, callback)
 }
@@ -171,21 +171,21 @@ func (s *ApplySessionState) PortalStreamExecute(
 // through the Sequence, which aborts before the Route fires.
 func (s *ApplySessionState) executeSetWithBinds(
 	ctx context.Context,
+	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
 	portalInfo *preparedstatement.PortalInfo,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	isLocal := false
+	// is_local resolves from the bind when bound; otherwise it falls back to the
+	// literal baked into the synthetic VariableStmt (true only for a
+	// gateway-managed set_config(..., true) — see planner.syntheticSetStmt).
+	isLocal := s.VariableStmt.IsLocal
 	if s.BindRefs.IsLocalParam != nil {
 		b, err := preparedstatement.DecodeBindAsBool(portalInfo, s.BindRefs.IsLocalParam, "set_config is_local argument")
 		if err != nil {
 			return err
 		}
 		isLocal = b
-	}
-	if isLocal {
-		// PG handles the SET LOCAL via the trailing Route; gateway stays out.
-		return nil
 	}
 
 	name := s.VariableStmt.Name
@@ -196,6 +196,15 @@ func (s *ApplySessionState) executeSetWithBinds(
 		}
 		name = v
 	}
+
+	// A SET LOCAL of an ordinary (non-gateway-managed) variable is owned by
+	// PostgreSQL via the trailing Route — the gateway tracks nothing and can
+	// skip decoding the value. Gateway-managed variables fall through so the
+	// transaction-local override is applied to gateway state.
+	if isLocal && !handler.IsGatewayManagedVariable(name) {
+		return nil
+	}
+
 	value := extractVariableValue(s.VariableStmt.Args)
 	if s.BindRefs.ValueParam != nil {
 		v, err := preparedstatement.DecodeBindAsText(portalInfo, s.BindRefs.ValueParam, "set_config value argument")
@@ -205,25 +214,21 @@ func (s *ApplySessionState) executeSetWithBinds(
 		value = v
 	}
 
-	state.SetSessionVariable(name, value)
-	if s.SilentTracking {
-		return nil
-	}
-	return callback(ctx, &sqltypes.Result{CommandTag: "SET"})
+	return s.applyTracked(ctx, conn, state, name, value, isLocal, callback)
 }
 
 // StreamExecute handles the SET/RESET command.
 func (s *ApplySessionState) StreamExecute(
 	ctx context.Context,
 	_ IExecute,
-	_ *server.Conn,
+	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
 	_ []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	switch s.VariableStmt.Kind {
 	case ast.VAR_SET_VALUE:
-		return s.executeSet(ctx, state, callback)
+		return s.executeSet(ctx, conn, state, callback)
 	case ast.VAR_RESET, ast.VAR_RESET_ALL:
 		return s.executeReset(ctx, state, callback)
 	default:
@@ -241,11 +246,45 @@ func (s *ApplySessionState) StreamExecute(
 //   - default: update state and emit CommandComplete "SET" (real SET stmt).
 func (s *ApplySessionState) executeSet(
 	ctx context.Context,
+	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
 	value := extractVariableValue(s.VariableStmt.Args)
-	state.SetSessionVariable(s.VariableStmt.Name, value)
+	return s.applyTracked(ctx, conn, state, s.VariableStmt.Name, value, s.VariableStmt.IsLocal, callback)
+}
+
+// applyTracked records a tracked SET / set_config into the right place:
+// gateway-managed variables (e.g. statement_timeout) go to gateway-local
+// state, everything else to SessionSettings. Routing GMVs away from
+// SessionSettings keeps SHOW consistent and prevents the value from being
+// replayed to a backend on pool rotation.
+//
+// A real `SET <gmv> = ...` is planned as GatewaySessionState, not this
+// primitive, so the gateway-managed branch here is reached only via
+// `SELECT set_config('<gmv>', ...)`.
+//
+// SET LOCAL of a gateway-managed variable issued outside a transaction is a
+// no-op in PostgreSQL (the change is scoped to the implicit single-statement
+// transaction). We mirror that and skip the gateway override, otherwise it
+// would leak for the connection's lifetime — no COMMIT/ROLLBACK fires to clear
+// it. This matches GatewaySessionState's SET LOCAL guard.
+func (s *ApplySessionState) applyTracked(
+	ctx context.Context,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	name, value string,
+	isLocal bool,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	skipLeakyLocal := isLocal && !conn.IsInTransaction() && handler.IsGatewayManagedVariable(name)
+	if !skipLeakyLocal {
+		if handled, err := state.ApplyGatewayManagedVariable(name, value, isLocal); err != nil {
+			return err
+		} else if !handled {
+			state.SetSessionVariable(name, value)
+		}
+	}
 
 	if s.SilentTracking {
 		return nil
@@ -277,7 +316,7 @@ func (s *ApplySessionState) executeReset(
 	case ast.VAR_RESET_ALL:
 		state.ResetAllSessionVariables()
 		// Also reset gateway-managed variables that live outside SessionSettings.
-		state.ResetStatementTimeout()
+		state.ResetGatewayManagedVariables()
 	default:
 		return mterrors.NewFeatureNotSupported(fmt.Sprintf("RESET kind %d is not supported", s.VariableStmt.Kind))
 	}

--- a/go/services/multigateway/engine/apply_session_state_bind_test.go
+++ b/go/services/multigateway/engine/apply_session_state_bind_test.go
@@ -15,15 +15,19 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -296,6 +300,144 @@ func TestApplySessionState_OutOfRangeParamRef(t *testing.T) {
 	_, _, err := runBindExecute(t, prim, portalInfo)
 	require.Error(t, err)
 	assertFeatureErrBind(t, err, "but the portal carries 1 values")
+}
+
+// ---------- Normalized-binds (simple-protocol) resolution ----------
+//
+// The tests below cover StreamExecute's BindRefs path: the ParamRefs were
+// minted by ast.Normalize (not by the client), so resolution reads the
+// normalizer-extracted bindVars instead of a portal's wire Bind values.
+// This is the path a cached `SELECT set_config('<gmv>', <value>, true)`
+// simple query takes — the value collapses into the plan-cache key, so the
+// primitive must re-resolve it on every execution.
+
+// runNormalizedExecute executes the primitive's StreamExecute (simple-
+// protocol path) against a fresh connection state with the given conn and
+// normalizer-extracted bindVars.
+func runNormalizedExecute(t *testing.T, prim *ApplySessionState, conn *server.Conn, bindVars []*ast.A_Const) (*handler.MultiGatewayConnectionState, []string, error) {
+	t.Helper()
+	state := &handler.MultiGatewayConnectionState{}
+	state.InitStatementTimeout(30 * time.Second)
+	var tags []string
+	err := prim.StreamExecute(context.Background(), nil, conn, state, bindVars,
+		func(_ context.Context, r *sqltypes.Result) error {
+			tags = append(tags, r.CommandTag)
+			return nil
+		})
+	return state, tags, err
+}
+
+// normalizedGMVLocalPrim builds the primitive planSelectStmt mints for
+// `SELECT set_config('statement_timeout', <value>, true)` after the
+// normalizer parameterized the value: synthetic stmt with IsLocal=true and
+// a `__bind_$1__` placeholder, BindRefs carrying the ValueParam.
+func normalizedGMVLocalPrim(sql string) *ApplySessionState {
+	stmt := syntheticSetForTest("statement_timeout", "__bind_$1__")
+	stmt.IsLocal = true
+	return NewApplySessionStateFromBind(sql, stmt, &BoundSetConfigRefs{
+		ValueParam: &ast.ParamRef{Number: 1},
+	})
+}
+
+func txnConn(t *testing.T) *server.Conn {
+	t.Helper()
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	return conn
+}
+
+// TestApplySessionState_NormalizedBindGMVLocalResolves — the gateway-managed
+// transaction-local override must be applied with the value resolved from
+// THIS execution's bindVars, not the `__bind_$1__` placeholder baked into
+// the cached plan's synthetic VariableStmt.
+func TestApplySessionState_NormalizedBindGMVLocalResolves(t *testing.T) {
+	const sql = "SELECT set_config('statement_timeout', $1, true)"
+	prim := normalizedGMVLocalPrim(sql)
+
+	state, tags, err := runNormalizedExecute(t, prim, txnConn(t),
+		[]*ast.A_Const{ast.NewA_Const(ast.NewString("250ms"), 0)})
+	require.NoError(t, err)
+	assert.Nil(t, tags, "SilentTracking must suppress the SET CommandComplete; Route owns the response")
+	assert.Equal(t, 250*time.Millisecond, state.GetStatementTimeout())
+	_, exists := state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists, "GMV must not land in SessionSettings")
+}
+
+// TestApplySessionState_NormalizedBindCacheReuseAcrossValues is the engine-
+// level regression for the plan-cache staleness report: the SAME primitive
+// (same cached plan, same BindRefs) must apply each execution's value. A
+// baked-in literal or placeholder would fail every iteration after the first.
+func TestApplySessionState_NormalizedBindCacheReuseAcrossValues(t *testing.T) {
+	const sql = "SELECT set_config('statement_timeout', $1, true)"
+	prim := normalizedGMVLocalPrim(sql)
+
+	for _, tc := range []struct {
+		value string
+		want  time.Duration
+	}{
+		{"100ms", 100 * time.Millisecond},
+		{"2s", 2 * time.Second},
+		{"1m", time.Minute},
+	} {
+		state, _, err := runNormalizedExecute(t, prim, txnConn(t),
+			[]*ast.A_Const{ast.NewA_Const(ast.NewString(tc.value), 0)})
+		require.NoError(t, err, "iteration %q", tc.value)
+		assert.Equal(t, tc.want, state.GetStatementTimeout(),
+			"iteration %q must reflect that iteration's normalized literal", tc.value)
+	}
+}
+
+// TestApplySessionState_NormalizedBindGMVLocalOutsideTxnIsNoOp — parity with
+// the literal path: a transaction-local GMV override outside a transaction
+// must not be applied (it would leak for the connection's lifetime; PG scopes
+// it to the implicit single-statement transaction).
+func TestApplySessionState_NormalizedBindGMVLocalOutsideTxnIsNoOp(t *testing.T) {
+	const sql = "SELECT set_config('statement_timeout', $1, true)"
+	prim := normalizedGMVLocalPrim(sql)
+
+	idleConn := server.NewTestConn(&bytes.Buffer{}).Conn // idle: not in a transaction
+	state, _, err := runNormalizedExecute(t, prim, idleConn,
+		[]*ast.A_Const{ast.NewA_Const(ast.NewString("2s"), 0)})
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "local override must not leak outside a transaction")
+}
+
+// TestApplySessionState_NormalizedBindSessionValueResolves covers the
+// is_local=false shape executed via the simple protocol (reachable through
+// cross-protocol plan-cache sharing): the resolved value must land in
+// SessionSettings under the literal name.
+func TestApplySessionState_NormalizedBindSessionValueResolves(t *testing.T) {
+	const sql = "SELECT set_config('search_path', $1, false)"
+	prim := NewApplySessionStateFromBind(sql, syntheticSetForTest("search_path", "__bind_$1__"),
+		&BoundSetConfigRefs{
+			ValueParam: &ast.ParamRef{Number: 1},
+		})
+
+	state, tags, err := runNormalizedExecute(t, prim, server.NewTestConn(&bytes.Buffer{}).Conn,
+		[]*ast.A_Const{ast.NewA_Const(ast.NewString("public,extensions"), 0)})
+	require.NoError(t, err)
+	assert.Nil(t, tags)
+	got, ok := state.GetSessionVariable("search_path")
+	require.True(t, ok)
+	assert.Equal(t, "public,extensions", got)
+}
+
+// TestApplySessionState_NormalizedBindOutOfRangeErrors — a ParamRef pointing
+// past the extracted literals (user-typed $N in a simple query) must error
+// before any gateway state is written; the Sequence aborts before the Route.
+func TestApplySessionState_NormalizedBindOutOfRangeErrors(t *testing.T) {
+	const sql = "SELECT set_config('statement_timeout', $2, true)"
+	stmt := syntheticSetForTest("statement_timeout", "__bind_$2__")
+	stmt.IsLocal = true
+	prim := NewApplySessionStateFromBind(sql, stmt, &BoundSetConfigRefs{
+		ValueParam: &ast.ParamRef{Number: 2},
+	})
+
+	state, _, err := runNormalizedExecute(t, prim, txnConn(t),
+		[]*ast.A_Const{ast.NewA_Const(ast.NewString("only-one"), 0)})
+	require.Error(t, err)
+	assertFeatureErrBind(t, err, "carries 1 normalized literal")
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "gateway state must not be updated on bind-resolution error")
 }
 
 // assertFeatureErrBind wraps the verbose unwrap-into-PgDiagnostic check.

--- a/go/services/multigateway/engine/apply_session_state_test.go
+++ b/go/services/multigateway/engine/apply_session_state_test.go
@@ -65,6 +65,111 @@ func TestApplySessionState_SET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
 	assert.Equal(t, "SET", results[0].CommandTag)
 }
 
+// TestApplySessionState_SetConfig_GatewayManagedRoutesToGatewayState verifies
+// set_config of a gateway-managed variable: it must update gateway-local
+// state (visible via SHOW) and must NOT land in SessionSettings, otherwise it
+// would be replayed to backends on pool rotation. Mirrors the silent
+// ApplySessionState the planner builds for
+// `SELECT set_config('statement_timeout', '5s', false)`.
+func TestApplySessionState_SetConfig_GatewayManagedRoutesToGatewayState(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultiGatewayConnectionState{}
+	ctx := context.Background()
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "statement_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "5s"}}}},
+	}
+	ssr := NewApplySessionStateSilent("SELECT set_config('statement_timeout', '5s', false)", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(ctx, nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+
+	// Silent: a sibling Route owns the client-facing result.
+	assert.Empty(t, results)
+	// Routed to gateway-managed state.
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout())
+	// NOT written to SessionSettings (would be replayed on pool rotation).
+	_, exists := state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists)
+	assert.Nil(t, state.GetSessionSettings())
+}
+
+// TestApplySessionState_SetConfig_GatewayManagedLocalInTransaction verifies that
+// set_config('<gmv>', v, true) inside a transaction applies a transaction-local
+// gateway override (parity with SET LOCAL <gmv>), visible via SHOW and kept out
+// of SessionSettings.
+func TestApplySessionState_SetConfig_GatewayManagedLocalInTransaction(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	testConn.Conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	state := &handler.MultiGatewayConnectionState{}
+
+	stmt := &ast.VariableSetStmt{
+		Kind:    ast.VAR_SET_VALUE,
+		Name:    "statement_timeout",
+		IsLocal: true,
+		Args:    &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "7s"}}}},
+	}
+	ssr := NewApplySessionStateSilent("SELECT set_config('statement_timeout', '7s', true)", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.Equal(t, 7*time.Second, state.GetStatementTimeout())
+	_, exists := state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists)
+}
+
+// TestApplySessionState_SetConfig_GatewayManagedLocalOutsideTxnIsNoOp verifies
+// that set_config('<gmv>', v, true) outside a transaction does NOT apply a
+// gateway override. PostgreSQL scopes such a change to the implicit
+// single-statement transaction, and applying it to gateway state would leak it
+// for the connection's lifetime (no COMMIT/ROLLBACK fires to clear it).
+func TestApplySessionState_SetConfig_GatewayManagedLocalOutsideTxnIsNoOp(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{}) // idle: not in a transaction
+	state := &handler.MultiGatewayConnectionState{}
+	state.InitStatementTimeout(30 * time.Second)
+
+	stmt := &ast.VariableSetStmt{
+		Kind:    ast.VAR_SET_VALUE,
+		Name:    "statement_timeout",
+		IsLocal: true,
+		Args:    &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "7s"}}}},
+	}
+	ssr := NewApplySessionStateSilent("SELECT set_config('statement_timeout', '7s', true)", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(),
+		"local override must not be applied/leaked outside a transaction")
+	_, exists := state.GetSessionVariable("statement_timeout")
+	assert.False(t, exists)
+}
+
+// TestApplySessionState_SetConfig_StatementTimeoutInvalidErrors confirms an
+// invalid gateway-managed value surfaces an error at execute time (the Sequence
+// aborts before the trailing Route fires), matching PostgreSQL's set-time check.
+func TestApplySessionState_SetConfig_StatementTimeoutInvalidErrors(t *testing.T) {
+	testConn := server.NewTestConn(&bytes.Buffer{})
+	state := &handler.MultiGatewayConnectionState{}
+
+	stmt := &ast.VariableSetStmt{
+		Kind: ast.VAR_SET_VALUE,
+		Name: "statement_timeout",
+		Args: &ast.NodeList{Items: []ast.Node{&ast.A_Const{Val: &ast.String{SVal: "not-a-duration"}}}},
+	}
+	ssr := NewApplySessionStateSilent("SELECT set_config('statement_timeout', 'not-a-duration', false)", stmt)
+
+	var results []*sqltypes.Result
+	err := ssr.StreamExecute(context.Background(), nil, testConn.Conn, state, nil, collectCallback(&results))
+	require.Error(t, err)
+	assert.Empty(t, results)
+}
+
 func TestApplySessionState_SET_InvalidParam_Succeeds(t *testing.T) {
 	// Invalid params are accepted locally — errors surface on next query.
 	testConn := server.NewTestConn(&bytes.Buffer{})
@@ -144,9 +249,11 @@ func TestApplySessionState_RESET_UpdatesStateAndReturnsSynthetic(t *testing.T) {
 
 func TestApplySessionState_RESET_ALL_ClearsAllVariables(t *testing.T) {
 	state := &handler.MultiGatewayConnectionState{}
+	state.InitStatementTimeout(30 * time.Second)
 	state.SetSessionVariable("work_mem", "256MB")
 	state.SetSessionVariable("search_path", "myschema")
 	state.SetSessionVariable("statement_timeout", "30s")
+	state.SetStatementTimeout(5 * time.Second)
 
 	testConn := server.NewTestConn(&bytes.Buffer{})
 	ctx := context.Background()
@@ -168,6 +275,7 @@ func TestApplySessionState_RESET_ALL_ClearsAllVariables(t *testing.T) {
 	assert.False(t, exists)
 	_, exists = state.GetSessionVariable("statement_timeout")
 	assert.False(t, exists)
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "RESET ALL should reset gateway-managed statement_timeout")
 
 	// Should receive synthetic CommandComplete
 	require.Len(t, results, 1)

--- a/go/services/multigateway/engine/discard_all_primitive.go
+++ b/go/services/multigateway/engine/discard_all_primitive.go
@@ -120,10 +120,10 @@ func (d *DiscardAllPrimitive) StreamExecute(
 	}
 
 	// RESET ALL + SET SESSION AUTHORIZATION DEFAULT — clear every SET-tracked
-	// GUC and the gateway-managed variables (e.g. statement_timeout). The next
-	// query replays an empty session-settings set, resetting the backend.
+	// GUC and every gateway-managed variable. The next query replays an empty
+	// session-settings set, resetting the backend.
 	state.ResetAllSessionVariables()
-	state.ResetStatementTimeout()
+	state.ResetGatewayManagedVariables()
 
 	// UNLISTEN * — drop all LISTEN subscriptions. Not in a transaction here, so
 	// apply immediately rather than queueing as a pending action.

--- a/go/services/multigateway/engine/discard_all_primitive_test.go
+++ b/go/services/multigateway/engine/discard_all_primitive_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,8 @@ func TestDiscardAllPrimitive_Success(t *testing.T) {
 
 	state := handler.NewMultiGatewayConnectionState()
 	state.SetSessionVariable("work_mem", "64MB")
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
 	state.AddOpenHoldCursor("c1")
 
 	prim := NewDiscardAllPrimitive("DISCARD ALL")
@@ -138,9 +141,10 @@ func TestDiscardAllPrimitive_Success(t *testing.T) {
 	assert.Equal(t, byte('A'), h.closeCalls[0].typ)
 	assert.Empty(t, h.closeCalls[0].name)
 
-	// RESET ALL: session settings cleared.
+	// RESET ALL: session settings and gateway-managed variables cleared.
 	_, ok := state.GetSessionVariable("work_mem")
 	assert.False(t, ok, "RESET ALL must clear session settings")
+	assert.Equal(t, 30*time.Second, state.GetStatementTimeout(), "DISCARD ALL must reset gateway-managed variables")
 
 	// CLOSE ALL: gateway HOLD-cursor bookkeeping cleared.
 	assert.False(t, state.HasAnyOpenHoldCursor(), "DISCARD ALL must clear HOLD cursor tracking")
@@ -162,6 +166,8 @@ func TestDiscardAllPrimitive_ReleaseError(t *testing.T) {
 	conn := newDiscardTestConn(t, h)
 	state := handler.NewMultiGatewayConnectionState()
 	state.SetSessionVariable("work_mem", "64MB")
+	state.InitStatementTimeout(30 * time.Second)
+	state.SetStatementTimeout(5 * time.Second)
 	state.AddOpenHoldCursor("c1")
 
 	prim := NewDiscardAllPrimitive("DISCARD ALL")
@@ -176,6 +182,7 @@ func TestDiscardAllPrimitive_ReleaseError(t *testing.T) {
 	v, ok := state.GetSessionVariable("work_mem")
 	assert.True(t, ok, "session settings must be left intact when release fails")
 	assert.Equal(t, "64MB", v)
+	assert.Equal(t, 5*time.Second, state.GetStatementTimeout(), "gateway-managed variables must be left intact when release fails")
 	assert.True(t, state.HasAnyOpenHoldCursor(), "HOLD cursor tracking must be left intact when release fails")
 }
 

--- a/go/services/multigateway/engine/sequence.go
+++ b/go/services/multigateway/engine/sequence.go
@@ -41,13 +41,17 @@ func NewSequence(primitives []Primitive) *Sequence {
 // StreamExecute executes each primitive in order, stopping on first error.
 //
 // bindVars are forwarded to every child. The current Sequence shape used by
-// planSelectStmt is [silent ApplySessionState..., Route]: the silent steps
-// ignore bindVars (their VariableSetStmt is fully synthesized at plan time
-// from the literal set_config args), while the trailing Route uses bindVars
-// + its NormalizedAST to reconstruct the original literals before sending
-// the query to the backend. Dropping bindVars here breaks that
-// reconstruction — the normalized `$N` placeholders reach PG unbound and
-// fail with "there is no parameter $N".
+// planSelectStmt is [silent ApplySessionState..., Route]: all-literal silent
+// steps ignore bindVars (their VariableSetStmt is fully synthesized at plan
+// time from the literal set_config args), BindRefs steps resolve their bound
+// set_config slots from bindVars (the normalizer parameterizes the value of
+// a gateway-managed set_config(..., true) — see
+// ApplySessionState.executeSetWithNormalizedBinds), and the trailing Route
+// uses bindVars + its NormalizedAST to reconstruct the original literals
+// before sending the query to the backend. Dropping bindVars here breaks
+// both: the tracker would record a `__bind_$N__` placeholder, and the
+// normalized `$N` placeholders would reach PG unbound and fail with "there
+// is no parameter $N".
 func (s *Sequence) StreamExecute(
 	ctx context.Context,
 	exec IExecute,

--- a/go/services/multigateway/executor/executor_test.go
+++ b/go/services/multigateway/executor/executor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/multigres/multigres/go/common/parser"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	pgClient "github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/sqltypes"
@@ -508,6 +509,50 @@ func TestStreamExecute_SetConfigWithSiblingLiteral(t *testing.T) {
 	got, ok := state.GetSessionVariable("work_mem")
 	require.True(t, ok)
 	assert.Equal(t, "256MB", got)
+}
+
+// TestStreamExecute_SetConfigGMVLocalPlanCacheReuse is the regression for
+// the simple-protocol plan-cache flow of a gateway-managed
+// set_config(..., true). The normalizer parameterizes the value (collapsing
+// different literals into one cached plan), so the silent ApplySessionState
+// carries a ValueParam BindRef that StreamExecute must resolve from the
+// normalizer-extracted bindVars on EVERY execution. Before the fix,
+// StreamExecute ignored bindVars entirely and applied the synthetic
+// `__bind_$1__` placeholder to gateway state.
+func TestStreamExecute_SetConfigGMVLocalPlanCacheReuse(t *testing.T) {
+	mock := &mockExec{}
+	exec := newTestExecutor(mock)
+	defer exec.planCache.Close()
+	ctx := context.Background()
+	conn := testConn()
+	conn.SetTxnStatus(protocol.TxnStatusInBlock)
+	state := handler.NewMultiGatewayConnectionState()
+	state.InitStatementTimeout(30 * time.Second)
+
+	// Cache miss: plan is minted from the normalized AST, so the value slot
+	// is a ParamRef and must be resolved from this execution's bindVars.
+	sql1 := "SELECT set_config('statement_timeout', '1s', true)"
+	res1, err := exec.StreamExecute(ctx, conn, state, sql1, parseOne(t, sql1), noopCallback)
+	require.NoError(t, err)
+	assert.False(t, res1.CacheHit)
+	assert.Equal(t, time.Second, state.GetStatementTimeout(),
+		"first execution must apply its own literal, not a __bind placeholder")
+
+	time.Sleep(50 * time.Millisecond) // plan cache Put is async
+
+	// Cache hit with a different literal: the same cached plan must apply
+	// THIS execution's value to gateway state.
+	sql2 := "SELECT set_config('statement_timeout', '2s', true)"
+	res2, err := exec.StreamExecute(ctx, conn, state, sql2, parseOne(t, sql2), noopCallback)
+	require.NoError(t, err)
+	assert.True(t, res2.CacheHit, "same normalized shape must hit the plan cache")
+	assert.Equal(t, 2*time.Second, state.GetStatementTimeout(),
+		"cache hit must apply this execution's value, not the first-seen literal or a placeholder")
+
+	// The trailing Route must still reconstruct the literal for PG.
+	backendSQL, _ := mock.lastStreamExecuteSQL.Load().(string)
+	assert.Contains(t, backendSQL, "2s", "backend SQL must carry the reconstructed literal")
+	assert.NotContains(t, backendSQL, "$1", "normalized placeholder must not reach the backend")
 }
 
 func TestCrossProtocol_CasingNormalization(t *testing.T) {

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -152,10 +153,10 @@ type MultiGatewayConnectionState struct {
 	// to apply subscription changes before reporting success to the client.
 	SubSync SubscriptionSync
 
-	// statementTimeout is the session-level statement timeout set via SET statement_timeout.
-	// This is managed entirely by the gateway and is NOT forwarded to PostgreSQL.
-	// The default is initialized from startup params (if present) or the --statement-timeout flag.
-	// Parsed at SET time to avoid repeated parsing on every query.
+	// statementTimeout is managed entirely by the gateway and is NOT forwarded
+	// to PostgreSQL. The default is initialized from startup params (if
+	// present) or the --statement-timeout flag. Parsed at SET time to avoid
+	// repeated parsing on every query.
 	statementTimeout GatewayManagedVariable[time.Duration]
 
 	// savepoints is the stack of per-savepoint snapshots driving GUC revert
@@ -165,16 +166,17 @@ type MultiGatewayConnectionState struct {
 	// present, is the BEGIN-level frame (name=""); indices 1+ correspond to
 	// user SAVEPOINTs.
 	//
-	// MAINTENANCE CONTRACT: every gateway-managed variable on this struct
-	// (e.g. statementTimeout) AND every non-GMV snapshot field stored on the
-	// savepointFrame (currently `openHoldCursors`) must be wired into all six
-	// lifecycle methods — pushFrameLocked, ReleaseSavepoint,
-	// RollbackToSavepoint, BeginTransaction, CommitTransaction,
-	// RollbackTransaction — or revert semantics break for the missing field.
-	// When a second GMV is added, refactor to a non-generic `gmvLifecycle`
-	// interface ({Snapshot, RestoreFromDepth(int), PopFrom(int),
-	// ClearSnapshots}) and iterate a `[]gmvLifecycle` registry instead of
-	// naming each variable explicitly.
+	// MAINTENANCE CONTRACT: every gateway-managed variable must be returned by
+	// gatewayManagedVariablesLocked so all transaction/savepoint lifecycle
+	// methods keep its snapshot stack in lockstep with savepoints. The
+	// gmvLifecycle interface (Snapshot/RestoreFromDepth/PopFrom/ClearSnapshots
+	// and ResetLocal) is the complete set of operations those methods need, so
+	// adding a GMV requires only extending gatewayManagedVariablesLocked — no
+	// per-variable wiring in the lifecycle methods themselves. Every non-GMV
+	// snapshot field stored on savepointFrame (currently `openHoldCursors`)
+	// must still be wired into pushFrameLocked, ReleaseSavepoint,
+	// RollbackToSavepoint, BeginTransaction, CommitTransaction, and
+	// RollbackTransaction.
 	savepoints []savepointFrame
 
 	// targetReplica is true when this connection arrived on the replica-reads
@@ -196,6 +198,20 @@ type savepointFrame struct {
 	// multipooler — PG closes those cursors server-side on
 	// ROLLBACK TO, and our reservation bookkeeping must follow.
 	openHoldCursors map[string]bool
+}
+
+type gmvLifecycle interface {
+	Snapshot()
+	RestoreFromDepth(int)
+	PopFrom(int)
+	ClearSnapshots()
+	// ResetLocal clears the transaction-local override at COMMIT/ROLLBACK.
+	// Part of the interface so the lifecycle methods can iterate generically
+	// rather than naming each variable (which is easy to forget for a new GMV).
+	ResetLocal()
+	// Reset clears both the session-level override and any transaction-local
+	// override, reverting to the startup/default value (RESET ALL semantics).
+	Reset()
 }
 
 type ShardState struct {
@@ -496,6 +512,18 @@ func (m *MultiGatewayConnectionState) ResetAllSessionVariables() {
 	m.SessionSettings = nil
 }
 
+// gatewayManagedVariablesLocked returns every gateway-managed variable for the
+// transaction/savepoint lifecycle methods to iterate. It returns a fixed-size
+// array (not a slice) so the result stays on the caller's stack — these are hot
+// transaction-boundary paths and a slice literal would escape to the heap on
+// every call. Adding a GMV means bumping the array size and adding the element
+// here; the compiler flags a size mismatch if you forget one.
+func (m *MultiGatewayConnectionState) gatewayManagedVariablesLocked() [1]gmvLifecycle {
+	return [1]gmvLifecycle{
+		&m.statementTimeout,
+	}
+}
+
 // SetStatementTimeout sets the session-level statement timeout override.
 func (m *MultiGatewayConnectionState) SetStatementTimeout(d time.Duration) {
 	m.mu.Lock()
@@ -533,13 +561,75 @@ func (m *MultiGatewayConnectionState) SetLocalStatementTimeoutToDefault() {
 	m.statementTimeout.SetLocalToDefault()
 }
 
+// gatewayManagedVariableNames is the canonical set of session variables the
+// gateway manages itself: SET / SHOW / RESET are handled locally and the value
+// is never written to SessionSettings (so it is not replayed to backends on
+// pool rotation). This is the single source of truth consulted by the planner
+// (routing decisions) and the engine (set_config execution). Names compare
+// case-insensitively.
+var gatewayManagedVariableNames = map[string]struct{}{
+	"statement_timeout": {},
+}
+
+// IsGatewayManagedVariable reports whether name (case-insensitive) is a session
+// variable managed entirely by the gateway and not forwarded to PostgreSQL.
+func IsGatewayManagedVariable(name string) bool {
+	_, ok := gatewayManagedVariableNames[strings.ToLower(name)]
+	return ok
+}
+
+// ApplyGatewayManagedVariable applies a SET / set_config(...) of a
+// gateway-managed variable to gateway-local state instead of the
+// SessionSettings map. Routing here (rather than SetSessionVariable) is what
+// keeps SHOW consistent and keeps the variable out of GetSessionSettings, so it
+// is never replayed to a backend on pool rotation.
+//
+// Returns (handled, err): handled is false when name is not gateway-managed and
+// the caller must fall back to SessionSettings. err is non-nil when value is
+// invalid for the variable (e.g. an unparsable statement_timeout), mirroring
+// PostgreSQL's set-time validation.
+//
+// isLocal selects the transaction-local override (SET LOCAL / set_config(...,
+// true)) over the session-level override.
+func (m *MultiGatewayConnectionState) ApplyGatewayManagedVariable(name, value string, isLocal bool) (bool, error) {
+	switch strings.ToLower(name) {
+	case "statement_timeout":
+		d, err := ParsePostgresInterval("statement_timeout", value)
+		if err != nil {
+			return true, err
+		}
+		if isLocal {
+			m.SetLocalStatementTimeout(d)
+		} else {
+			m.SetStatementTimeout(d)
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
 // ResetAllLocalGUCs clears all transaction-local overrides for gateway-managed
 // variables. Called at transaction end (COMMIT/ROLLBACK) so the next statement
 // observes the session-level (or default) value.
 func (m *MultiGatewayConnectionState) ResetAllLocalGUCs() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.statementTimeout.ResetLocal()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.ResetLocal()
+	}
+}
+
+// ResetGatewayManagedVariables reverts every gateway-managed variable to its
+// startup/default value (session and transaction-local overrides both
+// cleared). Called by RESET ALL, which must cover GMVs in addition to the
+// SessionSettings map since they live outside it.
+func (m *MultiGatewayConnectionState) ResetGatewayManagedVariables() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.Reset()
+	}
 }
 
 // snapshotSessionSettingsLocked returns a copy of SessionSettings (or nil if
@@ -574,7 +664,9 @@ func (m *MultiGatewayConnectionState) pushFrameLocked(name string) {
 		sessionSettings: m.snapshotSessionSettingsLocked(),
 		openHoldCursors: m.snapshotOpenHoldCursorsLocked(),
 	})
-	m.statementTimeout.Snapshot()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.Snapshot()
+	}
 }
 
 // snapshotOpenHoldCursorsLocked returns a copy of the current OpenHoldCursors
@@ -605,7 +697,9 @@ func (m *MultiGatewayConnectionState) BeginTransaction() {
 		return
 	}
 	m.savepoints = m.savepoints[:0]
-	m.statementTimeout.ClearSnapshots()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.ClearSnapshots()
+	}
 	m.pushFrameLocked("")
 }
 
@@ -630,7 +724,9 @@ func (m *MultiGatewayConnectionState) ReleaseSavepoint(name string) {
 		return
 	}
 	m.savepoints = m.savepoints[:idx]
-	m.statementTimeout.PopFrom(idx)
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.PopFrom(idx)
+	}
 }
 
 // HoldCursorsDeclaredAfterSavepoint returns the names of `DECLARE … WITH HOLD`
@@ -697,7 +793,9 @@ func (m *MultiGatewayConnectionState) RollbackToSavepoint(name string) {
 	}
 	m.OpenHoldCursors = surviving
 	m.savepoints = m.savepoints[:idx+1]
-	m.statementTimeout.RestoreFromDepth(idx)
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.RestoreFromDepth(idx)
+	}
 }
 
 // CommitTransaction drops all savepoint frames (current values become
@@ -707,8 +805,10 @@ func (m *MultiGatewayConnectionState) CommitTransaction() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.savepoints = nil
-	m.statementTimeout.ClearSnapshots()
-	m.statementTimeout.ResetLocal()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.ClearSnapshots()
+		gmv.ResetLocal()
+	}
 }
 
 // RollbackTransaction reverts all SET / RESET commands issued inside the
@@ -719,7 +819,9 @@ func (m *MultiGatewayConnectionState) RollbackTransaction() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if len(m.savepoints) == 0 {
-		m.statementTimeout.ResetLocal()
+		for _, gmv := range m.gatewayManagedVariablesLocked() {
+			gmv.ResetLocal()
+		}
 		return
 	}
 	m.SessionSettings = nil
@@ -727,9 +829,11 @@ func (m *MultiGatewayConnectionState) RollbackTransaction() {
 		m.SessionSettings = make(map[string]string, len(m.savepoints[0].sessionSettings))
 		maps.Copy(m.SessionSettings, m.savepoints[0].sessionSettings)
 	}
-	m.statementTimeout.RestoreFromDepth(0)
-	m.statementTimeout.ClearSnapshots()
-	m.statementTimeout.ResetLocal()
+	for _, gmv := range m.gatewayManagedVariablesLocked() {
+		gmv.RestoreFromDepth(0)
+		gmv.ClearSnapshots()
+		gmv.ResetLocal()
+	}
 	m.savepoints = nil
 }
 

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -200,20 +200,6 @@ type savepointFrame struct {
 	openHoldCursors map[string]bool
 }
 
-type gmvLifecycle interface {
-	Snapshot()
-	RestoreFromDepth(int)
-	PopFrom(int)
-	ClearSnapshots()
-	// ResetLocal clears the transaction-local override at COMMIT/ROLLBACK.
-	// Part of the interface so the lifecycle methods can iterate generically
-	// rather than naming each variable (which is easy to forget for a new GMV).
-	ResetLocal()
-	// Reset clears both the session-level override and any transaction-local
-	// override, reverting to the startup/default value (RESET ALL semantics).
-	Reset()
-}
-
 type ShardState struct {
 	// Target stores the information about the shard
 	Target *query.Target

--- a/go/services/multigateway/handler/gateway_managed_variable.go
+++ b/go/services/multigateway/handler/gateway_managed_variable.go
@@ -14,6 +14,23 @@
 
 package handler
 
+// gmvLifecycle is the lifecycle surface MultiGatewayConnectionState needs for
+// every gateway-managed variable. Keeping this next to GatewayManagedVariable
+// makes the maintenance contract explicit: adding a GMV means registering it in
+// gatewayManagedVariablesLocked(), after which transaction/savepoint lifecycle
+// methods can iterate generically rather than naming each variable.
+type gmvLifecycle interface {
+	Snapshot()
+	RestoreFromDepth(int)
+	PopFrom(int)
+	ClearSnapshots()
+	// ResetLocal clears the transaction-local override at COMMIT/ROLLBACK.
+	ResetLocal()
+	// Reset clears both the session-level override and any transaction-local
+	// override, reverting to the startup/default value (RESET ALL semantics).
+	Reset()
+}
+
 // GatewayManagedVariable holds a variable with three priority layers matching
 // PostgreSQL's GUC semantics:
 //

--- a/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
+++ b/go/services/multigateway/handler/gateway_managed_variable_apply_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGatewayManagedVariable(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"statement_timeout", true},
+		// Case-insensitive: PostgreSQL lowercases unquoted identifiers, but a
+		// quoted identifier preserves case and must still be recognized.
+		{"STATEMENT_TIMEOUT", true},
+		{"Statement_Timeout", true},
+		{"application_name", false},
+		{"work_mem", false},
+		{"search_path", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsGatewayManagedVariable(tc.name))
+		})
+	}
+}
+
+// TestApplyGatewayManagedVariable_RoutesToGatewayState confirms gateway-managed
+// variables are applied to gateway-local state (visible via SHOW) and are kept
+// out of SessionSettings, while non-managed variables are left for the caller.
+func TestApplyGatewayManagedVariable_RoutesToGatewayState(t *testing.T) {
+	t.Run("statement_timeout session", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("statement_timeout", "5s", false)
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, "5s", s.ShowStatementTimeout())
+		_, exists := s.GetSessionVariable("statement_timeout")
+		assert.False(t, exists)
+	})
+
+	t.Run("case-insensitive name", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("Statement_Timeout", "5s", false)
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, "5s", s.ShowStatementTimeout())
+	})
+
+	t.Run("invalid statement_timeout returns handled with error", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("statement_timeout", "not-a-duration", false)
+		require.Error(t, err)
+		assert.True(t, handled, "still gateway-managed even though the value is invalid")
+	})
+
+	t.Run("non-managed variable is not handled", func(t *testing.T) {
+		s := &MultiGatewayConnectionState{}
+		handled, err := s.ApplyGatewayManagedVariable("work_mem", "256MB", false)
+		require.NoError(t, err)
+		assert.False(t, handled)
+		// Caller is responsible for SessionSettings; ApplyGatewayManagedVariable
+		// must not have touched it.
+		_, exists := s.GetSessionVariable("work_mem")
+		assert.False(t, exists)
+	})
+}

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -191,6 +191,11 @@ func syntheticSetStmt(sc setConfigCall) *ast.VariableSetStmt {
 		BaseNode: ast.BaseNode{Tag: ast.T_VariableSetStmt},
 		Kind:     ast.VAR_SET_VALUE,
 		Name:     name,
+		// IsLocal is set only for a gateway-managed set_config(..., true), which
+		// the executor applies as a transaction-local override (parity with
+		// SET LOCAL <gmv>). Ordinary is_local=true calls never produce a
+		// setConfigCall, so this is false for them.
+		IsLocal: sc.IsLocalLiteralTrue,
 		Args: ast.NewNodeList(
 			ast.NewA_Const(ast.NewString(value), 0),
 		),

--- a/go/services/multigateway/planner/set_config_gmv_test.go
+++ b/go/services/multigateway/planner/set_config_gmv_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+)
+
+// TestSetConfig_GatewayManagedIsLocalTrueIsTracked verifies the is_local=true
+// asymmetry fix: set_config('<gmv>', v, true) is tracked as a transaction-local
+// override (so SHOW matches SET LOCAL <gmv>), while an ordinary variable with
+// is_local=true is still left untracked for PostgreSQL to execute via the Route.
+func TestSetConfig_GatewayManagedIsLocalTrueIsTracked(t *testing.T) {
+	t.Run("gateway-managed name is tracked as local", func(t *testing.T) {
+		res, err := analyzeStatement(parseOne(t, "SELECT set_config('statement_timeout', '5s', true)"))
+		require.NoError(t, err)
+		require.Len(t, res.SetConfigs, 1)
+		assert.Equal(t, "statement_timeout", res.SetConfigs[0].Name)
+		assert.Equal(t, "5s", res.SetConfigs[0].Value)
+		assert.True(t, res.SetConfigs[0].IsLocalLiteralTrue)
+	})
+
+	t.Run("ordinary name with is_local=true is not tracked", func(t *testing.T) {
+		res, err := analyzeStatement(parseOne(t, "SELECT set_config('work_mem', '64MB', true)"))
+		require.NoError(t, err)
+		assert.Empty(t, res.SetConfigs)
+	})
+}
+
+// TestPlanSetConfig_GatewayManagedIsLocalTruePlan verifies the full plan: a
+// Sequence[ApplySessionState, Route] whose ApplySessionState carries IsLocal so
+// the executor applies a transaction-local gateway override.
+func TestPlanSetConfig_GatewayManagedIsLocalTruePlan(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	sql := "SELECT set_config('statement_timeout', '5s', true)"
+	plan, err := p.Plan(sql, parseOne(t, sql), testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	seq, ok := plan.Primitive.(*engine.Sequence)
+	require.True(t, ok, "expected Sequence primitive, got %T", plan.Primitive)
+	require.GreaterOrEqual(t, len(seq.Primitives), 2)
+
+	ass, ok := seq.Primitives[0].(*engine.ApplySessionState)
+	require.True(t, ok, "first primitive should be ApplySessionState, got %T", seq.Primitives[0])
+	assert.Equal(t, "statement_timeout", ass.VariableStmt.Name)
+	assert.True(t, ass.VariableStmt.IsLocal, "is_local=true must be carried so the executor applies a transaction-local override")
+
+	_, ok = seq.Primitives[len(seq.Primitives)-1].(*engine.Route)
+	assert.True(t, ok, "last primitive should be Route, got %T", seq.Primitives[len(seq.Primitives)-1])
+}

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -77,19 +77,23 @@ var funcBlocklist = map[string]string{
 //
 // Two shapes:
 //   - all-literal: Name and Value carry the parsed strings, *Bind fields
-//     are nil. is_local was literal false (literal true short-circuits
-//     below and never produces a setConfigCall).
+//     are nil. is_local was either literal false or — for a gateway-managed
+//     variable only — literal true (see IsLocalLiteralTrue).
 //   - any-bound: at least one of NameBind/ValueBind/IsLocalBind is non-nil
-//     and points at the parser-produced ParamRef for that slot. Name/Value
-//     hold the parsed string for any slot that was NOT bound. The planner
-//     emits the deferred-resolution primitive that decodes the bound slots
-//     from the portal at execute time.
+//     and points at the ParamRef for that slot (parser-produced for the
+//     extended protocol, normalizer-produced for cacheable simple queries).
+//     Name/Value hold the parsed string for any slot that was NOT bound.
+//     The planner emits the deferred-resolution primitive that resolves the
+//     bound slots at execute time — from the portal's wire Bind values or
+//     from the normalizer-extracted bindVars, depending on the path.
 //
-// `is_local=true` literals never produce a setConfigCall — validation
-// returns (nil, nil) early so the call goes to PG via Route only, with no
-// SessionSettings write. That's also why we don't need to carry a literal
-// is_local: any returned setConfigCall implies is_local was literal false
-// or bound, and the executor defaults to false when IsLocalBind is nil.
+// `is_local=true` literals produce a setConfigCall only for gateway-managed
+// variables, tracked as a transaction-local override so SHOW matches the
+// `SET LOCAL <gmv>` statement form. For ordinary variables validation
+// returns (nil, nil) early and the call goes to PG via Route only, with no
+// SessionSettings write. A literal is_local therefore travels as
+// IsLocalLiteralTrue; the executor treats is_local as false when both
+// IsLocalBind is nil and IsLocalLiteralTrue is false.
 type setConfigCall struct {
 	Name  string
 	Value string
@@ -244,9 +248,10 @@ func analyzeStatement(stmt ast.Stmt) (*statementAnalysis, error) {
 // Runs BEFORE statement-type dispatch but AFTER normalization — by the time
 // we see stmt, non-set_config literals have become ParamRefs. The
 // normalizer skips inside set_config's args when is_local is literal false
-// (so the validator can extract the name/value), but allows recursion when
-// is_local is literal true (those calls are accepted but not tracked, and
-// parameterizing them keeps the plan cache stable for hot patterns).
+// (so the validator can extract the name/value), but parameterizes the
+// value when is_local is literal true: name and is_local stay literal, so
+// the gateway-managed check below still works; ordinary calls go untracked,
+// and the collapsed value keeps the plan cache stable for hot patterns.
 func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 	if stmt == nil {
 		return &statementAnalysis{}, nil
@@ -332,8 +337,10 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 		if setCfg != nil {
 			result.SetConfigs = append(result.SetConfigs, *setCfg)
 		}
-		// else is_local=true: leave it alone; PG executes it as a normal
-		// transaction-scoped call and the pooler does not track it.
+		// else is_local=true on an ordinary variable: leave it alone; PG
+		// executes it as a normal transaction-scoped call and the pooler
+		// does not track it. (Gateway-managed names DO produce a setCfg —
+		// see validateAcceptedSetConfig.)
 	}
 	return result, nil
 }
@@ -452,13 +459,16 @@ func isStaticSetConfigArg(n ast.Node) bool {
 // for execute-time resolution from the portal's wire-protocol Bind values.
 // Anything else (non-const non-ParamRef expression) errors out.
 //
-// is_local is inspected first because a literal `true` short-circuits:
-// transaction-scoped calls are not tracked at all (PG executes them via
-// Route, the gateway holds no state for them), so name/value need not be
-// validated and the normalizer is allowed to parameterize their args (see
-// isPlannerLiteralFunc / normalizer.go) — keeps the plan-cache fingerprint
-// stable for hot patterns like PostgREST's set_config('request.jwt.claims',
-// '<dynamic JSON>', true).
+// is_local is inspected first because a literal `true` usually
+// short-circuits: transaction-scoped calls on ordinary variables are not
+// tracked at all (PG executes them via Route, the gateway holds no state
+// for them), so name/value need not be validated and the normalizer is
+// allowed to parameterize their value (see isPlannerLiteralFunc /
+// normalizer.go) — keeps the plan-cache fingerprint stable for hot patterns
+// like PostgREST's set_config('request.jwt.claims', '<dynamic JSON>', true).
+// Gateway-managed variables are the exception: literal-true IS tracked
+// (IsLocalLiteralTrue) so SHOW matches SET LOCAL, and the parameterized
+// value is resolved from the execution's bindVars at execute time.
 //
 // A bound is_local cannot be short-circuited at plan time — the decision
 // to track is deferred to executeSetWithBinds.

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
 // funcBlocklist lists built-in functions that must be rejected wherever they
@@ -96,6 +97,13 @@ type setConfigCall struct {
 	NameBind    *ast.ParamRef
 	ValueBind   *ast.ParamRef
 	IsLocalBind *ast.ParamRef
+
+	// IsLocalLiteralTrue marks a call whose is_local argument is the literal
+	// `true`. Normally such a call is not tracked (it short-circuits below),
+	// but for a gateway-managed variable it is tracked as a transaction-local
+	// override so SHOW matches the `SET LOCAL <gmv>` statement form. Mutually
+	// exclusive with IsLocalBind (a bound is_local is resolved at execute time).
+	IsLocalLiteralTrue bool
 }
 
 func (sc setConfigCall) hasBoundParams() bool {
@@ -478,11 +486,22 @@ func validateAcceptedSetConfig(fc *ast.FuncCall) (*setConfigCall, error) {
 		sc.IsLocalBind = pr
 	} else if isLocal, ok := constBoolArg(fc.Args.Items[2]); ok {
 		if isLocal {
-			return nil, nil
+			// is_local literal true. For an ordinary variable we do not track
+			// it: PostgreSQL executes the call transaction-scoped via the
+			// trailing Route and the gateway holds no state (which also keeps
+			// the plan cache compact for hot PostgREST set_config(...,true)
+			// patterns). For a gateway-managed variable we DO track it as a
+			// transaction-local override, so SHOW matches the `SET LOCAL <gmv>`
+			// statement form. The normalizer keeps the name literal even on the
+			// is_local=true path, so the GMV check below is reliable.
+			if name, ok := constStringArg(fc.Args.Items[0]); !ok || !handler.IsGatewayManagedVariable(name) {
+				return nil, nil
+			}
+			sc.IsLocalLiteralTrue = true
 		}
 		// is_local literal false: fall through. No field to set — the
 		// returned setConfigCall represents false implicitly via the
-		// absence of IsLocalBind.
+		// absence of IsLocalBind and IsLocalLiteralTrue.
 	} else {
 		return nil, setConfigArgError(fc.Args.Items[2], "is_local")
 	}

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -127,14 +127,11 @@ func (p *Planner) planVariableSetStmt(
 // isGatewayManagedVariable returns true for session variables that are managed
 // entirely by the gateway and should NOT be forwarded to PostgreSQL.
 // These variables control gateway-level behavior (e.g., timeouts) and sending
-// them to PostgreSQL would be redundant or counterproductive for connection pooling.
+// them to PostgreSQL would be redundant or counterproductive for connection
+// pooling. It delegates to handler.IsGatewayManagedVariable so the planner and
+// engine share a single source of truth for the managed-variable set.
 func isGatewayManagedVariable(name string) bool {
-	switch strings.ToLower(name) {
-	case "statement_timeout":
-		return true
-	default:
-		return false
-	}
+	return handler.IsGatewayManagedVariable(name)
 }
 
 // planGatewayManagedVariable creates a GatewaySessionState primitive for a

--- a/go/services/multigateway/planner/variable_show_stmt.go
+++ b/go/services/multigateway/planner/variable_show_stmt.go
@@ -15,6 +15,8 @@
 package planner
 
 import (
+	"strings"
+
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
@@ -28,12 +30,19 @@ func (p *Planner) planVariableShowStmt(
 	stmt *ast.VariableShowStmt,
 	conn *server.Conn,
 ) (*engine.Plan, error) {
-	if !isGatewayManagedVariable(stmt.Name) {
+	// Canonicalize to the lowercase GUC name. PostgreSQL lowercases unquoted
+	// identifiers in the parser, but a quoted name (e.g. SHOW "Statement_Timeout")
+	// preserves case. isGatewayManagedVariable already compares
+	// case-insensitively; passing the lowercased name to the primitive keeps
+	// the executor's case-sensitive switch from missing it (which would panic)
+	// and matches the column label PostgreSQL returns.
+	name := strings.ToLower(stmt.Name)
+	if !isGatewayManagedVariable(name) {
 		return p.planDefault(sql, stmt, conn, PlannerOptions{})
 	}
 
-	p.logger.Debug("planning SHOW gateway-managed variable", "variable", stmt.Name)
-	primitive := engine.NewGatewayShowVariable(sql, stmt.Name)
+	p.logger.Debug("planning SHOW gateway-managed variable", "variable", name)
+	primitive := engine.NewGatewayShowVariable(sql, name)
 	plan := engine.NewPlan(sql, primitive)
 	return plan, nil
 }

--- a/go/services/multigateway/planner/variable_show_stmt_test.go
+++ b/go/services/multigateway/planner/variable_show_stmt_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// TestPlanVariableShowStmt_QuotedGatewayManagedName is a regression test for the
+// case-sensitive SHOW path: a quoted identifier (e.g. SHOW "Statement_Timeout")
+// preserves case, so the raw name must be lowercased before reaching the
+// executor's case-sensitive switch — otherwise it would miss the switch and
+// panic. The fix canonicalizes the name at plan time.
+func TestPlanVariableShowStmt_QuotedGatewayManagedName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	// Quoted identifier preserves case; the parser does not lowercase it.
+	stmt := &ast.VariableShowStmt{Name: "Statement_Timeout"}
+
+	plan, err := p.planVariableShowStmt(`SHOW "Statement_Timeout"`, stmt, testConn.Conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	prim, ok := plan.Primitive.(*engine.GatewayShowVariable)
+	require.True(t, ok, "expected GatewayShowVariable primitive, got %T", plan.Primitive)
+
+	state := &handler.MultiGatewayConnectionState{}
+	state.SetStatementTimeout(5 * time.Second)
+
+	var results []*sqltypes.Result
+	require.NotPanics(t, func() {
+		err = prim.StreamExecute(context.Background(), nil, testConn.Conn, state, nil,
+			func(_ context.Context, r *sqltypes.Result) error {
+				results = append(results, r)
+				return nil
+			})
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Fields, 1)
+	// Column label matches the canonical lowercased GUC name PostgreSQL returns.
+	assert.Equal(t, "statement_timeout", results[0].Fields[0].Name)
+	require.Len(t, results[0].Rows, 1)
+}


### PR DESCRIPTION
## Summary

This is a refactoring-only PR for gateway-managed variable (GMV) handling. It centralizes the lifecycle, planner, and engine plumbing around the existing `statement_timeout` GMV implementation.

The refactor makes GMV support modular:

- **`gmvLifecycle` interface + `gatewayManagedVariablesLocked()` registry** — transaction/savepoint lifecycle methods iterate the registry instead of naming variables in each method. The fixed-size array makes a forgotten registry entry a compile-time error.
- **`handler.IsGatewayManagedVariable` / `gatewayManagedVariableNames`** — single source of truth for the managed-variable set, shared by the planner and engine.
- **`ApplyGatewayManagedVariable`** — routes SET / `set_config()` of a GMV to gateway-local state with set-time validation, so the engine no longer special-cases variable names.
- **`set_config('<gmv>', v, false)`** updates gateway state instead of leaking into `SessionSettings`; **`set_config('<gmv>', v, true)`** is tracked as a transaction-local override, including bound parameters resolved at execute time.
- **RESET ALL** resets every registered GMV via the registry instead of naming each variable.
- **SHOW** canonicalizes quoted GMV names at plan time so the executor's case-sensitive switch cannot be missed.
- **GMV documentation** — adds `docs/query_serving/gateway_managed_variables.md` and trims duplicated generic GMV content from the session-setting and statement-timeout docs.

## Test report

- Multigateway unit tests pass (`go/services/multigateway/...`).
- Parser AST unit tests pass (`go/common/parser/ast/...`).
- Race-enabled tests pass for the changed engine/executor/planner packages.
