### PR TITLE
ci(govulncheck): dedupe SARIF rule tags so the upload validates

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -7,6 +7,7 @@ name: Go vulnerability check
     paths:
       - "go.mod"
       - "go.sum"
+      - ".github/workflows/govulncheck.yaml"
   workflow_dispatch: {}
 
 permissions: {}
@@ -38,6 +39,20 @@ jobs:
         id: scan
         continue-on-error: true
         run: govulncheck -format sarif ./... > govulncheck.sarif
+
+      - name: Deduplicate SARIF rule tags
+        # govulncheck v1.3.0 (latest) emits duplicate values in
+        # rules[].properties.tags, e.g. ["CVE-XXXX-YYYY","CVE-XXXX-YYYY"]. The
+        # SARIF upload validator rejects them because `tags` is declared with
+        # uniqueItems, failing the job even though the scan itself succeeded.
+        # Dedupe the tags so the upload validates. Leave non-JSON output (e.g. a
+        # hard govulncheck error) untouched so the upload step surfaces it.
+        run: |
+          if jq -e . govulncheck.sarif >/dev/null 2>&1; then
+            jq '.runs |= map(.tool.driver.rules |= map(if .properties.tags then .properties.tags |= unique else . end))' \
+              govulncheck.sarif > govulncheck.sarif.tmp
+            mv govulncheck.sarif.tmp govulncheck.sarif
+          fi
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1


### PR DESCRIPTION
## Summary

- The "Go vulnerability check" job has failed on every run since it was added in #1142 — including nightly runs on `main` — because the SARIF upload step rejects govulncheck's output. This is not a real vulnerability: the scan finds zero called vulnerabilities; the report file is just malformed.
- govulncheck v1.3.0 (the latest release) emits duplicate values in `rules[].properties.tags` (e.g. `["CVE-2025-61725","CVE-2025-61725"]`). GitHub's SARIF validator rejects this because `tags` is declared `uniqueItems`, so the upload — and the job — fail.
- Add a step that dedupes the tags with `jq` before upload, leaving non-JSON output untouched so a genuine govulncheck error still surfaces.
- Also trigger the workflow when the workflow file itself changes, so this fix is actually exercised on its own PR.

## Problem

The workflow runs `govulncheck -format sarif`, then uploads the SARIF via `codeql-action/upload-sarif`. govulncheck v1.3.0 duplicates tag values, and the validator fails with `rules[N].properties.tags contains duplicate item`. v1.3.0 is the newest govulncheck release, so upgrading is not an option.

This was never caught on the introducing PR (#1142) because that PR only added workflow/config files and did not change `go.mod`/`go.sum` — the workflow's only `pull_request` trigger paths — so the check never ran there. It only started failing afterward, on the nightly schedule and on dependency-bumping PRs.

## Solution

Insert a `jq` step between scan and upload that rewrites each rule's `properties.tags` to be unique. Verified locally against real output: 56 rules, 14 with duplicate tags before, 0 after, all rules preserved and the file still valid JSON. The scan exits 0 (no called vulnerabilities), so once the upload validates the job goes green.

Adding `.github/workflows/govulncheck.yaml` to the `pull_request.paths` closes the self-test gap that hid the bug in #1142: a workflow gated only on `go.mod`/`go.sum` can never test edits to itself.