### PR TITLE
feat(multipooler): two-stage graceful drain that serves single queries

### DIFF
--- a/docs/query_serving/graceful_drain_design.md
+++ b/docs/query_serving/graceful_drain_design.md
@@ -3,23 +3,37 @@
 ## Overview
 
 When multipooler transitions to `NOT_SERVING` (e.g., during demotion
-from primary to replica), it must reject new queries immediately while
-allowing existing reserved connections — transactions, portals, COPY
-operations — to finish cleanly. Without graceful drain, a sudden
-cutover would abort in-flight transactions, causing client errors and
-client-visible errors.
+from primary to replica), it must let in-flight work finish cleanly
+before the cutover, while steering new work to the new primary. A naive
+"reject everything immediately" cutover would abort in-flight
+transactions and needlessly bounce simple queries that the still-primary
+could have served.
+
+The drain runs in **two stages** under a single grace period:
+
+1. **Drain reserved** — reject new transactions/reservations (the gateway
+   buffers them for the new primary), but keep serving single autocommit
+   queries and let existing transactions finish.
+2. **Drain regular** — once transactions are done, also stop serving
+   single queries and wait for the in-flight ones to finish, so the
+   pooler reports `NOT_SERVING` with zero in-flight work and the
+   subsequent postgres demotion kills nothing.
 
 Key capabilities:
 
-- **Two-phase shutdown**: gate new requests first, then wait for
-  in-flight connections to drain before completing the state transition
+- **Two-stage drain**: drain transactions first (while single queries
+  keep flowing), then drain single queries, then complete the transition
 - **Reserved connection exemption**: existing transactions and portals
-  continue through shutdown; only new reservations are rejected
-- **Bounded grace period**: drain waits up to a configurable timeout
-  (default 3s) so shutdown is never blocked indefinitely
-- **Pool-level drain tracking**: connection borrow/recycle and
-  reserve/release events are tracked via callbacks, enabling efficient
-  zero-polling drain detection
+  always continue; only new reservations are rejected
+- **Single queries served during stage 1**: simple autocommit queries are
+  served on the still-primary until transactions have drained, then
+  buffered — minimizing latency during what can be a multi-second wait
+- **Bounded grace period**: both stages share a configurable timeout
+  (default 3s); on expiry everything is force-closed so shutdown is never
+  blocked indefinitely
+- **Pool-level drain tracking**: borrow/recycle and reserve/release
+  events feed two zero-polling counters — a combined count and a
+  reserved-only count — so each stage waits on exactly its pool
 
 ## Background
 
@@ -46,38 +60,40 @@ during planned state transitions like demotion.
                         │
                         │ OnStateChange(NOT_SERVING)
                         ▼
-              ┌─────────────────────┐
-              │  QueryPoolerServer  │
-              │                     │
-              │  1. shuttingDown=true│
-              │     (gate new reqs) │
-              │                     │
-              │  2. WaitForDrain()  │◄──── bounded by gracePeriod
-              │                     │
-              │  3. status=NOT_SERVING│
-              │     shuttingDown=false│
-              └─────────────────────┘
+              ┌──────────────────────────────┐
+              │     QueryPoolerServer        │
+              │                              │
+              │  1. drainPhase=drainReserved │
+              │     WaitForReservedDrain()   │◄── stage 1: serve single
+              │                              │    queries, finish txns
+              │  2. drainPhase=drainRegular  │
+              │     WaitForDrain()           │◄── stage 2: drain single
+              │                              │    queries (one deadline,
+              │  3. status=NOT_SERVING       │    bounded by gracePeriod)
+              │     drainPhase=drainNone     │
+              └──────────────────────────────┘
 
-    ┌──────────────────────────────────────────┐
-    │           gRPC Service Layer             │
-    │                                          │
-    │  StartRequest(allowOnShutdown)           │
-    │  ┌──────────┐  ┌───────────────────────┐ │
-    │  │ New req  │  │ Existing reserved conn│ │
-    │  │ → REJECT │  │ → ALLOW              │ │
-    │  └──────────┘  └───────────────────────┘ │
-    └──────────────────────────────────────────┘
+    ┌──────────────────────────────────────────────────┐
+    │                gRPC Service Layer                 │
+    │                                                   │
+    │  StartRequest(target, RequestKind)                │
+    │  ┌───────────────┐ ┌────────────┐ ┌─────────────┐ │
+    │  │ ExistingReser-│ │ SingleQuery│ │ NewReserva- │ │
+    │  │ ved → ALLOW   │ │ stage1 ✓   │ │ tion → BUF  │ │
+    │  └───────────────┘ └────────────┘ └─────────────┘ │
+    └──────────────────────────────────────────────────┘
 
     ┌──────────────────────────────────────────┐
     │        Connection Pool Manager           │
     │                                          │
-    │  lentCount: atomic counter               │
-    │  zeroCh: closed when lentCount == 0      │
+    │  regularCount  (single-query borrows)    │
+    │  reservedCount (reserved conns)          │
+    │  combined drain = regularCount+reserved  │
     │                                          │
