### PR TITLE
fix(multipooler): don't strand WAL replay paused after a failed SetTermPrimary

### DIFF
--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -190,6 +190,13 @@ type MultiPoolerManager struct {
 	// process restart implicitly clears it.
 	walReceiverManuallyStopped atomic.Bool
 
+	// replayManuallyPaused is set when StopReplication paused WAL replay
+	// (REPLAY_ONLY / REPLAY_AND_RECEIVER modes) — an explicit signal that apply
+	// should stay paused. It tells the postgres monitor not to self-heal the
+	// pause by resuming replay. Cleared by StartReplication. Not persisted; a
+	// process restart implicitly clears it.
+	replayManuallyPaused atomic.Bool
+
 	// pgMonitorLastLoggedReason tracks the last logged reason in the monitor to avoid duplicate logs.
 	pgMonitorLastLoggedReason string
 
@@ -1613,6 +1620,9 @@ type postgresState struct {
 	backupsAvailable         bool
 	isPrimary                bool
 	bootstrapSentinelPresent bool
+	// replayPaused reports whether WAL replay (apply) is paused. Only meaningful
+	// for a standby (postgresRunning && !isPrimary); false otherwise.
+	replayPaused bool
 	// primaryTerm is the coordinator term at which this pooler is the primary
 	// per the highest known rule. 0 if we are not the primary for that rule.
 	primaryTerm int64
@@ -1626,6 +1636,7 @@ func postgresStateEqual(a, b postgresState) bool {
 		a.backupsAvailable == b.backupsAvailable &&
 		a.isPrimary == b.isPrimary &&
 		a.bootstrapSentinelPresent == b.bootstrapSentinelPresent &&
+		a.replayPaused == b.replayPaused &&
 		a.primaryTerm == b.primaryTerm
 }
 
@@ -1647,6 +1658,11 @@ const (
 	// primary regardless of how it got out of sync (failed SetTermPrimary apply,
 	// hand edit, snapshot restore, etc.).
 	remedialActionFixPrimaryConnInfo
+	// remedialActionResumeReplay means a standby has WAL replay paused without an
+	// explicit stop (neither replayManuallyPaused nor walReceiverManuallyStopped
+	// is set), so the monitor resumes it. Recovers a standby left paused by an
+	// interrupted operation.
+	remedialActionResumeReplay
 )
 
 // monitorPostgresIteration performs one iteration of PostgreSQL monitoring.
@@ -1771,6 +1787,10 @@ func (pm *MultiPoolerManager) discoverPostgresState(ctx context.Context) (postgr
 		// which falls back to the cached rule when postgres is unreachable.
 		if cs, err := pm.getInconsistentConsensusStatus(ctx); err == nil {
 			state.primaryTerm = commonconsensus.LeaderTerm(cs)
+		}
+		// Replay pause only applies to a standby; skip the query on a primary.
+		if !state.isPrimary {
+			state.replayPaused = pm.isWALReplayPaused(ctx)
 		}
 	}
 
@@ -1934,6 +1954,17 @@ func (pm *MultiPoolerManager) determineRemedialAction(ctx context.Context, curre
 			// remedialActionFixPrimaryConnInfo iteration runs
 			// pg_rewind dry-run before re-establishing replication. Cheap
 			// when no divergence, conclusive when there is.
+			//
+			// Self-heal paused WAL replay. setPrimaryConnInfoLocked no longer
+			// resumes replay as a side effect of writing conninfo (replay
+			// pause/resume is owned by StopReplication/StartReplication), so a
+			// standby left paused by an interrupted op would otherwise keep
+			// receiving WAL without ever applying it. Resume it unless apply was
+			// explicitly paused (replayManuallyPaused); a RECEIVER_ONLY stop
+			// doesn't pause replay, and REPLAY_AND_RECEIVER sets this flag too.
+			if currentState.replayPaused && !pm.replayManuallyPaused.Load() {
+				return remedialActionResumeReplay
+			}
 		}
 		// Pooler type already matches; check for a stale GUC that needs re-applying.
 		// Only reconcile the GUC when actually running as primary: synchronous_standby_names
@@ -2028,9 +2059,14 @@ func (pm *MultiPoolerManager) takeRemedialAction(ctx context.Context, action rem
 		// re-establishing replication. This would let the monitor self-heal
 		// a stuck-replica scenario without waiting for orch's
 		// FixReplicationAction to issue a RewindToSource RPC.
-		if err := pm.setPrimaryConnInfoLocked(ctx, targetHost, targetPort,
-			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
+		if err := pm.setPrimaryConnInfoLocked(ctx, targetHost, targetPort); err != nil {
 			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to reconcile primary_conninfo", "error", err)
+		}
+
+	case remedialActionResumeReplay:
+		pm.logger.InfoContext(ctx, "MonitorPostgres: WAL replay paused on standby without an explicit stop; resuming")
+		if err := pm.resumeWALReplay(ctx); err != nil {
+			pm.logger.ErrorContext(ctx, "MonitorPostgres: failed to resume WAL replay", "error", err)
 		}
 
 	case remedialActionStartPostgres:

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -78,6 +78,25 @@ func (pm *MultiPoolerManager) isInRecovery(ctx context.Context) (bool, error) {
 	return inRecovery, nil
 }
 
+// isWALReplayPaused reports whether WAL replay (apply) is currently paused on
+// this standby. Returns false on error so the monitor does not act on an
+// unknown state.
+func (pm *MultiPoolerManager) isWALReplayPaused(ctx context.Context) bool {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	result, err := pm.query(queryCtx, "SELECT pg_is_wal_replay_paused()")
+	if err != nil {
+		pm.logger.WarnContext(ctx, "Failed to query pg_is_wal_replay_paused", "error", err)
+		return false
+	}
+	var paused bool
+	if err := executor.ScanSingleRow(result, &paused); err != nil {
+		pm.logger.WarnContext(ctx, "Failed to scan pg_is_wal_replay_paused result", "error", err)
+		return false
+	}
+	return paused
+}
+
 // getPrimaryLSN gets the current WAL write location (primary only)
 func (pm *MultiPoolerManager) getPrimaryLSN(ctx context.Context) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -529,6 +548,68 @@ func (pm *MultiPoolerManager) waitForReceiverDisconnect(ctx context.Context) (*m
 			}
 			return status, true, nil
 		})
+}
+
+// waitForReceiverTargeting waits until either no WAL receiver is running, or the
+// running receiver is configured to connect to host:port. It does not wait for
+// the connection to succeed — only for the receiver to be pointed at the
+// intended primary. This distinguishes a receiver freshly (re)started after a
+// primary_conninfo change from a lingering one still using the old target;
+// PostgreSQL restarts the receiver on reload, but not atomically, so a naive
+// "is a receiver streaming?" check can see the stale connection.
+//
+// Matching is done against the receiver's own conninfo (echoed in
+// pg_stat_wal_receiver with sensitive fields obfuscated) rather than
+// sender_host/sender_port, which report the resolved connection and may not
+// string-match the configured host (e.g. localhost vs 127.0.0.1).
+func (pm *MultiPoolerManager) waitForReceiverTargeting(ctx context.Context, host string, port int32) error {
+	var (
+		lastCount    int64 = -1
+		lastConnInfo string
+	)
+	_, err := pm.pollForReplicationStatus(ctx,
+		"timeout waiting for WAL receiver to target the new primary",
+		"context cancelled while waiting for WAL receiver to target the new primary",
+		func(cause error) {
+			pm.logger.ErrorContext(ctx, "WAL receiver did not target the new primary",
+				"cause", cause,
+				"host", host,
+				"port", port,
+				"last_receiver_count", lastCount,
+				"last_receiver_conninfo", lastConnInfo)
+		},
+		func(waitCtx context.Context) (*multipoolermanagerdatapb.StandbyReplicationStatus, bool, error) {
+			result, err := pm.query(waitCtx, `SELECT
+				(SELECT COUNT(*) FROM pg_stat_wal_receiver),
+				coalesce((SELECT conninfo FROM pg_stat_wal_receiver LIMIT 1), '')`)
+			if err != nil {
+				return nil, false, mterrors.Wrap(err, "failed to query pg_stat_wal_receiver")
+			}
+			if err := executor.ScanSingleRow(result, &lastCount, &lastConnInfo); err != nil {
+				return nil, false, mterrors.Wrap(err, "failed to scan pg_stat_wal_receiver row")
+			}
+			done := lastCount == 0 || conninfoTargets(lastConnInfo, host, port)
+			return nil, done, nil
+		})
+	return err
+}
+
+// conninfoTargets reports whether a libpq conninfo string is configured to
+// connect to host:port. It matches whole space-separated key=value tokens so a
+// host prefix (e.g. "pg-1" vs "pg-10") doesn't yield a false positive.
+func conninfoTargets(conninfo, host string, port int32) bool {
+	hostToken := "host=" + host
+	portToken := fmt.Sprintf("port=%d", port)
+	var hasHost, hasPort bool
+	for field := range strings.FieldsSeq(conninfo) {
+		switch field {
+		case hostToken:
+			hasHost = true
+		case portToken:
+			hasPort = true
+		}
+	}
+	return hasHost && hasPort
 }
 
 // pauseReplication pauses replication based on the specified mode.

--- a/go/services/multipooler/internal/manager/pg_replication_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_test.go
@@ -45,6 +45,15 @@ func expectReloadConfig(m *mock.QueryService) {
 		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2026-01-01 00:00:01+00"}}))
 }
 
+// expectReceiverTargeting sets up the mock query expectation for
+// MultiPoolerManager.waitForReceiverTargeting. Returning a zero WAL-receiver
+// count satisfies the "no receiver" arm so the wait loop exits on the first
+// poll, regardless of the target host/port.
+func expectReceiverTargeting(m *mock.QueryService) {
+	m.AddQueryPattern("conninfo FROM pg_stat_wal_receiver",
+		mock.MakeQueryResult([]string{"count", "conninfo"}, [][]any{{int64(0), ""}}))
+}
+
 // expectReloadConfigFailure sets up the mock query expectations for a call to
 // MultiPoolerManager.reloadPostgresConfig where pg_reload_conf itself fails.
 // The wait loop is never entered.
@@ -1651,4 +1660,58 @@ func TestQueryReplicationStatus(t *testing.T) {
 			assert.NoError(t, mockQueryService.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestConninfoTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		conninfo string
+		host     string
+		port     int32
+		want     bool
+	}{
+		{"matches host and port", "user=postgres host=primary-host port=5432 application_name=x", "primary-host", 5432, true},
+		{"order independent", "port=5432 host=primary-host", "primary-host", 5432, true},
+		{"host prefix is not a match", "host=pg-1 port=5432", "pg-10", 5432, false},
+		{"port mismatch", "host=primary-host port=5433", "primary-host", 5432, false},
+		{"host mismatch", "host=other port=5432", "primary-host", 5432, false},
+		{"empty", "", "primary-host", 5432, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, conninfoTargets(tt.conninfo, tt.host, tt.port))
+		})
+	}
+}
+
+func TestWaitForReceiverTargeting(t *testing.T) {
+	const receiverQuery = "conninfo FROM pg_stat_wal_receiver"
+
+	t.Run("no receiver returns immediately", func(t *testing.T) {
+		m := mock.NewQueryService()
+		m.AddQueryPattern(receiverQuery,
+			mock.MakeQueryResult([]string{"count", "conninfo"}, [][]any{{int64(0), ""}}))
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(3)})
+		require.NoError(t, pm.waitForReceiverTargeting(t.Context(), "primary-host", 5432))
+	})
+
+	t.Run("receiver targeting the new primary returns", func(t *testing.T) {
+		m := mock.NewQueryService()
+		m.AddQueryPattern(receiverQuery,
+			mock.MakeQueryResult([]string{"count", "conninfo"}, [][]any{{int64(1), "host=primary-host port=5432 user=postgres"}}))
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(3)})
+		require.NoError(t, pm.waitForReceiverTargeting(t.Context(), "primary-host", 5432))
+	})
+
+	t.Run("receiver still on old primary times out", func(t *testing.T) {
+		m := mock.NewQueryService()
+		m.AddQueryPattern(receiverQuery,
+			mock.MakeQueryResult([]string{"count", "conninfo"}, [][]any{{int64(1), "host=old-primary port=5432 user=postgres"}}))
+		pm, _ := setupManagerWithMockDB(t, m, &fakeRuleStore{pos: makeRulePosition(3)})
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancel()
+		err := pm.waitForReceiverTargeting(ctx, "primary-host", 5432)
+		require.Error(t, err)
+		assert.Equal(t, mtrpcpb.Code_DEADLINE_EXCEEDED, mterrors.Code(err))
+	})
 }

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -769,10 +769,9 @@ func (pm *MultiPoolerManager) SetTermPrimary(ctx context.Context, req *consensus
 		pm.logger.InfoContext(ctx, "SetTermPrimary: updating standby primary_conninfo",
 			"new_leader", leader.GetId().GetName(),
 			"incoming_rule", rule.GetRuleNumber())
-		// Already a standby with an active stream; pause replay, swap
-		// conninfo, resume on the new primary.
-		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port,
-			true /* stopReplicationBefore */, true /* startReplicationAfter */); err != nil {
+		// Already a standby with an active stream; point conninfo at the new
+		// primary.
+		if err := pm.setPrimaryConnInfoLocked(ctx, leader.GetHost(), port); err != nil {
 			return nil, err
 		}
 	}

