### PR TITLE
feat(multipooler): pooler-side backup observability

### DIFF
--- a/go/common/constants/manager.go
+++ b/go/common/constants/manager.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "time"
+
+// Multipooler manager constants.
+const (
+	// BackupHealthPollInterval is how often the multipooler's backup-health
+	// poller refreshes its cached snapshot (last-backup age/count, readiness,
+	// WAL archive lag) from the repo and PostgreSQL. The gauges and status page
+	// therefore reflect state that may be up to this old. The gauge callbacks
+	// derive ages from cached timestamps at scrape time, so this only needs to
+	// be frequent enough to catch state changes (a new backup, an expiration,
+	// the repo going unreachable), not to keep ages fresh — hence minutes.
+	BackupHealthPollInterval = 5 * time.Minute
+)

--- a/go/common/web/templates/pooler_index.html
+++ b/go/common/web/templates/pooler_index.html
@@ -53,6 +53,73 @@
         </table>
       </section>
 
+      <section>
+        <h4>Backups</h4>
+        {{if .Backups.LastRefreshed}}
+        <p>
+          <small>
+            <em
+              >The information below is only for the current pooler, except
+              where noted. Last refreshed {{.Backups.LastRefreshed}}.</em
+            >
+          </small>
+        </p>
+        {{end}}
+        <table>
+          <tbody>
+            <tr>
+              <th>Ready</th>
+              <td>
+                {{if .Backups.Ready}}<span class="success">yes</span
+                >{{else}}<span class="error">no ({{.Backups.ReadyReason}})</span
+                >{{end}}
+              </td>
+            </tr>
+            <tr>
+              <th>Last successful backup (across shard)</th>
+              <td>
+                {{if .Backups.HasBackup}}{{.Backups.LastBackupAt}}
+                ({{.Backups.LastBackupAge}} ago){{else}}<span class="error"
+                  >never</span
+                >{{end}}
+              </td>
+            </tr>
+            <tr>
+              <th>Complete backups (across shard)</th>
+              <td>{{.Backups.CompleteCount}}</td>
+            </tr>
+            <tr>
+              <th>Failures since success</th>
+              <td>{{.Backups.FailuresSince}}</td>
+            </tr>
+            <tr>
+              <th>In progress</th>
+              <td>
+                {{if .Backups.InProgress}}yes
+                ({{.Backups.InProgressFor}}){{else}}no{{end}}
+              </td>
+            </tr>
+            <tr>
+              <th>WAL archive lag</th>
+              <td>
+                {{if
+                .Backups.WALArchiveLag}}{{.Backups.WALArchiveLag}}{{else}}—{{end}}
+              </td>
+            </tr>
+            <tr>
+              <th>Backup lease held</th>
+              <td>{{if .Backups.LeaseHeld}}yes{{else}}no{{end}}</td>
+            </tr>
+            {{if .Backups.LastFailure}}
+            <tr>
+              <th>Last failure</th>
+              <td><span class="error">{{.Backups.LastFailure}}</span></td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </section>
+
       <section div class="grid">
         {{range .Links}}
         <article>

--- a/go/observability/metriccatalog/catalog_generated.go
+++ b/go/observability/metriccatalog/catalog_generated.go
@@ -54,7 +54,7 @@ type Metric struct {
 }
 
 // Metrics is the catalog of every metric Multigres defines, sorted by OTel name.
