### PR TITLE
ci: add nightly container image builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,136 @@
+# Copyright 2026 Supabase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build"
+        required: false
+        default: "main"
+  schedule:
+    - cron: "0 5 * * *" # 05:00 UTC nightly
+
+concurrency:
+  group: nightly-build-${{ github.event.inputs.ref || 'main' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-nightly-images:
+    name: Build Nightly Images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: multigres
+            context: .
+            file: ./Dockerfile
+          - image: pgctld
+            context: .
+            file: ./Dockerfile.pgctld
+          - image: multiadmin-web
+            context: web/multiadmin/
+            file: web/multiadmin/Dockerfile
+          - image: multigres-cluster
+            context: .
+            file: ./Dockerfile.cluster
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref || 'main' }}
+          persist-credentials: false
+
+      - name: Determine SHA
+        id: determine-sha
+        run: |
+          {
+            echo "sha=$(git rev-parse --short HEAD)"
+            echo "full_sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          flavor: |
+            latest=false
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.determine-sha.outputs.full_sha }}
+            multigres.branch.ref=${{ github.event.inputs.ref || 'main' }}
+          tags: |
+            type=raw,value=nightly-{{date 'YYYY-MM-DD'}}.${{ steps.determine-sha.outputs.sha }},priority=900
+            type=raw,value=nightly,priority=600
+            type=raw,value=nightly-sha-${{ steps.determine-sha.outputs.sha }},priority=500
+
+      - name: Report image version
+        run: |
+          echo "Nightly Docker image version: ${{ steps.meta.outputs.version }}"
+
+      - name: Build and push nightly image
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Verify published image
+        env:
+          IMAGE_REF: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: docker buildx imagetools inspect "${IMAGE_REF}@${IMAGE_DIGEST}"
+
+      - name: Add image summary
+        env:
+          IMAGE: ${{ matrix.image }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### ${IMAGE}"
+            echo
+            echo "- Version: \`${VERSION}\`"
+            echo "- Digest: \`${IMAGE_DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: Nightly Build
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Git ref to build"
-        required: false
-        default: "main"
   schedule:
     - cron: "0 5 * * *" # 05:00 UTC nightly
 
 concurrency:
-  group: nightly-build-${{ github.event.inputs.ref || 'main' }}
+  group: nightly-build-main
   cancel-in-progress: false
 
 permissions:
@@ -60,7 +56,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.ref || 'main' }}
+          ref: main
           persist-credentials: false
 
       - name: Determine SHA
@@ -91,15 +87,17 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.determine-sha.outputs.full_sha }}
-            multigres.branch.ref=${{ github.event.inputs.ref || 'main' }}
+            multigres.branch.ref=main
           tags: |
             type=raw,value=nightly-{{date 'YYYY-MM-DD'}}.${{ steps.determine-sha.outputs.sha }},priority=900
             type=raw,value=nightly,priority=600
             type=raw,value=nightly-sha-${{ steps.determine-sha.outputs.sha }},priority=500
 
       - name: Report image version
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          echo "Nightly Docker image version: ${{ steps.meta.outputs.version }}"
+          echo "Nightly Docker image version: ${VERSION}"
 
       - name: Build and push nightly image
         id: build

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,21 @@ Container images include:
 archive. `portpoolserver` is test and development infrastructure and is not a
 release artifact.
 
+## Nightly Container Images
+
+Nightly container images are published from `main` for pre-release testing and
+benchmarking. They are not releases and may change without notice.
+
+Nightly tags include:
+
+- `nightly`
+- `nightly-YYYY-MM-DD.<short-sha>`
+- `nightly-sha-<short-sha>`
+
+Use `nightly` when you want the latest daily build. Use a date-and-commit tag,
+or pin the resolved image digest, when you need a traceable or reproducible
+benchmark run.
+
 ## Kubernetes Installs
 
 For Kubernetes deployments, start with the Multigres Operator release you plan


### PR DESCRIPTION
## Description
this PR adds a nightly GitHub Actions workflow that publishes Multigres container images from `main` for pre-release testing and as a consumable for other tools. 

## Main Changes
- Add `.github/workflows/nightly-build.yml` to build and push nightly GHCR images for `multigres`, `pgctld`, `multiadmin-web`, and `multigres-cluster`
- Publish nightly, `nightly-YYYY-MM-DD.<short-sha>`, and `nightly-sha-<short-sha> tags`
- SBOM and provenance configuration included; updated docs

Closes https://github.com/multigres/multigres/issues/1133