### PR TITLE
feat(multigateway): support session-level advisory locks under pooling

### DIFF
--- a/docs/query_serving/advisory_locks_design.md
+++ b/docs/query_serving/advisory_locks_design.md
@@ -1,0 +1,149 @@
+# Session-Level Advisory Locks
+
+## Overview
+
+PostgreSQL session-level advisory locks (`pg_advisory_lock`,
+`pg_advisory_lock_shared`, and their `try` variants) live on a specific backend
+and survive transaction boundaries. Under multigateway's pooled model a client's
+logical session is not bound to one backend, so without special handling these
+locks would be taken on whatever backend ran the acquiring statement and then
+lost — or leaked to the next client — on the following query.
+
+Multigres makes session-level advisory locks work by **pinning** the backend to
+the client session for the lifetime of the lock, using the same
+reserved-connection machinery as transactions, temp tables, and `WITH HOLD`
+cursors. The key design choice is that **PostgreSQL remains the authority on the
+(reference-counted) lock state**: the gateway decides when to pin and when to
+ask, but `pg_locks` decides when to unpin.
+
+Transaction-level advisory locks (`pg_advisory_xact_lock*`) are out of scope:
+they are released at transaction end and never outlive a pooled backend's
+involvement in the session, so they need no pinning.
+
+## Background
+
+- A session advisory lock is acquired with `pg_advisory_lock(key)` /
+  `pg_advisory_lock(key1, key2)` (exclusive) or the `_shared` variant, plus the
+  non-blocking `pg_try_advisory_lock*` forms. It is **reference-counted**: N
+  acquires of the same key require N unlocks.
+- It is released by `pg_advisory_unlock` / `_shared` (one ref), by
+  `pg_advisory_unlock_all()` (all at once), by `DISCARD ALL`, or implicitly when
+  the session ends (disconnect, `pg_terminate_backend`, crash).
+- It is **not** released by COMMIT or ROLLBACK — even rolling back the
+  transaction that acquired it leaves the lock held.
+
+## Approach
+
+Three pieces, split across the gateway and the multipooler:
+
+1. **Detect + pin (gateway).** The planner inspects a statement's function calls.
+   A session-level advisory _acquire_ routes the query through an
+   `AdvisoryLockRoute`, which makes ScatterConn reserve (or promote an existing
+   reservation to) a backend with `ReasonSessionAdvisoryLock`. The connection
+   stays pinned to the session while that reason is set.
+
+2. **Unpin authoritatively (multipooler).** After a statement that _touches_
+   advisory locks, the multipooler probes `pg_locks` for the backend; if no
+   advisory lock remains (and it is not inside a transaction), it clears
+   `ReasonSessionAdvisoryLock` and releases the connection when no other reason
+   keeps it pinned. Because PostgreSQL answers the probe, this is correct for
+   reference-counted stacking, failed `try` locks, `pg_advisory_unlock_all()`,
+   and unlocks issued in surprising ways.
+
+3. **Scrub on release (multipooler).** When a reserved connection is handed back
+   to the pool (client disconnect, or `DISCARD ALL`), the release path runs
+   `SELECT pg_advisory_unlock_all()` before recycling it, so a backend never
+   returns to the pool still holding a session advisory lock. This is the narrow
+   fix — unlike forwarding `DISCARD ALL` to the backend, it leaves prepared
+   statements intact, keeping the multipooler's per-connection tracking in sync.
+
+## Detection
+
+The planner's pre-dispatch analysis (`analyzeFunctionCalls`) walks every
+`FuncCall` and classifies advisory functions:
+
+- **Acquire family** (`sessionAdvisoryLockAcquireFuncs`): `pg_advisory_lock`,
+  `pg_advisory_lock_shared`, `pg_try_advisory_lock`,
+  `pg_try_advisory_lock_shared`. Sets `AcquiresSessionAdvisoryLock`, which drives
+  the pin.
+- **Release family** (`sessionAdvisoryLockReleaseFuncs`): `pg_advisory_unlock`,
+  `pg_advisory_unlock_shared`, `pg_advisory_unlock_all`. Sets
+  `ReleasesSessionAdvisoryLock`.
+
+A statement that acquires or releases is wrapped in `AdvisoryLockRoute` with two
+intents:
+
+- **pin** (acquires only) → `ReservationOptions.reasons |= SESSION_ADVISORY_LOCK`.
+- **recheck** (acquires and releases) → `ReservationOptions.recheck_advisory_locks`.
+
+Detection is best-effort: it sees advisory calls in the statement text — the
+overwhelming common case — but not locks acquired or released indirectly (inside
+a PL/pgSQL function, a trigger, or dynamic SQL). A missed acquire means the
+session isn't pinned (the same pre-existing limitation as temp tables created via
+dynamic SQL); a missed release means the session stays pinned conservatively
+until the next observed advisory statement, `DISCARD ALL`, or disconnect — never
+a leak.
+
+## Pinning and the recheck signal
+
+Acquire and release both flow through `AdvisoryLockRoute`, which sets one-shot
+flags on the connection state that ScatterConn turns into `ReservationOptions`:
+
+- `PendingAdvisoryLockReservation` → adds `ReasonSessionAdvisoryLock`.
+- `PendingAdvisoryLockRecheck` → sets `recheck_advisory_locks`.
+
+This works on both the simple and extended (portal) protocols: portals carry
+`reservation_options` to the multipooler, which reserves-and-runs atomically, so
+an advisory lock acquired via a bound-parameter `pg_advisory_lock($1)` pins the
+same way a simple-protocol call does.
+
+The recheck signal is what keeps the probe off the hot path. Without it, the
+multipooler would have to probe `pg_locks` after _every_ statement on a pinned
+connection. Instead it probes only when the gateway flags a statement as
+touching advisory locks:
+
+- An **acquire** sets recheck so a failed `pg_try_advisory_lock` (which pinned
+  optimistically but took no lock) unpins immediately.
+- A **release** sets recheck so the connection unpins once the last lock is gone.
+- Any other statement on a pinned connection skips the probe entirely.
+
+The probe is still the authority — the flag only decides _when_ to ask. We
+deliberately do not count acquires/unlocks at the gateway: reference counting,
+failed `try` locks, and hidden unlocks make gateway-side counting unreliable.
+
+## Release paths
+
+| Trigger                          | How it's handled                                               |
+| -------------------------------- | -------------------------------------------------------------- |
+| `pg_advisory_unlock` / `_shared` | recheck signal → `pg_locks` probe → unpin if zero              |
+| `pg_advisory_unlock_all()`       | recheck signal → `pg_locks` probe → unpin                      |
+| `DISCARD ALL`                    | reserved-connection release → `pg_advisory_unlock_all()` scrub |
+| Disconnect / terminate / crash   | reserved-connection release → scrub (or socket close)          |
+| COMMIT / ROLLBACK                | not a release — lock survives, connection stays pinned         |
+
+## Limitations
+
+- Advisory locks acquired or released inside a function body, trigger, or
+  dynamic SQL are not detected; the session pins/unpins conservatively (never
+  leaks, but may hold a pin longer than strictly necessary).
+- Transaction-level advisory locks (`pg_advisory_xact_lock*`) are intentionally
+  not pinned.
+
+## Code map
+
+- Detection: `go/services/multigateway/planner/unsafe_funccall.go`
+  (`sessionAdvisoryLockAcquireFuncs`, `sessionAdvisoryLockReleaseFuncs`).
+- Routing: `planner.go` (`PlannerOptions`, `routePrimitive`),
+  `engine/advisory_lock_route.go`.
+- Reservation reason: `go/common/protoutil/reservation.go`
+  (`ReasonSessionAdvisoryLock`), `proto/multipoolerservice.proto`.
+- Gateway wiring: `scatterconn/scatter_conn.go`,
+  `handler/connection_state.go` (`PendingAdvisoryLockReservation`,
+  `PendingAdvisoryLockRecheck`).
+- Probe + scrub: `go/services/multipooler/internal/executor/executor.go`
+  (`maybeUnpinSessionAdvisoryLock`, `ReleaseReservedConnection`),
+  probe SQL in `go/common/constants/postgres.go`
+  (`PgLocksAdvisoryProbeSQL`).
+- Tests: `go/test/endtoend/queryserving/advisory_lock_test.go`,
+  `planner/advisory_lock_test.go`,
+  `multipooler/internal/executor/executor_test.go`.

--- a/go/common/constants/postgres.go
+++ b/go/common/constants/postgres.go
@@ -97,4 +97,11 @@ const (
 	// CrashRecoveryRetryDelay caps the delay between `postgres --single` retry
 	// attempts during the orphan-cleanup window.
 	CrashRecoveryRetryDelay = 500 * time.Millisecond
+
+	// PgLocksAdvisoryProbeSQL reports whether the current backend still holds any
+	// advisory lock. Run only outside a transaction, where every advisory lock
+	// visible here is session-level (transaction-level advisory locks are
+	// released at transaction end), so a false result means the session has
+	// released all of its advisory locks and the backend can be unpinned.
+	PgLocksAdvisoryProbeSQL = "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid())"
 )

--- a/go/common/protoutil/reservation.go
+++ b/go/common/protoutil/reservation.go
@@ -23,7 +23,7 @@ import (
 )
 
 // validReasonsMask is the bitmask of all known reservation reasons.
-const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen | ReasonLogicalReplication
+const validReasonsMask = ReasonTransaction | ReasonTempTable | ReasonPortal | ReasonCopy | ReasonListen | ReasonLogicalReplication | ReasonSessionAdvisoryLock
 
 // Reason constants as uint32 for bitmask operations.
 // These match the ReservationReason enum values.
@@ -52,6 +52,16 @@ const (
 	// consumers must cooperate by setting an application_name that
 	// multigateway recognizes (also future work).
 	ReasonLogicalReplication = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_LOGICAL_REPLICATION) // 32
+
+	// ReasonSessionAdvisoryLock indicates the session holds one or more
+	// session-level advisory locks (pg_advisory_lock / pg_advisory_lock_shared
+	// and their try-variants). These locks live on a specific Postgres backend
+	// and survive transaction boundaries, so the backend stays pinned to the
+	// client session until every such lock is released (pg_advisory_unlock /
+	// pg_advisory_unlock_all) or the session ends. Transaction-level advisory
+	// locks (pg_advisory_xact_lock) are released at transaction end and do NOT
+	// set this reason.
+	ReasonSessionAdvisoryLock = uint32(multipoolerpb.ReservationReason_RESERVATION_REASON_SESSION_ADVISORY_LOCK) // 64
 )
 
 // ValidateReasons returns an error if any unknown bits are set in the reasons bitmask.