-// There are 80 metrics.
+// There are 89 metrics.
 var Metrics = []Metric{
 	{
 		OTelName:       "db.client.connection.count",
@@ -672,9 +672,19 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:52",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:69",
 		PrometheusName: "pgbackrest_backup_attempts_total",
 		Series:         []string{"pgbackrest_backup_attempts_total"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.complete_count",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:146",
+		PrometheusName: "pgbackrest_backup_complete_count",
+		Series:         []string{"pgbackrest_backup_complete_count"},
 	},
 	{
 		OTelName:       "pgbackrest.backup.duration",
@@ -682,7 +692,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:88",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:111",
 		PrometheusName: "pgbackrest_backup_duration_seconds",
 		Series:         []string{"pgbackrest_backup_duration_seconds_bucket", "pgbackrest_backup_duration_seconds_count", "pgbackrest_backup_duration_seconds_sum"},
 	},
@@ -692,9 +702,69 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:64",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:81",
 		PrometheusName: "pgbackrest_backup_failures_total",
 		Series:         []string{"pgbackrest_backup_failures_total"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.failures_since_success",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:152",
+		PrometheusName: "pgbackrest_backup_failures_since_success",
+		Series:         []string{"pgbackrest_backup_failures_since_success"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.in_progress",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:171",
+		PrometheusName: "pgbackrest_backup_in_progress",
+		Series:         []string{"pgbackrest_backup_in_progress"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.in_progress_duration_seconds",
+		Constructor:    "Float64ObservableGauge",
+		Unit:           "s",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:177",
+		PrometheusName: "pgbackrest_backup_in_progress_duration_seconds",
+		Series:         []string{"pgbackrest_backup_in_progress_duration_seconds"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.last_success_age_seconds",
+		Constructor:    "Float64ObservableGauge",
+		Unit:           "s",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:139",
+		PrometheusName: "pgbackrest_backup_last_success_age_seconds",
+		Series:         []string{"pgbackrest_backup_last_success_age_seconds"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.lease.lost",
+		Constructor:    "Int64Counter",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:105",
+		PrometheusName: "pgbackrest_backup_lease_lost_total",
+		Series:         []string{"pgbackrest_backup_lease_lost_total"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.lease_held",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:184",
+		PrometheusName: "pgbackrest_backup_lease_held",
+		Series:         []string{"pgbackrest_backup_lease_held"},
 	},
 	{
 		OTelName:       "pgbackrest.backup.lock_wait",
@@ -702,9 +772,19 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:109",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:132",
 		PrometheusName: "pgbackrest_backup_lock_wait_seconds",
 		Series:         []string{"pgbackrest_backup_lock_wait_seconds_bucket", "pgbackrest_backup_lock_wait_seconds_count", "pgbackrest_backup_lock_wait_seconds_sum"},
+	},
+	{
+		OTelName:       "pgbackrest.backup.ready",
+		Constructor:    "Int64ObservableGauge",
+		Unit:           "",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:158",
+		PrometheusName: "pgbackrest_backup_ready",
+		Series:         []string{"pgbackrest_backup_ready"},
 	},
 	{
 		OTelName:       "pgbackrest.backup.successes",
@@ -712,7 +792,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:58",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:75",
 		PrometheusName: "pgbackrest_backup_successes_total",
 		Series:         []string{"pgbackrest_backup_successes_total"},
 	},
@@ -722,7 +802,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:95",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:118",
 		PrometheusName: "pgbackrest_backup_verify_duration_seconds",
 		Series:         []string{"pgbackrest_backup_verify_duration_seconds_bucket", "pgbackrest_backup_verify_duration_seconds_count", "pgbackrest_backup_verify_duration_seconds_sum"},
 	},
@@ -732,7 +812,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:70",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:87",
 		PrometheusName: "pgbackrest_restore_attempts_total",
 		Series:         []string{"pgbackrest_restore_attempts_total"},
 	},
@@ -742,7 +822,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:102",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:125",
 		PrometheusName: "pgbackrest_restore_duration_seconds",
 		Series:         []string{"pgbackrest_restore_duration_seconds_bucket", "pgbackrest_restore_duration_seconds_count", "pgbackrest_restore_duration_seconds_sum"},
 	},
@@ -752,7 +832,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:82",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:99",
 		PrometheusName: "pgbackrest_restore_failures_total",
 		Series:         []string{"pgbackrest_restore_failures_total"},
 	},
@@ -762,7 +842,7 @@ var Metrics = []Metric{
 		Unit:           "",
 		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
 		Binaries:       []string{"multipooler"},
-		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:76",
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:93",
 		PrometheusName: "pgbackrest_restore_successes_total",
 		Series:         []string{"pgbackrest_restore_successes_total"},
 	},
@@ -795,6 +875,16 @@ var Metrics = []Metric{
 		Source:         "go/cmd/pgctld/command/metrics.go:62",
 		PrometheusName: "pgbackrest_server_uptime",
 		Series:         []string{"pgbackrest_server_uptime"},
+	},
+	{
+		OTelName:       "pgbackrest.wal.archive_lag_seconds",
+		Constructor:    "Float64ObservableGauge",
+		Unit:           "s",
+		Package:        "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup",
+		Binaries:       []string{"multipooler"},
+		Source:         "go/services/multipooler/internal/manager/backup/metrics.go:164",
+		PrometheusName: "pgbackrest_wal_archive_lag_seconds",
+		Series:         []string{"pgbackrest_wal_archive_lag_seconds"},
 	},
 	{
 		OTelName:       "rpcclient.connection.cache.size",
@@ -867,7 +957,7 @@ var Metrics = []Metric{
 //     action: keep
 //
 // Histogram families collapse to a "<base>_(bucket|count|sum)" group.
-const PrometheusKeepListRegex = `db_client_connection_count|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|pgbackrest_backup_attempts_total|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
+const PrometheusKeepListRegex = `db_client_connection_count|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|pgbackrest_wal_archive_lag_seconds|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
 
 // PrometheusKeepListByBinary maps each binary to a keep-list regex covering only
 // the series that binary exposes, for scoping a keep rule per Prometheus scrape
@@ -879,7 +969,7 @@ var PrometheusKeepListByBinary = map[string]string{
 	"multigateway": `mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multigres":    `topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multiorch":    `multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
-	"multipooler":  `db_client_connection_count|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|pgbackrest_backup_attempts_total|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
+	"multipooler":  `db_client_connection_count|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|pgbackrest_backup_attempts_total|pgbackrest_backup_complete_count|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_since_success|pgbackrest_backup_failures_total|pgbackrest_backup_in_progress|pgbackrest_backup_in_progress_duration_seconds|pgbackrest_backup_last_success_age_seconds|pgbackrest_backup_lease_held|pgbackrest_backup_lease_lost_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_ready|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_wal_archive_lag_seconds|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"pgctld":       `pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 }
 

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2543,9 +2543,13 @@ type BackupMetadata struct {
 	// Multipooler ID that created this backup (from pgbackrest annotation)
 	MultipoolerId string `protobuf:"bytes,9,opt,name=multipooler_id,json=multipoolerId,proto3" json:"multipooler_id,omitempty"`
 	// Pooler type that created this backup (from pgbackrest annotation)
-	PoolerType    clustermetadata.PoolerType `protobuf:"varint,10,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PoolerType clustermetadata.PoolerType `protobuf:"varint,10,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
+	// When the backup started/stopped, parsed from pgbackrest info's
+	// backup[].timestamp.{start,stop}. Unset if unknown.
+	StartTimestamp *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=start_timestamp,json=startTimestamp,proto3" json:"start_timestamp,omitempty"`
+	StopTimestamp  *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=stop_timestamp,json=stopTimestamp,proto3" json:"stop_timestamp,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *BackupMetadata) Reset() {
@@ -2646,6 +2650,20 @@ func (x *BackupMetadata) GetPoolerType() clustermetadata.PoolerType {
 		return x.PoolerType
 	}
 	return clustermetadata.PoolerType(0)
+}
+
+func (x *BackupMetadata) GetStartTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTimestamp
+	}
+	return nil
+}
+
+func (x *BackupMetadata) GetStopTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StopTimestamp
+	}
+	return nil
 }
 
 // RewindToSourceRequest requests pg_rewind to synchronize with a source server.
@@ -2978,7 +2996,7 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x15VerifyBackupsResponse\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x1d\n" +
 	"\n" +
-	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xb9\x03\n" +
+	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xc1\x04\n" +
 	"\x0eBackupMetadata\x12\x1f\n" +
 	"\vtable_group\x18\x01 \x01(\tR\n" +
 	"tableGroup\x12\x14\n" +
@@ -2992,7 +3010,9 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x0emultipooler_id\x18\t \x01(\tR\rmultipoolerId\x12<\n" +
 	"\vpooler_type\x18\n" +
 	" \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
-	"poolerType\"3\n" +
+	"poolerType\x12C\n" +
+	"\x0fstart_timestamp\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\x0estartTimestamp\x12A\n" +
+	"\x0estop_timestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\"3\n" +
 	"\x06Status\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +
@@ -3161,12 +3181,14 @@ var file_multipoolermanagerdata_proto_depIdxs = []int32{
 	48, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 43: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
 	51, // 44: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	55, // 45: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
-	46, // [46:46] is the sub-list for method output_type
-	46, // [46:46] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	49, // 45: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	49, // 46: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	55, // 47: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	48, // [48:48] is the sub-list for method output_type
+	48, // [48:48] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_multipoolermanagerdata_proto_init() }

--- a/go/services/multipooler/init.go
+++ b/go/services/multipooler/init.go
@@ -341,6 +341,9 @@ func (mp *MultiPooler) Init(startCtx context.Context) error {
 
 	// Start the MultiPoolerManager
 	poolerManager.Start(mp.senv)
+	// Launch the background backup-health poller (service-level concern, kept
+	// out of manager.Start so RPC unit tests don't run background DB queries).
+	poolerManager.StartBackupHealth()
 	grpcmanagerservice.RegisterPoolerManagerServices(mp.senv, mp.grpcServer)
 	grpcconsensusservice.RegisterConsensusServices(mp.senv, mp.grpcServer)
 	grpcpoolerservice.RegisterPoolerServices(mp.senv, mp.grpcServer)

--- a/go/services/multipooler/internal/manager/backup/backup_health.go
+++ b/go/services/multipooler/internal/manager/backup/backup_health.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/multigres/multigres/go/common/constants"
+	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+// Bounded readiness reasons reported by the readiness gauge and status page.
+// Keeping this set small keeps metric cardinality bounded.
+const (
+	// ReadyReasonUnknown is the reason before the first poll completes.
+	ReadyReasonUnknown = "unknown"
+	// ReadyReasonOK means backups can run: repo reachable, stanza present,
+	// archiving configured and not failing, restore configured.
+	ReadyReasonOK = "ok"
+	// ReadyReasonStanzaMissing means the stanza has not been created yet.
+	ReadyReasonStanzaMissing = "stanza_missing"
+	// ReadyReasonRepoUnreachable means the repo could not be reached.
+	ReadyReasonRepoUnreachable = "repo_unreachable"
+	// ReadyReasonArchivingFailing means WAL archiving is failing.
+	ReadyReasonArchivingFailing = "archiving_failing"
+	// ReadyReasonArchiveCommandUnset means archive_command is empty (primary).
+	ReadyReasonArchiveCommandUnset = "archive_command_unset"
+	// ReadyReasonArchiveModeOff means archive_mode is not on/always (primary).
+	ReadyReasonArchiveModeOff = "archive_mode_off"
+	// ReadyReasonRestoreCommandUnset means restore_command is empty.
+	ReadyReasonRestoreCommandUnset = "restore_command_unset"
+	// ReadyReasonDisabled means backup config has not been loaded.
+	ReadyReasonDisabled = "disabled"
+)
+
+// HealthTracker holds the latest backup-health snapshot, refreshed by the
+// poller and read by OTel gauge callbacks + the status page. All fields are
+// guarded by mu; the poller does its pgbackrest/SQL I/O OUTSIDE the lock and
+// only takes mu to copy results in, so callbacks never block on I/O.
+//
+// A single mutex (rather than per-field atomics, à la pgctld) is used
+// deliberately: this is a cold path, and one lock gives consistent group
+// snapshots (independent atomics can be read torn — e.g. completeCount updated
+// but lastSuccessStop not yet) and naturally holds the string fail fields.
+type HealthTracker struct {
+	mu sync.Mutex
+
+	// Repo-derived (set by the poller from `pgbackrest info`).
+	lastSuccessStop time.Time // stop time of newest COMPLETE backup; zero if none
+	completeCount   int64
+
+	// Readiness, derived passively each poll from `pgbackrest info`
+	// (repo/stanza) + pg_settings (archive/restore config). No active probe.
+	ready  bool
+	reason string // one of the ReadyReason* constants
+
+	// WAL archive lag (primary only; set from pg_stat_archiver).
+	lastArchived time.Time // zero if unknown / not primary
+
+	// Updated inline by the Backup() RPC.
+	failuresSinceSuccess int64
+	inProgressStart      time.Time // zero when no backup running
+	leaseHeld            bool
+
+	// Last failure detail for the status page.
+	lastFailErr string
+	lastFailAt  time.Time
+
+	// lastRefresh is when the poller last completed a refresh cycle (the
+	// freshness of everything above). Zero before the first poll.
+	lastRefresh time.Time
+}
+
+// NewHealthTracker constructs a tracker with sane pre-poll defaults.
+func NewHealthTracker() *HealthTracker {
+	return &HealthTracker{reason: ReadyReasonUnknown}
+}
+
+// Snapshot is a plain-value, lock-free view of the tracker state for the gauge
+// callback and the status page. Ages are derived from the timestamps at read
+// time so they stay accurate between polls.
+type Snapshot struct {
+	LastSuccessStop      time.Time // zero if no COMPLETE backup
+	CompleteCount        int64
+	Ready                bool
+	Reason               string
+	LastArchived         time.Time // zero if unknown / not primary
+	FailuresSinceSuccess int64
+	InProgressStart      time.Time // zero when no backup running
+	LeaseHeld            bool
+	LastFailErr          string
+	LastFailAt           time.Time
+	LastRefresh          time.Time // when the poller last refreshed; zero before first poll
+}
+
+// Snapshot reads all tracker state into a plain value under a single lock — one
+// consistent read for both the gauge callback and the status page.
+func (t *HealthTracker) Snapshot() Snapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	reason := t.reason
+	if reason == "" {
+		reason = ReadyReasonUnknown
+	}
+	return Snapshot{
+		LastSuccessStop:      t.lastSuccessStop,
+		CompleteCount:        t.completeCount,
+		Ready:                t.ready,
+		Reason:               reason,
+		LastArchived:         t.lastArchived,
+		FailuresSinceSuccess: t.failuresSinceSuccess,
+		InProgressStart:      t.inProgressStart,
+		LeaseHeld:            t.leaseHeld,
+		LastFailErr:          t.lastFailErr,
+		LastFailAt:           t.lastFailAt,
+		LastRefresh:          t.lastRefresh,
+	}
+}
+
+// applyRepoInfo stores the repo-derived state computed by the poller.
+func (t *HealthTracker) applyRepoInfo(lastSuccessStop time.Time, completeCount int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastSuccessStop = lastSuccessStop
+	t.completeCount = completeCount
+}
+
+// applyReadiness stores the readiness state computed by the poller.
+func (t *HealthTracker) applyReadiness(ready bool, reason string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ready = ready
+	t.reason = reason
+}
+
+// applyArchiver stores the WAL archive state computed by the poller.
+func (t *HealthTracker) applyArchiver(lastArchived time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastArchived = lastArchived
+}
+
+// SetLeaseHeld records whether this pooler currently holds the backup lease.
+func (t *HealthTracker) SetLeaseHeld(held bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.leaseHeld = held
+}
+
+// markRefreshed records that the poller just completed a refresh cycle.
+func (t *HealthTracker) markRefreshed() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastRefresh = time.Now()
+}
+
+// BackupStarted records that a backup is now in progress. Called inline by the
+// Backup() RPC alongside the attempts counter.
+func (t *HealthTracker) BackupStarted() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.inProgressStart = time.Now()
+}
+
+// BackupSucceeded records a successful backup: clears the in-progress timer and
+// resets the failure streak.
+func (t *HealthTracker) BackupSucceeded() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.inProgressStart = time.Time{}
+	t.failuresSinceSuccess = 0
+}
+
+// BackupFailed records a failed backup: clears the in-progress timer, increments
+// the failure streak, and records the failure detail for the status page.
+func (t *HealthTracker) BackupFailed(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.inProgressStart = time.Time{}
+	t.failuresSinceSuccess++
+	if err != nil {
+		t.lastFailErr = err.Error()
+		t.lastFailAt = time.Now()
+	}
+}
+
+// RunHealthPoller refreshes the backup-health snapshot on a ticker until ctx is
+// cancelled. It is meant to be launched as a goroutine by the manager; it
+// returns when ctx is done, so cancelling the manager context stops the poller
+// (no leak). An initial refresh runs immediately so the snapshot is populated
+// without waiting a full interval.
+func (e *Engine) RunHealthPoller(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = constants.BackupHealthPollInterval
+	}
+	e.refreshHealth(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.refreshHealth(ctx)
+		}
+	}
+}
+
+// RefreshHealthNow performs a full one-off backup-health refresh, including the
+// readiness checks that issue pg queries (role, pg_settings, pg_stat_archiver).
+// The manager calls it from the service layer once bootstrap completes so the
+// gauges/status page reflect post-bootstrap state without waiting a poll tick.
+//
+// It is deliberately NOT used in the backup path — see RefreshRepoNow.
+func (e *Engine) RefreshHealthNow(ctx context.Context) {
+	e.refreshHealth(ctx)
+}
+
+// RefreshRepoNow refreshes only the repo-derived gauges (last-backup age +
+// complete count) from `pgbackrest info`. The manager calls it right after a
+// backup completes so the just-created backup is reflected immediately on the
+// pooler that took it, rather than waiting for the next poll tick.
+//
+// It is intentionally kept separate from (and narrower than) RefreshHealthNow —
+// it must NOT issue the readiness pg queries — for two reasons:
+//
+//  1. It runs inside the Backup() path's defer while the action lock AND the
+//     distributed backup lease are still held; limiting it to a single
+//     `pgbackrest info` keeps that critical section short.
+//  2. The cluster's first backup is created through this same path
+//     (backupLocked), which in unit tests runs against a strict mock query
+//     service with one-shot expectations. Issuing pg_is_in_recovery /
+//     pg_settings / pg_stat_archiver here would race with and consume those
+//     mocks, breaking unrelated consensus tests.
+//
+// A backup changes only repo state (a new backup), not role/config/archiver
+// readiness, so skipping the readiness refresh here loses nothing — the next
+// poll re-derives it.
+func (e *Engine) RefreshRepoNow(ctx context.Context) {
+	e.refreshFromRepo(ctx)
+	e.health.markRefreshed()
+}
+
+// refreshHealth recomputes the whole health snapshot for one tick. It derives
+// readiness passively — `pgbackrest info` (repo/stanza, which it also uses for
+// the age/count gauges) plus cheap pg_settings reads — so it never runs an
+// active probe like `pgbackrest check` that would force WAL/checkpoint I/O on
+// the primary.
+func (e *Engine) refreshHealth(ctx context.Context) {
+	// Record refresh completion on every poll, whatever path it takes.
+	defer e.health.markRefreshed()
+
+	// Disabled: backup config not loaded from topology yet.
+	if _, err := e.requireBackupConfig(); err != nil {
+		e.health.applyReadiness(false, ReadyReasonDisabled)
+		return
+	}
+
+	isPrimary := e.resolveRole(ctx)
+	reachable, repoReason := e.refreshFromRepo(ctx)
+	configReason := e.checkBackupSettings(ctx, isPrimary)
+	archivingFailing := e.refreshArchiver(ctx, isPrimary)
+
+	reason := resolveReadiness(reachable, repoReason, configReason, archivingFailing)
+	e.health.applyReadiness(reason == ReadyReasonOK, reason)
+}
+
+// resolveRole returns whether the local postgres is a primary, defaulting to
+// primary when the role is unknown so a real archiving issue on an actual
+// primary is never suppressed.
+func (e *Engine) resolveRole(ctx context.Context) bool {
+	fn := e.roleProvider()
+	if fn == nil {
+		return true
+	}
+	isPrimary, err := fn(ctx)
+	if err != nil {
+		e.logger.DebugContext(ctx, "backup health: role check failed; assuming primary", "error", err)
+		return true
+	}
+	return isPrimary
+}
+
+// refreshFromRepo runs `pgbackrest info` once: it updates the age/count gauges
+// and returns the repo reachability classification for readiness. On a
+// transient repo failure it leaves the cached age/count untouched (so the
+// gauges don't thrash to zero) and reports repo_unreachable.
+func (e *Engine) refreshFromRepo(ctx context.Context) (reachable bool, reason string) {
+	configPath, err := e.requireConfigPath()
+	if err != nil {
+		// pgbackrest.conf not generated yet (topology not loaded).
+		e.logger.DebugContext(ctx, "backup health: config path not set; repo unreachable", "error", err)
+		return false, ReadyReasonRepoUnreachable
+	}
+
+	output, err := e.runInfoCmd(ctx, configPath)
+	if err != nil {
+		if isStanzaMissing(output) {
+			// Stanza not created yet: there are genuinely no backups.
+			e.health.applyRepoInfo(time.Time{}, 0)
+			return false, ReadyReasonStanzaMissing
+		}
+		e.logger.DebugContext(ctx, "backup health: pgbackrest info failed; keeping cached age/count", "error", err)
+		return false, ReadyReasonRepoUnreachable
+	}
+
+	infoData, err := decodeInfo(output)
+	if err != nil {
+		e.logger.DebugContext(ctx, "backup health: failed to parse pgbackrest info; keeping cached age/count", "error", err)
+		return false, ReadyReasonRepoUnreachable
+	}
+
+	var completeCount int64
+	var lastSuccessStop time.Time
+	for _, b := range e.parseBackups(ctx, infoData) {
+		if b.GetStatus() != multipoolermanagerdata.BackupMetadata_COMPLETE {
+			continue
+		}
+		completeCount++
+		if ts := b.GetStopTimestamp(); ts != nil {
+			if stop := ts.AsTime(); stop.After(lastSuccessStop) {
+				lastSuccessStop = stop
+			}
+		}
+	}
+	e.health.applyRepoInfo(lastSuccessStop, completeCount)
+	return true, ""
+}
+
+// checkBackupSettings reads the PostgreSQL settings relevant to backup
+// readiness (cheap pg_settings reads, no forced I/O) and classifies them. It
+// returns "" when the settings are fine or cannot be read (we don't block
+// readiness on a transient query failure).
+func (e *Engine) checkBackupSettings(ctx context.Context, isPrimary bool) string {
+	fn := e.settingsProvider()
+	if fn == nil {
+		return ""
+	}
+	settings, err := fn(ctx)
+	if err != nil {
+		e.logger.DebugContext(ctx, "backup health: settings query failed; skipping config readiness check", "error", err)
+		return ""
+	}
+	return classifyBackupSettings(settings, isPrimary)
+}
+
+// classifyBackupSettings maps PostgreSQL backup-related settings to a bounded
+// readiness reason, or "" when they are fine. It is role-aware: archive_command
+// and archive_mode are only meaningful on a primary (only it archives WAL),
+// while restore_command is required on any node that may recover/restore.
+func classifyBackupSettings(s PGSettings, isPrimary bool) string {
+	if isPrimary {
+		if strings.TrimSpace(s.ArchiveCommand) == "" {
+			return ReadyReasonArchiveCommandUnset
+		}
+		if !archiveModeEnabled(s.ArchiveMode) {
+			return ReadyReasonArchiveModeOff
+		}
+	}
+	if strings.TrimSpace(s.RestoreCommand) == "" {
+		return ReadyReasonRestoreCommandUnset
+	}
+	return ""
+}
+
+// archiveModeEnabled reports whether archive_mode permits archiving.
+func archiveModeEnabled(mode string) bool {
+	switch strings.TrimSpace(strings.ToLower(mode)) {
+	case "on", "always":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveReadiness combines the repo, config, and archiving signals into a
+// single bounded reason, worst-first: an unreachable repo or missing stanza
+// dominates a config problem, which dominates an archiving failure.
+func resolveReadiness(reachable bool, repoReason, configReason string, archivingFailing bool) string {
+	if !reachable {
+		return repoReason
+	}
+	if configReason != "" {
+		return configReason
+	}
+	if archivingFailing {
+		return ReadyReasonArchivingFailing
+	}
+	return ReadyReasonOK
+}
+
+// refreshArchiver refreshes the WAL archive lag gauge from pg_stat_archiver and
+// reports whether archiving is currently failing (the most recent archive
+// attempt failed). Only a primary archives WAL, so on a standby it clears the
+// cached value (the gauge stops emitting) and reports not-failing. This is a
+// passive, continuous signal — a cheap system-view read, no forced I/O.
+func (e *Engine) refreshArchiver(ctx context.Context, isPrimary bool) (archivingFailing bool) {
+	if !isPrimary {
+		e.health.applyArchiver(time.Time{})
+		return false
+	}
+
+	fn := e.archiverStatsProvider()
+	if fn == nil {
+		return false
+	}
+	stats, err := fn(ctx)
+	if err != nil {
+		e.logger.DebugContext(ctx, "backup health: pg_stat_archiver query failed; keeping cached lag", "error", err)
+		return false
+	}
+
+	e.health.applyArchiver(stats.LastArchived)
+	return stats.FailedCount > 0 && stats.LastFailed.After(stats.LastArchived)
+}

--- a/go/services/multipooler/internal/manager/backup/backup_health_test.go
+++ b/go/services/multipooler/internal/manager/backup/backup_health_test.go
@@ -1,0 +1,489 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupTracker_SetLeaseHeld(t *testing.T) {
+	tr := NewHealthTracker()
+	assert.False(t, tr.Snapshot().LeaseHeld)
+
+	tr.SetLeaseHeld(true)
+	assert.True(t, tr.Snapshot().LeaseHeld)
+
+	tr.SetLeaseHeld(false)
+	assert.False(t, tr.Snapshot().LeaseHeld)
+}
+
+func TestBackupTracker_FailuresAndInProgress(t *testing.T) {
+	tr := NewHealthTracker()
+
+	tr.BackupStarted()
+	assert.False(t, tr.Snapshot().InProgressStart.IsZero(), "in-progress should be set after start")
+
+	tr.BackupFailed(errors.New("boom"))
+	s := tr.Snapshot()
+	assert.Equal(t, int64(1), s.FailuresSinceSuccess)
+	assert.True(t, s.InProgressStart.IsZero(), "in-progress cleared on failure")
+	assert.Equal(t, "boom", s.LastFailErr)
+	assert.False(t, s.LastFailAt.IsZero())
+
+	tr.BackupStarted()
+	tr.BackupFailed(errors.New("boom2"))
+	assert.Equal(t, int64(2), tr.Snapshot().FailuresSinceSuccess, "streak accumulates")
+
+	tr.BackupStarted()
+	tr.BackupSucceeded()
+	s = tr.Snapshot()
+	assert.Zero(t, s.FailuresSinceSuccess, "streak resets on success")
+	assert.True(t, s.InProgressStart.IsZero(), "in-progress cleared on success")
+}
+
+func TestResolveReadiness(t *testing.T) {
+	tests := []struct {
+		name             string
+		reachable        bool
+		repoReason       string
+		configReason     string
+		archivingFailing bool
+		want             string
+	}{
+		{name: "all good", reachable: true, want: ReadyReasonOK},
+		{name: "repo unreachable dominates", reachable: false, repoReason: ReadyReasonRepoUnreachable, configReason: ReadyReasonArchiveCommandUnset, want: ReadyReasonRepoUnreachable},
+		{name: "stanza missing", reachable: false, repoReason: ReadyReasonStanzaMissing, want: ReadyReasonStanzaMissing},
+		{name: "config dominates archiving", reachable: true, configReason: ReadyReasonArchiveModeOff, archivingFailing: true, want: ReadyReasonArchiveModeOff},
+		{name: "restore_command unset config reason", reachable: true, configReason: ReadyReasonRestoreCommandUnset, want: ReadyReasonRestoreCommandUnset},
+		{name: "archiving failing", reachable: true, archivingFailing: true, want: ReadyReasonArchivingFailing},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveReadiness(tt.reachable, tt.repoReason, tt.configReason, tt.archivingFailing))
+		})
+	}
+}
+
+func TestClassifyBackupSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		settings  PGSettings
+		isPrimary bool
+		want      string
+	}{
+		{
+			name:      "primary fully configured",
+			settings:  PGSettings{ArchiveCommand: "pgbackrest archive-push %p", ArchiveMode: "on", RestoreCommand: "pgbackrest archive-get %f %p"},
+			isPrimary: true,
+			want:      "",
+		},
+		{
+			name:      "primary archive_command unset",
+			settings:  PGSettings{ArchiveCommand: "  ", ArchiveMode: "on", RestoreCommand: "x"},
+			isPrimary: true,
+			want:      ReadyReasonArchiveCommandUnset,
+		},
+		{
+			name:      "primary archive_mode off",
+			settings:  PGSettings{ArchiveCommand: "x", ArchiveMode: "off", RestoreCommand: "x"},
+			isPrimary: true,
+			want:      ReadyReasonArchiveModeOff,
+		},
+		{
+			name:      "archive_mode always is enabled",
+			settings:  PGSettings{ArchiveCommand: "x", ArchiveMode: "always", RestoreCommand: "x"},
+			isPrimary: true,
+			want:      "",
+		},
+		{
+			name:      "restore_command unset flagged on both roles",
+			settings:  PGSettings{ArchiveCommand: "x", ArchiveMode: "on", RestoreCommand: ""},
+			isPrimary: true,
+			want:      ReadyReasonRestoreCommandUnset,
+		},
+		{
+			name:      "standby ignores archive settings",
+			settings:  PGSettings{ArchiveCommand: "", ArchiveMode: "off", RestoreCommand: "x"},
+			isPrimary: false,
+			want:      "",
+		},
+		{
+			name:      "standby still needs restore_command",
+			settings:  PGSettings{ArchiveCommand: "", ArchiveMode: "off", RestoreCommand: ""},
+			isPrimary: false,
+			want:      ReadyReasonRestoreCommandUnset,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyBackupSettings(tt.settings, tt.isPrimary))
+		})
+	}
+}
+
+func TestRefreshHealth_DisabledWhenNoBackupConfig(t *testing.T) {
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "") // no backup location → config not set
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonDisabled, snap.Reason)
+}
+
+func TestRefreshHealth_OKWhenRepoReachableAndConfigured(t *testing.T) {
+	stubPgbackrest(t, pgbackrestInfoStub(`[{"backup":[]}]`))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	e.SetRoleProvider(func(context.Context) (bool, error) { return true, nil })
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{ArchiveCommand: "x", ArchiveMode: "on", RestoreCommand: "x"}, nil
+	})
+
+	assert.True(t, e.Health().Snapshot().LastRefresh.IsZero(), "no refresh time before the first poll")
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.True(t, snap.Ready)
+	assert.Equal(t, ReadyReasonOK, snap.Reason)
+	assert.False(t, snap.LastRefresh.IsZero(), "refreshHealth should record the refresh time")
+}
+
+func TestRefreshHealth_StanzaMissing(t *testing.T) {
+	stubPgbackrest(t, "#!/bin/bash\necho \"ERROR: [055]: stanza 'multigres' does not exist\" >&2\nexit 1\n")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonStanzaMissing, snap.Reason)
+}
+
+func TestRefreshHealth_ArchiveCommandUnset(t *testing.T) {
+	stubPgbackrest(t, pgbackrestInfoStub(`[{"backup":[]}]`))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	e.SetRoleProvider(func(context.Context) (bool, error) { return true, nil })
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{ArchiveCommand: "", ArchiveMode: "on", RestoreCommand: "x"}, nil
+	})
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonArchiveCommandUnset, snap.Reason)
+}
+
+func TestRefreshHealth_ArchiveModeOff(t *testing.T) {
+	stubPgbackrest(t, pgbackrestInfoStub(`[{"backup":[]}]`))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	e.SetRoleProvider(func(context.Context) (bool, error) { return true, nil })
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{ArchiveCommand: "x", ArchiveMode: "off", RestoreCommand: "x"}, nil
+	})
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonArchiveModeOff, snap.Reason)
+}
+
+func TestRefreshHealth_RestoreCommandUnset(t *testing.T) {
+	stubPgbackrest(t, pgbackrestInfoStub(`[{"backup":[]}]`))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	e.SetRoleProvider(func(context.Context) (bool, error) { return true, nil })
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{ArchiveCommand: "x", ArchiveMode: "on", RestoreCommand: ""}, nil
+	})
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonRestoreCommandUnset, snap.Reason)
+}
+
+func TestRefreshHealth_ArchivingFailing(t *testing.T) {
+	stubPgbackrest(t, pgbackrestInfoStub(`[{"backup":[]}]`))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	e.SetRoleProvider(func(context.Context) (bool, error) { return true, nil })
+	// Config is healthy, so archiving failure is the dominant reason.
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{ArchiveCommand: "x", ArchiveMode: "on", RestoreCommand: "x"}, nil
+	})
+	e.SetArchiverStatsProvider(func(context.Context) (ArchiverStats, error) {
+		return ArchiverStats{
+			LastArchived: time.Unix(1735984000, 0),
+			LastFailed:   time.Unix(1735984900, 0), // newer failure than last success
+			FailedCount:  2,
+		}, nil
+	})
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonArchivingFailing, snap.Reason)
+}
+
+func TestRefreshHealth_RepoUnreachable(t *testing.T) {
+	// info fails with a non-stanza-missing error → the whole poll lands on
+	// repo_unreachable.
+	stubPgbackrest(t, "#!/bin/bash\necho \"ERROR: [049]: unable to connect to repository host\" >&2\nexit 1\n")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	e.refreshHealth(t.Context())
+	snap := e.Health().Snapshot()
+	assert.False(t, snap.Ready)
+	assert.Equal(t, ReadyReasonRepoUnreachable, snap.Reason)
+}
+
+func TestBackupHealthSnapshot_Defaults(t *testing.T) {
+	tr := NewHealthTracker()
+	snap := tr.Snapshot()
+
+	assert.Equal(t, ReadyReasonUnknown, snap.Reason, "reason should default to unknown before first poll")
+	assert.False(t, snap.Ready)
+	assert.True(t, snap.LastSuccessStop.IsZero())
+	assert.Zero(t, snap.CompleteCount)
+	assert.True(t, snap.LastArchived.IsZero())
+	assert.Zero(t, snap.FailuresSinceSuccess)
+	assert.True(t, snap.InProgressStart.IsZero())
+	assert.False(t, snap.LeaseHeld)
+	assert.Empty(t, snap.LastFailErr)
+}
+
+func TestRefreshFromRepo(t *testing.T) {
+	// Two COMPLETE backups + one errored; newest stop is 1735984860.
+	json := `[{"backup":[
+		{"label":"20250104-100000F","type":"full","timestamp":{"start":1735984000,"stop":1735984060},"annotation":{"table_group":"tg1","shard":"0","job_id":"j1"}},
+		{"label":"20250104-110000F","type":"full","timestamp":{"start":1735984800,"stop":1735984860},"annotation":{"table_group":"tg1","shard":"0","job_id":"j2"}},
+		{"label":"20250104-120000F","type":"full","error":true,"timestamp":{"start":1735985000,"stop":1735985060},"annotation":{"table_group":"tg1","shard":"0","job_id":"j3"}}
+	]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	e.refreshFromRepo(t.Context())
+	snap := e.Health().Snapshot()
+	assert.Equal(t, int64(2), snap.CompleteCount, "errored backup should not be counted")
+	assert.Equal(t, int64(1735984860), snap.LastSuccessStop.Unix(), "should be the newest COMPLETE stop time")
+}
+
+func TestRefreshFromRepo_RetainsValuesOnError(t *testing.T) {
+	// Prime the tracker with values, then point at a config-less engine so
+	// ListBackups errors; the cached values must be retained.
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	// No SetConfigPath → ListBackups returns an error.
+	primed := time.Unix(1735984860, 0)
+	e.Health().applyRepoInfo(primed, 5)
+
+	e.refreshFromRepo(t.Context())
+	snap := e.Health().Snapshot()
+	assert.Equal(t, int64(5), snap.CompleteCount, "values should be retained on error")
+	assert.Equal(t, primed.Unix(), snap.LastSuccessStop.Unix())
+}
+
+func TestRunHealthPoller_StopsOnContextCancel(t *testing.T) {
+	json := `[{"backup":[]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		e.RunHealthPoller(ctx, 10*time.Millisecond)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "poller did not stop after context cancel")
+	}
+}
+
+func TestRefreshArchiver_ComputesLagOnPrimary(t *testing.T) {
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	archived := time.Unix(1735984900, 0)
+	e.SetArchiverStatsProvider(func(context.Context) (ArchiverStats, error) {
+		return ArchiverStats{LastArchived: archived}, nil
+	})
+
+	failing := e.refreshArchiver(t.Context(), true)
+	assert.False(t, failing)
+	snap := e.Health().Snapshot()
+	assert.Equal(t, archived, snap.LastArchived)
+}
+
+func TestRefreshArchiver_SkipsOnStandby(t *testing.T) {
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	// Prime a stale value to ensure standby clears it.
+	e.Health().applyArchiver(time.Unix(1735984900, 0))
+	called := false
+	e.SetArchiverStatsProvider(func(context.Context) (ArchiverStats, error) {
+		called = true
+		return ArchiverStats{}, nil
+	})
+
+	failing := e.refreshArchiver(t.Context(), false)
+	assert.False(t, failing)
+	snap := e.Health().Snapshot()
+	assert.True(t, snap.LastArchived.IsZero(), "standby should report no archive lag")
+	assert.False(t, called, "archiver stats should not be queried on a standby")
+}
+
+func TestRefreshArchiver_ReportsFailingWhenLastFailedNewer(t *testing.T) {
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	archived := time.Unix(1735984000, 0)
+	failed := time.Unix(1735984900, 0) // newer failure than last success
+	e.SetArchiverStatsProvider(func(context.Context) (ArchiverStats, error) {
+		return ArchiverStats{LastArchived: archived, LastFailed: failed, FailedCount: 3}, nil
+	})
+
+	failing := e.refreshArchiver(t.Context(), true)
+	assert.True(t, failing, "a failure newer than the last success means archiving is failing")
+	snap := e.Health().Snapshot()
+	assert.Equal(t, archived, snap.LastArchived)
+}
+
+func TestBackupHealthSnapshot_ReflectsState(t *testing.T) {
+	tr := NewHealthTracker()
+	stop := time.Unix(1735984800, 0)
+	archived := time.Unix(1735984900, 0)
+	inProgress := time.Unix(1735985000, 0)
+	failAt := time.Unix(1735984860, 0)
+
+	tr.mu.Lock()
+	tr.lastSuccessStop = stop
+	tr.completeCount = 3
+	tr.ready = true
+	tr.reason = ReadyReasonOK
+	tr.lastArchived = archived
+	tr.failuresSinceSuccess = 2
+	tr.inProgressStart = inProgress
+	tr.leaseHeld = true
+	tr.lastFailErr = "boom"
+	tr.lastFailAt = failAt
+	tr.mu.Unlock()
+
+	snap := tr.Snapshot()
+
+	assert.Equal(t, stop, snap.LastSuccessStop)
+	assert.Equal(t, int64(3), snap.CompleteCount)
+	assert.True(t, snap.Ready)
+	assert.Equal(t, ReadyReasonOK, snap.Reason)
+	assert.Equal(t, archived, snap.LastArchived)
+	assert.Equal(t, int64(2), snap.FailuresSinceSuccess)
+	assert.Equal(t, inProgress, snap.InProgressStart)
+	assert.True(t, snap.LeaseHeld)
+	assert.Equal(t, "boom", snap.LastFailErr)
+	assert.Equal(t, failAt, snap.LastFailAt)
+}
+
+func TestRefreshFromRepo_RepoUnreachableRetainsCache(t *testing.T) {
+	// `pgbackrest info` fails with a non-stanza-missing error → repo_unreachable,
+	// and the previously cached age/count must be retained (not thrashed to 0).
+	stubPgbackrest(t, "#!/bin/bash\necho \"ERROR: [049]: unable to connect to repository host\" >&2\nexit 1\n")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	primed := time.Unix(1735984860, 0)
+	e.Health().applyRepoInfo(primed, 7)
+
+	reachable, reason := e.refreshFromRepo(t.Context())
+	assert.False(t, reachable)
+	assert.Equal(t, ReadyReasonRepoUnreachable, reason)
+	snap := e.Health().Snapshot()
+	assert.Equal(t, int64(7), snap.CompleteCount, "cached count retained on repo error")
+	assert.Equal(t, primed.Unix(), snap.LastSuccessStop.Unix())
+}
+
+func TestRefreshFromRepo_MalformedJSONRetainsCache(t *testing.T) {
+	// info returns non-JSON (exit 0) → decode fails → repo_unreachable, retained.
+	stubPgbackrest(t, "#!/bin/bash\nif [[ \"$*\" == *info* ]]; then echo \"not json\"; exit 0; fi\nexit 0\n")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+	primed := time.Unix(1735984860, 0)
+	e.Health().applyRepoInfo(primed, 7)
+
+	reachable, reason := e.refreshFromRepo(t.Context())
+	assert.False(t, reachable)
+	assert.Equal(t, ReadyReasonRepoUnreachable, reason)
+	assert.Equal(t, int64(7), e.Health().Snapshot().CompleteCount, "cached count retained on parse error")
+}
+
+func TestResolveRole(t *testing.T) {
+	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
+	assert.True(t, e.resolveRole(t.Context()), "nil provider defaults to primary")
+
+	e.SetRoleProvider(func(context.Context) (bool, error) { return false, errors.New("boom") })
+	assert.True(t, e.resolveRole(t.Context()), "role error must assume primary, not suppress archiving issues")
+
+	e.SetRoleProvider(func(context.Context) (bool, error) { return false, nil })
+	assert.False(t, e.resolveRole(t.Context()))
+}
+
+func TestCheckBackupSettings_DoesNotBlockOnNilOrError(t *testing.T) {
+	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
+	// nil provider → cannot check → don't block readiness.
+	assert.Equal(t, "", e.checkBackupSettings(t.Context(), true))
+
+	// provider error → don't block readiness.
+	e.SetPGSettingsProvider(func(context.Context) (PGSettings, error) {
+		return PGSettings{}, errors.New("query failed")
+	})
+	assert.Equal(t, "", e.checkBackupSettings(t.Context(), true))
+}
+
+func TestRefreshArchiver_QueryErrorKeepsCache(t *testing.T) {
+	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
+	primed := time.Unix(1735984900, 0)
+	e.Health().applyArchiver(primed)
+	e.SetArchiverStatsProvider(func(context.Context) (ArchiverStats, error) {
+		return ArchiverStats{}, errors.New("query failed")
+	})
+
+	failing := e.refreshArchiver(t.Context(), true)
+	assert.False(t, failing, "a query error is not an archiving failure")
+	assert.Equal(t, primed.Unix(), e.Health().Snapshot().LastArchived.Unix(), "cached lag retained on query error")
+}
+
+func TestRefreshArchiver_NilProvider(t *testing.T) {
+	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
+	assert.False(t, e.refreshArchiver(t.Context(), true), "no provider → cannot be failing")
+}

