### PR TITLE
refactor(proto): unify health-stream leader_observation on clustermetadata.LeaderObservation

### DIFF
--- a/go/pb/clustermetadata/clustermetadata.pb.go
+++ b/go/pb/clustermetadata/clustermetadata.pb.go
@@ -1865,14 +1865,12 @@ func (x *PoolerPosition) GetLsn() string {
 }
 
 // LeaderObservation represents a pooler's view of who the consensus leader is.
-// Stored on the leader's own MultiPooler topology record (self_leadership
-// field) so multigateway can bootstrap leader routing from etcd at discovery
-// time without relying on MultiPooler.type as a hint.
-//
-// Distinct from multipoolerservice.LeaderObservation, which carries the same
-// information on the multipooler health stream with an older (int64 leader_term)
-// shape. The two will eventually converge on this type via the gateway-routing
-// migration.
+// It is carried in two places:
+//   - the leader's own MultiPooler topology record (self_leadership field), so
+//     multigateway can bootstrap leader routing from etcd at discovery time
+//     without relying on MultiPooler.type as a hint; and
+//   - the multipooler health stream
+//     (StreamPoolerHealthResponse.leader_observation).
 type LeaderObservation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// leader_id is the ID of the pooler this node believes is the consensus leader.

--- a/go/pb/multipoolerservice/multipoolerservice.pb.go
+++ b/go/pb/multipoolerservice/multipoolerservice.pb.go
@@ -1758,7 +1758,7 @@ type StreamPoolerHealthResponse struct {
 	ServingStatus clustermetadata.PoolerServingStatus `protobuf:"varint,3,opt,name=serving_status,json=servingStatus,proto3,enum=clustermetadata.PoolerServingStatus" json:"serving_status,omitempty"`
 	// leader_observation contains this pooler's view of who the consensus leader is.
 	// Used by clients to identify the true leader when multiple poolers exist.
-	LeaderObservation *LeaderObservation `protobuf:"bytes,4,opt,name=leader_observation,json=leaderObservation,proto3" json:"leader_observation,omitempty"`
+	LeaderObservation *clustermetadata.LeaderObservation `protobuf:"bytes,4,opt,name=leader_observation,json=leaderObservation,proto3" json:"leader_observation,omitempty"`
 	// recommended_staleness_timeout is the duration clients should use
 	// to detect a stale/dead health stream. If no message is received within
 	// this duration, clients should mark the pooler as unhealthy.
@@ -1821,7 +1821,7 @@ func (x *StreamPoolerHealthResponse) GetServingStatus() clustermetadata.PoolerSe
 	return clustermetadata.PoolerServingStatus(0)
 }
 
