### PR TITLE
test(pgregresstest): patch test_setup for rejected synchronous_commit SET

### DIFF
--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/test_setup.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/test_setup.patch
@@ -1,0 +1,18 @@
+# multigateway rejects user changes to synchronous_commit (#1088): durability is
+# owned by the cluster (SyncStandbyManager keeps the primary at
+# synchronous_commit=on), so a session may not reassign it through the pooler.
+# test_setup runs `SET synchronous_commit = on` to stabilize hint-bit timing, but
+# the cluster already enforces that value, so the SET is redundant here and is now
+# rejected with a feature_not_supported ERROR instead of succeeding silently. The
+# rejection is intentional; this patch records the resulting expected-output diff.
+# See go/services/multigateway/planner/restricted_guc.go.
+--- a
++++ b
+@@ -13,6 +13,7 @@
+ -- that source of variability.
+ --
+ SET synchronous_commit = on;
++ERROR: setting synchronous_commit is not supported: replication durability is managed by the cluster; use RESET synchronous_commit (or SET synchronous_commit TO DEFAULT) to restore the managed value
+ --
+ -- Postgres formerly made the public schema read/write by default,
+ -- and most of the core regression tests still expect that.


### PR DESCRIPTION
## Summary

- multigateway now rejects user changes to `synchronous_commit` (#1088), so the core regression `test_setup` script — which runs `SET synchronous_commit = on` — gets a `feature_not_supported` ERROR instead of a silent `SET`, failing the test in CI.
- The cluster already enforces `synchronous_commit=on` on the primary (SyncStandbyManager), so that `SET` is redundant; the rejection is intentional. This records the resulting expected-output diff as a per-test patch, with a comment preamble explaining the rationale.

## Note: spgist (not addressed here)

The same nightly run also shows `spgist` newly failing — its 4-row domain-index query plans `Seq Scan` instead of the expected `Bitmap Index Scan`. `test_setup` and `spgist` are the only two regressions between the last green run and the failing one, so they looked related.

They are not. `synchronous_commit` is already on for the suite (primary, where all pg_regress queries route), so the plan flip is **not** a consequence of #1088. It also doesn't reproduce locally — in an isolated run the query plans `Bitmap` on both old and new binaries. The most likely explanation is flaky tiny-table plan-cost timing under the full parallel run rather than a clean regression.

I deliberately left `spgist` out of this PR rather than pin a possibly-flaky plan via patch. Follow-up: re-run `test-pgregress.yml` a couple times to confirm whether `spgist` is deterministically `Seq Scan` or flapping, then either patch it or treat it as flaky.