--- a/go/services/multipooler/internal/manager/backup/engine.go
+++ b/go/services/multipooler/internal/manager/backup/engine.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	commonbackup "github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -55,21 +56,60 @@ type Settings struct {
 // lifecycle/logging policy.
 type RunFunc func(ctx context.Context, cmd *executil.Cmd, operationName string) ([]byte, error)
 
+// RoleFunc reports whether the local PostgreSQL is currently a primary. It is
+// injected by the manager (which owns the pg connection) so the health poller
+// can be role-aware — e.g. only a primary archives WAL — without the engine
+// owning a connection.
+type RoleFunc func(ctx context.Context) (isPrimary bool, err error)
+
+// ArchiverStats is a snapshot of pg_stat_archiver relevant to WAL archive lag.
+// Zero time fields mean the corresponding timestamp was NULL (never archived /
+// never failed).
+type ArchiverStats struct {
+	LastArchived time.Time
+	LastFailed   time.Time
+	FailedCount  int64
+}
+
+// ArchiverStatsFunc returns pg_stat_archiver stats for the local primary. It is
+// injected by the manager (which owns the pg connection + result scanning) so
+// the health poller can compute WAL archive lag without coupling the engine to
+// the SQL result types or owning a connection.
+type ArchiverStatsFunc func(ctx context.Context) (ArchiverStats, error)
+
+// PGSettings holds the PostgreSQL settings relevant to backup readiness. Empty
+// strings mean the setting is unset.
+type PGSettings struct {
+	ArchiveCommand string
+	ArchiveMode    string // "on" / "off" / "always"
+	RestoreCommand string
+}
+
+// PGSettingsFunc returns the backup-relevant PostgreSQL settings. It is injected
+// by the manager (which owns the pg connection) so the health poller can
+// validate configuration via cheap pg_settings reads without owning a
+// connection.
+type PGSettingsFunc func(ctx context.Context) (PGSettings, error)
+
 // Engine owns all pgBackRest interaction for a single multipooler.
 type Engine struct {
 	logger   *slog.Logger
 	run      RunFunc
 	metrics  *Metrics
+	health   *HealthTracker
 	id       Identity
 	settings Settings
 
 	// mu guards the config resolved at runtime: the pgbackrest.conf path and
-	// pgpass file (resolved when topology loads) and the repo config (resolved
-	// at DB-open). All may be re-set on reopen.
+	// pgpass file (resolved when topology loads), the repo config (resolved
+	// at DB-open), and the role provider. All may be re-set on reopen.
 	mu         sync.Mutex
 	configPath string
 	pgpassPath string
 	backupCfg  *commonbackup.Config
+	roleFn     RoleFunc
+	archiverFn ArchiverStatsFunc
+	settingsFn PGSettingsFunc
 }
 
 // NewEngine constructs a backup engine and its metrics from the given fixed
