### PR TITLE
fix(multigateway): keep reserved connection across statement_timeout cancellation

### DIFF
--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -117,6 +117,25 @@ func (sc *ScatterConn) buildTarget(tableGroup, shard string, state *handler.Mult
 // as failed (TxnStatusFailed) so subsequent queries are rejected until ROLLBACK. This is
 // defense-in-depth — handler.go also sets TxnStatusFailed on query errors, but setting it
 // here ensures coverage for all code paths (COPY, portal, etc.).
+// isCancellationError reports whether err is a query cancellation: an explicit
+// cancel or statement_timeout (PostgreSQL SQLSTATE 57014, query_canceled) or a
+// context cancellation/deadline. After such a cancellation the backend has
+// rolled back the cancelled statement and returned to an idle, reusable state,
+// so a reserved connection that hit it is still valid and must not be dropped.
+func isCancellationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var pgDiag *mterrors.PgDiagnostic
+	if errors.As(err, &pgDiag) {
+		return pgDiag.Code == mterrors.PgSSQueryCanceled
+	}
+	return false
+}
+
 func (sc *ScatterConn) applyReservedState(
 	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
@@ -250,7 +269,31 @@ func (sc *ScatterConn) StreamExecute(
 		}
 
 		reservedState, err := qs.StreamExecute(ctx, target, sql, eo, reservationOpts, callback)
-		sc.applyReservedState(conn, state, target, reservedState)
+
+		// A query error on an existing reserved connection does not, by itself, mean
+		// the reserved backend is gone. The pooler returns a non-zero reserved state
+		// whenever it can still vouch for the connection (the common error case). But
+		// the gateway enforces statement_timeout with a context deadline, and when
+		// that fires mid-stream the RPC can return before the reserved-state trailer
+		// arrives, yielding a zero reserved state even though the backend — and the
+		// session's temp tables — are still alive. Clearing the reservation here would
+		// route the next statement to a different pooled backend and lose those temp
+		// tables (the PostGIS interrupt tests' CREATE TEMP TABLE ... AS + statement
+		// timeout reproduce this).
+		//
+		// Keep the existing reservation only when all of these hold: the query failed,
+		// no fresh reserved state came back, we are NOT inside an explicit transaction,
+		// and the failure was a cancellation (statement_timeout / context cancel, after
+		// which the backend has returned to an idle, reusable state). Every other case
+		// — all in-transaction behaviour, genuine connection loss, and ordinary query
+		// errors — is handled exactly as before via applyReservedState.
+		keepReservation := err != nil &&
+			reservedState.GetReservedConnectionId() == 0 &&
+			conn.TxnStatus() != protocol.TxnStatusInBlock &&
+			isCancellationError(err)
+		if !keepReservation {
+			sc.applyReservedState(conn, state, target, reservedState)
+		}
 
 		if err != nil {
 			return fmt.Errorf("query execution failed: %w", err)

--- a/go/test/endtoend/queryserving/temp_table_timeout_test.go
+++ b/go/test/endtoend/queryserving/temp_table_timeout_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestMultiGateway_TempTableSurvivesStatementTimeout is a regression test for a
+// reserved-connection bug: a session temp table created via CREATE TABLE AS
+// pins a reserved ("temp_table") connection, but a statement_timeout
+// cancellation on that connection caused the gateway to drop the reservation
+// (the cancelled stream returns a zero reserved state, which applyReservedState
+// treated as "connection gone"). Subsequent statements then ran on a different
+// pooled backend and the session temp table vanished — reproducing the PostGIS
+// interrupt tests' "relation \"_time\"/\"_inputs\" does not exist".
+//
+// PostgreSQL keeps session temp tables across a statement-level cancellation, so
+// the temp table must remain visible after the timeout.
+func TestMultiGateway_TempTableSurvivesStatementTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	// Pin a single client session so the temp table and the later read share one
+	// gateway connection.
+	c, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	// CREATE TABLE AS (CTAS) temp table — reserves a temp-table connection.
+	_, err = c.ExecContext(ctx, "CREATE TEMP TABLE _inputs AS SELECT 1::int AS id")
+	require.NoError(t, err, "failed to create temp table")
+
+	// A statement the server cancels via statement_timeout.
+	_, err = c.ExecContext(ctx, "SET statement_timeout TO 100")
+	require.NoError(t, err)
+	_, err = c.ExecContext(ctx, "SELECT pg_sleep(5)")
+	require.Error(t, err, "pg_sleep should be cancelled by statement_timeout")
+	_, err = c.ExecContext(ctx, "SET statement_timeout TO 0")
+	require.NoError(t, err)
+
+	// The session temp table must still be there.
+	var id int
+	err = c.QueryRowContext(ctx, "SELECT id FROM _inputs").Scan(&id)
+	require.NoError(t, err, "temp table must survive a statement_timeout cancellation")
+	require.Equal(t, 1, id)
+}
+
+// TestMultiGateway_StatementTimeoutInTransaction guards that the temp-table fix
+// does not change transaction semantics: a statement_timeout inside an explicit
+// transaction must abort the transaction (subsequent statements error until the
+// block ends), and ROLLBACK must recover the session.
+func TestMultiGateway_StatementTimeoutInTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	c, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.ExecContext(ctx, "BEGIN")
+	require.NoError(t, err)
+	_, err = c.ExecContext(ctx, "SET statement_timeout TO 100")
+	require.NoError(t, err)
+	_, err = c.ExecContext(ctx, "SELECT pg_sleep(5)")
+	require.Error(t, err, "pg_sleep should be cancelled by statement_timeout")
+
+	// The transaction is now aborted: a normal statement must fail until the
+	// block is closed (PostgreSQL: "current transaction is aborted").
+	_, err = c.ExecContext(ctx, "SELECT 1")
+	require.Error(t, err, "transaction must be aborted after a statement_timeout inside it")
+
+	// ROLLBACK ends the aborted block and the session recovers.
+	_, err = c.ExecContext(ctx, "ROLLBACK")
+	require.NoError(t, err)
+
+	var n int
+	err = c.QueryRowContext(ctx, "SELECT 1").Scan(&n)
+	require.NoError(t, err, "session must work normally after ROLLBACK")
+	require.Equal(t, 1, n)
+}


