### PR TITLE
fix(multipooler): keep pooled session state consistent across transaction rollback

### DIFF
--- a/go/services/multipooler/internal/connstate/connection_state.go
+++ b/go/services/multipooler/internal/connstate/connection_state.go
@@ -107,6 +107,49 @@ func (s *ConnectionState) Clone() *ConnectionState {
 	return clone
 }
 
+// TxnSnapshot captures the parts of ConnectionState that PostgreSQL rolls back
+// together with the surrounding transaction: session GUCs set via SET, and the
+// current role set via SET ROLE / SET SESSION AUTHORIZATION. A session SET (or
+// SET ROLE) issued inside a transaction is reverted on ROLLBACK and kept on
+// COMMIT; the pool caches that state in ConnectionState and relies on it (via
+// interned-Settings pointer identity) to decide when to re-apply settings to a
+// backend. A reserved connection snapshots its state when it opens a
+// transaction and restores the snapshot if the transaction rolls back, so the
+// pool's cached view never diverges from the backend's real session state.
+//
+// Settings is interned and immutable (it is replaced wholesale via SetSettings,
+// never mutated in place), so it is captured by reference; User is copied by
+// value. Prepared statements are intentionally NOT captured here — their
+// lifecycle is owned by the prepared-statement consolidator, not this cache.
+type TxnSnapshot struct {
+	settings *Settings
+	user     string
+}
+
+// SnapshotForTxn captures the transaction-revertible parts of the state.
+// Returns nil for a nil receiver.
+func (s *ConnectionState) SnapshotForTxn() *TxnSnapshot {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return &TxnSnapshot{settings: s.Settings, user: s.User}
+}
+
+// RestoreFromTxn restores state captured by SnapshotForTxn. It is called after a
+// ROLLBACK so the pool's view matches the backend, which PostgreSQL has just
+// reverted to its pre-transaction session state. No-op for a nil snapshot.
+func (s *ConnectionState) RestoreFromTxn(snap *TxnSnapshot) {
+	if s == nil || snap == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Settings = snap.settings
+	s.User = snap.user
+}
+
 // Close cleans up the connection state.
 func (s *ConnectionState) Close() {
 	if s == nil {

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -1626,6 +1626,21 @@ func (e *Executor) ConcludeTransaction(
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT:
 		commandTag = "COMMIT"
 		releaseReason = reserved.ReleaseCommit
+		// Reconcile the pool's cached connstate with the gateway's authoritative
+		// session settings before committing. A `ROLLBACK TO SAVEPOINT` earlier in
+		// this transaction can revert a session GUC (or role) on the backend while
+		// the pool's cached connstate still reflects the pre-rollback value, with no
+		// later settings-bearing query to re-sync it (full ROLLBACK is covered by the
+		// reserved conn's snapshot/restore; COMMIT is not). Re-applying here, inside
+		// the still-healthy transaction, brings backend and connstate back into
+		// agreement so the committed, recycled connection is bucketed and reused with
+		// the correct settings. Idempotent: ApplySettingsToConn short-circuits when
+		// connstate already matches, so this costs nothing unless a savepoint
+		// rollback actually left them diverged.
+		if err := e.poolManager.ApplySettingsToConn(ctx, reservedConn.Conn(), e.sessionSettingsForPool(options.SessionSettings)); err != nil {
+			reservedConn.Release(reserved.ReleaseError)
+			return nil, nil, err
+		}
 		if err := reservedConn.Commit(ctx); err != nil {
 			reservedConn.Release(reserved.ReleaseError)
 			return nil, nil, err

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -53,6 +53,15 @@ type Conn struct {
 	// reservedProps tracks why the connection is reserved.
 	reservedProps *ReservationProperties
 
+	// txnSnapshot captures the session state (GUCs, role) at the moment this
+	// connection opened its current transaction. PostgreSQL reverts session
+	// SET / SET ROLE issued inside a transaction on ROLLBACK; restoring this
+	// snapshot on rollback keeps the pool's cached connstate in lock-step with
+	// the backend, so a recycled connection is never reused with stale settings.
+	// nil when not in a transaction. Accessed only from the transaction-control
+	// methods, which the gateway serializes per reserved connection.
+	txnSnapshot *connstate.TxnSnapshot
+
 	// inactivityTimeout is the maximum duration the connection can be inactive
 	// (no client activity) before expiring. A value of 0 means no timeout.
 	inactivityTimeout time.Duration
@@ -114,6 +123,10 @@ func (c *Conn) BeginWithQuery(ctx context.Context, beginQuery string) error {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
+	// Snapshot the committed session-state baseline so a ROLLBACK can revert the
+	// pool's cached connstate in lock-step with PostgreSQL.
+	c.txnSnapshot = c.pooled.Conn.State().SnapshotForTxn()
+
 	c.AddReservationReason(protoutil.ReasonTransaction)
 	return nil
 }
@@ -129,6 +142,10 @@ func (c *Conn) Commit(ctx context.Context) error {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
+	// Committed: mid-transaction session changes are now durable and already
+	// reflected in connstate; drop the snapshot.
+	c.txnSnapshot = nil
+
 	c.RemoveReservationReason(protoutil.ReasonTransaction)
 	return nil
 }
@@ -143,6 +160,14 @@ func (c *Conn) Rollback(ctx context.Context) error {
 	_, err := c.pooled.Conn.Query(ctx, "ROLLBACK")
 	if err != nil {
 		return fmt.Errorf("failed to rollback transaction: %w", err)
+	}
+
+	// PostgreSQL just reverted any SET / SET ROLE issued inside this transaction
+	// to the pre-transaction baseline. Revert the pool's cached connstate to the
+	// same baseline so the recycled connection is bucketed and reused correctly.
+	if c.txnSnapshot != nil {
+		c.pooled.Conn.State().RestoreFromTxn(c.txnSnapshot)
+		c.txnSnapshot = nil
 	}
 
 	c.RemoveReservationReason(protoutil.ReasonTransaction)

--- a/go/test/endtoend/pgregresstest/guc_divergence_repro_test.go
+++ b/go/test/endtoend/pgregresstest/guc_divergence_repro_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// openGUCNoticeConn opens a pgx connection that starts at
+// client_min_messages=NOTICE (mirroring PostGIS run_test.pl's PGOPTIONS) and
+// records every server NOTICE it receives.
+func openGUCNoticeConn(ctx context.Context, t *testing.T, port int) (*pgx.Conn, func() []string, func()) {
+	t.Helper()
+	connStr := shardsetup.GetTestUserDSN("localhost", port, "sslmode=disable", "connect_timeout=5")
+	cfg, err := pgx.ParseConfig(connStr)
+	require.NoError(t, err)
+	if cfg.RuntimeParams == nil {
+		cfg.RuntimeParams = map[string]string{}
+	}
+	cfg.RuntimeParams["options"] = "-c client_min_messages=NOTICE"
+	var mu sync.Mutex
+	var notices []string
+	cfg.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
+		mu.Lock()
+		notices = append(notices, n.Message)
+		mu.Unlock()
+	}
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	require.NoError(t, err)
+	get := func() []string { mu.Lock(); defer mu.Unlock(); return append([]string(nil), notices...) }
+	return conn, get, func() { _ = conn.Close(ctx) }
+}
+
+// createLeakNoticeFn installs public.leak_notice(int), which RAISEs a NOTICE that
+// client_min_messages=error must suppress.
+func createLeakNoticeFn(t *testing.T, directPgPort int) {
+	t.Helper()
+	require.NoError(t, execOnPrimary(directPgPort, shardsetup.TestPostgresPassword,
+		`CREATE OR REPLACE FUNCTION public.leak_notice(x int) RETURNS int LANGUAGE plpgsql AS $$ BEGIN RAISE NOTICE 'leak-%', x; RETURN x; END $$`))
+	t.Cleanup(func() {
+		_ = execOnPrimary(directPgPort, shardsetup.TestPostgresPassword, `DROP FUNCTION IF EXISTS public.leak_notice(int)`)
+	})
+}
+
+// runGUCNoticeLeakRounds runs `rounds` poison+victim pairs against the given port.
+// Each round runs the poison SQL on one connection (a transaction whose
+// session-GUC change PostgreSQL reverts on rollback) and then a victim that sets
+// client_min_messages=error and expects leak_notice()'s NOTICE to be suppressed.
+// It returns how many victim rounds leaked the NOTICE and how many observed a
+// reserved backend whose client_min_messages != error (SHOW inside the txn).
+func runGUCNoticeLeakRounds(ctx context.Context, t *testing.T, port int, poison []string) (leaks, mismatches int) {
+	t.Helper()
+	const rounds = 40
+	m := pgx.QueryExecModeSimpleProtocol
+	for range rounds {
+		pc, _, pclose := openGUCNoticeConn(ctx, t, port)
+		for _, sql := range poison {
+			_, _ = pc.Exec(ctx, sql, m)
+		}
+		pclose()
+
+		vc, getNotices, vclose := openGUCNoticeConn(ctx, t, port)
+		_, _ = vc.Exec(ctx, "SET search_path TO public", m)
+		_, _ = vc.Exec(ctx, "SET client_min_messages TO error", m)
+		_, _ = vc.Exec(ctx, "BEGIN", m)
+		var inTxn string
+		_ = vc.QueryRow(ctx, "SHOW client_min_messages", m).Scan(&inTxn)
+		_, _ = vc.Exec(ctx, "SELECT public.leak_notice(1)", m)
+		_, _ = vc.Exec(ctx, "COMMIT", m)
+		got := getNotices()
+		vclose()
+
+		if inTxn != "error" {
+			mismatches++
+		}
+		if slices.Contains(got, "leak-1") {
+			leaks++
+			t.Logf("NOTICE leaked; reserved backend client_min_messages=%q (wanted error)", inTxn)
+		}
+	}
+	return leaks, mismatches
+}
+
+// TestGUCDivergenceRepro covers the plain BEGIN -> SET -> ROLLBACK case: a session
+// GUC set inside a transaction is reverted on the backend by ROLLBACK, and the
+// pool must revert its cached connstate in lock-step so the recycled connection
+// is not reused with stale settings.
+func TestGUCDivergenceRepro(t *testing.T) {
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 5*time.Minute)
+	directPgPort := setup.GetPrimary(t).Pgctld.PgPort
+	gatewayPgPort := setup.MultigatewayPgPort
+	createLeakNoticeFn(t, directPgPort)
+
+	poison := []string{
+		"SET search_path TO public",
+		"BEGIN",
+		"SET client_min_messages TO error",
+		"SELECT 1",
+		"ROLLBACK",
+	}
+
+	t.Run("direct_primary", func(t *testing.T) {
+		leaks, mism := runGUCNoticeLeakRounds(ctx, t, directPgPort, poison)
+		t.Logf("DIRECT:  leaks=%d/40 backend-mismatches=%d/40", leaks, mism)
+		require.Zero(t, leaks, "sanity: direct PostgreSQL must never leak")
+	})
+	t.Run("multigateway", func(t *testing.T) {
+		leaks, mism := runGUCNoticeLeakRounds(ctx, t, gatewayPgPort, poison)
+		t.Logf("GATEWAY: leaks=%d/40 backend-mismatches=%d/40", leaks, mism)
+		require.Zero(t, leaks, "transaction rollback must not leave stale pooled GUC state")
+	})
+}
+
+// TestGUCSavepointDivergenceRepro covers the ROLLBACK TO SAVEPOINT -> COMMIT hole:
+// a session GUC set inside a sub-transaction is reverted on the backend by
+// ROLLBACK TO SAVEPOINT, but the transaction-level snapshot only restores on a
+// full ROLLBACK, so without the COMMIT-time reconcile the committed connection is
+// recycled with a connstate that disagrees with the backend.
+func TestGUCSavepointDivergenceRepro(t *testing.T) {
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 5*time.Minute)
+	directPgPort := setup.GetPrimary(t).Pgctld.PgPort
+	gatewayPgPort := setup.MultigatewayPgPort
+	createLeakNoticeFn(t, directPgPort)
+
+	poison := []string{
+		"SET search_path TO public",
+		"BEGIN",
+		"SAVEPOINT sp",
+		"SET client_min_messages TO error",
+		"ROLLBACK TO SAVEPOINT sp",
+		"COMMIT",
+	}
+
+	t.Run("direct_primary", func(t *testing.T) {
+		leaks, mism := runGUCNoticeLeakRounds(ctx, t, directPgPort, poison)
+		t.Logf("DIRECT:  leaks=%d/40 backend-mismatches=%d/40", leaks, mism)
+		require.Zero(t, leaks, "sanity: direct PostgreSQL must never leak")
+	})
+	t.Run("multigateway", func(t *testing.T) {
+		leaks, mism := runGUCNoticeLeakRounds(ctx, t, gatewayPgPort, poison)
+		t.Logf("GATEWAY: leaks=%d/40 backend-mismatches=%d/40", leaks, mism)
+		require.Zero(t, leaks, "savepoint rollback-to + commit must not leave stale pooled GUC state")
+	})
+}


### PR DESCRIPTION
## Problem

PostgreSQL reverts a session-level `SET` / `set_config(…, is_local=false)` when the transaction it ran in is **rolled back** (and on `ROLLBACK TO SAVEPOINT`). The multipooler's cached connection state (`connstate`) did **not** revert — it kept the value the client set inside the transaction.

Because the pool decides whether to re-apply settings to a reused backend by comparing interned setting-pointers for equality, a backend whose cached state still "matched" was handed to the next session **without re-applying** — so a GUC the client set and then rolled back silently leaked into unrelated later sessions.

Surfaced by the PostGIS topology suite, where a `client_min_messages` set-then-rolled-back leaked **902** `NOTICE: SRID value -1 converted…` messages through the gateway that never appear on a direct connection. The regression test reproduces it with no PostGIS dependency.

## Fix

Make the pooler's cached `connstate` track PostgreSQL's transactional GUC semantics:

- `connstate`: add a transaction-scoped snapshot (`TxnSnapshot` + `SnapshotForTxn()` / `RestoreFromTxn()`) capturing the committed baseline (settings by interned pointer, role by value).
- reserved connection: snapshot at `BEGIN`, restore on `ROLLBACK`, drop on `COMMIT` — zero extra round trips, covering full rollback including `SET ROLE`.
- executor `ConcludeTransaction` (COMMIT): reconcile `connstate` against the gateway's authoritative session settings before COMMIT, covering the `ROLLBACK TO SAVEPOINT` → `COMMIT` hole (idempotent via the interned-pointer short-circuit).

## Tests

`TestGUCDivergenceRepro` and `TestGUCSavepointDivergenceRepro` (non-PostGIS): a poisoning session sets a GUC inside a transaction and rolls it back; a victim session then observes leaked NOTICEs via the gateway (0 direct). Both fail with the fix reverted.

Draft — opened for isolated review; one of three pooler/gateway session-state fixes surfaced by PostGIS compatibility testing.