@@ -95,6 +105,11 @@ func HasListenReason(reasons uint32) bool {
 // HasLogicalReplicationReason returns true if the reasons bitmask includes a logical-replication session.
 func HasLogicalReplicationReason(reasons uint32) bool {
 	return HasReason(reasons, ReasonLogicalReplication)
+}
+
+// HasSessionAdvisoryLockReason returns true if the reasons bitmask includes a session-level advisory lock.
+func HasSessionAdvisoryLockReason(reasons uint32) bool {
+	return HasReason(reasons, ReasonSessionAdvisoryLock)
 }
 
 // AddReason adds a reason to the bitmask and returns the new value.
@@ -177,6 +192,9 @@ func ReasonsString(reasons uint32) string {
 	}
 	if HasLogicalReplicationReason(reasons) {
 		parts = append(parts, "logical_replication")
+	}
+	if HasSessionAdvisoryLockReason(reasons) {
+		parts = append(parts, "session_advisory_lock")
 	}
 	if len(parts) == 0 {
 		return "unknown"

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -63,6 +63,12 @@ const (
 	// Connection is reserved for a logical-replication session (CREATE_REPLICATION_SLOT,
 	// START_REPLICATION, etc.). Pinned to a single backend for the session's lifetime.
 	ReservationReason_RESERVATION_REASON_LOGICAL_REPLICATION ReservationReason = 32 // 0b100000
+	// Connection is reserved because the session holds one or more session-level
+	// advisory locks (pg_advisory_lock / pg_advisory_lock_shared). These locks
+	// live on a specific backend and survive transaction boundaries, so the
+	// backend must stay pinned until every such lock is released. Transaction-level
+	// advisory locks (pg_advisory_xact_lock) do NOT set this reason.
+	ReservationReason_RESERVATION_REASON_SESSION_ADVISORY_LOCK ReservationReason = 64 // 0b1000000
 )
 
 // Enum value maps for ReservationReason.
@@ -75,15 +81,17 @@ var (
 		8:  "RESERVATION_REASON_COPY",
 		16: "RESERVATION_REASON_LISTEN",
 		32: "RESERVATION_REASON_LOGICAL_REPLICATION",
+		64: "RESERVATION_REASON_SESSION_ADVISORY_LOCK",
 	}
 	ReservationReason_value = map[string]int32{
-		"RESERVATION_REASON_UNSPECIFIED":         0,
-		"RESERVATION_REASON_TRANSACTION":         1,
-		"RESERVATION_REASON_TEMP_TABLE":          2,
-		"RESERVATION_REASON_PORTAL":              4,
-		"RESERVATION_REASON_COPY":                8,
-		"RESERVATION_REASON_LISTEN":              16,
-		"RESERVATION_REASON_LOGICAL_REPLICATION": 32,
+		"RESERVATION_REASON_UNSPECIFIED":           0,
+		"RESERVATION_REASON_TRANSACTION":           1,
+		"RESERVATION_REASON_TEMP_TABLE":            2,
+		"RESERVATION_REASON_PORTAL":                4,
+		"RESERVATION_REASON_COPY":                  8,
+		"RESERVATION_REASON_LISTEN":                16,
+		"RESERVATION_REASON_LOGICAL_REPLICATION":   32,
+		"RESERVATION_REASON_SESSION_ADVISORY_LOCK": 64,
 	}
 )
 
@@ -2120,7 +2128,7 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x12\x1a\n" +
 	"\bchannels\x18\x02 \x03(\tR\bchannels\"X\n" +
 	"\x1bStreamNotificationsResponse\x129\n" +
-	"\fnotification\x18\x01 \x01(\v2\x15.query.PgNotificationR\fnotification*\x85\x02\n" +
+	"\fnotification\x18\x01 \x01(\v2\x15.query.PgNotificationR\fnotification*\xb3\x02\n" +
 	"\x11ReservationReason\x12\"\n" +
 	"\x1eRESERVATION_REASON_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eRESERVATION_REASON_TRANSACTION\x10\x01\x12!\n" +
@@ -2128,7 +2136,8 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\x19RESERVATION_REASON_PORTAL\x10\x04\x12\x1b\n" +
 	"\x17RESERVATION_REASON_COPY\x10\b\x12\x1d\n" +
 	"\x19RESERVATION_REASON_LISTEN\x10\x10\x12*\n" +
-	"&RESERVATION_REASON_LOGICAL_REPLICATION\x10 *\x87\x01\n" +
+	"&RESERVATION_REASON_LOGICAL_REPLICATION\x10 \x12,\n" +
+	"(RESERVATION_REASON_SESSION_ADVISORY_LOCK\x10@*\x87\x01\n" +
 	"\x15TransactionConclusion\x12&\n" +
 	"\"TRANSACTION_CONCLUSION_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dTRANSACTION_CONCLUSION_COMMIT\x10\x01\x12#\n" +

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1294,8 +1294,16 @@ type ReservationOptions struct {
 	// the connection is released back to the pool and the returned
 	// ReservedState has connection_id == 0.
 	ReleasePortalNames []string `protobuf:"bytes,4,rep,name=release_portal_names,json=releasePortalNames,proto3" json:"release_portal_names,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// recheck_advisory_locks asks the multipooler to re-probe pg_locks after
+	// running this statement and drop ReasonSessionAdvisoryLock (releasing the
+	// connection if no other reason remains) when the session no longer holds any
+	// advisory lock. The gateway sets it only for statements that touch
+	// session-level advisory locks (an acquire — to catch a failed
+	// pg_try_advisory_lock — or a release), so the probe runs only when it can
+	// matter rather than after every query on a pinned connection.
+	RecheckAdvisoryLocks bool `protobuf:"varint,5,opt,name=recheck_advisory_locks,json=recheckAdvisoryLocks,proto3" json:"recheck_advisory_locks,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ReservationOptions) Reset() {
@@ -1354,6 +1362,13 @@ func (x *ReservationOptions) GetReleasePortalNames() []string {
 		return x.ReleasePortalNames
 	}
 	return nil
+}
+
+func (x *ReservationOptions) GetRecheckAdvisoryLocks() bool {
+	if x != nil {
+		return x.RecheckAdvisoryLocks
+	}
+	return false
 }
 
 var File_query_proto protoreflect.FileDescriptor
@@ -1458,13 +1473,14 @@ const file_query_proto_rawDesc = "" +
 	"\n" +
 	"client_key\x18\x01 \x01(\fB\x03\x80\x01\x01R\tclientKey\x12\"\n" +
 	"\n" +
-	"server_key\x18\x02 \x01(\fB\x03\x80\x01\x01R\tserverKey\"\xab\x01\n" +
+	"server_key\x18\x02 \x01(\fB\x03\x80\x01\x01R\tserverKey\"\xe1\x01\n" +
 	"\x12ReservationOptions\x12\x18\n" +
 	"\areasons\x18\x01 \x01(\rR\areasons\x12\x1f\n" +
 	"\vbegin_query\x18\x02 \x01(\tR\n" +
 	"beginQuery\x12(\n" +
 	"\x10pin_portal_names\x18\x03 \x03(\tR\x0epinPortalNames\x120\n" +
-	"\x14release_portal_names\x18\x04 \x03(\tR\x12releasePortalNamesB,Z*github.com/multigres/multigres/go/pb/queryb\x06proto3"
+	"\x14release_portal_names\x18\x04 \x03(\tR\x12releasePortalNames\x124\n" +
+	"\x16recheck_advisory_locks\x18\x05 \x01(\bR\x14recheckAdvisoryLocksB,Z*github.com/multigres/multigres/go/pb/queryb\x06proto3"
 
 var (
 	file_query_proto_rawDescOnce sync.Once

--- a/go/services/multigateway/engine/advisory_lock_route.go
+++ b/go/services/multigateway/engine/advisory_lock_route.go
@@ -25,12 +25,20 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/handler"
 )
 
-// AdvisoryLockRoute wraps an ordinary Route for a query that acquires a
-// session-level advisory lock (pg_advisory_lock / pg_advisory_lock_shared and
-// their try-variants). Before delegating execution to the inner Route, it sets
-// PendingAdvisoryLockReservation on the state so ScatterConn creates (or
-// promotes to) a reserved connection with ReasonSessionAdvisoryLock, following
-// the same pattern as TempTableRoute.
+// AdvisoryLockRoute wraps an ordinary Route for a query that touches
+// session-level advisory locks — either acquiring one (pg_advisory_lock /
+// pg_advisory_lock_shared and their try-variants) or releasing one
+// (pg_advisory_unlock / _shared / _all). Before delegating execution to the
+// inner Route it sets gateway state flags that ScatterConn turns into
+// reservation options:
+//
+//   - pin == true (acquire): PendingAdvisoryLockReservation, so ScatterConn
+//     creates (or promotes to) a reserved connection with
+//     ReasonSessionAdvisoryLock — following the same pattern as TempTableRoute.
+//   - always: PendingAdvisoryLockRecheck, so ScatterConn asks the multipooler to
+//     re-probe pg_locks after the statement and unpin if no advisory lock
+//     remains. This is what lets the (otherwise per-statement) probe run only on
+//     statements that actually touch advisory locks.
 //
 // Wrapping the Route (rather than re-implementing routing) keeps bind-variable
 // reconstruction in one place: `SELECT pg_advisory_lock(101)` is normalized to
@@ -40,21 +48,33 @@ import (
 // Session-level advisory locks live on the specific backend that executed the
 // acquiring call and survive transaction boundaries, so the session must stay
 // pinned to that backend until every such lock is released. The multipooler
-// authoritatively decides when to unpin by probing pg_locks after subsequent
-// statements (see the executor), so this primitive only establishes the pin.
+// authoritatively decides when to unpin (by probing pg_locks); this primitive
+// only establishes the pin and signals when a recheck is worthwhile.
 type AdvisoryLockRoute struct {
 	inner *Route
+	// pin is true when the statement acquires a lock (reserve the backend);
+	// false for a bare release (recheck only).
+	pin bool
 }
 
-// NewAdvisoryLockRoute wraps an existing Route so the session is pinned for the
-// lifetime of the session-level advisory lock the query acquires.
-func NewAdvisoryLockRoute(inner *Route) *AdvisoryLockRoute {
-	return &AdvisoryLockRoute{inner: inner}
+// NewAdvisoryLockRoute wraps an existing Route for a statement that touches
+// session-level advisory locks. pin reserves the backend (set for acquisitions);
+// a recheck is always requested.
+func NewAdvisoryLockRoute(inner *Route, pin bool) *AdvisoryLockRoute {
+	return &AdvisoryLockRoute{inner: inner, pin: pin}
 }
 
-// StreamExecute sets the advisory-lock reservation flag and delegates to the
-// inner Route. ScatterConn sees the flag and reserves the connection with
-// ReasonSessionAdvisoryLock.
+// signal sets the gateway state flags consumed by ScatterConn before the inner
+// Route runs.
+func (a *AdvisoryLockRoute) signal(state *handler.MultiGatewayConnectionState) {
+	if a.pin {
+		state.PendingAdvisoryLockReservation = true
+	}
+	state.PendingAdvisoryLockRecheck = true
+}
+
+// StreamExecute sets the advisory-lock state flags and delegates to the inner
+// Route.
 func (a *AdvisoryLockRoute) StreamExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -63,12 +83,12 @@ func (a *AdvisoryLockRoute) StreamExecute(
 	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	state.PendingAdvisoryLockReservation = true
+	a.signal(state)
 	return a.inner.StreamExecute(ctx, exec, conn, state, bindVars, callback)
 }
 
-// PortalStreamExecute sets the advisory-lock reservation flag and delegates to
-// the inner Route for the extended-protocol path.
+// PortalStreamExecute sets the advisory-lock state flags and delegates to the
+// inner Route for the extended-protocol path.
 func (a *AdvisoryLockRoute) PortalStreamExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -79,9 +99,14 @@ func (a *AdvisoryLockRoute) PortalStreamExecute(
 	includeDescribe bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	state.PendingAdvisoryLockReservation = true
+	a.signal(state)
 	return a.inner.PortalStreamExecute(ctx, exec, conn, state, portalInfo, maxRows, includeDescribe, callback)
 }
+
+// Pins reports whether this route reserves the backend (true for an acquire,
+// false for a bare release that only requests a recheck). Exposed for
+// observability and tests.
+func (a *AdvisoryLockRoute) Pins() bool { return a.pin }
 
 // GetTableGroup returns the target tablegroup.
 func (a *AdvisoryLockRoute) GetTableGroup() string { return a.inner.GetTableGroup() }

--- a/go/services/multigateway/engine/advisory_lock_route.go
+++ b/go/services/multigateway/engine/advisory_lock_route.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// AdvisoryLockRoute wraps an ordinary Route for a query that acquires a
+// session-level advisory lock (pg_advisory_lock / pg_advisory_lock_shared and
+// their try-variants). Before delegating execution to the inner Route, it sets
+// PendingAdvisoryLockReservation on the state so ScatterConn creates (or
+// promotes to) a reserved connection with ReasonSessionAdvisoryLock, following
+// the same pattern as TempTableRoute.
+//
+// Wrapping the Route (rather than re-implementing routing) keeps bind-variable
+// reconstruction in one place: `SELECT pg_advisory_lock(101)` is normalized to
+// `SELECT pg_advisory_lock($1)` for plan caching, and the inner Route
+// re-injects the literal at execution time.
+//
+// Session-level advisory locks live on the specific backend that executed the
+// acquiring call and survive transaction boundaries, so the session must stay
+// pinned to that backend until every such lock is released. The multipooler
+// authoritatively decides when to unpin by probing pg_locks after subsequent
+// statements (see the executor), so this primitive only establishes the pin.
+type AdvisoryLockRoute struct {
+	inner *Route
+}
+
+// NewAdvisoryLockRoute wraps an existing Route so the session is pinned for the
+// lifetime of the session-level advisory lock the query acquires.
+func NewAdvisoryLockRoute(inner *Route) *AdvisoryLockRoute {
+	return &AdvisoryLockRoute{inner: inner}
+}
+
+// StreamExecute sets the advisory-lock reservation flag and delegates to the
+// inner Route. ScatterConn sees the flag and reserves the connection with
+// ReasonSessionAdvisoryLock.
+func (a *AdvisoryLockRoute) StreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	bindVars []*ast.A_Const,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	state.PendingAdvisoryLockReservation = true
+	return a.inner.StreamExecute(ctx, exec, conn, state, bindVars, callback)
+}
+
+// PortalStreamExecute sets the advisory-lock reservation flag and delegates to
+// the inner Route for the extended-protocol path.
+func (a *AdvisoryLockRoute) PortalStreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	portalInfo *preparedstatement.PortalInfo,
+	maxRows int32,
+	includeDescribe bool,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	state.PendingAdvisoryLockReservation = true
+	return a.inner.PortalStreamExecute(ctx, exec, conn, state, portalInfo, maxRows, includeDescribe, callback)
+}
+
+// GetTableGroup returns the target tablegroup.
+func (a *AdvisoryLockRoute) GetTableGroup() string { return a.inner.GetTableGroup() }
+
+// GetQuery returns the SQL query.
+func (a *AdvisoryLockRoute) GetQuery() string { return a.inner.GetQuery() }
+
+// String returns a description of the primitive for debugging.
+func (a *AdvisoryLockRoute) String() string {
+	return fmt.Sprintf("AdvisoryLockRoute(%s)", a.inner.GetQuery())
+}
+
+// Ensure AdvisoryLockRoute implements Primitive interface.
+var _ Primitive = (*AdvisoryLockRoute)(nil)

--- a/go/services/multigateway/engine/discard_all_primitive.go
+++ b/go/services/multigateway/engine/discard_all_primitive.go
@@ -42,9 +42,9 @@ import (
 // any single backend: prepared statements (the consolidator), session GUCs
 // (SessionSettings + gateway-managed variables), and LISTEN subscriptions are
 // all gateway-side. The only backend-resident session state is whatever a
-// *reserved* connection holds — an open transaction, temp tables, or
-// `DECLARE … WITH HOLD` cursors — and that is cleaned up by handing the
-// reserved connection back to the pool.
+// *reserved* connection holds — an open transaction, temp tables,
+// `DECLARE … WITH HOLD` cursors, or session-level advisory locks — and that is
+// cleaned up by handing the reserved connection back to the pool.
 //
 // Forwarding the literal DISCARD ALL to a shared pooled backend would run
 // DEALLOCATE ALL on it, wiping the prepared statements the multipooler still
@@ -56,13 +56,13 @@ import (
 // per-session view (the consolidator) is cleared, which is what frees the
 // client's statement names.
 //
-// Out of scope: the `SELECT pg_advisory_unlock_all()` half of PG's DISCARD ALL
-// is NOT handled here. Session-level advisory locks live on whatever backend
-// executed pg_advisory_lock, and the reserved-connection release rolls back
-// (which only drops transaction-level locks) rather than running
-// pg_advisory_unlock_all on the backend. Session-level advisory locks are a
-// pre-existing limitation under pooling and are not addressed by this
-// primitive.
+// The `SELECT pg_advisory_unlock_all()` half of PG's DISCARD ALL is handled via
+// the reserved-connection release: ReleaseAllReservedConnections (below) runs
+// pg_advisory_unlock_all() on the backend before recycling it, so a session
+// holding session-level advisory locks has them dropped exactly as PG's
+// pg_advisory_unlock_all() step would. The narrow unlock_all call is used rather
+// than forwarding the literal DISCARD ALL, which would also DEALLOCATE the
+// pooled backend's prepared statements (see above).
 type DiscardAllPrimitive struct {
 	// Query is the original SQL string ("DISCARD ALL").
 	Query string
@@ -87,17 +87,19 @@ func (d *DiscardAllPrimitive) StreamExecute(
 	// PG rejects DISCARD ALL inside a transaction block — the idea is to
 	// catch mistakes that would otherwise leave the transaction uncommitted.
 	// conn.IsInTransaction() covers a deferred BEGIN too (the status flips at
-	// BEGIN even before the backend call), so the reserved connection below
-	// is only ever held for temp tables / WITH HOLD cursors here.
+	// BEGIN even before the backend call), so the reserved connection below is
+	// only ever held for temp tables, WITH HOLD cursors, or session-level
+	// advisory locks here.
 	if conn.IsInTransaction() {
 		return mterrors.NewPgError("ERROR", mterrors.PgSSActiveTransaction,
 			"DISCARD ALL cannot run inside a transaction block", "")
 	}
 
-	// CLOSE ALL + DISCARD TEMP + rollback of a reserved backend — release any
-	// reserved connection regardless of reason. ReleaseAllReservedConnections
-	// rolls back, discards temp tables, releases portals, returns the backend
-	// to the pool clean, and clears local shard state.
+	// CLOSE ALL + DISCARD TEMP + pg_advisory_unlock_all + rollback of a reserved
+	// backend — release any reserved connection regardless of reason.
+	// ReleaseAllReservedConnections rolls back, discards temp tables, releases
+	// session-level advisory locks, releases portals, returns the backend to the
+	// pool clean, and clears local shard state.
 	//
 	// This is done FIRST because it is the only step that can fail (it makes an
 	// RPC to the multipooler). The gateway-side resets below are pure in-memory

--- a/go/services/multigateway/engine/plan.go
+++ b/go/services/multigateway/engine/plan.go
@@ -36,6 +36,7 @@ const (
 	PlanTypeListenNotify        = "ListenNotify"
 	PlanTypeSequence            = "Sequence"
 	PlanTypeTempTableRoute      = "TempTableRoute"
+	PlanTypeAdvisoryLockRoute   = "AdvisoryLockRoute"
 	PlanTypeHoldCursorRoute     = "HoldCursorRoute"
 	PlanTypeCloseCursorRoute    = "CloseCursorRoute"
 	PlanTypeDiscardAll          = "DiscardAll"

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -98,6 +98,15 @@ type MultiGatewayConnectionState struct {
 	// created.
 	PendingAdvisoryLockReservation bool
 
+	// PendingAdvisoryLockRecheck is set by the planner (via AdvisoryLockRoute)
+	// when the current query touches a session-level advisory lock (acquire or
+	// release). ScatterConn consumes it to set ReservationOptions.RecheckAdvisoryLocks,
+	// asking the multipooler to re-probe pg_locks after the statement and unpin
+	// if no advisory lock remains. This is what keeps the probe off the
+	// per-statement hot path: it runs only on advisory-touching statements.
+	// One-shot: cleared after it is consumed.
+	PendingAdvisoryLockRecheck bool
+
 	// PendingPinPortals carries the cursor names that the next StreamExecute
 	// must register on the reserved backend's portal set via
 	// ReservationOptions.PinPortalNames. Populated by HoldCursorRoute when a

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -90,6 +90,14 @@ type MultiGatewayConnectionState struct {
 	// cleared after the reservation is created.
 	PendingTempTableReservation bool
 
+	// PendingAdvisoryLockReservation is set by the planner (via
+	// AdvisoryLockRoute) when the current query acquires a session-level
+	// advisory lock. ScatterConn consumes it to create (or promote to) a
+	// reserved connection with ReasonSessionAdvisoryLock, pinning the backend
+	// for the lifetime of the lock. One-shot: cleared after the reservation is
+	// created.
+	PendingAdvisoryLockReservation bool
+
 	// PendingPinPortals carries the cursor names that the next StreamExecute
 	// must register on the reserved backend's portal set via
 	// ReservationOptions.PinPortalNames. Populated by HoldCursorRoute when a

--- a/go/services/multigateway/planner/advisory_lock_test.go
+++ b/go/services/multigateway/planner/advisory_lock_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+)
+
+// TestPlan_SessionAdvisoryLockPins verifies that statements acquiring a
+// session-level advisory lock are dispatched through AdvisoryLockRoute so the
+// backend is pinned, while transaction-level locks and unlock calls are not.
+func TestPlan_SessionAdvisoryLockPins(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		wantPinned bool
+	}{
+		{name: "exclusive", sql: "SELECT pg_advisory_lock(101)", wantPinned: true},
+		{name: "shared", sql: "SELECT pg_advisory_lock_shared(101)", wantPinned: true},
+		{name: "try", sql: "SELECT pg_try_advisory_lock(101)", wantPinned: true},
+		{name: "try_shared", sql: "SELECT pg_try_advisory_lock_shared(101)", wantPinned: true},
+		{name: "two_key", sql: "SELECT pg_advisory_lock(7, 9)", wantPinned: true},
+		{name: "schema_qualified", sql: "SELECT pg_catalog.pg_advisory_lock(101)", wantPinned: true},
+		{name: "inside_larger_select", sql: "SELECT pg_advisory_lock(101), 42", wantPinned: true},
+
+		// Transaction-level locks are out of scope — released at transaction end.
+		{name: "xact_lock", sql: "SELECT pg_advisory_xact_lock(101)", wantPinned: false},
+		{name: "xact_shared", sql: "SELECT pg_advisory_xact_lock_shared(101)", wantPinned: false},
+
+		// Unlock calls do not acquire anything, so they must not pin.
+		{name: "unlock", sql: "SELECT pg_advisory_unlock(101)", wantPinned: false},
+		{name: "unlock_all", sql: "SELECT pg_advisory_unlock_all()", wantPinned: false},
+
+		// Unrelated queries are unaffected.
+		{name: "plain_select", sql: "SELECT 1", wantPinned: false},
+	}
+
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPlanner("default", logger, nil)
+			conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+			plan, err := p.Plan(tt.sql, parseOne(t, tt.sql), conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			_, isAdvisory := plan.Primitive.(*engine.AdvisoryLockRoute)
+			if tt.wantPinned {
+				assert.True(t, isAdvisory, "expected AdvisoryLockRoute, got %T", plan.Primitive)
+				assert.Equal(t, engine.PlanTypeAdvisoryLockRoute, plan.Type,
+					"plan.Type must be set for observability")
+			} else {
+				assert.False(t, isAdvisory, "did not expect AdvisoryLockRoute for %q", tt.sql)
+			}
+		})
+	}
+}
+
+// TestPlan_AdvisoryLockComposesWithSetConfig verifies that a statement which
+// both acquires a session-level advisory lock and tracks a set_config keeps
+// both behaviors: the plan is a Sequence with the set_config ApplySessionState
+// primitives AND a trailing AdvisoryLockRoute that pins the backend.
+func TestPlan_AdvisoryLockComposesWithSetConfig(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+	sql := "SELECT set_config('search_path', 'myschema', false), pg_advisory_lock(101)"
+	plan, err := p.Plan(sql, parseOne(t, sql), conn)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	seq, ok := plan.Primitive.(*engine.Sequence)
+	require.True(t, ok, "expected Sequence, got %T", plan.Primitive)
+	require.NotEmpty(t, seq.Primitives)
+
+	// The set_config tracking must still be planned.
+	var hasApplySessionState bool
+	for _, prim := range seq.Primitives {
+		if _, isApply := prim.(*engine.ApplySessionState); isApply {
+			hasApplySessionState = true
+		}
+	}
+	assert.True(t, hasApplySessionState, "set_config must still be tracked via ApplySessionState")
+
+	// The trailing route must be an AdvisoryLockRoute so the backend is pinned.
+	last := seq.Primitives[len(seq.Primitives)-1]
+	_, isAdvisory := last.(*engine.AdvisoryLockRoute)
+	assert.True(t, isAdvisory, "trailing route must be AdvisoryLockRoute, got %T", last)
+}

--- a/go/services/multigateway/planner/advisory_lock_test.go
+++ b/go/services/multigateway/planner/advisory_lock_test.go
@@ -26,33 +26,37 @@ import (
 	"github.com/multigres/multigres/go/services/multigateway/engine"
 )
 
-// TestPlan_SessionAdvisoryLockPins verifies that statements acquiring a
-// session-level advisory lock are dispatched through AdvisoryLockRoute so the
-// backend is pinned, while transaction-level locks and unlock calls are not.
-func TestPlan_SessionAdvisoryLockPins(t *testing.T) {
+// TestPlan_SessionAdvisoryLockRouting verifies how statements that touch
+// session-level advisory locks are routed. Both acquires and releases go
+// through AdvisoryLockRoute (so the multipooler re-probes pg_locks afterward),
+// but only acquires set the pin intent that reserves the backend. Transaction-
+// level locks and unrelated queries route through a plain Route.
+func TestPlan_SessionAdvisoryLockRouting(t *testing.T) {
 	tests := []struct {
-		name       string
-		sql        string
-		wantPinned bool
+		name         string
+		sql          string
+		wantAdvisory bool // routed through AdvisoryLockRoute (acquire or release)
+		wantPin      bool // reserves the backend (acquire only)
 	}{
-		{name: "exclusive", sql: "SELECT pg_advisory_lock(101)", wantPinned: true},
-		{name: "shared", sql: "SELECT pg_advisory_lock_shared(101)", wantPinned: true},
-		{name: "try", sql: "SELECT pg_try_advisory_lock(101)", wantPinned: true},
-		{name: "try_shared", sql: "SELECT pg_try_advisory_lock_shared(101)", wantPinned: true},
-		{name: "two_key", sql: "SELECT pg_advisory_lock(7, 9)", wantPinned: true},
-		{name: "schema_qualified", sql: "SELECT pg_catalog.pg_advisory_lock(101)", wantPinned: true},
-		{name: "inside_larger_select", sql: "SELECT pg_advisory_lock(101), 42", wantPinned: true},
+		{name: "exclusive", sql: "SELECT pg_advisory_lock(101)", wantAdvisory: true, wantPin: true},
+		{name: "shared", sql: "SELECT pg_advisory_lock_shared(101)", wantAdvisory: true, wantPin: true},
+		{name: "try", sql: "SELECT pg_try_advisory_lock(101)", wantAdvisory: true, wantPin: true},
+		{name: "try_shared", sql: "SELECT pg_try_advisory_lock_shared(101)", wantAdvisory: true, wantPin: true},
+		{name: "two_key", sql: "SELECT pg_advisory_lock(7, 9)", wantAdvisory: true, wantPin: true},
+		{name: "schema_qualified", sql: "SELECT pg_catalog.pg_advisory_lock(101)", wantAdvisory: true, wantPin: true},
+		{name: "inside_larger_select", sql: "SELECT pg_advisory_lock(101), 42", wantAdvisory: true, wantPin: true},
+
+		// Releases route through AdvisoryLockRoute for the recheck, but do not pin.
+		{name: "unlock", sql: "SELECT pg_advisory_unlock(101)", wantAdvisory: true, wantPin: false},
+		{name: "unlock_shared", sql: "SELECT pg_advisory_unlock_shared(101)", wantAdvisory: true, wantPin: false},
+		{name: "unlock_all", sql: "SELECT pg_advisory_unlock_all()", wantAdvisory: true, wantPin: false},
 
 		// Transaction-level locks are out of scope — released at transaction end.
-		{name: "xact_lock", sql: "SELECT pg_advisory_xact_lock(101)", wantPinned: false},
-		{name: "xact_shared", sql: "SELECT pg_advisory_xact_lock_shared(101)", wantPinned: false},
-
-		// Unlock calls do not acquire anything, so they must not pin.
-		{name: "unlock", sql: "SELECT pg_advisory_unlock(101)", wantPinned: false},
-		{name: "unlock_all", sql: "SELECT pg_advisory_unlock_all()", wantPinned: false},
+		{name: "xact_lock", sql: "SELECT pg_advisory_xact_lock(101)", wantAdvisory: false, wantPin: false},
+		{name: "xact_unlock", sql: "SELECT pg_advisory_xact_lock_shared(101)", wantAdvisory: false, wantPin: false},
 
 		// Unrelated queries are unaffected.
-		{name: "plain_select", sql: "SELECT 1", wantPinned: false},
+		{name: "plain_select", sql: "SELECT 1", wantAdvisory: false, wantPin: false},
 	}
 
 	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
@@ -65,9 +69,10 @@ func TestPlan_SessionAdvisoryLockPins(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, plan)
 
-			_, isAdvisory := plan.Primitive.(*engine.AdvisoryLockRoute)
-			if tt.wantPinned {
-				assert.True(t, isAdvisory, "expected AdvisoryLockRoute, got %T", plan.Primitive)
+			route, isAdvisory := plan.Primitive.(*engine.AdvisoryLockRoute)
+			if tt.wantAdvisory {
+				require.True(t, isAdvisory, "expected AdvisoryLockRoute, got %T", plan.Primitive)
+				assert.Equal(t, tt.wantPin, route.Pins(), "pin intent for %q", tt.sql)
 				assert.Equal(t, engine.PlanTypeAdvisoryLockRoute, plan.Type,
 					"plan.Type must be set for observability")
 			} else {

--- a/go/services/multigateway/planner/discard_stmt.go
+++ b/go/services/multigateway/planner/discard_stmt.go
@@ -65,5 +65,5 @@ func (p *Planner) planDiscardStmt(
 	}
 
 	// DISCARD PLANS / DISCARD SEQUENCES — route to PostgreSQL.
-	return p.planDefault(sql, stmt, conn)
+	return p.planDefault(sql, stmt, conn, PlannerOptions{})
 }

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -58,6 +58,13 @@ type PlannerOptions struct {
 	// advisory lock, so its route must keep the backend pinned for the lock's
 	// lifetime (AdvisoryLockRoute rather than a plain Route).
 	PinForAdvisoryLock bool
+
+	// RecheckForAdvisoryLock indicates the statement touches session-level
+	// advisory locks (an acquire or a release), so the multipooler should
+	// re-probe pg_locks afterward and unpin if none remain. It is a superset of
+	// PinForAdvisoryLock: every acquire also wants a recheck (to catch a failed
+	// pg_try_advisory_lock), and a bare release wants only the recheck.
+	RecheckForAdvisoryLock bool
 }
 
 // Plan creates an execution plan for the given SQL query and AST.
@@ -120,7 +127,8 @@ func (p *Planner) Plan(
 	// (planDefault / planSelectStmt), which fold them into whatever plan they
 	// would otherwise produce.
 	opts := PlannerOptions{
-		PinForAdvisoryLock: analysis.AcquiresSessionAdvisoryLock,
+		PinForAdvisoryLock:     analysis.AcquiresSessionAdvisoryLock,
+		RecheckForAdvisoryLock: analysis.AcquiresSessionAdvisoryLock || analysis.ReleasesSessionAdvisoryLock,
 	}
 
 	// Dispatch to appropriate planner function based on statement type
@@ -266,14 +274,19 @@ func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn, opts
 }
 
 // routePrimitive builds the routing primitive for an ordinary query: a plain
-// Route, or an AdvisoryLockRoute wrapping it when opts.PinForAdvisoryLock is
-// set. Centralizing this lets the set_config Sequence path (planSelectStmt) and
-// the bare-route path (planDefault) fold in the pin the same way, so a query
-// that both takes an advisory lock and tracks a set_config keeps both behaviors.
+// Route, or an AdvisoryLockRoute wrapping it when the statement touches
+// session-level advisory locks. Centralizing this lets the set_config Sequence
+// path (planSelectStmt) and the bare-route path (planDefault) fold in the
+// advisory handling the same way, so a query that both takes an advisory lock
+// and tracks a set_config keeps both behaviors.
+//
+// We wrap on RecheckForAdvisoryLock (the superset): an acquire wants both a pin
+// and a recheck, a bare release wants only the recheck. The wrapper carries the
+// pin intent separately so a release doesn't reserve a connection.
 func (p *Planner) routePrimitive(sql string, stmt ast.Stmt, opts PlannerOptions) engine.Primitive {
 	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
-	if opts.PinForAdvisoryLock {
-		return engine.NewAdvisoryLockRoute(route)
+	if opts.RecheckForAdvisoryLock {
+		return engine.NewAdvisoryLockRoute(route, opts.PinForAdvisoryLock)
 	}
 	return route
 }

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -48,6 +48,18 @@ func NewPlanner(defaultTableGroup string, logger *slog.Logger, txnMetrics *engin
 	}
 }
 
+// PlannerOptions carries per-statement planning signals — derived from
+// analyzing the statement (e.g. its expression tree) — that the routing
+// builders fold into the plan they produce. Grouping them in a struct keeps
+// builder signatures stable as new signals are added; the zero value means "no
+// special routing", which is what the non-routing statement handlers pass.
+type PlannerOptions struct {
+	// PinForAdvisoryLock indicates the statement acquires a session-level
+	// advisory lock, so its route must keep the backend pinned for the lock's
+	// lifetime (AdvisoryLockRoute rather than a plain Route).
+	PinForAdvisoryLock bool
+}
+
 // Plan creates an execution plan for the given SQL query and AST.
 //
 // The planner analyzes the AST to determine query type and creates
@@ -74,14 +86,15 @@ func (p *Planner) Plan(
 		"default_tablegroup", p.defaultTableGroup,
 		"statement_type", stmt.NodeTag())
 
-	// Reject unsupported constructs before dispatch: Tier 2 statement types
-	// (LOAD, ALTER SYSTEM, CREATE/DROP DATABASE, etc.) plus any blocklisted
-	// or misplaced FuncCalls in expression trees. Running here (not in the
-	// executor) means the plan cache short-circuits both checks: a cached
-	// plan is by construction safe. The normalizer is configured to
-	// preserve literals inside set_config calls so its args remain A_Const
-	// at this point.
-	exprResult, err := planUnsupportedConstructs(stmt)
+	// Analyze the statement before dispatch: reject unsupported constructs
+	// (Tier 2 statement types and blocklisted/misplaced FuncCalls) and gather
+	// the planning signals — tracked set_config calls, advisory-lock pinning —
+	// that the routing builders need. Running here (not in the executor) means
+	// the plan cache short-circuits this whole pass: a cached plan is by
+	// construction already analyzed and safe. The normalizer is configured to
+	// preserve literals inside set_config calls so its args remain A_Const at
+	// this point.
+	analysis, err := analyzeStatement(stmt)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +111,16 @@ func (p *Planner) Plan(
 		unwrappedPlan.TablesUsed = ast.ExtractTablesUsed(stmt)
 		unwrappedPlan.Type = primitiveName(unwrappedPlan.Primitive)
 		return unwrappedPlan, nil
+	}
+
+	// Collect per-statement routing signals derived from the expression
+	// analysis. These ride on ordinary queries that may simultaneously do other
+	// things the planner tracks (e.g. set_config), so rather than diverting to a
+	// dedicated path, the options are threaded into the normal routing builders
+	// (planDefault / planSelectStmt), which fold them into whatever plan they
+	// would otherwise produce.
+	opts := PlannerOptions{
+		PinForAdvisoryLock: analysis.AcquiresSessionAdvisoryLock,
 	}
 
 	// Dispatch to appropriate planner function based on statement type
@@ -142,40 +165,40 @@ func (p *Planner) Plan(
 		if cs := stmt.(*ast.CreateStmt); cs.Relation != nil && cs.Relation.RelPersistence == ast.RELPERSISTENCE_TEMP {
 			return p.planTempTableCreation(sql, conn)
 		}
-		plan, err = p.planDefault(sql, stmt, conn)
+		plan, err = p.planDefault(sql, stmt, conn, opts)
 
 	case ast.T_CreateTableAsStmt:
 		if cs := stmt.(*ast.CreateTableAsStmt); cs.Into != nil && cs.Into.Rel != nil && cs.Into.Rel.RelPersistence == ast.RELPERSISTENCE_TEMP {
 			return p.planTempTableCreation(sql, conn)
 		}
-		plan, err = p.planDefault(sql, stmt, conn)
+		plan, err = p.planDefault(sql, stmt, conn, opts)
 
 	case ast.T_SelectStmt:
 		ss := stmt.(*ast.SelectStmt)
 		if ss.IntoClause != nil && ss.IntoClause.Rel != nil && ss.IntoClause.Rel.RelPersistence == ast.RELPERSISTENCE_TEMP {
 			return p.planTempTableCreation(sql, conn)
 		}
-		plan, err = p.planSelectStmt(sql, ss, conn, exprResult.SetConfigs)
+		plan, err = p.planSelectStmt(sql, ss, conn, analysis.SetConfigs, opts)
 
 	case ast.T_ViewStmt:
 		if vs := stmt.(*ast.ViewStmt); vs.View != nil && vs.View.RelPersistence == ast.RELPERSISTENCE_TEMP {
 			return p.planTempTableCreation(sql, conn)
 		}
-		plan, err = p.planDefault(sql, stmt, conn)
+		plan, err = p.planDefault(sql, stmt, conn, opts)
 
 	case ast.T_DeclareCursorStmt:
 		dcs := stmt.(*ast.DeclareCursorStmt)
 		if dcs.Options&ast.CURSOR_OPT_HOLD != 0 {
 			return p.planHoldCursorDeclare(sql, dcs)
 		}
-		plan, err = p.planDefault(sql, stmt, conn)
+		plan, err = p.planDefault(sql, stmt, conn, opts)
 
 	case ast.T_ClosePortalStmt:
 		return p.planClosePortalStmt(sql, stmt.(*ast.ClosePortalStmt))
 
 	default:
 		// Default: simple route to PostgreSQL
-		plan, err = p.planDefault(sql, stmt, conn)
+		plan, err = p.planDefault(sql, stmt, conn, opts)
 	}
 
 	if err != nil {
@@ -230,15 +253,29 @@ func (p *Planner) planClosePortalStmt(sql string, stmt *ast.ClosePortalStmt) (*e
 }
 
 // planDefault creates a simple route plan for queries without special handling.
-// This is the fallback for most SQL statements.
-func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn) (*engine.Plan, error) {
-	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
-	plan := engine.NewPlan(sql, route)
+// This is the fallback for most SQL statements. opts.PinForAdvisoryLock routes
+// the query through an AdvisoryLockRoute so the backend stays pinned for the
+// session-level advisory lock's lifetime.
+func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn, opts PlannerOptions) (*engine.Plan, error) {
+	plan := engine.NewPlan(sql, p.routePrimitive(sql, stmt, opts))
 
 	p.logger.Debug("created default route plan",
 		"plan", plan.String(),
 		"tablegroup", p.defaultTableGroup)
 	return plan, nil
+}
+
+// routePrimitive builds the routing primitive for an ordinary query: a plain
+// Route, or an AdvisoryLockRoute wrapping it when opts.PinForAdvisoryLock is
+// set. Centralizing this lets the set_config Sequence path (planSelectStmt) and
+// the bare-route path (planDefault) fold in the pin the same way, so a query
+// that both takes an advisory lock and tracks a set_config keeps both behaviors.
+func (p *Planner) routePrimitive(sql string, stmt ast.Stmt, opts PlannerOptions) engine.Primitive {
+	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
+	if opts.PinForAdvisoryLock {
+		return engine.NewAdvisoryLockRoute(route)
+	}
+	return route
 }
 
 // PlanPortal creates an execution plan for the extended query protocol (portal path).
@@ -258,13 +295,15 @@ func (p *Planner) PlanPortal(
 ) (*engine.Plan, error) {
 	stmt := portalInfo.PreparedStatementInfo.AstStmt()
 
-	// Non-cacheable extended-protocol statements reach PlanPortal directly
-	// (cacheable ones go through resolvePortalPlan → Plan, which does the
-	// same checks), so both paths must share the same pre-dispatch rejection.
-	// We throw away the set_config result here: PlanPortal only routes
-	// gateway-local statement types, none of which are SELECTs that could
-	// carry tracked set_configs.
-	if _, err := planUnsupportedConstructs(stmt); err != nil {
+	// Non-cacheable extended-protocol statements reach PlanPortal directly;
+	// cacheable DML (SELECT/INSERT/UPDATE/DELETE) goes through
+	// resolvePortalPlan → Plan instead, which runs the full analysis and builds
+	// the routing primitive (including AdvisoryLockRoute). PlanPortal only
+	// handles gateway-local statement types, so here we keep just the rejection
+	// side of the analysis and discard the planning signals — none of the
+	// statement types PlanPortal routes track set_config or acquire advisory
+	// locks directly.
+	if _, err := analyzeStatement(stmt); err != nil {
 		return nil, err
 	}
 
@@ -378,6 +417,8 @@ func primitiveName(p engine.Primitive) string {
 		return engine.PlanTypeRoute
 	case *engine.TempTableRoute:
 		return engine.PlanTypeTempTableRoute
+	case *engine.AdvisoryLockRoute:
+		return engine.PlanTypeAdvisoryLockRoute
 	case *engine.HoldCursorRoute:
 		return engine.PlanTypeHoldCursorRoute
 	case *engine.CloseCursorRoute:

--- a/go/services/multigateway/planner/restricted_guc.go
+++ b/go/services/multigateway/planner/restricted_guc.go
@@ -71,7 +71,7 @@ func restrictedGUCError(name string) error {
 // Reverts are allowed because they can only restore the cluster-managed value:
 // RESET, RESET ALL, and SET ... TO DEFAULT.
 //
-// Runs pre-dispatch via planUnsupportedConstructs, so it covers both the simple
+// Runs pre-dispatch via analyzeStatement, so it covers both the simple
 // and extended query protocols and is short-circuited by the plan cache.
 func checkRestrictedGUCChange(stmt ast.Stmt) error {
 	var setstmt *ast.VariableSetStmt

--- a/go/services/multigateway/planner/restricted_guc_test.go
+++ b/go/services/multigateway/planner/restricted_guc_test.go
@@ -101,7 +101,7 @@ func TestSetConfigSynchronousCommit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := inspectExpressionFuncCalls(parseOne(t, tt.sql))
+			_, err := analyzeFunctionCalls(parseOne(t, tt.sql))
 			if !tt.wantErr {
 				assert.NoError(t, err)
 				return
@@ -121,7 +121,7 @@ func TestSetConfigSynchronousCommit(t *testing.T) {
 // the is_local=true path can still be inspected (see normalizer.go).
 func TestSetConfigSynchronousCommitAfterNormalization(t *testing.T) {
 	norm := ast.Normalize(parseOne(t, "SELECT set_config('synchronous_commit', 'off', true)"))
-	_, err := planUnsupportedConstructs(norm.NormalizedAST)
+	_, err := analyzeStatement(norm.NormalizedAST)
 	require.Error(t, err)
 	var diag *mterrors.PgDiagnostic
 	require.True(t, errors.As(err, &diag))
@@ -129,7 +129,7 @@ func TestSetConfigSynchronousCommitAfterNormalization(t *testing.T) {
 
 	// A normalized is_local=true call for an unrelated GUC must still pass.
 	normOK := ast.Normalize(parseOne(t, "SELECT set_config('work_mem', '64MB', true)"))
-	_, err = planUnsupportedConstructs(normOK.NormalizedAST)
+	_, err = analyzeStatement(normOK.NormalizedAST)
 	assert.NoError(t, err)
 }
 

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -17,7 +17,6 @@ package planner
 import (
 	"fmt"
 
-	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
@@ -50,9 +49,10 @@ func (p *Planner) planSelectStmt(
 	stmt *ast.SelectStmt,
 	conn *server.Conn,
 	setConfigs []setConfigCall,
+	opts PlannerOptions,
 ) (*engine.Plan, error) {
 	if len(setConfigs) == 0 {
-		return p.planDefault(sql, stmt, conn)
+		return p.planDefault(sql, stmt, conn, opts)
 	}
 
 	primitives := make([]engine.Primitive, 0, len(setConfigs)+1)
@@ -69,7 +69,11 @@ func (p *Planner) planSelectStmt(
 			primitives = append(primitives, engine.NewApplySessionStateSilent(sql, base))
 		}
 	}
-	primitives = append(primitives, engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt))
+	// The trailing route runs the SELECT itself. routePrimitive folds in the
+	// advisory-lock pin when needed, so a `SELECT set_config(...),
+	// pg_advisory_lock(...)` both tracks the session setting (via the
+	// ApplySessionState primitives above) and pins the backend for the lock.
+	primitives = append(primitives, p.routePrimitive(sql, stmt, opts))
 	return engine.NewPlan(sql, engine.NewSequence(primitives)), nil
 }
 

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -117,6 +117,19 @@ var sessionAdvisoryLockAcquireFuncs = map[string]struct{}{
 	"pg_try_advisory_lock_shared": {},
 }
 
+// sessionAdvisoryLockReleaseFuncs is the set of built-in functions that release
+// a SESSION-level advisory lock. Seeing one of these is the signal to re-probe
+// pg_locks and unpin if the session no longer holds any advisory lock —
+// PostgreSQL is still the authority on the reference count, this just decides
+// when to ask. pg_advisory_unlock / _shared are reference-counted single-key
+// releases; pg_advisory_unlock_all drops everything. The transaction-scoped
+// variants are excluded for the same reason as the acquire set.
+var sessionAdvisoryLockReleaseFuncs = map[string]struct{}{
+	"pg_advisory_unlock":        {},
+	"pg_advisory_unlock_shared": {},
+	"pg_advisory_unlock_all":    {},
+}
+
 // statementAnalysis carries the result of analyzing a statement before
 // dispatch: the planning signals gathered from its expression tree (which
 // set_config calls to track, whether it acquires a session-level advisory
@@ -141,6 +154,16 @@ type statementAnalysis struct {
 	// can't see — are not detected here and remain a pre-existing pooling
 	// limitation, the same way temp tables created via dynamic SQL are.
 	AcquiresSessionAdvisoryLock bool
+
+	// ReleasesSessionAdvisoryLock is true if any FuncCall in the statement is a
+	// session-level advisory unlock (see sessionAdvisoryLockReleaseFuncs). It's
+	// the signal that the multipooler should re-probe pg_locks after this
+	// statement and unpin the backend if no advisory lock remains. Same
+	// best-effort caveat as AcquiresSessionAdvisoryLock: an unlock hidden in a
+	// function body or dynamic SQL isn't seen here, so the session stays pinned
+	// (conservatively) until the next observed advisory statement, DISCARD ALL,
+	// or disconnect — never a leak.
+	ReleasesSessionAdvisoryLock bool
 }
 
 // analyzeStatement is the single pre-dispatch analysis pass that every planning
@@ -227,6 +250,10 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 			result.AcquiresSessionAdvisoryLock = true
 			// Keep walking: a statement can mix an advisory lock with other
 			// calls we still need to inspect (e.g. a blocklisted function).
+			return true
+		}
+		if _, isUnlock := sessionAdvisoryLockReleaseFuncs[name]; isUnlock {
+			result.ReleasesSessionAdvisoryLock = true
 			return true
 		}
 		if name != "set_config" {

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -101,37 +101,80 @@ func (sc setConfigCall) hasBoundParams() bool {
 	return sc.NameBind != nil || sc.ValueBind != nil || sc.IsLocalBind != nil
 }
 
-// expressionCheckResult carries the output of inspectExpressionFuncCalls.
-type expressionCheckResult struct {
+// sessionAdvisoryLockAcquireFuncs is the set of built-in functions that acquire
+// a SESSION-level advisory lock. Holding one of these locks pins the backend to
+// the client session: the lock lives on the backend that ran the call and
+// survives transaction boundaries, so the gateway must keep routing the session
+// to that backend until the lock is released.
+//
+// The transaction-scoped variants (pg_advisory_xact_lock, ...) are deliberately
+// excluded — those locks are released at transaction end and never outlive a
+// pooled backend's involvement in the session, so they need no pinning.
+var sessionAdvisoryLockAcquireFuncs = map[string]struct{}{
+	"pg_advisory_lock":            {},
+	"pg_advisory_lock_shared":     {},
+	"pg_try_advisory_lock":        {},
+	"pg_try_advisory_lock_shared": {},
+}
+
+// statementAnalysis carries the result of analyzing a statement before
+// dispatch: the planning signals gathered from its expression tree (which
+// set_config calls to track, whether it acquires a session-level advisory
+// lock). Rejection of unsupported constructs happens as part of the same pass
+// and surfaces as an error rather than a field here.
+type statementAnalysis struct {
 	// SetConfigs are the set_config calls the planner accepted — i.e., they
 	// appear in an allowed position (directly as a SelectStmt target-list
 	// entry), with literal arguments and is_local=false. Ordering matches
 	// the target-list positions left-to-right.
 	SetConfigs []setConfigCall
+
+	// AcquiresSessionAdvisoryLock is true if any FuncCall in the statement is a
+	// session-level advisory lock acquisition (see
+	// sessionAdvisoryLockAcquireFuncs). The planner uses this to route the
+	// statement through a reserved connection with ReasonSessionAdvisoryLock so
+	// the backend is pinned for the lifetime of the lock.
+	//
+	// This is best-effort: it catches advisory locks taken directly in the
+	// statement text (the overwhelming common case). Locks acquired indirectly —
+	// inside a PL/pgSQL function body, a trigger, or dynamic SQL the parser
+	// can't see — are not detected here and remain a pre-existing pooling
+	// limitation, the same way temp tables created via dynamic SQL are.
+	AcquiresSessionAdvisoryLock bool
 }
 
-// planUnsupportedConstructs runs the pre-dispatch rejection checks that every
-// planning path (simple `Plan()` and extended-protocol `PlanPortal()`) must
-// apply: unsupported statement types (Tier 2), the restricted-GUC guard (SET /
-// ALTER ROLE / ALTER DATABASE assignments to cluster-managed GUCs), and the
-// expression-level walker (blocklist + rogue set_config, which also rejects
-// set_config on those same GUCs). Returns the accepted set_config calls for
-// Plan's SELECT dispatch; PlanPortal ignores that result.
+// analyzeStatement is the single pre-dispatch analysis pass that every planning
+// path (simple `Plan()` and extended-protocol `PlanPortal()`) must apply. It
+// does two things in one place:
 //
-// Centralizing them here is the point — earlier versions called only
-// planUnsupportedStmt from PlanPortal and silently let blocklisted function
-// calls through on non-cacheable extended-protocol paths.
-func planUnsupportedConstructs(stmt ast.Stmt) (*expressionCheckResult, error) {
-	if err := planUnsupportedStmt(stmt); err != nil {
+//   - Rejects unsupported constructs: Tier 2 statement types (LOAD, ALTER
+//     SYSTEM, CREATE/DROP DATABASE, ...), changes to cluster-managed GUCs (the
+//     restricted-GUC guard, covering SET / ALTER ROLE / ALTER DATABASE and
+//     set_config on those same GUCs), and blocklisted or misplaced FuncCalls in
+//     expression trees. These surface as an error.
+//   - Gathers planning signals from the expression tree (accepted set_config
+//     calls, session-level advisory-lock acquisition) into statementAnalysis,
+//     which the routing builders fold into the plan.
+//
+// This mirrors how Vitess separates Normalize (runs on every query, builds the
+// cache key) from semantic Analyze (runs only when a query is actually being
+// planned): the normalizer stays policy-free, and everything that depends on
+// gateway routing policy lives here, on the cache-miss planning path.
+//
+// Centralizing both concerns here is the point — earlier versions ran only the
+// statement-type rejection from PlanPortal and silently let blocklisted
+// function calls through on non-cacheable extended-protocol paths.
+func analyzeStatement(stmt ast.Stmt) (*statementAnalysis, error) {
+	if err := rejectUnsupportedStatement(stmt); err != nil {
 		return nil, err
 	}
 	if err := checkRestrictedGUCChange(stmt); err != nil {
 		return nil, err
 	}
-	return inspectExpressionFuncCalls(stmt)
+	return analyzeFunctionCalls(stmt)
 }
 
-// inspectExpressionFuncCalls walks every FuncCall in stmt and either:
+// analyzeFunctionCalls walks every FuncCall in stmt and either:
 //   - returns an error to reject the statement (blocklisted function call,
 //     or a set_config in a disallowed position / with unsafe arguments), or
 //   - returns a result describing any accepted set_config calls that the
@@ -155,12 +198,12 @@ func planUnsupportedConstructs(stmt ast.Stmt) (*expressionCheckResult, error) {
 // (so the validator can extract the name/value), but allows recursion when
 // is_local is literal true (those calls are accepted but not tracked, and
 // parameterizing them keeps the plan cache stable for hot patterns).
-func inspectExpressionFuncCalls(stmt ast.Stmt) (*expressionCheckResult, error) {
+func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 	if stmt == nil {
-		return &expressionCheckResult{}, nil
+		return &statementAnalysis{}, nil
 	}
 
-	result := &expressionCheckResult{}
+	result := &statementAnalysis{}
 	allowedSetConfigs := collectTopLevelSetConfigs(stmt)
 
 	var walkErr error
@@ -179,6 +222,12 @@ func inspectExpressionFuncCalls(stmt ast.Stmt) (*expressionCheckResult, error) {
 		if msg, blocked := funcBlocklist[name]; blocked {
 			walkErr = mterrors.NewFeatureNotSupported(msg)
 			return false
+		}
+		if _, isAdvisory := sessionAdvisoryLockAcquireFuncs[name]; isAdvisory {
+			result.AcquiresSessionAdvisoryLock = true
+			// Keep walking: a statement can mix an advisory lock with other
+			// calls we still need to inspect (e.g. a blocklisted function).
+			return true
 		}
 		if name != "set_config" {
 			return true
@@ -212,7 +261,7 @@ func inspectExpressionFuncCalls(stmt ast.Stmt) (*expressionCheckResult, error) {
 // collectTopLevelSetConfigs returns the set of FuncCall pointers that occupy
 // an allowed position for set_config — "directly as the Val of a ResTarget
 // in the top-level SelectStmt's TargetList". The identity set is used by
-// inspectExpressionFuncCalls to distinguish allowed calls from the same
+// analyzeFunctionCalls to distinguish allowed calls from the same
 // function name appearing in a WHERE clause or subquery.
 //
 // This does NOT recurse into WithClause CTEs or set-operation subqueries:

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -97,7 +97,7 @@ func TestInspectExpressionFuncCalls_Blocklist(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt := parseOne(t, tt.sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.Nil(t, result)
 			require.Error(t, err)
 
@@ -197,7 +197,7 @@ func TestInspectExpressionFuncCalls_SetConfigAccepted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt := parseOne(t, tt.sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			assert.Equal(t, tt.wantCalls, result.SetConfigs)
@@ -270,7 +270,7 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt := parseOne(t, tt.sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.Error(t, err)
 			assert.Nil(t, result)
 			var diag *mterrors.PgDiagnostic
@@ -326,7 +326,7 @@ func TestInspectExpressionFuncCalls_BoundParametersAccepted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt := parseOne(t, tt.sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			require.Len(t, result.SetConfigs, 1)
@@ -357,7 +357,7 @@ func TestInspectExpressionFuncCalls_LiteralIsLocalTrueShortCircuits(t *testing.T
 	} {
 		t.Run(sql, func(t *testing.T) {
 			stmt := parseOne(t, sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			assert.Empty(t, result.SetConfigs, "is_local literal true must not produce a tracker entry")
@@ -382,7 +382,7 @@ func TestInspectExpressionFuncCalls_Allowed(t *testing.T) {
 	for _, sql := range allowed {
 		t.Run(sql, func(t *testing.T) {
 			stmt := parseOne(t, sql)
-			result, err := inspectExpressionFuncCalls(stmt)
+			result, err := analyzeFunctionCalls(stmt)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			assert.Empty(t, result.SetConfigs)

--- a/go/services/multigateway/planner/unsafe_stmt.go
+++ b/go/services/multigateway/planner/unsafe_stmt.go
@@ -19,7 +19,7 @@ import (
 	"github.com/multigres/multigres/go/common/parser/ast"
 )
 
-// planUnsupportedStmt rejects Tier 2 statements — server-level operations
+// rejectUnsupportedStatement rejects Tier 2 statements — server-level operations
 // that should not be available through a shared connection pooler in a
 // hosted environment: LOAD, ALTER SYSTEM, CREATE/DROP DATABASE, CREATE
 // LANGUAGE, CREATE SUBSCRIPTION, CREATE FOREIGN DATA WRAPPER, CREATE SERVER.
@@ -37,7 +37,7 @@ import (
 //
 // Returns a *mterrors.PgDiagnostic with SQLSTATE 0A000 (feature_not_supported)
 // if the statement is Tier 2, or nil otherwise.
-func planUnsupportedStmt(stmt ast.Stmt) error {
+func rejectUnsupportedStatement(stmt ast.Stmt) error {
 	switch stmt.NodeTag() {
 	// -- Tier 2: unsafe for hosted infrastructure --
 

--- a/go/services/multigateway/planner/unsafe_stmt_test.go
+++ b/go/services/multigateway/planner/unsafe_stmt_test.go
@@ -145,7 +145,7 @@ func TestPlanUnsupportedStmt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := planUnsupportedStmt(tt.stmt)
+			err := rejectUnsupportedStatement(tt.stmt)
 
 			if !tt.wantErr {
 				assert.NoError(t, err)

--- a/go/services/multigateway/planner/variable_set_stmt.go
+++ b/go/services/multigateway/planner/variable_set_stmt.go
@@ -68,7 +68,7 @@ func (p *Planner) planVariableSetStmt(
 	if stmt.IsLocal {
 		p.logger.Debug("SET LOCAL detected, passing through",
 			"variable", stmt.Name)
-		return p.planDefault(sql, stmt, conn)
+		return p.planDefault(sql, stmt, conn, PlannerOptions{})
 	}
 
 	// SET var TO DEFAULT is equivalent to RESET var in PostgreSQL
@@ -117,7 +117,7 @@ func (p *Planner) planVariableSetStmt(
 		// VAR_SET_CURRENT: SET var FROM CURRENT — reads current PG value, needs backend execution.
 		p.logger.Debug("passing through to PostgreSQL",
 			"kind", stmt.Kind, "variable", stmt.Name)
-		return p.planDefault(sql, stmt, conn)
+		return p.planDefault(sql, stmt, conn, PlannerOptions{})
 
 	default:
 		return nil, mterrors.NewFeatureNotSupported(fmt.Sprintf("SET kind %d is not yet supported", stmt.Kind))

--- a/go/services/multigateway/planner/variable_show_stmt.go
+++ b/go/services/multigateway/planner/variable_show_stmt.go
@@ -29,7 +29,7 @@ func (p *Planner) planVariableShowStmt(
 	conn *server.Conn,
 ) (*engine.Plan, error) {
 	if !isGatewayManagedVariable(stmt.Name) {
-		return p.planDefault(sql, stmt, conn)
+		return p.planDefault(sql, stmt, conn, PlannerOptions{})
 	}
 
 	p.logger.Debug("planning SHOW gateway-managed variable", "variable", stmt.Name)

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -188,6 +188,15 @@ func (sc *ScatterConn) StreamExecute(
 
 	ss := state.GetMatchingShardState(target)
 
+	// This statement may touch a session-level advisory lock (acquire or
+	// release). When it does, ask the multipooler to re-probe pg_locks afterward
+	// and unpin if none remain — keeping that probe off the per-statement hot
+	// path. One-shot: consume it here and attach it to whichever reservation path
+	// runs below (Case 3 has no reserved connection, so there's nothing to
+	// recheck).
+	recheckAdvisory := state.PendingAdvisoryLockRecheck
+	state.PendingAdvisoryLockRecheck = false
+
 	// Case 1: Already have reserved connection - use it
 	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
 		sc.logger.DebugContext(ctx, "using existing reserved connection",
@@ -261,6 +270,15 @@ func (sc *ScatterConn) StreamExecute(
 			reservationOpts.ReleasePortalNames = append(reservationOpts.ReleasePortalNames, releaseNames...)
 		}
 
+		// If this statement touched an advisory lock, ask for a post-statement
+		// pg_locks recheck so the multipooler unpins once the last lock is gone.
+		if recheckAdvisory {
+			if reservationOpts == nil {
+				reservationOpts = &querypb.ReservationOptions{}
+			}
+			reservationOpts.RecheckAdvisoryLocks = true
+		}
+
 		reservedState, err := qs.StreamExecute(ctx, target, sql, eo, reservationOpts, callback)
 		sc.applyReservedState(conn, state, target, reservedState)
 
@@ -310,6 +328,9 @@ func (sc *ScatterConn) StreamExecute(
 			reservationOpts.BeginQuery = state.PendingBeginQuery
 			state.PendingBeginQuery = ""
 		}
+		// A new reservation created by an advisory acquire also wants a recheck
+		// (so a failed pg_try_advisory_lock unpins immediately).
+		reservationOpts.RecheckAdvisoryLocks = recheckAdvisory
 		reservedState, err := sc.gateway.StreamExecute(ctx, target, sql, eo, reservationOpts, callback)
 		if err != nil {
 			return fmt.Errorf("query execution failed: %w", err)
@@ -407,6 +428,11 @@ func (sc *ScatterConn) PortalStreamExecute(
 	// separate no-op "SELECT 1" reserve round trip.
 	var reservationOpts *querypb.ReservationOptions
 
+	// One-shot advisory recheck signal — attached to reservationOpts after the
+	// reservation path below is chosen (see the end of the if/else).
+	recheckAdvisory := state.PendingAdvisoryLockRecheck
+	state.PendingAdvisoryLockRecheck = false
+
 	ss := state.GetMatchingShardState(target)
 	// If we have a reserved connection, we have to ensure
 	// we are routing the query to the pooler where we got the reserved
@@ -458,6 +484,18 @@ func (sc *ScatterConn) PortalStreamExecute(
 			state.PendingBeginQuery = ""
 		}
 	}
+
+	// If this portal touched an advisory lock, ask for a post-statement
+	// pg_locks recheck (covers both the existing-reservation and new-reservation
+	// paths above). A bare release on an already-pinned session needs options
+	// allocated just to carry the flag.
+	if recheckAdvisory {
+		if reservationOpts == nil {
+			reservationOpts = &querypb.ReservationOptions{}
+		}
+		reservationOpts.RecheckAdvisoryLocks = true
+	}
+
 	if err != nil {
 		return err
 	}

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -226,6 +226,18 @@ func (sc *ScatterConn) StreamExecute(
 			state.PendingTempTableReservation = false
 		}
 
+		// If this query acquires a session-level advisory lock, add the reason
+		// so the multipooler keeps the backend pinned until the lock is
+		// released. Promotes an existing reservation (e.g. an open transaction)
+		// to also hold the advisory-lock reason.
+		if state.PendingAdvisoryLockReservation {
+			if reservationOpts == nil {
+				reservationOpts = &querypb.ReservationOptions{}
+			}
+			reservationOpts.Reasons |= protoutil.ReasonSessionAdvisoryLock
+			state.PendingAdvisoryLockReservation = false
+		}
+
 		// If this query declares a `WITH HOLD` cursor, pin the cursor name on
 		// the reserved backend so the cursor survives COMMIT. Take the
 		// pending list through the mutex-protected accessor so concurrent
@@ -263,7 +275,7 @@ func (sc *ScatterConn) StreamExecute(
 	// list once up front so we don't double-lock the state mutex via a
 	// separate Has check.
 	pinPortalNames := state.TakePendingPinPortals()
-	if conn.IsInTransaction() || state.PendingTempTableReservation || len(pinPortalNames) > 0 {
+	if conn.IsInTransaction() || state.PendingTempTableReservation || state.PendingAdvisoryLockReservation || len(pinPortalNames) > 0 {
 		reasons := uint32(0)
 		if conn.IsInTransaction() {
 			reasons |= protoutil.ReasonTransaction
@@ -276,6 +288,10 @@ func (sc *ScatterConn) StreamExecute(
 		// include the temp table reason so the connection survives COMMIT.
 		if state.HasTempTableReservation() {
 			reasons |= protoutil.ReasonTempTable
+		}
+		if state.PendingAdvisoryLockReservation {
+			reasons |= protoutil.ReasonSessionAdvisoryLock
+			state.PendingAdvisoryLockReservation = false
 		}
 		if len(pinPortalNames) > 0 {
 			reasons |= protoutil.ReasonPortal
@@ -399,10 +415,21 @@ func (sc *ScatterConn) PortalStreamExecute(
 	if ss != nil && ss.ReservedState.GetReservedConnectionId() != 0 {
 		eo.ReservedConnectionId = ss.ReservedState.GetReservedConnectionId()
 		qs, err = sc.gateway.QueryServiceByID(ctx, ss.ReservedState.GetPoolerId(), target)
-	} else if conn.IsInTransaction() || state.PendingTempTableReservation {
+
+		// If this portal acquires a session-level advisory lock, OR the reason
+		// onto the existing reservation so the lock keeps the backend pinned and
+		// survives the other reason ending (e.g. a COMMIT). The multipooler
+		// applies the reason atomically, before running the portal, so unlike a
+		// separate promotion step there's no window for the unpin probe to see
+		// no lock and tear the reservation down — see portalExecuteWithReserved.
+		if state.PendingAdvisoryLockReservation {
+			reservationOpts = &querypb.ReservationOptions{Reasons: protoutil.ReasonSessionAdvisoryLock}
+			state.PendingAdvisoryLockReservation = false
+		}
+	} else if conn.IsInTransaction() || state.PendingTempTableReservation || state.PendingAdvisoryLockReservation {
 		// Case 2: Need a new reserved connection — for transaction, temp table,
-		// or both. Build reservation options the same way the simple
-		// StreamExecute path does and pass them on the portal RPC; the
+		// advisory lock, or a combination. Build reservation options the same way
+		// the simple StreamExecute path does and pass them on the portal RPC; the
 		// multipooler reserves-and-runs atomically.
 		reasons := uint32(0)
 		if conn.IsInTransaction() {
@@ -414,6 +441,10 @@ func (sc *ScatterConn) PortalStreamExecute(
 		}
 		if state.HasTempTableReservation() {
 			reasons |= protoutil.ReasonTempTable
+		}
+		if state.PendingAdvisoryLockReservation {
+			reasons |= protoutil.ReasonSessionAdvisoryLock
+			state.PendingAdvisoryLockReservation = false
 		}
 
 		sc.logger.DebugContext(ctx, "reserving connection for portal via reservation options",

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -610,13 +610,21 @@ func (e *Executor) maybeUnpinSessionAdvisoryLock(ctx context.Context, rc reserve
 		return false
 	}
 
+	// SELECT EXISTS always returns exactly one row, so an empty result is
+	// unexpected — treat it like a probe failure and stay pinned rather than
+	// fall through with held=false and risk releasing a backend that may still
+	// hold the client's locks.
+	if len(results) == 0 {
+		e.logger.WarnContext(ctx, "advisory-lock probe returned no rows; keeping connection pinned",
+			"reserved_conn_id", rc.ConnID())
+		return false
+	}
+
 	var held bool
-	if len(results) > 0 {
-		if scanErr := ScanSingleRow(results[0], &held); scanErr != nil {
-			e.logger.WarnContext(ctx, "advisory-lock probe returned unexpected result; keeping connection pinned",
-				"reserved_conn_id", rc.ConnID(), "error", scanErr)
-			return false
-		}
+	if scanErr := ScanSingleRow(results[0], &held); scanErr != nil {
+		e.logger.WarnContext(ctx, "advisory-lock probe returned unexpected result; keeping connection pinned",
+			"reserved_conn_id", rc.ConnID(), "error", scanErr)
+		return false
 	}
 	if held {
 		return false

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/common/preparedstatement"
@@ -460,6 +461,15 @@ func (e *Executor) reserveAndStreamExecute(
 		return nil, fmt.Errorf("query execution failed: %w", err)
 	}
 
+	// If the gateway flagged this statement as touching an advisory lock,
+	// re-probe pg_locks: it may have been a pg_try_advisory_lock that didn't
+	// acquire, in which case unpin immediately so the gateway doesn't keep an
+	// empty reservation. Gated on the recheck signal so the probe stays off the
+	// per-statement hot path.
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn) {
+		return nil, nil
+	}
+
 	reservedState := e.buildReservedState(reservedConn)
 
 	e.logger.DebugContext(ctx, "reserve stream execute completed",
@@ -559,7 +569,68 @@ func (e *Executor) streamExecuteOnReservedConn(
 		return nil, nil
 	}
 
+	// If the gateway flagged this statement as touching an advisory lock (e.g.
+	// pg_advisory_unlock), re-probe pg_locks and unpin if none remain. Gated on
+	// the recheck signal so the probe runs only on advisory-touching statements,
+	// not after every query on a pinned connection.
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, rc) {
+		return nil, nil
+	}
+
 	return e.buildReservedStateFromAPI(rc), nil
+}
+
+// maybeUnpinSessionAdvisoryLock checks, after a statement on a connection
+// reserved for session-level advisory locks, whether the session still holds
+// any advisory lock. If none remain it clears ReasonSessionAdvisoryLock and,
+// when no other reason keeps the connection reserved, releases the backend to
+// the pool. Returns true if the connection was released.
+//
+// PostgreSQL is the source of truth for the (reference-counted) lock state, so
+// this is robust against pg_try_advisory_lock calls that failed, keys locked
+// and unlocked an equal number of times, pg_advisory_unlock_all(), and unlock
+// calls buried in functions or dynamic SQL — cases gateway-side counting could
+// never get right. The cost is one extra round trip per statement while the
+// session holds an advisory lock, which is a rare and already-pinned state.
+func (e *Executor) maybeUnpinSessionAdvisoryLock(ctx context.Context, rc reservedConnAPI) bool {
+	// Only meaningful for advisory-lock reservations, and only outside a
+	// transaction: inside one ReasonTransaction keeps the backend pinned anyway,
+	// and transaction-level advisory locks would pollute the probe.
+	if !protoutil.HasSessionAdvisoryLockReason(rc.RemainingReasons()) || rc.IsInTransaction() {
+		return false
+	}
+
+	results, err := rc.Query(ctx, constants.PgLocksAdvisoryProbeSQL)
+	if err != nil {
+		// Err on the side of staying pinned: handing back a connection that may
+		// still hold the client's locks would leak them to the next session.
+		// The connection is reclaimed when the session ends regardless.
+		e.logger.WarnContext(ctx, "advisory-lock probe failed; keeping connection pinned",
+			"reserved_conn_id", rc.ConnID(), "error", err)
+		return false
+	}
+
+	var held bool
+	if len(results) > 0 {
+		if scanErr := ScanSingleRow(results[0], &held); scanErr != nil {
+			e.logger.WarnContext(ctx, "advisory-lock probe returned unexpected result; keeping connection pinned",
+				"reserved_conn_id", rc.ConnID(), "error", scanErr)
+			return false
+		}
+	}
+	if held {
+		return false
+	}
+
+	// No advisory locks remain. Drop the reason; release the backend if nothing
+	// else keeps it reserved.
+	if rc.RemoveReservationReason(protoutil.ReasonSessionAdvisoryLock) {
+		rc.Release(reserved.ReleaseAdvisoryUnlock)
+		e.logger.DebugContext(ctx, "released advisory-lock reservation; no locks remain",
+			"reserved_conn_id", rc.ConnID())
+		return true
+	}
+	return false
 }
 
 // Close closes the executor and releases resources.
@@ -757,17 +828,28 @@ func (e *Executor) portalExecuteWithReserved(
 		return nil, wrapQueryError(err)
 	}
 
-	// If portal is suspended (not completed), keep the reserved connection for continuation
+	// If portal is suspended (not completed), keep the reserved connection for
+	// continuation. Do NOT probe advisory locks here: the extended-protocol
+	// portal is mid-Execute, so issuing a simple probe query would corrupt the
+	// protocol state on this backend.
 	if !completed {
 		reservedConn.ReserveForPortal(portal.Name)
-	} else {
-		// Portal completed, release this portal's reservation.
-		// ReleasePortal returns true only when all reservation reasons are gone.
-		shouldRelease := reservedConn.ReleasePortal(portal.Name)
-		if shouldRelease {
-			reservedConn.Release(reserved.ReleasePortalComplete)
-			return nil, nil
-		}
+		return e.buildReservedState(reservedConn), nil
+	}
+
+	// Portal completed — release this portal's reservation. ReleasePortal returns
+	// true only when all reservation reasons are gone.
+	if reservedConn.ReleasePortal(portal.Name) {
+		reservedConn.Release(reserved.ReleasePortalComplete)
+		return nil, nil
+	}
+
+	// The connection stays reserved for other reasons. If the gateway flagged
+	// this portal as touching an advisory lock (acquire that may have failed, or
+	// a release over the extended protocol), re-probe pg_locks and unpin if none
+	// remain. Gated on the recheck signal to keep the probe off the hot path.
+	if reservationOptions.GetRecheckAdvisoryLocks() && e.maybeUnpinSessionAdvisoryLock(ctx, reservedConn) {
+		return nil, nil
 	}
 
 	return e.buildReservedState(reservedConn), nil
@@ -1796,6 +1878,23 @@ func (e *Executor) ReleaseReservedConnection(
 			e.logger.ErrorContext(ctx, "DISCARD TEMP failed during release",
 				"reserved_conn_id", options.ReservedConnectionId, "error", err)
 			cleanupFailed = true
+		}
+	}
+
+	// Step 3b: If the session holds session-level advisory locks, release them
+	// before the backend returns to the pool. Rolling back (Step 1) only drops
+	// transaction-level locks; session-level advisory locks would otherwise leak
+	// to whichever client next reuses this pooled backend. pg_advisory_unlock_all
+	// is the narrow, targeted fix — unlike DISCARD ALL it leaves prepared
+	// statements and other backend state intact, so the multipooler's
+	// per-connection prepared-statement tracking stays in sync.
+	if !cleanupFailed && protoutil.HasSessionAdvisoryLockReason(reservedConn.RemainingReasons()) {
+		if _, err := reservedConn.Conn().Query(ctx, "SELECT pg_advisory_unlock_all()"); err != nil {
+			e.logger.ErrorContext(ctx, "pg_advisory_unlock_all failed during release",
+				"reserved_conn_id", options.ReservedConnectionId, "error", err)
+			cleanupFailed = true
+		} else {
+			reservedConn.RemoveReservationReason(protoutil.ReasonSessionAdvisoryLock)
 		}
 	}
 

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/fakepgserver"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
@@ -53,6 +54,10 @@ type mockReservedConn struct {
 
 	beginErr     error
 	streamingErr error
+
+	queryCalls   []string
+	queryResults []*sqltypes.Result
+	queryErr     error
 
 	pinnedPortals   []string
 	releasedPortals []string
@@ -116,6 +121,14 @@ func (m *mockReservedConn) ReleasePortal(portalName string) bool {
 	return false
 }
 
+func (m *mockReservedConn) Query(_ context.Context, sql string) ([]*sqltypes.Result, error) {
+	m.queryCalls = append(m.queryCalls, sql)
+	if m.queryErr != nil {
+		return nil, m.queryErr
+	}
+	return m.queryResults, nil
+}
+
 func (m *mockReservedConn) Release(reason reserved.ReleaseReason) {
 	m.releaseCalls = append(m.releaseCalls, reason)
 }
@@ -173,6 +186,136 @@ func newTestExecutor() *Executor {
 }
 
 func noopCallback(_ context.Context, _ *sqltypes.Result) error { return nil }
+
+// boolResult builds a single-row, single-column result holding a PostgreSQL
+// boolean ("t"/"f"), as the pg_locks advisory probe returns.
+func boolResult(b bool) []*sqltypes.Result {
+	v := "f"
+	if b {
+		v = "t"
+	}
+	return []*sqltypes.Result{makeResult(makeRow(v))}
+}
+
+// TestStreamExecuteOnReservedConn_AdvisoryLockStillHeld verifies that after a
+// statement on an advisory-lock-reserved connection, if PostgreSQL still
+// reports an advisory lock the connection stays reserved.
+func TestStreamExecuteOnReservedConn_AdvisoryLockStillHeld(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock,
+		queryResults:     boolResult(true),
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT 1",
+		&query.ReservationOptions{RecheckAdvisoryLocks: true},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{constants.PgLocksAdvisoryProbeSQL}, rc.queryCalls, "should probe pg_locks once")
+	require.Empty(t, rc.releaseCalls, "connection must stay reserved while a lock is held")
+	require.NotNil(t, state)
+	require.Equal(t, protoutil.ReasonSessionAdvisoryLock, state.GetReservationReasons())
+}
+
+// TestStreamExecuteOnReservedConn_AdvisoryLockReleased verifies that when the
+// probe reports no advisory locks remain, the reason is cleared and the
+// connection is released back to the pool.
+func TestStreamExecuteOnReservedConn_AdvisoryLockReleased(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock,
+		queryResults:     boolResult(false),
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT pg_advisory_unlock(101)",
+		&query.ReservationOptions{RecheckAdvisoryLocks: true},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{constants.PgLocksAdvisoryProbeSQL}, rc.queryCalls)
+	require.Equal(t, protoutil.ReasonSessionAdvisoryLock, rc.removedReasons,
+		"advisory-lock reason must be cleared when no locks remain")
+	require.Equal(t, []reserved.ReleaseReason{reserved.ReleaseAdvisoryUnlock}, rc.releaseCalls,
+		"connection must be released once the last advisory lock is gone")
+	require.Nil(t, state, "released connection should report a nil (zero) reservation state")
+}
+
+// TestStreamExecuteOnReservedConn_AdvisoryLockSkippedInTxn verifies that the
+// probe is skipped while a transaction is open — ReasonTransaction keeps the
+// connection pinned and transaction-level advisory locks would pollute the
+// probe.
+func TestStreamExecuteOnReservedConn_AdvisoryLockSkippedInTxn(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		inTxn:            true,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock | protoutil.ReasonTransaction,
+	}
+	e := newTestExecutor()
+
+	_, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT 1",
+		&query.ReservationOptions{RecheckAdvisoryLocks: true},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, rc.queryCalls, "must not probe pg_locks inside a transaction")
+	require.Empty(t, rc.releaseCalls)
+}
+
+// TestStreamExecuteOnReservedConn_AdvisoryProbeErrorKeepsPinned verifies that a
+// failed probe leaves the connection pinned rather than risking a lock leak.
+func TestStreamExecuteOnReservedConn_AdvisoryProbeErrorKeepsPinned(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock,
+		queryErr:         errors.New("probe boom"),
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT 1",
+		&query.ReservationOptions{RecheckAdvisoryLocks: true},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, rc.releaseCalls, "probe failure must not release the connection")
+	require.NotNil(t, state)
+}
+
+// TestStreamExecuteOnReservedConn_AdvisoryNoRecheckNoProbe verifies the gating:
+// an ordinary statement on an advisory-pinned connection (recheck flag NOT set)
+// must not probe pg_locks at all, keeping the probe off the per-statement hot
+// path. The gateway only sets the recheck flag for statements that touch
+// advisory locks.
+func TestStreamExecuteOnReservedConn_AdvisoryNoRecheckNoProbe(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock,
+		queryResults:     boolResult(false), // would unpin IF the probe ran
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT 1",
+		&query.ReservationOptions{}, // no RecheckAdvisoryLocks
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, rc.queryCalls, "must not probe pg_locks without the recheck signal")
+	require.Empty(t, rc.releaseCalls, "must stay reserved without a recheck")
+	require.NotNil(t, state)
+	require.Equal(t, protoutil.ReasonSessionAdvisoryLock, state.GetReservationReasons())
+}
 
 // TestStreamExecuteOnReservedConn_AddsTransactionViaBegin covers the new code
 // path the reviewer flagged: an existing reserved connection (e.g. from a temp

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -291,6 +291,31 @@ func TestStreamExecuteOnReservedConn_AdvisoryProbeErrorKeepsPinned(t *testing.T)
 	require.NotNil(t, state)
 }
 
+// TestStreamExecuteOnReservedConn_AdvisoryEmptyProbeKeepsPinned verifies that an
+// unexpected empty probe result (no rows) is treated like a probe failure: the
+// connection stays pinned rather than being released with held defaulting to
+// false, which would risk leaking the client's locks.
+func TestStreamExecuteOnReservedConn_AdvisoryEmptyProbeKeepsPinned(t *testing.T) {
+	rc := &mockReservedConn{
+		connID:           42,
+		remainingReasons: protoutil.ReasonSessionAdvisoryLock,
+		queryResults:     nil, // probe returned no rows
+	}
+	e := newTestExecutor()
+
+	state, err := e.streamExecuteOnReservedConn(
+		context.Background(), rc, "SELECT pg_advisory_unlock(101)",
+		&query.ReservationOptions{RecheckAdvisoryLocks: true},
+		noopCallback,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{constants.PgLocksAdvisoryProbeSQL}, rc.queryCalls, "should still probe")
+	require.Empty(t, rc.releaseCalls, "empty probe result must not release the connection")
+	require.Empty(t, rc.removedReasons, "advisory reason must be kept on an empty probe result")
+	require.NotNil(t, state)
+}
+
 // TestStreamExecuteOnReservedConn_AdvisoryNoRecheckNoProbe verifies the gating:
 // an ordinary statement on an advisory-pinned connection (recheck flag NOT set)
 // must not probe pg_locks at all, keeping the probe off the per-statement hot

--- a/go/services/multipooler/internal/executor/reserved_conn.go
+++ b/go/services/multipooler/internal/executor/reserved_conn.go
@@ -34,6 +34,10 @@ type reservedConnAPI interface {
 	AddReservationReason(reason uint32)
 	RemoveReservationReason(reason uint32) bool
 	QueryStreaming(ctx context.Context, sql string, callback func(context.Context, *sqltypes.Result) error) error
+	// Query runs a simple query and buffers all results. Used for internal
+	// probes (e.g. checking pg_locks to decide whether a session still holds an
+	// advisory lock), not for streaming client query results.
+	Query(ctx context.Context, sql string) ([]*sqltypes.Result, error)
 	// ReserveForPortal pins the named portal/cursor on this reserved
 	// connection. Used for DECLARE … WITH HOLD so the cursor survives
 	// COMMIT — the multipooler's reservation bitmask keeps ReasonPortal

--- a/go/services/multipooler/internal/pools/reserved/properties.go
+++ b/go/services/multipooler/internal/pools/reserved/properties.go
@@ -133,6 +133,10 @@ const (
 	// ReleasePortalComplete indicates the portal execution completed.
 	ReleasePortalComplete
 
+	// ReleaseAdvisoryUnlock indicates the session released its last session-level
+	// advisory lock, so the backend no longer needs to stay pinned.
+	ReleaseAdvisoryUnlock
+
 	// ReleaseTimeout indicates the reservation timed out.
 	ReleaseTimeout
 
@@ -152,6 +156,8 @@ func (r ReleaseReason) String() string {
 		return "rollback"
 	case ReleasePortalComplete:
 		return "portal_complete"
+	case ReleaseAdvisoryUnlock:
+		return "advisory_unlock"
 	case ReleaseTimeout:
 		return "timeout"
 	case ReleaseKill:

--- a/go/test/endtoend/queryserving/advisory_lock_test.go
+++ b/go/test/endtoend/queryserving/advisory_lock_test.go
@@ -1,0 +1,474 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// Session-level advisory locks (pg_advisory_lock / pg_advisory_lock_shared) live
+// on a specific PostgreSQL backend and survive transaction boundaries. Under the
+// gateway's pooled model a client's logical session is not pinned to one
+// backend, so without special handling these locks would be acquired on whatever
+// backend ran the acquiring statement and then lost (or leaked) on the next
+// query. These tests verify the gateway pins the backend for the lifetime of a
+// session-level advisory lock and scrubs it on release.
+
+// skipIfNoRealPostgres skips a test when run in short mode or when the PostgreSQL
+// binaries needed to stand up a real cluster are unavailable.
+func skipIfNoRealPostgres(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping end-to-end test (short mode)")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("Skipping end-to-end test (no postgres binaries)")
+	}
+}
+
+// openGatewayConn opens a single *sql.Conn to the multigateway PG port. Forcing a
+// single underlying connection means every query goes through the same
+// multigateway session (TCP connection), which is what lets us observe pinning.
+func openGatewayConn(t *testing.T, setup *shardsetup.ShardSetup) *sql.Conn {
+	t.Helper()
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	conn, err := db.Conn(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+// advisoryLockHeld reports whether the backend currently serving conn holds a
+// single-key session advisory lock for key. PostgreSQL maps a one-argument
+// bigint key to pg_locks as classid = key>>32, objid = key&0xffffffff,
+// objsubid = 1; for the small keys used here classid is always 0. Scoping the
+// probe to a specific key keeps assertions precise even though backends are
+// shared across the pool (a leaked lock from another test on the same backend
+// won't be miscounted).
+func advisoryLockHeld(t *testing.T, conn *sql.Conn, key int) bool {
+	t.Helper()
+	var held bool
+	err := conn.QueryRowContext(t.Context(),
+		"SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid() AND classid = 0 AND objid = $1 AND objsubid = 1)",
+		key).Scan(&held)
+	require.NoError(t, err, "failed to probe advisory lock")
+	return held
+}
+
+// ---------- Pinning on acquire ----------
+
+// TestAdvisoryLock_ExclusiveLockPinsSession verifies that pg_advisory_lock pins
+// the multigateway session to a single backend. Before the fix the session is
+// not pinned, so the backend PID is free to change between queries.
+func TestAdvisoryLock_ExclusiveLockPinsSession(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(101)")
+	require.NoError(t, err)
+
+	// After acquiring a session-level advisory lock the session must be pinned.
+	utils.RequirePinned(t, conn)
+
+	_, _ = conn.ExecContext(t.Context(), "SELECT pg_advisory_unlock_all()")
+}
+
+// TestAdvisoryLock_SharedLockPinsSession verifies pg_advisory_lock_shared pins
+// the session.
+func TestAdvisoryLock_SharedLockPinsSession(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock_shared(102)")
+	require.NoError(t, err)
+	utils.RequirePinned(t, conn)
+
+	_, _ = conn.ExecContext(t.Context(), "SELECT pg_advisory_unlock_all()")
+}
+
+// TestAdvisoryLock_TryLockPinsSession verifies pg_try_advisory_lock pins the
+// session when it succeeds.
+func TestAdvisoryLock_TryLockPinsSession(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	var acquired bool
+	err := conn.QueryRowContext(t.Context(), "SELECT pg_try_advisory_lock(103)").Scan(&acquired)
+	require.NoError(t, err)
+	require.True(t, acquired, "try lock on a free key should succeed")
+	utils.RequirePinned(t, conn)
+
+	_, _ = conn.ExecContext(t.Context(), "SELECT pg_advisory_unlock_all()")
+}
+
+// TestAdvisoryLock_TwoKeyLockPinsSession verifies the two-argument
+// pg_advisory_lock(key1, key2) form pins the session.
+func TestAdvisoryLock_TwoKeyLockPinsSession(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(7, 9)")
+	require.NoError(t, err)
+	utils.RequirePinned(t, conn)
+
+	_, _ = conn.ExecContext(t.Context(), "SELECT pg_advisory_unlock_all()")
+}
+
+// ---------- Lock visibility across queries ----------
+
+// TestAdvisoryLock_VisibleAcrossQueries verifies a lock acquired in one query
+// remains held (visible in pg_locks) on the same pinned backend in subsequent
+// queries.
+func TestAdvisoryLock_VisibleAcrossQueries(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(104)")
+	require.NoError(t, err)
+	pinnedPID := utils.RequirePinned(t, conn)
+
+	// The advisory lock must remain visible across many subsequent queries, all
+	// served by the same backend.
+	for i := range 10 {
+		require.Equal(t, pinnedPID, utils.GetBackendPID(t, conn), "PID must stay stable on query %d", i)
+		require.True(t, advisoryLockHeld(t, conn, 104), "advisory lock must remain held on query %d", i)
+	}
+
+	_, _ = conn.ExecContext(t.Context(), "SELECT pg_advisory_unlock_all()")
+}
+
+// ---------- Unpin on release ----------
+
+// TestAdvisoryLock_UnlockAllUnpins verifies pg_advisory_unlock_all() releases
+// the lock and unpins the session.
+func TestAdvisoryLock_UnlockAllUnpins(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(105)")
+	require.NoError(t, err)
+	utils.RequirePinned(t, conn)
+
+	var released bool
+	err = conn.QueryRowContext(t.Context(), "SELECT pg_advisory_unlock_all() IS NOT NULL").Scan(&released)
+	require.NoError(t, err)
+
+	// After unlocking everything, the lock should be gone on whatever backend we
+	// land on next.
+	require.False(t, advisoryLockHeld(t, conn, 105), "no advisory lock should remain after unlock_all")
+}
+
+// TestAdvisoryLock_UnlockReferenceCounted verifies that a key locked twice stays
+// pinned after a single unlock (reference counted) and unpins only after the
+// matching second unlock.
+func TestAdvisoryLock_UnlockReferenceCounted(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	// Acquire the same key twice — PostgreSQL stacks session-level locks.
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(106)")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(106)")
+	require.NoError(t, err)
+	pinnedPID := utils.RequirePinned(t, conn)
+
+	// One unlock leaves the lock still held (count 1) — must remain pinned.
+	var ok bool
+	require.NoError(t, conn.QueryRowContext(t.Context(), "SELECT pg_advisory_unlock(106)").Scan(&ok))
+	require.True(t, ok)
+	require.Equal(t, pinnedPID, utils.GetBackendPID(t, conn), "must stay pinned while lock still held")
+	require.True(t, advisoryLockHeld(t, conn, 106), "lock should still be held after one of two unlocks")
+
+	// Second unlock fully releases the lock; the session should unpin.
+	require.NoError(t, conn.QueryRowContext(t.Context(), "SELECT pg_advisory_unlock(106)").Scan(&ok))
+	require.True(t, ok)
+	require.False(t, advisoryLockHeld(t, conn, 106), "no advisory lock should remain after matching unlocks")
+}
+
+// ---------- DISCARD ALL ----------
+
+// TestAdvisoryLock_DiscardAllReleases verifies DISCARD ALL through the gateway
+// releases session-level advisory locks (PG's DISCARD ALL runs
+// pg_advisory_unlock_all()).
+func TestAdvisoryLock_DiscardAllReleases(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_lock(107)")
+	require.NoError(t, err)
+	utils.RequirePinned(t, conn)
+
+	_, err = conn.ExecContext(t.Context(), "DISCARD ALL")
+	require.NoError(t, err)
+
+	// The lock should be gone on any backend we reach after DISCARD ALL.
+	require.False(t, advisoryLockHeld(t, conn, 107), "DISCARD ALL must release session advisory locks")
+}
+
+// ---------- No leak to next client ----------
+
+// TestAdvisoryLock_NoLeakToNextClient verifies that when a session holding a
+// session-level advisory lock disconnects without explicitly unlocking, the
+// backend does not return to the pool still holding the lock — a new client can
+// acquire the same key.
+func TestAdvisoryLock_NoLeakToNextClient(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+
+	// First client: take the lock and abandon it (disconnect without unlocking).
+	db1, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	db1.SetMaxOpenConns(1)
+	db1.SetMaxIdleConns(1)
+	conn1, err := db1.Conn(t.Context())
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(t.Context(), "SELECT pg_advisory_lock(108)")
+	require.NoError(t, err)
+	conn1.Close()
+	db1.Close()
+
+	// Second client: must be able to acquire the same key. If the backend leaked
+	// the lock back into the pool, every backend still holding key 108 would
+	// fail the try-lock; retry across backends to surface a leak deterministically.
+	db2, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db2.Close()
+	db2.SetMaxOpenConns(1)
+	db2.SetMaxIdleConns(1)
+	conn2, err := db2.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	require.Eventually(t, func() bool {
+		var acquired bool
+		if err := conn2.QueryRowContext(t.Context(), "SELECT pg_try_advisory_lock(108)").Scan(&acquired); err != nil {
+			return false
+		}
+		if acquired {
+			_, _ = conn2.ExecContext(t.Context(), "SELECT pg_advisory_unlock(108)")
+		}
+		return acquired
+	}, 5*time.Second, 100*time.Millisecond, "key 108 must be acquirable — backend leaked the lock")
+}
+
+// ---------- Transaction-level locks are out of scope ----------
+
+// TestAdvisoryLock_XactLockDoesNotPin documents that transaction-level advisory
+// locks (pg_advisory_xact_lock) are out of scope: outside an explicit
+// transaction they are released at statement end, so the session must NOT stay
+// pinned.
+func TestAdvisoryLock_XactLockDoesNotPin(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	conn := openGatewayConn(t, setup)
+
+	_, err := conn.ExecContext(t.Context(), "SELECT pg_advisory_xact_lock(109)")
+	require.NoError(t, err)
+
+	// The xact lock was released at the end of the implicit transaction, so the
+	// lock for key 109 should not remain held.
+	assert.False(t, advisoryLockHeld(t, conn, 109), "xact advisory lock should not survive the statement")
+}
+
+// ---------- Extended query protocol (pgx, bound parameters) ----------
+//
+// pgx uses the extended protocol with a bound parameter for `pg_advisory_lock($1)`,
+// which exercises a different gateway path than lib/pq's simple protocol: the
+// portal is planned via resolvePortalPlan → Plan (so the AdvisoryLockRoute is
+// built) and executed through the reserved-connection portal path. These tests
+// guard that path end to end.
+
+// openGatewayPgxConn opens a single pgx connection to the multigateway. A single
+// *pgx.Conn means every query rides the same gateway session, so pinning is
+// observable via a stable backend PID.
+func openGatewayPgxConn(t *testing.T, ctx context.Context, setup *shardsetup.ShardSetup) *pgx.Conn {
+	t.Helper()
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable")
+	cfg, err := pgx.ParseConfig(connStr)
+	require.NoError(t, err)
+	// QueryExecModeExec still uses the extended protocol with a server-bound
+	// parameter (the portal path we're testing), but without pgx's client-side
+	// prepared-statement cache. That keeps these tests focused on advisory-lock
+	// behavior and avoids the orthogonal gotcha that DISCARD ALL deallocates
+	// server prepared statements, which would invalidate a client-side cache.
+	cfg.DefaultQueryExecMode = pgx.QueryExecModeExec
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close(ctx) })
+	return conn
+}
+
+// pgxBackendPID returns the backend PID serving conn (extended protocol).
+func pgxBackendPID(t *testing.T, ctx context.Context, conn *pgx.Conn) int {
+	t.Helper()
+	var pid int
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid))
+	return pid
+}
+
+// pgxAdvisoryLockHeld reports whether the backend serving conn holds the
+// single-key session advisory lock for key. See advisoryLockHeld for the
+// pg_locks key mapping.
+func pgxAdvisoryLockHeld(t *testing.T, ctx context.Context, conn *pgx.Conn, key int) bool {
+	t.Helper()
+	var held bool
+	require.NoError(t, conn.QueryRow(ctx,
+		"SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid() AND classid = 0 AND objid = $1 AND objsubid = 1)",
+		key).Scan(&held))
+	return held
+}
+
+// TestAdvisoryLock_ExtendedProtocol_PinsAndReleases verifies that acquiring a
+// session-level advisory lock over the extended protocol (bound parameter) pins
+// the session, keeps the lock visible across queries, and that an
+// extended-protocol pg_advisory_unlock releases it.
+func TestAdvisoryLock_ExtendedProtocol_PinsAndReleases(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	conn := openGatewayPgxConn(t, ctx, setup)
+
+	_, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", 201)
+	require.NoError(t, err)
+
+	// Pinned: backend PID is stable, and the lock is visible on it.
+	pid1 := pgxBackendPID(t, ctx, conn)
+	pid2 := pgxBackendPID(t, ctx, conn)
+	require.Equal(t, pid1, pid2, "session should be pinned after extended-protocol advisory lock")
+	require.True(t, pgxAdvisoryLockHeld(t, ctx, conn, 201), "lock must be held on the pinned backend")
+
+	// Unlock over the extended protocol; the lock must be gone afterward.
+	var released bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", 201).Scan(&released))
+	require.True(t, released)
+	require.False(t, pgxAdvisoryLockHeld(t, ctx, conn, 201), "lock must be released after extended-protocol unlock")
+}
+
+// TestAdvisoryLock_ExtendedProtocol_DiscardAllReleases verifies DISCARD ALL
+// releases a session advisory lock acquired over the extended protocol.
+func TestAdvisoryLock_ExtendedProtocol_DiscardAllReleases(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	conn := openGatewayPgxConn(t, ctx, setup)
+
+	_, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", 202)
+	require.NoError(t, err)
+	require.True(t, pgxAdvisoryLockHeld(t, ctx, conn, 202))
+
+	_, err = conn.Exec(ctx, "DISCARD ALL")
+	require.NoError(t, err)
+	require.False(t, pgxAdvisoryLockHeld(t, ctx, conn, 202), "DISCARD ALL must release the lock")
+}
+
+// TestAdvisoryLock_ExtendedProtocol_SurvivesCommit exercises the
+// existing-reservation promotion path: a transaction first establishes a
+// reserved connection, then a session-level advisory lock is acquired over the
+// extended protocol on top of it. The lock (and the pin) must survive COMMIT —
+// session-level advisory locks outlive transactions.
+func TestAdvisoryLock_ExtendedProtocol_SurvivesCommit(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	conn := openGatewayPgxConn(t, ctx, setup)
+
+	// Open a transaction and run a query so the backend is reserved for the
+	// transaction before the advisory lock is taken.
+	_, err := conn.Exec(ctx, "BEGIN")
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, "SELECT 1")
+	require.NoError(t, err)
+	pinnedPID := pgxBackendPID(t, ctx, conn)
+
+	// Acquire the session advisory lock over the extended protocol inside the txn.
+	_, err = conn.Exec(ctx, "SELECT pg_advisory_lock($1)", 203)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, "COMMIT")
+	require.NoError(t, err)
+
+	// After COMMIT the transaction reason is gone, but the advisory lock keeps
+	// the same backend pinned and the lock held.
+	require.Equal(t, pinnedPID, pgxBackendPID(t, ctx, conn), "advisory lock must keep the backend pinned past COMMIT")
+	require.True(t, pgxAdvisoryLockHeld(t, ctx, conn, 203), "session advisory lock must survive COMMIT")
+
+	// Cleanup unpins.
+	var released bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", 203).Scan(&released))
+	require.True(t, released)
+}
+
+// TestAdvisoryLock_ExtendedProtocol_SurvivesDiscardTemp covers the case that was
+// a known limitation before portals could reserve atomically (PR #1114):
+// acquiring a session-level advisory lock over the extended protocol while a
+// temp table already holds the backend. The advisory reason is now OR'd onto the
+// existing reservation atomically, so DISCARD TEMP — which drops only the
+// temp-table reason — leaves the lock held and the backend pinned. No leak.
+func TestAdvisoryLock_ExtendedProtocol_SurvivesDiscardTemp(t *testing.T) {
+	skipIfNoRealPostgres(t)
+	setup := getSharedSetup(t)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	conn := openGatewayPgxConn(t, ctx, setup)
+
+	// Temp table pins the backend (ReasonTempTable).
+	_, err := conn.Exec(ctx, "CREATE TEMP TABLE adv_tmp (id int)")
+	require.NoError(t, err)
+	pinnedPID := pgxBackendPID(t, ctx, conn)
+
+	// Acquire a session advisory lock over the extended protocol on top of it.
+	_, err = conn.Exec(ctx, "SELECT pg_advisory_lock($1)", 204)
+	require.NoError(t, err)
+	require.True(t, pgxAdvisoryLockHeld(t, ctx, conn, 204))
+
+	// DISCARD TEMP drops the temp-table reason; the advisory lock must keep the
+	// backend pinned and the lock held.
+	_, err = conn.Exec(ctx, "DISCARD TEMP")
+	require.NoError(t, err)
+	require.Equal(t, pinnedPID, pgxBackendPID(t, ctx, conn), "advisory lock must keep the backend pinned past DISCARD TEMP")
+	require.True(t, pgxAdvisoryLockHeld(t, ctx, conn, 204), "session advisory lock must survive DISCARD TEMP")
+
+	// Cleanup unpins.
+	var released bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", 204).Scan(&released))
+	require.True(t, released)
+}

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -376,6 +376,12 @@ enum ReservationReason {
   // Connection is reserved for a logical-replication session (CREATE_REPLICATION_SLOT,
   // START_REPLICATION, etc.). Pinned to a single backend for the session's lifetime.
   RESERVATION_REASON_LOGICAL_REPLICATION = 32;  // 0b100000
+  // Connection is reserved because the session holds one or more session-level
+  // advisory locks (pg_advisory_lock / pg_advisory_lock_shared). These locks
+  // live on a specific backend and survive transaction boundaries, so the
+  // backend must stay pinned until every such lock is released. Transaction-level
+  // advisory locks (pg_advisory_xact_lock) do NOT set this reason.
+  RESERVATION_REASON_SESSION_ADVISORY_LOCK = 64;  // 0b1000000
 }
 
 // TransactionConclusion specifies how to conclude a transaction.

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -383,4 +383,13 @@ message ReservationOptions {
   // the connection is released back to the pool and the returned
   // ReservedState has connection_id == 0.
   repeated string release_portal_names = 4;
+
+  // recheck_advisory_locks asks the multipooler to re-probe pg_locks after
+  // running this statement and drop ReasonSessionAdvisoryLock (releasing the
+  // connection if no other reason remains) when the session no longer holds any
+  // advisory lock. The gateway sets it only for statements that touch
+  // session-level advisory locks (an acquire — to catch a failed
+  // pg_try_advisory_lock — or a release), so the probe runs only when it can
+  // matter rather than after every query on a pinned connection.
+  bool recheck_advisory_locks = 5;
 }


### PR DESCRIPTION
## Summary

- Session-level advisory locks (`pg_advisory_lock` / `_shared` and the `try` variants) now work through the gateway: the acquiring statement pins the client session to its backend via a new `ReasonSessionAdvisoryLock` reserved-connection reason, so the lock stays visible in `pg_locks` and usable across subsequent queries.
- The multipooler decides when to unpin **authoritatively**, by probing `pg_locks` rather than counting at the gateway — correct for reference-counted stacking, a failed `pg_try_advisory_lock`, and `pg_advisory_unlock_all()`. The probe is gated on statements that actually touch advisory locks, so it stays off the per-query hot path.
- A backend never returns to the pool still holding a lock: `DISCARD ALL` and client disconnect scrub via `pg_advisory_unlock_all()` on the reserved-connection release path (the narrow fix — prepared-statement tracking stays in sync).
- Works on both the simple and extended (portal) protocols. Transaction-level `pg_advisory_xact_lock*` is intentionally out of scope (released at transaction end).

## Description

Detection is best-effort: the planner sees advisory calls in the statement text (the common case) but not locks taken/released inside a PL/pgSQL function, trigger, or dynamic SQL — the same limitation as temp tables created via dynamic SQL. A missed acquire just isn't pinned; a missed release keeps the session pinned conservatively until the next observed advisory statement, `DISCARD ALL`, or disconnect — never a leak.

Design notes: `docs/query_serving/advisory_locks_design.md`.

Covered by unit tests (planner detection/routing, executor probe gating) and end-to-end tests in `queryserving` across both protocols, including pinning, cross-query visibility, reference-counted unlock, `pg_advisory_unlock_all`, `DISCARD ALL`, and no-leak-on-disconnect.



Closes https://github.com/multigres/multigres/issues/1126