### PR TITLE
feat(multigateway): resolve dynamic-name set_config for pg_dump

### DIFF
--- a/go/common/sqltypes/sqltypes.go
+++ b/go/common/sqltypes/sqltypes.go
@@ -87,6 +87,8 @@
 package sqltypes
 
 import (
+	"strings"
+
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/pb/query"
 )
@@ -98,6 +100,33 @@ type Value []byte
 // IsNull returns true if the value is NULL.
 func (v Value) IsNull() bool {
 	return v == nil
+}
+
+// IsTrue interprets the value as PostgreSQL's text encoding of a boolean and
+// reports whether it is true. NULL and any unrecognized encoding are false.
+// The accepted spellings mirror PostgreSQL's boolin() —
+// t/true/y/yes/on/1, case-insensitive.
+func (v Value) IsTrue() bool {
+	if v.IsNull() {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(string(v))) {
+	case "t", "true", "y", "yes", "on", "1":
+		return true
+	}
+	return false
+}
+
+// SQLLiteral renders the value as a SQL literal: a single-quoted, escaped
+// string literal for a non-NULL value (embedded single quotes doubled, the
+// standard_conforming_strings form), or the keyword NULL. The value is treated
+// as text — a numeric or boolean value is rendered as a quoted string, which
+// PostgreSQL coerces at the call site.
+func (v Value) SQLLiteral() string {
+	if v.IsNull() {
+		return "NULL"
+	}
+	return "'" + strings.ReplaceAll(string(v), "'", "''") + "'"
 }
 
 // Row represents a row with nullable column values.

--- a/go/common/sqltypes/sqltypes_test.go
+++ b/go/common/sqltypes/sqltypes_test.go
@@ -54,6 +54,56 @@ func TestValueIsNull(t *testing.T) {
 	}
 }
 
