### PR TITLE
ci: add dependency updates and vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,24 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "npm"
+    directory: "/web/multiadmin"
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 7
+    groups:
+      multiadmin-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,12 +1,12 @@
 name: Go vulnerability check
 
-on:
+"on":
   schedule:
-    - cron: '0 6 * * *' # daily at 06:00 UTC
+    - cron: "0 6 * * *" # daily at 06:00 UTC
   pull_request:
     paths:
-      - 'go.mod'
-      - 'go.sum'
+      - "go.mod"
+      - "go.sum"
   workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,51 @@
+name: Go vulnerability check
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily at 06:00 UTC
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      - name: Run govulncheck (SARIF)
+        id: scan
+        continue-on-error: true
+        run: govulncheck -format sarif ./... > govulncheck.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: govulncheck.sarif
+
+      - name: Run govulncheck (text)
+        if: ${{ steps.scan.outcome == 'failure' }}
+        run: |
+          echo "::error::govulncheck found vulnerabilities in Go dependencies"
+          govulncheck ./...

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":configMigration"
+  ],
+  "enabledManagers": ["gomod", "github-actions"],
+  "semanticCommits": "auto",
+  "rangeStrategy": "bump",
+  "updatePinnedDependencies": true,
+  "postUpdateOptions": ["gomodTidy"],
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "description": "Only update the Go directive in go.mod",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+      "enabled": true
+    },
+    {
+      "description": "Leave Go module dependency updates to Dependabot",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "enabled": false
+    },
+    {
+      "description": "Pin and update GitHub Actions by commit SHA",
+      "matchManagers": ["github-actions"],
+      "updatePinnedDependencies": true
+    },
+    {
+      "description": "Group GitHub Actions minor and patch updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "[github-actions] all non-major dependencies",
+      "groupSlug": "github-actions-all-minor-patch"
+    },
+    {
+      "description": "Disable major Go version bumps",
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Description
This PR adds secure dependency update automation and Go vulnerability scanning for multigres while preserving the repo’s GitHub Actions SHA-pinning policy and existing Go version source, until we discuss a more robust approach.

## Main Changes
- Adds Renovate for Go directive updates and GitHub Actions updates while keeping Actions pinned to immutable commit SHAs.
- Keeps Dependabot for normal dependency ecosystems, with grouped Go module updates and npm updates for web/multiadmin.
- Adds a govulncheck workflow that runs daily, on relevant dependency PRs, and manually, uploads SARIF to code scanning, and fails clearly when Go vulnerabilities are found.