--- a/go/services/multipooler/internal/manager/rpc_initialization_test.go
+++ b/go/services/multipooler/internal/manager/rpc_initialization_test.go
@@ -396,13 +396,14 @@ func TestDiscoverPostgresState_StatusError(t *testing.T) {
 // This is a table-driven test covering all decision paths in the monitor loop.
 func TestDetermineRemedialAction(t *testing.T) {
 	tests := []struct {
-		name               string
-		state              postgresState
-		poolerType         clustermetadatapb.PoolerType
-		primaryTerm        int64
-		resignedLeaderTerm int64
-		inconsistentGUC    bool
-		expectedAction     remedialAction
+		name                 string
+		state                postgresState
+		poolerType           clustermetadatapb.PoolerType
+		primaryTerm          int64
+		resignedLeaderTerm   int64
+		inconsistentGUC      bool
+		replayManuallyPaused bool
+		expectedAction       remedialAction
 	}{
 		{
 			name:           "pgctld_unavailable",
@@ -534,6 +535,31 @@ func TestDetermineRemedialAction(t *testing.T) {
 			inconsistentGUC: true,
 			expectedAction:  remedialActionReconcileGUC,
 		},
+		{
+			// Standby with replay paused and no explicit stop: the monitor resumes it.
+			name: "postgres_ready_replica_replay_paused_resumes",
+			state: postgresState{
+				pgctldAvailable: true,
+				postgresRunning: true,
+				isPrimary:       false,
+				replayPaused:    true,
+			},
+			poolerType:     clustermetadatapb.PoolerType_REPLICA,
+			expectedAction: remedialActionResumeReplay,
+		},
+		{
+			// Replay paused but explicitly via StopReplication: leave it alone.
+			name: "postgres_ready_replica_replay_paused_manually",
+			state: postgresState{
+				pgctldAvailable: true,
+				postgresRunning: true,
+				isPrimary:       false,
+				replayPaused:    true,
+			},
+			poolerType:           clustermetadatapb.PoolerType_REPLICA,
+			replayManuallyPaused: true,
+			expectedAction:       remedialActionNone,
+		},
 	}
 
 	for _, tt := range tests {
@@ -546,6 +572,7 @@ func TestDetermineRemedialAction(t *testing.T) {
 			pm.consensusState = consensus.NewConsensusState("", nil)
 			pm.resignedLeaderAtTerm = tt.resignedLeaderTerm
 			pm.rules = &fakeRuleStore{inconsistentGUC: tt.inconsistentGUC}
+			pm.replayManuallyPaused.Store(tt.replayManuallyPaused)
 			tt.state.primaryTerm = tt.primaryTerm
 
 			got := pm.determineRemedialAction(t.Context(), tt.state)

--- a/go/services/multipooler/internal/manager/rpc_manager.go
+++ b/go/services/multipooler/internal/manager/rpc_manager.go
@@ -99,7 +99,7 @@ func (pm *MultiPoolerManager) WaitForLSN(ctx context.Context, targetLsn string) 
 // flag before rewriting conninfo. demoteStalePrimaryLocked clears the flag itself before reaching
 // this point — a stale-primary detection is an escalated event that
 // supersedes an older admin pause.
-func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host string, port int32, stopReplicationBefore, startReplicationAfter bool) error {
+func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host string, port int32) error {
 	if err := actionlock.AssertActionLockHeld(ctx); err != nil {
 		return err
 	}
@@ -128,14 +128,6 @@ func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 
 	appName := pm.servicePoolerID
 
-	// Optionally stop replication before making changes
-	if stopReplicationBefore {
-		_, err := pm.pauseReplication(ctx, multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_ONLY, false)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Build primary_conninfo connection string
 	// Format: host=<host> port=<port> user=<user> application_name=<name> [passfile=<path>]
 	// The heartbeat_interval is converted to keepalives_interval/keepalives_idle.
@@ -163,27 +155,19 @@ func (pm *MultiPoolerManager) setPrimaryConnInfoLocked(ctx context.Context, host
 		return err
 	}
 
-	// Optionally start replication after making changes.
-	// Note: If replication was already running when setPrimaryConnInfoLocked was called,
-	// even if we don't set startReplicationAfter to true, replication will be running.
-	if startReplicationAfter {
-		// Wait for database to be available after restart
-		if err := pm.waitForDatabaseConnection(ctx); err != nil {
-			pm.logger.ErrorContext(ctx, "Failed to reconnect to database after restart", "error", err)
-			return mterrors.Wrap(err, "failed to reconnect to database")
-		}
-
-		pm.logger.InfoContext(ctx, "Starting replication after setting primary_conninfo")
-		if err := pm.resumeWALReplay(ctx); err != nil {
-			return err
-		}
+	// PostgreSQL restarts the WAL receiver against the new primary on reload,
+	// but not atomically. Wait until that has taken effect: either no receiver
+	// is running, or the running receiver targets the host:port we just set
+	// (not a lingering one still pointed at the old primary). We don't wait for
+	// the connection to succeed — confirming the target is enough; whether
+	// replication is actually flowing is the orchestrator's job to verify.
+	if err := pm.waitForReceiverTargeting(ctx, host, port); err != nil {
+		return err
 	}
 
 	pm.logger.InfoContext(ctx, "setPrimaryConnInfo completed successfully",
 		"host", host,
-		"port", port,
-		"stop_replication_before", stopReplicationBefore,
-		"start_replication_after", startReplicationAfter)
+		"port", port)
 
 	return nil
 }
@@ -210,14 +194,17 @@ func (pm *MultiPoolerManager) StartReplication(ctx context.Context) error {
 	}
 	defer pm.actionLock.Release(ctx)
 
+	// Clear both manual-stop signals (receiver stopped / replay paused) so the
+	// monitor's self-heal is re-enabled; broadcast if either was set.
 	started := pm.walReceiverManuallyStopped.CompareAndSwap(true, false)
+	started = pm.replayManuallyPaused.CompareAndSwap(true, false) || started
 
 	// Check REPLICA guardrails (pooler type and recovery mode)
 	if err = pm.checkReplicaGuardrails(ctx); err != nil {
 		return err
 	}
 
-	// Resume WAL replay on the standby
+	// Resume WAL replay on the standby.
 	if err := pm.resumeWALReplay(ctx); err != nil {
 		return err
 	}
@@ -264,6 +251,15 @@ func (pm *MultiPoolerManager) StopReplication(ctx context.Context, mode multipoo
 		if pm.walReceiverManuallyStopped.CompareAndSwap(false, true) {
 			pm.broadcastHealth()
 		}
+	}
+
+	// Modes that pause WAL replay are an explicit signal that apply should stay
+	// paused; mark it so the postgres monitor does not resume replay on its own.
+	// Cleared by StartReplication.
+	switch mode {
+	case multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_ONLY,
+		multipoolermanagerdatapb.ReplicationPauseMode_REPLICATION_PAUSE_MODE_REPLAY_AND_RECEIVER:
+		pm.replayManuallyPaused.Store(true)
 	}
 
 	return nil
@@ -978,11 +974,7 @@ func (pm *MultiPoolerManager) restartAsStandbyLocked(
 	// the WAL receiver idle. Discovered in the mg-scale12 AZ-outage test
 	// (2026-05-29). Idempotent re-write when conninfo already points at
 	// source.
-	//
-	// (false, false): postgres just restarted, so there's no in-flight
-	// replication to pause, and WAL replay isn't paused — it starts
-	// automatically once postgres reads the new conninfo.
-	if err := pm.setPrimaryConnInfoLocked(ctx, sourceHost, sourcePort, false, false); err != nil {
+	if err := pm.setPrimaryConnInfoLocked(ctx, sourceHost, sourcePort); err != nil {
 		return false, mterrors.Wrap(err, "set primary_conninfo after restart as standby")
 	}
 

--- a/go/services/multipooler/internal/manager/rpc_manager_test.go
+++ b/go/services/multipooler/internal/manager/rpc_manager_test.go
@@ -1028,6 +1028,8 @@ func TestRewindToSource_RestoresPrimaryConnInfo(t *testing.T) {
 	// pg_conf_load_time after reload (different value signals reload completed)
 	mockQueryService.AddQueryPattern("SELECT pg_conf_load_time",
 		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:01"}}))
+	// setPrimaryConnInfoLocked then waits for the WAL receiver to target the new primary.
+	expectReceiverTargeting(mockQueryService)
 
 	config := &Config{
 		TopoClient: ts,
@@ -1144,6 +1146,7 @@ func TestRewindToSource_NoDivergence_StillSetsPrimaryConnInfo(t *testing.T) {
 		mock.MakeQueryResult([]string{"pg_reload_conf"}, [][]any{{true}}))
 	mockQueryService.AddQueryPattern("SELECT pg_conf_load_time",
 		mock.MakeQueryResult([]string{"pg_conf_load_time"}, [][]any{{"2024-01-01 00:00:01"}}))
+	expectReceiverTargeting(mockQueryService)
 
 	config := &Config{
 		TopoClient: ts,

--- a/go/services/multipooler/internal/manager/rpc_set_term_primary_test.go
+++ b/go/services/multipooler/internal/manager/rpc_set_term_primary_test.go
@@ -217,13 +217,6 @@ func TestSetTermPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	mockQueryService.AddQueryPatternOnce("SELECT pg_is_in_recovery",
 		mock.MakeQueryResult([]string{"pg_is_in_recovery"}, [][]any{{"t"}}))
 
-	// pauseReplication(REPLAY_ONLY): pg_wal_replay_pause + verify paused.
-	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_pause",
-		mock.MakeQueryResult(nil, nil))
-	replayStateCols := []string{"replay_lsn", "is_paused"}
-	mockQueryService.AddQueryPattern("^SELECT pg_last_wal_replay_lsn",
-		mock.MakeQueryResult(replayStateCols, [][]any{{"0/100", true}}))
-
 	// Capture the rendered primary_conninfo so we can assert host=primary-host.
 	var capturedConnInfoSQL string
 	mockQueryService.AddQueryPatternWithCallback(
@@ -233,10 +226,9 @@ func TestSetTermPrimary_StandbyAppliesNewPrimary(t *testing.T) {
 	)
 	expectReloadConfig(mockQueryService)
 
-	// startReplicationAfter=true: waitForDatabaseConnection + pg_wal_replay_resume.
-	mockQueryService.AddQueryPattern("^SELECT 1$", mock.MakeQueryResult(nil, nil))
-	mockQueryService.AddQueryPatternOnce("SELECT pg_wal_replay_resume",
-		mock.MakeQueryResult(nil, nil))
+	// After reload, setPrimaryConnInfoLocked waits for the WAL receiver to target
+	// the new primary.
+	expectReceiverTargeting(mockQueryService)
 
 	pm, _ := setupManagerWithMockDB(t, mockQueryService, &fakeRuleStore{pos: makeRulePosition(3)})
 
@@ -287,7 +279,8 @@ func TestSetTermPrimary_StalePrimaryDemotes(t *testing.T) {
 		mock.MakeQueryResult(nil, nil))
 	expectReloadConfig(mockQueryService)
 
-	// 5. setPrimaryConnInfoLocked(false, false): rewrite primary_conninfo + reload.
+	// 5. setPrimaryConnInfoLocked: rewrite primary_conninfo, reload, then wait
+	// for the WAL receiver to target the new primary.
 	var capturedConnInfoSQL string
 	mockQueryService.AddQueryPatternWithCallback(
 		"ALTER SYSTEM SET primary_conninfo",
@@ -295,6 +288,7 @@ func TestSetTermPrimary_StalePrimaryDemotes(t *testing.T) {
 		func(sql string) { capturedConnInfoSQL = sql },
 	)
 	expectReloadConfig(mockQueryService)
+	expectReceiverTargeting(mockQueryService)
 
 	// 6. getStandbyReplayLSN — best-effort LSN read after demote.
 	mockQueryService.AddQueryPattern("SELECT pg_last_wal_replay_lsn",


### PR DESCRIPTION
setPrimaryConnInfoLocked paused WAL replay before writing primary_conninfo and only resumed on success, so a failed write/reload left replay paused. The pause was unnecessary and the stop/start bool params were left over from RPCs deleted in #999.

Reduce it to: set conninfo, reload, then wait until the WAL receiver targets the new primary (matched on the receiver's conninfo to ignore a stale one).

Replay pause/resume now belongs to StopReplication/StartReplication. The postgres monitor resumes a standby left with replay paused unless it was paused explicitly, tracked by a new replayManuallyPaused flag.