+func TestValueIsTrue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    Value
+		expected bool
+	}{
+		{"nil is false", nil, false},
+		{"empty is false", Value{}, false},
+		{"t is true", Value("t"), true},
+		{"true is true", Value("true"), true},
+		{"uppercase TRUE is true", Value("TRUE"), true},
+		{"on is true", Value("on"), true},
+		{"1 is true", Value("1"), true},
+		{"y is true", Value("y"), true},
+		{"padded t is true", Value("  t  "), true},
+		{"f is false", Value("f"), false},
+		{"false is false", Value("false"), false},
+		{"0 is false", Value("0"), false},
+		{"unrecognized is false", Value("maybe"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.value.IsTrue())
+		})
+	}
+}
+
+func TestValueSQLLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    Value
+		expected string
+	}{
+		{"nil is NULL keyword", nil, "NULL"},
+		{"empty string", Value{}, "''"},
+		{"plain text", Value("hello"), "'hello'"},
+		{"value with comma", Value("view, foreign-table"), "'view, foreign-table'"},
+		{"single quote is doubled", Value("O'Brien"), "'O''Brien'"},
+		{"multiple single quotes", Value("a'b'c"), "'a''b''c'"},
+		{"numeric rendered as string", Value("256"), "'256'"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.value.SQLLiteral())
+		})
+	}
+}
+
 func TestRowToProtoAndBack(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/go/services/multigateway/engine/plan.go
+++ b/go/services/multigateway/engine/plan.go
@@ -27,20 +27,21 @@ import (
 
 // Plan type constants identify the root primitive for observability.
 const (
-	PlanTypeRoute               = "Route"
-	PlanTypeTransaction         = "Transaction"
-	PlanTypeCopyStatement       = "CopyStatement"
-	PlanTypeApplySessionState   = "ApplySessionState"
-	PlanTypeGatewaySessionState = "GatewaySessionState"
-	PlanTypeGatewayShowVariable = "GatewayShowVariable"
-	PlanTypeListenNotify        = "ListenNotify"
-	PlanTypeSequence            = "Sequence"
-	PlanTypeTempTableRoute      = "TempTableRoute"
-	PlanTypeAdvisoryLockRoute   = "AdvisoryLockRoute"
-	PlanTypeHoldCursorRoute     = "HoldCursorRoute"
-	PlanTypeCloseCursorRoute    = "CloseCursorRoute"
-	PlanTypeDiscardAll          = "DiscardAll"
-	PlanTypeUnknown             = "Unknown"
+	PlanTypeRoute                 = "Route"
+	PlanTypeTransaction           = "Transaction"
+	PlanTypeCopyStatement         = "CopyStatement"
+	PlanTypeApplySessionState     = "ApplySessionState"
+	PlanTypeResolveTrackSetConfig = "ResolveTrackSetConfig"
+	PlanTypeGatewaySessionState   = "GatewaySessionState"
+	PlanTypeGatewayShowVariable   = "GatewayShowVariable"
+	PlanTypeListenNotify          = "ListenNotify"
+	PlanTypeSequence              = "Sequence"
+	PlanTypeTempTableRoute        = "TempTableRoute"
+	PlanTypeAdvisoryLockRoute     = "AdvisoryLockRoute"
+	PlanTypeHoldCursorRoute       = "HoldCursorRoute"
+	PlanTypeCloseCursorRoute      = "CloseCursorRoute"
+	PlanTypeDiscardAll            = "DiscardAll"
+	PlanTypeUnknown               = "Unknown"
 )
 
 // Plan represents a query execution plan.

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -251,6 +251,14 @@ func (s *ResolveTrackSetConfig) buildApplySQL(rows []*sqltypes.Row) (string, err
 // SessionSettings. A NULL value resets the GUC to its default
 // (set_config(name, NULL, false) semantics); a NULL name is skipped (the apply
 // query would already have raised PostgreSQL's error).
+//
+// It calls SetSessionVariable / ResetSessionVariable directly — the same
+// methods ApplySessionState.executeSet/executeReset call — rather than
+// constructing ApplySessionState primitives per tuple. Those primitives do
+// nothing more than these calls, so wrapping each runtime-resolved tuple in a
+// synthetic VariableSetStmt + primitive would be more code for identical
+// behavior. This also matches how the literal `SELECT set_config(...)` path
+// tracks (plain ApplySessionState → SetSessionVariable, no revalidation).
 func (s *ResolveTrackSetConfig) track(state *handler.MultiGatewayConnectionState, rows []*sqltypes.Row) {
 	numCalls := len(s.Aliases)
 	for _, row := range rows {

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/parser/ast"
+	"github.com/multigres/multigres/go/common/pgprotocol/server"
+	"github.com/multigres/multigres/go/common/preparedstatement"
+	"github.com/multigres/multigres/go/common/sqltypes"
+	"github.com/multigres/multigres/go/pb/query"
+	"github.com/multigres/multigres/go/services/multigateway/handler"
+)
+
+// ResolveTrackSetConfig handles a SELECT whose target list is entirely
+// set_config(...) calls where at least one argument can't be resolved at plan
+// time — the shape pg_dump uses on PG17+:
+//
+//	SELECT set_config(name, 'view, foreign-table', false)
+//	FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'
+//
+// A session-scoped (is_local=false) set_config must be tracked in
+// SessionSettings so it survives pool rotation, which needs the concrete GUC
+// name — but here the name is a column reference resolved per row. Rather than
+// reject it (or pin the connection), this primitive runs in three steps:
+//
+//  1. Resolve: execute the "unroll" projection — the original SELECT with each
+//     set_config(a, b, c) target replaced by its three arguments a, b, c — once.
+//     This is a pure read (no set_config side effect) that yields the concrete
+//     (name, value, is_local) tuple per row.
+//  2. Apply: synthesize a set_config(...) query from the *captured literals* and
+//     run it, forwarding PostgreSQL's authoritative result to the client. Using
+//     the captured literals — not a re-run of the original dynamic query — is
+//     essential: the original could resolve to different rows/values the second
+//     time (concurrent catalog change, volatile FROM).
+//  3. Track: record the session-scoped (is_local=false) tuples in
+//     SessionSettings for pool-rotation replay. is_local=true tuples were
+//     applied by step 2 but are transaction-scoped and deliberately not tracked.
+//
+// Zero resolved rows (e.g. a WHERE that matches nothing — a GUC absent on this
+// server version) means nothing is set and the client gets an empty result,
+// matching stock PostgreSQL.
+type ResolveTrackSetConfig struct {
+	// TableGroup is the target tablegroup for the resolve and apply queries.
+	TableGroup string
+
+	// Shard is the target shard (empty for unsharded).
+	Shard string
+
+	// Query is the original SQL string, kept for GetQuery/debug output.
+	Query string
+
+	// UnrollAST is the cloned SELECT with its target list replaced by the flat
+	// projection of every set_config call's (name, value, is_local) arguments.
+	// Non-set_config literals are $N ParamRefs: on the simple protocol they are
+	// resolved from the normalizer's bindVars, on the portal protocol from the
+	// portal's Bind values.
+	UnrollAST ast.Stmt
+
+	// Aliases holds the per-call output-column alias in target-list order
+	// (ResTarget.Name, "" when the call had no AS). len(Aliases) is the number
+	// of set_config calls; the unroll result has three columns per call.
+	Aliases []string
+}
+
+// NewResolveTrackSetConfig creates a new ResolveTrackSetConfig primitive.
+func NewResolveTrackSetConfig(tableGroup, shard, sql string, unrollAST ast.Stmt, aliases []string) *ResolveTrackSetConfig {
+	return &ResolveTrackSetConfig{
+		TableGroup: tableGroup,
+		Shard:      shard,
+		Query:      sql,
+		UnrollAST:  unrollAST,
+		Aliases:    aliases,
+	}
+}
+
+// StreamExecute runs the resolve/apply/track flow on the simple-query-protocol
+// path, where non-set_config literals arrive as bindVars from the normalizer.
+func (s *ResolveTrackSetConfig) StreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	bindVars []*ast.A_Const,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	return s.execute(ctx, exec, conn, state, bindVars, callback)
+}
+
+// PortalStreamExecute runs the same flow on the extended-protocol path. The
+// unroll's $N placeholders are the user's prepared-statement parameters, so we
+// decode them from the portal's Bind values into literals before reconstructing
+// the projection SQL.
+func (s *ResolveTrackSetConfig) PortalStreamExecute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	portalInfo *preparedstatement.PortalInfo,
+	_ int32,
+	_ bool,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	bindVars, err := s.bindVarsFromPortal(portalInfo)
+	if err != nil {
+		return err
+	}
+	return s.execute(ctx, exec, conn, state, bindVars, callback)
+}
+
+// execute drives resolve → apply → track. bindVars resolves any $N ParamRefs
+// in the unroll projection (empty when there are none).
+func (s *ResolveTrackSetConfig) execute(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	bindVars []*ast.A_Const,
+	callback func(context.Context, *sqltypes.Result) error,
+) error {
+	rows, err := s.resolve(ctx, exec, conn, state, s.unrollSQL(bindVars))
+	if err != nil {
+		return err
+	}
+
+	// Nothing matched: no GUC is set and the client sees an empty result with
+	// the original's columns, exactly as stock PostgreSQL would respond.
+	if len(rows) == 0 {
+		return callback(ctx, s.emptyResult())
+	}
+
+	// Apply every resolved tuple with literals (is_local := true — see
+	// buildApplySQL) and forward PostgreSQL's authoritative result to the client.
+	applySQL, err := s.buildApplySQL(rows)
+	if err != nil {
+		return err
+	}
+	if err := exec.StreamExecute(ctx, conn, s.TableGroup, s.Shard, applySQL, nil, state, callback); err != nil {
+		return err
+	}
+
+	// Track the session-scoped settings only after a successful apply, so we
+	// never record a setting PostgreSQL rejected.
+	s.track(state, rows)
+	return nil
+}
+
+// resolve runs the unroll projection and accumulates its rows. The result is
+// consumed internally (never forwarded to the client). Each row must have
+// three columns per set_config call.
+func (s *ResolveTrackSetConfig) resolve(
+	ctx context.Context,
+	exec IExecute,
+	conn *server.Conn,
+	state *handler.MultiGatewayConnectionState,
+	unrollSQL string,
+) ([]*sqltypes.Row, error) {
+	var rows []*sqltypes.Row
+	err := exec.StreamExecute(ctx, conn, s.TableGroup, s.Shard, unrollSQL, nil, state,
+		func(_ context.Context, res *sqltypes.Result) error {
+			rows = append(rows, res.Rows...)
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	want := len(s.Aliases) * 3
+	for _, r := range rows {
+		if len(r.Values) != want {
+			// The unroll projects exactly three columns per set_config call, so a
+			// mismatch means the plan and the executed projection disagree — a bug.
+			return nil, mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+				"internal error resolving set_config (please report this as a bug)",
+				fmt.Sprintf("expected %d columns in the projection result, got %d", want, len(r.Values)))
+		}
+	}
+	return rows, nil
+}
+
+// buildApplySQL synthesizes a query that re-runs each set_config call with the
+// captured literal arguments, reproducing the original's columns (and aliases)
+// and one row per resolved row. Rows are combined with UNION ALL, which takes
+// its column names from the first leg — so aliases are emitted on the first row
+// only.
+//
+// Every call is applied with is_local := true regardless of the captured
+// is_local, because the multipooler is the sole authority on session GUC state
+// (see also ValidateSetting). A session-scoped (is_local=false) set_config that
+// persisted on the pooled backend would leak across clients when the backend is
+// reused — the multipooler doesn't track raw set_config mutations. So the apply
+// only needs to *return* the authoritative value (set_config returns the value
+// it set even under GUC_ACTION_LOCAL, which reverts at statement end), while
+// persistence for session-scoped settings is delivered by track() →
+// SessionSettings replay. A genuinely is_local=true call is correct as-is, and
+// a tracked is_local=false call is re-applied on every subsequent query by the
+// replay path.
+func (s *ResolveTrackSetConfig) buildApplySQL(rows []*sqltypes.Row) (string, error) {
+	numCalls := len(s.Aliases)
+	legs := make([]string, 0, len(rows))
+	for ri, row := range rows {
+		targets := make([]string, 0, numCalls)
+		for ci := range numCalls {
+			name := row.Values[ci*3]
+			value := row.Values[ci*3+1]
+			call := fmt.Sprintf("set_config(%s, %s, true)",
+				name.SQLLiteral(), value.SQLLiteral())
+			if ri == 0 && s.Aliases[ci] != "" {
+				call += " AS " + ast.QuoteIdentifier(s.Aliases[ci])
+			}
+			targets = append(targets, call)
+		}
+		legs = append(legs, "SELECT "+strings.Join(targets, ", "))
+	}
+	return strings.Join(legs, " UNION ALL "), nil
+}
+
+// track records the session-scoped (is_local=false) resolved tuples in
+// SessionSettings. A NULL value resets the GUC to its default
+// (set_config(name, NULL, false) semantics); a NULL name is skipped (the apply
+// query would already have raised PostgreSQL's error).
+func (s *ResolveTrackSetConfig) track(state *handler.MultiGatewayConnectionState, rows []*sqltypes.Row) {
+	numCalls := len(s.Aliases)
+	for _, row := range rows {
+		for ci := range numCalls {
+			name := row.Values[ci*3]
+			value := row.Values[ci*3+1]
+			isLocal := row.Values[ci*3+2]
+			if name.IsNull() || isLocal.IsTrue() {
+				continue
+			}
+			if value.IsNull() {
+				state.ResetSessionVariable(string(name))
+				continue
+			}
+			state.SetSessionVariable(string(name), string(value))
+		}
+	}
+}
+
+// emptyResult builds a zero-row result carrying the original's columns (text),
+// used when the unroll projection matched no rows.
+func (s *ResolveTrackSetConfig) emptyResult() *sqltypes.Result {
+	fields := make([]*query.Field, len(s.Aliases))
+	for i, alias := range s.Aliases {
+		name := alias
+		if name == "" {
+			name = "set_config"
+		}
+		fields[i] = &query.Field{Name: name, Type: "text", DataTypeOid: uint32(ast.TEXTOID)}
+	}
+	return &sqltypes.Result{
+		Fields:     fields,
+		CommandTag: "SELECT 0",
+	}
+}
+
+// unrollSQL reconstructs the projection SQL, substituting bindVars into any $N
+// placeholders (mirrors Route.StreamExecute).
+func (s *ResolveTrackSetConfig) unrollSQL(bindVars []*ast.A_Const) string {
+	if len(bindVars) > 0 {
+		return ast.ReconstructSQL(s.UnrollAST, bindVars)
+	}
+	return s.UnrollAST.SqlString()
+}
+
+// bindVarsFromPortal decodes the portal's Bind values for every $N referenced
+// in the unroll projection, returning them positionally (index 0 is $1) so
+// ReconstructSQL can substitute them. Returns nil when the projection has no
+// parameters.
+func (s *ResolveTrackSetConfig) bindVarsFromPortal(portalInfo *preparedstatement.PortalInfo) ([]*ast.A_Const, error) {
+	maxNum := 0
+	var refs []*ast.ParamRef
+	ast.Rewrite(s.UnrollAST, func(cursor *ast.Cursor) bool {
+		if pr, ok := cursor.Node().(*ast.ParamRef); ok {
+			refs = append(refs, pr)
+			if pr.Number > maxNum {
+				maxNum = pr.Number
+			}
+		}
+		return true
+	}, nil)
+	if maxNum == 0 {
+		return nil, nil
+	}
+	bindVars := make([]*ast.A_Const, maxNum)
+	for _, pr := range refs {
+		text, err := preparedstatement.DecodeBindAsText(portalInfo, pr, "set_config resolve projection parameter")
+		if err != nil {
+			return nil, err
+		}
+		bindVars[pr.Number-1] = ast.NewA_Const(ast.NewString(text), 0)
+	}
+	return bindVars, nil
+}
+
+// GetTableGroup returns the target tablegroup.
+func (s *ResolveTrackSetConfig) GetTableGroup() string {
+	return s.TableGroup
+}
+
+// GetQuery returns the original SQL string.
+func (s *ResolveTrackSetConfig) GetQuery() string {
+	return s.Query
+}
+
+// String returns a description for debugging.
+func (s *ResolveTrackSetConfig) String() string {
+	return fmt.Sprintf("ResolveTrackSetConfig(%s)", s.Query)
+}
+
+// Ensure ResolveTrackSetConfig implements Primitive.
+var _ Primitive = (*ResolveTrackSetConfig)(nil)

--- a/go/services/multigateway/engine/resolve_set_config.go
+++ b/go/services/multigateway/engine/resolve_set_config.go
@@ -41,9 +41,12 @@ import (
 // reject it (or pin the connection), this primitive runs in three steps:
 //
 //  1. Resolve: execute the "unroll" projection — the original SELECT with each
-//     set_config(a, b, c) target replaced by its three arguments a, b, c — once.
-//     This is a pure read (no set_config side effect) that yields the concrete
-//     (name, value, is_local) tuple per row.
+//     set_config(a, b, c) target replaced by its three arguments a, b, c — once,
+//     reading the rows internally. This is a pure read that yields the concrete
+//     (name, value, is_local) tuple per row. It runs through ResolveRoute, an
+//     ordinary Route (or an AdvisoryLockRoute when a set_config argument
+//     acquires/releases a session advisory lock), so backend pinning and
+//     bindVar reconstruction reuse the existing routing machinery.
 //  2. Apply: synthesize a set_config(...) query from the *captured literals* and
 //     run it, forwarding PostgreSQL's authoritative result to the client. Using
 //     the captured literals — not a re-run of the original dynamic query — is
@@ -57,7 +60,7 @@ import (
 // server version) means nothing is set and the client gets an empty result,
 // matching stock PostgreSQL.
 type ResolveTrackSetConfig struct {
-	// TableGroup is the target tablegroup for the resolve and apply queries.
+	// TableGroup is the target tablegroup for the apply query.
 	TableGroup string
 
 	// Shard is the target shard (empty for unsharded).
@@ -66,12 +69,19 @@ type ResolveTrackSetConfig struct {
 	// Query is the original SQL string, kept for GetQuery/debug output.
 	Query string
 
-	// UnrollAST is the cloned SELECT with its target list replaced by the flat
-	// projection of every set_config call's (name, value, is_local) arguments.
-	// Non-set_config literals are $N ParamRefs: on the simple protocol they are
-	// resolved from the normalizer's bindVars, on the portal protocol from the
-	// portal's Bind values.
-	UnrollAST ast.Stmt
+	// ResolveRoute runs the unroll projection. It is a Route, or an
+	// AdvisoryLockRoute wrapping one when the projection acquires/releases a
+	// session-level advisory lock — so opts/advisory pinning and $N bindVar
+	// reconstruction flow through the same primitives as ordinary queries. It is
+	// executed with a capturing callback: the resolve reads the rows, the client
+	// never sees them.
+	ResolveRoute Primitive
+
+	// unrollAST is the projection's AST. ResolveRoute already holds it for
+	// execution; we keep a reference only to enumerate $N parameters on the
+	// extended-protocol path, where the portal's Bind values must be decoded
+	// before ResolveRoute can reconstruct the SQL.
+	unrollAST ast.Stmt
 
 	// Aliases holds the per-call output-column alias in target-list order
 	// (ResTarget.Name, "" when the call had no AS). len(Aliases) is the number
@@ -80,13 +90,17 @@ type ResolveTrackSetConfig struct {
 }
 
 // NewResolveTrackSetConfig creates a new ResolveTrackSetConfig primitive.
-func NewResolveTrackSetConfig(tableGroup, shard, sql string, unrollAST ast.Stmt, aliases []string) *ResolveTrackSetConfig {
+// resolveRoute runs the unroll projection (built by the planner via
+// routePrimitive so advisory-lock pinning is folded in); unrollAST is the same
+// projection AST, used to enumerate parameters on the portal path.
+func NewResolveTrackSetConfig(tableGroup, shard, sql string, resolveRoute Primitive, unrollAST ast.Stmt, aliases []string) *ResolveTrackSetConfig {
 	return &ResolveTrackSetConfig{
-		TableGroup: tableGroup,
-		Shard:      shard,
-		Query:      sql,
-		UnrollAST:  unrollAST,
-		Aliases:    aliases,
+		TableGroup:   tableGroup,
+		Shard:        shard,
+		Query:        sql,
+		ResolveRoute: resolveRoute,
+		unrollAST:    unrollAST,
+		Aliases:      aliases,
 	}
 }
 
@@ -105,8 +119,8 @@ func (s *ResolveTrackSetConfig) StreamExecute(
 
 // PortalStreamExecute runs the same flow on the extended-protocol path. The
 // unroll's $N placeholders are the user's prepared-statement parameters, so we
-// decode them from the portal's Bind values into literals before reconstructing
-// the projection SQL.
+// decode them from the portal's Bind values into literals; ResolveRoute then
+// reconstructs the projection SQL from them, exactly as on the simple path.
 func (s *ResolveTrackSetConfig) PortalStreamExecute(
 	ctx context.Context,
 	exec IExecute,
@@ -134,7 +148,7 @@ func (s *ResolveTrackSetConfig) execute(
 	bindVars []*ast.A_Const,
 	callback func(context.Context, *sqltypes.Result) error,
 ) error {
-	rows, err := s.resolve(ctx, exec, conn, state, s.unrollSQL(bindVars))
+	rows, err := s.resolve(ctx, exec, conn, state, bindVars)
 	if err != nil {
 		return err
 	}
@@ -161,18 +175,21 @@ func (s *ResolveTrackSetConfig) execute(
 	return nil
 }
 
-// resolve runs the unroll projection and accumulates its rows. The result is
-// consumed internally (never forwarded to the client). Each row must have
-// three columns per set_config call.
+// resolve runs the unroll projection through ResolveRoute and accumulates its
+// rows. The result is consumed internally via the capturing callback (never
+// forwarded to the client). Running through ResolveRoute means any
+// advisory-lock pinning and $N bindVar reconstruction happen in the existing
+// Route/AdvisoryLockRoute primitives. Each row must have three columns per
+// set_config call.
 func (s *ResolveTrackSetConfig) resolve(
 	ctx context.Context,
 	exec IExecute,
 	conn *server.Conn,
 	state *handler.MultiGatewayConnectionState,
-	unrollSQL string,
+	bindVars []*ast.A_Const,
 ) ([]*sqltypes.Row, error) {
 	var rows []*sqltypes.Row
-	err := exec.StreamExecute(ctx, conn, s.TableGroup, s.Shard, unrollSQL, nil, state,
+	err := s.ResolveRoute.StreamExecute(ctx, exec, conn, state, bindVars,
 		func(_ context.Context, res *sqltypes.Result) error {
 			rows = append(rows, res.Rows...)
 			return nil
@@ -270,23 +287,14 @@ func (s *ResolveTrackSetConfig) emptyResult() *sqltypes.Result {
 	}
 }
 
-// unrollSQL reconstructs the projection SQL, substituting bindVars into any $N
-// placeholders (mirrors Route.StreamExecute).
-func (s *ResolveTrackSetConfig) unrollSQL(bindVars []*ast.A_Const) string {
-	if len(bindVars) > 0 {
-		return ast.ReconstructSQL(s.UnrollAST, bindVars)
-	}
-	return s.UnrollAST.SqlString()
-}
-
 // bindVarsFromPortal decodes the portal's Bind values for every $N referenced
 // in the unroll projection, returning them positionally (index 0 is $1) so
-// ReconstructSQL can substitute them. Returns nil when the projection has no
+// ResolveRoute can substitute them. Returns nil when the projection has no
 // parameters.
 func (s *ResolveTrackSetConfig) bindVarsFromPortal(portalInfo *preparedstatement.PortalInfo) ([]*ast.A_Const, error) {
 	maxNum := 0
 	var refs []*ast.ParamRef
-	ast.Rewrite(s.UnrollAST, func(cursor *ast.Cursor) bool {
+	ast.Rewrite(s.unrollAST, func(cursor *ast.Cursor) bool {
 		if pr, ok := cursor.Node().(*ast.ParamRef); ok {
 			refs = append(refs, pr)
 			if pr.Number > maxNum {

--- a/go/services/multigateway/planner/planner.go
+++ b/go/services/multigateway/planner/planner.go
@@ -186,7 +186,7 @@ func (p *Planner) Plan(
 		if ss.IntoClause != nil && ss.IntoClause.Rel != nil && ss.IntoClause.Rel.RelPersistence == ast.RELPERSISTENCE_TEMP {
 			return p.planTempTableCreation(sql, conn)
 		}
-		plan, err = p.planSelectStmt(sql, ss, conn, analysis.SetConfigs, opts)
+		plan, err = p.planSelectStmt(sql, ss, conn, analysis.SetConfigs, analysis.DynamicSetConfig, opts)
 
 	case ast.T_ViewStmt:
 		if vs := stmt.(*ast.ViewStmt); vs.View != nil && vs.View.RelPersistence == ast.RELPERSISTENCE_TEMP {
@@ -442,6 +442,8 @@ func primitiveName(p engine.Primitive) string {
 		return engine.PlanTypeCopyStatement
 	case *engine.ApplySessionState:
 		return engine.PlanTypeApplySessionState
+	case *engine.ResolveTrackSetConfig:
+		return engine.PlanTypeResolveTrackSetConfig
 	case *engine.GatewaySessionState:
 		return engine.PlanTypeGatewaySessionState
 	case *engine.GatewayShowVariable:

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -17,6 +17,8 @@ package planner
 import (
 	"fmt"
 
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 	"github.com/multigres/multigres/go/common/pgprotocol/server"
 	"github.com/multigres/multigres/go/services/multigateway/engine"
@@ -49,8 +51,12 @@ func (p *Planner) planSelectStmt(
 	stmt *ast.SelectStmt,
 	conn *server.Conn,
 	setConfigs []setConfigCall,
+	dynamicSetConfig bool,
 	opts PlannerOptions,
 ) (*engine.Plan, error) {
+	if dynamicSetConfig {
+		return p.planResolveSetConfig(sql, stmt)
+	}
 	if len(setConfigs) == 0 {
 		return p.planDefault(sql, stmt, conn, opts)
 	}
@@ -75,6 +81,79 @@ func (p *Planner) planSelectStmt(
 	// ApplySessionState primitives above) and pins the backend for the lock.
 	primitives = append(primitives, p.routePrimitive(sql, stmt, opts))
 	return engine.NewPlan(sql, engine.NewSequence(primitives)), nil
+}
+
+// planResolveSetConfig plans a SELECT whose target list is entirely
+// set_config(...) calls where at least one argument can't be resolved at plan
+// time (the analyzer set DynamicSetConfig). We can't mint a literal SET to
+// track, so the plan is a single ResolveTrackSetConfig primitive that:
+//
+//  1. runs an "unroll" projection — the SELECT with each set_config(a, b, c)
+//     target replaced by its three arguments a, b, c — once, to learn the
+//     concrete (name, value, is_local) tuples per row (pure read, no
+//     set_config side effect);
+//  2. tracks the session-scoped (is_local=false) tuples in SessionSettings so
+//     they survive pool rotation;
+//  3. applies all tuples with literals (a synthesized set_config(...) over the
+//     captured values) and forwards that authoritative result to the client.
+//
+// Running the projection once is essential: re-running the original dynamic
+// query could resolve to different rows/values (concurrent catalog change,
+// volatile FROM), so the first resolution is the source of truth.
+func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt) (*engine.Plan, error) {
+	// Clone before mutating: the AST may be a cached plan's normalized tree
+	// shared across executions.
+	unroll := ast.CloneRefOfSelectStmt(stmt)
+
+	aliases, err := rewriteToUnrollProjection(unroll)
+	if err != nil {
+		return nil, err
+	}
+
+	prim := engine.NewResolveTrackSetConfig(p.defaultTableGroup, constants.DefaultShard, sql, unroll, aliases)
+	return engine.NewPlan(sql, prim), nil
+}
+
+// rewriteToUnrollProjection rewrites ss in place: its target list (already
+// validated by the analyzer to be entirely set_config(name, value, is_local)
+// calls) is replaced with a flat projection of every call's three arguments,
+// in order. The FROM/WHERE/GROUP BY/... clauses are kept verbatim so the
+// projection resolves the same rows the original would have. It returns the
+// per-call output-column aliases (ResTarget.Name, "" when the call had no
+// explicit AS) so the apply step can reproduce the original's column names.
+func rewriteToUnrollProjection(ss *ast.SelectStmt) ([]string, error) {
+	if ss.TargetList == nil || ss.TargetList.Len() == 0 {
+		return nil, resolveSetConfigBug("target list is empty")
+	}
+
+	aliases := make([]string, 0, ss.TargetList.Len())
+	projected := ast.NewNodeList()
+	for _, item := range ss.TargetList.Items {
+		rt, ok := item.(*ast.ResTarget)
+		if !ok {
+			return nil, resolveSetConfigBug(fmt.Sprintf("target is a %T, not a ResTarget", item))
+		}
+		fc, ok := rt.Val.(*ast.FuncCall)
+		if !ok || fc.Args == nil || fc.Args.Len() != 3 {
+			return nil, resolveSetConfigBug("target is not a three-argument set_config call")
+		}
+		aliases = append(aliases, rt.Name)
+		for _, arg := range fc.Args.Items {
+			projected.Append(ast.NewResTarget("", arg))
+		}
+	}
+	ss.TargetList = projected
+	return aliases, nil
+}
+
+// resolveSetConfigBug builds an internal-error diagnostic for an invariant the
+// analyzer was supposed to guarantee before the planner reached this code (the
+// target list being entirely three-argument set_config calls). Reaching it
+// means analyzer and planner disagree — a bug — so it surfaces as SQLSTATE
+// XX000 with a report-this-bug hint rather than a bare Go error.
+func resolveSetConfigBug(detail string) error {
+	return mterrors.NewPgError("ERROR", mterrors.PgSSInternalError,
+		"internal error building set_config plan (please report this as a bug)", detail)
 }
 
 // syntheticSetStmt builds a VariableSetStmt equivalent to `SET name = value`

--- a/go/services/multigateway/planner/select_stmt.go
+++ b/go/services/multigateway/planner/select_stmt.go
@@ -55,7 +55,7 @@ func (p *Planner) planSelectStmt(
 	opts PlannerOptions,
 ) (*engine.Plan, error) {
 	if dynamicSetConfig {
-		return p.planResolveSetConfig(sql, stmt)
+		return p.planResolveSetConfig(sql, stmt, opts)
 	}
 	if len(setConfigs) == 0 {
 		return p.planDefault(sql, stmt, conn, opts)
@@ -100,7 +100,13 @@ func (p *Planner) planSelectStmt(
 // Running the projection once is essential: re-running the original dynamic
 // query could resolve to different rows/values (concurrent catalog change,
 // volatile FROM), so the first resolution is the source of truth.
-func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt) (*engine.Plan, error) {
+//
+// opts carries advisory-lock pinning intent. A set_config argument can itself
+// acquire a session-level advisory lock (e.g.
+// set_config('x', pg_try_advisory_lock(1)::text, false)); that call runs when
+// the resolve projection evaluates the arguments, so the primitive must pin the
+// backend the same way routePrimitive would for an ordinary query.
+func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt, opts PlannerOptions) (*engine.Plan, error) {
 	// Clone before mutating: the AST may be a cached plan's normalized tree
 	// shared across executions.
 	unroll := ast.CloneRefOfSelectStmt(stmt)
@@ -110,7 +116,13 @@ func (p *Planner) planResolveSetConfig(sql string, stmt *ast.SelectStmt) (*engin
 		return nil, err
 	}
 
-	prim := engine.NewResolveTrackSetConfig(p.defaultTableGroup, constants.DefaultShard, sql, unroll, aliases)
+	// The resolve projection runs through the ordinary routing primitive, so
+	// opts (advisory-lock pinning) and bindVar reconstruction are handled by the
+	// same Route / AdvisoryLockRoute as any other query — the resolve primitive
+	// just reads the rows the route streams back.
+	resolveRoute := p.routePrimitive(unroll.SqlString(), unroll, opts)
+
+	prim := engine.NewResolveTrackSetConfig(p.defaultTableGroup, constants.DefaultShard, sql, resolveRoute, unroll, aliases)
 	return engine.NewPlan(sql, prim), nil
 }
 

--- a/go/services/multigateway/planner/unsafe_funccall.go
+++ b/go/services/multigateway/planner/unsafe_funccall.go
@@ -15,6 +15,7 @@
 package planner
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -142,6 +143,23 @@ type statementAnalysis struct {
 	// the target-list positions left-to-right.
 	SetConfigs []setConfigCall
 
+	// DynamicSetConfig is true when the statement is a SELECT whose target
+	// list is entirely set_config(...) calls and at least one call has an
+	// argument that can't be resolved at plan time (a column reference or
+	// other expression rather than a literal or bound parameter) — the shape
+	// pg_dump uses on PG17+:
+	//
+	//	SELECT set_config(name, 'view, foreign-table', false)
+	//	FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'
+	//
+	// We can't mint a literal SET to track up front, so the planner emits a
+	// ResolveTrackSetConfig primitive that executes the argument projection
+	// once to learn the concrete (name, value, is_local) tuples, tracks the
+	// session-scoped ones, and applies them with literals. When this is set,
+	// SetConfigs is empty — every call in the target list is handled by the
+	// resolve path. See planResolveSetConfig.
+	DynamicSetConfig bool
+
 	// AcquiresSessionAdvisoryLock is true if any FuncCall in the statement is a
 	// session-level advisory lock acquisition (see
 	// sessionAdvisoryLockAcquireFuncs). The planner uses this to route the
@@ -229,6 +247,12 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 	result := &statementAnalysis{}
 	allowedSetConfigs := collectTopLevelSetConfigs(stmt)
 
+	// accepted collects the set_config calls that sit in an allowed position,
+	// in target-list order. We validate them after the walk so we can first
+	// decide between the literal/bound fast path and the resolve-and-apply
+	// path for dynamic arguments — a decision that depends on the whole
+	// target list, not a single call.
+	var accepted []*ast.FuncCall
 	var walkErr error
 	ast.Rewrite(stmt, func(cursor *ast.Cursor) bool {
 		if walkErr != nil {
@@ -265,22 +289,43 @@ func analyzeFunctionCalls(stmt ast.Stmt) (*statementAnalysis, error) {
 				"set_config is only supported as a top-level SELECT target list entry — use a SET statement, or set_config(..., true) for a transaction-scoped change")
 			return false
 		}
+		accepted = append(accepted, fc)
+		return true
+	}, nil)
 
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	// Resolve-and-apply path: the whole target list is set_config(...) and at
+	// least one call has a non-literal, non-bound argument the literal/bound
+	// fast path can't track (pg_dump's column-reference name). Hand the
+	// statement to the planner's ResolveTrackSetConfig primitive rather than
+	// erroring in validateAcceptedSetConfig.
+	if targetListAllSetConfig(stmt, allowedSetConfigs) && slices.ContainsFunc(accepted, setConfigNeedsDynamic) {
+		// A cluster-managed GUC is still rejected when the name is a literal;
+		// a dynamic name is a documented gap (matches validateAcceptedSetConfig).
+		for _, fc := range accepted {
+			if name, ok := constStringArg(fc.Args.Items[0]); ok {
+				if err := restrictedGUCError(name); err != nil {
+					return nil, err
+				}
+			}
+		}
+		result.DynamicSetConfig = true
+		return result, nil
+	}
+
+	for _, fc := range accepted {
 		setCfg, err := validateAcceptedSetConfig(fc)
 		if err != nil {
-			walkErr = err
-			return false
+			return nil, err
 		}
 		if setCfg != nil {
 			result.SetConfigs = append(result.SetConfigs, *setCfg)
 		}
 		// else is_local=true: leave it alone; PG executes it as a normal
 		// transaction-scoped call and the pooler does not track it.
-		return true
-	}, nil)
-
-	if walkErr != nil {
-		return nil, walkErr
 	}
 	return result, nil
 }
@@ -328,6 +373,68 @@ func collectTopLevelSetConfigs(stmt ast.Stmt) map[*ast.FuncCall]struct{} {
 		allowed[fc] = struct{}{}
 	}
 	return allowed
+}
+
+// targetListAllSetConfig reports whether every entry in stmt's top-level
+// target list is one of the allowed set_config calls — i.e. the SELECT does
+// nothing but set_config(...). Only this shape takes the resolve-and-apply
+// path: the projection that resolves the arguments (each call's args become
+// output columns) must not have to also compute unrelated columns, and the
+// synthesized apply query reproduces exactly the original's columns.
+func targetListAllSetConfig(stmt ast.Stmt, allowed map[*ast.FuncCall]struct{}) bool {
+	ss, ok := stmt.(*ast.SelectStmt)
+	if !ok || ss.TargetList == nil || ss.TargetList.Len() == 0 {
+		return false
+	}
+	for _, item := range ss.TargetList.Items {
+		rt, ok := item.(*ast.ResTarget)
+		if !ok {
+			return false
+		}
+		fc, ok := rt.Val.(*ast.FuncCall)
+		if !ok {
+			return false
+		}
+		if _, isAllowed := allowed[fc]; !isAllowed {
+			return false
+		}
+	}
+	return true
+}
+
+// setConfigNeedsDynamic reports whether fc is a set_config call the literal/
+// bound fast path cannot handle — i.e. it would otherwise error in
+// validateAcceptedSetConfig. That is: it has exactly three arguments, is_local
+// is not a literal true (those run transaction-scoped via Route and need no
+// tracking — validateAcceptedSetConfig short-circuits them), and at least one
+// argument is neither a literal constant nor a bound parameter (a column
+// reference or other expression).
+func setConfigNeedsDynamic(fc *ast.FuncCall) bool {
+	if fc.Args == nil || fc.Args.Len() != 3 {
+		// Wrong arity: let validateAcceptedSetConfig raise its specific error.
+		return false
+	}
+	if isLocal, ok := constBoolArg(fc.Args.Items[2]); ok && isLocal {
+		return false
+	}
+	for _, arg := range fc.Args.Items {
+		if !isStaticSetConfigArg(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// isStaticSetConfigArg reports whether a set_config argument can be resolved
+// at plan time: a literal A_Const or a bound parameter (ParamRef), after
+// stripping any TypeCast. Anything else (a column reference, function call,
+// operator expression, ...) must be evaluated by PostgreSQL.
+func isStaticSetConfigArg(n ast.Node) bool {
+	switch unwrapTypeCast(n).(type) {
+	case *ast.ParamRef, *ast.A_Const:
+		return true
+	}
+	return false
 }
 
 // validateAcceptedSetConfig verifies that an allowed-position set_config

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -250,19 +250,23 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 			sql:     "SELECT set_config('work_mem','256MB',false), * INTO TEMP foo FROM t",
 			wantMsg: "set_config is only supported as a top-level SELECT target list entry",
 		},
+		// A dynamic argument is only accepted when the whole target list is
+		// set_config(...) (the resolve-and-apply path — see
+		// TestInspectExpressionFuncCalls_DynamicSetConfigAccepted). Mixed with
+		// any other target it still can't be tracked, so it's rejected.
 		{
-			name:    "non-literal non-bound name arg (column ref)",
-			sql:     "SELECT set_config(name, '256MB', false) FROM gucs",
+			name:    "non-literal name arg (column ref) in mixed target list",
+			sql:     "SELECT set_config(name, '256MB', false), x FROM gucs",
 			wantMsg: "set_config name argument must be a literal constant or a bound parameter",
 		},
 		{
-			name:    "non-literal non-bound value arg (column ref)",
-			sql:     "SELECT set_config('work_mem', v, false) FROM gucs",
+			name:    "non-literal value arg (column ref) in mixed target list",
+			sql:     "SELECT set_config('work_mem', v, false), x FROM gucs",
 			wantMsg: "set_config value argument must be a literal constant or a bound parameter",
 		},
 		{
-			name:    "non-literal non-bound is_local (column ref)",
-			sql:     "SELECT set_config('work_mem', '256MB', islocal) FROM gucs",
+			name:    "non-literal is_local (column ref) in mixed target list",
+			sql:     "SELECT set_config('work_mem', '256MB', islocal), x FROM gucs",
 			wantMsg: "set_config is_local argument must be a literal constant or a bound parameter",
 		},
 	}
@@ -277,6 +281,94 @@ func TestInspectExpressionFuncCalls_SetConfigRejected(t *testing.T) {
 			require.True(t, errors.As(err, &diag))
 			assert.Equal(t, mterrors.PgSSFeatureNotSupported, diag.Code)
 			assert.Contains(t, diag.Message, tt.wantMsg)
+		})
+	}
+}
+
+// TestInspectExpressionFuncCalls_DynamicSetConfigAccepted pins the
+// resolve-and-apply path: a SELECT whose target list is entirely
+// set_config(...) and that has at least one argument the literal/bound fast
+// path can't resolve (a column reference) is accepted with
+// DynamicSetConfig=true (and no SetConfigs) rather than rejected. This is the
+// shape pg_dump uses on PG17+.
+func TestInspectExpressionFuncCalls_DynamicSetConfigAccepted(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "pg_dump restrict_nonsystem_relation_kind probe",
+			sql:  "SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'",
+		},
+		{
+			name: "dynamic name",
+			sql:  "SELECT set_config(name, '256MB', false) FROM gucs",
+		},
+		{
+			name: "dynamic value",
+			sql:  "SELECT set_config('work_mem', v, false) FROM gucs",
+		},
+		{
+			name: "dynamic is_local",
+			sql:  "SELECT set_config('work_mem', '256MB', islocal) FROM gucs",
+		},
+		{
+			name: "multiple set_config calls, one dynamic (multi-column)",
+			sql:  "SELECT set_config('a', 'b', false), set_config(name, 'c', false) FROM gucs",
+		},
+		{
+			name: "all dynamic multi-column",
+			sql:  "SELECT set_config(n1, v1, false), set_config(n2, v2, false) FROM gucs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			result, err := analyzeFunctionCalls(stmt)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.DynamicSetConfig, "expected DynamicSetConfig")
+			assert.Empty(t, result.SetConfigs, "dynamic path tracks via the primitive, not SetConfigs")
+		})
+	}
+}
+
+// TestInspectExpressionFuncCalls_DynamicSetConfigNotTriggered pins the cases
+// that must NOT take the resolve-and-apply path: all-literal/bound calls keep
+// the fast path, and a literal is_local=true call (even with a dynamic name)
+// runs transaction-scoped via Route, untracked, exactly as before.
+func TestInspectExpressionFuncCalls_DynamicSetConfigNotTriggered(t *testing.T) {
+	tests := []struct {
+		name           string
+		sql            string
+		wantSetConfigs int
+	}{
+		{
+			name:           "all literal stays on fast path",
+			sql:            "SELECT set_config('work_mem', '256MB', false)",
+			wantSetConfigs: 1,
+		},
+		{
+			name:           "bound value stays on fast path",
+			sql:            "SELECT set_config('search_path', $1, false)",
+			wantSetConfigs: 1,
+		},
+		{
+			name:           "literal is_local=true with dynamic name is passthrough, untracked",
+			sql:            "SELECT set_config(name, 'v', true) FROM gucs",
+			wantSetConfigs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			result, err := analyzeFunctionCalls(stmt)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.DynamicSetConfig, "should not take the dynamic path")
+			assert.Len(t, result.SetConfigs, tt.wantSetConfigs)
 		})
 	}
 }
@@ -474,6 +566,51 @@ func TestPlan_SetConfig_ProducesSequence(t *testing.T) {
 	}
 }
 
+// TestPlan_DynamicSetConfig_ProducesResolvePrimitive verifies that the pg_dump
+// shape (target list all set_config with a dynamic argument) plans as a single
+// ResolveTrackSetConfig primitive, whose unroll projection replaces each
+// set_config(a, b, c) with its three arguments while preserving FROM/WHERE.
+func TestPlan_DynamicSetConfig_ProducesResolvePrimitive(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantUnroll  string
+		wantAliases []string
+	}{
+		{
+			name:        "pg_dump probe",
+			sql:         "SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'",
+			wantUnroll:  "SELECT name, 'view, foreign-table', FALSE FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'",
+			wantAliases: []string{""},
+		},
+		{
+			name:        "multi-column with alias",
+			sql:         "SELECT set_config(name, '1', false) AS a, set_config('work_mem', v, false) FROM gucs",
+			wantUnroll:  "SELECT name, '1', FALSE, 'work_mem', v, FALSE FROM gucs",
+			wantAliases: []string{"a", ""},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseOne(t, tt.sql)
+			plan, err := p.Plan(tt.sql, stmt, testConn.Conn)
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			prim, ok := plan.Primitive.(*engine.ResolveTrackSetConfig)
+			require.True(t, ok, "expected ResolveTrackSetConfig, got %T", plan.Primitive)
+			assert.Equal(t, tt.wantAliases, prim.Aliases)
+			assert.Equal(t, tt.wantUnroll, prim.UnrollAST.SqlString())
+			assert.Equal(t, engine.PlanTypeResolveTrackSetConfig, plan.Type)
+		})
+	}
+}
+
 // TestPlan_RejectsUnsafeFuncCalls verifies Plan() itself rejects blocklisted
 // function calls (not just the walker in isolation).
 func TestPlan_RejectsUnsafeFuncCalls(t *testing.T) {
@@ -496,8 +633,10 @@ func TestPlan_RejectsUnsafeFuncCalls(t *testing.T) {
 			"set_config is only supported as a top-level SELECT target list entry",
 		},
 		{
-			"non-literal set_config rejected",
-			"SELECT set_config('x', v, false) FROM gucs",
+			// Dynamic value mixed with another target can't take the
+			// resolve-and-apply path, so it's still rejected.
+			"non-literal set_config in mixed target list rejected",
+			"SELECT set_config('x', v, false), 1 FROM gucs",
 			"set_config value argument must be a literal constant",
 		},
 	}

--- a/go/services/multigateway/planner/unsafe_funccall_test.go
+++ b/go/services/multigateway/planner/unsafe_funccall_test.go
@@ -605,10 +605,37 @@ func TestPlan_DynamicSetConfig_ProducesResolvePrimitive(t *testing.T) {
 			prim, ok := plan.Primitive.(*engine.ResolveTrackSetConfig)
 			require.True(t, ok, "expected ResolveTrackSetConfig, got %T", plan.Primitive)
 			assert.Equal(t, tt.wantAliases, prim.Aliases)
-			assert.Equal(t, tt.wantUnroll, prim.UnrollAST.SqlString())
+			assert.Equal(t, tt.wantUnroll, prim.ResolveRoute.GetQuery())
 			assert.Equal(t, engine.PlanTypeResolveTrackSetConfig, plan.Type)
+			// No advisory lock: the resolve runs through a plain Route.
+			_, isPlainRoute := prim.ResolveRoute.(*engine.Route)
+			assert.True(t, isPlainRoute, "expected plain Route, got %T", prim.ResolveRoute)
 		})
 	}
+}
+
+// TestPlan_DynamicSetConfig_AdvisoryLockPins verifies that a dynamic set_config
+// whose argument acquires a session-level advisory lock still pins the backend.
+// The lock is taken when the resolve projection evaluates the arguments, so the
+// resolve must run through an AdvisoryLockRoute — built by routePrimitive from
+// the forwarded opts — rather than a plain Route.
+func TestPlan_DynamicSetConfig_AdvisoryLockPins(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+	p := NewPlanner("default", logger, nil)
+	testConn := server.NewTestConn(&bytes.Buffer{})
+
+	// Value argument acquires an advisory lock — both dynamic (a function call,
+	// not a literal/bound param) and advisory-lock-acquiring.
+	sql := "SELECT set_config('x', pg_try_advisory_lock(1)::text, false)"
+	stmt := parseOne(t, sql)
+	plan, err := p.Plan(sql, stmt, testConn.Conn)
+	require.NoError(t, err)
+
+	prim, ok := plan.Primitive.(*engine.ResolveTrackSetConfig)
+	require.True(t, ok, "expected ResolveTrackSetConfig, got %T", plan.Primitive)
+	alr, ok := prim.ResolveRoute.(*engine.AdvisoryLockRoute)
+	require.True(t, ok, "expected resolve to run through AdvisoryLockRoute, got %T", prim.ResolveRoute)
+	assert.True(t, alr.Pins(), "advisory-lock acquire must pin the backend")
 }
 
 // TestPlan_RejectsUnsafeFuncCalls verifies Plan() itself rejects blocklisted

--- a/go/test/endtoend/queryserving/dynamic_set_config_test.go
+++ b/go/test/endtoend/queryserving/dynamic_set_config_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestDynamicSetConfig covers the resolve-and-apply path for a SELECT whose
+// target list is entirely set_config(...) with an argument that can't be
+// resolved at plan time (a column reference) — the shape pg_dump uses on PG17+.
+// The gateway runs the argument projection once to learn the concrete
+// (name, value, is_local) tuples, tracks the session-scoped ones so they
+// survive pool rotation, and applies them with literals.
+func TestDynamicSetConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping dynamic set_config test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping dynamic set_config test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err, "failed to open database connection")
+	defer db.Close()
+
+	ctx := utils.WithTimeout(t, 150*time.Second)
+	require.NoError(t, db.PingContext(ctx), "failed to ping multigateway")
+
+	// Dynamic GUC name resolved from pg_settings, then tracked so it survives
+	// pool rotation — the core of the pg_dump fix.
+	t.Run("dynamic name tracked and survives pool rotation", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`SELECT set_config(name, 'dynmatic_schema', false) FROM pg_settings WHERE name = 'search_path'`)
+		require.NoError(t, err, "dynamic-name set_config should succeed")
+
+		// Verify across many queries (interleaved) — the tracked setting must
+		// be replayed onto whatever backend the pool hands out.
+		for i := range 30 {
+			var got string
+			err = db.QueryRowContext(ctx, "SHOW search_path").Scan(&got)
+			require.NoError(t, err, "SHOW search_path iteration %d", i)
+			require.Equal(t, "dynmatic_schema", got, "iteration %d", i)
+
+			var one int
+			require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+		}
+	})
+
+	// The actual PG17+ pg_dump probe statement. set_config returns the new
+	// value; the restriction must then be in effect for the session.
+	t.Run("pg_dump restrict_nonsystem_relation_kind probe", func(t *testing.T) {
+		var got string
+		err := db.QueryRowContext(ctx,
+			`SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'`).Scan(&got)
+		require.NoError(t, err, "restrict_nonsystem_relation_kind probe should succeed")
+		require.Equal(t, "view, foreign-table", got, "set_config returns the applied value")
+
+		var shown string
+		err = db.QueryRowContext(ctx, "SHOW restrict_nonsystem_relation_kind").Scan(&shown)
+		require.NoError(t, err, "SHOW restrict_nonsystem_relation_kind")
+		assert.Equal(t, "view, foreign-table", shown, "restriction must be in effect for the session")
+	})
+
+	// WHERE matching no row: nothing is set, an empty result comes back, and no
+	// error — the version-guarded form's whole point (GUC absent → no-op).
+	t.Run("zero rows is a harmless no-op", func(t *testing.T) {
+		rows, err := db.QueryContext(ctx,
+			`SELECT set_config(name, 'whatever', false) FROM pg_settings WHERE name = 'no_such_guc_xyz'`)
+		require.NoError(t, err, "zero-row resolve should not error")
+		defer rows.Close()
+		assert.False(t, rows.Next(), "expected zero rows")
+		require.NoError(t, rows.Err())
+	})
+
+	// Multiple set_config columns, both with a dynamic argument, in one SELECT.
+	t.Run("multi-column", func(t *testing.T) {
+		var workMem, searchPath string
+		err := db.QueryRowContext(ctx,
+			`SELECT set_config(name, '256MB', false), set_config('search_path', name, false) FROM pg_settings WHERE name = 'work_mem'`).
+			Scan(&workMem, &searchPath)
+		require.NoError(t, err, "multi-column dynamic set_config should succeed")
+		assert.Equal(t, "256MB", workMem)
+		assert.Equal(t, "work_mem", searchPath)
+
+		var shownWorkMem string
+		require.NoError(t, db.QueryRowContext(ctx, "SHOW work_mem").Scan(&shownWorkMem))
+		assert.Equal(t, "256MB", shownWorkMem, "first column's setting must be tracked")
+
+		var shownSearchPath string
+		require.NoError(t, db.QueryRowContext(ctx, "SHOW search_path").Scan(&shownSearchPath))
+		assert.Equal(t, "work_mem", shownSearchPath, "second column's setting must be tracked")
+	})
+
+	// A dynamic is_local resolving to true inside a transaction: applied
+	// transaction-locally (visible until COMMIT) but NOT tracked, so it does
+	// not survive the transaction.
+	t.Run("dynamic is_local=true is transaction-scoped, untracked", func(t *testing.T) {
+		// Establish a known session value first.
+		_, err := db.ExecContext(ctx, "SET work_mem = '64MB'")
+		require.NoError(t, err)
+
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback() }()
+
+		var applied string
+		err = tx.QueryRowContext(ctx,
+			`SELECT set_config('work_mem', '128MB', islocal) FROM (SELECT true AS islocal) s`).Scan(&applied)
+		require.NoError(t, err, "dynamic is_local set_config should succeed")
+		require.Equal(t, "128MB", applied)
+
+		var inTxn string
+		require.NoError(t, tx.QueryRowContext(ctx, "SHOW work_mem").Scan(&inTxn))
+		assert.Equal(t, "128MB", inTxn, "SET LOCAL visible within the transaction")
+
+		require.NoError(t, tx.Commit())
+
+		// After commit the local change is gone and the session value remains.
+		var afterTxn string
+		require.NoError(t, db.QueryRowContext(ctx, "SHOW work_mem").Scan(&afterTxn))
+		assert.Equal(t, "64MB", afterTxn, "transaction-local change must not persist")
+	})
+}

--- a/go/test/endtoend/queryserving/pg_dump_test.go
+++ b/go/test/endtoend/queryserving/pg_dump_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryserving
+
+import (
+	"database/sql"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+	"github.com/multigres/multigres/go/tools/executil"
+)
+
+// TestPgDump runs pg_dump through the multigateway end to end.
+//
+// pg_dump on PostgreSQL 17+ performs a startup probe that pins a hostile GUC
+// before introspecting the catalog:
+//
+//	SELECT set_config(name, 'view, foreign-table', false)
+//	FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'
+//
+// The name argument is a column reference, not a literal or bound parameter, so
+// it is evaluated per row by PostgreSQL. The multigateway's session-scoped
+// set_config path currently rejects anything other than a bare literal or bound
+// parameter ("set_config name argument must be a literal constant or a bound
+// parameter"), which aborts pg_dump before it emits any schema.
+//
+// This test exercises the real binary so we know exactly what breaks; it is
+// expected to fail until the gateway supports evaluating the name argument on
+// the session-scoped path.
+func TestPgDump(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping pg_dump test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping pg_dump test")
+	}
+
+	pgDumpPath, err := exec.LookPath("pg_dump")
+	if err != nil {
+		t.Skip("pg_dump not found on PATH, skipping pg_dump test")
+	}
+
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+
+	ctx := utils.WithTimeout(t, 150*time.Second)
+
+	// Seed a small schema so the dump has something to emit. Routed through the
+	// gateway to keep setup on the same pooled path the dump will use.
+	connStr := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err, "failed to open database connection")
+	defer db.Close()
+	require.NoError(t, db.PingContext(ctx), "failed to ping multigateway")
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS pg_dump_probe (id int PRIMARY KEY, name text)`)
+	require.NoError(t, err, "failed to create seed table")
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS pg_dump_probe`)
+	})
+
+	// Subtest 1: reproduce the exact PG17+ startup probe directly, so we pin the
+	// precise statement that breaks independently of pg_dump's other queries.
+	t.Run("set_config startup probe", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'`)
+		require.NoError(t, err, "pg_dump's restrict_nonsystem_relation_kind probe should succeed through the gateway")
+	})
+
+	// Subtest 2: run the real pg_dump binary against the gateway.
+	t.Run("schema-only dump", func(t *testing.T) {
+		cmd := executil.Command(ctx, pgDumpPath,
+			"--schema-only",
+			"--no-owner",
+			"--no-privileges",
+			"-d", "postgres")
+		cmd.AddEnv(
+			"PGHOST=localhost",
+			fmt.Sprintf("PGPORT=%d", setup.MultigatewayPgPort),
+			"PGUSER="+shardsetup.DefaultTestUser,
+			"PGPASSWORD="+shardsetup.TestPostgresPassword,
+			"PGSSLMODE=disable",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "pg_dump through the gateway should succeed\noutput:\n%s", string(out))
+		require.Contains(t, string(out), "pg_dump_probe", "dump should contain the seeded table")
+	})
+}

--- a/go/test/endtoend/queryserving/unsafe_funccall_test.go
+++ b/go/test/endtoend/queryserving/unsafe_funccall_test.go
@@ -305,8 +305,12 @@ func TestMultiGateway_UnsafeFuncCallRejection(t *testing.T) {
 			"set_config is only supported as a top-level SELECT target list entry",
 		},
 		{
-			"non-literal set_config value",
-			"SELECT set_config('work_mem', name, false) FROM (SELECT 'x' AS name) s",
+			// A dynamic set_config argument is supported only when the whole
+			// target list is set_config(...) (the resolve-and-apply path, see
+			// TestDynamicSetConfig). Mixed with another target it still can't be
+			// tracked, so it's rejected.
+			"non-literal set_config value in mixed target list",
+			"SELECT set_config('work_mem', name, false), 1 FROM (SELECT 'x' AS name) s",
 			"set_config value argument must be a literal constant",
 		},
 	}


