### PR TITLE
fix(multipooler): check reservation reasons in the portal stage-1 admission gate

### DIFF
--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -267,10 +267,12 @@ func (pg *PoolerGateway) PortalStreamExecute(
 	callback func(context.Context, *sqltypes.Result) error,
 ) (*query.ReservedState, error) {
 	var state *query.ReservedState
-	// A portal reserves a connection only as a suspendable cursor (MaxRows > 0);
-	// a fetch-all portal (MaxRows == 0) runs on a pooled connection and is a
-	// single query — mirrors the pooler's classification.
-	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), options.GetMaxRows() > 0), func(conn *PoolerConnection) error {
+	// A portal reserves a connection as a suspendable cursor (MaxRows > 0) or when
+	// it carries reservation reasons (e.g. a deferred BEGIN folded into the first
+	// portal); only a fetch-all portal with no reasons is a single query — mirrors
+	// the pooler's classification and the executor's reserve decision.
+	portalReserves := options.GetMaxRows() > 0 || reservationOptions.GetReasons() != 0
+	err := pg.withBuffering(ctx, target, isSingleQuery(options.GetReservedConnectionId(), portalReserves), func(conn *PoolerConnection) error {
 		var err error
 		state, err = conn.QueryService().PortalStreamExecute(ctx, target, preparedStatement, portal, options, portalOptions, reservationOptions, callback)
 		return err

--- a/go/services/multipooler/grpcpoolerservice/admission_test.go
+++ b/go/services/multipooler/grpcpoolerservice/admission_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/multigres/multigres/go/common/protoutil"
+	"github.com/multigres/multigres/go/pb/query"
 	"github.com/multigres/multigres/go/services/multipooler/internal/poolerserver"
 )
 
@@ -29,9 +31,10 @@ import (
 //   - id > 0          → ExistingReserved (ConcludeTransaction, DiscardTempTables,
 //     ReleaseReservedConnection, or any handler continuing a reserved conn)
 //   - id == 0, reserves → NewReservation (StreamExecute with reservation reasons,
-//     PortalStreamExecute with MaxRows > 0, CopyBidiExecute which always pins)
+//     PortalStreamExecute with MaxRows > 0 or reasons, CopyBidiExecute which
+//     always pins)
 //   - id == 0, !reserves → SingleQuery (StreamExecute without reasons,
-//     ExecuteQuery/Describe, PortalStreamExecute with MaxRows == 0)
+//     ExecuteQuery/Describe, fetch-all PortalStreamExecute with no reasons)
 func TestAdmissionKind(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -47,6 +50,35 @@ func TestAdmissionKind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, admissionKind(tt.connID, tt.reserves))
+		})
+	}
+}
+
+// TestPortalReserves locks the portal reserve predicate against the executor's
+// decision: a portal reserves on MaxRows > 0 OR reservation reasons. The reasons
+// case is the regression guard — a fetch-all portal (MaxRows == 0) that folds a
+// deferred BEGIN into its first execute carries ReasonTransaction and must NOT
+// be admitted as a single query during a graceful drain.
+func TestPortalReserves(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxRows uint64
+		reasons uint32
+		want    bool
+	}{
+		{"fetch-all, no reasons → single query", 0, 0, false},
+		{"suspendable cursor (MaxRows > 0)", 100, 0, true},
+		{"fetch-all with deferred BEGIN folded in (reasons set)", 0, protoutil.ReasonTransaction, true},
+		{"cursor and reasons", 100, protoutil.ReasonTransaction, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &query.ExecuteOptions{MaxRows: tt.maxRows}
+			var ro *query.ReservationOptions // nil when reasons == 0, exercising the nil-safe getter
+			if tt.reasons != 0 {
+				ro = &query.ReservationOptions{Reasons: tt.reasons}
+			}
+			assert.Equal(t, tt.want, portalReserves(opts, ro))
 		})
 	}
 }