@@ -81,11 +121,15 @@ type Engine struct {
 // still returned rather than failing construction (which previously left the
 // manager with a nil engine that panicked on first use).
 func NewEngine(logger *slog.Logger, run RunFunc, id Identity, settings Settings) *Engine {
+	health := NewHealthTracker()
 	metrics, err := NewMetrics()
 	if err != nil {
 		logger.Warn("pgBackRest metric registration partially failed; backup metrics may be incomplete", "error", err)
 	}
-	return &Engine{logger: logger, run: run, metrics: metrics, id: id, settings: settings, pgpassPath: settings.PgpassPath}
+	if err := metrics.RegisterHealthCallback(health); err != nil {
+		logger.Warn("pgBackRest health gauge registration failed; backup health metrics may be missing", "error", err)
+	}
+	return &Engine{logger: logger, run: run, metrics: metrics, health: health, id: id, settings: settings, pgpassPath: settings.PgpassPath}
 }
 
 // SetConfigPath sets the path to this pooler's pgbackrest.conf, resolved once
@@ -111,6 +155,53 @@ func (e *Engine) SetPgpassPath(path string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.pgpassPath = path
+}
+
+// SetRoleProvider injects the function the health poller uses to learn whether
+// the local postgres is a primary. The manager wires this to its own role
+// check (which owns the pg connection).
+func (e *Engine) SetRoleProvider(fn RoleFunc) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.roleFn = fn
+}
+
+// roleProvider returns the currently-set role provider, or nil.
+func (e *Engine) roleProvider() RoleFunc {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.roleFn
+}
+
+// SetArchiverStatsProvider injects the function the health poller uses to read
+// pg_stat_archiver. The manager wires this to its own query path.
+func (e *Engine) SetArchiverStatsProvider(fn ArchiverStatsFunc) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.archiverFn = fn
+}
+
+// archiverStatsProvider returns the currently-set archiver stats provider, or nil.
+func (e *Engine) archiverStatsProvider() ArchiverStatsFunc {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.archiverFn
+}
+
+// SetPGSettingsProvider injects the function the health poller uses to read the
+// backup-relevant PostgreSQL settings. The manager wires this to its own query
+// path.
+func (e *Engine) SetPGSettingsProvider(fn PGSettingsFunc) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.settingsFn = fn
+}
+
+// settingsProvider returns the currently-set PG settings provider, or nil.
+func (e *Engine) settingsProvider() PGSettingsFunc {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.settingsFn
 }
 
 // requireConfigPath returns the pgbackrest.conf path or an error if topology
@@ -158,4 +249,11 @@ func (e *Engine) shardID() string {
 // restore lifecycle).
 func (e *Engine) Metrics() *Metrics {
 	return e.metrics
+}
+
+// Health returns the engine's backup-health tracker. The manager uses this to
+// expose a snapshot on the status page and to update inline counters from the
+// Backup() path.
+func (e *Engine) Health() *HealthTracker {
+	return e.health
 }

--- a/go/services/multipooler/internal/manager/backup/list.go
+++ b/go/services/multipooler/internal/manager/backup/list.go
@@ -19,6 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonbackup "github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/mterrors"
@@ -53,7 +56,27 @@ func (e *Engine) ListBackups(ctx context.Context) ([]*multipoolermanagerdata.Bac
 		return nil, mterrors.New(mtrpcpb.Code_INVALID_ARGUMENT, "backup config not loaded from topology")
 	}
 
-	// Execute pgbackrest info command with JSON output
+	output, err := e.runInfoCmd(ctx, configPath)
+	if err != nil {
+		// Handle case where stanza doesn't exist yet or config file is missing - return empty list
+		if output == "" || isStanzaMissing(output) {
+			return []*multipoolermanagerdata.BackupMetadata{}, nil
+		}
+		return nil, mterrors.New(mtrpcpb.Code_INTERNAL,
+			fmt.Sprintf("pgbackrest info failed: %v\nOutput: %s", err, output))
+	}
+
+	infoData, err := decodeInfo(output)
+	if err != nil {
+		return nil, err
+	}
+	return e.parseBackups(ctx, infoData), nil
+}
+
+// runInfoCmd runs `pgbackrest info --output=json` with the given config path and
+// returns the combined output. It is shared by ListBackups, FindByJobID, and the
+// health poller so a single code path produces the repo's JSON.
+func (e *Engine) runInfoCmd(ctx context.Context, configPath string) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, commonbackup.InfoTimeout)
 	defer cancel()
 
@@ -63,34 +86,40 @@ func (e *Engine) ListBackups(ctx context.Context) ([]*multipoolermanagerdata.Bac
 		"--output=json",
 		"--log-level-console=off", // Override console logging to prevent contaminating JSON output
 		"info")
+	return safeCombinedOutput(cmd)
+}
 
-	output, err := safeCombinedOutput(cmd)
-	if err != nil {
-		// Handle case where stanza doesn't exist yet or config file is missing - return empty list
-		if output == "" || strings.Contains(output, "does not exist") || strings.Contains(output, "unable to open missing file") {
-			return []*multipoolermanagerdata.BackupMetadata{}, nil
-		}
-		return nil, mterrors.New(mtrpcpb.Code_INTERNAL,
-			fmt.Sprintf("pgbackrest info failed: %v\nOutput: %s", err, output))
-	}
+// isStanzaMissing reports whether pgbackrest info output indicates the stanza
+// has not been created yet (a normal pre-init state), as opposed to a repo
+// that is unreachable.
+func isStanzaMissing(output string) bool {
+	return strings.Contains(output, "does not exist") ||
+		strings.Contains(output, "unable to open missing file")
+}
 
-	// Parse JSON output
+// decodeInfo unmarshals `pgbackrest info` JSON output.
+func decodeInfo(output string) ([]pgBackRestInfo, error) {
 	var infoData []pgBackRestInfo
 	if err := json.Unmarshal([]byte(output), &infoData); err != nil {
 		return nil, mterrors.New(mtrpcpb.Code_INTERNAL,
 			fmt.Sprintf("failed to parse pgbackrest info JSON: %v", err))
 	}
+	return infoData, nil
+}
 
