### PR TITLE
test(sqllogictest): run only the postgres-passing subset against multigateway in CI

### DIFF
--- a/.github/workflows/test-sqllogictest.yml
+++ b/.github/workflows/test-sqllogictest.yml
@@ -69,6 +69,11 @@ jobs:
         env:
           RUN_EXTENDED_QUERY_SERVING_TESTS: "1"
           TEST_PRINT_LOGS: "1"
+          # Run only the committed postgres-passing allowlist, against
+          # multigateway only (the postgres baseline is assumed passing by
+          # definition of the allowlist). This keeps the run well within the
+          # timeout; the full 622-file differential run is for local/manual use.
+          SLT_REGRESSION_MODE: "1"
         run: |
           go test -json -v -run TestPostgreSQLSqlLogicTest \
             ./go/test/endtoend/queryserving/sqllogictest/... \

--- a/go/test/endtoend/queryserving/sqllogictest/corpus.go
+++ b/go/test/endtoend/queryserving/sqllogictest/corpus.go
@@ -15,11 +15,14 @@
 package sqllogictest
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -122,4 +125,64 @@ func ensureUpstreamCorpus(t *testing.T, ctx context.Context) (string, error) {
 
 	t.Logf("sqllogictest corpus ready at %s (sha=%s)", dir, CorpusCommit)
 	return dir, nil
+}
+
+// postgresPassingRaw is the committed allowlist of corpus-relative paths that
+// pass against a standalone PostgreSQL baseline. In regression mode the suite
+// runs only these files (against multigateway only); for them the corpus's
+// embedded expected output is the postgres-correct output, so a multigateway
+// pass is equivalent to a live diff against postgres. See the file header for
+// how it is generated.
+//
+//go:embed testdata/postgres_passing.txt
+var postgresPassingRaw string
+
+// postgresPassingSet parses postgresPassingRaw into a set of corpus-relative
+// paths. Blank lines and #-prefixed comments are ignored.
+func postgresPassingSet() map[string]bool {
+	set := make(map[string]bool)
+	sc := bufio.NewScanner(strings.NewReader(postgresPassingRaw))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		set[line] = true
+	}
+	return set
+}
+
+// filterToPostgresPassing keeps only the corpus files whose corpus-relative
+// path appears in the embedded postgres-passing allowlist, preserving input
+// order. Any allowlisted path absent from the corpus is reported via t.Errorf
+// — that signals the allowlist has drifted from the pinned corpus commit and
+// must be regenerated.
+func filterToPostgresPassing(t *testing.T, corpusRoot string, files []string) []string {
+	t.Helper()
+	set := postgresPassingSet()
+	seen := make(map[string]bool, len(set))
+	kept := make([]string, 0, len(set))
+	for _, f := range files {
+		rel, err := filepath.Rel(corpusRoot, f)
+		if err != nil {
+			continue
+		}
+		rel = filepath.ToSlash(rel)
+		if set[rel] {
+			kept = append(kept, f)
+			seen[rel] = true
+		}
+	}
+	var missing []string
+	for p := range set {
+		if !seen[p] {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("postgres-passing allowlist has %d entr(ies) not present in the corpus (commit %s); "+
+			"regenerate testdata/postgres_passing.txt: %v", len(missing), CorpusCommit, missing)
+	}
+	return kept
 }

--- a/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
+++ b/go/test/endtoend/queryserving/sqllogictest/sqllogictest_test.go
@@ -52,8 +52,10 @@ const (
 )
 
 // protocolConfig pairs a short human name (used in report keys) with the
-// sqllogictest-rs engine string. Both configurations run against both
-// targets, producing four invocations per file.
+// sqllogictest-rs engine string. Both configurations run against both targets
+// (postgres baseline + multigateway), producing four invocations per file —
+// or two (multigateway only) in regression mode, where the postgres baseline
+// is skipped.
 type protocolConfig struct {
 	// Key labels the suite in results.json: "SQLLogicTest-" + Key.
 	Key string
@@ -84,6 +86,13 @@ var protocols = []protocolConfig{
 //	SLT_CORPUS_DIR=<dir>                — use an external corpus instead of testdata/
 //	SLT_CORPUS_GLOB=<glob>              — scope which corpus files run (default: **/*.slt)
 //	SLT_PER_FILE_TIMEOUT=<d>            — Go duration, e.g. "90s" (default: 10m)
+//	SLT_REGRESSION_MODE=1               — run only the committed postgres-passing
+//	                                      allowlist (testdata/postgres_passing.txt),
+//	                                      against multigateway only. The postgres
+//	                                      baseline is skipped and assumed passing
+//	                                      by definition of the allowlist, so any
+//	                                      file that fails on multigateway is a
+//	                                      real proxy regression. Used by CI.
 func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	suiteutil.SkipUnlessEnabled(t, suiteutil.EnvRunExtendedQueryServingTests)
 
@@ -103,6 +112,10 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 		}
 		perFileTimeout = d
 	}
+
+	// Regression mode (CI): run only the committed postgres-passing allowlist
+	// against multigateway, skipping the standalone postgres baseline.
+	regressionMode := os.Getenv("SLT_REGRESSION_MODE") == "1"
 
 	// Phase 1: build PostgreSQL 17.6 from source (cached across runs).
 	buildCtx := utils.WithTimeout(t, defaultBuildTimeout)
@@ -148,30 +161,46 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	t.Logf("Phase 3: corpus = %d files from %s (glob=%q, commit=%s)",
 		len(files), corpusRoot, firstNonEmpty(os.Getenv("SLT_CORPUS_GLOB"), DefaultCorpusGlob), CorpusCommit)
 
+	if regressionMode {
+		files = filterToPostgresPassing(t, corpusRoot, files)
+		if len(files) == 0 {
+			t.Fatalf("regression mode: no corpus files matched the postgres-passing allowlist")
+		}
+		t.Logf("Phase 3: regression mode — restricted to %d postgres-passing files", len(files))
+	}
+
 	// Phase 4: start the baseline standalone postgres. Separate context so
 	// initdb + postgres launch + pg_isready polling each get their budget
 	// independent of what Phase 1 and Phase 3 already consumed.
-	t.Logf("Phase 4: starting standalone PostgreSQL...")
-	standaloneCtx := utils.WithTimeout(t, defaultStandaloneStartTimeout)
-	standalone, err := pgbuilder.StartStandalone(t, standaloneCtx, builder, standalonePassword)
-	if err != nil {
-		t.Fatalf("StartStandalone: %v", err)
+	//
+	// Skipped in regression mode: the allowlist already encodes the
+	// postgres-passing verdict, so there is no live baseline to run against.
+	var pgTarget suiteutil.Target
+	if !regressionMode {
+		t.Logf("Phase 4: starting standalone PostgreSQL...")
+		standaloneCtx := utils.WithTimeout(t, defaultStandaloneStartTimeout)
+		standalone, err := pgbuilder.StartStandalone(t, standaloneCtx, builder, standalonePassword)
+		if err != nil {
+			t.Fatalf("StartStandalone: %v", err)
+		}
+		t.Cleanup(func() { _ = standalone.Stop() })
+		pgTarget = suiteutil.Target{
+			Name: "postgres",
+			Host: "127.0.0.1",
+			Port: standalone.Port,
+			User: standalone.User,
+			Pass: standalone.Password,
+			DB:   standalone.Database,
+		}
+	} else {
+		t.Logf("Phase 4: skipped (regression mode — postgres baseline assumed passing per allowlist)")
 	}
-	t.Cleanup(func() { _ = standalone.Stop() })
 
 	// Phase 5: bring up the multigres cluster + multigateway.
 	t.Logf("Phase 5: starting multigres cluster...")
 	setup := getSharedSetup(t)
 	setup.SetupTest(t)
 
-	pgTarget := suiteutil.Target{
-		Name: "postgres",
-		Host: "127.0.0.1",
-		Port: standalone.Port,
-		User: standalone.User,
-		Pass: standalone.Password,
-		DB:   standalone.Database,
-	}
 	mgTarget := suiteutil.Target{
 		Name: "multigateway",
 		Host: "127.0.0.1",
@@ -198,7 +227,10 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	// inval scatter across the multipooler's regular pool. Connecting
 	// directly to the primary PG bypasses the pool and pins all resets to
 	// a single backend.
-	pgResetter := suiteutil.NewSchemaResetterWithCleanup(t, pgTarget)
+	var pgResetter *suiteutil.SchemaResetter
+	if !regressionMode {
+		pgResetter = suiteutil.NewSchemaResetterWithCleanup(t, pgTarget)
+	}
 	primary := setup.GetPrimary(t)
 	mgResetTarget := suiteutil.Target{
 		Name: "multigateway-pg-direct",
@@ -211,9 +243,14 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	mgResetter := suiteutil.NewSchemaResetterWithCleanup(t, mgResetTarget)
 
 	// Phase 6: for each file, run both targets under both protocols. Four
-	// invocations per file. Honors the overall test deadline so a timeout
-	// still produces a coherent partial report.
-	t.Logf("Phase 6: running %d files × %d protocols × 2 targets...", len(files), len(protocols))
+	// invocations per file (multigateway only — two — in regression mode).
+	// Honors the overall test deadline so a timeout still produces a coherent
+	// partial report.
+	if regressionMode {
+		t.Logf("Phase 6: running %d files × %d protocols × multigateway only (regression mode)...", len(files), len(protocols))
+	} else {
+		t.Logf("Phase 6: running %d files × %d protocols × 2 targets...", len(files), len(protocols))
+	}
 
 	overall := t.Context()
 	startedAt := time.Now()
@@ -228,9 +265,17 @@ func TestPostgreSQLSqlLogicTest(t *testing.T) {
 	ranAgainst, timedOut := suiteutil.RunCorpusLoop(t, overall, files,
 		func(i int, f string) {
 			for _, p := range protocols {
-				pgRes := suiteutil.RunWithTimeout(overall, perFileTimeout, func(ctx context.Context) *runResult {
-					return runSqllogictest(ctx, pgTarget, pgResetter, p.Engine, f)
-				})
+				var pgRes *runResult
+				if regressionMode {
+					// Postgres baseline isn't run; the allowlist guarantees it
+					// passes. Synthesize the verdict so the report shape and the
+					// divergence check (PG pass && MG fail) stay intact.
+					pgRes = &runResult{File: f, Passed: true}
+				} else {
+					pgRes = suiteutil.RunWithTimeout(overall, perFileTimeout, func(ctx context.Context) *runResult {
+						return runSqllogictest(ctx, pgTarget, pgResetter, p.Engine, f)
+					})
+				}
 				mgRes := suiteutil.RunWithTimeout(overall, perFileTimeout, func(ctx context.Context) *runResult {
 					return runSqllogictest(ctx, mgTarget, mgResetter, p.Engine, f)
 				})

--- a/go/test/endtoend/queryserving/sqllogictest/testdata/postgres_passing.txt
+++ b/go/test/endtoend/queryserving/sqllogictest/testdata/postgres_passing.txt
@@ -1,0 +1,179 @@
+# sqllogictest corpus files that pass against a standalone PostgreSQL baseline.
+#
+# Generated from the differential suite's full run (all 622 corpus files x
+# both wire protocols x both targets). A file appears here iff it passes
+# against the standalone PostgreSQL baseline; for those files the corpus's
+# embedded expected output IS the postgres-correct output, so running them
+# against multigateway and checking they pass is equivalent to a live diff
+# against postgres.
+#
+# CI runs ONLY these files, and ONLY against multigateway (SLT_REGRESSION_MODE=1):
+# the postgres baseline is assumed passing by definition of this list. Any
+# file here that fails on multigateway is a real proxy divergence/regression.
+#
+# Source run: https://github.com/multigres/multigres/actions/runs/26817719179
+# Corpus commit: c67f97bf3ca7e590d12e073408bcacaf2ff0f3a0 (gregrahn/sqllogictest)
+# The set is identical across the simple and extended protocols.
+#
+# To regenerate: run the suite WITHOUT SLT_REGRESSION_MODE (full differential
+# run) and extract files where postgres.passed==true from results.json:
+#   jq -r '.[0].tests[] | select(.postgres.passed) | .name' results.json | sort -u
+#
+# One corpus-relative path per line. Blank lines and #-comments are ignored.
+test/evidence/slt_lang_aggfunc.test
+test/evidence/slt_lang_createtrigger.test
+test/evidence/slt_lang_dropindex.test
+test/evidence/slt_lang_droptable.test
+test/evidence/slt_lang_droptrigger.test
+test/evidence/slt_lang_dropview.test
+test/evidence/slt_lang_reindex.test
+test/evidence/slt_lang_replace.test
+test/index/between/1/slt_good_0.test
+test/index/between/10/slt_good_0.test
+test/index/between/10/slt_good_1.test
+test/index/between/10/slt_good_2.test
+test/index/between/10/slt_good_3.test
+test/index/between/10/slt_good_4.test
+test/index/between/10/slt_good_5.test
+test/index/between/100/slt_good_0.test
+test/index/between/100/slt_good_1.test
+test/index/between/100/slt_good_2.test
+test/index/between/100/slt_good_3.test
+test/index/between/100/slt_good_4.test
+test/index/between/1000/slt_good_0.test
+test/index/commute/10/slt_good_0.test
+test/index/commute/10/slt_good_1.test
+test/index/commute/10/slt_good_10.test
+test/index/commute/10/slt_good_11.test
+test/index/commute/10/slt_good_12.test
+test/index/commute/10/slt_good_13.test
+test/index/commute/10/slt_good_14.test
+test/index/commute/10/slt_good_15.test
+test/index/commute/10/slt_good_16.test
+test/index/commute/10/slt_good_17.test
+test/index/commute/10/slt_good_18.test
+test/index/commute/10/slt_good_19.test
+test/index/commute/10/slt_good_2.test
+test/index/commute/10/slt_good_20.test
+test/index/commute/10/slt_good_21.test
+test/index/commute/10/slt_good_22.test
+test/index/commute/10/slt_good_23.test
+test/index/commute/10/slt_good_24.test
+test/index/commute/10/slt_good_25.test
+test/index/commute/10/slt_good_26.test
+test/index/commute/10/slt_good_27.test
+test/index/commute/10/slt_good_28.test
+test/index/commute/10/slt_good_29.test
+test/index/commute/10/slt_good_3.test
+test/index/commute/10/slt_good_30.test
+test/index/commute/10/slt_good_31.test
+test/index/commute/10/slt_good_32.test
+test/index/commute/10/slt_good_33.test
+test/index/commute/10/slt_good_34.test
+test/index/commute/10/slt_good_4.test
+test/index/commute/10/slt_good_5.test
+test/index/commute/10/slt_good_6.test
+test/index/commute/10/slt_good_7.test
+test/index/commute/10/slt_good_8.test
+test/index/commute/10/slt_good_9.test
+test/index/commute/100/slt_good_0.test
+test/index/commute/100/slt_good_1.test
+test/index/commute/100/slt_good_10.test
+test/index/commute/100/slt_good_11.test
+test/index/commute/100/slt_good_12.test
+test/index/commute/100/slt_good_2.test
+test/index/commute/100/slt_good_3.test
+test/index/commute/100/slt_good_4.test
+test/index/commute/100/slt_good_5.test
+test/index/commute/100/slt_good_6.test
+test/index/commute/100/slt_good_7.test
+test/index/commute/100/slt_good_8.test
+test/index/commute/100/slt_good_9.test
+test/index/commute/1000/slt_good_0.test
+test/index/commute/1000/slt_good_1.test
+test/index/commute/1000/slt_good_2.test
+test/index/commute/1000/slt_good_3.test
+test/index/delete/1/slt_good_0.test
+test/index/delete/10/slt_good_0.test
+test/index/delete/10/slt_good_1.test
+test/index/delete/10/slt_good_2.test
+test/index/delete/10/slt_good_3.test
+test/index/delete/10/slt_good_4.test
+test/index/delete/10/slt_good_5.test
+test/index/delete/100/slt_good_0.test
+test/index/delete/100/slt_good_1.test
+test/index/delete/100/slt_good_2.test
+test/index/delete/100/slt_good_3.test
+test/index/delete/1000/slt_good_0.test
+test/index/delete/1000/slt_good_1.test
+test/index/delete/10000/slt_good_0.test
+test/index/in/10/slt_good_0.test
+test/index/in/10/slt_good_1.test
+test/index/in/10/slt_good_2.test
+test/index/in/10/slt_good_3.test
+test/index/in/10/slt_good_4.test
+test/index/in/10/slt_good_5.test
+test/index/in/100/slt_good_0.test
+test/index/in/100/slt_good_1.test
+test/index/in/100/slt_good_2.test
+test/index/in/100/slt_good_3.test
+test/index/in/100/slt_good_4.test
+test/index/in/1000/slt_good_0.test
+test/index/in/1000/slt_good_1.test
+test/index/orderby/10/slt_good_0.test
+test/index/orderby/10/slt_good_1.test
+test/index/orderby/10/slt_good_10.test
+test/index/orderby/10/slt_good_11.test
+test/index/orderby/10/slt_good_12.test
+test/index/orderby/10/slt_good_13.test
+test/index/orderby/10/slt_good_14.test
+test/index/orderby/10/slt_good_15.test
+test/index/orderby/10/slt_good_16.test
+test/index/orderby/10/slt_good_17.test
+test/index/orderby/10/slt_good_18.test
+test/index/orderby/10/slt_good_19.test
+test/index/orderby/10/slt_good_2.test
+test/index/orderby/10/slt_good_20.test
+test/index/orderby/10/slt_good_21.test
+test/index/orderby/10/slt_good_22.test
+test/index/orderby/10/slt_good_23.test
+test/index/orderby/10/slt_good_24.test
+test/index/orderby/10/slt_good_25.test
+test/index/orderby/10/slt_good_3.test
+test/index/orderby/10/slt_good_4.test
+test/index/orderby/10/slt_good_5.test
+test/index/orderby/10/slt_good_6.test
+test/index/orderby/10/slt_good_7.test
+test/index/orderby/10/slt_good_8.test
+test/index/orderby/10/slt_good_9.test
+test/index/orderby/100/slt_good_0.test
+test/index/orderby/100/slt_good_1.test
+test/index/orderby/100/slt_good_2.test
+test/index/orderby/100/slt_good_3.test
+test/index/orderby/1000/slt_good_0.test
+test/index/orderby_nosort/10/slt_good_12.test
+test/index/orderby_nosort/10/slt_good_15.test
+test/index/orderby_nosort/10/slt_good_16.test
+test/index/orderby_nosort/10/slt_good_17.test
+test/index/orderby_nosort/10/slt_good_18.test
+test/index/orderby_nosort/10/slt_good_20.test
+test/index/orderby_nosort/10/slt_good_21.test
+test/index/orderby_nosort/10/slt_good_22.test
+test/index/orderby_nosort/10/slt_good_23.test
+test/index/orderby_nosort/10/slt_good_24.test
+test/index/orderby_nosort/10/slt_good_26.test
+test/index/orderby_nosort/10/slt_good_28.test
+test/index/orderby_nosort/10/slt_good_29.test
+test/index/orderby_nosort/10/slt_good_31.test
+test/index/orderby_nosort/10/slt_good_32.test
+test/index/orderby_nosort/10/slt_good_33.test
+test/index/orderby_nosort/10/slt_good_34.test
+test/index/orderby_nosort/10/slt_good_35.test
+test/index/orderby_nosort/10/slt_good_36.test
+test/index/orderby_nosort/10/slt_good_37.test
+test/index/orderby_nosort/10/slt_good_38.test
+test/index/random/1000/slt_good_2.test
+test/index/random/1000/slt_good_3.test
+test/index/view/10/slt_good_0.test
+test/random/select/slt_good_125.test
+test/random/select/slt_good_126.test


### PR DESCRIPTION
## Summary

- The weekly SQLLogicTest differential suite ran all 622 corpus files × 2 protocols × 2 targets and could not finish within the 170m test timeout (it panicked at ~150/622 files), so it never wrote `results.json` — which surfaced as the recurring "suite failed to produce results" Slack alert.
- Restrict the CI run to the 157 corpus files that pass against the standalone PostgreSQL baseline, run them against multigateway only, and skip the postgres baseline entirely. This cuts the run from a multi-hour job that times out to ~117m that completes.
- Commit the postgres-passing allowlist so the subset is reproducible and pinned to the corpus commit; the full 622-file differential run remains available for local/manual use.

## Problem

`TestPostgreSQLSqlLogicTest` runs every corpus file against both a standalone PostgreSQL baseline and multigateway, under both wire protocols — four runner invocations per file. At 622 files that does not fit in the 170m `go test -timeout`, so the run hit Go's hard timeout panic before the loop's graceful "write partial report" path could run. No `results.json` was produced, the artifact upload found nothing, and the weekly Slack job reported an infrastructure failure.

## Solution

For any corpus file that passes against the standalone PostgreSQL baseline, the file's embedded expected output *is* the postgres-correct output. So running that file against multigateway and checking it passes is equivalent to a live diff against postgres — no live baseline needed.

This adds `SLT_REGRESSION_MODE=1` (set in the workflow) which:

- filters the corpus to the committed allowlist in `testdata/postgres_passing.txt` (157 files, identical across both protocols),
- skips Phase 4 (standalone postgres) and its schema resetter, and
- synthesizes each file's postgres verdict as passing — true by definition of the allowlist.

The report shape is unchanged, so the existing divergence detection (`postgres.passed == true && multigateway.passed == false`) now means exactly "an allowlisted file regressed on multigateway," and the existing Slack divergence/weekly-summary steps keep working. Because the run now completes, `results.json` is produced and the false "infra failure" alert goes away.

Default behavior (the full differential run, used locally) is unchanged. `filterToPostgresPassing` reports via `t.Errorf` if any allowlisted path is missing from the pinned corpus, catching allowlist drift. The allowlist was generated from the last successful full run (#26817719179); the header documents how to regenerate it.