### PR TITLE
fix(demo/k8s): emit explicit-bucket histograms for Grafana dashboard

### DIFF
--- a/demo/k8s/k8s-observability.yaml
+++ b/demo/k8s/k8s-observability.yaml
@@ -33,7 +33,7 @@ data:
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_METRICS_EXPORTER: "otlp"
   OTEL_LOGS_EXPORTER: "otlp"
-  OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: "base2_exponential_bucket_histogram"
+  OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: "explicit_bucket_histogram"
   # Custom file-based sampling configuration
   OTEL_TRACES_SAMPLER: "multigres_custom"
   OTEL_TRACES_SAMPLER_CONFIG: "/etc/otel/sampling-config.yaml"


### PR DESCRIPTION
## Problem

In `demo/k8s`, the `otel-config` ConfigMap sets:

```
OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: "base2_exponential_bucket_histogram"
```

Native/exponential histograms do **not** produce classic `_bucket`/`le` series. The bundled `multigres-overview` dashboard (`demo/observability/grafana-dashboard.json`) queries those series with `histogram_quantile(..., rate(..._bucket[...]))`, so these panels render empty:

- Query Duration
- Rows Returned
- Top Queries by p99 Latency (by SQL)

`demo/local/run-with-otel.sh` already uses `explicit_bucket_histogram`, so the same dashboard works there — only `demo/k8s` diverged.

## Fix

Set `demo/k8s` to `explicit_bucket_histogram` to match `demo/local` and the dashboard's PromQL.

## Verification (kind)

After applying the change and restarting the data plane, then running pgbench through the gateway:

- `mg_gateway_query_duration_seconds_bucket`: 176 series (was 0)
- `mg_gateway_query_rows_returned_bucket`: 176 series (was 0)
- Dashboard PromQL now returns values (e.g. Query Duration p95 UPDATE ≈ 46ms; Top p99 by SQL returns fingerprints)

The Query Errors panel remains empty only because the workload produced 0 errors (expected).

## Note

For native histograms one could instead update the dashboard PromQL; this PR keeps the dashboard as-is and aligns the demo's export format with it.