### PR TITLE
feat(multipooler): refresh pooled connections on ALTER DATABASE/ROLE SET

### DIFF
--- a/docs/query_serving/session_settings.md
+++ b/docs/query_serving/session_settings.md
@@ -34,6 +34,72 @@ Behaviour:
 - `SHOW var` reports the current gateway-managed value in PostgreSQL-compatible form.
 - `RESET ALL` clears gateway-managed variables alongside `SessionSettings`.
 
+## Per-Database / Per-Role Default Changes (ALTER DATABASE/ROLE … SET)
+
+`ALTER DATABASE … SET` and `ALTER ROLE … SET` change *per-database* / *per-role*
+session GUC defaults, stored in the `pg_db_role_setting` catalog. PostgreSQL
+applies these defaults to a session **only at session start** (they become the
+session's GUC *reset values*). A connection pooler therefore has a problem:
+backends opened **before** such an `ALTER` keep the old defaults until they
+reconnect — `RESET`, `RESET ALL`, and `DISCARD ALL` all revert to the
+session-start reset value, never re-reading `pg_db_role_setting`.
+
+To keep pooled sessions consistent with a fresh connection, the multigateway
+flags statements that change these defaults and the multipooler refreshes its
+pooled connections:
+
+1. **Planner detection** (`planner/connection_defaults.go`,
+   `statementChangesConnectionDefaults`): a statement is flagged when it is
+   - `ALTER DATABASE … SET`/`RESET` or `ALTER ROLE … SET`/`RESET` (any form —
+     every one mutates `pg_db_role_setting`), or
+   - `CREATE EXTENSION <name>` for a `name` on a small hardcoded allowlist of
+     extensions whose install script runs such an `ALTER` internally
+     (`extensionsAlteringConnectionDefaults`; today: `postgis_topology`, whose
+     `topology.AddToSearchPath` runs `ALTER DATABASE … SET search_path`). The
+     `ALTER` runs server-side inside the extension, invisible to the gateway,
+     so the extension name is the only signal — hence an explicit allowlist
+     rather than general detection.
+
+   The flag rides the execute request as
+   `ExecuteOptions.InvalidatesConnectionDefaults`.
+
+2. **Durability-aware bump** (multipooler executor): on **successful**
+   execution, if the connection is now idle (autocommit, or a
+   non-transactional reserved connection) the change is durable, so the
+   executor bumps the pool's *defaults generation* immediately. If the
+   statement ran inside an explicit transaction the change is durable only at
+   `COMMIT`, so the executor marks the reserved connection pending and bumps on
+   a successful `COMMIT`. `ROLLBACK` discards the mark (no bump). A
+   `ROLLBACK TO SAVEPOINT` keeps the mark — a deliberately conservative choice
+   (an extra refresh is harmless; a missed one would leak stale defaults). This
+   mirrors PostgreSQL's transactional-DDL semantics.
+
+3. **Lazy refresh** (`connpool.Pool`): bumping the generation does not close any
+   connection. Each pooled connection records the generation it was
+   established under; on its **next borrow**, a connection whose generation is
+   stale is transparently reconnected (`refreshIfStale`) so the fresh backend
+   re-reads `pg_db_role_setting`. The hot-path cost is one atomic load plus an
+   int compare; an actual reconnect happens at most once per connection per
+   bump, and only when that connection is next used.
+
+### Deviations and limitations of this behaviour
+
+- **More eager than stock pooling, by design.** A plain connection pooler
+  (pgbouncer/odyssey) never refreshes pooled server connections after an
+  `ALTER DATABASE/ROLE … SET`; the change is observed only as connections
+  naturally cycle. Multigres refreshes them proactively so a pooled session
+  behaves like a fresh PostgreSQL connection.
+- **Standby/replica poolers refresh lazily.** The flagged statement executes
+  on the **primary**, so only the primary's pooler bumps immediately. Replica
+  poolers receive the catalog change via WAL but are not signalled, so their
+  pooled backends pick up the new default on their own lifecycle (idle /
+  max-lifetime recycle) or the next invalidating statement. Reads routed to a
+  replica may briefly observe the old per-database/role default.
+- **Cross-pooler over-approximation.** A bump invalidates *all* of a pooler's
+  user pools and its admin pool, not just the affected role/database. An
+  unnecessary refresh only costs a reconnect on next borrow, whereas a missed
+  one would leak stale defaults, so the bump is intentionally broad.
+
 ## Behaviour Deviations from PostgreSQL
 
 ### SET does not validate parameters

--- a/go/pb/query/query.pb.go
+++ b/go/pb/query/query.pb.go
@@ -1111,8 +1111,20 @@ type ExecuteOptions struct {
 	// functions can map virtual PIDs (visible to clients) back to real
 	// backend PIDs via pg_stat_activity.
 	ClientConnectionId uint32 `protobuf:"varint,8,opt,name=client_connection_id,json=clientConnectionId,proto3" json:"client_connection_id,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// invalidates_connection_defaults marks a statement that changes
+	// per-database or per-role session GUC defaults (pg_db_role_setting):
+	// ALTER DATABASE ... SET / ALTER ROLE ... SET that pins a value, or a
+	// CREATE EXTENSION on the multigateway planner's allowlist of extensions
+	// known to run such an ALTER internally (e.g. postgis_topology's
+	// AddToSearchPath). The multigateway sets it during planning. PostgreSQL
+	// applies these defaults only at session start, so already-open pooled
+	// backends would keep serving stale defaults; on success the multipooler
+	// bumps its pools' defaults generation (at COMMIT when the statement runs
+	// inside an explicit transaction) so each pooled connection reconnects on
+	// its next borrow and re-reads the new defaults.
+	InvalidatesConnectionDefaults bool `protobuf:"varint,9,opt,name=invalidates_connection_defaults,json=invalidatesConnectionDefaults,proto3" json:"invalidates_connection_defaults,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *ExecuteOptions) Reset() {
@@ -1192,6 +1204,13 @@ func (x *ExecuteOptions) GetClientConnectionId() uint32 {
 		return x.ClientConnectionId
 	}
 	return 0
+}
+
+func (x *ExecuteOptions) GetInvalidatesConnectionDefaults() bool {
+	if x != nil {
+		return x.InvalidatesConnectionDefaults
+	}
+	return false
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM
@@ -1442,7 +1461,7 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x01 \x01(\x04R\x14reservedConnectionId\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12/\n" +
 	"\x13reservation_reasons\x18\x03 \x01(\rR\x12reservationReasons\x12,\n" +
-	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\xb9\x03\n" +
+	"\x12backend_process_id\x18\x04 \x01(\rR\x10backendProcessId\"\x81\x04\n" +
 	"\x0eExecuteOptions\x12U\n" +
 	"\x10session_settings\x18\x01 \x03(\v2*.query.ExecuteOptions.SessionSettingsEntryR\x0fsessionSettings\x12\x12\n" +
 	"\x04user\x18\x02 \x01(\tR\x04user\x12\x19\n" +
@@ -1450,7 +1469,8 @@ const file_query_proto_rawDesc = "" +
 	"\x16reserved_connection_id\x18\x05 \x01(\x04R\x14reservedConnectionId\x12G\n" +
 	"\x12prepared_statement\x18\x06 \x01(\v2\x18.query.PreparedStatementR\x11preparedStatement\x12,\n" +
 	"\tuser_auth\x18\a \x01(\v2\x0f.query.UserAuthR\buserAuth\x120\n" +
-	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x1aB\n" +
+	"\x14client_connection_id\x18\b \x01(\rR\x12clientConnectionId\x12F\n" +
+	"\x1finvalidates_connection_defaults\x18\t \x01(\bR\x1dinvalidatesConnectionDefaults\x1aB\n" +
 	"\x14SessionSettingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +

--- a/go/services/multigateway/engine/route.go
+++ b/go/services/multigateway/engine/route.go
@@ -53,6 +53,15 @@ type Route struct {
 	// name ("p") to the canonical name and attaches the metadata here so
 	// the multipooler can ensurePrepared() on the chosen backend connection.
 	PreparedStatement *query.PreparedStatement
+
+	// InvalidatesConnectionDefaults is set by the planner for statements that
+	// change per-database/role session GUC defaults (ALTER DATABASE/ROLE ... SET,
+	// or an allowlisted CREATE EXTENSION; see
+	// planner.statementChangesConnectionDefaults). When set, execution records
+	// PendingInvalidateConnectionDefaults on the session state so ScatterConn
+	// marks the request (ExecuteOptions.InvalidatesConnectionDefaults) and the
+	// multipooler refreshes its pooled connections once the change is durable.
+	InvalidatesConnectionDefaults bool
 }
 
 // NewRoute creates a new Route primitive.
@@ -99,6 +108,9 @@ func (r *Route) StreamExecute(
 	if len(bindVars) > 0 && r.NormalizedAST != nil {
 		query = ast.ReconstructSQL(r.NormalizedAST, bindVars)
 	}
+	if r.InvalidatesConnectionDefaults {
+		state.PendingInvalidateConnectionDefaults = true
+	}
 	// Execute the query through the execution interface.
 	// We pass ctx (not conn.Context()) so that deadlines set by executeWithTimeout
 	// propagate through gRPC to the multipooler for statement timeout enforcement.
@@ -128,6 +140,9 @@ func (r *Route) PortalStreamExecute(
 	includeDescribe bool,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
+	if r.InvalidatesConnectionDefaults {
+		state.PendingInvalidateConnectionDefaults = true
+	}
 	return exec.PortalStreamExecute(ctx, r.TableGroup, r.Shard, conn, state, portalInfo, maxRows, includeDescribe, callback)
 }
 

--- a/go/services/multigateway/handler/connection_state.go
+++ b/go/services/multigateway/handler/connection_state.go
@@ -90,6 +90,14 @@ type MultiGatewayConnectionState struct {
 	// cleared after the reservation is created.
 	PendingTempTableReservation bool
 
+	// PendingInvalidateConnectionDefaults is set by the planner (via Route) when
+	// the current statement changes per-database/role session GUC defaults
+	// (ALTER DATABASE/ROLE ... SET, or an allowlisted CREATE EXTENSION).
+	// ScatterConn consumes it to set ExecuteOptions.InvalidatesConnectionDefaults
+	// so the multipooler refreshes its pooled connections once the change is
+	// durable. One-shot: cleared after the request is sent.
+	PendingInvalidateConnectionDefaults bool
+
 	// PendingPinPortals carries the cursor names that the next StreamExecute
 	// must register on the reserved backend's portal set via
 	// ReservationOptions.PinPortalNames. Populated by HoldCursorRoute when a

--- a/go/services/multigateway/planner/connection_defaults.go
+++ b/go/services/multigateway/planner/connection_defaults.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"strings"
+
+	"github.com/multigres/multigres/go/common/parser/ast"
+)
+
+// extensionsAlteringConnectionDefaults lists extensions whose installation runs
+// an ALTER DATABASE/ROLE ... SET internally, so an already-open pooled backend
+// would not observe the new per-database/role GUC defaults until it reconnects.
+// CREATE EXTENSION of one of these is treated as changing connection defaults
+// (see statementChangesConnectionDefaults).
+//
+// This is a deliberate, narrow allowlist rather than general detection: the
+// ALTER runs server-side inside the extension's install script, invisible to
+// the gateway, so the only signal is the extension name. Keys are lowercased;
+// CREATE EXTENSION resolves names against lowercase control-file names.
+//
+//   - postgis_topology: its install script calls topology.AddToSearchPath(...),
+//     which runs `ALTER DATABASE <db> SET search_path = ..., topology`.
+var extensionsAlteringConnectionDefaults = map[string]struct{}{
+	"postgis_topology": {},
+}
+
+// statementChangesConnectionDefaults reports whether stmt changes per-database
+// or per-role session GUC defaults (the pg_db_role_setting catalog) in a way
+// that an already-open pooled backend will not observe until it reconnects.
+// PostgreSQL applies those defaults only at session start, so the multigateway
+// flags such statements (ExecuteOptions.InvalidatesConnectionDefaults) and the
+// multipooler refreshes its pooled connections once the change is durable.
+//
+//   - ALTER DATABASE ... SET/RESET and ALTER ROLE ... SET/RESET: every form
+//     mutates pg_db_role_setting (a value pin, or a RESET that drops an entry),
+//     so all are flagged. Over-flagging only costs an extra pool refresh.
+//   - CREATE EXTENSION <name>: flagged only for the allowlist above.
+func statementChangesConnectionDefaults(stmt ast.Stmt) bool {
+	switch s := stmt.(type) {
+	case *ast.AlterDatabaseSetStmt:
+		return true
+	case *ast.AlterRoleSetStmt:
+		return true
+	case *ast.CreateExtensionStmt:
+		_, ok := extensionsAlteringConnectionDefaults[strings.ToLower(s.Extname)]
+		return ok
+	default:
+		return false
+	}
+}

--- a/go/services/multigateway/planner/connection_defaults_test.go
+++ b/go/services/multigateway/planner/connection_defaults_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/services/multigateway/engine"
+)
+
+func TestStatementChangesConnectionDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"alter database set value", "ALTER DATABASE postgres SET search_path = public, topology", true},
+		{"alter database reset", "ALTER DATABASE postgres RESET search_path", true},
+		{"alter role set value", "ALTER ROLE app SET search_path = public", true},
+		{"alter role in database set", "ALTER ROLE app IN DATABASE postgres SET work_mem = '64MB'", true},
+		{"alter role reset", "ALTER ROLE app RESET search_path", true},
+		{"create extension on allowlist", "CREATE EXTENSION postgis_topology", true},
+		{"create extension on allowlist if not exists", "CREATE EXTENSION IF NOT EXISTS postgis_topology", true},
+		{"create extension off allowlist", "CREATE EXTENSION postgis", false},
+		{"create extension hstore", "CREATE EXTENSION hstore", false},
+		{"plain select", "SELECT 1", false},
+		{"session set is not a per-db default", "SET search_path = public", false},
+		{"alter table is unrelated", "ALTER TABLE t ADD COLUMN c int", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statementChangesConnectionDefaults(parseOne(t, tt.sql))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestPlan_FlagsConnectionDefaultsOnRoute verifies the planner surfaces the
+// detection on the Route primitive so ScatterConn can mark the request.
+func TestPlan_FlagsConnectionDefaultsOnRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"alter database set", "ALTER DATABASE postgres SET search_path = public, topology", true},
+		{"alter role set", "ALTER ROLE app SET search_path = public", true},
+		{"create extension postgis_topology", "CREATE EXTENSION postgis_topology", true},
+		{"create extension postgis (off allowlist)", "CREATE EXTENSION postgis", false},
+		{"plain select routes without the flag", "SELECT 1", false},
+	}
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPlanner("default", logger, nil)
+			conn := server.NewTestConn(&bytes.Buffer{}).Conn
+
+			plan, err := p.Plan(tt.sql, parseOne(t, tt.sql), conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			route, ok := plan.Primitive.(*engine.Route)
+			require.True(t, ok, "expected Route, got %T", plan.Primitive)
+			assert.Equal(t, tt.want, route.InvalidatesConnectionDefaults)
+		})
+	}
+}

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -233,6 +233,10 @@ func (p *Planner) planClosePortalStmt(sql string, stmt *ast.ClosePortalStmt) (*e
 // This is the fallback for most SQL statements.
 func (p *Planner) planDefault(sql string, stmt ast.Stmt, conn *server.Conn) (*engine.Plan, error) {
 	route := engine.NewRoute(p.defaultTableGroup, constants.DefaultShard, sql, stmt)
+	// Flag statements that change per-database/role session GUC defaults so the
+	// multipooler refreshes pooled connections (which otherwise keep PostgreSQL's
+	// session-start snapshot of those defaults). See connection_defaults.go.
+	route.InvalidatesConnectionDefaults = statementChangesConnectionDefaults(stmt)
 	plan := engine.NewPlan(sql, route)
 
 	p.logger.Debug("created default route plan",
@@ -351,6 +355,16 @@ func (p *Planner) PlanPortal(
 		// CLOSE / CLOSE ALL must go through CloseCursorRoute so HOLD-cursor
 		// pin bookkeeping on the multipooler stays in sync — otherwise the
 		// reserved backend would leak with a stale ReasonPortal.
+		return p.Plan(portalInfo.PreparedStatementInfo.Query, stmt, conn)
+
+	case ast.T_AlterDatabaseSetStmt, ast.T_AlterRoleSetStmt, ast.T_CreateExtensionStmt:
+		// Statements that may change per-database/role session GUC defaults must
+		// route through Plan (planDefault) so the resulting Route carries
+		// InvalidatesConnectionDefaults; a bare portal execute would skip the
+		// pooled-connection refresh. statementChangesConnectionDefaults filters
+		// non-flagged CREATE EXTENSIONs back to a plain forward (the Route's flag
+		// is simply false), so this only adds the gateway-local hop, not a
+		// behavior change, for those.
 		return p.Plan(portalInfo.PreparedStatementInfo.Query, stmt, conn)
 
 	default:

--- a/go/services/multigateway/scatterconn/scatter_conn.go
+++ b/go/services/multigateway/scatterconn/scatter_conn.go
@@ -185,6 +185,13 @@ func (sc *ScatterConn) StreamExecute(
 		SessionSettings:    state.GetSessionSettings(),
 		PreparedStatement:  preparedStatement,
 	}
+	// One-shot: the planner flagged this statement as changing per-database/role
+	// session GUC defaults, so the multipooler must refresh its pooled connections
+	// once the change is durable. Consume and clear.
+	if state.PendingInvalidateConnectionDefaults {
+		eo.InvalidatesConnectionDefaults = true
+		state.PendingInvalidateConnectionDefaults = false
+	}
 
 	ss := state.GetMatchingShardState(target)
 
@@ -370,6 +377,13 @@ func (sc *ScatterConn) PortalStreamExecute(
 		ClientConnectionId: conn.ConnectionID(),
 		MaxRows:            uint64(maxRows),
 		SessionSettings:    state.GetSessionSettings(),
+	}
+	// One-shot: see the matching block in StreamExecute. A flagged statement that
+	// arrives over the extended protocol routes through Route.PortalStreamExecute,
+	// which sets PendingInvalidateConnectionDefaults before we build eo here.
+	if state.PendingInvalidateConnectionDefaults {
+		eo.InvalidatesConnectionDefaults = true
+		state.PendingInvalidateConnectionDefaults = false
 	}
 
 	// When the protocol layer folded a Describe('P') into this Execute, ask

--- a/go/services/multipooler/internal/connpoolmanager/interface.go
+++ b/go/services/multipooler/internal/connpoolmanager/interface.go
@@ -68,6 +68,13 @@ type PoolManager interface {
 	// GetAdminConn acquires an admin connection from the pool.
 	GetAdminConn(ctx context.Context) (admin.PooledConn, error)
 
+	// InvalidateConnectionDefaults marks every pooled connection (all user pools
+	// and the shared admin pool) stale so it reconnects on its next borrow,
+	// re-reading per-database/role GUC defaults changed by ALTER DATABASE/ROLE
+	// ... SET (or an extension that runs one). Lazy and non-disruptive: borrowed
+	// and idle connections are never closed eagerly.
+	InvalidateConnectionDefaults()
+
 	// --- Regular Pool Operations ---
 
 	// GetRegularConn acquires a regular connection for the specified user,

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -529,6 +529,35 @@ func (m *Manager) GetAdminConn(ctx context.Context) (admin.PooledConn, error) {
 	return adminPool.Get(ctx)
 }
 
+// InvalidateConnectionDefaults marks every pooled connection — across all user
+// pools and the shared admin pool — stale so it reconnects on its next borrow.
+// A fresh backend re-reads per-database/role GUC defaults (pg_db_role_setting),
+// picking up changes made by ALTER DATABASE/ROLE ... SET (or an extension that
+// runs one, e.g. postgis_topology's AddToSearchPath). PostgreSQL applies those
+// defaults only at session start, so an already-open pooled backend would
+// otherwise keep serving stale defaults until it reconnects.
+//
+// The bump is lazy and non-disruptive: it never closes a borrowed or idle
+// connection eagerly; each connection refreshes when it is next borrowed (see
+// connpool.Pool.refreshIfStale). Invalidating across all users is intentional
+// over-approximation — an unnecessary refresh only costs a reconnect, whereas a
+// missed one would leak stale defaults.
+func (m *Manager) InvalidateConnectionDefaults() {
+	if pools := m.userPoolsSnapshot.Load(); pools != nil {
+		for _, pool := range *pools {
+			pool.InvalidateDefaults()
+		}
+	}
+	// Mirror GetAdminConn's nil-safe read: Close() clears m.adminPool under
+	// createMu, so a snapshot taken here is either the live pool or nil.
+	m.createMu.Lock()
+	adminPool := m.adminPool
+	m.createMu.Unlock()
+	if adminPool != nil {
+		adminPool.InvalidateDefaults()
+	}
+}
+
 // --- Regular Pool Operations ---
 
 // GetRegularConn acquires a regular connection for the specified user,

--- a/go/services/multipooler/internal/connpoolmanager/user_pool.go
+++ b/go/services/multipooler/internal/connpoolmanager/user_pool.go
@@ -343,6 +343,15 @@ func (p *UserPool) SetCapacity(ctx context.Context, regularCap, reservedCap int6
 	return nil
 }
 
+// InvalidateDefaults marks this user's regular and reserved pooled connections
+// stale so they reconnect on their next borrow, re-reading per-database/role GUC
+// defaults changed by ALTER DATABASE/ROLE ... SET (or an extension that runs
+// one). The shared admin pool is invalidated once by the Manager, not here.
+func (p *UserPool) InvalidateDefaults() {
+	p.regularPool.InvalidateDefaults()
+	p.reservedPool.InvalidateDefaults()
+}
+
 // UserPoolStats holds statistics for a user's pools.
 type UserPoolStats struct {
 	Username       string

--- a/go/services/multipooler/internal/executor/connection_defaults_test.go
+++ b/go/services/multipooler/internal/executor/connection_defaults_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/pb/query"
+)
+
+// pendingMarkerSpy is a lightweight pendingDefaultsMarker for asserting the
+// defer-to-COMMIT branch without a live reserved connection.
+type pendingMarkerSpy struct{ marked bool }
+
+func (s *pendingMarkerSpy) MarkPendingDefaultsInvalidation() { s.marked = true }
+
+func TestNoteConnectionDefaultsChange(t *testing.T) {
+	newExec := func() (*Executor, *stubPoolManager) {
+		pm := &stubPoolManager{}
+		return &Executor{logger: slog.Default(), poolManager: pm}, pm
+	}
+	flagged := &query.ExecuteOptions{InvalidatesConnectionDefaults: true}
+
+	t.Run("nil options is a no-op", func(t *testing.T) {
+		e, pm := newExec()
+		e.noteConnectionDefaultsChange(nil, protocol.TxnStatusIdle, nil)
+		assert.Equal(t, 0, pm.invalidateDefaultsCalls)
+	})
+
+	t.Run("flag unset is a no-op", func(t *testing.T) {
+		e, pm := newExec()
+		e.noteConnectionDefaultsChange(&query.ExecuteOptions{}, protocol.TxnStatusIdle, nil)
+		assert.Equal(t, 0, pm.invalidateDefaultsCalls)
+	})
+
+	t.Run("autocommit regular connection bumps immediately", func(t *testing.T) {
+		e, pm := newExec()
+		e.noteConnectionDefaultsChange(flagged, protocol.TxnStatusIdle, nil)
+		assert.Equal(t, 1, pm.invalidateDefaultsCalls)
+	})
+
+	t.Run("idle reserved connection bumps immediately", func(t *testing.T) {
+		e, pm := newExec()
+		spy := &pendingMarkerSpy{}
+		e.noteConnectionDefaultsChange(flagged, protocol.TxnStatusIdle, spy)
+		assert.Equal(t, 1, pm.invalidateDefaultsCalls)
+		assert.False(t, spy.marked, "an idle (autocommitted) statement must not defer")
+	})
+
+	t.Run("in-transaction defers to COMMIT", func(t *testing.T) {
+		e, pm := newExec()
+		spy := &pendingMarkerSpy{}
+		e.noteConnectionDefaultsChange(flagged, protocol.TxnStatusInBlock, spy)
+		assert.Equal(t, 0, pm.invalidateDefaultsCalls, "must not bump until COMMIT")
+		assert.True(t, spy.marked, "must mark the reserved connection pending")
+	})
+
+	t.Run("failed transaction block defers (COMMIT becomes ROLLBACK in PG)", func(t *testing.T) {
+		e, pm := newExec()
+		spy := &pendingMarkerSpy{}
+		e.noteConnectionDefaultsChange(flagged, protocol.TxnStatusFailed, spy)
+		assert.Equal(t, 0, pm.invalidateDefaultsCalls)
+		assert.True(t, spy.marked)
+	})
+}

--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
 	"github.com/multigres/multigres/go/common/preparedstatement"
 	"github.com/multigres/multigres/go/common/protoutil"
 	"github.com/multigres/multigres/go/common/queryservice"
@@ -37,6 +38,14 @@ import (
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/regular"
 	"github.com/multigres/multigres/go/services/multipooler/internal/pools/reserved"
 )
+
+// pendingDefaultsMarker is the subset of *reserved.Conn that
+// noteConnectionDefaultsChange needs in order to defer a defaults-invalidation
+// bump to COMMIT. Declared as an interface so the decision logic can be unit
+// tested with a lightweight double instead of a live reserved connection.
+type pendingDefaultsMarker interface {
+	MarkPendingDefaultsInvalidation()
+}
 
 // Executor implements the QueryService interface for executing queries against PostgreSQL.
 // It uses the connpoolmanager for per-user connection pool management and consolidates
@@ -147,6 +156,36 @@ func (e *Executor) buildReservedStateFromAPI(rc reservedConnAPI) *query.Reserved
 	}
 }
 
+// noteConnectionDefaultsChange handles a statement that the multigateway flagged
+// (options.InvalidatesConnectionDefaults) as changing per-database/role GUC
+// defaults. Call it only after the statement executed successfully.
+//
+// The change is durable when the connection is no longer inside a transaction
+// block: for an autocommit statement (regular pooled connection, rc == nil) or a
+// non-transactional reserved connection the post-execution status is idle, so we
+// bump the pools' defaults generation immediately. When the connection is still
+// in a transaction block the change is durable only at COMMIT, so we mark the
+// reserved connection pending and let ConcludeTransaction bump on a successful
+// COMMIT (and discard the mark on ROLLBACK). This mirrors PostgreSQL's
+// transactional-DDL semantics for ALTER DATABASE/ROLE ... SET.
+//
+// rc is the *reserved.Conn the statement ran on, or nil for an autocommit
+// statement on a regular pooled connection. It is taken as an interface so the
+// decision logic is unit-testable without a live backend connection. Pass a
+// literal nil (not a typed-nil *reserved.Conn) for the regular-connection path.
+func (e *Executor) noteConnectionDefaultsChange(options *query.ExecuteOptions, txnStatus protocol.TransactionStatus, rc pendingDefaultsMarker) {
+	if options == nil || !options.GetInvalidatesConnectionDefaults() {
+		return
+	}
+	if rc != nil && txnStatus != protocol.TxnStatusIdle {
+		// In a transaction block (or a failed block whose COMMIT will roll back):
+		// defer to COMMIT.
+		rc.MarkPendingDefaultsInvalidation()
+		return
+	}
+	e.poolManager.InvalidateConnectionDefaults()
+}
+
 // ExecuteQuery implements queryservice.QueryService.
 // It executes a query using a pooled connection for the specified user.
 // If ReservedConnectionId is set in options, uses that reserved connection instead.
@@ -194,6 +233,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 			// Query failed but connection still exists — return current state
 			return nil, e.buildReservedState(reservedConn), wrapQueryError(err)
 		}
+		e.noteConnectionDefaultsChange(options, reservedConn.TxnStatus(), reservedConn)
 
 		if len(results) == 0 {
 			return &sqltypes.Result{}, e.buildReservedState(reservedConn), nil
@@ -227,6 +267,7 @@ func (e *Executor) ExecuteQuery(ctx context.Context, target *query.Target, sql s
 	if err != nil {
 		return nil, nil, wrapQueryError(err)
 	}
+	e.noteConnectionDefaultsChange(options, conn.Conn.TxnStatus(), nil)
 
 	// Return first result (simple query returns single result)
 	if len(results) == 0 {
@@ -310,7 +351,15 @@ func (e *Executor) StreamExecute(
 			}
 		}
 
-		return e.streamExecuteOnReservedConn(ctx, reservedConn, sql, reservationOptions, callback)
+		rs, err := e.streamExecuteOnReservedConn(ctx, reservedConn, sql, reservationOptions, callback)
+		// Only inspect the reserved connection when the statement is flagged and the
+		// connection is still held: streamExecuteOnReservedConn may have released it
+		// (e.g. a CLOSE that drained the last reservation reason), after which it can
+		// be re-borrowed by another session and must not be touched here.
+		if err == nil && options.GetInvalidatesConnectionDefaults() && !reservedConn.IsReleased() {
+			e.noteConnectionDefaultsChange(options, reservedConn.TxnStatus(), reservedConn)
+		}
+		return rs, err
 	}
 
 	// Case 2: Create a new reserved connection
@@ -348,6 +397,7 @@ func (e *Executor) StreamExecute(
 		if err := conn.Conn.QueryStreaming(ctx, sql, callback); err != nil {
 			return nil, wrapQueryError(err)
 		}
+		e.noteConnectionDefaultsChange(options, conn.Conn.TxnStatus(), nil)
 		return nil, nil
 	}
 
@@ -355,6 +405,7 @@ func (e *Executor) StreamExecute(
 	if err := conn.Conn.QueryStreamingWithRetry(ctx, sql, callback); err != nil {
 		return nil, wrapQueryError(err)
 	}
+	e.noteConnectionDefaultsChange(options, conn.Conn.TxnStatus(), nil)
 
 	return nil, nil
 }
@@ -459,6 +510,8 @@ func (e *Executor) reserveAndStreamExecute(
 		reservedConn.Release(reserved.ReleaseError)
 		return nil, fmt.Errorf("query execution failed: %w", err)
 	}
+
+	e.noteConnectionDefaultsChange(options, reservedConn.TxnStatus(), reservedConn)
 
 	reservedState := e.buildReservedState(reservedConn)
 
@@ -757,6 +810,8 @@ func (e *Executor) portalExecuteWithReserved(
 		return nil, wrapQueryError(err)
 	}
 
+	e.noteConnectionDefaultsChange(options, reservedConn.TxnStatus(), reservedConn)
+
 	// If portal is suspended (not completed), keep the reserved connection for continuation
 	if !completed {
 		reservedConn.ReserveForPortal(portal.Name)
@@ -816,6 +871,7 @@ func (e *Executor) portalExecuteWithRegular(
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
+	e.noteConnectionDefaultsChange(options, conn.Conn.TxnStatus(), nil)
 
 	// No reserved connection for regular execution
 	return nil, nil
@@ -1626,9 +1682,17 @@ func (e *Executor) ConcludeTransaction(
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_COMMIT:
 		commandTag = "COMMIT"
 		releaseReason = reserved.ReleaseCommit
+		// Capture the pending defaults-invalidation before COMMIT (Commit clears
+		// it). A defaults-changing statement (ALTER DATABASE/ROLE ... SET, or an
+		// allowlisted CREATE EXTENSION) that ran inside this transaction becomes
+		// durable only now, so the generation bump is owed on a successful COMMIT.
+		pendingDefaultsInvalidation := reservedConn.PendingDefaultsInvalidation()
 		if err := reservedConn.Commit(ctx); err != nil {
 			reservedConn.Release(reserved.ReleaseError)
 			return nil, nil, err
+		}
+		if pendingDefaultsInvalidation {
+			e.poolManager.InvalidateConnectionDefaults()
 		}
 	case multipoolerpb.TransactionConclusion_TRANSACTION_CONCLUSION_ROLLBACK:
 		commandTag = "ROLLBACK"

--- a/go/services/multipooler/internal/executor/executor_test.go
+++ b/go/services/multipooler/internal/executor/executor_test.go
@@ -126,6 +126,10 @@ var _ reservedConnAPI = (*mockReservedConn)(nil)
 type stubPoolManager struct {
 	reservedConn   *reserved.Conn
 	reservedConnOK bool
+
+	// invalidateDefaultsCalls counts InvalidateConnectionDefaults invocations so
+	// tests can assert when the executor bumps the pool's defaults generation.
+	invalidateDefaultsCalls int
 }
 
 func (m *stubPoolManager) Open(context.Context, *connpoolmanager.ConnectionConfig) {}
@@ -134,6 +138,7 @@ func (m *stubPoolManager) CloseForReopen()                                      
 func (m *stubPoolManager) PgUser() string                                          { return "postgres" }
 func (m *stubPoolManager) PgPassword() (string, bool)                              { return "", true }
 func (m *stubPoolManager) GetAdminConn(context.Context) (admin.PooledConn, error)  { return nil, nil }
+func (m *stubPoolManager) InvalidateConnectionDefaults()                           { m.invalidateDefaultsCalls++ }
 func (m *stubPoolManager) GetRegularConn(context.Context, string, []byte, []byte) (regular.PooledConn, error) {
 	return nil, nil
 }

--- a/go/services/multipooler/internal/pools/admin/admin_pool.go
+++ b/go/services/multipooler/internal/pools/admin/admin_pool.go
@@ -114,3 +114,10 @@ func (p *Pool) Close() {
 func (p *Pool) Stats() connpool.PoolStats {
 	return p.pool.Stats()
 }
+
+// InvalidateDefaults marks every pooled connection stale so it reconnects on its
+// next borrow, re-reading per-database/role GUC defaults changed by ALTER
+// DATABASE/ROLE ... SET (or an extension that runs one).
+func (p *Pool) InvalidateDefaults() {
+	p.pool.InvalidateDefaults()
+}

--- a/go/services/multipooler/internal/pools/connpool/pool.go
+++ b/go/services/multipooler/internal/pools/connpool/pool.go
@@ -139,6 +139,14 @@ type Pool[C Connection] struct {
 	// idleCount is the maximum idle connections in the pool
 	idleCount atomic.Int64
 
+	// generation is the pool's defaults-generation counter. InvalidateDefaults
+	// increments it; on borrow, any connection whose stored generation is older
+	// is reconnected (refreshIfStale) so its backend re-reads per-database/role
+	// GUC defaults. Lazy by design: only stale connections pay a reconnect, and
+	// only on their first borrow after a bump. Reads on the hot borrow path are a
+	// single atomic load plus an int compare.
+	generation atomic.Int64
+
 	// workers is a waitgroup for all the currently running worker goroutines
 	workers    sync.WaitGroup
 	close      atomic.Pointer[chan struct{}]
@@ -630,6 +638,38 @@ func (pool *Pool[C]) connReopen(ctx context.Context, dbconn *Pooled[C], now time
 
 	dbconn.timeCreated.set(now)
 	dbconn.timeUsed.set(now)
+	dbconn.generation = pool.generation.Load()
+	return nil
+}
+
+// InvalidateDefaults bumps the pool's defaults-generation so that every
+// currently-pooled connection is treated as stale and reconnected on its next
+// borrow (see refreshIfStale and the generation field on Pooled). Used to pick
+// up per-database/role GUC defaults changed by ALTER DATABASE/ROLE ... SET (or
+// an extension that runs one) that an already-open backend would otherwise not
+// observe until it reconnects. Cheap and non-disruptive: it never closes a
+// borrowed connection or an idle one eagerly; refresh happens lazily at borrow.
+func (pool *Pool[C]) InvalidateDefaults() {
+	pool.generation.Add(1)
+}
+
+// refreshIfStale reconnects conn with a fresh backend when its generation
+// predates the pool's current defaults-generation. A fresh backend re-reads
+// pg_db_role_setting at session start, picking up ALTER DATABASE/ROLE ... SET
+// changes. Reuses connReopen, which establishes a brand-new backend with no
+// session settings applied (the new connection reports empty Settings()), so
+// the caller's normal settings logic then applies the correct settings on top.
+// On reconnect failure the active slot is dropped (closedConn) and the error is
+// returned to the borrower.
+func (pool *Pool[C]) refreshIfStale(ctx context.Context, conn *Pooled[C]) error {
+	if conn.generation >= pool.generation.Load() {
+		return nil
+	}
+	conn.Close()
+	if err := pool.connReopen(ctx, conn, monotonicNow()); err != nil {
+		pool.closedConn()
+		return err
+	}
 	return nil
 }
 
@@ -648,6 +688,7 @@ func (pool *Pool[C]) connNew(ctx context.Context) (*Pooled[C], error) {
 	now := monotonicNow()
 	pooled.timeUsed.set(now)
 	pooled.timeCreated.set(now)
+	pooled.generation = pool.generation.Load()
 	return pooled, nil
 }
 
@@ -710,6 +751,9 @@ func (pool *Pool[C]) get(ctx context.Context) (*Pooled[C], error) {
 
 	// best case: if there's a connection in the clean stack, return it right away
 	if conn := pool.pop(&pool.clean); conn != nil {
+		if err := pool.refreshIfStale(ctx, conn); err != nil {
+			return returnErr(err)
+		}
 		pool.borrowed.Add(1)
 		if pool.config.onBorrow != nil {
 			pool.config.onBorrow()
@@ -747,6 +791,13 @@ func (pool *Pool[C]) get(ctx context.Context) (*Pooled[C], error) {
 		return returnErr(ErrTimeout)
 	}
 
+	// A defaults-generation bump may have marked this connection stale; reconnect
+	// it first so the fresh backend re-reads per-database/role GUC defaults. After
+	// a reconnect the connection reports empty settings, so the reset below is a
+	// no-op for it.
+	if err := pool.refreshIfStale(ctx, conn); err != nil {
+		return returnErr(err)
+	}
 	// if the connection we've acquired has settings applied, we must reset them before returning
 	if settings := conn.Conn.Settings(); settings != nil && !settings.IsEmpty() {
 		pool.Metrics.resetState.Add(1)
@@ -829,6 +880,13 @@ func (pool *Pool[C]) getWithSettings(ctx context.Context, settings *connstate.Se
 		return returnErr(ErrTimeout)
 	}
 
+	// A defaults-generation bump may have marked this connection stale; reconnect
+	// it first so the fresh backend re-reads per-database/role GUC defaults. After
+	// a reconnect the connection reports empty settings, so the block below simply
+	// applies our target settings on top of the fresh backend.
+	if err := pool.refreshIfStale(ctx, conn); err != nil {
+		return returnErr(err)
+	}
 	// ensure that the settings applied to the connection matches the one we want
 	connSettings := conn.Conn.Settings()
 	if connSettings != settings {

--- a/go/services/multipooler/internal/pools/connpool/pool_test.go
+++ b/go/services/multipooler/internal/pools/connpool/pool_test.go
@@ -30,6 +30,9 @@ import (
 type mockConnection struct {
 	settings *connstate.Settings
 	closed   atomic.Bool
+	// id distinguishes distinct backends produced by a counting connector, so a
+	// test can tell a reused connection from a freshly (re)established one.
+	id int
 }
 
 func newMockConnection() *mockConnection {
@@ -98,6 +101,84 @@ func TestPoolBasicGetPut(t *testing.T) {
 	conn2, err := pool.Get(ctx)
 	require.NoError(t, err)
 	assert.Same(t, conn1, conn2)
+}
+
+func TestPoolInvalidateDefaults_LazyReconnectOnBorrow(t *testing.T) {
+	var created atomic.Int64
+	ctx := context.Background()
+	pool := NewPool[*mockConnection](ctx, &Config{Name: "test", Capacity: 4, MaxIdleCount: 4})
+	pool.Open(func(_ context.Context, _ context.Context) (*mockConnection, error) {
+		c := newMockConnection()
+		c.id = int(created.Add(1)) // 1, 2, 3, ...
+		return c, nil
+	}, nil)
+	defer pool.Close()
+
+	// Borrow + recycle: establishes backend id=1 in the clean stack.
+	c1, err := pool.Get(ctx)
+	require.NoError(t, err)
+	first := c1.Conn
+	require.Equal(t, 1, first.id)
+	c1.Recycle()
+
+	// Without an invalidation, the same backend is reused.
+	c2, err := pool.Get(ctx)
+	require.NoError(t, err)
+	require.Same(t, first, c2.Conn, "should reuse the same backend without invalidation")
+	c2.Recycle()
+
+	// Invalidate defaults: the next borrow must reconnect a fresh backend so it
+	// re-reads per-database/role GUC defaults.
+	pool.InvalidateDefaults()
+
+	c3, err := pool.Get(ctx)
+	require.NoError(t, err)
+	require.NotSame(t, first, c3.Conn, "stale connection must be reconnected after InvalidateDefaults")
+	require.True(t, first.IsClosed(), "stale backend must be closed on reconnect")
+	require.Equal(t, 2, c3.Conn.id, "borrow must return the freshly reconnected backend")
+	require.False(t, c3.Conn.IsClosed())
+	c3.Recycle()
+
+	// Capacity is preserved across the reconnect (slot reused, not leaked).
+	assert.Equal(t, int64(1), pool.Stats().Active)
+
+	// Generation is now current again: a borrow without a fresh bump reuses the
+	// refreshed backend (no spurious reconnect).
+	c4, err := pool.Get(ctx)
+	require.NoError(t, err)
+	require.Same(t, c3.Conn, c4.Conn, "no reconnect when the generation is current")
+	c4.Recycle()
+}
+
+func TestPoolInvalidateDefaults_ReconnectPreservesTargetSettings(t *testing.T) {
+	var created atomic.Int64
+	ctx := context.Background()
+	pool := NewPool[*mockConnection](ctx, &Config{Name: "test", Capacity: 4, MaxIdleCount: 4})
+	pool.Open(func(_ context.Context, _ context.Context) (*mockConnection, error) {
+		c := newMockConnection()
+		c.id = int(created.Add(1))
+		return c, nil
+	}, nil)
+	defer pool.Close()
+
+	settings := connstate.NewSettings(map[string]string{"timezone": "UTC"}, 1)
+
+	c1, err := pool.GetWithSettings(ctx, settings)
+	require.NoError(t, err)
+	first := c1.Conn
+	require.Same(t, settings, c1.Conn.Settings())
+	c1.Recycle()
+
+	// After an invalidation, the stale backend is reconnected AND the target
+	// settings are re-applied on top of the fresh backend.
+	pool.InvalidateDefaults()
+
+	c2, err := pool.GetWithSettings(ctx, settings)
+	require.NoError(t, err)
+	require.NotSame(t, first, c2.Conn, "stale settings connection must be reconnected")
+	require.True(t, first.IsClosed())
+	require.Same(t, settings, c2.Conn.Settings(), "target settings must be applied to the fresh backend")
+	c2.Recycle()
 }
 
 func TestPoolGetWithSettings(t *testing.T) {

--- a/go/services/multipooler/internal/pools/connpool/pooled.go
+++ b/go/services/multipooler/internal/pools/connpool/pooled.go
@@ -31,6 +31,16 @@ type Pooled[C Connection] struct {
 	// This is used for idle timeout tracking.
 	timeUsed timestamp
 
+	// generation is the pool's defaults-generation at the time this connection
+	// was (re)established. When the pool's generation is bumped (see
+	// Pool.InvalidateDefaults), a connection whose generation is older is stale:
+	// its backend cached per-database/role GUC defaults (pg_db_role_setting) that
+	// have since changed (ALTER DATABASE/ROLE ... SET, or an extension that runs
+	// one). The pool lazily reconnects such a connection on its next borrow so the
+	// fresh backend re-reads those defaults. Owned by whoever currently holds the
+	// connection (single owner at a time), so it needs no synchronization.
+	generation int64
+
 	// pool is a reference to the pool that owns this connection.
 	// Used for the Recycle pattern.
 	pool *Pool[C]

--- a/go/services/multipooler/internal/pools/regular/pool.go
+++ b/go/services/multipooler/internal/pools/regular/pool.go
@@ -159,6 +159,13 @@ func (p *Pool) InnerPool() *connpool.Pool[*Conn] {
 	return p.pool
 }
 
+// InvalidateDefaults marks every pooled connection stale so it reconnects on its
+// next borrow, re-reading per-database/role GUC defaults changed by ALTER
+// DATABASE/ROLE ... SET (or an extension that runs one).
+func (p *Pool) InvalidateDefaults() {
+	p.pool.InvalidateDefaults()
+}
+
 // Requested returns the number of currently requested connections (borrowed + waiters).
 // Used for demand tracking in the rebalancer.
 func (p *Pool) Requested() int64 {

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -53,6 +53,19 @@ type Conn struct {
 	// reservedProps tracks why the connection is reserved.
 	reservedProps *ReservationProperties
 
+	// pendingDefaultsInvalidation records that a statement which changes
+	// per-database/role GUC defaults (ALTER DATABASE/ROLE ... SET, or an
+	// allowlisted CREATE EXTENSION) executed successfully inside the current
+	// transaction. The change is durable only at COMMIT, so the pool's defaults
+	// generation must be bumped then, not when the statement runs. The executor
+	// sets this via MarkPendingDefaultsInvalidation and consumes it at COMMIT;
+	// Commit and Rollback both clear it. A ROLLBACK TO SAVEPOINT runs as an
+	// ordinary statement (not Rollback), so the flag survives it — a deliberately
+	// conservative choice: an extra refresh is harmless, a missed one leaks stale
+	// defaults. Accessed only from the executor, which the gateway serializes per
+	// reserved connection.
+	pendingDefaultsInvalidation bool
+
 	// inactivityTimeout is the maximum duration the connection can be inactive
 	// (no client activity) before expiring. A value of 0 means no timeout.
 	inactivityTimeout time.Duration
@@ -129,6 +142,11 @@ func (c *Conn) Commit(ctx context.Context) error {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
+	// The executor reads PendingDefaultsInvalidation before calling Commit and
+	// bumps the pool generation after a successful COMMIT; clear the now-consumed
+	// transaction-scoped flag.
+	c.pendingDefaultsInvalidation = false
+
 	c.RemoveReservationReason(protoutil.ReasonTransaction)
 	return nil
 }
@@ -145,8 +163,25 @@ func (c *Conn) Rollback(ctx context.Context) error {
 		return fmt.Errorf("failed to rollback transaction: %w", err)
 	}
 
+	// The transaction (and any defaults-changing DDL it ran) was discarded, so no
+	// generation bump is owed; drop the transaction-scoped flag.
+	c.pendingDefaultsInvalidation = false
+
 	c.RemoveReservationReason(protoutil.ReasonTransaction)
 	return nil
+}
+
+// MarkPendingDefaultsInvalidation records that a statement changing
+// per-database/role GUC defaults committed-pending inside the current
+// transaction. See pendingDefaultsInvalidation.
+func (c *Conn) MarkPendingDefaultsInvalidation() {
+	c.pendingDefaultsInvalidation = true
+}
+
+// PendingDefaultsInvalidation reports whether a defaults-changing statement has
+// run in the current transaction and is awaiting a COMMIT to become durable.
+func (c *Conn) PendingDefaultsInvalidation() bool {
+	return c.pendingDefaultsInvalidation
 }
 
 // IsInTransaction returns true if there's an active transaction.

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -442,6 +442,15 @@ func (p *Pool) SetCapacity(ctx context.Context, newcap int64) error {
 	return p.conns.SetCapacity(ctx, newcap)
 }
 
+// InvalidateDefaults marks every pooled connection stale so it reconnects on its
+// next borrow, re-reading per-database/role GUC defaults changed by ALTER
+// DATABASE/ROLE ... SET (or an extension that runs one). Connections currently
+// checked out as live reserved connections (open transactions / temp tables)
+// are unaffected; they refresh after they are released back to the pool.
+func (p *Pool) InvalidateDefaults() {
+	p.conns.InvalidateDefaults()
+}
+
 // Requested returns the number of currently requested connections (borrowed + waiters).
 // Used for demand tracking in the rebalancer.
 func (p *Pool) Requested() int64 {

--- a/go/test/endtoend/queryserving/connection_defaults_test.go
+++ b/go/test/endtoend/queryserving/connection_defaults_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// newSearchPath is a distinctive per-database default that a freshly-connected
+// backend reports verbatim from SHOW search_path, but that PostgreSQL's boot
+// default ("$user", public) never produces — so the assertion is meaningful.
+const newSearchPath = "public, information_schema"
+
+// resetDatabaseSearchPath clears the per-database search_path default so the
+// shared cluster is left clean for other tests. Runs on its own connection with
+// a background context so it still fires when the test's context is done.
+func resetDatabaseSearchPath(db *sql.DB, dbName string) {
+	cc, err := db.Conn(context.Background())
+	if err != nil {
+		return
+	}
+	defer cc.Close()
+	_, _ = cc.ExecContext(context.Background(),
+		fmt.Sprintf("ALTER DATABASE %s RESET search_path", dbName))
+}
+
+// TestMultiGateway_ConnectionDefaultsRefreshedAfterAlterDatabase verifies that
+// changing a per-database session GUC default via the multigateway is observed
+// by already-open pooled backends. PostgreSQL applies pg_db_role_setting only at
+// session start, so a pooled backend opened before the ALTER would keep the old
+// default until it reconnects. The multigateway flags ALTER DATABASE ... SET
+// (ExecuteOptions.InvalidatesConnectionDefaults) and the multipooler refreshes
+// its pooled connections, so the next statement observes the new default.
+//
+// This is the non-PostGIS analogue of the PostGIS `totopogeom` failure, where
+// CREATE EXTENSION postgis_topology runs ALTER DATABASE ... SET search_path
+// internally and a stale pooled backend then resolved unqualified topology
+// functions against the pre-extension search_path.
+func TestMultiGateway_ConnectionDefaultsRefreshedAfterAlterDatabase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	c, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var dbName string
+	require.NoError(t, c.QueryRowContext(ctx, "SELECT current_database()").Scan(&dbName))
+	t.Cleanup(func() { resetDatabaseSearchPath(db, dbName) })
+
+	// Warm a pooled backend so at least one connection exists BEFORE the ALTER;
+	// it caches PostgreSQL's session-start search_path and is therefore stale.
+	_, err = c.ExecContext(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	var before string
+	require.NoError(t, c.QueryRowContext(ctx, "SHOW search_path").Scan(&before))
+	require.NotEqual(t, newSearchPath, before, "baseline search_path must differ for the assertion to be meaningful")
+
+	// Autocommit ALTER DATABASE ... SET — durable immediately, so the bump fires
+	// as soon as the statement completes.
+	_, err = c.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET search_path TO %s", dbName, newSearchPath))
+	require.NoError(t, err)
+
+	// A pooled backend opened before the ALTER must now report the new default.
+	// Without the refresh it would keep the stale, pre-ALTER value.
+	var after string
+	require.NoError(t, c.QueryRowContext(ctx, "SHOW search_path").Scan(&after))
+	require.Equal(t, newSearchPath, after,
+		"pooled backend must reconnect and observe the new per-database search_path default")
+}
+
+// TestMultiGateway_ConnectionDefaultsRefreshedAfterAlterDatabaseInTransaction is
+// the transaction-correct counterpart: ALTER DATABASE ... SET inside an explicit
+// transaction is durable only at COMMIT, so the multipooler defers the refresh
+// until then. After COMMIT, a pooled backend must observe the new default; a
+// ROLLBACK (covered by unit tests) must not refresh, because the change is
+// discarded. This guards the deferred (COMMIT-time) bump path.
+func TestMultiGateway_ConnectionDefaultsRefreshedAfterAlterDatabaseInTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 120*time.Second)
+
+	c, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var dbName string
+	require.NoError(t, c.QueryRowContext(ctx, "SELECT current_database()").Scan(&dbName))
+	t.Cleanup(func() { resetDatabaseSearchPath(db, dbName) })
+
+	_, err = c.ExecContext(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	_, err = c.ExecContext(ctx, "BEGIN")
+	require.NoError(t, err)
+	_, err = c.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET search_path TO %s", dbName, newSearchPath))
+	require.NoError(t, err)
+	_, err = c.ExecContext(ctx, "COMMIT")
+	require.NoError(t, err)
+
+	var after string
+	require.NoError(t, c.QueryRowContext(ctx, "SHOW search_path").Scan(&after))
+	require.Equal(t, newSearchPath, after,
+		"after COMMIT, pooled backends must observe the new per-database search_path default")
+}

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -325,6 +325,19 @@ message ExecuteOptions {
   // functions can map virtual PIDs (visible to clients) back to real
   // backend PIDs via pg_stat_activity.
   uint32 client_connection_id = 8;
+
+  // invalidates_connection_defaults marks a statement that changes
+  // per-database or per-role session GUC defaults (pg_db_role_setting):
+  // ALTER DATABASE ... SET / ALTER ROLE ... SET that pins a value, or a
+  // CREATE EXTENSION on the multigateway planner's allowlist of extensions
+  // known to run such an ALTER internally (e.g. postgis_topology's
+  // AddToSearchPath). The multigateway sets it during planning. PostgreSQL
+  // applies these defaults only at session start, so already-open pooled
+  // backends would keep serving stale defaults; on success the multipooler
+  // bumps its pools' defaults generation (at COMMIT when the statement runs
+  // inside an explicit transaction) so each pooled connection reconnects on
+  // its next borrow and re-reads the new defaults.
+  bool invalidates_connection_defaults = 9;
 }
 
 // UserAuth carries cryptographic material extracted from the client's SCRAM


### PR DESCRIPTION
## Problem

PostgreSQL reads per-database / per-role GUC defaults (`pg_db_role_setting`) **only at session start**. A pooled backend opened before an `ALTER DATABASE/ROLE … SET` keeps the old defaults forever — `RESET` / `RESET ALL` / `DISCARD ALL` revert to the session-start value, never re-reading the catalog (and `pg_reload_conf()` only re-reads `postgresql.conf`, not the catalog). So a pooled session diverged from a fresh connection.

Surfaced by the PostGIS `totopogeom` test: `CREATE EXTENSION postgis_topology` runs `ALTER DATABASE … SET search_path = …, topology` internally (`topology.AddToSearchPath`), but stale pooled backends then resolved unqualified `topology.*` functions against the pre-extension `search_path` and failed.

## Fix — lazy generation-invalidation, planner-triggered, transaction-correct

- **Planner** flags statements that change per-db/role defaults: `ALTER DATABASE/ROLE … SET/RESET`, and `CREATE EXTENSION` for a small hardcoded allowlist of extensions whose install script runs such an `ALTER` (today: `postgis_topology` — the `ALTER` runs server-side, invisible to the gateway, so the extension name is the only signal). The flag rides the execute request (`ExecuteOptions.invalidates_connection_defaults`). `PlanPortal` routes these through `Plan` so the extended protocol carries it too.
- **Executor** bumps the pool's defaults generation on success, honoring transactional-DDL semantics: immediately when the connection is idle (autocommit / non-transactional reserved), or deferred to a successful `COMMIT` when it ran inside a transaction. `ROLLBACK` discards the pending bump; `ROLLBACK TO SAVEPOINT` conservatively keeps it (an extra refresh is harmless; a missed one leaks stale defaults).
- **connpool** refresh is lazy and non-disruptive: `InvalidateConnectionDefaults` bumps a generation counter without closing any connection; each pooled connection records the generation it was established under and is transparently reconnected on its **next borrow** if stale, so the fresh backend re-reads `pg_db_role_setting`. Hot-path cost is one atomic load plus a compare.

Documented deviations (`docs/query_serving/session_settings.md`): more eager than stock pooling (which never refreshes); replica poolers refresh lazily because the `ALTER` executes on the primary; the bump over-approximates across a pooler's user/admin pools.

## Tests

connpool lazy-reconnect (incl. settings re-application, `-race`); planner detection + allowlist; executor durability-aware decision (autocommit vs defer-to-COMMIT, failed block); e2e regression for autocommit and in-transaction `ALTER DATABASE … SET` — verified non-vacuous (fails with the refresh disabled, returning the stale `"$user", public`).

Draft — opened for isolated review; one of three pooler/gateway session-state fixes surfaced by PostGIS compatibility testing.