-func (x *StreamPoolerHealthResponse) GetLeaderObservation() *LeaderObservation {
+func (x *StreamPoolerHealthResponse) GetLeaderObservation() *clustermetadata.LeaderObservation {
 	if x != nil {
 		return x.LeaderObservation
 	}
@@ -1842,64 +1842,6 @@ func (x *StreamPoolerHealthResponse) GetReplicationLagNs() int64 {
 	return 0
 }
 
-// LeaderObservation represents a pooler's view of who the consensus leader is.
-type LeaderObservation struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// leader_id is the ID of the pooler this node believes is the consensus leader.
-	// May be this pooler's own ID if it believes itself to be leader.
-	LeaderId *clustermetadata.ID `protobuf:"bytes,1,opt,name=leader_id,json=leaderId,proto3" json:"leader_id,omitempty"`
-	// leader_term is the consensus term at which this observation was made.
-	// The leader never changes within a leader_term. Higher values indicate
-	// more recent leader appointments.
-	LeaderTerm    int64 `protobuf:"varint,2,opt,name=leader_term,json=leaderTerm,proto3" json:"leader_term,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *LeaderObservation) Reset() {
-	*x = LeaderObservation{}
-	mi := &file_multipoolerservice_proto_msgTypes[21]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *LeaderObservation) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*LeaderObservation) ProtoMessage() {}
-
-func (x *LeaderObservation) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolerservice_proto_msgTypes[21]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use LeaderObservation.ProtoReflect.Descriptor instead.
-func (*LeaderObservation) Descriptor() ([]byte, []int) {
-	return file_multipoolerservice_proto_rawDescGZIP(), []int{21}
-}
-
-func (x *LeaderObservation) GetLeaderId() *clustermetadata.ID {
-	if x != nil {
-		return x.LeaderId
-	}
-	return nil
-}
-
-func (x *LeaderObservation) GetLeaderTerm() int64 {
-	if x != nil {
-		return x.LeaderTerm
-	}
-	return 0
-}
-
 // StreamNotificationsRequest subscribes to or unsubscribes from PG notification channels.
 type StreamNotificationsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1913,7 +1855,7 @@ type StreamNotificationsRequest struct {
 
 func (x *StreamNotificationsRequest) Reset() {
 	*x = StreamNotificationsRequest{}
-	mi := &file_multipoolerservice_proto_msgTypes[22]
+	mi := &file_multipoolerservice_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1925,7 +1867,7 @@ func (x *StreamNotificationsRequest) String() string {
 func (*StreamNotificationsRequest) ProtoMessage() {}
 
 func (x *StreamNotificationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolerservice_proto_msgTypes[22]
+	mi := &file_multipoolerservice_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1938,7 +1880,7 @@ func (x *StreamNotificationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamNotificationsRequest.ProtoReflect.Descriptor instead.
 func (*StreamNotificationsRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolerservice_proto_rawDescGZIP(), []int{22}
+	return file_multipoolerservice_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *StreamNotificationsRequest) GetTarget() *query.Target {
@@ -1966,7 +1908,7 @@ type StreamNotificationsResponse struct {
 
 func (x *StreamNotificationsResponse) Reset() {
 	*x = StreamNotificationsResponse{}
-	mi := &file_multipoolerservice_proto_msgTypes[23]
+	mi := &file_multipoolerservice_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1978,7 +1920,7 @@ func (x *StreamNotificationsResponse) String() string {
 func (*StreamNotificationsResponse) ProtoMessage() {}
 
 func (x *StreamNotificationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolerservice_proto_msgTypes[23]
+	mi := &file_multipoolerservice_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1991,7 +1933,7 @@ func (x *StreamNotificationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamNotificationsResponse.ProtoReflect.Descriptor instead.
 func (*StreamNotificationsResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolerservice_proto_rawDescGZIP(), []int{23}
+	return file_multipoolerservice_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *StreamNotificationsResponse) GetNotification() *query.PgNotification {
@@ -2112,18 +2054,14 @@ const file_multipoolerservice_proto_rawDesc = "" +
 	"\tcaller_id\x18\x02 \x01(\v2\x0f.mtrpc.CallerIDR\bcallerId\x12/\n" +
 	"\aoptions\x18\x03 \x01(\v2\x15.query.ExecuteOptionsR\aoptions\"#\n" +
 	"!ReleaseReservedConnectionResponse\"\x1b\n" +
-	"\x19StreamPoolerHealthRequest\"\xa5\x03\n" +
+	"\x19StreamPoolerHealthRequest\"\xa2\x03\n" +
 	"\x1aStreamPoolerHealthResponse\x12%\n" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x120\n" +
 	"\tpooler_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\x12K\n" +
-	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12T\n" +
-	"\x12leader_observation\x18\x04 \x01(\v2%.multipoolerservice.LeaderObservationR\x11leaderObservation\x12]\n" +
+	"\x0eserving_status\x18\x03 \x01(\x0e2$.clustermetadata.PoolerServingStatusR\rservingStatus\x12Q\n" +
+	"\x12leader_observation\x18\x04 \x01(\v2\".clustermetadata.LeaderObservationR\x11leaderObservation\x12]\n" +
 	"\x1drecommended_staleness_timeout\x18\x05 \x01(\v2\x19.google.protobuf.DurationR\x1brecommendedStalenessTimeout\x12,\n" +
-	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\"f\n" +
-	"\x11LeaderObservation\x120\n" +
-	"\tleader_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bleaderId\x12\x1f\n" +
-	"\vleader_term\x18\x02 \x01(\x03R\n" +
-	"leaderTerm\"_\n" +
+	"\x12replication_lag_ns\x18\x06 \x01(\x03R\x10replicationLagNs\"_\n" +
 	"\x1aStreamNotificationsRequest\x12%\n" +
 	"\x06target\x18\x01 \x01(\v2\r.query.TargetR\x06target\x12\x1a\n" +
 	"\bchannels\x18\x02 \x03(\tR\bchannels\"X\n" +
@@ -2168,7 +2106,7 @@ func file_multipoolerservice_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolerservice_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_multipoolerservice_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_multipoolerservice_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_multipoolerservice_proto_goTypes = []any{
 	(ReservationReason)(0),                    // 0: multipoolerservice.ReservationReason
 	(TransactionConclusion)(0),                // 1: multipoolerservice.TransactionConclusion
@@ -2196,112 +2134,111 @@ var file_multipoolerservice_proto_goTypes = []any{
 	(*ReleaseReservedConnectionResponse)(nil), // 23: multipoolerservice.ReleaseReservedConnectionResponse
 	(*StreamPoolerHealthRequest)(nil),         // 24: multipoolerservice.StreamPoolerHealthRequest
 	(*StreamPoolerHealthResponse)(nil),        // 25: multipoolerservice.StreamPoolerHealthResponse
-	(*LeaderObservation)(nil),                 // 26: multipoolerservice.LeaderObservation
-	(*StreamNotificationsRequest)(nil),        // 27: multipoolerservice.StreamNotificationsRequest
-	(*StreamNotificationsResponse)(nil),       // 28: multipoolerservice.StreamNotificationsResponse
-	(*query.Target)(nil),                      // 29: query.Target
-	(*mtrpc.CallerID)(nil),                    // 30: mtrpc.CallerID
-	(*query.ExecuteOptions)(nil),              // 31: query.ExecuteOptions
-	(*query.QueryResult)(nil),                 // 32: query.QueryResult
-	(*query.ReservedState)(nil),               // 33: query.ReservedState
-	(*query.ReservationOptions)(nil),          // 34: query.ReservationOptions
-	(*query.QueryResultPayload)(nil),          // 35: query.QueryResultPayload
-	(*query.PreparedStatement)(nil),           // 36: query.PreparedStatement
-	(*query.Portal)(nil),                      // 37: query.Portal
-	(*query.StatementDescription)(nil),        // 38: query.StatementDescription
-	(*query.PgDiagnostic)(nil),                // 39: query.PgDiagnostic
-	(*clustermetadata.ID)(nil),                // 40: clustermetadata.ID
-	(clustermetadata.PoolerServingStatus)(0),  // 41: clustermetadata.PoolerServingStatus
+	(*StreamNotificationsRequest)(nil),        // 26: multipoolerservice.StreamNotificationsRequest
+	(*StreamNotificationsResponse)(nil),       // 27: multipoolerservice.StreamNotificationsResponse
+	(*query.Target)(nil),                      // 28: query.Target
+	(*mtrpc.CallerID)(nil),                    // 29: mtrpc.CallerID
+	(*query.ExecuteOptions)(nil),              // 30: query.ExecuteOptions
+	(*query.QueryResult)(nil),                 // 31: query.QueryResult
+	(*query.ReservedState)(nil),               // 32: query.ReservedState
+	(*query.ReservationOptions)(nil),          // 33: query.ReservationOptions
+	(*query.QueryResultPayload)(nil),          // 34: query.QueryResultPayload
+	(*query.PreparedStatement)(nil),           // 35: query.PreparedStatement
+	(*query.Portal)(nil),                      // 36: query.Portal
+	(*query.StatementDescription)(nil),        // 37: query.StatementDescription
+	(*query.PgDiagnostic)(nil),                // 38: query.PgDiagnostic
+	(*clustermetadata.ID)(nil),                // 39: clustermetadata.ID
+	(clustermetadata.PoolerServingStatus)(0),  // 40: clustermetadata.PoolerServingStatus
+	(*clustermetadata.LeaderObservation)(nil), // 41: clustermetadata.LeaderObservation
 	(*durationpb.Duration)(nil),               // 42: google.protobuf.Duration
 	(*query.PgNotification)(nil),              // 43: query.PgNotification
 }
 var file_multipoolerservice_proto_depIdxs = []int32{
-	29, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
-	30, // 1: multipoolerservice.ExecuteQueryRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 2: multipoolerservice.ExecuteQueryRequest.options:type_name -> query.ExecuteOptions
-	32, // 3: multipoolerservice.ExecuteQueryResponse.result:type_name -> query.QueryResult
-	33, // 4: multipoolerservice.ExecuteQueryResponse.reserved_state:type_name -> query.ReservedState
-	29, // 5: multipoolerservice.StreamExecuteRequest.target:type_name -> query.Target
-	30, // 6: multipoolerservice.StreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 7: multipoolerservice.StreamExecuteRequest.options:type_name -> query.ExecuteOptions
-	34, // 8: multipoolerservice.StreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
-	35, // 9: multipoolerservice.StreamExecuteResponse.result:type_name -> query.QueryResultPayload
-	33, // 10: multipoolerservice.StreamExecuteResponse.reserved_state:type_name -> query.ReservedState
-	29, // 11: multipoolerservice.PortalStreamExecuteRequest.target:type_name -> query.Target
-	36, // 12: multipoolerservice.PortalStreamExecuteRequest.prepared_statement:type_name -> query.PreparedStatement
-	37, // 13: multipoolerservice.PortalStreamExecuteRequest.portal:type_name -> query.Portal
-	30, // 14: multipoolerservice.PortalStreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 15: multipoolerservice.PortalStreamExecuteRequest.options:type_name -> query.ExecuteOptions
+	28, // 0: multipoolerservice.ExecuteQueryRequest.target:type_name -> query.Target
+	29, // 1: multipoolerservice.ExecuteQueryRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 2: multipoolerservice.ExecuteQueryRequest.options:type_name -> query.ExecuteOptions
+	31, // 3: multipoolerservice.ExecuteQueryResponse.result:type_name -> query.QueryResult
+	32, // 4: multipoolerservice.ExecuteQueryResponse.reserved_state:type_name -> query.ReservedState
+	28, // 5: multipoolerservice.StreamExecuteRequest.target:type_name -> query.Target
+	29, // 6: multipoolerservice.StreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 7: multipoolerservice.StreamExecuteRequest.options:type_name -> query.ExecuteOptions
+	33, // 8: multipoolerservice.StreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
+	34, // 9: multipoolerservice.StreamExecuteResponse.result:type_name -> query.QueryResultPayload
+	32, // 10: multipoolerservice.StreamExecuteResponse.reserved_state:type_name -> query.ReservedState
+	28, // 11: multipoolerservice.PortalStreamExecuteRequest.target:type_name -> query.Target
+	35, // 12: multipoolerservice.PortalStreamExecuteRequest.prepared_statement:type_name -> query.PreparedStatement
+	36, // 13: multipoolerservice.PortalStreamExecuteRequest.portal:type_name -> query.Portal
+	29, // 14: multipoolerservice.PortalStreamExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 15: multipoolerservice.PortalStreamExecuteRequest.options:type_name -> query.ExecuteOptions
 	10, // 16: multipoolerservice.PortalStreamExecuteRequest.portal_options:type_name -> multipoolerservice.PortalExecuteOptions
-	34, // 17: multipoolerservice.PortalStreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
-	35, // 18: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResultPayload
-	33, // 19: multipoolerservice.PortalStreamExecuteResponse.reserved_state:type_name -> query.ReservedState
-	29, // 20: multipoolerservice.DescribeRequest.target:type_name -> query.Target
-	36, // 21: multipoolerservice.DescribeRequest.prepared_statement:type_name -> query.PreparedStatement
-	37, // 22: multipoolerservice.DescribeRequest.portal:type_name -> query.Portal
-	30, // 23: multipoolerservice.DescribeRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 24: multipoolerservice.DescribeRequest.options:type_name -> query.ExecuteOptions
-	38, // 25: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
+	33, // 17: multipoolerservice.PortalStreamExecuteRequest.reservation_options:type_name -> query.ReservationOptions
+	34, // 18: multipoolerservice.PortalStreamExecuteResponse.result:type_name -> query.QueryResultPayload
+	32, // 19: multipoolerservice.PortalStreamExecuteResponse.reserved_state:type_name -> query.ReservedState
+	28, // 20: multipoolerservice.DescribeRequest.target:type_name -> query.Target
+	35, // 21: multipoolerservice.DescribeRequest.prepared_statement:type_name -> query.PreparedStatement
+	36, // 22: multipoolerservice.DescribeRequest.portal:type_name -> query.Portal
+	29, // 23: multipoolerservice.DescribeRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 24: multipoolerservice.DescribeRequest.options:type_name -> query.ExecuteOptions
+	37, // 25: multipoolerservice.DescribeResponse.description:type_name -> query.StatementDescription
 	2,  // 26: multipoolerservice.CopyBidiExecuteRequest.phase:type_name -> multipoolerservice.CopyBidiExecuteRequest.Phase
 	3,  // 27: multipoolerservice.CopyBidiExecuteRequest.direction:type_name -> multipoolerservice.CopyBidiExecuteRequest.Direction
-	29, // 28: multipoolerservice.CopyBidiExecuteRequest.target:type_name -> query.Target
-	30, // 29: multipoolerservice.CopyBidiExecuteRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 30: multipoolerservice.CopyBidiExecuteRequest.options:type_name -> query.ExecuteOptions
-	34, // 31: multipoolerservice.CopyBidiExecuteRequest.reservation_options:type_name -> query.ReservationOptions
+	28, // 28: multipoolerservice.CopyBidiExecuteRequest.target:type_name -> query.Target
+	29, // 29: multipoolerservice.CopyBidiExecuteRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 30: multipoolerservice.CopyBidiExecuteRequest.options:type_name -> query.ExecuteOptions
+	33, // 31: multipoolerservice.CopyBidiExecuteRequest.reservation_options:type_name -> query.ReservationOptions
 	4,  // 32: multipoolerservice.CopyBidiExecuteResponse.phase:type_name -> multipoolerservice.CopyBidiExecuteResponse.Phase
-	33, // 33: multipoolerservice.CopyBidiExecuteResponse.reserved_state:type_name -> query.ReservedState
-	32, // 34: multipoolerservice.CopyBidiExecuteResponse.result:type_name -> query.QueryResult
-	39, // 35: multipoolerservice.CopyBidiExecuteResponse.notices:type_name -> query.PgDiagnostic
-	39, // 36: multipoolerservice.CopyBidiExecuteResponse.error_diagnostic:type_name -> query.PgDiagnostic
-	29, // 37: multipoolerservice.ConcludeTransactionRequest.target:type_name -> query.Target
-	30, // 38: multipoolerservice.ConcludeTransactionRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 39: multipoolerservice.ConcludeTransactionRequest.options:type_name -> query.ExecuteOptions
+	32, // 33: multipoolerservice.CopyBidiExecuteResponse.reserved_state:type_name -> query.ReservedState
+	31, // 34: multipoolerservice.CopyBidiExecuteResponse.result:type_name -> query.QueryResult
+	38, // 35: multipoolerservice.CopyBidiExecuteResponse.notices:type_name -> query.PgDiagnostic
+	38, // 36: multipoolerservice.CopyBidiExecuteResponse.error_diagnostic:type_name -> query.PgDiagnostic
+	28, // 37: multipoolerservice.ConcludeTransactionRequest.target:type_name -> query.Target
+	29, // 38: multipoolerservice.ConcludeTransactionRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 39: multipoolerservice.ConcludeTransactionRequest.options:type_name -> query.ExecuteOptions
 	1,  // 40: multipoolerservice.ConcludeTransactionRequest.conclusion:type_name -> multipoolerservice.TransactionConclusion
-	32, // 41: multipoolerservice.ConcludeTransactionResponse.result:type_name -> query.QueryResult
-	33, // 42: multipoolerservice.ConcludeTransactionResponse.reserved_state:type_name -> query.ReservedState
-	29, // 43: multipoolerservice.DiscardTempTablesRequest.target:type_name -> query.Target
-	30, // 44: multipoolerservice.DiscardTempTablesRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 45: multipoolerservice.DiscardTempTablesRequest.options:type_name -> query.ExecuteOptions
-	32, // 46: multipoolerservice.DiscardTempTablesResponse.result:type_name -> query.QueryResult
-	33, // 47: multipoolerservice.DiscardTempTablesResponse.reserved_state:type_name -> query.ReservedState
-	29, // 48: multipoolerservice.ReleaseReservedConnectionRequest.target:type_name -> query.Target
-	30, // 49: multipoolerservice.ReleaseReservedConnectionRequest.caller_id:type_name -> mtrpc.CallerID
-	31, // 50: multipoolerservice.ReleaseReservedConnectionRequest.options:type_name -> query.ExecuteOptions
-	29, // 51: multipoolerservice.StreamPoolerHealthResponse.target:type_name -> query.Target
-	40, // 52: multipoolerservice.StreamPoolerHealthResponse.pooler_id:type_name -> clustermetadata.ID
-	41, // 53: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
-	26, // 54: multipoolerservice.StreamPoolerHealthResponse.leader_observation:type_name -> multipoolerservice.LeaderObservation
+	31, // 41: multipoolerservice.ConcludeTransactionResponse.result:type_name -> query.QueryResult
+	32, // 42: multipoolerservice.ConcludeTransactionResponse.reserved_state:type_name -> query.ReservedState
+	28, // 43: multipoolerservice.DiscardTempTablesRequest.target:type_name -> query.Target
+	29, // 44: multipoolerservice.DiscardTempTablesRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 45: multipoolerservice.DiscardTempTablesRequest.options:type_name -> query.ExecuteOptions
+	31, // 46: multipoolerservice.DiscardTempTablesResponse.result:type_name -> query.QueryResult
+	32, // 47: multipoolerservice.DiscardTempTablesResponse.reserved_state:type_name -> query.ReservedState
+	28, // 48: multipoolerservice.ReleaseReservedConnectionRequest.target:type_name -> query.Target
+	29, // 49: multipoolerservice.ReleaseReservedConnectionRequest.caller_id:type_name -> mtrpc.CallerID
+	30, // 50: multipoolerservice.ReleaseReservedConnectionRequest.options:type_name -> query.ExecuteOptions
+	28, // 51: multipoolerservice.StreamPoolerHealthResponse.target:type_name -> query.Target
+	39, // 52: multipoolerservice.StreamPoolerHealthResponse.pooler_id:type_name -> clustermetadata.ID
+	40, // 53: multipoolerservice.StreamPoolerHealthResponse.serving_status:type_name -> clustermetadata.PoolerServingStatus
+	41, // 54: multipoolerservice.StreamPoolerHealthResponse.leader_observation:type_name -> clustermetadata.LeaderObservation
 	42, // 55: multipoolerservice.StreamPoolerHealthResponse.recommended_staleness_timeout:type_name -> google.protobuf.Duration
-	40, // 56: multipoolerservice.LeaderObservation.leader_id:type_name -> clustermetadata.ID
-	29, // 57: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
-	43, // 58: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
-	5,  // 59: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
-	7,  // 60: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
-	9,  // 61: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
-	12, // 62: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
-	14, // 63: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
-	16, // 64: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
-	18, // 65: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
-	20, // 66: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
-	22, // 67: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
-	24, // 68: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
-	27, // 69: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
-	6,  // 70: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
-	8,  // 71: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
-	11, // 72: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
-	13, // 73: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
-	15, // 74: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
-	17, // 75: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
-	19, // 76: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
-	21, // 77: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
-	23, // 78: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
-	25, // 79: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
-	28, // 80: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
-	70, // [70:81] is the sub-list for method output_type
-	59, // [59:70] is the sub-list for method input_type
-	59, // [59:59] is the sub-list for extension type_name
-	59, // [59:59] is the sub-list for extension extendee
-	0,  // [0:59] is the sub-list for field type_name
+	28, // 56: multipoolerservice.StreamNotificationsRequest.target:type_name -> query.Target
+	43, // 57: multipoolerservice.StreamNotificationsResponse.notification:type_name -> query.PgNotification
+	5,  // 58: multipoolerservice.MultiPoolerService.ExecuteQuery:input_type -> multipoolerservice.ExecuteQueryRequest
+	7,  // 59: multipoolerservice.MultiPoolerService.StreamExecute:input_type -> multipoolerservice.StreamExecuteRequest
+	9,  // 60: multipoolerservice.MultiPoolerService.PortalStreamExecute:input_type -> multipoolerservice.PortalStreamExecuteRequest
+	12, // 61: multipoolerservice.MultiPoolerService.Describe:input_type -> multipoolerservice.DescribeRequest
+	14, // 62: multipoolerservice.MultiPoolerService.GetAuthCredentials:input_type -> multipoolerservice.GetAuthCredentialsRequest
+	16, // 63: multipoolerservice.MultiPoolerService.CopyBidiExecute:input_type -> multipoolerservice.CopyBidiExecuteRequest
+	18, // 64: multipoolerservice.MultiPoolerService.ConcludeTransaction:input_type -> multipoolerservice.ConcludeTransactionRequest
+	20, // 65: multipoolerservice.MultiPoolerService.DiscardTempTables:input_type -> multipoolerservice.DiscardTempTablesRequest
+	22, // 66: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:input_type -> multipoolerservice.ReleaseReservedConnectionRequest
+	24, // 67: multipoolerservice.MultiPoolerService.StreamPoolerHealth:input_type -> multipoolerservice.StreamPoolerHealthRequest
+	26, // 68: multipoolerservice.MultiPoolerService.StreamNotifications:input_type -> multipoolerservice.StreamNotificationsRequest
+	6,  // 69: multipoolerservice.MultiPoolerService.ExecuteQuery:output_type -> multipoolerservice.ExecuteQueryResponse
+	8,  // 70: multipoolerservice.MultiPoolerService.StreamExecute:output_type -> multipoolerservice.StreamExecuteResponse
+	11, // 71: multipoolerservice.MultiPoolerService.PortalStreamExecute:output_type -> multipoolerservice.PortalStreamExecuteResponse
+	13, // 72: multipoolerservice.MultiPoolerService.Describe:output_type -> multipoolerservice.DescribeResponse
+	15, // 73: multipoolerservice.MultiPoolerService.GetAuthCredentials:output_type -> multipoolerservice.GetAuthCredentialsResponse
+	17, // 74: multipoolerservice.MultiPoolerService.CopyBidiExecute:output_type -> multipoolerservice.CopyBidiExecuteResponse
+	19, // 75: multipoolerservice.MultiPoolerService.ConcludeTransaction:output_type -> multipoolerservice.ConcludeTransactionResponse
+	21, // 76: multipoolerservice.MultiPoolerService.DiscardTempTables:output_type -> multipoolerservice.DiscardTempTablesResponse
+	23, // 77: multipoolerservice.MultiPoolerService.ReleaseReservedConnection:output_type -> multipoolerservice.ReleaseReservedConnectionResponse
+	25, // 78: multipoolerservice.MultiPoolerService.StreamPoolerHealth:output_type -> multipoolerservice.StreamPoolerHealthResponse
+	27, // 79: multipoolerservice.MultiPoolerService.StreamNotifications:output_type -> multipoolerservice.StreamNotificationsResponse
+	69, // [69:80] is the sub-list for method output_type
+	58, // [58:69] is the sub-list for method input_type
+	58, // [58:58] is the sub-list for extension type_name
+	58, // [58:58] is the sub-list for extension extendee
+	0,  // [0:58] is the sub-list for field type_name
 }
 
 func init() { file_multipoolerservice_proto_init() }
@@ -2315,7 +2252,7 @@ func file_multipoolerservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolerservice_proto_rawDesc), len(file_multipoolerservice_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   24,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -25,11 +25,11 @@ import (
 
 	"google.golang.org/grpc"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	mtrpcpb "github.com/multigres/multigres/go/pb/mtrpc"
-	"github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 )
 
@@ -68,7 +68,7 @@ type LoadBalancer struct {
 	// shard. Populated only from health-stream observations; never from topology.
 	// The leader_id field of the observation may name a pooler we are not
 	// currently connected to — GetConnection handles that case at read time.
-	leaders map[shardKey]*multipoolerservice.LeaderObservation
+	leaders map[shardKey]*clustermetadatapb.LeaderObservation
 
 	// onPrimaryServing is called when a new primary is detected via health stream.
 	// Used to stop failover buffering for the shard. May be nil.
@@ -97,7 +97,7 @@ func NewLoadBalancer(ctx context.Context, localCell string, logger *slog.Logger,
 		logger:      logger,
 		ctx:         ctx,
 		connections: make(map[string]*PoolerConnection),
-		leaders:     make(map[shardKey]*multipoolerservice.LeaderObservation),
+		leaders:     make(map[shardKey]*clustermetadatapb.LeaderObservation),
 		grpcDialOpt: grpcDialOpt,
 	}
 }
@@ -197,9 +197,8 @@ func (lb *LoadBalancer) maybeSeedColdStartLeaderLocked(key shardKey, pooler *clu
 	if lb.leaders[key] != nil {
 		return
 	}
-	lb.leaders[key] = &multipoolerservice.LeaderObservation{
-		LeaderId:   pooler.Id,
-		LeaderTerm: 0,
+	lb.leaders[key] = &clustermetadatapb.LeaderObservation{
+		LeaderId: pooler.Id,
 	}
 	lb.logger.Debug("cold-start leader hint from topology",
 		"pooler_id", poolerIDString(pooler.Id),
@@ -268,12 +267,13 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 	}
 
 	// REPLICA: collect every connection eligible to serve reads in the shard.
-	// A consensus-confirmed leader (term >= 1) is excluded by ID; the
-	// cold-start topology seed (term 0) is treated as if no leader is known
+	// A consensus-confirmed leader (rule > zero) is excluded by ID; the
+	// cold-start topology seed (zero rule) is treated as if no leader is known
 	// yet, so a pooler that has since transitioned to Type=REPLICA can still
-	// be selected.
+	// be selected. CompareRuleNumbers treats a nil/zero rule as the smallest
+	// value, so this also covers the no-leader-observed case.
 	confirmedLeaderID := ""
-	if leaderObs != nil && leaderObs.LeaderTerm > 0 {
+	if commonconsensus.CompareRuleNumbers(leaderObs.GetLeaderRuleNumber(), nil) > 0 {
 		confirmedLeaderID = poolerIDString(leaderObs.LeaderId)
 	}
 	var candidates []*PoolerConnection
@@ -448,18 +448,21 @@ func (lb *LoadBalancer) onPoolerHealthUpdate(conn *PoolerConnection) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
+	// CompareRuleNumbers treats a nil rule as the smallest value, so a first
+	// observation (existing == nil) compares strictly greater and is recorded.
 	existing := lb.leaders[key]
+	cmp := commonconsensus.CompareRuleNumbers(obs.GetLeaderRuleNumber(), existing.GetLeaderRuleNumber())
 
 	switch {
-	case existing == nil || obs.LeaderTerm > existing.LeaderTerm:
-		// New leader or higher term — record identity unconditionally. The
+	case cmp > 0:
+		// New leader or higher rule — record identity unconditionally. The
 		// named pooler may not be in `connections` yet; that's fine.
 		lb.leaders[key] = obs
 		lb.logger.Debug("leader observation recorded",
 			"tablegroup", key.tableGroup,
 			"shard", key.shard,
 			"leader_id", poolerIDString(obs.LeaderId),
-			"term", obs.LeaderTerm)
+			"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
 
 		// If the named leader is connected and serving, drain the buffer.
 		// (Only stop failover buffering when the leader is SERVING — the
@@ -472,8 +475,8 @@ func (lb *LoadBalancer) onPoolerHealthUpdate(conn *PoolerConnection) {
 			lb.notifyIfLeaderServingLocked(key, leaderConn)
 		}
 
-	case obs.LeaderTerm == existing.LeaderTerm:
-		// Same term — the leader is already known but may not have been
+	case cmp == 0:
+		// Same rule — the leader is already known but may not have been
 		// SERVING when we first saw the observation. Re-check now so that
 		// StopBuffering fires once the leader transitions to SERVING.
 		if leaderConn, ok := lb.connections[poolerIDString(existing.LeaderId)]; ok {
@@ -568,7 +571,7 @@ func (lb *LoadBalancer) Close() error {
 	lb.mu.Lock()
 	connections := lb.connections
 	lb.connections = make(map[string]*PoolerConnection)
-	lb.leaders = make(map[shardKey]*multipoolerservice.LeaderObservation)
+	lb.leaders = make(map[shardKey]*clustermetadatapb.LeaderObservation)
 	lb.mu.Unlock()
 
 	lb.logger.Info("closing all pooler connections", "count", len(connections))

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -110,7 +110,7 @@ func TestLoadBalancer_GetConnection_Primary(t *testing.T) {
 	connPrimary := lb.connections[poolerID(primary)]
 	lb.mu.Unlock()
 	simulateHealthUpdate(connPrimary, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: primary.Id, LeaderTerm: 1})
+		&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 	// Should find the primary via cache
 	target := &query.Target{
@@ -155,7 +155,7 @@ func TestLoadBalancer_GetConnection_CrossCellPrimary(t *testing.T) {
 	connRemote := lb.connections[poolerID(remotePrimary)]
 	lb.mu.Unlock()
 	simulateHealthUpdate(connRemote, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: remotePrimary.Id, LeaderTerm: 1})
+		&clustermetadatapb.LeaderObservation{LeaderId: remotePrimary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 	// Should find primary in remote cell via cache
 	target := &query.Target{
@@ -210,9 +210,9 @@ func TestLoadBalancer_GetConnection_ShardMatch(t *testing.T) {
 	connShard1 := lb.connections[poolerID(shard1)]
 	lb.mu.Unlock()
 	simulateHealthUpdate(connShard0, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: shard0.Id, LeaderTerm: 1})
+		&clustermetadatapb.LeaderObservation{LeaderId: shard0.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 	simulateHealthUpdate(connShard1, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: shard1.Id, LeaderTerm: 1})
+		&clustermetadatapb.LeaderObservation{LeaderId: shard1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 	// Request specific shard — should find correct primary via cache
 	target := &query.Target{
@@ -249,7 +249,7 @@ func TestLoadBalancer_Close(t *testing.T) {
 
 // simulateHealthUpdate simulates receiving a health update from the stream.
 // This uses the same code path as real health updates, ensuring any callbacks are triggered.
-func simulateHealthUpdate(conn *PoolerConnection, status clustermetadatapb.PoolerServingStatus, observation *multipoolerservice.LeaderObservation) {
+func simulateHealthUpdate(conn *PoolerConnection, status clustermetadatapb.PoolerServingStatus, observation *clustermetadatapb.LeaderObservation) {
 	info := conn.PoolerInfo()
 	conn.processHealthResponse(&multipoolerservice.StreamPoolerHealthResponse{
 		Target: &query.Target{
@@ -285,26 +285,17 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		// primary1 thinks primary1 is leader with term 5
 		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary1.Id,
-				LeaderTerm: 5,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
 
 		// primary2 thinks primary2 is leader with term 10 (higher)
 		simulateHealthUpdate(connPrimary2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary2.Id,
-				LeaderTerm: 10,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
 
 		// replica1 also thinks primary2 is leader with term 10
 		simulateHealthUpdate(connReplica1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary2.Id,
-				LeaderTerm: 10,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
 
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
@@ -337,26 +328,17 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		// primary1 thinks primary1 is leader with term 15
 		simulateHealthUpdate(connPrimary1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary1.Id,
-				LeaderTerm: 15,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 15}})
 
 		// primary2 thinks primary2 is leader with term 12 (stale)
 		simulateHealthUpdate(connPrimary2,
 			clustermetadatapb.PoolerServingStatus_NOT_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary2.Id,
-				LeaderTerm: 12,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 12}})
 
 		// replica1 observed the new leader (primary1) with term 20 (highest)
 		simulateHealthUpdate(connReplica1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary1.Id,
-				LeaderTerm: 20,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 20}})
 
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
@@ -405,10 +387,7 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		// observation.
 		simulateHealthUpdate(connPrimary,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   primary.Id,
-				LeaderTerm: 1,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: primary.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 		// Verify routing
 		target := &query.Target{
@@ -463,7 +442,7 @@ func TestLoadBalancer_HealthStreamOverridesSeed(t *testing.T) {
 	conn := lb.connections[poolerID(pooler)]
 	lb.mu.Unlock()
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: pooler.Id, LeaderTerm: 5})
+		&clustermetadatapb.LeaderObservation{LeaderId: pooler.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
 
 	// Topo update: type changed to REPLICA — but health-confirmed entry (term > 0) is NOT invalidated
 	poolerAsReplica := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
@@ -516,16 +495,10 @@ func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
 		// Both UNKNOWN poolers point to each other (pathological case)
 		simulateHealthUpdate(connUnknown1,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   unknown2.Id,
-				LeaderTerm: 10,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: unknown2.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 10}})
 		simulateHealthUpdate(connUnknown2,
 			clustermetadatapb.PoolerServingStatus_SERVING,
-			&multipoolerservice.LeaderObservation{
-				LeaderId:   unknown1.Id,
-				LeaderTerm: 5,
-			})
+			&clustermetadatapb.LeaderObservation{LeaderId: unknown1.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
 
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
@@ -633,10 +606,7 @@ func TestLoadBalancer_LeaderObservationBeforeConnection(t *testing.T) {
 	// observer reports that future-leader is the consensus leader at term 7.
 	simulateHealthUpdate(connObserver,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{
-			LeaderId:   futureLeader.Id,
-			LeaderTerm: 7,
-		})
+		&clustermetadatapb.LeaderObservation{LeaderId: futureLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 7}})
 
 	target := &query.Target{
 		TableGroup: constants.DefaultTableGroup,
@@ -679,10 +649,7 @@ func TestLoadBalancer_StalePrimaryTypeDoesNotEvict(t *testing.T) {
 	// post-failover state).
 	simulateHealthUpdate(connNewLeader,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{
-			LeaderId:   newLeader.Id,
-			LeaderTerm: 2,
-		})
+		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
 
 	target := &query.Target{
 		TableGroup: constants.DefaultTableGroup,
@@ -734,7 +701,7 @@ func TestLoadBalancer_ReplicaCandidatesExcludeLeader(t *testing.T) {
 	// a observes itself as leader; b and c are eligible replica candidates.
 	simulateHealthUpdate(connA,
 		clustermetadatapb.PoolerServingStatus_SERVING,
-		&multipoolerservice.LeaderObservation{LeaderId: a.Id, LeaderTerm: 1})
+		&clustermetadatapb.LeaderObservation{LeaderId: a.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
 
 	target := &query.Target{
 		TableGroup: constants.DefaultTableGroup,

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -53,9 +53,10 @@ type PoolerHealth struct {
 	// ServingStatus is the serving state reported by the pooler.
 	ServingStatus clustermetadatapb.PoolerServingStatus
 
-	// LeaderObservation contains the pooler's view of who the consensus leader is.
-	// Used for term-based leader reconciliation.
-	LeaderObservation *multipoolerservice.LeaderObservation
+	// LeaderObservation contains the pooler's view of who the consensus leader
+	// is, identified by leader id and the rule number under which the
+	// observation was made. Used for rule-number-based leader reconciliation.
+	LeaderObservation *clustermetadatapb.LeaderObservation
 
 	// ReplicationLagNs is the replication lag in nanoseconds reported by the pooler.
 	// Zero on the primary or when not yet measured.

--- a/go/services/multigateway/poolergateway/pooler_health_test.go
+++ b/go/services/multigateway/poolergateway/pooler_health_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
-	"github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/tools/prototest"
 )
 
 func TestPoolerHealth_IsServing(t *testing.T) {
@@ -87,10 +87,7 @@ func TestPoolerHealth_SimpleCopy(t *testing.T) {
 			Cell:      "zone1",
 			Name:      "pooler1",
 		}
-		primaryObs := &multipoolerservice.LeaderObservation{
-			LeaderId:   poolerID,
-			LeaderTerm: 42,
-		}
+		primaryObs := &clustermetadatapb.LeaderObservation{LeaderId: poolerID, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42}}
 		lastErr := errors.New("test error")
 		lastResp := time.Now()
 
@@ -107,10 +104,10 @@ func TestPoolerHealth_SimpleCopy(t *testing.T) {
 
 		// Verify all fields are copied
 		require.NotNil(t, copy)
-		assert.Equal(t, original.Target, copy.Target)
-		assert.Equal(t, original.PoolerID, copy.PoolerID)
+		prototest.AssertEqual(t, original.Target, copy.Target)
+		prototest.AssertEqual(t, original.PoolerID, copy.PoolerID)
 		assert.Equal(t, original.ServingStatus, copy.ServingStatus)
-		assert.Equal(t, original.LeaderObservation, copy.LeaderObservation)
+		prototest.AssertEqual(t, original.LeaderObservation, copy.LeaderObservation)
 		assert.Equal(t, original.LastError, copy.LastError)
 		assert.Equal(t, original.LastResponse, copy.LastResponse)
 

--- a/go/services/multigateway/poolergateway/pooler_streaming_test.go
+++ b/go/services/multigateway/poolergateway/pooler_streaming_test.go
@@ -384,13 +384,13 @@ func TestPoolerConnection_StreamHealth_LeaderObservation(t *testing.T) {
 
 	// Send a response with LeaderObservation.
 	resp := makeHealthResponse(clustermetadatapb.PoolerServingStatus_SERVING)
-	resp.LeaderObservation = &multipoolerservice.LeaderObservation{
+	resp.LeaderObservation = &clustermetadatapb.LeaderObservation{
 		LeaderId: &clustermetadatapb.ID{
 			Component: clustermetadatapb.ID_MULTIPOOLER,
 			Cell:      "zone1",
 			Name:      "primary-pooler",
 		},
-		LeaderTerm: 42,
+		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 42},
 	}
 	setup.server.responseCh <- resp
 
@@ -400,6 +400,6 @@ func TestPoolerConnection_StreamHealth_LeaderObservation(t *testing.T) {
 
 	health := setup.conn.Health()
 	require.NotNil(t, health.LeaderObservation)
-	assert.Equal(t, int64(42), health.LeaderObservation.LeaderTerm)
+	assert.Equal(t, int64(42), health.LeaderObservation.GetLeaderRuleNumber().GetCoordinatorTerm())
 	assert.Equal(t, "primary-pooler", health.LeaderObservation.LeaderId.GetName())
 }

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/servenv"
 	"github.com/multigres/multigres/go/common/sqltypes"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
 	multipoolerpb "github.com/multigres/multigres/go/pb/multipoolerservice"
 	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/connpoolmanager"
@@ -849,9 +850,13 @@ func healthStateToProto(state *poolerserver.HealthState) *multipoolerpb.StreamPo
 	}
 
 	if state.LeaderObservation != nil {
-		resp.LeaderObservation = &multipoolerpb.LeaderObservation{
-			LeaderId:   state.LeaderObservation.LeaderID,
-			LeaderTerm: state.LeaderObservation.LeaderTerm,
+		// The pooler still tracks the observation by integer term internally;
+		// map it onto the rule-number-based wire type with leader_subterm 0.
+		// TODO: drive this from the (rule, primary) consensus state directly so
+		// the rule number (including subterm) is carried end to end.
+		resp.LeaderObservation = &clustermetadatapb.LeaderObservation{
+			LeaderId:         state.LeaderObservation.LeaderID,
+			LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: state.LeaderObservation.LeaderTerm},
 		}
 	}
 

--- a/proto/clustermetadata.proto
+++ b/proto/clustermetadata.proto
@@ -461,14 +461,12 @@ message PoolerPosition {
 }
 
 // LeaderObservation represents a pooler's view of who the consensus leader is.
-// Stored on the leader's own MultiPooler topology record (self_leadership
-// field) so multigateway can bootstrap leader routing from etcd at discovery
-// time without relying on MultiPooler.type as a hint.
-//
-// Distinct from multipoolerservice.LeaderObservation, which carries the same
-// information on the multipooler health stream with an older (int64 leader_term)
-// shape. The two will eventually converge on this type via the gateway-routing
-// migration.
+// It is carried in two places:
+//   - the leader's own MultiPooler topology record (self_leadership field), so
+//     multigateway can bootstrap leader routing from etcd at discovery time
+//     without relying on MultiPooler.type as a hint; and
+//   - the multipooler health stream
+//     (StreamPoolerHealthResponse.leader_observation).
 message LeaderObservation {
   // leader_id is the ID of the pooler this node believes is the consensus leader.
   // May be this pooler's own ID if it believes itself to be leader.

--- a/proto/multipoolerservice.proto
+++ b/proto/multipoolerservice.proto
@@ -501,7 +501,7 @@ message StreamPoolerHealthResponse {
 
   // leader_observation contains this pooler's view of who the consensus leader is.
   // Used by clients to identify the true leader when multiple poolers exist.
-  LeaderObservation leader_observation = 4;
+  clustermetadata.LeaderObservation leader_observation = 4;
 
   // recommended_staleness_timeout is the duration clients should use
   // to detect a stale/dead health stream. If no message is received within
@@ -511,18 +511,6 @@ message StreamPoolerHealthResponse {
   // replication_lag_ns is the current replication lag in nanoseconds,
   // measured via heartbeat timestamps. Zero on a leader or when unknown.
   int64 replication_lag_ns = 6;
-}
-
-// LeaderObservation represents a pooler's view of who the consensus leader is.
-message LeaderObservation {
-  // leader_id is the ID of the pooler this node believes is the consensus leader.
-  // May be this pooler's own ID if it believes itself to be leader.
-  clustermetadata.ID leader_id = 1;
-
-  // leader_term is the consensus term at which this observation was made.
-  // The leader never changes within a leader_term. Higher values indicate
-  // more recent leader appointments.
-  int64 leader_term = 2;
 }
 
 // StreamNotificationsRequest subscribes to or unsubscribes from PG notification channels.


### PR DESCRIPTION
Point StreamPoolerHealthResponse.leader_observation at the existing clustermetadata.LeaderObservation (rule-number based) and delete the duplicate multipoolerservice.LeaderObservation (int64 leader_term). Pure refactor: the pooler still tracks the observation by integer term internally and maps it onto the wire type with leader_subterm 0; the gateway compares observations via the common consensus helpers (CompareRuleNumbers) instead of inspecting terms.

This lets the pooler (how the observation is populated) and the gateway (how it is consumed) evolve in parallel on a single shared type.