-    │  OnBorrow() → lentAdd(+1)                │
-    │  OnRecycle() → lentAdd(-1)               │
-    │  OnReserve() → lentAdd(+1)               │
-    │  OnRelease() → lentAdd(-1)               │
+    │  OnBorrow()  → regularAdd(+1)            │
+    │  OnRecycle() → regularAdd(-1)            │
+    │  OnReserve() → reservedAdd(+1)           │
+    │  OnRelease() → reservedAdd(-1)           │
     └──────────────────────────────────────────┘
 ```
 
@@ -85,111 +101,140 @@ during planned state transitions like demotion.
 
 ### Drain Tracking
 
-The `connpoolmanager.Manager` tracks how many connections are
-currently lent out across all user pools via a `lentCount` counter and
-a `zeroCh` channel:
+The `connpoolmanager.Manager` keeps two independent counters and two
+zero-polling channels:
 
-- **`lentAdd(n)`**: adjusts the counter. When transitioning to zero,
-  `zeroCh` is closed to unblock any `WaitForDrain` caller. When
-  transitioning away from zero, a new open channel is allocated.
-- **`WaitForDrain(ctx)`**: blocks on `zeroCh` until either the count
-  reaches zero or the context is cancelled.
+- **`regularCount`**: regular (single-query) borrows.
+- **`reservedCount`**: reserved connections (transactions, temp tables,
+  portals, COPY, etc.).
+- **`zeroCh`** closes when `regularCount + reservedCount == 0`;
+  `WaitForDrain(ctx)` blocks on it (the full drain).
+- **`reservedZeroCh`** closes when `reservedCount == 0`;
+  `WaitForReservedDrain(ctx)` blocks on it (the reserved-only drain).
 
-This channel-based approach avoids polling. The counter increments on
-connection borrow (regular pool) or reserve (reserved pool), and
-decrements on recycle or release/kill.
+`regularAdd(n)` and `reservedAdd(n)` adjust one counter each and
+reconcile the affected channel(s) via `signalZeroChanLocked`. The
+two-stage drain waits on `WaitForReservedDrain` first (transactions only
+— single-query borrows don't touch `reservedCount`, so they never hold
+it up), then on `WaitForDrain`.
 
-Regular pool connections and reserved pool connections use separate
-callback pairs to avoid double-counting:
+The counters are bumped by callbacks on borrow/recycle and
+reserve/release:
 
-| Pool type | Increment callback | Decrement callback |
-| --------- | ------------------ | ------------------ |
-| Regular   | `OnBorrow`         | `OnRecycle`        |
-| Reserved  | `OnReserve`        | `OnRelease`        |
+| Pool type | Increment callback | Decrement callback | Counter bumped  |
+| --------- | ------------------ | ------------------ | --------------- |
+| Regular   | `OnBorrow`         | `OnRecycle`        | `regularCount`  |
+| Reserved  | `OnReserve`        | `OnRelease`        | `reservedCount` |
 
-The reserved pool's inner regular connpool does **not** get
-`OnBorrow`/`OnRecycle` callbacks. This is intentional: the reserved
-pool borrows a regular connection internally when creating a reserved
-connection, but from the drain-tracking perspective this is a single
-logical lend tracked by `OnReserve`/`OnRelease`.
+Keeping the counters separate means each event takes the drain lock
+exactly once: a regular borrow touches only `regularCount` (and `zeroCh`),
+a reserve touches only `reservedCount` (and both channels). The reserved
+pool's inner regular connpool does **not** get `OnBorrow`/`OnRecycle`
+callbacks: creating a reserved connection is a single logical lend
+tracked by `OnReserve`/`OnRelease`, so it is counted once, under
+`reservedCount`.
 
 ### Admission Control
 
-`QueryPoolerServer.StartRequest(allowOnShutdown bool)` is the
-admission gate called by every gRPC handler before acquiring an
-executor:
+`QueryPoolerServer.StartRequest(target, RequestKind)` is the admission
+gate called by every gRPC handler before acquiring an executor. The
+handler classifies the request into one of three kinds, and the gate
+decides per kind and drain stage. Rejection returns `MTF01`, which the
+gateway buffers and retries on the new primary.
 
-| State                            | `allowOnShutdown=false` | `allowOnShutdown=true` |
-| -------------------------------- | ----------------------- | ---------------------- |
-| SERVING, not shutting down       | Allow                   | Allow                  |
-| SERVING, shutting down (drain)   | Reject (`MTF01`)        | Allow                  |
-| NOT_SERVING / demoted to REPLICA | Reject (`MTF01`)        | Allow                  |
+| `RequestKind`      | SERVING | drainReserved (stage 1) | drainRegular (stage 2) | NOT_SERVING      |
+| ------------------ | ------- | ----------------------- | ---------------------- | ---------------- |
+| `ExistingReserved` | Allow   | Allow                   | Allow                  | Allow¹           |
+| `SingleQuery`      | Allow   | Allow                   | Reject (`MTF01`)       | Reject (`MTF01`) |
+| `NewReservation`   | Allow   | Reject (`MTF01`)        | Reject (`MTF01`)       | Reject (`MTF01`) |
 
-`allowOnShutdown=true` marks an in-flight operation on an **existing
-reserved connection**, so it is admitted regardless of serving status
-or demotion: the reserved connection itself is the real gate, not the
+¹ `ExistingReserved` is always admitted regardless of serving status or
+demotion: the reserved connection itself is the real gate, not the
 pooler's serving state. Tablegroup/shard mismatches (`MTD01`) are still
-rejected. Once admitted, two outcomes are possible:
+rejected for every kind. Once an `ExistingReserved` op is admitted, two
+outcomes are possible:
 
 - **Connection still alive** (the normal in-drain case): the operation
   runs on the live backend. PostgreSQL is demoted only _after_ the
   drain finishes, so a surviving reserved connection is still on the
   primary and the transaction concludes cleanly.
 - **Connection already force-closed** (the drain exceeded its grace
-  period while the client sat idle-in-transaction): the executor
-  returns SQLSTATE `40001` (`serialization_failure`, _"transaction
-  aborted: connection terminated during a planned failover"_) so the
-  client retries the whole transaction. This is deliberately **not**
-  `MTF01` — the transaction no longer exists, so there is nothing for
-  the gateway to buffer or auto-retry; only the client can replay it.
+  period): the executor returns SQLSTATE `40001` (`serialization_failure`,
+  _"transaction aborted: connection terminated during a planned
+  failover"_) so the client retries the whole transaction. This is
+  deliberately **not** `MTF01` — the transaction no longer exists, so
+  there is nothing for the gateway to buffer or auto-retry; only the
+  client can replay it.
 
-Each gRPC method sets `allowOnShutdown` based on whether it operates
-on an existing reserved connection:
+Each gRPC handler reports `id = ReservedConnectionId > 0` (existing
+reserved) and, when `id == 0`, whether the request will create a new
+reservation — mirroring the executor's own reserve decision:
 
-| Method                      | `allowOnShutdown`    | Rationale                                |
-| --------------------------- | -------------------- | ---------------------------------------- |
-| `StreamExecute`             | `reservedConnId > 0` | Allow if continuing existing reservation |
-| `ExecuteQuery`              | `reservedConnId > 0` | Same                                     |
-| `Describe`                  | `reservedConnId > 0` | Same                                     |
-| `PortalStreamExecute`       | `reservedConnId > 0` | Same                                     |
-| `CopyBidiExecute`           | `reservedConnId > 0` | Same                                     |
-| `ReserveStreamExecute`      | `false`              | Always a new reservation                 |
-| `ConcludeTransaction`       | `true`               | Always on existing reserved conn         |
-| `DiscardTempTables`         | `true`               | Always on existing reserved conn         |
-| `ReleaseReservedConnection` | `true`               | Always on existing reserved conn         |
-| `GetAuthCredentials`        | `false`              | Admin operation, not query path          |
-| `StreamPoolerHealth`        | No gate              | Health streaming is independent          |
+| Method                      | Reserves when (id == 0)                    |
+| --------------------------- | ------------------------------------------ |
+| `StreamExecute`             | `ReservationOptions` reasons != 0          |
+| `ExecuteQuery`, `Describe`  | never (no reservation path) → single query |
+| `PortalStreamExecute`       | `MaxRows > 0` (suspendable cursor)         |
+| `CopyBidiExecute`           | always (COPY pins a connection)            |
+| `ConcludeTransaction`       | always existing reserved                   |
+| `DiscardTempTables`         | always existing reserved                   |
+| `ReleaseReservedConnection` | always existing reserved                   |
+| `GetAuthCredentials`        | treated as new reservation (buffered)      |
+| `StreamPoolerHealth`        | no gate (health streaming is independent)  |
 
-### Two-Phase Shutdown
+Each predicate matches what the executor actually does: a `MaxRows == 0`
+portal (fetch-all) runs on a pooled connection, so it is a single query;
+a COPY adds `ReasonCopy` pooler-side (the request's reservation reasons
+can be 0 for an autocommit COPY), so it is always classified as a
+reservation by `id` alone rather than by reasons.
 
-When `OnStateChange` receives `NOT_SERVING`:
+#### Gateway cooperation
 
-1. **Phase 1 — Gate**: set `shuttingDown=true` (under mutex), then
-   release the mutex. New `StartRequest(false)` calls immediately
-   return `ErrShuttingDown`. Existing reserved connections continue.
+The pooler willingly serving single queries during stage 1 is only
+useful if the gateway actually sends them. Today, once a shard enters
+its failover buffer the gateway _proactively_ blocks every PRIMARY
+request. So `PoolerGateway.withBuffering` takes an `isSingleQuery` flag
+(set when there is no reservation and no existing reserved connection):
+single queries **skip the proactive block** and are sent straight to the
+pooler, buffering only _reactively_ if they bounce with `MTF01` (stage 2
+onward). New transactions keep the proactive block — the pooler rejects
+them throughout the drain, so a wasted round-trip is pointless.
 
-2. **Phase 2 — Drain**: call `poolManager.WaitForDrain(ctx)` with a
-   context bounded by `gracePeriod` (default 3s). This blocks until
-   all lent connections are returned or the timeout elapses.
+### Two-Stage Drain
 
-3. **Phase 3 — Complete**: re-acquire the mutex, set
-   `servingStatus=NOT_SERVING` and `shuttingDown=false`.
+When `OnStateChange` receives `NOT_SERVING`, it runs two drain stages
+under one `gracePeriod`-bounded deadline (default 3s). The `poolerType`
+is **not** updated until the very end, so in-flight reserved-connection
+ops still see the old type and pass `checkTargetLocked` throughout.
 
-If the grace period expires before drain completes, all remaining
-reserved connections are forcibly killed via
-`poolManager.CloseReservedConnections()`. This ensures no reserved
-connections survive into a non-serving state where they could execute
-queries against a demoted replica. The force-close kills the backend
-PostgreSQL processes and returns the connections to the pool.
+1. **Stage 1 — drain reserved**: set `drainPhase=drainReserved` (under
+   mutex), then call `poolManager.WaitForReservedDrain(ctx)`. New
+   reservations are rejected (`MTF01`); single queries are still served;
+   existing transactions run to completion. Blocks until `reservedCount`
+   hits zero or the deadline elapses.
+
+2. **Stage 2 — drain regular**: set `drainPhase=drainRegular`, then call
+   `poolManager.WaitForDrain(ctx)`. Now single queries are rejected too;
+   the wait blocks until the remaining in-flight single queries finish
+   (the combined total reaches zero, since reserved is already zero).
+
+3. **Complete**: re-acquire the mutex, set `poolerType`,
+   `servingStatus=NOT_SERVING`, and `drainPhase=drainNone`.
+
+If the shared deadline expires in either stage, all reserved connections
+are force-closed via `poolManager.CloseReservedConnections()` (killing
+the backend processes; their transactions surface `40001`), and the
+transition completes. Any still-running single queries are then killed
+by the postgres demotion that follows — acceptable, since that is
+exactly what the grace period bounds.
 
 A late operation (e.g. a `COMMIT`) that arrives after its reserved
-connection was force-closed is admitted by the gate (`allowOnShutdown`)
-but finds the connection gone, and the executor returns SQLSTATE
-`40001` so the client retries the whole transaction. See the Admission
-Control section above.
+connection was force-closed is admitted by the gate (`ExistingReserved`)
+but finds the connection gone, and the executor returns `40001` so the
+client retries the whole transaction. See Admission Control above.
 
 When `OnStateChange` receives `SERVING`, the transition is immediate:
-set `servingStatus=SERVING` and `shuttingDown=false`.
+set `servingStatus=SERVING` and `drainPhase=drainNone`.
 
 ## Callback Plumbing
 
@@ -198,7 +243,7 @@ Callbacks flow through the pool creation hierarchy:
 ```text
 Manager.createUserPoolSlow()
   │
-  │  creates closures: onBorrow = m.lentAdd(1), etc.
+  │  creates closures: onBorrow = m.regularAdd(1), onReserve = m.reservedAdd(1), etc.
   │
   └─► UserPoolConfig { OnBorrow, OnRecycle, OnReserve, OnRelease }
         │