### PR DESCRIPTION
## Problem

The multigateway enforces `statement_timeout` with a context deadline. When the deadline fired mid-stream, the gRPC `StreamExecute` returned **before** the trailer carrying the reserved-connection state arrived, so the gateway saw `reservedState == nil`. `ScatterConn` then treated nil as "the reserved connection is gone" and **unconditionally cleared the reservation** — even though the backend (with its session temp tables / open transaction) was still alive. The next statement landed on a different pooled backend, so the session temp state had vanished.

PostgreSQL keeps session temp tables across a statement-level cancellation, so this diverged from PostgreSQL. Surfaced by the PostGIS `interrupt` / `interrupt_relate` / `interrupt_buffer` tests, which do `CREATE TEMP TABLE … AS SELECT` + `SET statement_timeout` + a long query and then read the temp table — failing with `relation "_inputs"/"_time" does not exist`.

## Fix

In `ScatterConn`, only clear the reservation when the stream genuinely lost the backend — i.e. keep it when the error is a cancellation (`context.Canceled` / `DeadlineExceeded`, or `PgDiagnostic.Code == 57014` query-cancelled), the connection is not in a transaction block, and no new reserved id was returned. A cancellation is no longer misread as connection loss. Transaction-safe by construction (gated on not-in-block), so transaction abort/rollback semantics are unchanged.

## Tests

`TestMultiGateway_TempTableSurvivesStatementTimeout` (regression): a CTAS temp table survives a `statement_timeout` cancellation. `TestMultiGateway_StatementTimeoutInTransaction` (guard): a timeout inside an explicit transaction still aborts the transaction and recovers on ROLLBACK. The regression test fails with the fix reverted.

Draft — opened for isolated review; one of three pooler/gateway session-state fixes surfaced by PostGIS compatibility testing.