--- a/go/services/multipooler/grpcpoolerservice/service.go
+++ b/go/services/multipooler/grpcpoolerservice/service.go
@@ -65,9 +65,9 @@ func RegisterPoolerServices(senv *servenv.ServEnv, grpc *servenv.GrpcServer) {
 // reserves reports whether the request will create a NEW reserved connection —
 // if not, it is a single autocommit query. Each handler computes reserves from
 // the signal it actually carries, mirroring the executor's own reservation
-// decision (reservation reasons for StreamExecute, MaxRows for portals, always
-// for COPY). The graceful drain serves single queries longer than new
-// reservations, so the distinction matters during shutdown.
+// decision (reservation reasons for StreamExecute, MaxRows or reasons for
+// portals, always for COPY). The graceful drain serves single queries longer
+// than new reservations, so the distinction matters during shutdown.
 func admissionKind(reservedConnID uint64, reserves bool) poolerserver.RequestKind {
 	switch {
 	case reservedConnID > 0:
@@ -77,6 +77,17 @@ func admissionKind(reservedConnID uint64, reserves bool) poolerserver.RequestKin
 	default:
 		return poolerserver.RequestSingleQuery
 	}
+}
+
+// portalReserves reports whether a PortalStreamExecute will use or create a
+// reserved connection, mirroring the executor's reserve decision exactly: a
+// suspendable cursor (MaxRows > 0) OR a portal carrying reservation reasons.
+// The reasons case is reachable on the extended-query path — a deferred BEGIN
+// is folded into the first portal as ReasonTransaction while MaxRows == 0 — so
+// checking MaxRows alone would mis-admit such a portal as a single query during
+// a graceful drain, and the executor would then open a reserved connection.
+func portalReserves(options *query.ExecuteOptions, reservationOptions *query.ReservationOptions) bool {
+	return options.GetMaxRows() > 0 || reservationOptions.GetReasons() != 0
 }
 
 // StreamExecute executes a SQL query and streams the results back to the client.
@@ -307,11 +318,12 @@ func (s *poolerService) Describe(ctx context.Context, req *multipoolerpb.Describ
 // PortalStreamExecute executes a portal (bound prepared statement) and streams results.
 // Used by multigateway for the Extended Query Protocol.
 func (s *poolerService) PortalStreamExecute(req *multipoolerpb.PortalStreamExecuteRequest, stream multipoolerpb.MultiPoolerService_PortalStreamExecuteServer) error {
-	// A portal reserves a connection only when it is a suspendable cursor
-	// (MaxRows > 0) or already on a reserved connection — this mirrors the
-	// executor's own reserve decision. A MaxRows == 0 portal (fetch-all) runs on
-	// a pooled connection, so it is a single query and may be served during stage 1.
-	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), req.Options.GetMaxRows() > 0)); err != nil {
+	// A portal reserves when it is a suspendable cursor (MaxRows > 0) or carries
+	// reservation reasons (e.g. a deferred BEGIN folded into the first portal),
+	// or is already on a reserved connection — this mirrors the executor's own
+	// reserve decision. Only a fetch-all portal with no reasons runs on a pooled
+	// connection as a single query and may be served during stage 1.
+	if err := s.pooler.StartRequest(req.Target, admissionKind(req.Options.GetReservedConnectionId(), portalReserves(req.Options, req.GetReservationOptions()))); err != nil {
 		return mterrors.ToGRPC(err)
 	}
 


### PR DESCRIPTION
## Problem

The two-stage graceful drain serves single autocommit queries during stage 1, gating each request on whether it will create a reserved connection. For `PortalStreamExecute` the gate only checked `MaxRows > 0`, but the executor reserves a connection on `MaxRows > 0` **or** non-zero reservation `reasons`.

This is reachable on the extended-query path: after a deferred `BEGIN`, the first portal folds the `BEGIN` in with `Reasons = ReasonTransaction` while `MaxRows == 0`. If a drain starts and that portal arrives during stage 1, the gate admits it as a single query, but the executor then opens a reserved connection — so the drain degrades to a force-close at `gracePeriod` instead of only serving autocommits.

(Found in review on #1122 by @haritabh17. Thank you!)

## Solution

Mirror the executor's reserve decision (`MaxRows > 0 || reasons != 0`) in both gates:

- Pooler admission gate (`grpcpoolerservice`): extract a `portalReserves(options, reservationOptions)` helper and use it to compute the `RequestKind`, so a reasons-carrying portal is classified as a new reservation and rejected/buffered during the drain.
- Gateway (`poolergateway`): apply the same check in `PortalStreamExecute` so a reserving portal is proactively buffered rather than sent through.

Adds `TestPortalReserves` covering the regression scenario (fetch-all portal with a folded-in `BEGIN`).