@@ -210,23 +255,32 @@ Manager.createUserPoolSlow()
 ```
 
 Each user pool created by the manager gets its own set of callback
-closures that all funnel into the single `Manager.lentAdd` counter.
+closures that funnel into the `Manager.regularAdd` / `Manager.reservedAdd`
+counters.
 
 ## Configuration
 
 The drain grace period is configurable via the
-`--connpool-drain-grace-period` flag (default: 3s). This controls how
-long `OnStateChange` waits for in-flight connections to drain before
-force-closing reserved connections and completing the NOT_SERVING
-transition.
+`--connpool-drain-grace-period` flag (default: 3s). It is the single
+deadline shared by both drain stages: when it expires, remaining reserved
+connections are force-closed and the NOT_SERVING transition completes.
 
 ## Testing
 
-- **`connpoolmanager/drain_test.go`**: unit tests for `lentAdd`
-  counter and channel behavior, `WaitForDrain` immediate return,
-  blocking until zero, and context cancellation
-- **`poolerserver/pooler_test.go`**: unit tests for `StartRequest`
-  across all state combinations (serving, not serving, shutting down
-  with and without `allowOnShutdown`), concurrency tests for
-  `OnStateChange` drain behavior, grace period expiry, and
-  SERVING/NOT_SERVING round-trips
+- **`connpoolmanager/drain_test.go`**: unit tests for the `regularAdd` and
+  `reservedAdd` counters and their channels, `WaitForDrain` /
+  `WaitForReservedDrain` immediate-return, blocking-until-zero, and
+  context cancellation — including that a regular borrow does **not**
+  hold up the reserved-only wait
+- **`poolerserver/pooler_test.go`**: unit tests for `StartRequest` across
+  all `RequestKind` × drain-phase combinations, plus `OnStateChange`
+  two-stage drain behavior (single query served in stage 1, rejected in
+  stage 2), grace-period expiry in both stages, and SERVING/NOT_SERVING
+  round-trips
+- **`grpcpoolerservice/admission_test.go`**: the `admissionKind` classifier
+  (existing reserved / new reservation / single query)
+- **`poolergateway/pooler_gateway_test.go`**: the gateway `isSingleQuery`
+  classifier that decides which requests skip proactive failover buffering
+- End-to-end failover survival (continuous traffic across a planned
+  failover with zero client-visible errors) is covered by the existing
+  `queryserving` buffer tests (e.g. `TestBufferPlannedFailover`).

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -97,6 +97,16 @@ func NewPoolerGateway(
 	}
 }
 
+// isSingleQuery reports whether a request is a single autocommit query — no
+// existing reserved connection and not about to create one. Such queries can be
+// served on a pooler that is draining for a planned failover, so they skip the
+// proactive failover-buffer block (see withBuffering). It mirrors the pooler's
+// own classification (poolerserver.admissionKind); each caller computes
+// willReserve from the signal it carries (reservation options, portal MaxRows).
+func isSingleQuery(reservedConnID uint64, willReserve bool) bool {
+	return reservedConnID == 0 && !willReserve
+}
+
 // withBuffering wraps a query execution with failover buffering. It handles:
 //  1. Proactive buffering — if the shard is already known to be failing over,
 //     the request waits before sending any query (avoids a wasted round-trip).
@@ -121,6 +131,7 @@ func NewPoolerGateway(
 func (pg *PoolerGateway) withBuffering(
 	ctx context.Context,
 	target *query.Target,
+	singleQuery bool,
 	inner func(conn *PoolerConnection) error,
 ) error {
 	bufferedOnce := false
@@ -136,7 +147,17 @@ func (pg *PoolerGateway) withBuffering(
 			var bufErr error
 			if err == nil {
 				// Proactive: first attempt, check if shard is already buffering.
-				retryDone, bufErr = pg.buffer.WaitIfAlreadyBuffering(ctx, sk)
+				//
+				// Single autocommit queries skip the proactive block: a pooler
+				// draining for a planned failover can still serve them during the
+				// first drain stage, so we send them through and only buffer
+				// reactively (below) if they actually bounce with MTF01. New
+				// transactions/reservations keep the proactive block — the pooler
+				// rejects them throughout the drain, so a wasted round-trip is
+				// pointless.
+				if !singleQuery {
+					retryDone, bufErr = pg.buffer.WaitIfAlreadyBuffering(ctx, sk)
+				}
 			} else {
 				// Reactive: after a buffer-worthy error, wait for failover to end.
 				retryDone, bufErr = pg.buffer.WaitForFailoverEnd(ctx, sk)
@@ -210,7 +231,8 @@ func (pg *PoolerGateway) StreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	var state *query.ReservedState
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	// StreamExecute creates a reservation only when ReservationOptions is set.
+	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), reservationOptions != nil), func(conn *PoolerConnection) error {
 		var err error
 		state, err = conn.QueryService().StreamExecute(ctx, target, sql, options, reservationOptions, callback)
 		return err
@@ -224,7 +246,8 @@ func (pg *PoolerGateway) StreamExecute(
 func (pg *PoolerGateway) ExecuteQuery(ctx context.Context, target *query.Target, sql string, options *query.ExecuteOptions) (*sqltypes.Result, *query.ReservedState, error) {
 	var result *sqltypes.Result
 	var state *query.ReservedState
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	// ExecuteQuery cannot create a reservation.
+	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), false), func(conn *PoolerConnection) error {
 		var err error
 		result, state, err = conn.QueryService().ExecuteQuery(ctx, target, sql, options)
 		return err
@@ -244,7 +267,10 @@ func (pg *PoolerGateway) PortalStreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	var state *query.ReservedState
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	// A portal reserves a connection only as a suspendable cursor (MaxRows > 0);
+	// a fetch-all portal (MaxRows == 0) runs on a pooled connection and is a
+	// single query — mirrors the pooler's classification.
+	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), options.GetMaxRows() > 0), func(conn *PoolerConnection) error {
 		var err error
 		state, err = conn.QueryService().PortalStreamExecute(ctx, target, preparedStatement, portal, options, portalOptions, reservationOptions, callback)
 		return err
@@ -261,7 +287,8 @@ func (pg *PoolerGateway) Describe(
 	options *query.ExecuteOptions,
 ) (*query.StatementDescription, error) {
 	var desc *query.StatementDescription
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	// Describe never creates a reservation.
+	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), false), func(conn *PoolerConnection) error {
 		var err error
 		desc, err = conn.QueryService().Describe(ctx, target, preparedStatement, portal, options)
 		return err
@@ -283,7 +310,7 @@ func (pg *PoolerGateway) CopyReady(
 		colFormats []int16
 		state      *query.ReservedState
 	)
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	err := pg.withBuffering(ctx, target, false, func(conn *PoolerConnection) error {
 		var err error
 		format, colFormats, state, err = conn.QueryService().CopyReady(ctx, target, copyQuery, options, reservationOptions)
 		return err
@@ -307,7 +334,7 @@ func (pg *PoolerGateway) CopyOutReady(
 		notices    []*mterrors.PgDiagnostic
 		state      *query.ReservedState
 	)
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	err := pg.withBuffering(ctx, target, false, func(conn *PoolerConnection) error {
 		var err error
 		format, colFormats, notices, state, err = conn.QueryService().CopyOutReady(ctx, target, copyQuery, options, reservationOptions)
 		return err
@@ -370,7 +397,7 @@ func (pg *PoolerGateway) GetAuthCredentials(ctx context.Context, req *multipoole
 	}
 
 	var resp *multipoolerpb.GetAuthCredentialsResponse
-	err := pg.withBuffering(ctx, target, func(conn *PoolerConnection) error {
+	err := pg.withBuffering(ctx, target, false, func(conn *PoolerConnection) error {
 		var err error
 		resp, err = conn.ServiceClient().GetAuthCredentials(ctx, req)
 		// Convert gRPC error so classifyError can read the PgDiagnostic SQLSTATE for buffering.

--- a/go/services/multigateway/poolergateway/pooler_gateway_test.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway_test.go
@@ -90,3 +90,36 @@ func TestClassifyError(t *testing.T) {
 		})
 	}
 }
+
+// TestIsSingleQuery covers the classification that decides whether a request
+// skips proactive failover buffering. Only a request with no existing reserved
+// connection AND that will not create one is a single query. The scenarios are
+// labelled by the handler input that produces each (reservedConnID, willReserve)
+// pair, so this also documents what each handler passes:
+//
+//   - StreamExecute:        willReserve = ReservationOptions != nil
+//   - ExecuteQuery/Describe: willReserve = false (no reservation path)
+//   - PortalStreamExecute:   willReserve = MaxRows > 0 (suspendable cursor)
+//   - CopyReady/CopyOutReady/GetAuthCredentials: always proactively buffered
+//     (pass singleQuery=false directly; not via this helper)
+func TestIsSingleQuery(t *testing.T) {
+	tests := []struct {
+		name           string
+		reservedConnID uint64
+		willReserve    bool
+		want           bool
+	}{
+		{"StreamExecute autocommit (no reservation, no conn)", 0, false, true},
+		{"ExecuteQuery/Describe standalone (no conn)", 0, false, true},
+		{"PortalStreamExecute fetch-all (MaxRows==0, no conn)", 0, false, true},
+		{"StreamExecute new transaction (reservation requested)", 0, true, false},
+		{"PortalStreamExecute cursor (MaxRows>0)", 0, true, false},
+		{"on an existing reserved connection (never a single query)", 42, false, false},
+		{"existing reserved conn + would reserve", 42, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSingleQuery(tt.reservedConnID, tt.willReserve))
+		})
+	}
+}

--- a/go/services/multipooler/grpcpoolerservice/admission_test.go
+++ b/go/services/multipooler/grpcpoolerservice/admission_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcpoolerservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
+)
+
+// TestAdmissionKind locks the request classification used by every query
+// handler. The scenarios are labelled by the handler input that produces them,
+// so this doubles as documentation of each handler's intended mapping:
+//
+//   - id > 0          → ExistingReserved (ConcludeTransaction, DiscardTempTables,
+//     ReleaseReservedConnection, or any handler continuing a reserved conn)
+//   - id == 0, reserves → NewReservation (StreamExecute with reservation reasons,
+//     PortalStreamExecute with MaxRows > 0, CopyBidiExecute which always pins)
+//   - id == 0, !reserves → SingleQuery (StreamExecute without reasons,
+//     ExecuteQuery/Describe, PortalStreamExecute with MaxRows == 0)
+func TestAdmissionKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		connID   uint64
+		reserves bool
+		want     poolerserver.RequestKind
+	}{
+		{"existing reserved ignores reserves=false", 42, false, poolerserver.RequestExistingReserved},
+		{"existing reserved ignores reserves=true", 42, true, poolerserver.RequestExistingReserved},
+		{"fresh request that reserves → new reservation", 0, true, poolerserver.RequestNewReservation},
+		{"fresh request that does not reserve → single query", 0, false, poolerserver.RequestSingleQuery},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, admissionKind(tt.connID, tt.reserves))
+		})
+	}
+}

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -59,15 +59,33 @@ func RegisterPoolerServices(senv *servenv.ServEnv, grpc *servenv.GrpcServer) {
 	})
 }
 
+// admissionKind classifies a query-path request for StartRequest. A non-zero
+// reservedConnID means it continues an EXISTING reserved connection; otherwise
+// reserves reports whether the request will create a NEW reserved connection —
+// if not, it is a single autocommit query. Each handler computes reserves from
+// the signal it actually carries, mirroring the executor's own reservation
+// decision (reservation reasons for StreamExecute, MaxRows for portals, always
+// for COPY). The graceful drain serves single queries longer than new
+// reservations, so the distinction matters during shutdown.
+func admissionKind(reservedConnID uint64, reserves bool) poolerserver.RequestKind {
+	switch {
+	case reservedConnID > 0:
+		return poolerserver.RequestExistingReserved
+	case reserves:
+		return poolerserver.RequestNewReservation
+	default:
+		return poolerserver.RequestSingleQuery
+	}
+}
+
 // StreamExecute executes a SQL query and streams the results back to the client.
 // This is the main execution method used by multigateway.
 // When req.ReservationOptions has non-zero reasons, creates or extends a reserved connection.
 func (s *poolerService) StreamExecute(req *multipoolerpb.StreamExecuteRequest, stream multipoolerpb.MultiPoolerService_StreamExecuteServer) error {
-	// Allow during shutdown if using an existing reserved connection.
-	// For new reservations (ReservationOptions has reasons but no ReservedConnectionId),
-	// block during shutdown since new reservations should not be created.
-	isExistingReserved := req.Options.GetReservedConnectionId() > 0
-	if err := s.pooler.StartRequest(req.Target, isExistingReserved); err != nil {
+	// StreamExecute is the only query handler that can create a new reservation
+	// (ReservationOptions reasons with no ReservedConnectionId). Classify it so a
+	// graceful drain keeps serving single queries while rejecting new transactions.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), req.GetReservationOptions().GetReasons() != 0)); err != nil {
 		return mterrors.ToGRPC(err)
 	}
 
@@ -133,7 +151,8 @@ func (s *poolerService) StreamExecute(req *multipoolerpb.StreamExecuteRequest, s
 // This should be used sparingly only when we know the result set is small,
 // otherwise StreamExecute should be used.
 func (s *poolerService) ExecuteQuery(ctx context.Context, req *multipoolerpb.ExecuteQueryRequest) (*multipoolerpb.ExecuteQueryResponse, error) {
-	if err := s.pooler.StartRequest(req.Target, req.Options.GetReservedConnectionId() > 0); err != nil {
+	// No ReservationOptions: an existing reserved connection, otherwise a single query.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), false)); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 
@@ -174,7 +193,9 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 		return nil, status.Error(codes.Unavailable, "pooler not initialized")
 	}
 
-	if err := s.pooler.StartRequest(nil, false); err != nil {
+	// Admin credential fetch (not a query). Treat like a new reservation so it is
+	// buffered during any drain — the same behavior as before the two-stage drain.
+	if err := s.pooler.StartRequest(nil, poolerserver.RequestNewReservation); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 
@@ -259,7 +280,8 @@ func (s *poolerService) GetAuthCredentials(ctx context.Context, req *multipooler
 // Describe returns metadata about a prepared statement or portal.
 // Used by multigateway for the Extended Query Protocol.
 func (s *poolerService) Describe(ctx context.Context, req *multipoolerpb.DescribeRequest) (*multipoolerpb.DescribeResponse, error) {
-	if err := s.pooler.StartRequest(req.Target, req.Options.GetReservedConnectionId() > 0); err != nil {
+	// No ReservationOptions: an existing reserved connection, otherwise a single query.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), false)); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 
@@ -284,7 +306,11 @@ func (s *poolerService) Describe(ctx context.Context, req *multipoolerpb.Describ
 // PortalStreamExecute executes a portal (bound prepared statement) and streams results.
 // Used by multigateway for the Extended Query Protocol.
 func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecuteRequest, stream multipoolerpb.MultiPoolerService_PortalStreamExecuteServer) error {
-	if err := s.pooler.StartRequest(req.Target, req.Options.GetReservedConnectionId() > 0); err != nil {
+	// A portal reserves a connection only when it is a suspendable cursor
+	// (MaxRows > 0) or already on a reserved connection — this mirrors the
+	// executor's own reserve decision. A MaxRows == 0 portal (fetch-all) runs on
+	// a pooled connection, so it is a single query and may be served during stage 1.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), req.Options.GetMaxRows() > 0)); err != nil {
 		return mterrors.ToGRPC(err)
 	}
 
@@ -376,7 +402,11 @@ func (s *poolerService) CopyBidiExecute(stream multipoolerpb.MultiPoolerService_
 		return status.Errorf(codes.InvalidArgument, "expected INITIATE, got %v", req.Phase)
 	}
 
-	if err := s.pooler.StartRequest(req.Target, req.Options.GetReservedConnectionId() > 0); err != nil {
+	// COPY always pins a connection (the executor adds ReasonCopy internally, so
+	// reservation reasons in the request can be 0 for an autocommit COPY that
+	// still reserves). So a COPY without an existing reserved connection is always
+	// a new reservation, never a single query.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), true)); err != nil {
 		return mterrors.ToGRPC(err)
 	}
 
@@ -691,8 +721,8 @@ func (s *poolerService) copyBidiExecuteToStdout(
 // ConcludeTransaction concludes a transaction on a reserved connection.
 // Executes COMMIT or ROLLBACK based on the conclusion. Returns remaining reasons if connection is still reserved.
 func (s *poolerService) ConcludeTransaction(ctx context.Context, req *multipoolerpb.ConcludeTransactionRequest) (*multipoolerpb.ConcludeTransactionResponse, error) {
-	// Always on existing reserved connection, allow during shutdown.
-	if err := s.pooler.StartRequest(req.Target, true); err != nil {
+	// Always on an existing reserved connection — admitted regardless of drain.
+	if err := s.pooler.StartRequest(req.Target, poolerserver.RequestExistingReserved); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 
@@ -723,8 +753,8 @@ func (s *poolerService) ConcludeTransaction(ctx context.Context, req *multipoole
 // DiscardTempTables sends DISCARD TEMP on a reserved connection and removes the temp table reason.
 // Returns remaining reasons if connection is still reserved.
 func (s *poolerService) DiscardTempTables(ctx context.Context, req *multipoolerpb.DiscardTempTablesRequest) (*multipoolerpb.DiscardTempTablesResponse, error) {
-	// Always on existing reserved connection, allow during shutdown.
-	if err := s.pooler.StartRequest(req.Target, true); err != nil {
+	// Always on an existing reserved connection — admitted regardless of drain.
+	if err := s.pooler.StartRequest(req.Target, poolerserver.RequestExistingReserved); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 
@@ -747,8 +777,8 @@ func (s *poolerService) DiscardTempTables(ctx context.Context, req *multipoolerp
 
 // ReleaseReservedConnection forcefully releases a reserved connection regardless of reason.
 func (s *poolerService) ReleaseReservedConnection(ctx context.Context, req *multipoolerpb.ReleaseReservedConnectionRequest) (*multipoolerpb.ReleaseReservedConnectionResponse, error) {
-	// Always on existing reserved connection, allow during shutdown.
-	if err := s.pooler.StartRequest(req.Target, true); err != nil {
+	// Always on an existing reserved connection — admitted regardless of drain.
+	if err := s.pooler.StartRequest(req.Target, poolerserver.RequestExistingReserved); err != nil {
 		return nil, mterrors.ToGRPC(err)
 	}
 

--- a/go/services/multipooler/internal/connpoolmanager/drain_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/drain_test.go
@@ -29,10 +29,13 @@ func newDrainTestManager() *Manager {
 	zeroCh := make(chan struct{})
 	close(zeroCh)
 	m.zeroCh = zeroCh
+	reservedZeroCh := make(chan struct{})
+	close(reservedZeroCh)
+	m.reservedZeroCh = reservedZeroCh
 	return m
 }
 
-func TestLentAdd_CounterAndChannel(t *testing.T) {
+func TestRegularAdd_CounterAndChannel(t *testing.T) {
 	m := newDrainTestManager()
 
 	// Initially at zero, channel should be closed (drained)
@@ -44,8 +47,8 @@ func TestLentAdd_CounterAndChannel(t *testing.T) {
 	}
 
 	// Add one: should create a new open channel
-	m.lentAdd(1)
-	assert.Equal(t, int64(1), m.lentCount)
+	m.regularAdd(1)
+	assert.Equal(t, int64(1), m.regularCount)
 	select {
 	case <-m.zeroCh:
 		t.Fatal("expected zeroCh to be open when count > 0")
@@ -54,12 +57,12 @@ func TestLentAdd_CounterAndChannel(t *testing.T) {
 	}
 
 	// Add another
-	m.lentAdd(1)
-	assert.Equal(t, int64(2), m.lentCount)
+	m.regularAdd(1)
+	assert.Equal(t, int64(2), m.regularCount)
 
 	// Return one: still > 0, channel should still be open
-	m.lentAdd(-1)
-	assert.Equal(t, int64(1), m.lentCount)
+	m.regularAdd(-1)
+	assert.Equal(t, int64(1), m.regularCount)
 	select {
 	case <-m.zeroCh:
 		t.Fatal("expected zeroCh to be open when count > 0")
@@ -68,8 +71,8 @@ func TestLentAdd_CounterAndChannel(t *testing.T) {
 	}
 
 	// Return last one: back to zero, channel should be closed
-	m.lentAdd(-1)
-	assert.Equal(t, int64(0), m.lentCount)
+	m.regularAdd(-1)
+	assert.Equal(t, int64(0), m.regularCount)
 	select {
 	case <-m.zeroCh:
 		// expected: channel is closed
@@ -93,7 +96,7 @@ func TestWaitForDrain_BlocksUntilZero(t *testing.T) {
 	m := newDrainTestManager()
 
 	// Simulate a lent connection
-	m.lentAdd(1)
+	m.regularAdd(1)
 
 	var wg sync.WaitGroup
 	var drainErr error
@@ -108,7 +111,7 @@ func TestWaitForDrain_BlocksUntilZero(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Return the connection
-	m.lentAdd(-1)
+	m.regularAdd(-1)
 
 	wg.Wait()
 	require.NoError(t, drainErr)
@@ -118,7 +121,7 @@ func TestWaitForDrain_RespectsContextCancellation(t *testing.T) {
 	m := newDrainTestManager()
 
 	// Simulate a lent connection that never returns
-	m.lentAdd(1)
+	m.regularAdd(1)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
@@ -126,4 +129,98 @@ func TestWaitForDrain_RespectsContextCancellation(t *testing.T) {
 	err := m.WaitForDrain(ctx)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestWaitForReservedDrain_IgnoresRegularBorrows is the crux of the two-stage
+// drain: regular (single-query) borrows must NOT hold up the reserved-only wait,
+// so stage 1 can complete while single queries keep flowing.
+func TestWaitForReservedDrain_IgnoresRegularBorrows(t *testing.T) {
+	m := newDrainTestManager()
+
+	// A regular borrow bumps the regular count but not the reserved count.
+	m.regularAdd(1)
+	assert.Equal(t, int64(1), m.regularCount)
+	assert.Equal(t, int64(0), m.reservedCount)
+
+	// WaitForReservedDrain returns immediately despite the in-flight regular borrow.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	require.NoError(t, m.WaitForReservedDrain(ctx))
+
+	// WaitForDrain, by contrast, still blocks on the regular borrow (combined > 0).
+	require.Error(t, m.WaitForDrain(ctx))
+
+	m.regularAdd(-1)
+}
+
+// TestSignalZeroChan_ReArmsAcrossCycles drives the combined drain channel
+// through 0 → positive → 0 → positive with mixed regular and reserved adds,
+// confirming zeroCh closes at zero and re-arms (a fresh open channel) when the
+// total goes positive again.
+func TestSignalZeroChan_ReArmsAcrossCycles(t *testing.T) {
+	m := newDrainTestManager()
+
+	isClosed := func(ch chan struct{}) bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}
+
+	// Starts drained.
+	assert.True(t, isClosed(m.zeroCh), "zeroCh should start closed")
+
+	// Cycle 1: a regular borrow and a reserved conn both lift the combined total.
+	m.regularAdd(1)
+	assert.False(t, isClosed(m.zeroCh), "combined open after regular borrow")
+	m.reservedAdd(1)
+	assert.False(t, isClosed(m.zeroCh), "combined still open with both")
+	assert.False(t, isClosed(m.reservedZeroCh), "reserved open with a reserved conn")
+
+	// Release the regular borrow: combined still > 0 (reserved remains).
+	m.regularAdd(-1)
+	assert.False(t, isClosed(m.zeroCh), "combined still open while reserved > 0")
+
+	// Release the reserved conn: both reach zero and close.
+	m.reservedAdd(-1)
+	assert.True(t, isClosed(m.zeroCh), "combined closed when total reaches zero")
+	assert.True(t, isClosed(m.reservedZeroCh), "reserved closed when reserved reaches zero")
+
+	// Cycle 2: the channel must re-arm — a new borrow re-opens the closed zeroCh.
+	m.regularAdd(1)
+	assert.False(t, isClosed(m.zeroCh), "zeroCh must re-arm (re-open) on 0→positive")
+	m.regularAdd(-1)
+	assert.True(t, isClosed(m.zeroCh), "zeroCh closes again at zero")
+}
+
+// TestWaitForReservedDrain_BlocksUntilReservedZero verifies a reserved
+// connection (a single reservedAdd) holds the reserved wait open and also keeps
+// the combined drain non-zero.
+func TestWaitForReservedDrain_BlocksUntilReservedZero(t *testing.T) {
+	m := newDrainTestManager()
+
+	// onReserve is a single reservedAdd; the combined total is regular + reserved.
+	m.reservedAdd(1)
+	assert.Equal(t, int64(1), m.reservedCount)
+	assert.Equal(t, int64(0), m.regularCount)
+
+	var wg sync.WaitGroup
+	var drainErr error
+	wg.Go(func() {
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
+		drainErr = m.WaitForReservedDrain(ctx)
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	// onRelease.
+	m.reservedAdd(-1)
+
+	wg.Wait()
+	require.NoError(t, drainErr)
+	assert.Equal(t, int64(0), m.reservedCount)
+	// Combined drain is also satisfied now.
+	require.NoError(t, m.WaitForDrain(t.Context()))
 }

--- a/go/services/multipooler/internal/connpoolmanager/interface.go
+++ b/go/services/multipooler/internal/connpoolmanager/interface.go
@@ -108,6 +108,12 @@ type PoolManager interface {
 	// Used during graceful shutdown to wait for in-flight queries to complete.
 	WaitForDrain(ctx context.Context) error
 
+	// WaitForReservedDrain blocks until all RESERVED connections (transactions,
+	// temp tables, portals, COPY) have been released or ctx is cancelled. It
+	// ignores transient single-query borrows, so the first stage of a graceful
+	// drain can wait for transactions while still serving single queries.
+	WaitForReservedDrain(ctx context.Context) error
+
 	// CloseReservedConnections kills all active reserved connections across all user pools.
 	// Used after drain grace period expires to prevent reserved connections from being
 	// used in a non-serving state.

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -137,9 +137,20 @@ type Manager struct {
 
 	// Drain tracking: counts connections currently lent out across all pools.
 	// Used for graceful drain during state transitions (NOT_SERVING).
-	drainMu   sync.Mutex
-	lentCount int64
-	zeroCh    chan struct{}
+	//
+	// regularCount tracks regular (single-query) borrows; reservedCount tracks
+	// reserved connections (transactions, temp tables, portals, COPY, etc.). They
+	// are kept separate so a borrow/recycle or reserve/release touches exactly one
+	// counter under a single lock acquisition. The combined total (regularCount +
+	// reservedCount) drives zeroCh; reservedCount alone drives reservedZeroCh. The
+	// two-stage drain waits on reservedZeroCh first (let transactions finish while
+	// still serving single queries), then on zeroCh (let the remaining in-flight
+	// single queries finish). All guarded by drainMu.
+	drainMu        sync.Mutex
+	regularCount   int64
+	reservedCount  int64
+	zeroCh         chan struct{} // closed when regularCount + reservedCount == 0
+	reservedZeroCh chan struct{} // closed when reservedCount == 0
 }
 
 // CredentialQueryRecorder returns a narrow recorder for the gRPC service's
@@ -172,6 +183,11 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 	zeroCh := make(chan struct{})
 	close(zeroCh)
 	m.zeroCh = zeroCh
+
+	// Same for the reserved-only drain channel.
+	reservedZeroCh := make(chan struct{})
+	close(reservedZeroCh)
+	m.reservedZeroCh = reservedZeroCh
 	m.settingsCache = connstate.NewSettingsCache(m.config.SettingsCacheSize())
 	m.setLifecycle(lifecycleRunning)
 
@@ -363,10 +379,13 @@ func (m *Manager) createUserPoolSlow(ctx context.Context, user string, clientKey
 
 	// Create drain tracking callbacks for this user pool.
 	// These are called on every borrow/recycle/reserve/release to track lent connections.
-	onBorrow := func() { m.lentAdd(1) }
-	onRecycle := func() { m.lentAdd(-1) }
-	onReserve := func() { m.lentAdd(1) }
-	onRelease := func() { m.lentAdd(-1) }
+	// Regular borrows and reserved connections bump separate counters, so each
+	// event takes the drain lock exactly once. The combined total drives the
+	// full drain; the reserved count alone drives the reserved-only drain.
+	onBorrow := func() { m.regularAdd(1) }
+	onRecycle := func() { m.regularAdd(-1) }
+	onReserve := func() { m.reservedAdd(1) }
+	onRelease := func() { m.reservedAdd(-1) }
 
 	// Create new user pool with per-user pool names for metric cardinality.
 	// Note: Including username in pool names enables per-user monitoring but increases
@@ -847,40 +866,92 @@ type ManagerStats struct {
 	UserPools map[string]UserPoolStats // Per-user pool stats
 }
 
-// lentAdd adjusts the lent connection count by n.
-// When the count transitions to zero, zeroCh is closed to unblock WaitForDrain.
-// When it transitions away from zero, a new zeroCh is created.
-func (m *Manager) lentAdd(n int64) {
-	m.drainMu.Lock()
-	defer m.drainMu.Unlock()
-
-	if m.lentCount+n < 0 {
-		m.logger.Error("lentCount going negative, likely a bug in borrow/recycle or reserve/release callbacks",
-			"current", m.lentCount, "delta", n)
-	}
-	m.lentCount += n
-	if m.lentCount == 0 {
-		// Signal drain complete by closing the channel.
+// signalZeroChanLocked reconciles a drain channel with its counter total: it
+// closes ch when total has reached zero (releasing WaitFor* callers), or re-arms
+// a fresh open channel when total is positive but ch is still closed from a prior
+// drain. Caller must hold drainMu.
+func signalZeroChanLocked(total int64, ch *chan struct{}) {
+	if total == 0 {
 		select {
-		case <-m.zeroCh:
+		case <-*ch:
 			// Already closed, nothing to do.
 		default:
-			close(m.zeroCh)
+			close(*ch)
 		}
-	} else if m.lentCount == n && n > 0 {
-		// Transitioned from 0 to positive: create a new open channel.
-		m.zeroCh = make(chan struct{})
+		return
+	}
+	// total > 0: ensure an open channel for future waiters.
+	select {
+	case <-*ch:
+		// Was closed (drained); re-arm.
+		*ch = make(chan struct{})
+	default:
+		// Already open.
 	}
 }
 
-// WaitForDrain blocks until all lent connections have been returned or ctx is cancelled.
+// regularAdd adjusts the regular (single-query) borrow count by n. It touches
+// only zeroCh (the combined drain) — regular borrows never affect the
+// reserved-only drain.
+func (m *Manager) regularAdd(n int64) {
+	m.drainMu.Lock()
+	defer m.drainMu.Unlock()
+
+	if m.regularCount+n < 0 {
+		m.logger.Error("regularCount going negative, likely a bug in borrow/recycle callbacks",
+			"current", m.regularCount, "delta", n)
+	}
+	m.regularCount += n
+	signalZeroChanLocked(m.regularCount+m.reservedCount, &m.zeroCh)
+}
+
+// reservedAdd adjusts the reserved connection count by n. A reserved connection
+// affects both drains, so it reconciles reservedZeroCh and the combined zeroCh —
+// under a single lock acquisition (unlike calling two separate *Add methods).
+func (m *Manager) reservedAdd(n int64) {
+	m.drainMu.Lock()
+	defer m.drainMu.Unlock()
+
+	if m.reservedCount+n < 0 {
+		m.logger.Error("reservedCount going negative, likely a bug in reserve/release callbacks",
+			"current", m.reservedCount, "delta", n)
+	}
+	m.reservedCount += n
+	signalZeroChanLocked(m.reservedCount, &m.reservedZeroCh)
+	signalZeroChanLocked(m.regularCount+m.reservedCount, &m.zeroCh)
+}
+
+// WaitForDrain blocks until all lent connections (regular + reserved) have been
+// returned or ctx is cancelled.
 func (m *Manager) WaitForDrain(ctx context.Context) error {
 	m.drainMu.Lock()
-	if m.lentCount == 0 {
+	if m.regularCount+m.reservedCount == 0 {
 		m.drainMu.Unlock()
 		return nil
 	}
 	ch := m.zeroCh
+	m.drainMu.Unlock()
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// WaitForReservedDrain blocks until all RESERVED connections (transactions, temp
+// tables, portals, COPY, etc.) have been released or ctx is cancelled. Unlike
+// WaitForDrain it ignores transient single-query borrows, so the first stage of
+// a graceful drain can wait for in-flight transactions to finish while the
+// pooler keeps serving single autocommit queries.
+func (m *Manager) WaitForReservedDrain(ctx context.Context) error {
+	m.drainMu.Lock()
+	if m.reservedCount == 0 {
+		m.drainMu.Unlock()
+		return nil
+	}
+	ch := m.reservedZeroCh
 	m.drainMu.Unlock()
 
 	select {

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -154,6 +154,7 @@ func (m *stubPoolManager) ApplySettingsToConn(context.Context, *regular.Conn, ma
 	return nil
 }
 func (m *stubPoolManager) WaitForDrain(context.Context) error           { return nil }
+func (m *stubPoolManager) WaitForReservedDrain(context.Context) error   { return nil }
 func (m *stubPoolManager) CloseReservedConnections(context.Context) int { return 0 }
 func (m *stubPoolManager) Stats() connpoolmanager.ManagerStats          { return connpoolmanager.ManagerStats{} }
 func (m *stubPoolManager) CredentialQueryRecorder() connpoolmanager.CredentialQueryRecorder {

--- a/go/services/multipooler/internal/manager/pg_multischema_test.go
+++ b/go/services/multipooler/internal/manager/pg_multischema_test.go
@@ -47,7 +47,11 @@ func (m *mockPoolerController) IsServing() bool            { return true }
 func (m *mockPoolerController) OnStateChange(context.Context, clustermetadatapb.PoolerType, clustermetadatapb.PoolerServingStatus) error {
 	return nil
 }
-func (m *mockPoolerController) StartRequest(*query.Target, bool) error { return nil }
+
+func (m *mockPoolerController) StartRequest(*query.Target, poolerserver.RequestKind) error {
+	return nil
+}
+
 func (m *mockPoolerController) AwaitStateChange(context.Context, clustermetadatapb.PoolerType, clustermetadatapb.PoolerServingStatus) {
 }
 func (m *mockPoolerController) Executor() (queryservice.QueryService, error) { return nil, nil }

--- a/go/services/multipooler/internal/poolerserver/controller.go
+++ b/go/services/multipooler/internal/poolerserver/controller.go
@@ -51,16 +51,14 @@ type PoolerController interface {
 	// Returns error if the transition fails.
 	OnStateChange(ctx context.Context, poolerType clustermetadatapb.PoolerType, servingStatus clustermetadatapb.PoolerServingStatus) error
 
-	// StartRequest checks whether a new request should be admitted.
-	// For fresh requests (allowOnShutdown=false) it validates that the target's
-	// pooler type matches this pooler's actual type (returning MTF01 on mismatch
-	// to trigger gateway buffering) and checks serving status. allowOnShutdown=true
-	// marks an in-flight operation on an existing reserved connection: it is
-	// admitted regardless of serving status or demotion (the reserved connection
-	// is the real gate), so in-flight transactions can complete on the live backend
-	// — or surface an honest 40001 from the executor if the connection was already
-	// force-closed during the drain.
-	StartRequest(target *query.Target, allowOnShutdown bool) error
+	// StartRequest checks whether a request should be admitted, based on its
+	// RequestKind and the pooler's drain phase. It returns MTF01 (which the
+	// gateway buffers and retries on the new primary) when rejected. Existing
+	// reserved-connection ops are always admitted (the connection's existence is
+	// the real gate); during a graceful drain, single queries are served until
+	// the reserved pool has drained, while new reservations are rejected
+	// throughout. See StartRequest for the full admission matrix.
+	StartRequest(target *query.Target, kind RequestKind) error
 
 	// AwaitStateChange blocks until the pooler's type and serving status match
 	// the given targets, or ctx is cancelled. Used by the health streamer to

--- a/go/services/multipooler/internal/poolerserver/metrics_test.go
+++ b/go/services/multipooler/internal/poolerserver/metrics_test.go
@@ -144,7 +144,7 @@ func TestDrainMetricForceCloseOutcome(t *testing.T) {
 	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 
 	// Simulate an in-flight connection that never returns → WaitForDrain blocks until grace period.
-	mock.lentAdd(1)
+	mock.regularAdd(1)
 	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
 
 	assert.Equal(t, int64(0), readCounterByOutcome(t, reader, "mg.pooler.drain.outcome", "graceful"))

--- a/go/services/multipooler/internal/poolerserver/pooler.go
+++ b/go/services/multipooler/internal/poolerserver/pooler.go
@@ -60,10 +60,9 @@ type QueryPoolerServer struct {
 	// pubsubListener is the shared LISTEN/NOTIFY listener, set by MultiPoolerManager.
 	pubsubListener *pubsub.Listener
 
-	// shuttingDown is true during the graceful drain phase (between receiving
-	// NOT_SERVING and completing the transition). During this phase, new requests
-	// are rejected but existing reserved connections are allowed to finish.
-	shuttingDown bool
+	// drainPhase tracks the graceful-drain stage during a NOT_SERVING transition.
+	// See drainPhase constants and StartRequest for the admission rules per stage.
+	drainPhase drainPhase
 
 	// gracePeriod is how long OnStateChange waits for in-flight connections to drain
 	// before force-closing reserved connections. Configured via --connpool-drain-grace-period.
@@ -77,6 +76,43 @@ type QueryPoolerServer struct {
 	// drainStats holds drain-observability metrics. Never nil.
 	drainStats *drainStats
 }
+
+// drainPhase is the stage of a graceful NOT_SERVING transition. The drain runs
+// in two stages so single autocommit queries keep flowing while transactions
+// finish, and the pooler reports NOT_SERVING only once nothing is in flight.
+type drainPhase int
+
+const (
+	// drainNone: not draining. Normal serving (or already NOT_SERVING).
+	drainNone drainPhase = iota
+	// drainReserved: stage 1 — waiting for reserved connections (transactions)
+	// to finish. New reservations are rejected; single queries are still served;
+	// existing reserved connections continue.
+	drainReserved
+	// drainRegular: stage 2 — transactions are drained; now also reject single
+	// queries and wait for the remaining in-flight ones to finish, so the cutover
+	// happens with zero in-flight work.
+	drainRegular
+)
+
+// RequestKind classifies an incoming request for admission control during a
+// graceful drain. It is computed by the gRPC handlers from the request's
+// reservation fields and passed to StartRequest.
+type RequestKind int
+
+const (
+	// RequestExistingReserved is an op on an EXISTING reserved connection
+	// (continuing a transaction, COMMIT/ROLLBACK, temp-table cleanup, etc.).
+	// Always admitted; the reserved connection's existence is the real gate.
+	RequestExistingReserved RequestKind = iota
+	// RequestSingleQuery is a one-off autocommit query that holds no reserved
+	// connection. Served during stage 1 of the drain; rejected from stage 2 on.
+	RequestSingleQuery
+	// RequestNewReservation starts a NEW reserved connection (BEGIN/first
+	// transaction statement, new temp table, portal, COPY). Rejected for the
+	// whole drain so no new transactions accumulate.
+	RequestNewReservation
+)
 
 // NewQueryPoolerServer creates a new QueryPoolerServer instance with the given pool manager
 // and health provider.
@@ -110,10 +146,21 @@ func NewQueryPoolerServer(logger *slog.Logger, poolManager connpoolmanager.PoolM
 // This method is only called by the StateManager, which serializes calls behind
 // a mutex. Concurrent calls are not possible or expected.
 //
-// For NOT_SERVING transitions, this performs a two-phase graceful drain:
-//  1. Set shuttingDown=true to reject new requests (existing reserved connections continue)
-//  2. Wait for in-flight connections to drain (up to gracePeriod)
-//  3. Set servingStatus=NOT_SERVING
+// For NOT_SERVING transitions, this performs a two-stage graceful drain under a
+// single gracePeriod deadline:
+//  1. drainReserved — reject new transactions/reservations, keep serving single
+//     autocommit queries, and wait for in-flight transactions (reserved
+//     connections) to finish.
+//  2. drainRegular — also reject single queries, and wait for the remaining
+//     in-flight ones to finish, so the cutover happens with zero in-flight work
+//     and the subsequent postgres demotion kills nothing.
+//  3. Set servingStatus=NOT_SERVING.
+//
+// If the shared deadline expires in either stage, all reserved connections are
+// force-closed (their transactions surface 40001) and the transition completes;
+// any still-running single queries are killed by the postgres demotion that
+// follows. On timeout, errors are acceptable — that is what the grace period
+// bounds.
 func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType clustermetadatapb.PoolerType, servingStatus clustermetadatapb.PoolerServingStatus) error {
 	s.mu.Lock()
 
@@ -124,22 +171,22 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 	if servingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
 		s.poolerType = poolerType
 		s.servingStatus = servingStatus
-		s.shuttingDown = false
+		s.drainPhase = drainNone
 		s.notifyStateChangedLocked()
 		s.mu.Unlock()
 		return nil
 	}
 
-	// NOT_SERVING: begin graceful drain.
+	// NOT_SERVING: begin stage 1 of the graceful drain.
 	// The poolerType is NOT updated yet — in-flight requests on reserved
 	// connections (e.g., COMMIT after a demotion) must still see the old type
 	// so that checkTargetLocked allows them to complete.
-	s.shuttingDown = true
+	s.drainPhase = drainReserved
 	s.mu.Unlock()
 
-	// Wait for in-flight connections to drain.
-	// If gracePeriod > 0, the wait is bounded and reserved connections are force-closed on timeout.
-	// If gracePeriod == 0, the wait is unbounded (drain must complete before transition finishes).
+	// Both stages share one deadline bounded by gracePeriod. If gracePeriod == 0
+	// the wait is unbounded (each stage still terminates because it rejects the
+	// new work that would otherwise keep its pool non-empty).
 	if s.poolManager != nil {
 		drainStart := time.Now()
 		drainCtx := ctx
@@ -150,13 +197,24 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 		}
 
 		outcome := drainOutcomeGraceful
-		if err := s.poolManager.WaitForDrain(drainCtx); err != nil {
+		// Stage 1: wait for transactions to finish while single queries flow.
+		if err := s.poolManager.WaitForReservedDrain(drainCtx); err != nil {
 			outcome = drainOutcomeForceClose
+		} else {
+			// Stage 2: stop serving single queries, then wait for the in-flight
+			// ones to complete.
+			s.setDrainPhase(drainRegular)
+			if err := s.poolManager.WaitForDrain(drainCtx); err != nil {
+				outcome = drainOutcomeForceClose
+			}
+		}
+
+		if outcome == drainOutcomeForceClose {
 			s.logger.WarnContext(ctx, "Graceful drain did not complete within grace period, force-closing reserved connections",
-				"grace_period", s.gracePeriod, "error", err)
-			// Force-close all reserved connections to prevent them from being used
-			// in a non-serving state. This kills backend processes and returns
-			// connections to the pool.
+				"grace_period", s.gracePeriod)
+			// Force-close all reserved connections so no transaction survives into
+			// a non-serving state. In-flight single queries (if any) are killed by
+			// the postgres demotion that follows the NOT_SERVING transition.
 			killed := s.poolManager.CloseReservedConnections(ctx)
 			s.drainStats.recordForceClosed(ctx, killed)
 			if killed > 0 {
@@ -172,60 +230,80 @@ func (s *QueryPoolerServer) OnStateChange(ctx context.Context, poolerType cluste
 	s.mu.Lock()
 	s.poolerType = poolerType
 	s.servingStatus = servingStatus
-	s.shuttingDown = false
+	s.drainPhase = drainNone
 	s.notifyStateChangedLocked()
 	s.mu.Unlock()
 
 	return nil
 }
 
-// StartRequest checks whether a new request should be admitted.
-// Returns nil if the request is allowed, or an error if it should be rejected.
+// setDrainPhase updates the drain phase under the mutex. Used to advance from
+// stage 1 (drainReserved) to stage 2 (drainRegular) mid-drain.
+func (s *QueryPoolerServer) setDrainPhase(p drainPhase) {
+	s.mu.Lock()
+	s.drainPhase = p
+	s.mu.Unlock()
+}
+
+// StartRequest checks whether a request should be admitted, based on its
+// RequestKind and the current drain phase. Returns nil if allowed, or MTF01
+// (which the gateway buffers + retries on the new primary) if rejected.
 //
-// It validates the target against this pooler's identity (tablegroup, shard, type)
-// via checkTargetLocked, then checks serving status. A PRIMARY-to-REPLICA target
-// mismatch or a non-serving status returns MTF01, which causes the gateway to
-// buffer the request until the correct pooler is available.
+// Admission matrix:
 //
-// allowOnShutdown=true marks an in-flight operation on an existing reserved
-// connection (COMMIT/ROLLBACK, temp-table cleanup, a mid-transaction statement).
-// These are admitted regardless of serving status or demotion — the reserved
-// connection is the real gate. During the graceful drain the connection is still
-// alive and the operation completes; if the drain exceeded its grace period and
-// force-closed the connection, the executor returns an honest 40001
-// (transaction aborted) so the client retries the whole transaction. New
-// reservations and fresh queries (allowOnShutdown=false) are rejected with MTF01
-// once the pooler stops serving.
-func (s *QueryPoolerServer) StartRequest(target *query.Target, allowOnShutdown bool) error {
+//	kind \ state      | SERVING | drainReserved | drainRegular | NOT_SERVING
+//	------------------+---------+---------------+--------------+------------
+//	ExistingReserved  | allow   | allow         | allow        | allow¹
+//	SingleQuery       | allow   | allow         | reject MTF01 | reject MTF01
+//	NewReservation    | allow   | reject MTF01  | reject MTF01 | reject MTF01
+//
+// ¹ ExistingReserved is always admitted regardless of serving status or
+// demotion — the reserved connection's existence is the real gate. If the
+// connection was force-closed during the drain, the executor returns an honest
+// 40001 (transaction aborted) rather than the misleading MTF01. Tablegroup/shard
+// mismatches (MTD01) are still rejected for every kind.
+//
+// The two-stage drain lets single autocommit queries keep flowing while
+// transactions finish (drainReserved), then stops them too so the cutover
+// happens with zero in-flight work (drainRegular).
+func (s *QueryPoolerServer) StartRequest(target *query.Target, kind RequestKind) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.checkTargetLocked(target, allowOnShutdown); err != nil {
+	existingReserved := kind == RequestExistingReserved
+	if err := s.checkTargetLocked(target, existingReserved); err != nil {
 		return err
 	}
 
-	// In-flight operations on an existing reserved connection (allowOnShutdown)
-	// are admitted regardless of serving status or demotion. The reserved
+	// In-flight operations on an existing reserved connection are admitted
+	// regardless of serving status, demotion, or drain phase. The reserved
 	// connection itself is the real gate: if it still exists the operation
 	// completes on the live backend (postgres is demoted only after the drain
 	// finishes); if it was force-closed because the drain exceeded its grace
-	// period, the executor returns an honest "transaction aborted" error (40001)
-	// so the client retries the whole transaction — rather than the misleading
-	// MTF01 "failover in progress, will be retried automatically" signal, which
-	// is neither buffered nor retryable for a transaction that no longer exists.
-	if allowOnShutdown {
+	// period, the executor returns an honest 40001 so the client retries the
+	// whole transaction — rather than the misleading MTF01 signal, which is
+	// neither buffered nor retryable for a transaction that no longer exists.
+	if existingReserved {
 		return nil
 	}
 
-	if s.servingStatus != clustermetadatapb.PoolerServingStatus_SERVING && !s.shuttingDown {
+	switch s.drainPhase {
+	case drainNone:
+		// Not draining: admit while serving, reject once NOT_SERVING.
+		if s.servingStatus != clustermetadatapb.PoolerServingStatus_SERVING {
+			return mterrors.MTF01.New()
+		}
+		return nil
+	case drainReserved:
+		// Stage 1: keep serving single queries; reject new reservations.
+		if kind == RequestSingleQuery {
+			return nil
+		}
+		return mterrors.MTF01.New()
+	default: // drainRegular
+		// Stage 2: reject everything new (single queries and reservations).
 		return mterrors.MTF01.New()
 	}
-
-	if s.shuttingDown {
-		return mterrors.MTF01.New()
-	}
-
-	return nil
 }
 
 // checkTargetLocked validates that the request's target matches this pooler's identity.
@@ -237,7 +315,7 @@ func (s *QueryPoolerServer) StartRequest(target *query.Target, allowOnShutdown b
 //     buffering until the new primary is discovered. All other type combinations
 //     are allowed (PRIMARY serves both PRIMARY and REPLICA traffic).
 //
-// allowOnShutdown signals an in-flight operation on an existing reserved
+// existingReserved signals an in-flight operation on an existing reserved
 // connection. Such operations bypass the demotion (PRIMARY→REPLICA) check: the
 // reserved connection's existence is the real gate (see StartRequest), so a
 // demoted pooler whose reserved connection survived the drain can still conclude
@@ -246,7 +324,7 @@ func (s *QueryPoolerServer) StartRequest(target *query.Target, allowOnShutdown b
 // routing bugs) are still rejected.
 //
 // Caller must hold s.mu.
-func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, allowOnShutdown bool) error {
+func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, existingReserved bool) error {
 	if target == nil {
 		return nil
 	}
@@ -259,7 +337,7 @@ func (s *QueryPoolerServer) checkTargetLocked(target *query.Target, allowOnShutd
 		return mterrors.MTD01.New("target shard %q does not match pooler shard %q", target.Shard, s.shard)
 	}
 
-	if allowOnShutdown {
+	if existingReserved {
 		return nil
 	}
 

--- a/go/services/multipooler/internal/poolerserver/pooler_test.go
+++ b/go/services/multipooler/internal/poolerserver/pooler_test.go
@@ -88,33 +88,57 @@ func newStartRequestTestServer() *QueryPoolerServer {
 	}
 }
 
+// requireMTF01 asserts that err is the MTF01 (planned-failover) gateway-buffering signal.
+func requireMTF01(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
+}
+
 func TestStartRequest_Serving(t *testing.T) {
 	s := newStartRequestTestServer()
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 
-	// Both allowOnShutdown=true and false should succeed when serving
-	err := s.StartRequest(nil, false)
-	require.NoError(t, err)
-
-	err = s.StartRequest(nil, true)
-	require.NoError(t, err)
+	// All request kinds are admitted while serving normally.
+	require.NoError(t, s.StartRequest(nil, RequestExistingReserved))
+	require.NoError(t, s.StartRequest(nil, RequestSingleQuery))
+	require.NoError(t, s.StartRequest(nil, RequestNewReservation))
 }
 
 func TestStartRequest_NotServing(t *testing.T) {
 	s := newStartRequestTestServer()
-	s.servingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING // drainPhase is drainNone (post-flip)
 
-	// Fresh requests (allowOnShutdown=false) fail with MTF01 (triggers gateway buffering).
-	err := s.StartRequest(nil, false)
-	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
+	// Existing reserved ops are still admitted (the connection's existence is the
+	// gate; a force-closed connection surfaces an honest 40001 from the executor).
+	require.NoError(t, s.StartRequest(nil, RequestExistingReserved))
+	// Single queries and new reservations are rejected with MTF01 (gateway buffers).
+	requireMTF01(t, s.StartRequest(nil, RequestSingleQuery))
+	requireMTF01(t, s.StartRequest(nil, RequestNewReservation))
+}
 
-	// In-flight ops on an existing reserved connection (allowOnShutdown=true) are
-	// admitted regardless of serving status — the reserved connection is the real
-	// gate. If it was force-closed, the executor (not StartRequest) surfaces an
-	// honest 40001 instead of the misleading MTF01.
-	err = s.StartRequest(nil, true)
-	require.NoError(t, err)
+func TestStartRequest_DrainReserved_ServesSingleQueries(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.drainPhase = drainReserved
+
+	// Stage 1: single queries keep flowing and existing reserved ops finish, but
+	// new reservations are rejected so no new transactions accumulate.
+	require.NoError(t, s.StartRequest(nil, RequestSingleQuery))
+	require.NoError(t, s.StartRequest(nil, RequestExistingReserved))
+	requireMTF01(t, s.StartRequest(nil, RequestNewReservation))
+}
+
+func TestStartRequest_DrainRegular_RejectsSingleQueries(t *testing.T) {
+	s := newStartRequestTestServer()
+	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+	s.drainPhase = drainRegular
+
+	// Stage 2: single queries are now rejected too; only existing reserved ops
+	// (concluding in-flight transactions) are still admitted.
+	requireMTF01(t, s.StartRequest(nil, RequestSingleQuery))
+	requireMTF01(t, s.StartRequest(nil, RequestNewReservation))
+	require.NoError(t, s.StartRequest(nil, RequestExistingReserved))
 }
 
 func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
@@ -122,40 +146,15 @@ func TestStartRequest_PrimaryOpOnReplica_ReservedConnAllowed(t *testing.T) {
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_NOT_SERVING
 	s.poolerType = clustermetadatapb.PoolerType_REPLICA
 
-	// A PRIMARY-targeted op on a demoted (REPLICA) pooler is rejected with MTF01
-	// when it's a fresh request...
 	target := &query.Target{PoolerType: clustermetadatapb.PoolerType_PRIMARY}
-	err := s.StartRequest(target, false)
-	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
-
-	// ...but admitted when it's an in-flight op on an existing reserved connection
-	// (e.g. a COMMIT after a planned demotion). This lets the executor conclude the
-	// transaction on the live backend, or return an honest 40001 if the connection
-	// was force-closed during the drain.
-	err = s.StartRequest(target, true)
-	require.NoError(t, err)
-}
-
-func TestStartRequest_ShuttingDown_NewRequestRejected(t *testing.T) {
-	s := newStartRequestTestServer()
-	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.shuttingDown = true
-
-	// New requests (allowOnShutdown=false) should be rejected
-	err := s.StartRequest(nil, false)
-	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
-}
-
-func TestStartRequest_ShuttingDown_ExistingReservedAllowed(t *testing.T) {
-	s := newStartRequestTestServer()
-	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
-	s.shuttingDown = true
-
-	// Existing reserved connections (allowOnShutdown=true) should be allowed
-	err := s.StartRequest(nil, true)
-	require.NoError(t, err)
+	// A fresh PRIMARY-targeted request on a demoted (REPLICA) pooler is rejected
+	// with MTF01...
+	requireMTF01(t, s.StartRequest(target, RequestSingleQuery))
+	// ...but an in-flight op on an existing reserved connection (e.g. a COMMIT
+	// after a planned demotion) is admitted, so the executor can conclude the
+	// transaction on the live backend or return an honest 40001 if it was
+	// force-closed during the drain.
+	require.NoError(t, s.StartRequest(target, RequestExistingReserved))
 }
 
 func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
@@ -163,11 +162,9 @@ func TestStartRequest_PrimaryQueryOnReplica_Rejected(t *testing.T) {
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	s.poolerType = clustermetadatapb.PoolerType_REPLICA
 
-	// PRIMARY query hitting a REPLICA pooler should be rejected with MTF01
+	// PRIMARY query hitting a REPLICA pooler should be rejected with MTF01.
 	target := &query.Target{PoolerType: clustermetadatapb.PoolerType_PRIMARY}
-	err := s.StartRequest(target, false)
-	require.Error(t, err)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
+	requireMTF01(t, s.StartRequest(target, RequestSingleQuery))
 }
 
 func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
@@ -176,8 +173,7 @@ func TestStartRequest_PrimaryQueryOnPrimary_Allowed(t *testing.T) {
 	s.poolerType = clustermetadatapb.PoolerType_PRIMARY
 
 	target := &query.Target{PoolerType: clustermetadatapb.PoolerType_PRIMARY}
-	err := s.StartRequest(target, false)
-	require.NoError(t, err)
+	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
 }
 
 func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
@@ -185,10 +181,9 @@ func TestStartRequest_ReplicaQueryOnPrimary_Allowed(t *testing.T) {
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	s.poolerType = clustermetadatapb.PoolerType_PRIMARY
 
-	// PRIMARY pooler can serve REPLICA traffic
+	// PRIMARY pooler can serve REPLICA traffic.
 	target := &query.Target{PoolerType: clustermetadatapb.PoolerType_REPLICA}
-	err := s.StartRequest(target, false)
-	require.NoError(t, err)
+	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
 }
 
 func TestStartRequest_NilTarget_Skipped(t *testing.T) {
@@ -196,9 +191,8 @@ func TestStartRequest_NilTarget_Skipped(t *testing.T) {
 	s.servingStatus = clustermetadatapb.PoolerServingStatus_SERVING
 	s.poolerType = clustermetadatapb.PoolerType_REPLICA
 
-	// Nil target should skip validation (e.g., GetAuthCredentials)
-	err := s.StartRequest(nil, false)
-	require.NoError(t, err)
+	// Nil target should skip target validation (e.g., GetAuthCredentials).
+	require.NoError(t, s.StartRequest(nil, RequestSingleQuery))
 }
 
 func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
@@ -208,13 +202,13 @@ func TestStartRequest_TableGroupMismatch_Bug(t *testing.T) {
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
-	// Tablegroup mismatch is a routing bug (MTD01)
+	// Tablegroup mismatch is a routing bug (MTD01), rejected for every kind.
 	target := &query.Target{
 		TableGroup: "tg2",
 		Shard:      "0",
 		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 	}
-	err := s.StartRequest(target, false)
+	err := s.StartRequest(target, RequestExistingReserved)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTD01.ID), "expected MTD01 error, got: %v", err)
 	assert.Contains(t, err.Error(), "tg2")
@@ -228,13 +222,13 @@ func TestStartRequest_ShardMismatch_Bug(t *testing.T) {
 	s.tableGroup = "tg1"
 	s.shard = "0"
 
-	// Shard mismatch is a routing bug (MTD01)
+	// Shard mismatch is a routing bug (MTD01).
 	target := &query.Target{
 		TableGroup: "tg1",
 		Shard:      "1",
 		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 	}
-	err := s.StartRequest(target, false)
+	err := s.StartRequest(target, RequestSingleQuery)
 	require.Error(t, err)
 	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTD01.ID), "expected MTD01 error, got: %v", err)
 	assert.Contains(t, err.Error(), "shard")
@@ -252,42 +246,66 @@ func TestStartRequest_FullTargetMatch_Allowed(t *testing.T) {
 		Shard:      "0",
 		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
 	}
-	err := s.StartRequest(target, false)
-	require.NoError(t, err)
+	require.NoError(t, s.StartRequest(target, RequestSingleQuery))
 }
 
-// drainMockPoolManager is a mock pool manager that supports drain tracking
-// via lentAdd/WaitForDrain, similar to connpoolmanager.Manager.
+// drainMockPoolManager is a mock pool manager that supports two-stage drain
+// tracking, similar to connpoolmanager.Manager. regularAdd simulates a regular
+// (single-query) borrow; reservedAdd simulates a reserved connection. The
+// combined drain (WaitForDrain) sees regularCount + reservedCount; the
+// reserved-only drain (WaitForReservedDrain) sees reservedCount.
 type drainMockPoolManager struct {
 	connpoolmanager.PoolManager // embed for default nil implementations
 
-	mu        sync.Mutex
-	lentCount int64
-	zeroCh    chan struct{}
+	mu             sync.Mutex
+	regularCount   int64
+	reservedCount  int64
+	zeroCh         chan struct{}
+	reservedZeroCh chan struct{}
 
 	closeReservedCount int
+	closeReservedCalls int
 }
 
 func newDrainMockPoolManager() *drainMockPoolManager {
 	ch := make(chan struct{})
 	close(ch) // starts drained
-	return &drainMockPoolManager{zeroCh: ch}
+	rch := make(chan struct{})
+	close(rch)
+	return &drainMockPoolManager{zeroCh: ch, reservedZeroCh: rch}
 }
 
-func (m *drainMockPoolManager) lentAdd(n int64) {
+// signalZeroChan reconciles a drain channel with its total, mirroring
+// Manager.signalZeroChanLocked. Caller must hold m.mu.
+func signalZeroChan(total int64, ch *chan struct{}) {
+	if total == 0 {
+		select {
+		case <-*ch:
+		default:
+			close(*ch)
+		}
+		return
+	}
+	select {
+	case <-*ch:
+		*ch = make(chan struct{})
+	default:
+	}
+}
+
+func (m *drainMockPoolManager) regularAdd(n int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.regularCount += n
+	signalZeroChan(m.regularCount+m.reservedCount, &m.zeroCh)
+}
 
-	m.lentCount += n
-	if m.lentCount == 0 {
-		select {
-		case <-m.zeroCh:
-		default:
-			close(m.zeroCh)
-		}
-	} else if m.lentCount == n && n > 0 {
-		m.zeroCh = make(chan struct{})
-	}
+func (m *drainMockPoolManager) reservedAdd(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reservedCount += n
+	signalZeroChan(m.reservedCount, &m.reservedZeroCh)
+	signalZeroChan(m.regularCount+m.reservedCount, &m.zeroCh)
 }
 
 func (m *drainMockPoolManager) WaitForDrain(ctx context.Context) error {
@@ -303,8 +321,30 @@ func (m *drainMockPoolManager) WaitForDrain(ctx context.Context) error {
 	}
 }
 
+func (m *drainMockPoolManager) WaitForReservedDrain(ctx context.Context) error {
+	m.mu.Lock()
+	ch := m.reservedZeroCh
+	m.mu.Unlock()
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (m *drainMockPoolManager) CloseReservedConnections(ctx context.Context) int {
+	m.mu.Lock()
+	m.closeReservedCalls++
+	m.mu.Unlock()
 	return m.closeReservedCount
+}
+
+func (m *drainMockPoolManager) closeReservedCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeReservedCalls
 }
 
 func newTestPoolerWithDrain(mock *drainMockPoolManager) *QueryPoolerServer {
@@ -319,51 +359,89 @@ func newTestPoolerWithDrain(mock *drainMockPoolManager) *QueryPoolerServer {
 	}
 }
 
-// TestStartRequest_ShuttingDown_WithDrain tests the full drain lifecycle:
-// in-flight connections keep drain blocked, allowOnShutdown=false is rejected,
-// allowOnShutdown=true is allowed, and drain completes when connections return.
-func TestStartRequest_ShuttingDown_WithDrain(t *testing.T) {
+// waitForDrainPhase blocks until the pooler reaches the given drain phase.
+func waitForDrainPhase(t *testing.T, pooler *QueryPoolerServer, phase drainPhase) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		pooler.mu.Lock()
+		defer pooler.mu.Unlock()
+		return pooler.drainPhase == phase
+	}, time.Second, 10*time.Millisecond, "pooler did not reach drain phase %d", phase)
+}
+
+// TestOnStateChange_TwoStageDrain exercises the two-stage graceful drain:
+// stage 1 (drainReserved) serves single queries while a transaction is in
+// flight; stage 2 (drainRegular) starts only after the transaction finishes and
+// then rejects single queries too; the transition completes once the in-flight
+// single query also finishes.
+func TestOnStateChange_TwoStageDrain(t *testing.T) {
 	mock := newDrainMockPoolManager()
 	pooler := newTestPoolerWithDrain(mock)
 	pooler.gracePeriod = 5 * time.Second
 	ctx := t.Context()
 
-	// Transition to SERVING
 	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 
-	// Simulate an in-flight connection to keep drain waiting
-	mock.lentAdd(1)
+	// One in-flight transaction (reserved) and one in-flight single query (regular).
+	mock.reservedAdd(1)
+	mock.regularAdd(1)
 
-	// Begin NOT_SERVING transition in background (will block on drain)
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
 		_ = pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING)
 	}()
 
-	// Wait for shuttingDown to be set
-	require.Eventually(t, func() bool {
-		pooler.mu.Lock()
-		defer pooler.mu.Unlock()
-		return pooler.shuttingDown
-	}, time.Second, 10*time.Millisecond)
+	// Stage 1: blocked on the in-flight transaction. Single queries are served,
+	// existing reserved ops are admitted, new reservations are rejected.
+	waitForDrainPhase(t, pooler, drainReserved)
+	require.NoError(t, pooler.StartRequest(nil, RequestSingleQuery))
+	require.NoError(t, pooler.StartRequest(nil, RequestExistingReserved))
+	requireMTF01(t, pooler.StartRequest(nil, RequestNewReservation))
 
-	// allowOnShutdown=false should fail during shutdown
-	err := pooler.StartRequest(nil, false)
-	assert.True(t, mterrors.IsErrorCode(err, mterrors.MTF01.ID), "expected MTF01 error, got: %v", err)
+	// Finish the transaction → advances to stage 2.
+	mock.reservedAdd(-1)
+	waitForDrainPhase(t, pooler, drainRegular)
 
-	// allowOnShutdown=true should succeed during shutdown
-	err = pooler.StartRequest(nil, true)
-	assert.NoError(t, err)
+	// Stage 2: single queries are now rejected too; existing reserved ops still admitted.
+	requireMTF01(t, pooler.StartRequest(nil, RequestSingleQuery))
+	require.NoError(t, pooler.StartRequest(nil, RequestExistingReserved))
 
-	// Return the in-flight connection to let drain complete
-	mock.lentAdd(-1)
-
+	// Finish the in-flight single query → drain completes.
+	mock.regularAdd(-1)
 	select {
 	case <-drainDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("drain did not complete after in-flight connection returned")
+		t.Fatal("drain did not complete after in-flight work returned")
 	}
+	assert.False(t, pooler.IsServing())
+}
+
+// TestOnStateChange_GracePeriodExpiresInStage1 covers the force-close path: a
+// transaction that never finishes keeps stage 1 (reserved drain) blocked past
+// the shared grace period, so the pooler force-closes reserved connections and
+// completes the transition anyway.
+func TestOnStateChange_GracePeriodExpiresInStage1(t *testing.T) {
+	mock := newDrainMockPoolManager()
+	pooler := newTestPoolerWithDrain(mock)
+	pooler.gracePeriod = 100 * time.Millisecond
+	ctx := t.Context()
+
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
+
+	// A transaction that never commits — stage 1 (WaitForReservedDrain) blocks.
+	mock.reservedAdd(1)
+
+	start := time.Now()
+	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_NOT_SERVING))
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "should block ~grace period waiting on the held transaction")
+	assert.Less(t, elapsed, 2*time.Second, "should not block much past the grace period")
+	assert.Positive(t, mock.closeReservedCallCount(), "reserved connections should be force-closed on grace expiry")
+	assert.False(t, pooler.IsServing(), "transition completes despite the held transaction")
+
+	mock.reservedAdd(-1) // clean up
 }
 
 // TestOnStateChange_WaitsForInflightRequests verifies that OnStateChange blocks
@@ -377,8 +455,8 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 
 	// Simulate two in-flight connections
-	mock.lentAdd(1)
-	mock.lentAdd(1)
+	mock.regularAdd(1)
+	mock.regularAdd(1)
 
 	drainDone := make(chan struct{})
 	go func() {
@@ -394,8 +472,8 @@ func TestOnStateChange_WaitsForInflightRequests(t *testing.T) {
 	}
 
 	// Return both connections
-	mock.lentAdd(-1)
-	mock.lentAdd(-1)
+	mock.regularAdd(-1)
+	mock.regularAdd(-1)
 
 	select {
 	case <-drainDone:
@@ -419,7 +497,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	require.NoError(t, pooler.OnStateChange(ctx, clustermetadatapb.PoolerType_PRIMARY, clustermetadatapb.PoolerServingStatus_SERVING))
 
 	// Simulate a connection that will never return
-	mock.lentAdd(1)
+	mock.regularAdd(1)
 
 	start := time.Now()
 	drainDone := make(chan struct{})
@@ -441,7 +519,7 @@ func TestOnStateChange_GracePeriodExpires(t *testing.T) {
 	assert.False(t, pooler.IsServing())
 
 	// Clean up
-	mock.lentAdd(-1)
+	mock.regularAdd(-1)
 }
 
 // TestOnStateChange_BackToServing verifies the SERVING → NOT_SERVING → SERVING round-trip.
@@ -463,7 +541,7 @@ func TestOnStateChange_BackToServing(t *testing.T) {
 	assert.True(t, pooler.IsServing())
 
 	// Requests should work again
-	err := pooler.StartRequest(nil, false)
+	err := pooler.StartRequest(nil, RequestSingleQuery)
 	require.NoError(t, err)
 }
 
@@ -485,12 +563,12 @@ func TestOnStateChange_ConcurrentRequests(t *testing.T) {
 	for range numRequests {
 		go func() {
 			defer wg.Done()
-			if err := pooler.StartRequest(nil, false); err != nil {
+			if err := pooler.StartRequest(nil, RequestSingleQuery); err != nil {
 				return
 			}
-			mock.lentAdd(1)
+			mock.regularAdd(1)
 			time.Sleep(50 * time.Millisecond)
-			mock.lentAdd(-1)
+			mock.regularAdd(-1)
 		}()
 	}
 


### PR DESCRIPTION
## Summary

- Two-stage graceful drain in the multipooler: when a primary transitions to `NOT_SERVING`, stage 1 drains in-flight transactions while still serving single autocommit queries on the still-primary; stage 2 then drains the remaining in-flight single queries, so the pooler reports `NOT_SERVING` with zero in-flight work and the subsequent postgres demotion kills nothing.
- The connection pool manager gains a reserved-only drain (`WaitForReservedDrain`, backed by a separate `reservedCount`) alongside the combined one, so stage 1 waits for transactions without being held up by transient single-query borrows. Each borrow/reserve event now touches exactly one counter under a single lock.
- `StartRequest`'s admission bool becomes a `RequestKind` (`ExistingReserved` / `SingleQuery` / `NewReservation`), gated per drain stage. The gRPC handlers classify each request from the signal it actually carries — reservation reasons (`StreamExecute`), `MaxRows` (portals), always-reserves (COPY).
- The multigateway's failover buffer no longer proactively blocks single queries during a failover: they are sent straight to a draining pooler and buffered only reactively (on `MTF01`), so they keep flowing instead of stalling. New transactions stay proactively buffered.

## Testing

Unit tests cover the reserved-only drain (including that a regular borrow does not hold up the reserved wait, and channel re-arm), the full `RequestKind` × drain-phase admission matrix, the two-stage `OnStateChange` lifecycle with grace-period force-close in both stages, and the `admissionKind` / `isSingleQuery` classifiers. `-race` clean on the concurrency-heavy packages. End-to-end failover survival (continuous traffic across a planned failover with zero client-visible errors) is covered by the existing `queryserving` buffer tests.