### PR DESCRIPTION
## Summary

- pg_dump on PG17+ fails through the gateway: its startup probe `SELECT set_config(name, 'view, foreign-table', false) FROM pg_settings WHERE name = 'restrict_nonsystem_relation_kind'` is rejected because the `name` argument is a column reference, not a literal or bound parameter, so the session-scoped setting can't be tracked for pool-rotation replay.
- Adds a resolve-and-apply path for a `SELECT` whose target list is entirely `set_config(...)` with a dynamic argument: run the argument projection once to learn the concrete `(name, value, is_local)` tuples, track the session-scoped ones, and apply them with literals.
- pg_dump — and any version-guarded `set_config` over `pg_settings` — now works through the gateway.

## Problem

The gateway must know a session-scoped `set_config`'s GUC name up front to track it in `SessionSettings` and replay it after pool rotation. pg_dump's probe resolves the name per row from a `pg_settings` column, so the planner couldn't extract it and rejected the statement — blocking pg_dump before it emits any schema.

## Solution

When the analyzer sees a target list made entirely of `set_config(...)` with an argument that isn't a literal or bound parameter, the planner emits a `ResolveTrackSetConfig` primitive:

1. **Resolve** — run the projection of the call arguments (`set_config(a,b,c)` → `a, b, c`) once. The first resolution is the source of truth; re-running the original dynamic query could resolve to different rows/values.
2. **Track** — record the session-scoped (`is_local=false`) tuples in `SessionSettings` for replay.
3. **Apply** — run `set_config(<captured literals>, true)` and forward PostgreSQL's authoritative result. `is_local := true` returns the new value without leaving a session GUC on the pooled backend (which would leak to the next client); persistence comes from tracking + replay.

The literal/bound fast path and the rejection of dynamic `set_config` mixed with other target-list entries are unchanged.

## Testing

e2e `TestPgDump` (real `pg_dump` binary) and `TestDynamicSetConfig` (pool-rotation, zero-row no-op, multi-column, `is_local=true` transaction-scoped), plus analyzer/plan-shape/`sqltypes` unit tests; existing session-settings and extended-protocol suites still pass.