+// parseBackups maps decoded pgbackrest info into BackupMetadata for this
+// pooler's shard, skipping any backups whose annotations don't match (defense
+// in depth — stanzas are already shard-scoped).
+func (e *Engine) parseBackups(ctx context.Context, infoData []pgBackRestInfo) []*multipoolermanagerdata.BackupMetadata {
 	if len(infoData) == 0 || len(infoData[0].Backup) == 0 {
-		return []*multipoolermanagerdata.BackupMetadata{}, nil
+		return []*multipoolermanagerdata.BackupMetadata{}
 	}
 
-	// Get current pooler's table_group and shard for filtering
 	currentTableGroup := e.id.ShardKey().GetTableGroup()
 	currentShard := e.shardID()
 
 	// Extract backups from the first stanza (should be the only one)
-	var backups []*multipoolermanagerdata.BackupMetadata
+	backups := []*multipoolermanagerdata.BackupMetadata{}
 	for _, pgBackup := range infoData[0].Backup {
 		status := multipoolermanagerdata.BackupMetadata_COMPLETE
 		if pgBackup.Error {
@@ -143,6 +172,16 @@ func (e *Engine) ListBackups(ctx context.Context) ([]*multipoolermanagerdata.Bac
 			backupSizeBytes = pgBackup.Info.Size
 		}
 
+		// pgBackRest reports backup start/stop as epoch seconds. Leave unset
+		// (nil) when not reported so consumers can distinguish "unknown".
+		var startTs, stopTs *timestamppb.Timestamp
+		if pgBackup.Timestamp.Start != 0 {
+			startTs = timestamppb.New(time.Unix(pgBackup.Timestamp.Start, 0))
+		}
+		if pgBackup.Timestamp.Stop != 0 {
+			stopTs = timestamppb.New(time.Unix(pgBackup.Timestamp.Stop, 0))
+		}
+
 		backups = append(backups, &multipoolermanagerdata.BackupMetadata{
 			BackupId:        pgBackup.Label,
 			Status:          status,
@@ -154,10 +193,12 @@ func (e *Engine) ListBackups(ctx context.Context) ([]*multipoolermanagerdata.Bac
 			Type:            pgBackup.Type,
 			MultipoolerId:   multipoolerID,
 			PoolerType:      poolerType,
+			StartTimestamp:  startTs,
+			StopTimestamp:   stopTs,
 		})
 	}
 
-	return backups, nil
+	return backups
 }
 
 // FindByJobID finds a backup by matching the job_id annotation
@@ -174,28 +215,15 @@ func (e *Engine) FindByJobID(
 		return "", mterrors.Wrap(err, "pgbackrest config not found")
 	}
 
-	// Execute pgbackrest info command with JSON output
-	infoCtx, cancel := context.WithTimeout(ctx, commonbackup.InfoTimeout)
-	defer cancel()
-
-	cmd := e.pgbackrestCmd(infoCtx,
-		"--stanza="+stanzaName,
-		"--config="+configPath,
-		"--output=json",
-		"--log-level-console=off",
-		"info")
-
-	output, err := safeCombinedOutput(cmd)
+	output, err := e.runInfoCmd(ctx, configPath)
 	if err != nil {
 		return "", mterrors.New(mtrpcpb.Code_INTERNAL,
 			fmt.Sprintf("pgbackrest info failed: %v\nOutput: %s", err, output))
 	}
 
-	// Parse JSON output
-	var infoData []pgBackRestInfo
-	if err := json.Unmarshal([]byte(output), &infoData); err != nil {
-		return "", mterrors.New(mtrpcpb.Code_INTERNAL,
-			fmt.Sprintf("failed to parse pgbackrest info JSON: %v", err))
+	infoData, err := decodeInfo(output)
+	if err != nil {
+		return "", err
 	}
 
 	// Search for backup with matching annotations

--- a/go/services/multipooler/internal/manager/backup/list_test.go
+++ b/go/services/multipooler/internal/manager/backup/list_test.go
@@ -15,7 +15,6 @@
 package backup
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,7 @@ func TestListBackups(t *testing.T) {
 	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
 	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
 
-	backups, err := e.ListBackups(context.Background())
+	backups, err := e.ListBackups(t.Context())
 	require.NoError(t, err)
 	require.Len(t, backups, 1, "the mismatched-shard backup should be filtered out")
 	assert.Equal(t, "20250104-100000F", backups[0].BackupId)
@@ -45,6 +44,60 @@ func TestListBackups(t *testing.T) {
 	assert.Equal(t, "mp1", backups[0].MultipoolerId)
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, backups[0].PoolerType)
 	assert.Equal(t, multipoolermanagerdata.BackupMetadata_COMPLETE, backups[0].Status)
+}
+
+func TestListBackups_SkipsMismatchedTableGroup(t *testing.T) {
+	// A backup annotated with a different table_group must be filtered out
+	// (defense-in-depth), exercising the table_group-mismatch skip branch.
+	json := `[{"backup":[
+		{"label":"20250104-100000F","type":"full","annotation":{"table_group":"tg1","shard":"0","job_id":"j1"}},
+		{"label":"20250104-110000F","type":"full","annotation":{"table_group":"other","shard":"0","job_id":"j2"}}
+	]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	backups, err := e.ListBackups(t.Context())
+	require.NoError(t, err)
+	require.Len(t, backups, 1, "the mismatched-table_group backup should be filtered out")
+	assert.Equal(t, "20250104-100000F", backups[0].BackupId)
+}
+
+func TestListBackups_ParsesTimestamps(t *testing.T) {
+	// A COMPLETE backup with start/stop epoch seconds in its timestamp object.
+	json := `[{"backup":[
+		{"label":"20250104-100000F","type":"full","timestamp":{"start":1735984800,"stop":1735984860},"annotation":{"table_group":"tg1","shard":"0","job_id":"j1"}}
+	]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	backups, err := e.ListBackups(t.Context())
+	require.NoError(t, err)
+	require.Len(t, backups, 1)
+	require.NotNil(t, backups[0].StartTimestamp, "start_timestamp should be set")
+	require.NotNil(t, backups[0].StopTimestamp, "stop_timestamp should be set")
+	assert.Equal(t, int64(1735984800), backups[0].StartTimestamp.AsTime().Unix())
+	assert.Equal(t, int64(1735984860), backups[0].StopTimestamp.AsTime().Unix())
+}
+
+func TestListBackups_UnsetTimestamps(t *testing.T) {
+	// A backup with no timestamp object → both timestamps should be nil.
+	json := `[{"backup":[
+		{"label":"20250104-100000F","type":"full","annotation":{"table_group":"tg1","shard":"0","job_id":"j1"}}
+	]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	backups, err := e.ListBackups(t.Context())
+	require.NoError(t, err)
+	require.Len(t, backups, 1)
+	assert.Nil(t, backups[0].StartTimestamp)
+	assert.Nil(t, backups[0].StopTimestamp)
 }
 
 func TestList_AppliesLimit(t *testing.T) {
@@ -57,11 +110,11 @@ func TestList_AppliesLimit(t *testing.T) {
 	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
 	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
 
-	all, err := e.List(context.Background(), 0)
+	all, err := e.List(t.Context(), 0)
 	require.NoError(t, err)
 	require.Len(t, all, 2)
 
-	limited, err := e.List(context.Background(), 1)
+	limited, err := e.List(t.Context(), 1)
 	require.NoError(t, err)
 	require.Len(t, limited, 1)
 }
@@ -72,14 +125,25 @@ func TestListBackups_EmptyWhenStanzaMissing(t *testing.T) {
 	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
 	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
 
-	backups, err := e.ListBackups(context.Background())
+	backups, err := e.ListBackups(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, backups)
 }
 
+func TestListBackups_ErrorOnMalformedJSON(t *testing.T) {
+	stubPgbackrest(t, "#!/bin/bash\nif [[ \"$*\" == *info* ]]; then echo \"garbage not json\"; exit 0; fi\nexit 0\n")
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	_, err := e.ListBackups(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse pgbackrest info JSON")
+}
+
 func TestListBackups_ErrorWhenConfigPathMissing(t *testing.T) {
 	e, _ := newTestEngine(t, t.TempDir(), "tg1", "0", "/tmp/backups")
-	_, err := e.ListBackups(context.Background())
+	_, err := e.ListBackups(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pgbackrest config not found")
 }
@@ -88,7 +152,7 @@ func TestListBackups_ErrorWhenBackupConfigMissing(t *testing.T) {
 	poolerDir := t.TempDir()
 	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "") // no backup location → no repo config
 	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
-	_, err := e.ListBackups(context.Background())
+	_, err := e.ListBackups(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "backup config not loaded")
 }

--- a/go/services/multipooler/internal/manager/backup/metrics.go
+++ b/go/services/multipooler/internal/manager/backup/metrics.go
@@ -17,8 +17,10 @@ package backup
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -34,14 +36,29 @@ type Metrics struct {
 	restoreSuccesses metric.Int64Counter
 	restoreFailures  metric.Int64Counter
 
+	leaseLost metric.Int64Counter
+
 	backupDuration       metric.Float64Histogram
 	backupVerifyDuration metric.Float64Histogram
 	restoreDuration      metric.Float64Histogram
 	backupLockWait       metric.Float64Histogram
+
+	// Observable gauges, registered against a HealthTracker via
+	// RegisterHealthCallback.
+	lastSuccessAge       metric.Float64ObservableGauge
+	completeCount        metric.Int64ObservableGauge
+	failuresSinceSuccess metric.Int64ObservableGauge
+	ready                metric.Int64ObservableGauge
+	walArchiveLag        metric.Float64ObservableGauge
+	inProgress           metric.Int64ObservableGauge
+	inProgressDuration   metric.Float64ObservableGauge
+	leaseHeld            metric.Int64ObservableGauge
 }
 
-// NewMetrics creates and registers the pgBackRest backup counters.
-// It always returns a non-nil *Metrics; any registration errors are collected and returned.
+// NewMetrics creates and registers the pgBackRest backup counters and declares
+// the HealthTracker-backed observable gauges. It always returns a non-nil
+// *Metrics; any registration errors are collected and returned. The gauges are
+// not observed until RegisterHealthCallback wires them to a tracker.
 func NewMetrics() (*Metrics, error) {
 	m := &Metrics{}
 	meter := otel.Meter(meterName)
@@ -85,6 +102,12 @@ func NewMetrics() (*Metrics, error) {
 	)
 	errs = append(errs, err)
 
+	m.leaseLost, err = meter.Int64Counter(
+		"pgbackrest.backup.lease.lost",
+		metric.WithDescription("Total number of times this pooler lost the backup lease mid-operation (stolen or expired)"),
+	)
+	errs = append(errs, err)
+
 	m.backupDuration, err = meter.Float64Histogram(
 		"pgbackrest.backup.duration",
 		metric.WithDescription("Duration of the pgbackrest backup command in seconds"),
@@ -113,7 +136,112 @@ func NewMetrics() (*Metrics, error) {
 	)
 	errs = append(errs, err)
 
+	m.lastSuccessAge, err = meter.Float64ObservableGauge(
+		"pgbackrest.backup.last_success_age_seconds",
+		metric.WithDescription("Seconds since the newest COMPLETE backup finished; not emitted if no backup exists"),
+		metric.WithUnit("s"),
+	)
+	errs = append(errs, err)
+
+	m.completeCount, err = meter.Int64ObservableGauge(
+		"pgbackrest.backup.complete_count",
+		metric.WithDescription("Number of COMPLETE backups visible in the repo"),
+	)
+	errs = append(errs, err)
+
+	m.failuresSinceSuccess, err = meter.Int64ObservableGauge(
+		"pgbackrest.backup.failures_since_success",
+		metric.WithDescription("Consecutive backup failures since the last success"),
+	)
+	errs = append(errs, err)
+
+	m.ready, err = meter.Int64ObservableGauge(
+		"pgbackrest.backup.ready",
+		metric.WithDescription("1 if backups can run (repo reachable, stanza present, archiving configured & healthy), 0 otherwise; carries a 'reason' attribute"),
+	)
+	errs = append(errs, err)
+
+	m.walArchiveLag, err = meter.Float64ObservableGauge(
+		"pgbackrest.wal.archive_lag_seconds",
+		metric.WithDescription("Seconds since the last WAL segment was archived (primary only); not emitted if unknown"),
+		metric.WithUnit("s"),
+	)
+	errs = append(errs, err)
+
+	m.inProgress, err = meter.Int64ObservableGauge(
+		"pgbackrest.backup.in_progress",
+		metric.WithDescription("1 if a backup is currently running, 0 otherwise"),
+	)
+	errs = append(errs, err)
+
+	m.inProgressDuration, err = meter.Float64ObservableGauge(
+		"pgbackrest.backup.in_progress_duration_seconds",
+		metric.WithDescription("Seconds the in-progress backup has been running, 0 if none"),
+		metric.WithUnit("s"),
+	)
+	errs = append(errs, err)
+
+	m.leaseHeld, err = meter.Int64ObservableGauge(
+		"pgbackrest.backup.lease_held",
+		metric.WithDescription("1 if this pooler currently holds the backup lease, 0 otherwise"),
+	)
+	errs = append(errs, err)
+
 	return m, errors.Join(errs...)
+}
+
+// RegisterHealthCallback wires the observable gauges to tracker, so each scrape
+// reads a single consistent Snapshot. It is split from NewMetrics so the
+// tracker is supplied after construction (and captured by the callback closure
+// rather than stored on Metrics). Safe to call on a nil receiver.
+func (m *Metrics) RegisterHealthCallback(tracker *HealthTracker) error {
+	if m == nil {
+		return nil
+	}
+	meter := otel.Meter(meterName)
+	_, err := meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			// One consistent read; derive ages from timestamps at observe
+			// time so they stay accurate between polls.
+			snap := tracker.Snapshot()
+			now := time.Now()
+
+			if !snap.LastSuccessStop.IsZero() {
+				o.ObserveFloat64(m.lastSuccessAge, now.Sub(snap.LastSuccessStop).Seconds())
+			}
+			o.ObserveInt64(m.completeCount, snap.CompleteCount)
+			o.ObserveInt64(m.failuresSinceSuccess, snap.FailuresSinceSuccess)
+
+			readyVal := int64(0)
+			if snap.Ready {
+				readyVal = 1
+			}
+			o.ObserveInt64(m.ready, readyVal, metric.WithAttributes(attribute.String("reason", snap.Reason)))
+
+			if !snap.LastArchived.IsZero() {
+				o.ObserveFloat64(m.walArchiveLag, now.Sub(snap.LastArchived).Seconds())
+			}
+
+			inProgressVal := int64(0)
+			var inProgressDur float64
+			if !snap.InProgressStart.IsZero() {
+				inProgressVal = 1
+				inProgressDur = now.Sub(snap.InProgressStart).Seconds()
+			}
+			o.ObserveInt64(m.inProgress, inProgressVal)
+			o.ObserveFloat64(m.inProgressDuration, inProgressDur)
+
+			leaseVal := int64(0)
+			if snap.LeaseHeld {
+				leaseVal = 1
+			}
+			o.ObserveInt64(m.leaseHeld, leaseVal)
+			return nil
+		},
+		m.lastSuccessAge, m.completeCount, m.failuresSinceSuccess, m.ready,
+		m.walArchiveLag, m.inProgress, m.inProgressDuration, m.leaseHeld,
+	)
+	return err
 }
 
 // IncBackupAttempts increments the backup attempts counter.
@@ -137,6 +265,14 @@ func (m *Metrics) IncBackupSuccesses(ctx context.Context) {
 func (m *Metrics) IncBackupFailures(ctx context.Context) {
 	if m != nil && m.backupFailures != nil {
 		m.backupFailures.Add(ctx, 1)
+	}
+}
+
+// IncLeaseLost increments the backup lease-lost counter.
+// Safe to call on a nil receiver or with a nil instrument.
+func (m *Metrics) IncLeaseLost(ctx context.Context) {
+	if m != nil && m.leaseLost != nil {
+		m.leaseLost.Add(ctx, 1)
 	}
 }
 

--- a/go/services/multipooler/internal/manager/backup/metrics_test.go
+++ b/go/services/multipooler/internal/manager/backup/metrics_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,6 +148,19 @@ func TestMetrics_SingleAttemptFailure(t *testing.T) {
 	assert.Equal(t, int64(1), counterValue(failures))
 }
 
+// TestMetrics_LeaseLost verifies the lease-lost counter increments.
+func TestMetrics_LeaseLost(t *testing.T) {
+	m, reader := setupMetrics(t)
+	ctx := t.Context()
+
+	m.IncLeaseLost(ctx)
+	m.IncLeaseLost(ctx)
+
+	lost := getCounterInt64(t, reader, "pgbackrest.backup.lease.lost")
+	require.NotNil(t, lost, "pgbackrest.backup.lease.lost counter not found")
+	assert.Equal(t, int64(2), counterValue(lost))
+}
+
 // TestMetrics_NewMetrics_ReturnsNonNil verifies that NewMetrics() returns non-nil
 // even with the default (noop) provider.
 func TestMetrics_NewMetrics_ReturnsNonNil(t *testing.T) {
@@ -167,6 +181,7 @@ func TestMetrics_NilSafe(t *testing.T) {
 	assert.NotPanics(t, func() { m.IncRestoreAttempts(ctx) })
 	assert.NotPanics(t, func() { m.IncRestoreSuccesses(ctx) })
 	assert.NotPanics(t, func() { m.IncRestoreFailures(ctx) })
+	assert.NotPanics(t, func() { m.IncLeaseLost(ctx) })
 	assert.NotPanics(t, func() { m.RecordBackupDuration(ctx, 1.0) })
 	assert.NotPanics(t, func() { m.RecordBackupVerifyDuration(ctx, 1.0) })
 	assert.NotPanics(t, func() { m.RecordRestoreDuration(ctx, 1.0) })
@@ -290,4 +305,86 @@ func TestMetrics_BackupLockWait(t *testing.T) {
 	hist := getHistogramFloat64(t, reader, "pgbackrest.backup.lock_wait")
 	require.NotNil(t, hist, "pgbackrest.backup.lock_wait histogram not found")
 	assert.Equal(t, uint64(1), histogramCount(hist))
+}
+
+// gaugeInt64 returns the single Int64 observable-gauge value for name, or (0, false) if absent.
+func gaugeInt64(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64, bool) {
+	t.Helper()
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &data))
+	for _, sm := range data.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				g, ok := m.Data.(metricdata.Gauge[int64])
+				require.True(t, ok, "expected Gauge[int64] for %s", name)
+				if len(g.DataPoints) == 0 {
+					return 0, false
+				}
+				return g.DataPoints[0].Value, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// gaugeFloat64Present reports whether a Float64 observable gauge emitted a data point.
+func gaugeFloat64Present(t *testing.T, reader *sdkmetric.ManualReader, name string) bool {
+	t.Helper()
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &data))
+	for _, sm := range data.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				g, ok := m.Data.(metricdata.Gauge[float64])
+				require.True(t, ok, "expected Gauge[float64] for %s", name)
+				return len(g.DataPoints) > 0
+			}
+		}
+	}
+	return false
+}
+
+// TestMetrics_HealthGauges_Populated exercises the gauge callback with a fully
+// populated tracker: the conditional gauges (age, lag, in-progress) are emitted
+// and the 1/0 gauges reflect the state.
+func TestMetrics_HealthGauges_Populated(t *testing.T) {
+	m, reader := setupMetrics(t)
+	tr := NewHealthTracker()
+	tr.applyRepoInfo(time.Now().Add(-time.Hour), 4)
+	tr.applyReadiness(true, ReadyReasonOK)
+	tr.applyArchiver(time.Now().Add(-30 * time.Second))
+	tr.BackupStarted() // sets inProgressStart
+	tr.SetLeaseHeld(true)
+	require.NoError(t, m.RegisterHealthCallback(tr))
+
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.complete_count"); assert.True(t, ok) {
+		assert.Equal(t, int64(4), v)
+	}
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.lease_held"); assert.True(t, ok) {
+		assert.Equal(t, int64(1), v)
+	}
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.in_progress"); assert.True(t, ok) {
+		assert.Equal(t, int64(1), v)
+	}
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.ready"); assert.True(t, ok) {
+		assert.Equal(t, int64(1), v)
+	}
+	assert.True(t, gaugeFloat64Present(t, reader, "pgbackrest.backup.last_success_age_seconds"), "age emitted when a backup exists")
+	assert.True(t, gaugeFloat64Present(t, reader, "pgbackrest.wal.archive_lag_seconds"), "lag emitted when last-archived is set")
+}
+
+// TestMetrics_HealthGauges_Empty exercises the callback with a default tracker:
+// the conditional age/lag gauges are NOT emitted, and the 1/0 gauges are 0.
+func TestMetrics_HealthGauges_Empty(t *testing.T) {
+	m, reader := setupMetrics(t)
+	require.NoError(t, m.RegisterHealthCallback(NewHealthTracker()))
+
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.lease_held"); assert.True(t, ok) {
+		assert.Equal(t, int64(0), v)
+	}
+	if v, ok := gaugeInt64(t, reader, "pgbackrest.backup.in_progress"); assert.True(t, ok) {
+		assert.Equal(t, int64(0), v)
+	}
+	assert.False(t, gaugeFloat64Present(t, reader, "pgbackrest.backup.last_success_age_seconds"), "no age without a backup")
+	assert.False(t, gaugeFloat64Present(t, reader, "pgbackrest.wal.archive_lag_seconds"), "no lag without last-archived")
 }

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -202,6 +202,14 @@ type MultiPoolerManager struct {
 	// owns the gRPC handlers, delegating the pgBackRest steps to the engine.
 	backup *backupengine.Engine
 
+	// backupHealthEnabled records whether the service layer opted this manager
+	// into the background backup-health poller (via StartBackupHealth). When
+	// set, openLocked (re)launches the poller on every open so it survives
+	// Pause/resume cycles, which recreate pm.ctx. RPC/consensus unit tests that
+	// never call StartBackupHealth leave this false, so they don't spin up
+	// background pg queries. Guarded by pm.mu.
+	backupHealthEnabled bool
+
 	// healthStreamer streams health state to subscribers.
 	// Owns all health-related state and provides typed update methods.
 	healthStreamer *healthStreamer
@@ -476,6 +484,15 @@ func (pm *MultiPoolerManager) openLocked(ctx context.Context, targetServingStatu
 	pm.logger.InfoContext(pm.ctx, "MonitorPostgres enabled successfully")
 
 	pm.isOpen = true
+
+	// Relaunch the backup-health poller on the fresh context when the service
+	// layer has opted in (see StartBackupHealth). closeLocked cancels pm.ctx,
+	// which stops the previous poller goroutine; without this, a Pause/resume
+	// cycle (pg_rewind, restart-as-standby, stale-primary demote) would leave
+	// the passive backup-health gauges frozen for the rest of the process.
+	if pm.backupHealthEnabled {
+		pm.startBackupHealthPollerLocked()
+	}
 
 	// Start health heartbeat goroutine and transition to the target status.
 	// SetState notifies all components (query service, heartbeat, health
@@ -1623,22 +1640,42 @@ func (pm *MultiPoolerManager) Start(senv *servenv.ServEnv) {
 	})
 }
 
-// StartBackupHealth launches the background backup-health poller and, once the
-// manager reaches its ready state, captures an initial snapshot so the
-// gauges/status page reflect post-bootstrap state without waiting a poll
-// interval. Both goroutines are bound to pm.ctx and stop on shutdown.
+// StartBackupHealth opts this manager into the background backup-health poller
+// and launches it. Once the manager reaches its ready state, it captures an
+// initial snapshot so the gauges/status page reflect post-bootstrap state
+// without waiting a poll interval.
+//
+// The poller is bound to the open/close lifecycle (pm.ctx), not the manager
+// lifetime: closeLocked cancels pm.ctx and openLocked recreates it, so the
+// poller is paused during maintenance (e.g. pg_rewind, when the connection
+// pool is closed) and relaunched on resume. Setting backupHealthEnabled makes
+// openLocked restart the poller on every subsequent open.
 //
 // This is invoked by the multipooler service rather than from Start() so that
 // manager RPC/consensus unit tests, which drive Start() directly against a
 // strict mock DB, do not spin up background health queries (pg_is_in_recovery,
 // pg_settings, pg_stat_archiver) that would race with their query expectations.
 func (pm *MultiPoolerManager) StartBackupHealth() {
-	go pm.backup.RunHealthPoller(pm.ctx, 0)
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.backupHealthEnabled = true
+	pm.startBackupHealthPollerLocked()
+}
+
+// startBackupHealthPollerLocked launches the backup-health poller goroutine on
+// the current pm.ctx, plus a one-shot goroutine that captures an initial
+// snapshot once the manager is ready. Both stop when pm.ctx is cancelled.
+//
+// Caller must hold pm.mu (read of pm.ctx). Invoked from StartBackupHealth (first
+// launch) and from openLocked on every reopen when backupHealthEnabled is set.
+func (pm *MultiPoolerManager) startBackupHealthPollerLocked() {
+	ctx := pm.ctx
+	go pm.backup.RunHealthPoller(ctx, 0)
 	go func() {
-		if err := pm.WaitUntilReady(pm.ctx); err != nil {
+		if err := pm.WaitUntilReady(ctx); err != nil {
 			return // ctx cancelled before ready (shutdown); nothing to refresh
 		}
-		pm.backup.RefreshHealthNow(pm.ctx)
+		pm.backup.RefreshHealthNow(ctx)
 	}()
 }
 

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -348,6 +348,12 @@ func NewMultiPoolerManagerWithTimeout(logger *slog.Logger, multiPooler *clusterm
 		PgpassPath: pm.pgpassPath,
 		PgDataDir:  postgresDataDir(),
 	})
+	// Wire the backup-health poller to the manager's pg connection: role
+	// (only a primary archives WAL), pg_stat_archiver (WAL archive lag), and
+	// the backup-relevant settings (archive/restore config).
+	pm.backup.SetRoleProvider(pm.isPrimary)
+	pm.backup.SetArchiverStatsProvider(pm.archiverStats)
+	pm.backup.SetPGSettingsProvider(pm.backupSettings)
 
 	return pm, nil
 }
@@ -789,6 +795,12 @@ func (pm *MultiPoolerManager) leaderObs(rule *clustermetadatapb.ShardRule) *clus
 // shardKey returns a ShardKey identifying this pooler's shard.
 func (pm *MultiPoolerManager) shardKey() *clustermetadatapb.ShardKey {
 	return pm.record.ShardKey()
+}
+
+// BackupStatusSnapshot returns a consistent snapshot of the backup-health
+// tracker for the status page.
+func (pm *MultiPoolerManager) BackupStatusSnapshot() backupengine.Snapshot {
+	return pm.backup.Health().Snapshot()
 }
 
 // checkReady returns an error if the manager is not in Ready state
@@ -1609,6 +1621,25 @@ func (pm *MultiPoolerManager) Start(senv *servenv.ServEnv) {
 		pm.logger.Info("MultiPoolerManager gRPC services registered")
 		return nil
 	})
+}
+
+// StartBackupHealth launches the background backup-health poller and, once the
+// manager reaches its ready state, captures an initial snapshot so the
+// gauges/status page reflect post-bootstrap state without waiting a poll
+// interval. Both goroutines are bound to pm.ctx and stop on shutdown.
+//
+// This is invoked by the multipooler service rather than from Start() so that
+// manager RPC/consensus unit tests, which drive Start() directly against a
+// strict mock DB, do not spin up background health queries (pg_is_in_recovery,
+// pg_settings, pg_stat_archiver) that would race with their query expectations.
+func (pm *MultiPoolerManager) StartBackupHealth() {
+	go pm.backup.RunHealthPoller(pm.ctx, 0)
+	go func() {
+		if err := pm.WaitUntilReady(pm.ctx); err != nil {
+			return // ctx cancelled before ready (shutdown); nothing to refresh
+		}
+		pm.backup.RefreshHealthNow(pm.ctx)
+	}()
 }
 
 // StartTopoRegistration starts the publisher goroutine and kicks off the

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -1655,9 +1655,16 @@ func (pm *MultiPoolerManager) Start(senv *servenv.ServEnv) {
 // manager RPC/consensus unit tests, which drive Start() directly against a
 // strict mock DB, do not spin up background health queries (pg_is_in_recovery,
 // pg_settings, pg_stat_archiver) that would race with their query expectations.
+//
+// Idempotent: only the first call takes effect. A second call is a no-op so a
+// double wire-up cannot leak a duplicate poller goroutine (openLocked owns
+// relaunch from here on).
 func (pm *MultiPoolerManager) StartBackupHealth() {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
+	if pm.backupHealthEnabled {
+		return
+	}
 	pm.backupHealthEnabled = true
 	pm.startBackupHealthPollerLocked()
 }

--- a/go/services/multipooler/internal/manager/manager_test.go
+++ b/go/services/multipooler/internal/manager/manager_test.go
@@ -1054,3 +1054,70 @@ func TestPause_PreservesPublisher(t *testing.T) {
 
 	resume(lockCtx)
 }
+
+// TestPause_RestartsBackupHealthPoller verifies that the backup-health poller
+// survives a Pause/resume cycle. The poller is bound to pm.ctx, which
+// closeLocked cancels and openLocked recreates; StartBackupHealth opts the
+// manager in so openLocked relaunches the poller on resume. Without that, the
+// passive backup-health gauges would freeze after maintenance paths like
+// pg_rewind / restart-as-standby.
+//
+// LastRefresh advances on every poll. The poll interval is 5 minutes, so within
+// this test it only advances if resume actually relaunches the poller (which
+// does an immediate refresh on launch) — making this a tight regression guard.
+func TestPause_RestartsBackupHealthPoller(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	t.Cleanup(func() { ts.Close() })
+
+	serviceID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIPOOLER,
+		Cell:      "zone1",
+		Name:      "test-pause-backup-health",
+	}
+	multipooler := &clustermetadatapb.MultiPooler{
+		Id:            serviceID,
+		Hostname:      "localhost",
+		PortMap:       map[string]int32{"grpc": 8080},
+		Type:          clustermetadatapb.PoolerType_REPLICA,
+		ServingStatus: clustermetadatapb.PoolerServingStatus_NOT_SERVING,
+		PoolerDir:     t.TempDir(),
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "testdb",
+			TableGroup: constants.DefaultTableGroup,
+			Shard:      constants.DefaultShard,
+		},
+	}
+	require.NoError(t, ts.CreateMultiPooler(ctx, multipooler))
+
+	pm, err := NewMultiPoolerManager(logger, multipooler, &Config{TopoClient: ts})
+	require.NoError(t, err)
+	t.Cleanup(func() { pm.ShutdownForTest(context.Background()) })
+
+	// No-op query service so Open's heartbeat start doesn't panic on a nil pool.
+	pm.qsc = &mockPoolerController{queryService: mock.NewQueryService()}
+
+	lockCtx, err := pm.actionLock.Acquire(ctx, "test-pause-backup-health")
+	require.NoError(t, err)
+	defer pm.actionLock.Release(lockCtx)
+	pm.Open(lockCtx)
+
+	// Opt into the poller (init.go does this once after Start in production).
+	pm.StartBackupHealth()
+
+	// Wait for the initial poll to populate the snapshot.
+	require.Eventually(t, func() bool {
+		return !pm.backup.Health().Snapshot().LastRefresh.IsZero()
+	}, 2*time.Second, 25*time.Millisecond, "poller should refresh once after StartBackupHealth")
+	beforeResume := pm.backup.Health().Snapshot().LastRefresh
+
+	// Pause cancels pm.ctx (stopping the poller); resume recreates it and must
+	// relaunch the poller, which refreshes again.
+	resume := pm.Pause(lockCtx)
+	resume(lockCtx)
+
+	require.Eventually(t, func() bool {
+		return pm.backup.Health().Snapshot().LastRefresh.After(beforeResume)
+	}, 2*time.Second, 25*time.Millisecond, "poller should refresh again after resume")
+}

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -27,6 +27,7 @@ import (
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/services/multipooler/internal/executor"
+	backupengine "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup"
 	"github.com/multigres/multigres/go/services/multipooler/internal/manager/consensus"
 	"github.com/multigres/multigres/go/tools/retry"
 
@@ -76,6 +77,67 @@ func (pm *MultiPoolerManager) isInRecovery(ctx context.Context) (bool, error) {
 	}
 
 	return inRecovery, nil
+}
+
+// archiverStats reads pg_stat_archiver for the backup-health poller. NULL
+// timestamps map to zero time.Time values. It reuses the manager's query path
+// (no new connection pool) and is injected into the backup engine via
+// SetArchiverStatsProvider.
+func (pm *MultiPoolerManager) archiverStats(ctx context.Context) (backupengine.ArchiverStats, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	sql := `SELECT
+		COALESCE(EXTRACT(EPOCH FROM last_archived_time)::bigint, 0) AS last_archived,
+		COALESCE(EXTRACT(EPOCH FROM last_failed_time)::bigint, 0)   AS last_failed,
+		failed_count
+	FROM pg_stat_archiver`
+	result, err := pm.query(queryCtx, sql)
+	if err != nil {
+		return backupengine.ArchiverStats{}, mterrors.Wrap(err, "failed to query pg_stat_archiver")
+	}
+
+	var lastArchived, lastFailed, failedCount int64
+	if err := executor.ScanSingleRow(result, &lastArchived, &lastFailed, &failedCount); err != nil {
+		return backupengine.ArchiverStats{}, mterrors.Wrap(err, "failed to scan pg_stat_archiver result")
+	}
+
+	stats := backupengine.ArchiverStats{FailedCount: failedCount}
+	if lastArchived > 0 {
+		stats.LastArchived = time.Unix(lastArchived, 0)
+	}
+	if lastFailed > 0 {
+		stats.LastFailed = time.Unix(lastFailed, 0)
+	}
+	return stats, nil
+}
+
+// backupSettings reads the backup-relevant PostgreSQL settings for the
+// backup-health poller. These are cheap pg_settings reads (no forced I/O). It
+// reuses the manager's query path and is injected into the backup engine via
+// SetPGSettingsProvider.
+func (pm *MultiPoolerManager) backupSettings(ctx context.Context) (backupengine.PGSettings, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	sql := `SELECT
+		COALESCE(current_setting('archive_command', true), '') AS archive_command,
+		COALESCE(current_setting('archive_mode', true), '')    AS archive_mode,
+		COALESCE(current_setting('restore_command', true), '') AS restore_command`
+	result, err := pm.query(queryCtx, sql)
+	if err != nil {
+		return backupengine.PGSettings{}, mterrors.Wrap(err, "failed to query backup settings")
+	}
+
+	var archiveCommand, archiveMode, restoreCommand string
+	if err := executor.ScanSingleRow(result, &archiveCommand, &archiveMode, &restoreCommand); err != nil {
+		return backupengine.PGSettings{}, mterrors.Wrap(err, "failed to scan backup settings result")
+	}
+	return backupengine.PGSettings{
+		ArchiveCommand: archiveCommand,
+		ArchiveMode:    archiveMode,
+		RestoreCommand: restoreCommand,
+	}, nil
 }
 
 // getPrimaryLSN gets the current WAL write location (primary only)

--- a/go/services/multipooler/internal/manager/pg_replication_backup_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_backup_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/services/multipooler/internal/executor/mock"
+)
+
+// managerWithMockQuery builds a minimal manager whose pm.query routes to the
+// given mock query service — enough to unit-test the backup-health query
+// helpers (archiverStats / backupSettings) without standing up a full manager.
+func managerWithMockQuery(qs *mock.QueryService) *MultiPoolerManager {
+	return &MultiPoolerManager{qsc: &mockPoolerController{queryService: qs}}
+}
+
+func TestArchiverStats(t *testing.T) {
+	t.Run("maps epoch seconds to time and count", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		qs.AddQueryPattern("pg_stat_archiver", mock.MakeQueryResult(
+			[]string{"last_archived", "last_failed", "failed_count"},
+			[][]any{{int64(1735984800), int64(1735984900), int64(3)}}))
+
+		stats, err := managerWithMockQuery(qs).archiverStats(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, int64(1735984800), stats.LastArchived.Unix())
+		assert.Equal(t, int64(1735984900), stats.LastFailed.Unix())
+		assert.Equal(t, int64(3), stats.FailedCount)
+	})
+
+	t.Run("zero (NULL→COALESCE 0) maps to zero time", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		qs.AddQueryPattern("pg_stat_archiver", mock.MakeQueryResult(
+			[]string{"last_archived", "last_failed", "failed_count"},
+			[][]any{{int64(0), int64(0), int64(0)}}))
+
+		stats, err := managerWithMockQuery(qs).archiverStats(t.Context())
+		require.NoError(t, err)
+		assert.True(t, stats.LastArchived.IsZero(), "epoch 0 must map to zero time, not 1970")
+		assert.True(t, stats.LastFailed.IsZero())
+		assert.Zero(t, stats.FailedCount)
+	})
+
+	t.Run("query error is wrapped", func(t *testing.T) {
+		qs := mock.NewQueryService() // no pattern registered → query errors
+		_, err := managerWithMockQuery(qs).archiverStats(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pg_stat_archiver")
+	})
+
+	t.Run("scan error on unexpected row shape", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		qs.AddQueryPattern("pg_stat_archiver", mock.MakeQueryResult(
+			[]string{"only_one"}, [][]any{{int64(1)}})) // 1 column, scanner needs 3
+		_, err := managerWithMockQuery(qs).archiverStats(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scan")
+	})
+}
+
+func TestBackupSettings(t *testing.T) {
+	t.Run("maps the three settings", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		qs.AddQueryPattern("current_setting", mock.MakeQueryResult(
+			[]string{"archive_command", "archive_mode", "restore_command"},
+			[][]any{{"pgbackrest archive-push %p", "on", "pgbackrest archive-get %f %p"}}))
+
+		s, err := managerWithMockQuery(qs).backupSettings(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "pgbackrest archive-push %p", s.ArchiveCommand)
+		assert.Equal(t, "on", s.ArchiveMode)
+		assert.Equal(t, "pgbackrest archive-get %f %p", s.RestoreCommand)
+	})
+
+	t.Run("empty settings pass through", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		qs.AddQueryPattern("current_setting", mock.MakeQueryResult(
+			[]string{"archive_command", "archive_mode", "restore_command"},
+			[][]any{{"", "off", ""}}))
+
+		s, err := managerWithMockQuery(qs).backupSettings(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, s.ArchiveCommand)
+		assert.Equal(t, "off", s.ArchiveMode)
+		assert.Empty(t, s.RestoreCommand)
+	})
+
+	t.Run("query error is wrapped", func(t *testing.T) {
+		qs := mock.NewQueryService()
+		_, err := managerWithMockQuery(qs).backupSettings(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backup settings")
+	})
+}

--- a/go/services/multipooler/internal/manager/rpc_backup.go
+++ b/go/services/multipooler/internal/manager/rpc_backup.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/multigres/multigres/go/common/backup"
 	"github.com/multigres/multigres/go/common/eventlog"
 	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
 	multipoolermanagerdata "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
@@ -54,15 +56,36 @@ func (pm *MultiPoolerManager) Backup(ctx context.Context, forcePrimary bool, bac
 	// If another pooler holds the lease, revoke it and acquire a new one.
 	// This ensures the most recent backup request always wins.
 	var backupID string
+	health := pm.backup.Health()
 	err = pm.topoClient.WithStolenBackupLease(ctx, pm.shardKey(), pm.record.Id().Name, "backup", pm.logger, func(ctx context.Context) error {
+		// The lease is held for the duration of this function.
+		health.SetLeaseHeld(true)
+		defer health.SetLeaseHeld(false)
+
 		var backupErr error
 		backupID, backupErr = pm.backupLocked(ctx, forcePrimary, backupType, jobID, overrides)
+		// A lease-loss abort intentionally counts as BOTH a backup failure
+		// (recorded inside backupLocked) and a lease loss recorded here.
+		pm.recordLeaseLossIfApplicable(ctx, backupErr)
 		return backupErr
 	})
 	if err != nil {
 		return "", mterrors.Wrap(err, "failed to acquire backup lease")
 	}
 	return backupID, nil
+}
+
+// recordLeaseLossIfApplicable records a lost-lease event + counter when a backup
+// failed because this pooler's lease was lost mid-operation (stolen by another
+// pooler or expired) — detected via the ErrLeaseLost context cause set by the
+// lease monitor. Returns true if it recorded a loss.
+func (pm *MultiPoolerManager) recordLeaseLossIfApplicable(ctx context.Context, backupErr error) bool {
+	if backupErr == nil || !errors.Is(context.Cause(ctx), topoclient.ErrLeaseLost) {
+		return false
+	}
+	pm.backup.Metrics().IncLeaseLost(ctx)
+	eventlog.Emit(ctx, pm.logger, eventlog.Failed, eventlog.BackupLeaseLost{Holder: pm.record.Id().Name})
+	return true
 }
 
 // backupLocked performs a backup. Caller must hold the action lock and backup lease.
@@ -73,12 +96,22 @@ func (pm *MultiPoolerManager) backupLocked(ctx context.Context, forcePrimary boo
 	// The engine performs the pgBackRest work; the manager owns these
 	// operation-level metrics.
 	metrics := pm.backup.Metrics()
+	health := pm.backup.Health()
 	metrics.IncBackupAttempts(ctx)
+	health.BackupStarted()
 	defer func() {
 		if retErr == nil {
 			metrics.IncBackupSuccesses(ctx)
+			health.BackupSucceeded()
+			// Reflect the just-created backup in the age/count gauges and
+			// status page immediately, rather than waiting for the next poll
+			// tick. This covers both the regular backup RPC and the bootstrap
+			// first-backup path, which both funnel through backupLocked.
+			// Synchronous + repo-only (one `pgbackrest info`, no pg queries).
+			pm.backup.RefreshRepoNow(ctx)
 		} else {
 			metrics.IncBackupFailures(ctx)
+			health.BackupFailed(retErr)
 		}
 	}()
 

--- a/go/services/multipooler/internal/manager/rpc_backup_test.go
+++ b/go/services/multipooler/internal/manager/rpc_backup_test.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -597,6 +598,117 @@ pg1-path=/tmp/pg_data
 		assert.NotContains(t, file.Name(), "pgbackrest-backup.conf", "temp backup config should not be created")
 		assert.NotContains(t, file.Name(), "tmp", "no temp files should be created")
 	}
+}
+
+func TestRecordLeaseLossIfApplicable(t *testing.T) {
+	poolerDir := t.TempDir()
+	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, t.TempDir())
+
+	t.Run("no error → not recorded", func(t *testing.T) {
+		assert.False(t, pm.recordLeaseLossIfApplicable(t.Context(), nil))
+	})
+
+	t.Run("error without lease-lost cause → not recorded", func(t *testing.T) {
+		assert.False(t, pm.recordLeaseLossIfApplicable(t.Context(), errors.New("some other failure")))
+	})
+
+	t.Run("error with lease-lost cause → recorded", func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		cancel(topoclient.ErrLeaseLost)
+		assert.True(t, pm.recordLeaseLossIfApplicable(ctx, errors.New("backup aborted")))
+	})
+}
+
+func TestBackup_TracksFailuresAndInProgress(t *testing.T) {
+	// Drive a real backup through pm.Backup with a pgbackrest stub that fails
+	// the first backup and succeeds the second, asserting the health tracker's
+	// failure streak and in-progress timer are maintained inline.
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	marker := filepath.Join(tmpDir, "backup_attempted_marker")
+	mockScript := `#!/bin/bash
+if [[ "$*" == *"info"* ]]; then
+cat << 'JSONEOF'
+[{"backup":[{"label":"20250104-100000F","annotation":{"multipooler_id":"test-multipooler","job_id":"test-job-id"}}]}]
+JSONEOF
+exit 0
+fi
+if [[ "$*" == *"backup"* ]]; then
+  if [[ -f ` + marker + ` ]]; then exit 0; fi
+  touch ` + marker + `
+  echo "ERROR: simulated backup failure" >&2
+  exit 1
+fi
+exit 0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "pgbackrest"), []byte(mockScript), 0o755))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	poolerDir := filepath.Join(tmpDir, "pooler")
+	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
+	configPath := setupMockPgBackRestConfig(t, poolerDir)
+	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm.backup.SetConfigPath(configPath)
+	setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+	overrides := map[string]string{"pg2_path": filepath.Join(poolerDir, "pg_data")}
+
+	// First backup fails → streak 1, in-progress cleared.
+	_, err := pm.Backup(ctx, false, "full", "test-job-id", overrides)
+	require.Error(t, err)
+	snap := pm.backup.Health().Snapshot()
+	assert.Equal(t, int64(1), snap.FailuresSinceSuccess)
+	assert.True(t, snap.InProgressStart.IsZero(), "in-progress must be cleared after a failed backup")
+	assert.NotEmpty(t, snap.LastFailErr)
+
+	// Second backup succeeds → streak resets, in-progress cleared.
+	_, err = pm.Backup(ctx, false, "full", "test-job-id", overrides)
+	require.NoError(t, err)
+	snap = pm.backup.Health().Snapshot()
+	assert.Zero(t, snap.FailuresSinceSuccess, "streak resets after a successful backup")
+	assert.True(t, snap.InProgressStart.IsZero(), "in-progress must be cleared after a successful backup")
+}
+
+func TestBackup_RefreshesRepoGaugesOnSuccess(t *testing.T) {
+	// After a successful backup, the taker should reflect the new backup in its
+	// age/count gauges immediately (RefreshRepoNow), not wait for the next poll.
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	// info returns one COMPLETE backup whose annotations match this pooler's
+	// shard (default / 0-inf) so parseBackups includes it; backup/verify exit 0.
+	mockScript := `#!/bin/bash
+if [[ "$*" == *"info"* ]]; then
+cat << 'JSONEOF'
+[{"backup":[{"label":"20260101-000000F","error":false,"timestamp":{"start":1735689600,"stop":1735689660},"annotation":{"job_id":"test-job-id","multipooler_id":"test-multipooler","pooler_type":"REPLICA","table_group":"default","shard":"0-inf"}}]}]
+JSONEOF
+exit 0
+fi
+exit 0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "pgbackrest"), []byte(mockScript), 0o755))
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	poolerDir := filepath.Join(tmpDir, "pooler")
+	require.NoError(t, os.MkdirAll(poolerDir, 0o755))
+	configPath := setupMockPgBackRestConfig(t, poolerDir)
+	pm := createTestManagerWithBackupLocation(poolerDir, "", "", clustermetadatapb.PoolerType_REPLICA, tmpDir)
+	pm.backup.SetConfigPath(configPath)
+	setBackupPrimary(pm, "primary-pooler", "primary.local", 5432)
+
+	// Gauges start empty before any backup.
+	require.Zero(t, pm.backup.Health().Snapshot().CompleteCount)
+
+	_, err := pm.Backup(ctx, false, "full", "test-job-id", map[string]string{"pg2_path": filepath.Join(poolerDir, "pg_data")})
+	require.NoError(t, err)
+
+	snap := pm.backup.Health().Snapshot()
+	assert.Equal(t, int64(1), snap.CompleteCount, "completed backup should be reflected immediately")
+	assert.Equal(t, int64(1735689660), snap.LastSuccessStop.Unix(), "last-success time should come from the backup's stop timestamp")
 }
 
 func TestBackup_RejectsEmptyTableGroup(t *testing.T) {

--- a/go/services/multipooler/status.go
+++ b/go/services/multipooler/status.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/multigres/multigres/go/common/web"
+	backupengine "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup"
 )
 
 // Link represents a link on the status page.
@@ -46,7 +48,39 @@ type Status struct {
 	PgctldAddr     string `json:"pgctld_addr"`
 	SocketFilePath string `json:"socket_file_path"`
 
+	Backups BackupStatusView `json:"backups"`
+
 	Links []Link `json:"links"`
+}
+
+// BackupStatusView is the formatted, template-ready view of the backup-health
+// snapshot. Durations are pre-formatted here (not in the template).
+type BackupStatusView struct {
+	HasBackup     bool   `json:"has_backup"`
+	LastBackupAt  string `json:"last_backup_at"`  // formatted; empty if none
+	LastBackupAge string `json:"last_backup_age"` // e.g. "2h13m"; empty if none
+	CompleteCount int64  `json:"complete_count"`
+	FailuresSince int64  `json:"failures_since"`
+	InProgress    bool   `json:"in_progress"`
+	InProgressFor string `json:"in_progress_for"`
+	Ready         bool   `json:"ready"`
+	ReadyReason   string `json:"ready_reason"`
+	WALArchiveLag string `json:"wal_archive_lag"` // empty when unknown / standby
+	LeaseHeld     bool   `json:"lease_held"`
+	LastFailure   string `json:"last_failure"` // err + timestamp; empty if none
+	// LastRefreshed is when the poller last refreshed this snapshot, formatted
+	// as "<timestamp> (<age> ago)"; empty before the first poll. Rendered as a
+	// freshness note on the status page.
+	LastRefreshed string `json:"last_refreshed"`
+}
+
+// formatAge renders the time elapsed since t, rounded to the second, or "" if t
+// is the zero time.
+func formatAge(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return time.Since(t).Round(time.Second).String()
 }
 
 // handleIndex serves the index page
@@ -61,9 +95,48 @@ func (mp *MultiPooler) handleIndex(w http.ResponseWriter, r *http.Request) {
 	mp.serverStatus.PgctldAddr = mp.pgctldAddr.Get()
 	mp.serverStatus.SocketFilePath = mp.socketFilePath.Get()
 	mp.serverStatus.TopoStatus = mp.ts.Status()
+	mp.serverStatus.Backups = mp.backupStatusView()
 	err := web.Templates.ExecuteTemplate(w, "pooler_index.html", &mp.serverStatus)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
 		return
 	}
+}
+
+// backupStatusView builds the template-ready backup view from the manager's
+// health snapshot. During early startup the manager may not exist yet; in that
+// case it returns an "unknown" view rather than panicking.
+func (mp *MultiPooler) backupStatusView() BackupStatusView {
+	if mp.poolerManager == nil {
+		return BackupStatusView{ReadyReason: "unknown"}
+	}
+	return buildBackupStatusView(mp.poolerManager.BackupStatusSnapshot())
+}
+
+// buildBackupStatusView maps a backup-health snapshot into the template-ready
+// view, pre-formatting durations/timestamps. Pure (no manager) so it is
+// directly unit-testable.
+func buildBackupStatusView(snap backupengine.Snapshot) BackupStatusView {
+	view := BackupStatusView{
+		HasBackup:     !snap.LastSuccessStop.IsZero(),
+		CompleteCount: snap.CompleteCount,
+		FailuresSince: snap.FailuresSinceSuccess,
+		InProgress:    !snap.InProgressStart.IsZero(),
+		InProgressFor: formatAge(snap.InProgressStart),
+		Ready:         snap.Ready,
+		ReadyReason:   snap.Reason,
+		WALArchiveLag: formatAge(snap.LastArchived),
+		LeaseHeld:     snap.LeaseHeld,
+	}
+	if view.HasBackup {
+		view.LastBackupAt = snap.LastSuccessStop.Format(time.RFC3339)
+		view.LastBackupAge = formatAge(snap.LastSuccessStop)
+	}
+	if snap.LastFailErr != "" {
+		view.LastFailure = fmt.Sprintf("%s (%s)", snap.LastFailErr, snap.LastFailAt.Format(time.RFC3339))
+	}
+	if !snap.LastRefresh.IsZero() {
+		view.LastRefreshed = fmt.Sprintf("%s (%s ago)", snap.LastRefresh.Format(time.RFC3339), formatAge(snap.LastRefresh))
+	}
+	return view
 }

--- a/go/services/multipooler/status_test.go
+++ b/go/services/multipooler/status_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/web"
+	backupengine "github.com/multigres/multigres/go/services/multipooler/internal/manager/backup"
+)
+
+func renderPoolerIndex(t *testing.T, status *Status) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, web.Templates.ExecuteTemplate(&buf, "pooler_index.html", status))
+	return buf.String()
+}
+
+func TestBuildBackupStatusView_WithBackup(t *testing.T) {
+	stop := time.Now().Add(-2 * time.Hour)
+	failAt := time.Now().Add(-3 * time.Hour)
+	snap := backupengine.Snapshot{
+		LastSuccessStop:      stop,
+		CompleteCount:        5,
+		Ready:                true,
+		Reason:               backupengine.ReadyReasonOK,
+		LastArchived:         time.Now().Add(-15 * time.Second),
+		FailuresSinceSuccess: 2,
+		InProgressStart:      time.Now().Add(-30 * time.Second),
+		LeaseHeld:            true,
+		LastFailErr:          "boom",
+		LastFailAt:           failAt,
+		LastRefresh:          time.Now().Add(-10 * time.Second),
+	}
+
+	view := buildBackupStatusView(snap)
+	assert.True(t, view.HasBackup)
+	assert.Equal(t, stop.Format(time.RFC3339), view.LastBackupAt)
+	assert.NotEmpty(t, view.LastBackupAge)
+	assert.Equal(t, int64(5), view.CompleteCount)
+	assert.Equal(t, int64(2), view.FailuresSince)
+	assert.True(t, view.Ready)
+	assert.Equal(t, "ok", view.ReadyReason)
+	assert.NotEmpty(t, view.WALArchiveLag, "WAL lag should render when last-archived is set")
+	assert.True(t, view.InProgress)
+	assert.NotEmpty(t, view.InProgressFor)
+	assert.True(t, view.LeaseHeld)
+	assert.Contains(t, view.LastFailure, "boom")
+	assert.Contains(t, view.LastFailure, failAt.Format(time.RFC3339))
+	assert.Contains(t, view.LastRefreshed, "ago", "should render the last-refreshed time with an age")
+}
+
+func TestBuildBackupStatusView_NoBackup(t *testing.T) {
+	// Zero snapshot: no backup, nothing in progress, no lag, no failure.
+	view := buildBackupStatusView(backupengine.Snapshot{Reason: backupengine.ReadyReasonStanzaMissing})
+	assert.False(t, view.HasBackup)
+	assert.Empty(t, view.LastRefreshed, "no refresh time before the first poll")
+	assert.Empty(t, view.LastBackupAt)
+	assert.Empty(t, view.LastBackupAge)
+	assert.False(t, view.InProgress)
+	assert.Empty(t, view.InProgressFor)
+	assert.Empty(t, view.WALArchiveLag, "no WAL lag when last-archived is zero (standby/unknown)")
+	assert.Empty(t, view.LastFailure)
+	assert.Equal(t, "stanza_missing", view.ReadyReason)
+}
+
+func TestBackupStatusView_NilManagerDuringStartup(t *testing.T) {
+	// Before the pooler manager is constructed (early startup), the view must
+	// render an "unknown" state rather than panicking on a nil manager.
+	mp := &MultiPooler{}
+	view := mp.backupStatusView()
+	assert.Equal(t, "unknown", view.ReadyReason)
+	assert.False(t, view.HasBackup)
+	assert.False(t, view.Ready)
+}
+
+func TestPoolerIndex_BackupsSection_NoBackup(t *testing.T) {
+	status := &Status{
+		Title: "pooler",
+		Backups: BackupStatusView{
+			HasBackup:   false,
+			Ready:       false,
+			ReadyReason: "stanza_missing",
+		},
+	}
+	html := renderPoolerIndex(t, status)
+
+	assert.Contains(t, html, "<h4>Backups</h4>")
+	assert.Contains(t, html, "never", "should show 'never' when there is no backup")
+	assert.Contains(t, html, "stanza_missing", "should show the not-ready reason")
+}
+
+func TestPoolerIndex_BackupsSection_WithBackup(t *testing.T) {
+	status := &Status{
+		Title: "pooler",
+		Backups: BackupStatusView{
+			HasBackup:     true,
+			LastBackupAt:  "2026-06-10T12:00:00Z",
+			LastBackupAge: "2h13m0s",
+			CompleteCount: 4,
+			FailuresSince: 1,
+			Ready:         true,
+			ReadyReason:   "ok",
+			WALArchiveLag: "15s",
+			LeaseHeld:     true,
+			LastFailure:   "boom (2026-06-10T11:00:00Z)",
+			LastRefreshed: "2026-06-10T14:00:00Z (12s ago)",
+		},
+	}
+	html := renderPoolerIndex(t, status)
+
+	assert.Contains(t, html, "2026-06-10T12:00:00Z")
+	assert.Contains(t, html, "2h13m0s ago")
+	assert.Contains(t, html, "15s", "should show WAL archive lag")
+	assert.Contains(t, html, "boom (2026-06-10T11:00:00Z)", "should show last failure")
+	assert.NotContains(t, html, "never")
+	assert.Contains(t, html, "Last refreshed 2026-06-10T14:00:00Z (12s ago)", "should show the last-refreshed note")
+}

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -554,6 +554,11 @@ message BackupMetadata {
   // Pooler type that created this backup (from pgbackrest annotation)
   clustermetadata.PoolerType pooler_type = 10;
 
+  // When the backup started/stopped, parsed from pgbackrest info's
+  // backup[].timestamp.{start,stop}. Unset if unknown.
+  google.protobuf.Timestamp start_timestamp = 11;
+  google.protobuf.Timestamp stop_timestamp = 12;
+
   // Status represents the state of a backup
   enum Status {
     UNKNOWN = 0;


### PR DESCRIPTION
## Summary

- Adds pooler-side backup observability: OTel gauges (last-backup age, complete count, failures-since-success, readiness + reason, WAL archive lag, in-progress, lease held/lost) plus a "Backups" section on the per-pooler status page.
- Readiness is derived **passively** from `pgbackrest info` + cheap `pg_settings` reads + `pg_stat_archiver` — never `pgbackrest check`, which would force a WAL switch / extra I/O on the primary. Bounded reasons; role-aware (`archive_*` on primary only, `restore_command` on both).
- A ~5-minute background poller refreshes repo-derived state; failure-streak / in-progress / lease state are updated inline in the `Backup()` path. A snapshot is also captured the moment bootstrap completes, so post-bootstrap health is visible immediately instead of up to a poll interval later.
- `BackupMetadata` gains start/stop timestamps. The backup engine stays a leaf package — the manager injects typed providers (role / `pg_stat_archiver` / `pg_settings`), so the engine owns no pg connection.

Status page screenshot:
<img width="972" height="592" alt="image" src="https://github.com/user-attachments/assets/d41cd106-62cb-4b4c-a834-8ea788a8837b" />


## Test Plan

- [x] Unit tests: health tracker, gauges, passive readiness, repo classification, lease-loss detection, status-page render.
- [x] Backup endtoend suite (create/list/restore, lease-stealing, backup-from-standby, expire, primary-failover) and 3-node cluster bootstrap — all pass.