### PR TITLE
feat(multiadmin): add SwitchPrimary RPC for graceful planned failover

### DIFF
--- a/go/cmd/multigres/command/cluster.go
+++ b/go/cmd/multigres/command/cluster.go
@@ -41,6 +41,7 @@ func AddClusterCommand(root *cobra.Command, mc *MultigresCommand) {
 	cluster.AddExpireBackupsCommand(clusterCmd)
 	cluster.AddVerifyBackupsCommand(clusterCmd)
 	cluster.AddApplyRuleChangeCommand(clusterCmd)
+	cluster.AddSwitchPrimaryCommand(clusterCmd)
 
 	// Register cluster command with root
 	root.AddCommand(clusterCmd)

--- a/go/cmd/multigres/command/cluster/switch_primary.go
+++ b/go/cmd/multigres/command/cluster/switch_primary.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/multigres/multigres/go/cmd/multigres/command/admin"
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	"github.com/multigres/multigres/go/tools/viperutil"
+)
+
+type switchPrimaryCmd struct {
+	database       viperutil.Value[string]
+	tableGroup     viperutil.Value[string]
+	shard          viperutil.Value[string]
+	catchupTimeout viperutil.Value[time.Duration]
+	reason         viperutil.Value[string]
+	yes            viperutil.Value[bool]
+	timeout        viperutil.Value[time.Duration]
+}
+
+// AddSwitchPrimaryCommand registers the switch-primary subcommand.
+func AddSwitchPrimaryCommand(clusterCmd *cobra.Command) {
+	reg := viperutil.NewRegistry()
+	pf := &switchPrimaryCmd{
+		database: viperutil.Configure(reg, "database", viperutil.Options[string]{
+			Default: "postgres", FlagName: "database",
+		}),
+		tableGroup: viperutil.Configure(reg, "table-group", viperutil.Options[string]{
+			Default: constants.DefaultTableGroup, FlagName: "table-group",
+		}),
+		shard: viperutil.Configure(reg, "shard", viperutil.Options[string]{
+			Default: constants.DefaultShard, FlagName: "shard",
+		}),
+		catchupTimeout: viperutil.Configure(reg, "catchup-timeout", viperutil.Options[time.Duration]{
+			Default: 30 * time.Second, FlagName: "catchup-timeout",
+		}),
+		reason: viperutil.Configure(reg, "reason", viperutil.Options[string]{
+			Default: "", FlagName: "reason",
+		}),
+		yes: viperutil.Configure(reg, "yes", viperutil.Options[bool]{
+			Default: false, FlagName: "yes",
+		}),
+		timeout: viperutil.Configure(reg, "timeout", viperutil.Options[time.Duration]{
+			Default: 120 * time.Second, FlagName: "timeout",
+		}),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "switch-primary",
+		Short: "Perform a graceful switchover to a standby pooler",
+		Long: `Perform a graceful switchover for a shard.
+
+New queries for the current primary are rejected with MTF01 so the
+gateway can buffer and retry. The current primary is then restarted as
+a standby and publishes REQUESTING_DEMOTION. Multiorch's recovery engine
+picks the most-advanced standby and promotes it via the normal
+Recruit/Promote consensus flow.
+
+No pg_rewind is required because the old primary and the new primary
+diverge at the same WAL position.
+
+--catchup-timeout controls how long to wait for multiorch to elect a new
+primary. If the timeout expires, the REQUESTING_DEMOTION signal persists
+and multiorch will complete the election on its own.
+
+Examples:
+
+  # Switchover with default 30s timeout
+  multigres cluster switch-primary \
+    --database=postgres --reason="maintenance"
+
+  # Switchover with extended election wait
+  multigres cluster switch-primary \
+    --database=postgres --catchup-timeout=60s --reason="zone1 maintenance"`,
+		RunE: pf.run,
+	}
+
+	cmd.Flags().String("database", pf.database.Default(), "Database name")
+	cmd.Flags().String("table-group", pf.tableGroup.Default(), "Table group name")
+	cmd.Flags().String("shard", pf.shard.Default(), "Shard name")
+	cmd.Flags().Duration("catchup-timeout", pf.catchupTimeout.Default(), "How long to wait for multiorch to elect a new primary")
+	cmd.Flags().String("reason", pf.reason.Default(), "Free-text reason for the failover (recorded for audit)")
+	cmd.Flags().Bool("yes", pf.yes.Default(), "Skip the interactive confirmation prompt")
+	cmd.Flags().Duration("timeout", pf.timeout.Default(), "Overall RPC timeout (must exceed --catchup-timeout)")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+
+	viperutil.BindFlags(cmd.Flags(),
+		pf.database, pf.tableGroup, pf.shard,
+		pf.catchupTimeout, pf.reason, pf.yes, pf.timeout)
+
+	clusterCmd.AddCommand(cmd)
+}
+
+func (pf *switchPrimaryCmd) run(cmd *cobra.Command, _ []string) error {
+	if pf.timeout.Get() <= pf.catchupTimeout.Get() {
+		return fmt.Errorf("--timeout (%s) must be greater than --catchup-timeout (%s)",
+			pf.timeout.Get(), pf.catchupTimeout.Get())
+	}
+
+	req, err := pf.buildRequest()
+	if err != nil {
+		return err
+	}
+
+	if !pf.yes.Get() {
+		if err := confirmSwitchPrimary(cmd, req); err != nil {
+			return err
+		}
+	}
+
+	client, err := admin.NewClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), pf.timeout.Get())
+	defer cancel()
+
+	resp, err := client.SwitchPrimary(ctx, req)
+	if err != nil {
+		return fmt.Errorf("switch-primary failed: %w", err)
+	}
+
+	cmd.Printf("Switch-primary complete.\n")
+	cmd.Printf("Old leader: %s/%s\n",
+		resp.GetOldLeaderId().GetCell(),
+		resp.GetOldLeaderId().GetName())
+	cmd.Printf("New leader: %s/%s\n",
+		resp.GetNewLeaderId().GetCell(),
+		resp.GetNewLeaderId().GetName())
+	return nil
+}
+
+func (pf *switchPrimaryCmd) buildRequest() (*multiadminpb.SwitchPrimaryRequest, error) {
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   pf.database.Get(),
+			TableGroup: pf.tableGroup.Get(),
+			Shard:      pf.shard.Get(),
+		},
+		Reason:         pf.reason.Get(),
+		CatchupTimeout: durationpb.New(pf.catchupTimeout.Get()),
+	}
+
+	return req, nil
+}
+
+// confirmSwitchPrimary prints a summary and prompts the operator to type the
+// shard name before proceeding.
+func confirmSwitchPrimary(cmd *cobra.Command, req *multiadminpb.SwitchPrimaryRequest) error {
+	sk := req.GetShardKey()
+	cmd.Printf("\nShard:           %s/%s/%s\n", sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
+	cmd.Printf("Target standby:  (multiorch will pick the most-advanced standby)\n")
+	cmd.Printf("Catchup timeout: %s\n", req.GetCatchupTimeout().AsDuration())
+	cmd.Printf("Reason:          %s\n", req.GetReason())
+
+	cmd.Print("\nThis will quiesce writes on the current primary. The gateway will\n" +
+		"buffer client queries and retry them on the new primary.\n\n")
+	cmd.Printf("Type the shard name (%s) to confirm: ", sk.GetShard())
+
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		return errors.New("aborted")
+	}
+	if strings.TrimSpace(scanner.Text()) != sk.GetShard() {
+		return errors.New("aborted: confirmation did not match shard name")
+	}
+	return nil
+}

--- a/go/cmd/multigres/command/cluster/switch_primary.go
+++ b/go/cmd/multigres/command/cluster/switch_primary.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multigres/multigres/go/cmd/multigres/command/admin"
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	"github.com/multigres/multigres/go/tools/viperutil"
+)
+
+type switchPrimaryCmd struct {
+	database   viperutil.Value[string]
+	tableGroup viperutil.Value[string]
+	shard      viperutil.Value[string]
+	reason     viperutil.Value[string]
+	yes        viperutil.Value[bool]
+	timeout    viperutil.Value[time.Duration]
+}
+
+// AddSwitchPrimaryCommand registers the switch-primary subcommand.
+func AddSwitchPrimaryCommand(clusterCmd *cobra.Command) {
+	reg := viperutil.NewRegistry()
+	pf := &switchPrimaryCmd{
+		database: viperutil.Configure(reg, "database", viperutil.Options[string]{
+			Default: "postgres", FlagName: "database",
+		}),
+		tableGroup: viperutil.Configure(reg, "table-group", viperutil.Options[string]{
+			Default: constants.DefaultTableGroup, FlagName: "table-group",
+		}),
+		shard: viperutil.Configure(reg, "shard", viperutil.Options[string]{
+			Default: constants.DefaultShard, FlagName: "shard",
+		}),
+		reason: viperutil.Configure(reg, "reason", viperutil.Options[string]{
+			Default: "", FlagName: "reason",
+		}),
+		yes: viperutil.Configure(reg, "yes", viperutil.Options[bool]{
+			Default: false, FlagName: "yes",
+		}),
+		timeout: viperutil.Configure(reg, "timeout", viperutil.Options[time.Duration]{
+			Default: 120 * time.Second, FlagName: "timeout",
+		}),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "switch-primary",
+		Short: "Perform a graceful switchover to a standby pooler",
+		Long: `Perform a graceful switchover for a shard.
+
+New queries for the current primary are rejected with MTF01 so the
+gateway can buffer and retry. The current primary is then restarted as
+a standby and publishes REQUESTING_DEMOTION. Multiorch's recovery engine
+picks the most-advanced standby and promotes it via the normal
+Recruit/Promote consensus flow.
+
+No pg_rewind is required because the old primary and the new primary
+diverge at the same WAL position.
+
+The command returns as soon as the old primary has been quiesced and
+restarted as a standby. Use "multigres cluster status" to watch for the
+new primary to appear.
+
+Examples:
+
+  # Graceful switchover
+  multigres cluster switch-primary \
+    --database=postgres --reason="maintenance"`,
+		RunE: pf.run,
+	}
+
+	cmd.Flags().String("database", pf.database.Default(), "Database name")
+	cmd.Flags().String("table-group", pf.tableGroup.Default(), "Table group name")
+	cmd.Flags().String("shard", pf.shard.Default(), "Shard name")
+	cmd.Flags().String("reason", pf.reason.Default(), "Free-text reason for the failover (recorded for audit)")
+	cmd.Flags().Bool("yes", pf.yes.Default(), "Skip the interactive confirmation prompt")
+	cmd.Flags().Duration("timeout", pf.timeout.Default(), "Overall RPC timeout")
+	cmd.Flags().String("admin-server", "", "host:port of the multiadmin server (overrides config)")
+
+	viperutil.BindFlags(cmd.Flags(),
+		pf.database, pf.tableGroup, pf.shard,
+		pf.reason, pf.yes, pf.timeout)
+
+	clusterCmd.AddCommand(cmd)
+}
+
+func (pf *switchPrimaryCmd) run(cmd *cobra.Command, _ []string) error {
+	req, err := pf.buildRequest()
+	if err != nil {
+		return err
+	}
+
+	if !pf.yes.Get() {
+		if err := confirmSwitchPrimary(cmd, req); err != nil {
+			return err
+		}
+	}
+
+	client, err := admin.NewClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), pf.timeout.Get())
+	defer cancel()
+
+	resp, err := client.SwitchPrimary(ctx, req)
+	if err != nil {
+		return fmt.Errorf("switch-primary failed: %w", err)
+	}
+
+	cmd.Printf("Switch-primary complete.\n")
+	cmd.Printf("Old leader: %s/%s\n",
+		resp.GetOldLeaderId().GetCell(),
+		resp.GetOldLeaderId().GetName())
+	cmd.Printf("Multiorch will elect a new leader. Run \"multigres cluster status\" to monitor.\n")
+	return nil
+}
+
+func (pf *switchPrimaryCmd) buildRequest() (*multiadminpb.SwitchPrimaryRequest, error) {
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   pf.database.Get(),
+			TableGroup: pf.tableGroup.Get(),
+			Shard:      pf.shard.Get(),
+		},
+		Reason: pf.reason.Get(),
+	}
+
+	return req, nil
+}
+
+// confirmSwitchPrimary prints a summary and prompts the operator to type the
+// shard name before proceeding.
+func confirmSwitchPrimary(cmd *cobra.Command, req *multiadminpb.SwitchPrimaryRequest) error {
+	sk := req.GetShardKey()
+	cmd.Printf("\nShard:   %s/%s/%s\n", sk.GetDatabase(), sk.GetTableGroup(), sk.GetShard())
+	cmd.Printf("Reason:  %s\n", req.GetReason())
+
+	cmd.Print("\nThis will quiesce writes on the current primary. The gateway will\n" +
+		"buffer client queries and retry them on the new primary.\n\n")
+	cmd.Printf("Type the shard name (%s) to confirm: ", sk.GetShard())
+
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() {
+		return errors.New("aborted")
+	}
+	if strings.TrimSpace(scanner.Text()) != sk.GetShard() {
+		return errors.New("aborted: confirmation did not match shard name")
+	}
+	return nil
+}

--- a/go/cmd/multigres/command/cluster/switch_primary_test.go
+++ b/go/cmd/multigres/command/cluster/switch_primary_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+)
+
+func getSwitchPrimaryCommand() *cobra.Command {
+	clusterCmd := &cobra.Command{Use: "cluster"}
+	AddSwitchPrimaryCommand(clusterCmd)
+	cmd, _, _ := clusterCmd.Find([]string{"switch-primary"})
+	return cmd
+}
+
+func TestSwitchPrimaryCommandFlags(t *testing.T) {
+	cmd := getSwitchPrimaryCommand()
+	require.NotNil(t, cmd)
+
+	tests := []struct {
+		flag     string
+		defValue string
+	}{
+		{"database", "postgres"},
+		{"table-group", constants.DefaultTableGroup},
+		{"shard", constants.DefaultShard},
+		{"reason", ""},
+		{"yes", "false"},
+		{"timeout", (120 * time.Second).String()},
+		{"admin-server", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			f := cmd.Flag(tt.flag)
+			require.NotNil(t, f, "flag %q should exist", tt.flag)
+			assert.Equal(t, tt.defValue, f.DefValue)
+		})
+	}
+}
+
+func TestConfirmSwitchPrimary_Success(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("0-inf\n"))
+
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "db1",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		Reason: "maintenance",
+	}
+	err := confirmSwitchPrimary(cmd, req)
+	require.NoError(t, err)
+}
+
+func TestConfirmSwitchPrimary_WrongShard(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("wrong-shard\n"))
+
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Shard: "0-inf"},
+	}
+	err := confirmSwitchPrimary(cmd, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aborted")
+}
+
+func TestConfirmSwitchPrimary_EOF(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(""))
+
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Shard: "0-inf"},
+	}
+	err := confirmSwitchPrimary(cmd, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aborted")
+}
+
+func TestConfirmSwitchPrimary_Whitespace(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("  0-inf  \n"))
+
+	req := &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Shard: "0-inf"},
+	}
+	err := confirmSwitchPrimary(cmd, req)
+	require.NoError(t, err, "leading/trailing whitespace should be trimmed")
+}

--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -207,6 +207,9 @@ type MultiPoolerClient interface {
 	// Manager Service Methods - PostgreSQL Restart Control
 	//
 
+	// ResignLeadership gracefully resigns the pooler from leadership for a planned failover.
+	ResignLeadership(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error)
+
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 	SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error)
 

--- a/go/common/rpcclient/client.go
+++ b/go/common/rpcclient/client.go
@@ -201,6 +201,9 @@ type MultipoolerClient interface {
 	// Manager Service Methods - PostgreSQL Restart Control
 	//
 
+	// ResignLeadership gracefully resigns the pooler from leadership for a planned failover.
+	ResignLeadership(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error)
+
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 	SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error)
 

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -75,6 +75,7 @@ type FakeClient struct {
 	GetBackupsResponses                 map[string]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[string]*multipoolermanagerdatapb.GetBackupByJobIdResponse
 	RewindToSourceResponses             map[string]*multipoolermanagerdatapb.RewindToSourceResponse
+	ResignLeadershipResponses           map[string]*multipoolermanagerdatapb.ResignLeadershipResponse
 	SetPostgresRestartsEnabledResponses map[string]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
 
 	// Errors to return - keyed by pooler ID
@@ -108,6 +109,7 @@ func NewFakeClient() *FakeClient {
 		GetBackupsResponses:                 make(map[string]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[string]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
 		RewindToSourceResponses:             make(map[string]*multipoolermanagerdatapb.RewindToSourceResponse),
+		ResignLeadershipResponses:           make(map[string]*multipoolermanagerdatapb.ResignLeadershipResponse),
 		SetPostgresRestartsEnabledResponses: make(map[string]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		Errors:                              make(map[string]error),
 		CallLog:                             make([]string, 0),
@@ -175,6 +177,13 @@ func (f *FakeClient) SetStatusResponseWithDelay(poolerID string, resp *multipool
 		Response: resp,
 		Delay:    delay,
 	}
+}
+
+// SetResignLeadershipResponse sets a ResignLeadership response for a pooler.
+func (f *FakeClient) SetResignLeadershipResponse(poolerID string, resp *multipoolermanagerdatapb.ResignLeadershipResponse) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ResignLeadershipResponses[poolerID] = resp
 }
 
 // SetPostgresRestartsEnabledResponse sets a SetPostgresRestartsEnabled response for a pooler.
@@ -466,6 +475,26 @@ func (f *FakeClient) RewindToSource(ctx context.Context, pooler *clustermetadata
 		return resp, nil
 	}
 	return &multipoolermanagerdatapb.RewindToSourceResponse{}, nil
+}
+
+//
+// Manager Service Methods - SwitchPrimary
+//
+
+func (f *FakeClient) ResignLeadership(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	poolerID := f.getPoolerID(pooler)
+	f.logCall("ResignLeadership", poolerID)
+
+	if err := f.checkError(poolerID); err != nil {
+		return nil, err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if resp, ok := f.ResignLeadershipResponses[poolerID]; ok {
+		return resp, nil
+	}
+	return &multipoolermanagerdatapb.ResignLeadershipResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/fake_client.go
+++ b/go/common/rpcclient/fake_client.go
@@ -73,6 +73,7 @@ type FakeClient struct {
 	BackupResponses                     map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse
 	GetBackupsResponses                 map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse
 	GetBackupByJobIdResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse
+	ResignLeadershipResponses           map[topoclient.ComponentID]*multipoolermanagerdatapb.ResignLeadershipResponse
 	SetPostgresRestartsEnabledResponses map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse
 	ReloadConfigResponses               map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse
 
@@ -116,6 +117,7 @@ func NewFakeClient() *FakeClient {
 		BackupResponses:                     make(map[topoclient.ComponentID]*multipoolermanagerdatapb.BackupResponse),
 		GetBackupsResponses:                 make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupsResponse),
 		GetBackupByJobIdResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.GetBackupByJobIdResponse),
+		ResignLeadershipResponses:           make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ResignLeadershipResponse),
 		SetPostgresRestartsEnabledResponses: make(map[topoclient.ComponentID]*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse),
 		ReloadConfigResponses:               make(map[topoclient.ComponentID]*multipoolermanagerdatapb.ReloadConfigResponse),
 		Errors:                              make(map[topoclient.ComponentID]error),
@@ -186,6 +188,13 @@ func (f *FakeClient) SetStatusResponseWithDelay(poolerID topoclient.ComponentID,
 		Response: resp,
 		Delay:    delay,
 	}
+}
+
+// SetResignLeadershipResponse sets a ResignLeadership response for a pooler.
+func (f *FakeClient) SetResignLeadershipResponse(poolerID topoclient.ComponentID, resp *multipoolermanagerdatapb.ResignLeadershipResponse) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ResignLeadershipResponses[poolerID] = resp
 }
 
 // SetPostgresRestartsEnabledResponse sets a SetPostgresRestartsEnabled response for a pooler.
@@ -463,6 +472,26 @@ func (f *FakeClient) VerifyBackups(ctx context.Context, pooler *clustermetadatap
 	}
 
 	return &multipoolermanagerdatapb.VerifyBackupsResponse{}, nil
+}
+
+//
+// Manager Service Methods - SwitchPrimary
+//
+
+func (f *FakeClient) ResignLeadership(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	poolerID := f.getPoolerID(pooler)
+	f.logCall("ResignLeadership", poolerID)
+
+	if err := f.checkError(poolerID); err != nil {
+		return nil, err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if resp, ok := f.ResignLeadershipResponses[poolerID]; ok {
+		return resp, nil
+	}
+	return &multipoolermanagerdatapb.ResignLeadershipResponse{}, nil
 }
 
 //

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -280,6 +280,19 @@ func (c *Client) VerifyBackups(ctx context.Context, pooler *clustermetadatapb.Mu
 // Manager Service Methods - PostgreSQL Restart Control
 //
 
+// ResignLeadership gracefully resigns the pooler from leadership for a planned failover.
+func (c *Client) ResignLeadership(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	conn, closer, err := c.dialPersistent(ctx, pooler)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = closer()
+	}()
+
+	return conn.managerClient.ResignLeadership(ctx, request)
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 func (c *Client) SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.MultiPooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	conn, closer, err := c.dialPersistent(ctx, pooler)

--- a/go/common/rpcclient/grpc_client.go
+++ b/go/common/rpcclient/grpc_client.go
@@ -254,6 +254,19 @@ func (c *Client) VerifyBackups(ctx context.Context, pooler *clustermetadatapb.Mu
 // Manager Service Methods - PostgreSQL Restart Control
 //
 
+// ResignLeadership gracefully resigns the pooler from leadership for a planned failover.
+func (c *Client) ResignLeadership(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	conn, closer, err := c.dialPersistent(ctx, pooler)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = closer()
+	}()
+
+	return conn.managerClient.ResignLeadership(ctx, request)
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts on a pooler.
 func (c *Client) SetPostgresRestartsEnabled(ctx context.Context, pooler *clustermetadatapb.Multipooler, request *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	conn, closer, err := c.dialPersistent(ctx, pooler)

--- a/go/pb/multiadmin/multiadminconnect/multiadminservice.connect.go
+++ b/go/pb/multiadmin/multiadminconnect/multiadminservice.connect.go
@@ -98,6 +98,9 @@ const (
 	// MultiadminServiceApplyCertifiedRuleChangeProcedure is the fully-qualified name of the
 	// MultiadminService's ApplyCertifiedRuleChange RPC.
 	MultiadminServiceApplyCertifiedRuleChangeProcedure = "/multiadmin.MultiadminService/ApplyCertifiedRuleChange"
+	// MultiadminServiceSwitchPrimaryProcedure is the fully-qualified name of the MultiadminService's
+	// SwitchPrimary RPC.
+	MultiadminServiceSwitchPrimaryProcedure = "/multiadmin.MultiadminService/SwitchPrimary"
 )
 
 // MultiadminServiceClient is a client for the multiadmin.MultiadminService service.
@@ -149,6 +152,13 @@ type MultiadminServiceClient interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(context.Context, *connect.Request[multiadmin.ApplyCertifiedRuleChangeRequest]) (*connect.Response[multiadmin.ApplyCertifiedRuleChangeResponse], error)
+	// SwitchPrimary performs a graceful switchover for a shard. It quiesces
+	// writes on the current leader, restarts it as a standby, and publishes
+	// REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+	// leader through the normal consensus flow. The RPC returns as soon as the
+	// old primary has been quiesced — it does not wait for the new leader to
+	// appear.
+	SwitchPrimary(context.Context, *connect.Request[multiadmin.SwitchPrimaryRequest]) (*connect.Response[multiadmin.SwitchPrimaryResponse], error)
 }
 
 // NewMultiadminServiceClient constructs a client for the multiadmin.MultiadminService service. By
@@ -264,6 +274,12 @@ func NewMultiadminServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithSchema(multiadminServiceMethods.ByName("ApplyCertifiedRuleChange")),
 			connect.WithClientOptions(opts...),
 		),
+		switchPrimary: connect.NewClient[multiadmin.SwitchPrimaryRequest, multiadmin.SwitchPrimaryResponse](
+			httpClient,
+			baseURL+MultiadminServiceSwitchPrimaryProcedure,
+			connect.WithSchema(multiadminServiceMethods.ByName("SwitchPrimary")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -286,6 +302,7 @@ type multiadminServiceClient struct {
 	getGatewayQueries          *connect.Client[multiadmin.GetGatewayQueriesRequest, multiadmin.GetGatewayQueriesResponse]
 	getGatewayConsolidator     *connect.Client[multiadmin.GetGatewayConsolidatorRequest, multiadmin.GetGatewayConsolidatorResponse]
 	applyCertifiedRuleChange   *connect.Client[multiadmin.ApplyCertifiedRuleChangeRequest, multiadmin.ApplyCertifiedRuleChangeResponse]
+	switchPrimary              *connect.Client[multiadmin.SwitchPrimaryRequest, multiadmin.SwitchPrimaryResponse]
 }
 
 // GetCell calls multiadmin.MultiadminService.GetCell.
@@ -373,6 +390,11 @@ func (c *multiadminServiceClient) ApplyCertifiedRuleChange(ctx context.Context, 
 	return c.applyCertifiedRuleChange.CallUnary(ctx, req)
 }
 
+// SwitchPrimary calls multiadmin.MultiadminService.SwitchPrimary.
+func (c *multiadminServiceClient) SwitchPrimary(ctx context.Context, req *connect.Request[multiadmin.SwitchPrimaryRequest]) (*connect.Response[multiadmin.SwitchPrimaryResponse], error) {
+	return c.switchPrimary.CallUnary(ctx, req)
+}
+
 // MultiadminServiceHandler is an implementation of the multiadmin.MultiadminService service.
 type MultiadminServiceHandler interface {
 	// GetCell retrieves information about a specific cell
@@ -422,6 +444,13 @@ type MultiadminServiceHandler interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(context.Context, *connect.Request[multiadmin.ApplyCertifiedRuleChangeRequest]) (*connect.Response[multiadmin.ApplyCertifiedRuleChangeResponse], error)
+	// SwitchPrimary performs a graceful switchover for a shard. It quiesces
+	// writes on the current leader, restarts it as a standby, and publishes
+	// REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+	// leader through the normal consensus flow. The RPC returns as soon as the
+	// old primary has been quiesced — it does not wait for the new leader to
+	// appear.
+	SwitchPrimary(context.Context, *connect.Request[multiadmin.SwitchPrimaryRequest]) (*connect.Response[multiadmin.SwitchPrimaryResponse], error)
 }
 
 // NewMultiadminServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -533,6 +562,12 @@ func NewMultiadminServiceHandler(svc MultiadminServiceHandler, opts ...connect.H
 		connect.WithSchema(multiadminServiceMethods.ByName("ApplyCertifiedRuleChange")),
 		connect.WithHandlerOptions(opts...),
 	)
+	multiadminServiceSwitchPrimaryHandler := connect.NewUnaryHandler(
+		MultiadminServiceSwitchPrimaryProcedure,
+		svc.SwitchPrimary,
+		connect.WithSchema(multiadminServiceMethods.ByName("SwitchPrimary")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/multiadmin.MultiadminService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case MultiadminServiceGetCellProcedure:
@@ -569,6 +604,8 @@ func NewMultiadminServiceHandler(svc MultiadminServiceHandler, opts ...connect.H
 			multiadminServiceGetGatewayConsolidatorHandler.ServeHTTP(w, r)
 		case MultiadminServiceApplyCertifiedRuleChangeProcedure:
 			multiadminServiceApplyCertifiedRuleChangeHandler.ServeHTTP(w, r)
+		case MultiadminServiceSwitchPrimaryProcedure:
+			multiadminServiceSwitchPrimaryHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -644,4 +681,8 @@ func (UnimplementedMultiadminServiceHandler) GetGatewayConsolidator(context.Cont
 
 func (UnimplementedMultiadminServiceHandler) ApplyCertifiedRuleChange(context.Context, *connect.Request[multiadmin.ApplyCertifiedRuleChangeRequest]) (*connect.Response[multiadmin.ApplyCertifiedRuleChangeResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multiadmin.MultiadminService.ApplyCertifiedRuleChange is not implemented"))
+}
+
+func (UnimplementedMultiadminServiceHandler) SwitchPrimary(context.Context, *connect.Request[multiadmin.SwitchPrimaryRequest]) (*connect.Response[multiadmin.SwitchPrimaryResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multiadmin.MultiadminService.SwitchPrimary is not implemented"))
 }

--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -2418,6 +2418,124 @@ func (x *ApplyCertifiedRuleChangeResponse) GetCertUsed() *clustermetadata.Extern
 	return nil
 }
 
+type SwitchPrimaryRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shard to perform the switchover on (required).
+	ShardKey *clustermetadata.ShardKey `protobuf:"bytes,1,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"`
+	// Free-text reason recorded in rule_history for audit.
+	Reason string `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
+	// How long to poll for a new leader to be elected after the old primary
+	// resigns. Defaults to 30s if unset.
+	CatchupTimeout *durationpb.Duration `protobuf:"bytes,4,opt,name=catchup_timeout,json=catchupTimeout,proto3" json:"catchup_timeout,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SwitchPrimaryRequest) Reset() {
+	*x = SwitchPrimaryRequest{}
+	mi := &file_multiadminservice_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwitchPrimaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwitchPrimaryRequest) ProtoMessage() {}
+
+func (x *SwitchPrimaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multiadminservice_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwitchPrimaryRequest.ProtoReflect.Descriptor instead.
+func (*SwitchPrimaryRequest) Descriptor() ([]byte, []int) {
+	return file_multiadminservice_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *SwitchPrimaryRequest) GetShardKey() *clustermetadata.ShardKey {
+	if x != nil {
+		return x.ShardKey
+	}
+	return nil
+}
+
+func (x *SwitchPrimaryRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *SwitchPrimaryRequest) GetCatchupTimeout() *durationpb.Duration {
+	if x != nil {
+		return x.CatchupTimeout
+	}
+	return nil
+}
+
+type SwitchPrimaryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The pooler that was promoted to leader.
+	NewLeaderId *clustermetadata.ID `protobuf:"bytes,1,opt,name=new_leader_id,json=newLeaderId,proto3" json:"new_leader_id,omitempty"`
+	// The pooler that was demoted.
+	OldLeaderId   *clustermetadata.ID `protobuf:"bytes,2,opt,name=old_leader_id,json=oldLeaderId,proto3" json:"old_leader_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SwitchPrimaryResponse) Reset() {
+	*x = SwitchPrimaryResponse{}
+	mi := &file_multiadminservice_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwitchPrimaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwitchPrimaryResponse) ProtoMessage() {}
+
+func (x *SwitchPrimaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multiadminservice_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwitchPrimaryResponse.ProtoReflect.Descriptor instead.
+func (*SwitchPrimaryResponse) Descriptor() ([]byte, []int) {
+	return file_multiadminservice_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *SwitchPrimaryResponse) GetNewLeaderId() *clustermetadata.ID {
+	if x != nil {
+		return x.NewLeaderId
+	}
+	return nil
+}
+
+func (x *SwitchPrimaryResponse) GetOldLeaderId() *clustermetadata.ID {
+	if x != nil {
+		return x.OldLeaderId
+	}
+	return nil
+}
+
 var File_multiadminservice_proto protoreflect.FileDescriptor
 
 const file_multiadminservice_proto_rawDesc = "" +
@@ -2565,7 +2683,14 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x17UnsafeDeriveCertOptions\"\xb2\x01\n" +
 	" ApplyCertifiedRuleChangeResponse\x12A\n" +
 	"\x0einstalled_rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\rinstalledRule\x12K\n" +
-	"\tcert_used\x18\x02 \x01(\v2..clustermetadata.ExternallyCertifiedRevocationR\bcertUsed*J\n" +
+	"\tcert_used\x18\x02 \x01(\v2..clustermetadata.ExternallyCertifiedRevocationR\bcertUsed\"\xaa\x01\n" +
+	"\x14SwitchPrimaryRequest\x126\n" +
+	"\tshard_key\x18\x01 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\x12B\n" +
+	"\x0fcatchup_timeout\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\x0ecatchupTimeout\"\x89\x01\n" +
+	"\x15SwitchPrimaryResponse\x127\n" +
+	"\rnew_leader_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\vnewLeaderId\x127\n" +
+	"\rold_leader_id\x18\x02 \x01(\v2\x13.clustermetadata.IDR\voldLeaderId*J\n" +
 	"\aJobType\x12\x14\n" +
 	"\x10JOB_TYPE_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0fJOB_TYPE_BACKUP\x10\x01\x12\x14\n" +
@@ -2580,7 +2705,7 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x15BACKUP_STATUS_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18BACKUP_STATUS_INCOMPLETE\x10\x01\x12\x1a\n" +
 	"\x16BACKUP_STATUS_COMPLETE\x10\x02\x12\x18\n" +
-	"\x14BACKUP_STATUS_FAILED\x10\x032\xe3\x12\n" +
+	"\x14BACKUP_STATUS_FAILED\x10\x032\xa3\x14\n" +
 	"\x11MultiAdminService\x12`\n" +
 	"\aGetCell\x12\x1a.multiadmin.GetCellRequest\x1a\x1b.multiadmin.GetCellResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/api/v1/cells/{name}\x12p\n" +
 	"\vGetDatabase\x12\x1e.multiadmin.GetDatabaseRequest\x1a\x1f.multiadmin.GetDatabaseResponse\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/api/v1/databases/{name}\x12h\n" +
@@ -2601,7 +2726,8 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x1aSetPostgresRestartsEnabled\x12-.multiadmin.SetPostgresRestartsEnabledRequest\x1a..multiadmin.SetPostgresRestartsEnabledResponse\"N\x82\xd3\xe4\x93\x02H:\x01*\"C/api/v1/poolers/{pooler_id.cell}/{pooler_id.name}/postgres-restarts\x12\xa6\x01\n" +
 	"\x11GetGatewayQueries\x12$.multiadmin.GetGatewayQueriesRequest\x1a%.multiadmin.GetGatewayQueriesResponse\"D\x82\xd3\xe4\x93\x02>\x12</api/v1/gateways/{gateway_id.cell}/{gateway_id.name}/queries\x12\xba\x01\n" +
 	"\x16GetGatewayConsolidator\x12).multiadmin.GetGatewayConsolidatorRequest\x1a*.multiadmin.GetGatewayConsolidatorResponse\"I\x82\xd3\xe4\x93\x02C\x12A/api/v1/gateways/{gateway_id.cell}/{gateway_id.name}/consolidator\x12\xdb\x01\n" +
-	"\x18ApplyCertifiedRuleChange\x12+.multiadmin.ApplyCertifiedRuleChangeRequest\x1a,.multiadmin.ApplyCertifiedRuleChangeResponse\"d\x82\xd3\xe4\x93\x02^:\x01*\"Y/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/rule-changeB1Z/github.com/multigres/multigres/go/pb/multiadminb\x06proto3"
+	"\x18ApplyCertifiedRuleChange\x12+.multiadmin.ApplyCertifiedRuleChangeRequest\x1a,.multiadmin.ApplyCertifiedRuleChangeResponse\"d\x82\xd3\xe4\x93\x02^:\x01*\"Y/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/rule-change\x12\xbd\x01\n" +
+	"\rSwitchPrimary\x12 .multiadmin.SwitchPrimaryRequest\x1a!.multiadmin.SwitchPrimaryResponse\"g\x82\xd3\xe4\x93\x02a:\x01*\"\\/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primaryB1Z/github.com/multigres/multigres/go/pb/multiadminb\x06proto3"
 
 var (
 	file_multiadminservice_proto_rawDescOnce sync.Once
@@ -2616,7 +2742,7 @@ func file_multiadminservice_proto_rawDescGZIP() []byte {
 }
 
 var file_multiadminservice_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_multiadminservice_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_multiadminservice_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
 var file_multiadminservice_proto_goTypes = []any{
 	(JobType)(0),                                          // 0: multiadmin.JobType
 	(JobStatus)(0),                                        // 1: multiadmin.JobStatus
@@ -2659,94 +2785,102 @@ var file_multiadminservice_proto_goTypes = []any{
 	(*ApplyCertifiedRuleChangeRequest)(nil),               // 38: multiadmin.ApplyCertifiedRuleChangeRequest
 	(*UnsafeDeriveCertOptions)(nil),                       // 39: multiadmin.UnsafeDeriveCertOptions
 	(*ApplyCertifiedRuleChangeResponse)(nil),              // 40: multiadmin.ApplyCertifiedRuleChangeResponse
-	nil,                                                   // 41: multiadmin.ExpireBackupsRequest.OverridesEntry
-	(*clustermetadata.Cell)(nil),                          // 42: clustermetadata.Cell
-	(*clustermetadata.Database)(nil),                      // 43: clustermetadata.Database
-	(*clustermetadata.MultiGateway)(nil),                  // 44: clustermetadata.MultiGateway
-	(*clustermetadata.MultiPooler)(nil),                   // 45: clustermetadata.MultiPooler
-	(*clustermetadata.MultiOrch)(nil),                     // 46: clustermetadata.MultiOrch
-	(*clustermetadata.ID)(nil),                            // 47: clustermetadata.ID
-	(*durationpb.Duration)(nil),                           // 48: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                         // 49: google.protobuf.Timestamp
-	(clustermetadata.PoolerType)(0),                       // 50: clustermetadata.PoolerType
-	(*multipoolermanagerdata.Status)(nil),                 // 51: multipoolermanagerdata.Status
-	(*clustermetadata.ConsensusStatus)(nil),               // 52: clustermetadata.ConsensusStatus
-	(*multigatewaymanagerdata.QueryRegistrySnapshot)(nil), // 53: multigatewaymanagerdata.QueryRegistrySnapshot
-	(*multigatewaymanagerdata.ConsolidatorStats)(nil),     // 54: multigatewaymanagerdata.ConsolidatorStats
-	(*clustermetadata.ShardKey)(nil),                      // 55: clustermetadata.ShardKey
-	(*clustermetadata.ShardRule)(nil),                     // 56: clustermetadata.ShardRule
-	(*clustermetadata.ExternallyCertifiedRevocation)(nil), // 57: clustermetadata.ExternallyCertifiedRevocation
+	(*SwitchPrimaryRequest)(nil),                          // 41: multiadmin.SwitchPrimaryRequest
+	(*SwitchPrimaryResponse)(nil),                         // 42: multiadmin.SwitchPrimaryResponse
+	nil,                                                   // 43: multiadmin.ExpireBackupsRequest.OverridesEntry
+	(*clustermetadata.Cell)(nil),                          // 44: clustermetadata.Cell
+	(*clustermetadata.Database)(nil),                      // 45: clustermetadata.Database
+	(*clustermetadata.MultiGateway)(nil),                  // 46: clustermetadata.MultiGateway
+	(*clustermetadata.MultiPooler)(nil),                   // 47: clustermetadata.MultiPooler
+	(*clustermetadata.MultiOrch)(nil),                     // 48: clustermetadata.MultiOrch
+	(*clustermetadata.ID)(nil),                            // 49: clustermetadata.ID
+	(*durationpb.Duration)(nil),                           // 50: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                         // 51: google.protobuf.Timestamp
+	(clustermetadata.PoolerType)(0),                       // 52: clustermetadata.PoolerType
+	(*multipoolermanagerdata.Status)(nil),                 // 53: multipoolermanagerdata.Status
+	(*clustermetadata.ConsensusStatus)(nil),               // 54: clustermetadata.ConsensusStatus
+	(*multigatewaymanagerdata.QueryRegistrySnapshot)(nil), // 55: multigatewaymanagerdata.QueryRegistrySnapshot
+	(*multigatewaymanagerdata.ConsolidatorStats)(nil),     // 56: multigatewaymanagerdata.ConsolidatorStats
+	(*clustermetadata.ShardKey)(nil),                      // 57: clustermetadata.ShardKey
+	(*clustermetadata.ShardRule)(nil),                     // 58: clustermetadata.ShardRule
+	(*clustermetadata.ExternallyCertifiedRevocation)(nil), // 59: clustermetadata.ExternallyCertifiedRevocation
 }
 var file_multiadminservice_proto_depIdxs = []int32{
-	42, // 0: multiadmin.GetCellResponse.cell:type_name -> clustermetadata.Cell
-	43, // 1: multiadmin.GetDatabaseResponse.database:type_name -> clustermetadata.Database
-	44, // 2: multiadmin.GetGatewaysResponse.gateways:type_name -> clustermetadata.MultiGateway
-	45, // 3: multiadmin.GetPoolersResponse.poolers:type_name -> clustermetadata.MultiPooler
-	46, // 4: multiadmin.GetOrchsResponse.orchs:type_name -> clustermetadata.MultiOrch
-	47, // 5: multiadmin.RestoreFromBackupRequest.pooler_id:type_name -> clustermetadata.ID
+	44, // 0: multiadmin.GetCellResponse.cell:type_name -> clustermetadata.Cell
+	45, // 1: multiadmin.GetDatabaseResponse.database:type_name -> clustermetadata.Database
+	46, // 2: multiadmin.GetGatewaysResponse.gateways:type_name -> clustermetadata.MultiGateway
+	47, // 3: multiadmin.GetPoolersResponse.poolers:type_name -> clustermetadata.MultiPooler
+	48, // 4: multiadmin.GetOrchsResponse.orchs:type_name -> clustermetadata.MultiOrch
+	49, // 5: multiadmin.RestoreFromBackupRequest.pooler_id:type_name -> clustermetadata.ID
 	0,  // 6: multiadmin.GetBackupJobStatusResponse.job_type:type_name -> multiadmin.JobType
 	1,  // 7: multiadmin.GetBackupJobStatusResponse.status:type_name -> multiadmin.JobStatus
 	29, // 8: multiadmin.GetBackupsResponse.backups:type_name -> multiadmin.BackupInfo
-	41, // 9: multiadmin.ExpireBackupsRequest.overrides:type_name -> multiadmin.ExpireBackupsRequest.OverridesEntry
-	48, // 10: multiadmin.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	43, // 9: multiadmin.ExpireBackupsRequest.overrides:type_name -> multiadmin.ExpireBackupsRequest.OverridesEntry
+	50, // 10: multiadmin.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	2,  // 11: multiadmin.BackupInfo.status:type_name -> multiadmin.BackupStatus
-	49, // 12: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
-	50, // 13: multiadmin.BackupInfo.pooler_type:type_name -> clustermetadata.PoolerType
-	47, // 14: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
-	51, // 15: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
-	52, // 16: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	47, // 17: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
-	47, // 18: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
-	53, // 19: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
-	47, // 20: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
-	54, // 21: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
-	55, // 22: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
-	56, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_rule:type_name -> clustermetadata.ShardRule
-	57, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	51, // 12: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
+	52, // 13: multiadmin.BackupInfo.pooler_type:type_name -> clustermetadata.PoolerType
+	49, // 14: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
+	53, // 15: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
+	54, // 16: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	49, // 17: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
+	49, // 18: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
+	55, // 19: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
+	49, // 20: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
+	56, // 21: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
+	57, // 22: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
+	58, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_rule:type_name -> clustermetadata.ShardRule
+	59, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
 	39, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
-	56, // 26: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
-	57, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	3,  // 28: multiadmin.MultiAdminService.GetCell:input_type -> multiadmin.GetCellRequest
-	5,  // 29: multiadmin.MultiAdminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
-	7,  // 30: multiadmin.MultiAdminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
-	9,  // 31: multiadmin.MultiAdminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
-	11, // 32: multiadmin.MultiAdminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
-	13, // 33: multiadmin.MultiAdminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
-	15, // 34: multiadmin.MultiAdminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
-	17, // 35: multiadmin.MultiAdminService.Backup:input_type -> multiadmin.BackupRequest
-	19, // 36: multiadmin.MultiAdminService.RestoreFromBackup:input_type -> multiadmin.RestoreFromBackupRequest
-	21, // 37: multiadmin.MultiAdminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
-	23, // 38: multiadmin.MultiAdminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
-	25, // 39: multiadmin.MultiAdminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
-	27, // 40: multiadmin.MultiAdminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
-	30, // 41: multiadmin.MultiAdminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
-	32, // 42: multiadmin.MultiAdminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
-	34, // 43: multiadmin.MultiAdminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
-	36, // 44: multiadmin.MultiAdminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
-	38, // 45: multiadmin.MultiAdminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
-	4,  // 46: multiadmin.MultiAdminService.GetCell:output_type -> multiadmin.GetCellResponse
-	6,  // 47: multiadmin.MultiAdminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
-	8,  // 48: multiadmin.MultiAdminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
-	10, // 49: multiadmin.MultiAdminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
-	12, // 50: multiadmin.MultiAdminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
-	14, // 51: multiadmin.MultiAdminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
-	16, // 52: multiadmin.MultiAdminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
-	18, // 53: multiadmin.MultiAdminService.Backup:output_type -> multiadmin.BackupResponse
-	20, // 54: multiadmin.MultiAdminService.RestoreFromBackup:output_type -> multiadmin.RestoreFromBackupResponse
-	22, // 55: multiadmin.MultiAdminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
-	24, // 56: multiadmin.MultiAdminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
-	26, // 57: multiadmin.MultiAdminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
-	28, // 58: multiadmin.MultiAdminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
-	31, // 59: multiadmin.MultiAdminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
-	33, // 60: multiadmin.MultiAdminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
-	35, // 61: multiadmin.MultiAdminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
-	37, // 62: multiadmin.MultiAdminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
-	40, // 63: multiadmin.MultiAdminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
-	46, // [46:64] is the sub-list for method output_type
-	28, // [28:46] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	58, // 26: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
+	59, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	57, // 28: multiadmin.SwitchPrimaryRequest.shard_key:type_name -> clustermetadata.ShardKey
+	50, // 29: multiadmin.SwitchPrimaryRequest.catchup_timeout:type_name -> google.protobuf.Duration
+	49, // 30: multiadmin.SwitchPrimaryResponse.new_leader_id:type_name -> clustermetadata.ID
+	49, // 31: multiadmin.SwitchPrimaryResponse.old_leader_id:type_name -> clustermetadata.ID
+	3,  // 32: multiadmin.MultiAdminService.GetCell:input_type -> multiadmin.GetCellRequest
+	5,  // 33: multiadmin.MultiAdminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
+	7,  // 34: multiadmin.MultiAdminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
+	9,  // 35: multiadmin.MultiAdminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
+	11, // 36: multiadmin.MultiAdminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
+	13, // 37: multiadmin.MultiAdminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
+	15, // 38: multiadmin.MultiAdminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
+	17, // 39: multiadmin.MultiAdminService.Backup:input_type -> multiadmin.BackupRequest
+	19, // 40: multiadmin.MultiAdminService.RestoreFromBackup:input_type -> multiadmin.RestoreFromBackupRequest
+	21, // 41: multiadmin.MultiAdminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
+	23, // 42: multiadmin.MultiAdminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
+	25, // 43: multiadmin.MultiAdminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
+	27, // 44: multiadmin.MultiAdminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
+	30, // 45: multiadmin.MultiAdminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
+	32, // 46: multiadmin.MultiAdminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
+	34, // 47: multiadmin.MultiAdminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
+	36, // 48: multiadmin.MultiAdminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
+	38, // 49: multiadmin.MultiAdminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
+	41, // 50: multiadmin.MultiAdminService.SwitchPrimary:input_type -> multiadmin.SwitchPrimaryRequest
+	4,  // 51: multiadmin.MultiAdminService.GetCell:output_type -> multiadmin.GetCellResponse
+	6,  // 52: multiadmin.MultiAdminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
+	8,  // 53: multiadmin.MultiAdminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
+	10, // 54: multiadmin.MultiAdminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
+	12, // 55: multiadmin.MultiAdminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
+	14, // 56: multiadmin.MultiAdminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
+	16, // 57: multiadmin.MultiAdminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
+	18, // 58: multiadmin.MultiAdminService.Backup:output_type -> multiadmin.BackupResponse
+	20, // 59: multiadmin.MultiAdminService.RestoreFromBackup:output_type -> multiadmin.RestoreFromBackupResponse
+	22, // 60: multiadmin.MultiAdminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
+	24, // 61: multiadmin.MultiAdminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
+	26, // 62: multiadmin.MultiAdminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
+	28, // 63: multiadmin.MultiAdminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
+	31, // 64: multiadmin.MultiAdminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
+	33, // 65: multiadmin.MultiAdminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
+	35, // 66: multiadmin.MultiAdminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
+	37, // 67: multiadmin.MultiAdminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
+	40, // 68: multiadmin.MultiAdminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
+	42, // 69: multiadmin.MultiAdminService.SwitchPrimary:output_type -> multiadmin.SwitchPrimaryResponse
+	51, // [51:70] is the sub-list for method output_type
+	32, // [32:51] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_multiadminservice_proto_init() }
@@ -2764,7 +2898,7 @@ func file_multiadminservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multiadminservice_proto_rawDesc), len(file_multiadminservice_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   39,
+			NumMessages:   41,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -2358,6 +2358,105 @@ func (x *ApplyCertifiedRuleChangeResponse) GetCertUsed() *clustermetadata.Extern
 	return nil
 }
 
+type SwitchPrimaryRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Shard to perform the switchover on (required).
+	ShardKey *clustermetadata.ShardKey `protobuf:"bytes,1,opt,name=shard_key,json=shardKey,proto3" json:"shard_key,omitempty"`
+	// Free-text reason recorded in rule_history for audit.
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SwitchPrimaryRequest) Reset() {
+	*x = SwitchPrimaryRequest{}
+	mi := &file_multiadminservice_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwitchPrimaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwitchPrimaryRequest) ProtoMessage() {}
+
+func (x *SwitchPrimaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multiadminservice_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwitchPrimaryRequest.ProtoReflect.Descriptor instead.
+func (*SwitchPrimaryRequest) Descriptor() ([]byte, []int) {
+	return file_multiadminservice_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *SwitchPrimaryRequest) GetShardKey() *clustermetadata.ShardKey {
+	if x != nil {
+		return x.ShardKey
+	}
+	return nil
+}
+
+func (x *SwitchPrimaryRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type SwitchPrimaryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The pooler that was demoted.
+	OldLeaderId   *clustermetadata.ID `protobuf:"bytes,1,opt,name=old_leader_id,json=oldLeaderId,proto3" json:"old_leader_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SwitchPrimaryResponse) Reset() {
+	*x = SwitchPrimaryResponse{}
+	mi := &file_multiadminservice_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwitchPrimaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwitchPrimaryResponse) ProtoMessage() {}
+
+func (x *SwitchPrimaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multiadminservice_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwitchPrimaryResponse.ProtoReflect.Descriptor instead.
+func (*SwitchPrimaryResponse) Descriptor() ([]byte, []int) {
+	return file_multiadminservice_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *SwitchPrimaryResponse) GetOldLeaderId() *clustermetadata.ID {
+	if x != nil {
+		return x.OldLeaderId
+	}
+	return nil
+}
+
 var File_multiadminservice_proto protoreflect.FileDescriptor
 
 const file_multiadminservice_proto_rawDesc = "" +
@@ -2502,7 +2601,12 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x17UnsafeDeriveCertOptions\"\xb2\x01\n" +
 	" ApplyCertifiedRuleChangeResponse\x12A\n" +
 	"\x0einstalled_rule\x18\x01 \x01(\v2\x1a.clustermetadata.ShardRuleR\rinstalledRule\x12K\n" +
-	"\tcert_used\x18\x02 \x01(\v2..clustermetadata.ExternallyCertifiedRevocationR\bcertUsed*J\n" +
+	"\tcert_used\x18\x02 \x01(\v2..clustermetadata.ExternallyCertifiedRevocationR\bcertUsed\"f\n" +
+	"\x14SwitchPrimaryRequest\x126\n" +
+	"\tshard_key\x18\x01 \x01(\v2\x19.clustermetadata.ShardKeyR\bshardKey\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\"P\n" +
+	"\x15SwitchPrimaryResponse\x127\n" +
+	"\rold_leader_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\voldLeaderId*J\n" +
 	"\aJobType\x12\x14\n" +
 	"\x10JOB_TYPE_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0fJOB_TYPE_BACKUP\x10\x01\x12\x14\n" +
@@ -2517,7 +2621,7 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x15BACKUP_STATUS_UNKNOWN\x10\x00\x12\x1c\n" +
 	"\x18BACKUP_STATUS_INCOMPLETE\x10\x01\x12\x1a\n" +
 	"\x16BACKUP_STATUS_COMPLETE\x10\x02\x12\x18\n" +
-	"\x14BACKUP_STATUS_FAILED\x10\x032\xe4\x11\n" +
+	"\x14BACKUP_STATUS_FAILED\x10\x032\xa4\x13\n" +
 	"\x11MultiadminService\x12`\n" +
 	"\aGetCell\x12\x1a.multiadmin.GetCellRequest\x1a\x1b.multiadmin.GetCellResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/api/v1/cells/{name}\x12p\n" +
 	"\vGetDatabase\x12\x1e.multiadmin.GetDatabaseRequest\x1a\x1f.multiadmin.GetDatabaseResponse\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/api/v1/databases/{name}\x12h\n" +
@@ -2537,7 +2641,8 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x1aSetPostgresRestartsEnabled\x12-.multiadmin.SetPostgresRestartsEnabledRequest\x1a..multiadmin.SetPostgresRestartsEnabledResponse\"N\x82\xd3\xe4\x93\x02H:\x01*\"C/api/v1/poolers/{pooler_id.cell}/{pooler_id.name}/postgres-restarts\x12\xa6\x01\n" +
 	"\x11GetGatewayQueries\x12$.multiadmin.GetGatewayQueriesRequest\x1a%.multiadmin.GetGatewayQueriesResponse\"D\x82\xd3\xe4\x93\x02>\x12</api/v1/gateways/{gateway_id.cell}/{gateway_id.name}/queries\x12\xba\x01\n" +
 	"\x16GetGatewayConsolidator\x12).multiadmin.GetGatewayConsolidatorRequest\x1a*.multiadmin.GetGatewayConsolidatorResponse\"I\x82\xd3\xe4\x93\x02C\x12A/api/v1/gateways/{gateway_id.cell}/{gateway_id.name}/consolidator\x12\xdb\x01\n" +
-	"\x18ApplyCertifiedRuleChange\x12+.multiadmin.ApplyCertifiedRuleChangeRequest\x1a,.multiadmin.ApplyCertifiedRuleChangeResponse\"d\x82\xd3\xe4\x93\x02^:\x01*\"Y/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/rule-changeB1Z/github.com/multigres/multigres/go/pb/multiadminb\x06proto3"
+	"\x18ApplyCertifiedRuleChange\x12+.multiadmin.ApplyCertifiedRuleChangeRequest\x1a,.multiadmin.ApplyCertifiedRuleChangeResponse\"d\x82\xd3\xe4\x93\x02^:\x01*\"Y/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/rule-change\x12\xbd\x01\n" +
+	"\rSwitchPrimary\x12 .multiadmin.SwitchPrimaryRequest\x1a!.multiadmin.SwitchPrimaryResponse\"g\x82\xd3\xe4\x93\x02a:\x01*\"\\/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primaryB1Z/github.com/multigres/multigres/go/pb/multiadminb\x06proto3"
 
 var (
 	file_multiadminservice_proto_rawDescOnce sync.Once
@@ -2552,7 +2657,7 @@ func file_multiadminservice_proto_rawDescGZIP() []byte {
 }
 
 var file_multiadminservice_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_multiadminservice_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_multiadminservice_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_multiadminservice_proto_goTypes = []any{
 	(JobType)(0),                                          // 0: multiadmin.JobType
 	(JobStatus)(0),                                        // 1: multiadmin.JobStatus
@@ -2593,94 +2698,100 @@ var file_multiadminservice_proto_goTypes = []any{
 	(*ApplyCertifiedRuleChangeRequest)(nil),               // 36: multiadmin.ApplyCertifiedRuleChangeRequest
 	(*UnsafeDeriveCertOptions)(nil),                       // 37: multiadmin.UnsafeDeriveCertOptions
 	(*ApplyCertifiedRuleChangeResponse)(nil),              // 38: multiadmin.ApplyCertifiedRuleChangeResponse
-	nil,                                                   // 39: multiadmin.ExpireBackupsRequest.OverridesEntry
-	(*clustermetadata.Cell)(nil),                          // 40: clustermetadata.Cell
-	(*clustermetadata.Database)(nil),                      // 41: clustermetadata.Database
-	(*clustermetadata.Multigateway)(nil),                  // 42: clustermetadata.Multigateway
-	(*clustermetadata.Multipooler)(nil),                   // 43: clustermetadata.Multipooler
-	(*clustermetadata.Multiorch)(nil),                     // 44: clustermetadata.Multiorch
-	(*durationpb.Duration)(nil),                           // 45: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                         // 46: google.protobuf.Timestamp
-	(clustermetadata.RoutingRole)(0),                      // 47: clustermetadata.RoutingRole
-	(*clustermetadata.ID)(nil),                            // 48: clustermetadata.ID
-	(*multipoolermanagerdata.Status)(nil),                 // 49: multipoolermanagerdata.Status
-	(*clustermetadata.ConsensusStatus)(nil),               // 50: clustermetadata.ConsensusStatus
-	(*multigatewaymanagerdata.QueryRegistrySnapshot)(nil), // 51: multigatewaymanagerdata.QueryRegistrySnapshot
-	(*multigatewaymanagerdata.ConsolidatorStats)(nil),     // 52: multigatewaymanagerdata.ConsolidatorStats
-	(*clustermetadata.ShardKey)(nil),                      // 53: clustermetadata.ShardKey
-	(*clustermetadata.RulePosition)(nil),                  // 54: clustermetadata.RulePosition
-	(*clustermetadata.ExternallyCertifiedRevocation)(nil), // 55: clustermetadata.ExternallyCertifiedRevocation
-	(*clustermetadata.ShardRule)(nil),                     // 56: clustermetadata.ShardRule
+	(*SwitchPrimaryRequest)(nil),                          // 39: multiadmin.SwitchPrimaryRequest
+	(*SwitchPrimaryResponse)(nil),                         // 40: multiadmin.SwitchPrimaryResponse
+	nil,                                                   // 41: multiadmin.ExpireBackupsRequest.OverridesEntry
+	(*clustermetadata.Cell)(nil),                          // 42: clustermetadata.Cell
+	(*clustermetadata.Database)(nil),                      // 43: clustermetadata.Database
+	(*clustermetadata.Multigateway)(nil),                  // 44: clustermetadata.Multigateway
+	(*clustermetadata.Multipooler)(nil),                   // 45: clustermetadata.Multipooler
+	(*clustermetadata.Multiorch)(nil),                     // 46: clustermetadata.Multiorch
+	(*durationpb.Duration)(nil),                           // 47: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                         // 48: google.protobuf.Timestamp
+	(clustermetadata.RoutingRole)(0),                      // 49: clustermetadata.RoutingRole
+	(*clustermetadata.ID)(nil),                            // 50: clustermetadata.ID
+	(*multipoolermanagerdata.Status)(nil),                 // 51: multipoolermanagerdata.Status
+	(*clustermetadata.ConsensusStatus)(nil),               // 52: clustermetadata.ConsensusStatus
+	(*multigatewaymanagerdata.QueryRegistrySnapshot)(nil), // 53: multigatewaymanagerdata.QueryRegistrySnapshot
+	(*multigatewaymanagerdata.ConsolidatorStats)(nil),     // 54: multigatewaymanagerdata.ConsolidatorStats
+	(*clustermetadata.ShardKey)(nil),                      // 55: clustermetadata.ShardKey
+	(*clustermetadata.RulePosition)(nil),                  // 56: clustermetadata.RulePosition
+	(*clustermetadata.ExternallyCertifiedRevocation)(nil), // 57: clustermetadata.ExternallyCertifiedRevocation
+	(*clustermetadata.ShardRule)(nil),                     // 58: clustermetadata.ShardRule
 }
 var file_multiadminservice_proto_depIdxs = []int32{
-	40, // 0: multiadmin.GetCellResponse.cell:type_name -> clustermetadata.Cell
-	41, // 1: multiadmin.GetDatabaseResponse.database:type_name -> clustermetadata.Database
-	42, // 2: multiadmin.GetGatewaysResponse.gateways:type_name -> clustermetadata.Multigateway
-	43, // 3: multiadmin.GetPoolersResponse.poolers:type_name -> clustermetadata.Multipooler
-	44, // 4: multiadmin.GetOrchsResponse.orchs:type_name -> clustermetadata.Multiorch
+	42, // 0: multiadmin.GetCellResponse.cell:type_name -> clustermetadata.Cell
+	43, // 1: multiadmin.GetDatabaseResponse.database:type_name -> clustermetadata.Database
+	44, // 2: multiadmin.GetGatewaysResponse.gateways:type_name -> clustermetadata.Multigateway
+	45, // 3: multiadmin.GetPoolersResponse.poolers:type_name -> clustermetadata.Multipooler
+	46, // 4: multiadmin.GetOrchsResponse.orchs:type_name -> clustermetadata.Multiorch
 	0,  // 5: multiadmin.GetBackupJobStatusResponse.job_type:type_name -> multiadmin.JobType
 	1,  // 6: multiadmin.GetBackupJobStatusResponse.status:type_name -> multiadmin.JobStatus
 	27, // 7: multiadmin.GetBackupsResponse.backups:type_name -> multiadmin.BackupInfo
-	39, // 8: multiadmin.ExpireBackupsRequest.overrides:type_name -> multiadmin.ExpireBackupsRequest.OverridesEntry
-	45, // 9: multiadmin.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	41, // 8: multiadmin.ExpireBackupsRequest.overrides:type_name -> multiadmin.ExpireBackupsRequest.OverridesEntry
+	47, // 9: multiadmin.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	2,  // 10: multiadmin.BackupInfo.status:type_name -> multiadmin.BackupStatus
-	46, // 11: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
-	47, // 12: multiadmin.BackupInfo.routing_role:type_name -> clustermetadata.RoutingRole
-	46, // 13: multiadmin.BackupInfo.start_timestamp:type_name -> google.protobuf.Timestamp
-	46, // 14: multiadmin.BackupInfo.stop_timestamp:type_name -> google.protobuf.Timestamp
-	48, // 15: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
-	49, // 16: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 17: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
-	48, // 18: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
-	48, // 19: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
-	51, // 20: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
-	48, // 21: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
-	52, // 22: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
-	53, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
-	54, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
-	55, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	48, // 11: multiadmin.BackupInfo.backup_time:type_name -> google.protobuf.Timestamp
+	49, // 12: multiadmin.BackupInfo.routing_role:type_name -> clustermetadata.RoutingRole
+	48, // 13: multiadmin.BackupInfo.start_timestamp:type_name -> google.protobuf.Timestamp
+	48, // 14: multiadmin.BackupInfo.stop_timestamp:type_name -> google.protobuf.Timestamp
+	50, // 15: multiadmin.GetPoolerStatusRequest.pooler_id:type_name -> clustermetadata.ID
+	51, // 16: multiadmin.GetPoolerStatusResponse.status:type_name -> multipoolermanagerdata.Status
+	52, // 17: multiadmin.GetPoolerStatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	50, // 18: multiadmin.SetPostgresRestartsEnabledRequest.pooler_id:type_name -> clustermetadata.ID
+	50, // 19: multiadmin.GetGatewayQueriesRequest.gateway_id:type_name -> clustermetadata.ID
+	53, // 20: multiadmin.GetGatewayQueriesResponse.snapshot:type_name -> multigatewaymanagerdata.QueryRegistrySnapshot
+	50, // 21: multiadmin.GetGatewayConsolidatorRequest.gateway_id:type_name -> clustermetadata.ID
+	54, // 22: multiadmin.GetGatewayConsolidatorResponse.stats:type_name -> multigatewaymanagerdata.ConsolidatorStats
+	55, // 23: multiadmin.ApplyCertifiedRuleChangeRequest.shard_key:type_name -> clustermetadata.ShardKey
+	56, // 24: multiadmin.ApplyCertifiedRuleChangeRequest.proposed_transition:type_name -> clustermetadata.RulePosition
+	57, // 25: multiadmin.ApplyCertifiedRuleChangeRequest.cert:type_name -> clustermetadata.ExternallyCertifiedRevocation
 	37, // 26: multiadmin.ApplyCertifiedRuleChangeRequest.unsafe_derive_cert:type_name -> multiadmin.UnsafeDeriveCertOptions
-	56, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
-	55, // 28: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
-	3,  // 29: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
-	5,  // 30: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
-	7,  // 31: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
-	9,  // 32: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
-	11, // 33: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
-	13, // 34: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
-	15, // 35: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
-	17, // 36: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
-	19, // 37: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
-	21, // 38: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
-	23, // 39: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
-	25, // 40: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
-	28, // 41: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
-	30, // 42: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
-	32, // 43: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
-	34, // 44: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
-	36, // 45: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
-	4,  // 46: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
-	6,  // 47: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
-	8,  // 48: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
-	10, // 49: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
-	12, // 50: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
-	14, // 51: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
-	16, // 52: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
-	18, // 53: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
-	20, // 54: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
-	22, // 55: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
-	24, // 56: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
-	26, // 57: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
-	29, // 58: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
-	31, // 59: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
-	33, // 60: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
-	35, // 61: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
-	38, // 62: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
-	46, // [46:63] is the sub-list for method output_type
-	29, // [29:46] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	58, // 27: multiadmin.ApplyCertifiedRuleChangeResponse.installed_rule:type_name -> clustermetadata.ShardRule
+	57, // 28: multiadmin.ApplyCertifiedRuleChangeResponse.cert_used:type_name -> clustermetadata.ExternallyCertifiedRevocation
+	55, // 29: multiadmin.SwitchPrimaryRequest.shard_key:type_name -> clustermetadata.ShardKey
+	50, // 30: multiadmin.SwitchPrimaryResponse.old_leader_id:type_name -> clustermetadata.ID
+	3,  // 31: multiadmin.MultiadminService.GetCell:input_type -> multiadmin.GetCellRequest
+	5,  // 32: multiadmin.MultiadminService.GetDatabase:input_type -> multiadmin.GetDatabaseRequest
+	7,  // 33: multiadmin.MultiadminService.GetCellNames:input_type -> multiadmin.GetCellNamesRequest
+	9,  // 34: multiadmin.MultiadminService.GetDatabaseNames:input_type -> multiadmin.GetDatabaseNamesRequest
+	11, // 35: multiadmin.MultiadminService.GetGateways:input_type -> multiadmin.GetGatewaysRequest
+	13, // 36: multiadmin.MultiadminService.GetPoolers:input_type -> multiadmin.GetPoolersRequest
+	15, // 37: multiadmin.MultiadminService.GetOrchs:input_type -> multiadmin.GetOrchsRequest
+	17, // 38: multiadmin.MultiadminService.Backup:input_type -> multiadmin.BackupRequest
+	19, // 39: multiadmin.MultiadminService.GetBackupJobStatus:input_type -> multiadmin.GetBackupJobStatusRequest
+	21, // 40: multiadmin.MultiadminService.GetBackups:input_type -> multiadmin.GetBackupsRequest
+	23, // 41: multiadmin.MultiadminService.ExpireBackups:input_type -> multiadmin.ExpireBackupsRequest
+	25, // 42: multiadmin.MultiadminService.VerifyBackups:input_type -> multiadmin.VerifyBackupsRequest
+	28, // 43: multiadmin.MultiadminService.GetPoolerStatus:input_type -> multiadmin.GetPoolerStatusRequest
+	30, // 44: multiadmin.MultiadminService.SetPostgresRestartsEnabled:input_type -> multiadmin.SetPostgresRestartsEnabledRequest
+	32, // 45: multiadmin.MultiadminService.GetGatewayQueries:input_type -> multiadmin.GetGatewayQueriesRequest
+	34, // 46: multiadmin.MultiadminService.GetGatewayConsolidator:input_type -> multiadmin.GetGatewayConsolidatorRequest
+	36, // 47: multiadmin.MultiadminService.ApplyCertifiedRuleChange:input_type -> multiadmin.ApplyCertifiedRuleChangeRequest
+	39, // 48: multiadmin.MultiadminService.SwitchPrimary:input_type -> multiadmin.SwitchPrimaryRequest
+	4,  // 49: multiadmin.MultiadminService.GetCell:output_type -> multiadmin.GetCellResponse
+	6,  // 50: multiadmin.MultiadminService.GetDatabase:output_type -> multiadmin.GetDatabaseResponse
+	8,  // 51: multiadmin.MultiadminService.GetCellNames:output_type -> multiadmin.GetCellNamesResponse
+	10, // 52: multiadmin.MultiadminService.GetDatabaseNames:output_type -> multiadmin.GetDatabaseNamesResponse
+	12, // 53: multiadmin.MultiadminService.GetGateways:output_type -> multiadmin.GetGatewaysResponse
+	14, // 54: multiadmin.MultiadminService.GetPoolers:output_type -> multiadmin.GetPoolersResponse
+	16, // 55: multiadmin.MultiadminService.GetOrchs:output_type -> multiadmin.GetOrchsResponse
+	18, // 56: multiadmin.MultiadminService.Backup:output_type -> multiadmin.BackupResponse
+	20, // 57: multiadmin.MultiadminService.GetBackupJobStatus:output_type -> multiadmin.GetBackupJobStatusResponse
+	22, // 58: multiadmin.MultiadminService.GetBackups:output_type -> multiadmin.GetBackupsResponse
+	24, // 59: multiadmin.MultiadminService.ExpireBackups:output_type -> multiadmin.ExpireBackupsResponse
+	26, // 60: multiadmin.MultiadminService.VerifyBackups:output_type -> multiadmin.VerifyBackupsResponse
+	29, // 61: multiadmin.MultiadminService.GetPoolerStatus:output_type -> multiadmin.GetPoolerStatusResponse
+	31, // 62: multiadmin.MultiadminService.SetPostgresRestartsEnabled:output_type -> multiadmin.SetPostgresRestartsEnabledResponse
+	33, // 63: multiadmin.MultiadminService.GetGatewayQueries:output_type -> multiadmin.GetGatewayQueriesResponse
+	35, // 64: multiadmin.MultiadminService.GetGatewayConsolidator:output_type -> multiadmin.GetGatewayConsolidatorResponse
+	38, // 65: multiadmin.MultiadminService.ApplyCertifiedRuleChange:output_type -> multiadmin.ApplyCertifiedRuleChangeResponse
+	40, // 66: multiadmin.MultiadminService.SwitchPrimary:output_type -> multiadmin.SwitchPrimaryResponse
+	49, // [49:67] is the sub-list for method output_type
+	31, // [31:49] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_multiadminservice_proto_init() }
@@ -2698,7 +2809,7 @@ func file_multiadminservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multiadminservice_proto_rawDesc), len(file_multiadminservice_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   37,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/pb/multiadmin/multiadminservice.pb.gw.go
+++ b/go/pb/multiadmin/multiadminservice.pb.gw.go
@@ -801,6 +801,83 @@ func local_request_MultiAdminService_ApplyCertifiedRuleChange_0(ctx context.Cont
 	return msg, metadata, err
 }
 
+func request_MultiAdminService_SwitchPrimary_0(ctx context.Context, marshaler runtime.Marshaler, client MultiAdminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SwitchPrimaryRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["shard_key.database"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.database")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.database", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.database", err)
+	}
+	val, ok = pathParams["shard_key.table_group"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.table_group")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.table_group", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.table_group", err)
+	}
+	val, ok = pathParams["shard_key.shard"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.shard")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.shard", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.shard", err)
+	}
+	msg, err := client.SwitchPrimary(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiAdminService_SwitchPrimary_0(ctx context.Context, marshaler runtime.Marshaler, server MultiAdminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SwitchPrimaryRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["shard_key.database"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.database")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.database", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.database", err)
+	}
+	val, ok = pathParams["shard_key.table_group"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.table_group")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.table_group", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.table_group", err)
+	}
+	val, ok = pathParams["shard_key.shard"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.shard")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.shard", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.shard", err)
+	}
+	msg, err := server.SwitchPrimary(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMultiAdminServiceHandlerServer registers the http handlers for service MultiAdminService to "mux".
 // UnaryRPC     :call MultiAdminServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1167,6 +1244,26 @@ func RegisterMultiAdminServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_MultiAdminService_ApplyCertifiedRuleChange_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiAdminService_SwitchPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multiadmin.MultiAdminService/SwitchPrimary", runtime.WithHTTPPathPattern("/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiAdminService_SwitchPrimary_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiAdminService_SwitchPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -1513,6 +1610,23 @@ func RegisterMultiAdminServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_MultiAdminService_ApplyCertifiedRuleChange_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiAdminService_SwitchPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multiadmin.MultiAdminService/SwitchPrimary", runtime.WithHTTPPathPattern("/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiAdminService_SwitchPrimary_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiAdminService_SwitchPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1535,6 +1649,7 @@ var (
 	pattern_MultiAdminService_GetGatewayQueries_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "gateways", "gateway_id.cell", "gateway_id.name", "queries"}, ""))
 	pattern_MultiAdminService_GetGatewayConsolidator_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "gateways", "gateway_id.cell", "gateway_id.name", "consolidator"}, ""))
 	pattern_MultiAdminService_ApplyCertifiedRuleChange_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "v1", "shards", "shard_key.database", "shard_key.table_group", "shard_key.shard", "rule-change"}, ""))
+	pattern_MultiAdminService_SwitchPrimary_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "v1", "shards", "shard_key.database", "shard_key.table_group", "shard_key.shard", "switch-primary"}, ""))
 )
 
 var (
@@ -1556,4 +1671,5 @@ var (
 	forward_MultiAdminService_GetGatewayQueries_0          = runtime.ForwardResponseMessage
 	forward_MultiAdminService_GetGatewayConsolidator_0     = runtime.ForwardResponseMessage
 	forward_MultiAdminService_ApplyCertifiedRuleChange_0   = runtime.ForwardResponseMessage
+	forward_MultiAdminService_SwitchPrimary_0              = runtime.ForwardResponseMessage
 )

--- a/go/pb/multiadmin/multiadminservice.pb.gw.go
+++ b/go/pb/multiadmin/multiadminservice.pb.gw.go
@@ -774,6 +774,83 @@ func local_request_MultiadminService_ApplyCertifiedRuleChange_0(ctx context.Cont
 	return msg, metadata, err
 }
 
+func request_MultiadminService_SwitchPrimary_0(ctx context.Context, marshaler runtime.Marshaler, client MultiadminServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SwitchPrimaryRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["shard_key.database"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.database")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.database", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.database", err)
+	}
+	val, ok = pathParams["shard_key.table_group"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.table_group")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.table_group", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.table_group", err)
+	}
+	val, ok = pathParams["shard_key.shard"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.shard")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.shard", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.shard", err)
+	}
+	msg, err := client.SwitchPrimary(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiadminService_SwitchPrimary_0(ctx context.Context, marshaler runtime.Marshaler, server MultiadminServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SwitchPrimaryRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["shard_key.database"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.database")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.database", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.database", err)
+	}
+	val, ok = pathParams["shard_key.table_group"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.table_group")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.table_group", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.table_group", err)
+	}
+	val, ok = pathParams["shard_key.shard"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "shard_key.shard")
+	}
+	err = runtime.PopulateFieldFromPath(&protoReq, "shard_key.shard", val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "shard_key.shard", err)
+	}
+	msg, err := server.SwitchPrimary(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterMultiadminServiceHandlerServer registers the http handlers for service MultiadminService to "mux".
 // UnaryRPC     :call MultiadminServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1120,6 +1197,26 @@ func RegisterMultiadminServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_MultiadminService_ApplyCertifiedRuleChange_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiadminService_SwitchPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multiadmin.MultiadminService/SwitchPrimary", runtime.WithHTTPPathPattern("/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiadminService_SwitchPrimary_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiadminService_SwitchPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -1449,6 +1546,23 @@ func RegisterMultiadminServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_MultiadminService_ApplyCertifiedRuleChange_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiadminService_SwitchPrimary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multiadmin.MultiadminService/SwitchPrimary", runtime.WithHTTPPathPattern("/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiadminService_SwitchPrimary_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiadminService_SwitchPrimary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1470,6 +1584,7 @@ var (
 	pattern_MultiadminService_GetGatewayQueries_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "gateways", "gateway_id.cell", "gateway_id.name", "queries"}, ""))
 	pattern_MultiadminService_GetGatewayConsolidator_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 2, 5}, []string{"api", "v1", "gateways", "gateway_id.cell", "gateway_id.name", "consolidator"}, ""))
 	pattern_MultiadminService_ApplyCertifiedRuleChange_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "v1", "shards", "shard_key.database", "shard_key.table_group", "shard_key.shard", "rule-change"}, ""))
+	pattern_MultiadminService_SwitchPrimary_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 1, 0, 4, 1, 5, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "v1", "shards", "shard_key.database", "shard_key.table_group", "shard_key.shard", "switch-primary"}, ""))
 )
 
 var (
@@ -1490,4 +1605,5 @@ var (
 	forward_MultiadminService_GetGatewayQueries_0          = runtime.ForwardResponseMessage
 	forward_MultiadminService_GetGatewayConsolidator_0     = runtime.ForwardResponseMessage
 	forward_MultiadminService_ApplyCertifiedRuleChange_0   = runtime.ForwardResponseMessage
+	forward_MultiadminService_SwitchPrimary_0              = runtime.ForwardResponseMessage
 )

--- a/go/pb/multiadmin/multiadminservice_grpc.pb.go
+++ b/go/pb/multiadmin/multiadminservice_grpc.pb.go
@@ -51,6 +51,7 @@ const (
 	MultiAdminService_GetGatewayQueries_FullMethodName          = "/multiadmin.MultiAdminService/GetGatewayQueries"
 	MultiAdminService_GetGatewayConsolidator_FullMethodName     = "/multiadmin.MultiAdminService/GetGatewayConsolidator"
 	MultiAdminService_ApplyCertifiedRuleChange_FullMethodName   = "/multiadmin.MultiAdminService/ApplyCertifiedRuleChange"
+	MultiAdminService_SwitchPrimary_FullMethodName              = "/multiadmin.MultiAdminService/SwitchPrimary"
 )
 
 // MultiAdminServiceClient is the client API for MultiAdminService service.
@@ -108,6 +109,15 @@ type MultiAdminServiceClient interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(ctx context.Context, in *ApplyCertifiedRuleChangeRequest, opts ...grpc.CallOption) (*ApplyCertifiedRuleChangeResponse, error)
+	// SwitchPrimary performs a graceful switchover for a shard. It stops writes
+	// and freezes the WAL position on the current primary, waits for the chosen
+	// standby to catch up, then promotes it as the new leader via
+	// ApplyCertifiedRuleChange. The old leader is demoted to standby by the
+	// subsequent Recruit round.
+	//
+	// If target_leader_id is not set, multiadmin picks the standby with the
+	// highest current WAL position.
+	SwitchPrimary(ctx context.Context, in *SwitchPrimaryRequest, opts ...grpc.CallOption) (*SwitchPrimaryResponse, error)
 }
 
 type multiAdminServiceClient struct {
@@ -298,6 +308,16 @@ func (c *multiAdminServiceClient) ApplyCertifiedRuleChange(ctx context.Context, 
 	return out, nil
 }
 
+func (c *multiAdminServiceClient) SwitchPrimary(ctx context.Context, in *SwitchPrimaryRequest, opts ...grpc.CallOption) (*SwitchPrimaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SwitchPrimaryResponse)
+	err := c.cc.Invoke(ctx, MultiAdminService_SwitchPrimary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MultiAdminServiceServer is the server API for MultiAdminService service.
 // All implementations must embed UnimplementedMultiAdminServiceServer
 // for forward compatibility.
@@ -353,6 +373,15 @@ type MultiAdminServiceServer interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(context.Context, *ApplyCertifiedRuleChangeRequest) (*ApplyCertifiedRuleChangeResponse, error)
+	// SwitchPrimary performs a graceful switchover for a shard. It stops writes
+	// and freezes the WAL position on the current primary, waits for the chosen
+	// standby to catch up, then promotes it as the new leader via
+	// ApplyCertifiedRuleChange. The old leader is demoted to standby by the
+	// subsequent Recruit round.
+	//
+	// If target_leader_id is not set, multiadmin picks the standby with the
+	// highest current WAL position.
+	SwitchPrimary(context.Context, *SwitchPrimaryRequest) (*SwitchPrimaryResponse, error)
 	mustEmbedUnimplementedMultiAdminServiceServer()
 }
 
@@ -416,6 +445,9 @@ func (UnimplementedMultiAdminServiceServer) GetGatewayConsolidator(context.Conte
 }
 func (UnimplementedMultiAdminServiceServer) ApplyCertifiedRuleChange(context.Context, *ApplyCertifiedRuleChangeRequest) (*ApplyCertifiedRuleChangeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ApplyCertifiedRuleChange not implemented")
+}
+func (UnimplementedMultiAdminServiceServer) SwitchPrimary(context.Context, *SwitchPrimaryRequest) (*SwitchPrimaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SwitchPrimary not implemented")
 }
 func (UnimplementedMultiAdminServiceServer) mustEmbedUnimplementedMultiAdminServiceServer() {}
 func (UnimplementedMultiAdminServiceServer) testEmbeddedByValue()                           {}
@@ -762,6 +794,24 @@ func _MultiAdminService_ApplyCertifiedRuleChange_Handler(srv interface{}, ctx co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiAdminService_SwitchPrimary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SwitchPrimaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiAdminServiceServer).SwitchPrimary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiAdminService_SwitchPrimary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiAdminServiceServer).SwitchPrimary(ctx, req.(*SwitchPrimaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MultiAdminService_ServiceDesc is the grpc.ServiceDesc for MultiAdminService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -840,6 +890,10 @@ var MultiAdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ApplyCertifiedRuleChange",
 			Handler:    _MultiAdminService_ApplyCertifiedRuleChange_Handler,
+		},
+		{
+			MethodName: "SwitchPrimary",
+			Handler:    _MultiAdminService_SwitchPrimary_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/pb/multiadmin/multiadminservice_grpc.pb.go
+++ b/go/pb/multiadmin/multiadminservice_grpc.pb.go
@@ -50,6 +50,7 @@ const (
 	MultiadminService_GetGatewayQueries_FullMethodName          = "/multiadmin.MultiadminService/GetGatewayQueries"
 	MultiadminService_GetGatewayConsolidator_FullMethodName     = "/multiadmin.MultiadminService/GetGatewayConsolidator"
 	MultiadminService_ApplyCertifiedRuleChange_FullMethodName   = "/multiadmin.MultiadminService/ApplyCertifiedRuleChange"
+	MultiadminService_SwitchPrimary_FullMethodName              = "/multiadmin.MultiadminService/SwitchPrimary"
 )
 
 // MultiadminServiceClient is the client API for MultiadminService service.
@@ -105,6 +106,13 @@ type MultiadminServiceClient interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(ctx context.Context, in *ApplyCertifiedRuleChangeRequest, opts ...grpc.CallOption) (*ApplyCertifiedRuleChangeResponse, error)
+	// SwitchPrimary performs a graceful switchover for a shard. It quiesces
+	// writes on the current leader, restarts it as a standby, and publishes
+	// REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+	// leader through the normal consensus flow. The RPC returns as soon as the
+	// old primary has been quiesced — it does not wait for the new leader to
+	// appear.
+	SwitchPrimary(ctx context.Context, in *SwitchPrimaryRequest, opts ...grpc.CallOption) (*SwitchPrimaryResponse, error)
 }
 
 type multiadminServiceClient struct {
@@ -285,6 +293,16 @@ func (c *multiadminServiceClient) ApplyCertifiedRuleChange(ctx context.Context, 
 	return out, nil
 }
 
+func (c *multiadminServiceClient) SwitchPrimary(ctx context.Context, in *SwitchPrimaryRequest, opts ...grpc.CallOption) (*SwitchPrimaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SwitchPrimaryResponse)
+	err := c.cc.Invoke(ctx, MultiadminService_SwitchPrimary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MultiadminServiceServer is the server API for MultiadminService service.
 // All implementations must embed UnimplementedMultiadminServiceServer
 // for forward compatibility.
@@ -338,6 +356,13 @@ type MultiadminServiceServer interface {
 	// the proposed cohort. Multiadmin then forwards the request to the shard's
 	// multiorch.
 	ApplyCertifiedRuleChange(context.Context, *ApplyCertifiedRuleChangeRequest) (*ApplyCertifiedRuleChangeResponse, error)
+	// SwitchPrimary performs a graceful switchover for a shard. It quiesces
+	// writes on the current leader, restarts it as a standby, and publishes
+	// REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+	// leader through the normal consensus flow. The RPC returns as soon as the
+	// old primary has been quiesced — it does not wait for the new leader to
+	// appear.
+	SwitchPrimary(context.Context, *SwitchPrimaryRequest) (*SwitchPrimaryResponse, error)
 	mustEmbedUnimplementedMultiadminServiceServer()
 }
 
@@ -398,6 +423,9 @@ func (UnimplementedMultiadminServiceServer) GetGatewayConsolidator(context.Conte
 }
 func (UnimplementedMultiadminServiceServer) ApplyCertifiedRuleChange(context.Context, *ApplyCertifiedRuleChangeRequest) (*ApplyCertifiedRuleChangeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ApplyCertifiedRuleChange not implemented")
+}
+func (UnimplementedMultiadminServiceServer) SwitchPrimary(context.Context, *SwitchPrimaryRequest) (*SwitchPrimaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SwitchPrimary not implemented")
 }
 func (UnimplementedMultiadminServiceServer) mustEmbedUnimplementedMultiadminServiceServer() {}
 func (UnimplementedMultiadminServiceServer) testEmbeddedByValue()                           {}
@@ -726,6 +754,24 @@ func _MultiadminService_ApplyCertifiedRuleChange_Handler(srv interface{}, ctx co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiadminService_SwitchPrimary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SwitchPrimaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiadminServiceServer).SwitchPrimary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiadminService_SwitchPrimary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiadminServiceServer).SwitchPrimary(ctx, req.(*SwitchPrimaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MultiadminService_ServiceDesc is the grpc.ServiceDesc for MultiadminService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -800,6 +846,10 @@ var MultiadminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ApplyCertifiedRuleChange",
 			Handler:    _MultiadminService_ApplyCertifiedRuleChange_Handler,
+		},
+		{
+			MethodName: "SwitchPrimary",
+			Handler:    _MultiadminService_SwitchPrimary_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
+++ b/go/pb/multipoolermanager/multipoolermanagerconnect/multipoolermanagerservice.connect.go
@@ -75,6 +75,9 @@ const (
 	// MultipoolerManagerVerifyBackupsProcedure is the fully-qualified name of the MultipoolerManager's
 	// VerifyBackups RPC.
 	MultipoolerManagerVerifyBackupsProcedure = "/multipoolermanager.MultipoolerManager/VerifyBackups"
+	// MultipoolerManagerResignLeadershipProcedure is the fully-qualified name of the
+	// MultipoolerManager's ResignLeadership RPC.
+	MultipoolerManagerResignLeadershipProcedure = "/multipoolermanager.MultipoolerManager/ResignLeadership"
 	// MultipoolerManagerSetPostgresRestartsEnabledProcedure is the fully-qualified name of the
 	// MultipoolerManager's SetPostgresRestartsEnabled RPC.
 	MultipoolerManagerSetPostgresRestartsEnabledProcedure = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
@@ -110,6 +113,16 @@ type MultipoolerManagerClient interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(context.Context, *connect.Request[multipoolermanagerdata.VerifyBackupsRequest]) (*connect.Response[multipoolermanagerdata.VerifyBackupsResponse], error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(context.Context, *connect.Request[multipoolermanagerdata.ResignLeadershipRequest]) (*connect.Response[multipoolermanagerdata.ResignLeadershipResponse], error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -202,6 +215,12 @@ func NewMultipoolerManagerClient(httpClient connect.HTTPClient, baseURL string, 
 			connect.WithSchema(multipoolerManagerMethods.ByName("VerifyBackups")),
 			connect.WithClientOptions(opts...),
 		),
+		resignLeadership: connect.NewClient[multipoolermanagerdata.ResignLeadershipRequest, multipoolermanagerdata.ResignLeadershipResponse](
+			httpClient,
+			baseURL+MultipoolerManagerResignLeadershipProcedure,
+			connect.WithSchema(multipoolerManagerMethods.ByName("ResignLeadership")),
+			connect.WithClientOptions(opts...),
+		),
 		setPostgresRestartsEnabled: connect.NewClient[multipoolermanagerdata.SetPostgresRestartsEnabledRequest, multipoolermanagerdata.SetPostgresRestartsEnabledResponse](
 			httpClient,
 			baseURL+MultipoolerManagerSetPostgresRestartsEnabledProcedure,
@@ -234,6 +253,7 @@ type multipoolerManagerClient struct {
 	getBackupByJobId           *connect.Client[multipoolermanagerdata.GetBackupByJobIdRequest, multipoolermanagerdata.GetBackupByJobIdResponse]
 	expireBackups              *connect.Client[multipoolermanagerdata.ExpireBackupsRequest, multipoolermanagerdata.ExpireBackupsResponse]
 	verifyBackups              *connect.Client[multipoolermanagerdata.VerifyBackupsRequest, multipoolermanagerdata.VerifyBackupsResponse]
+	resignLeadership           *connect.Client[multipoolermanagerdata.ResignLeadershipRequest, multipoolermanagerdata.ResignLeadershipResponse]
 	setPostgresRestartsEnabled *connect.Client[multipoolermanagerdata.SetPostgresRestartsEnabledRequest, multipoolermanagerdata.SetPostgresRestartsEnabledResponse]
 	reloadConfig               *connect.Client[multipoolermanagerdata.ReloadConfigRequest, multipoolermanagerdata.ReloadConfigResponse]
 	managerHealthStream        *connect.Client[multipoolermanagerdata.ManagerHealthStreamClientMessage, multipoolermanagerdata.ManagerHealthStreamResponse]
@@ -284,6 +304,11 @@ func (c *multipoolerManagerClient) VerifyBackups(ctx context.Context, req *conne
 	return c.verifyBackups.CallUnary(ctx, req)
 }
 
+// ResignLeadership calls multipoolermanager.MultipoolerManager.ResignLeadership.
+func (c *multipoolerManagerClient) ResignLeadership(ctx context.Context, req *connect.Request[multipoolermanagerdata.ResignLeadershipRequest]) (*connect.Response[multipoolermanagerdata.ResignLeadershipResponse], error) {
+	return c.resignLeadership.CallUnary(ctx, req)
+}
+
 // SetPostgresRestartsEnabled calls
 // multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled.
 func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Context, req *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error) {
@@ -325,6 +350,16 @@ type MultipoolerManagerHandler interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(context.Context, *connect.Request[multipoolermanagerdata.VerifyBackupsRequest]) (*connect.Response[multipoolermanagerdata.VerifyBackupsResponse], error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(context.Context, *connect.Request[multipoolermanagerdata.ResignLeadershipRequest]) (*connect.Response[multipoolermanagerdata.ResignLeadershipResponse], error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -413,6 +448,12 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 		connect.WithSchema(multipoolerManagerMethods.ByName("VerifyBackups")),
 		connect.WithHandlerOptions(opts...),
 	)
+	multipoolerManagerResignLeadershipHandler := connect.NewUnaryHandler(
+		MultipoolerManagerResignLeadershipProcedure,
+		svc.ResignLeadership,
+		connect.WithSchema(multipoolerManagerMethods.ByName("ResignLeadership")),
+		connect.WithHandlerOptions(opts...),
+	)
 	multipoolerManagerSetPostgresRestartsEnabledHandler := connect.NewUnaryHandler(
 		MultipoolerManagerSetPostgresRestartsEnabledProcedure,
 		svc.SetPostgresRestartsEnabled,
@@ -451,6 +492,8 @@ func NewMultipoolerManagerHandler(svc MultipoolerManagerHandler, opts ...connect
 			multipoolerManagerExpireBackupsHandler.ServeHTTP(w, r)
 		case MultipoolerManagerVerifyBackupsProcedure:
 			multipoolerManagerVerifyBackupsHandler.ServeHTTP(w, r)
+		case MultipoolerManagerResignLeadershipProcedure:
+			multipoolerManagerResignLeadershipHandler.ServeHTTP(w, r)
 		case MultipoolerManagerSetPostgresRestartsEnabledProcedure:
 			multipoolerManagerSetPostgresRestartsEnabledHandler.ServeHTTP(w, r)
 		case MultipoolerManagerReloadConfigProcedure:
@@ -500,6 +543,10 @@ func (UnimplementedMultipoolerManagerHandler) ExpireBackups(context.Context, *co
 
 func (UnimplementedMultipoolerManagerHandler) VerifyBackups(context.Context, *connect.Request[multipoolermanagerdata.VerifyBackupsRequest]) (*connect.Response[multipoolermanagerdata.VerifyBackupsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.VerifyBackups is not implemented"))
+}
+
+func (UnimplementedMultipoolerManagerHandler) ResignLeadership(context.Context, *connect.Request[multipoolermanagerdata.ResignLeadershipRequest]) (*connect.Response[multipoolermanagerdata.ResignLeadershipResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("multipoolermanager.MultipoolerManager.ResignLeadership is not implemented"))
 }
 
 func (UnimplementedMultipoolerManagerHandler) SetPostgresRestartsEnabled(context.Context, *connect.Request[multipoolermanagerdata.SetPostgresRestartsEnabledRequest]) (*connect.Response[multipoolermanagerdata.SetPostgresRestartsEnabledResponse], error) {

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,8 +39,7 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xe9\n" +
-	"\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xe0\v\n" +
 	"\x12MultiPoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
@@ -53,7 +52,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"GetBackups\x12).multipoolermanagerdata.GetBackupsRequest\x1a*.multipoolermanagerdata.GetBackupsResponse\x12u\n" +
 	"\x10GetBackupByJobId\x12/.multipoolermanagerdata.GetBackupByJobIdRequest\x1a0.multipoolermanagerdata.GetBackupByJobIdResponse\x12l\n" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12l\n" +
-	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12\x93\x01\n" +
+	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12u\n" +
+	"\x10ResignLeadership\x12/.multipoolermanagerdata.ResignLeadershipRequest\x1a0.multipoolermanagerdata.ResignLeadershipResponse\x12\x93\x01\n" +
 	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12\x88\x01\n" +
 	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
 
@@ -68,20 +68,22 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.GetBackupByJobIdRequest)(nil),            // 7: multipoolermanagerdata.GetBackupByJobIdRequest
 	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 8: multipoolermanagerdata.ExpireBackupsRequest
 	(*multipoolermanagerdata.VerifyBackupsRequest)(nil),               // 9: multipoolermanagerdata.VerifyBackupsRequest
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 10: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 11: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 12: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 13: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 14: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 15: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 16: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 17: multipoolermanagerdata.RestoreFromBackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 18: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 19: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 20: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 21: multipoolermanagerdata.VerifyBackupsResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 22: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 23: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.ResignLeadershipRequest)(nil),            // 10: multipoolermanagerdata.ResignLeadershipRequest
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 11: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 12: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 13: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 14: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 15: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 16: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 17: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.RestoreFromBackupResponse)(nil),          // 18: multipoolermanagerdata.RestoreFromBackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 19: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 20: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 21: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 22: multipoolermanagerdata.VerifyBackupsResponse
+	(*multipoolermanagerdata.ResignLeadershipResponse)(nil),           // 23: multipoolermanagerdata.ResignLeadershipResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 24: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 25: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultiPoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -94,22 +96,24 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	7,  // 7: multipoolermanager.MultiPoolerManager.GetBackupByJobId:input_type -> multipoolermanagerdata.GetBackupByJobIdRequest
 	8,  // 8: multipoolermanager.MultiPoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
 	9,  // 9: multipoolermanager.MultiPoolerManager.VerifyBackups:input_type -> multipoolermanagerdata.VerifyBackupsRequest
-	10, // 10: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	11, // 11: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	12, // 12: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	13, // 13: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	14, // 14: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	15, // 15: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	16, // 16: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	17, // 17: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
-	18, // 18: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	19, // 19: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	20, // 20: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	21, // 21: multipoolermanager.MultiPoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
-	22, // 22: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	23, // 23: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	12, // [12:24] is the sub-list for method output_type
-	0,  // [0:12] is the sub-list for method input_type
+	10, // 10: multipoolermanager.MultiPoolerManager.ResignLeadership:input_type -> multipoolermanagerdata.ResignLeadershipRequest
+	11, // 11: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	12, // 12: multipoolermanager.MultiPoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	13, // 13: multipoolermanager.MultiPoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	14, // 14: multipoolermanager.MultiPoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	15, // 15: multipoolermanager.MultiPoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	16, // 16: multipoolermanager.MultiPoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	17, // 17: multipoolermanager.MultiPoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	18, // 18: multipoolermanager.MultiPoolerManager.RestoreFromBackup:output_type -> multipoolermanagerdata.RestoreFromBackupResponse
+	19, // 19: multipoolermanager.MultiPoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	20, // 20: multipoolermanager.MultiPoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	21, // 21: multipoolermanager.MultiPoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	22, // 22: multipoolermanager.MultiPoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
+	23, // 23: multipoolermanager.MultiPoolerManager.ResignLeadership:output_type -> multipoolermanagerdata.ResignLeadershipResponse
+	24, // 24: multipoolermanager.MultiPoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	25, // 25: multipoolermanager.MultiPoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	13, // [13:26] is the sub-list for method output_type
+	0,  // [0:13] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.go
@@ -39,8 +39,7 @@ var File_multipoolermanagerservice_proto protoreflect.FileDescriptor
 
 const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"\n" +
-	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xda\n" +
-	"\n" +
+	"\x1fmultipoolermanagerservice.proto\x12\x12multipoolermanager\x1a\x1cmultipoolermanagerdata.proto2\xd1\v\n" +
 	"\x12MultipoolerManager\x12c\n" +
 	"\n" +
 	"WaitForLSN\x12).multipoolermanagerdata.WaitForLSNRequest\x1a*.multipoolermanagerdata.WaitForLSNResponse\x12u\n" +
@@ -52,7 +51,8 @@ const file_multipoolermanagerservice_proto_rawDesc = "" +
 	"GetBackups\x12).multipoolermanagerdata.GetBackupsRequest\x1a*.multipoolermanagerdata.GetBackupsResponse\x12u\n" +
 	"\x10GetBackupByJobId\x12/.multipoolermanagerdata.GetBackupByJobIdRequest\x1a0.multipoolermanagerdata.GetBackupByJobIdResponse\x12l\n" +
 	"\rExpireBackups\x12,.multipoolermanagerdata.ExpireBackupsRequest\x1a-.multipoolermanagerdata.ExpireBackupsResponse\x12l\n" +
-	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12\x93\x01\n" +
+	"\rVerifyBackups\x12,.multipoolermanagerdata.VerifyBackupsRequest\x1a-.multipoolermanagerdata.VerifyBackupsResponse\x12u\n" +
+	"\x10ResignLeadership\x12/.multipoolermanagerdata.ResignLeadershipRequest\x1a0.multipoolermanagerdata.ResignLeadershipResponse\x12\x93\x01\n" +
 	"\x1aSetPostgresRestartsEnabled\x129.multipoolermanagerdata.SetPostgresRestartsEnabledRequest\x1a:.multipoolermanagerdata.SetPostgresRestartsEnabledResponse\x12i\n" +
 	"\fReloadConfig\x12+.multipoolermanagerdata.ReloadConfigRequest\x1a,.multipoolermanagerdata.ReloadConfigResponse\x12\x88\x01\n" +
 	"\x13ManagerHealthStream\x128.multipoolermanagerdata.ManagerHealthStreamClientMessage\x1a3.multipoolermanagerdata.ManagerHealthStreamResponse(\x010\x01B9Z7github.com/multigres/multigres/go/pb/multipoolermanagerb\x06proto3"
@@ -67,21 +67,23 @@ var file_multipoolermanagerservice_proto_goTypes = []any{
 	(*multipoolermanagerdata.GetBackupByJobIdRequest)(nil),            // 6: multipoolermanagerdata.GetBackupByJobIdRequest
 	(*multipoolermanagerdata.ExpireBackupsRequest)(nil),               // 7: multipoolermanagerdata.ExpireBackupsRequest
 	(*multipoolermanagerdata.VerifyBackupsRequest)(nil),               // 8: multipoolermanagerdata.VerifyBackupsRequest
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 9: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*multipoolermanagerdata.ReloadConfigRequest)(nil),                // 10: multipoolermanagerdata.ReloadConfigRequest
-	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 11: multipoolermanagerdata.ManagerHealthStreamClientMessage
-	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 12: multipoolermanagerdata.WaitForLSNResponse
-	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 13: multipoolermanagerdata.StartReplicationResponse
-	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 14: multipoolermanagerdata.StopReplicationResponse
-	(*multipoolermanagerdata.StatusResponse)(nil),                     // 15: multipoolermanagerdata.StatusResponse
-	(*multipoolermanagerdata.BackupResponse)(nil),                     // 16: multipoolermanagerdata.BackupResponse
-	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 17: multipoolermanagerdata.GetBackupsResponse
-	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 18: multipoolermanagerdata.GetBackupByJobIdResponse
-	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 19: multipoolermanagerdata.ExpireBackupsResponse
-	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 20: multipoolermanagerdata.VerifyBackupsResponse
-	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 21: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*multipoolermanagerdata.ReloadConfigResponse)(nil),               // 22: multipoolermanagerdata.ReloadConfigResponse
-	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 23: multipoolermanagerdata.ManagerHealthStreamResponse
+	(*multipoolermanagerdata.ResignLeadershipRequest)(nil),            // 9: multipoolermanagerdata.ResignLeadershipRequest
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledRequest)(nil),  // 10: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*multipoolermanagerdata.ReloadConfigRequest)(nil),                // 11: multipoolermanagerdata.ReloadConfigRequest
+	(*multipoolermanagerdata.ManagerHealthStreamClientMessage)(nil),   // 12: multipoolermanagerdata.ManagerHealthStreamClientMessage
+	(*multipoolermanagerdata.WaitForLSNResponse)(nil),                 // 13: multipoolermanagerdata.WaitForLSNResponse
+	(*multipoolermanagerdata.StartReplicationResponse)(nil),           // 14: multipoolermanagerdata.StartReplicationResponse
+	(*multipoolermanagerdata.StopReplicationResponse)(nil),            // 15: multipoolermanagerdata.StopReplicationResponse
+	(*multipoolermanagerdata.StatusResponse)(nil),                     // 16: multipoolermanagerdata.StatusResponse
+	(*multipoolermanagerdata.BackupResponse)(nil),                     // 17: multipoolermanagerdata.BackupResponse
+	(*multipoolermanagerdata.GetBackupsResponse)(nil),                 // 18: multipoolermanagerdata.GetBackupsResponse
+	(*multipoolermanagerdata.GetBackupByJobIdResponse)(nil),           // 19: multipoolermanagerdata.GetBackupByJobIdResponse
+	(*multipoolermanagerdata.ExpireBackupsResponse)(nil),              // 20: multipoolermanagerdata.ExpireBackupsResponse
+	(*multipoolermanagerdata.VerifyBackupsResponse)(nil),              // 21: multipoolermanagerdata.VerifyBackupsResponse
+	(*multipoolermanagerdata.ResignLeadershipResponse)(nil),           // 22: multipoolermanagerdata.ResignLeadershipResponse
+	(*multipoolermanagerdata.SetPostgresRestartsEnabledResponse)(nil), // 23: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*multipoolermanagerdata.ReloadConfigResponse)(nil),               // 24: multipoolermanagerdata.ReloadConfigResponse
+	(*multipoolermanagerdata.ManagerHealthStreamResponse)(nil),        // 25: multipoolermanagerdata.ManagerHealthStreamResponse
 }
 var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	0,  // 0: multipoolermanager.MultipoolerManager.WaitForLSN:input_type -> multipoolermanagerdata.WaitForLSNRequest
@@ -93,23 +95,25 @@ var file_multipoolermanagerservice_proto_depIdxs = []int32{
 	6,  // 6: multipoolermanager.MultipoolerManager.GetBackupByJobId:input_type -> multipoolermanagerdata.GetBackupByJobIdRequest
 	7,  // 7: multipoolermanager.MultipoolerManager.ExpireBackups:input_type -> multipoolermanagerdata.ExpireBackupsRequest
 	8,  // 8: multipoolermanager.MultipoolerManager.VerifyBackups:input_type -> multipoolermanagerdata.VerifyBackupsRequest
-	9,  // 9: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	10, // 10: multipoolermanager.MultipoolerManager.ReloadConfig:input_type -> multipoolermanagerdata.ReloadConfigRequest
-	11, // 11: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
-	12, // 12: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
-	13, // 13: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
-	14, // 14: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
-	15, // 15: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
-	16, // 16: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
-	17, // 17: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
-	18, // 18: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
-	19, // 19: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
-	20, // 20: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
-	21, // 21: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	22, // 22: multipoolermanager.MultipoolerManager.ReloadConfig:output_type -> multipoolermanagerdata.ReloadConfigResponse
-	23, // 23: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
-	12, // [12:24] is the sub-list for method output_type
-	0,  // [0:12] is the sub-list for method input_type
+	9,  // 9: multipoolermanager.MultipoolerManager.ResignLeadership:input_type -> multipoolermanagerdata.ResignLeadershipRequest
+	10, // 10: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:input_type -> multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	11, // 11: multipoolermanager.MultipoolerManager.ReloadConfig:input_type -> multipoolermanagerdata.ReloadConfigRequest
+	12, // 12: multipoolermanager.MultipoolerManager.ManagerHealthStream:input_type -> multipoolermanagerdata.ManagerHealthStreamClientMessage
+	13, // 13: multipoolermanager.MultipoolerManager.WaitForLSN:output_type -> multipoolermanagerdata.WaitForLSNResponse
+	14, // 14: multipoolermanager.MultipoolerManager.StartReplication:output_type -> multipoolermanagerdata.StartReplicationResponse
+	15, // 15: multipoolermanager.MultipoolerManager.StopReplication:output_type -> multipoolermanagerdata.StopReplicationResponse
+	16, // 16: multipoolermanager.MultipoolerManager.Status:output_type -> multipoolermanagerdata.StatusResponse
+	17, // 17: multipoolermanager.MultipoolerManager.Backup:output_type -> multipoolermanagerdata.BackupResponse
+	18, // 18: multipoolermanager.MultipoolerManager.GetBackups:output_type -> multipoolermanagerdata.GetBackupsResponse
+	19, // 19: multipoolermanager.MultipoolerManager.GetBackupByJobId:output_type -> multipoolermanagerdata.GetBackupByJobIdResponse
+	20, // 20: multipoolermanager.MultipoolerManager.ExpireBackups:output_type -> multipoolermanagerdata.ExpireBackupsResponse
+	21, // 21: multipoolermanager.MultipoolerManager.VerifyBackups:output_type -> multipoolermanagerdata.VerifyBackupsResponse
+	22, // 22: multipoolermanager.MultipoolerManager.ResignLeadership:output_type -> multipoolermanagerdata.ResignLeadershipResponse
+	23, // 23: multipoolermanager.MultipoolerManager.SetPostgresRestartsEnabled:output_type -> multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	24, // 24: multipoolermanager.MultipoolerManager.ReloadConfig:output_type -> multipoolermanagerdata.ReloadConfigResponse
+	25, // 25: multipoolermanager.MultipoolerManager.ManagerHealthStream:output_type -> multipoolermanagerdata.ManagerHealthStreamResponse
+	13, // [13:26] is the sub-list for method output_type
+	0,  // [0:13] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -306,6 +306,33 @@ func local_request_MultiPoolerManager_VerifyBackups_0(ctx context.Context, marsh
 	return msg, metadata, err
 }
 
+func request_MultiPoolerManager_ResignLeadership_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ResignLeadershipRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ResignLeadership(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultiPoolerManager_ResignLeadership_0(ctx context.Context, marshaler runtime.Marshaler, server MultiPoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ResignLeadershipRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ResignLeadership(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultiPoolerManager_SetPostgresRestartsEnabled_0(ctx context.Context, marshaler runtime.Marshaler, client MultiPoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq multipoolermanagerdata.SetPostgresRestartsEnabledRequest
@@ -582,6 +609,26 @@ func RegisterMultiPoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_VerifyBackups_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ResignLeadership_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/ResignLeadership", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/ResignLeadership"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultiPoolerManager_ResignLeadership_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_ResignLeadership_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_SetPostgresRestartsEnabled_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -819,6 +866,23 @@ func RegisterMultiPoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultiPoolerManager_VerifyBackups_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_ResignLeadership_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultiPoolerManager/ResignLeadership", runtime.WithHTTPPathPattern("/multipoolermanager.MultiPoolerManager/ResignLeadership"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultiPoolerManager_ResignLeadership_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultiPoolerManager_ResignLeadership_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultiPoolerManager_SetPostgresRestartsEnabled_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -867,6 +931,7 @@ var (
 	pattern_MultiPoolerManager_GetBackupByJobId_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "GetBackupByJobId"}, ""))
 	pattern_MultiPoolerManager_ExpireBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ExpireBackups"}, ""))
 	pattern_MultiPoolerManager_VerifyBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "VerifyBackups"}, ""))
+	pattern_MultiPoolerManager_ResignLeadership_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ResignLeadership"}, ""))
 	pattern_MultiPoolerManager_SetPostgresRestartsEnabled_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "SetPostgresRestartsEnabled"}, ""))
 	pattern_MultiPoolerManager_ManagerHealthStream_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultiPoolerManager", "ManagerHealthStream"}, ""))
 )
@@ -882,6 +947,7 @@ var (
 	forward_MultiPoolerManager_GetBackupByJobId_0           = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_ExpireBackups_0              = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_VerifyBackups_0              = runtime.ForwardResponseMessage
+	forward_MultiPoolerManager_ResignLeadership_0           = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_SetPostgresRestartsEnabled_0 = runtime.ForwardResponseMessage
 	forward_MultiPoolerManager_ManagerHealthStream_0        = runtime.ForwardResponseStream
 )

--- a/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice.pb.gw.go
@@ -279,6 +279,33 @@ func local_request_MultipoolerManager_VerifyBackups_0(ctx context.Context, marsh
 	return msg, metadata, err
 }
 
+func request_MultipoolerManager_ResignLeadership_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ResignLeadershipRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ResignLeadership(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_MultipoolerManager_ResignLeadership_0(ctx context.Context, marshaler runtime.Marshaler, server MultipoolerManagerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq multipoolermanagerdata.ResignLeadershipRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ResignLeadership(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_MultipoolerManager_SetPostgresRestartsEnabled_0(ctx context.Context, marshaler runtime.Marshaler, client MultipoolerManagerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq multipoolermanagerdata.SetPostgresRestartsEnabledRequest
@@ -562,6 +589,26 @@ func RegisterMultipoolerManagerHandlerServer(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_VerifyBackups_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ResignLeadership_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ResignLeadership", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ResignLeadership"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_MultipoolerManager_ResignLeadership_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ResignLeadership_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_SetPostgresRestartsEnabled_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -802,6 +849,23 @@ func RegisterMultipoolerManagerHandlerClient(ctx context.Context, mux *runtime.S
 		}
 		forward_MultipoolerManager_VerifyBackups_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_MultipoolerManager_ResignLeadership_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/multipoolermanager.MultipoolerManager/ResignLeadership", runtime.WithHTTPPathPattern("/multipoolermanager.MultipoolerManager/ResignLeadership"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_MultipoolerManager_ResignLeadership_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_MultipoolerManager_ResignLeadership_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_MultipoolerManager_SetPostgresRestartsEnabled_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -866,6 +930,7 @@ var (
 	pattern_MultipoolerManager_GetBackupByJobId_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "GetBackupByJobId"}, ""))
 	pattern_MultipoolerManager_ExpireBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ExpireBackups"}, ""))
 	pattern_MultipoolerManager_VerifyBackups_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "VerifyBackups"}, ""))
+	pattern_MultipoolerManager_ResignLeadership_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ResignLeadership"}, ""))
 	pattern_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "SetPostgresRestartsEnabled"}, ""))
 	pattern_MultipoolerManager_ReloadConfig_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ReloadConfig"}, ""))
 	pattern_MultipoolerManager_ManagerHealthStream_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"multipoolermanager.MultipoolerManager", "ManagerHealthStream"}, ""))
@@ -881,6 +946,7 @@ var (
 	forward_MultipoolerManager_GetBackupByJobId_0           = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ExpireBackups_0              = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_VerifyBackups_0              = runtime.ForwardResponseMessage
+	forward_MultipoolerManager_ResignLeadership_0           = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_SetPostgresRestartsEnabled_0 = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ReloadConfig_0               = runtime.ForwardResponseMessage
 	forward_MultipoolerManager_ManagerHealthStream_0        = runtime.ForwardResponseStream

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	MultiPoolerManager_GetBackupByJobId_FullMethodName           = "/multipoolermanager.MultiPoolerManager/GetBackupByJobId"
 	MultiPoolerManager_ExpireBackups_FullMethodName              = "/multipoolermanager.MultiPoolerManager/ExpireBackups"
 	MultiPoolerManager_VerifyBackups_FullMethodName              = "/multipoolermanager.MultiPoolerManager/VerifyBackups"
+	MultiPoolerManager_ResignLeadership_FullMethodName           = "/multipoolermanager.MultiPoolerManager/ResignLeadership"
 	MultiPoolerManager_SetPostgresRestartsEnabled_FullMethodName = "/multipoolermanager.MultiPoolerManager/SetPostgresRestartsEnabled"
 	MultiPoolerManager_ManagerHealthStream_FullMethodName        = "/multipoolermanager.MultiPoolerManager/ManagerHealthStream"
 )
@@ -78,6 +79,16 @@ type MultiPoolerManagerClient interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(ctx context.Context, in *multipoolermanagerdata.VerifyBackupsRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.VerifyBackupsResponse, error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(ctx context.Context, in *multipoolermanagerdata.ResignLeadershipRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ResignLeadershipResponse, error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -208,6 +219,16 @@ func (c *multiPoolerManagerClient) VerifyBackups(ctx context.Context, in *multip
 	return out, nil
 }
 
+func (c *multiPoolerManagerClient) ResignLeadership(ctx context.Context, in *multipoolermanagerdata.ResignLeadershipRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ResignLeadershipResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.ResignLeadershipResponse)
+	err := c.cc.Invoke(ctx, MultiPoolerManager_ResignLeadership_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *multiPoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.SetPostgresRestartsEnabledResponse)
@@ -261,6 +282,16 @@ type MultiPoolerManagerServer interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(context.Context, *multipoolermanagerdata.VerifyBackupsRequest) (*multipoolermanagerdata.VerifyBackupsResponse, error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(context.Context, *multipoolermanagerdata.ResignLeadershipRequest) (*multipoolermanagerdata.ResignLeadershipResponse, error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -320,6 +351,9 @@ func (UnimplementedMultiPoolerManagerServer) ExpireBackups(context.Context, *mul
 }
 func (UnimplementedMultiPoolerManagerServer) VerifyBackups(context.Context, *multipoolermanagerdata.VerifyBackupsRequest) (*multipoolermanagerdata.VerifyBackupsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method VerifyBackups not implemented")
+}
+func (UnimplementedMultiPoolerManagerServer) ResignLeadership(context.Context, *multipoolermanagerdata.ResignLeadershipRequest) (*multipoolermanagerdata.ResignLeadershipResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResignLeadership not implemented")
 }
 func (UnimplementedMultiPoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
@@ -528,6 +562,24 @@ func _MultiPoolerManager_VerifyBackups_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultiPoolerManager_ResignLeadership_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.ResignLeadershipRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultiPoolerManagerServer).ResignLeadership(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultiPoolerManager_ResignLeadership_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultiPoolerManagerServer).ResignLeadership(ctx, req.(*multipoolermanagerdata.ResignLeadershipRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MultiPoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
 	if err := dec(in); err != nil {
@@ -599,6 +651,10 @@ var MultiPoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "VerifyBackups",
 			Handler:    _MultiPoolerManager_VerifyBackups_Handler,
+		},
+		{
+			MethodName: "ResignLeadership",
+			Handler:    _MultiPoolerManager_ResignLeadership_Handler,
 		},
 		{
 			MethodName: "SetPostgresRestartsEnabled",

--- a/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
+++ b/go/pb/multipoolermanager/multipoolermanagerservice_grpc.pb.go
@@ -43,6 +43,7 @@ const (
 	MultipoolerManager_GetBackupByJobId_FullMethodName           = "/multipoolermanager.MultipoolerManager/GetBackupByJobId"
 	MultipoolerManager_ExpireBackups_FullMethodName              = "/multipoolermanager.MultipoolerManager/ExpireBackups"
 	MultipoolerManager_VerifyBackups_FullMethodName              = "/multipoolermanager.MultipoolerManager/VerifyBackups"
+	MultipoolerManager_ResignLeadership_FullMethodName           = "/multipoolermanager.MultipoolerManager/ResignLeadership"
 	MultipoolerManager_SetPostgresRestartsEnabled_FullMethodName = "/multipoolermanager.MultipoolerManager/SetPostgresRestartsEnabled"
 	MultipoolerManager_ReloadConfig_FullMethodName               = "/multipoolermanager.MultipoolerManager/ReloadConfig"
 	MultipoolerManager_ManagerHealthStream_FullMethodName        = "/multipoolermanager.MultipoolerManager/ManagerHealthStream"
@@ -76,6 +77,16 @@ type MultipoolerManagerClient interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(ctx context.Context, in *multipoolermanagerdata.VerifyBackupsRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.VerifyBackupsResponse, error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(ctx context.Context, in *multipoolermanagerdata.ResignLeadershipRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ResignLeadershipResponse, error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -201,6 +212,16 @@ func (c *multipoolerManagerClient) VerifyBackups(ctx context.Context, in *multip
 	return out, nil
 }
 
+func (c *multipoolerManagerClient) ResignLeadership(ctx context.Context, in *multipoolermanagerdata.ResignLeadershipRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.ResignLeadershipResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(multipoolermanagerdata.ResignLeadershipResponse)
+	err := c.cc.Invoke(ctx, MultipoolerManager_ResignLeadership_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *multipoolerManagerClient) SetPostgresRestartsEnabled(ctx context.Context, in *multipoolermanagerdata.SetPostgresRestartsEnabledRequest, opts ...grpc.CallOption) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(multipoolermanagerdata.SetPostgresRestartsEnabledResponse)
@@ -262,6 +283,16 @@ type MultipoolerManagerServer interface {
 	// VerifyBackups runs a full-stanza pgbackrest verify (no --set). This is
 	// a periodic backup-integrity check; not scoped to any single backup.
 	VerifyBackups(context.Context, *multipoolermanagerdata.VerifyBackupsRequest) (*multipoolermanagerdata.VerifyBackupsResponse, error)
+	// ResignLeadership gracefully resigns this pooler from leadership.
+	// Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+	// drains write connections, publishes REQUESTING_DEMOTION, and returns the
+	// WAL flush LSN at the moment writes were quiesced. The caller can then wait
+	// for standbys to reach that LSN before triggering a new election.
+	//
+	// Only valid on a pooler that is currently the consensus leader (PRIMARY).
+	// Does NOT restart postgres as standby — that happens later via the normal
+	// Recruit path when multiorch picks up REQUESTING_DEMOTION.
+	ResignLeadership(context.Context, *multipoolermanagerdata.ResignLeadershipRequest) (*multipoolermanagerdata.ResignLeadershipResponse, error)
 	// SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
 	// When disabled, the monitor continues to run but will not auto-restart a stopped
 	// PostgreSQL instance. Used by tests and demos to prevent premature restarts during
@@ -323,6 +354,9 @@ func (UnimplementedMultipoolerManagerServer) ExpireBackups(context.Context, *mul
 }
 func (UnimplementedMultipoolerManagerServer) VerifyBackups(context.Context, *multipoolermanagerdata.VerifyBackupsRequest) (*multipoolermanagerdata.VerifyBackupsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method VerifyBackups not implemented")
+}
+func (UnimplementedMultipoolerManagerServer) ResignLeadership(context.Context, *multipoolermanagerdata.ResignLeadershipRequest) (*multipoolermanagerdata.ResignLeadershipResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ResignLeadership not implemented")
 }
 func (UnimplementedMultipoolerManagerServer) SetPostgresRestartsEnabled(context.Context, *multipoolermanagerdata.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdata.SetPostgresRestartsEnabledResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetPostgresRestartsEnabled not implemented")
@@ -516,6 +550,24 @@ func _MultipoolerManager_VerifyBackups_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MultipoolerManager_ResignLeadership_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(multipoolermanagerdata.ResignLeadershipRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MultipoolerManagerServer).ResignLeadership(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MultipoolerManager_ResignLeadership_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MultipoolerManagerServer).ResignLeadership(ctx, req.(*multipoolermanagerdata.ResignLeadershipRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MultipoolerManager_SetPostgresRestartsEnabled_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(multipoolermanagerdata.SetPostgresRestartsEnabledRequest)
 	if err := dec(in); err != nil {
@@ -601,6 +653,10 @@ var MultipoolerManager_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "VerifyBackups",
 			Handler:    _MultipoolerManager_VerifyBackups_Handler,
+		},
+		{
+			MethodName: "ResignLeadership",
+			Handler:    _MultipoolerManager_ResignLeadership_Handler,
 		},
 		{
 			MethodName: "SetPostgresRestartsEnabled",

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2763,6 +2763,91 @@ func (x *RewindToSourceResponse) GetRewindPerformed() bool {
 	return false
 }
 
+// ResignLeadershipRequest asks the primary pooler to gracefully resign from leadership.
+type ResignLeadershipRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResignLeadershipRequest) Reset() {
+	*x = ResignLeadershipRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResignLeadershipRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResignLeadershipRequest) ProtoMessage() {}
+
+func (x *ResignLeadershipRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResignLeadershipRequest.ProtoReflect.Descriptor instead.
+func (*ResignLeadershipRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+}
+
+// ResignLeadershipResponse returns the WAL flush LSN at the moment writes were quiesced.
+type ResignLeadershipResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// flush_lsn is the WAL flush position at the moment postgres stopped accepting
+	// writes. Callers should wait for standbys to reach this LSN before triggering
+	// a new election, ensuring no data loss.
+	FlushLsn      string `protobuf:"bytes,1,opt,name=flush_lsn,json=flushLsn,proto3" json:"flush_lsn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResignLeadershipResponse) Reset() {
+	*x = ResignLeadershipResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResignLeadershipResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResignLeadershipResponse) ProtoMessage() {}
+
+func (x *ResignLeadershipResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResignLeadershipResponse.ProtoReflect.Descriptor instead.
+func (*ResignLeadershipResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *ResignLeadershipResponse) GetFlushLsn() string {
+	if x != nil {
+		return x.FlushLsn
+	}
+	return ""
+}
+
 // SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
 // by the postgres monitor. When disabled, the monitor will still run and detect problems,
 // but will not automatically restart a stopped PostgreSQL instance.
@@ -2776,7 +2861,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2788,7 +2873,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2801,7 +2886,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -2821,7 +2906,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2833,7 +2918,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2846,7 +2931,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{39}
 }
 
 var File_multipoolermanagerdata_proto protoreflect.FileDescriptor
@@ -3003,7 +3088,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x16RewindToSourceResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\x12)\n" +
-	"\x10rewind_performed\x18\x03 \x01(\bR\x0frewindPerformed\"=\n" +
+	"\x10rewind_performed\x18\x03 \x01(\bR\x0frewindPerformed\"\x19\n" +
+	"\x17ResignLeadershipRequest\"7\n" +
+	"\x18ResignLeadershipResponse\x12\x1b\n" +
+	"\tflush_lsn\x18\x01 \x01(\tR\bflushLsn\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
 	"\"SetPostgresRestartsEnabledResponse*\xa4\x01\n" +
@@ -3056,7 +3144,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -3102,66 +3190,68 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*BackupMetadata)(nil),                      // 41: multipoolermanagerdata.BackupMetadata
 	(*RewindToSourceRequest)(nil),               // 42: multipoolermanagerdata.RewindToSourceRequest
 	(*RewindToSourceResponse)(nil),              // 43: multipoolermanagerdata.RewindToSourceResponse
-	(*SetPostgresRestartsEnabledRequest)(nil),   // 44: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),  // 45: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	nil,                             // 46: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                             // 47: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),     // 48: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),   // 49: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),      // 50: clustermetadata.ID
-	(clustermetadata.PoolerType)(0), // 51: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil), // 52: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),    // 53: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),         // 54: clustermetadata.RuleNumber
-	(*clustermetadata.MultiPooler)(nil),        // 55: clustermetadata.MultiPooler
+	(*ResignLeadershipRequest)(nil),             // 44: multipoolermanagerdata.ResignLeadershipRequest
+	(*ResignLeadershipResponse)(nil),            // 45: multipoolermanagerdata.ResignLeadershipResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),   // 46: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),  // 47: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	nil,                             // 48: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                             // 49: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),     // 50: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),   // 51: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),      // 52: clustermetadata.ID
+	(clustermetadata.PoolerType)(0), // 53: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil), // 54: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),    // 55: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),         // 56: clustermetadata.RuleNumber
+	(*clustermetadata.MultiPooler)(nil),        // 57: clustermetadata.MultiPooler
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	48, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	50, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	49, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	48, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	48, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	48, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	51, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	50, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	50, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	50, // 5: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 6: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 7: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 8: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	50, // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	50, // 11: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	52, // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	52, // 11: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 12: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	51, // 13: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	53, // 13: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 14: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 15: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 16: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 17: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	48, // 18: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
-	50, // 19: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
+	50, // 18: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	52, // 19: multipoolermanagerdata.Status.cohort_members:type_name -> clustermetadata.ID
 	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	52, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	53, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	54, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	55, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	48, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	48, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	48, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	48, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	50, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	50, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	50, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	50, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	48, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	50, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
 	5,  // 34: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.CohortUpdateOperation
-	50, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	54, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	50, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	46, // 38: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	52, // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	56, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	52, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	48, // 38: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	41, // 39: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	41, // 40: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	47, // 41: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	48, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	49, // 41: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	50, // 42: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 43: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	51, // 44: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
-	55, // 45: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
+	53, // 44: multipoolermanagerdata.BackupMetadata.pooler_type:type_name -> clustermetadata.PoolerType
+	57, // 45: multipoolermanagerdata.RewindToSourceRequest.source:type_name -> clustermetadata.MultiPooler
 	46, // [46:46] is the sub-list for method output_type
 	46, // [46:46] is the sub-list for method input_type
 	46, // [46:46] is the sub-list for extension type_name
@@ -3188,7 +3278,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   40,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2650,6 +2650,91 @@ func (x *BackupMetadata) GetPgVersion() string {
 	return ""
 }
 
+// ResignLeadershipRequest asks the primary pooler to gracefully resign from leadership.
+type ResignLeadershipRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResignLeadershipRequest) Reset() {
+	*x = ResignLeadershipRequest{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResignLeadershipRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResignLeadershipRequest) ProtoMessage() {}
+
+func (x *ResignLeadershipRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResignLeadershipRequest.ProtoReflect.Descriptor instead.
+func (*ResignLeadershipRequest) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
+}
+
+// ResignLeadershipResponse returns the WAL flush LSN at the moment writes were quiesced.
+type ResignLeadershipResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// flush_lsn is the WAL flush position at the moment postgres stopped accepting
+	// writes. Callers should wait for standbys to reach this LSN before triggering
+	// a new election, ensuring no data loss.
+	FlushLsn      string `protobuf:"bytes,1,opt,name=flush_lsn,json=flushLsn,proto3" json:"flush_lsn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResignLeadershipResponse) Reset() {
+	*x = ResignLeadershipResponse{}
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResignLeadershipResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResignLeadershipResponse) ProtoMessage() {}
+
+func (x *ResignLeadershipResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResignLeadershipResponse.ProtoReflect.Descriptor instead.
+func (*ResignLeadershipResponse) Descriptor() ([]byte, []int) {
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ResignLeadershipResponse) GetFlushLsn() string {
+	if x != nil {
+		return x.FlushLsn
+	}
+	return ""
+}
+
 // SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
 // by the postgres monitor. When disabled, the monitor will still run and detect problems,
 // but will not automatically restart a stopped PostgreSQL instance.
@@ -2663,7 +2748,7 @@ type SetPostgresRestartsEnabledRequest struct {
 
 func (x *SetPostgresRestartsEnabledRequest) Reset() {
 	*x = SetPostgresRestartsEnabledRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2675,7 +2760,7 @@ func (x *SetPostgresRestartsEnabledRequest) String() string {
 func (*SetPostgresRestartsEnabledRequest) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[32]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2688,7 +2773,7 @@ func (x *SetPostgresRestartsEnabledRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use SetPostgresRestartsEnabledRequest.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{32}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SetPostgresRestartsEnabledRequest) GetEnabled() bool {
@@ -2708,7 +2793,7 @@ type SetPostgresRestartsEnabledResponse struct {
 
 func (x *SetPostgresRestartsEnabledResponse) Reset() {
 	*x = SetPostgresRestartsEnabledResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2720,7 +2805,7 @@ func (x *SetPostgresRestartsEnabledResponse) String() string {
 func (*SetPostgresRestartsEnabledResponse) ProtoMessage() {}
 
 func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[33]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2733,7 +2818,7 @@ func (x *SetPostgresRestartsEnabledResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use SetPostgresRestartsEnabledResponse.ProtoReflect.Descriptor instead.
 func (*SetPostgresRestartsEnabledResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{33}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
 }
 
 // ReloadConfigRequest asks the multipooler to trigger a PostgreSQL
@@ -2747,7 +2832,7 @@ type ReloadConfigRequest struct {
 
 func (x *ReloadConfigRequest) Reset() {
 	*x = ReloadConfigRequest{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2759,7 +2844,7 @@ func (x *ReloadConfigRequest) String() string {
 func (*ReloadConfigRequest) ProtoMessage() {}
 
 func (x *ReloadConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[34]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2772,7 +2857,7 @@ func (x *ReloadConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReloadConfigRequest.ProtoReflect.Descriptor instead.
 func (*ReloadConfigRequest) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{34}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{36}
 }
 
 // ReloadConfigResponse reports the outcome of a configuration reload.
@@ -2791,7 +2876,7 @@ type ReloadConfigResponse struct {
 
 func (x *ReloadConfigResponse) Reset() {
 	*x = ReloadConfigResponse{}
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2803,7 +2888,7 @@ func (x *ReloadConfigResponse) String() string {
 func (*ReloadConfigResponse) ProtoMessage() {}
 
 func (x *ReloadConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_multipoolermanagerdata_proto_msgTypes[35]
+	mi := &file_multipoolermanagerdata_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2816,7 +2901,7 @@ func (x *ReloadConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReloadConfigResponse.ProtoReflect.Descriptor instead.
 func (*ReloadConfigResponse) Descriptor() ([]byte, []int) {
-	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{35}
+	return file_multipoolermanagerdata_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ReloadConfigResponse) GetConfigLoadTime() *timestamppb.Timestamp {
@@ -2979,7 +3064,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +
 	"INCOMPLETE\x10\x01\x12\f\n" +
-	"\bCOMPLETE\x10\x02\"=\n" +
+	"\bCOMPLETE\x10\x02\"\x19\n" +
+	"\x17ResignLeadershipRequest\"7\n" +
+	"\x18ResignLeadershipResponse\x12\x1b\n" +
+	"\tflush_lsn\x18\x01 \x01(\tR\bflushLsn\"=\n" +
 	"!SetPostgresRestartsEnabledRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\"$\n" +
 	"\"SetPostgresRestartsEnabledResponse\"\x15\n" +
@@ -3036,7 +3124,7 @@ func file_multipoolermanagerdata_proto_rawDescGZIP() []byte {
 }
 
 var file_multipoolermanagerdata_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_multipoolermanagerdata_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_multipoolermanagerdata_proto_goTypes = []any{
 	(PostgresStatus)(0),                         // 0: multipoolermanagerdata.PostgresStatus
 	(PostgresAction)(0),                         // 1: multipoolermanagerdata.PostgresAction
@@ -3078,73 +3166,75 @@ var file_multipoolermanagerdata_proto_goTypes = []any{
 	(*VerifyBackupsRequest)(nil),                // 37: multipoolermanagerdata.VerifyBackupsRequest
 	(*VerifyBackupsResponse)(nil),               // 38: multipoolermanagerdata.VerifyBackupsResponse
 	(*BackupMetadata)(nil),                      // 39: multipoolermanagerdata.BackupMetadata
-	(*SetPostgresRestartsEnabledRequest)(nil),   // 40: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
-	(*SetPostgresRestartsEnabledResponse)(nil),  // 41: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
-	(*ReloadConfigRequest)(nil),                 // 42: multipoolermanagerdata.ReloadConfigRequest
-	(*ReloadConfigResponse)(nil),                // 43: multipoolermanagerdata.ReloadConfigResponse
-	nil,                                         // 44: multipoolermanagerdata.BackupRequest.OverridesEntry
-	nil,                                         // 45: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	(*durationpb.Duration)(nil),                 // 46: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),               // 47: google.protobuf.Timestamp
-	(*clustermetadata.ID)(nil),                  // 48: clustermetadata.ID
-	(clustermetadata.PoolerType)(0),             // 49: clustermetadata.PoolerType
-	(*clustermetadata.AvailabilityStatus)(nil),  // 50: clustermetadata.AvailabilityStatus
-	(*clustermetadata.ConsensusStatus)(nil),     // 51: clustermetadata.ConsensusStatus
-	(*clustermetadata.RuleNumber)(nil),          // 52: clustermetadata.RuleNumber
-	(*clustermetadata.PoolerPosition)(nil),      // 53: clustermetadata.PoolerPosition
-	(clustermetadata.RoutingRole)(0),            // 54: clustermetadata.RoutingRole
+	(*ResignLeadershipRequest)(nil),             // 40: multipoolermanagerdata.ResignLeadershipRequest
+	(*ResignLeadershipResponse)(nil),            // 41: multipoolermanagerdata.ResignLeadershipResponse
+	(*SetPostgresRestartsEnabledRequest)(nil),   // 42: multipoolermanagerdata.SetPostgresRestartsEnabledRequest
+	(*SetPostgresRestartsEnabledResponse)(nil),  // 43: multipoolermanagerdata.SetPostgresRestartsEnabledResponse
+	(*ReloadConfigRequest)(nil),                 // 44: multipoolermanagerdata.ReloadConfigRequest
+	(*ReloadConfigResponse)(nil),                // 45: multipoolermanagerdata.ReloadConfigResponse
+	nil,                                         // 46: multipoolermanagerdata.BackupRequest.OverridesEntry
+	nil,                                         // 47: multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	(*durationpb.Duration)(nil),                 // 48: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),               // 49: google.protobuf.Timestamp
+	(*clustermetadata.ID)(nil),                  // 50: clustermetadata.ID
+	(clustermetadata.PoolerType)(0),             // 51: clustermetadata.PoolerType
+	(*clustermetadata.AvailabilityStatus)(nil),  // 52: clustermetadata.AvailabilityStatus
+	(*clustermetadata.ConsensusStatus)(nil),     // 53: clustermetadata.ConsensusStatus
+	(*clustermetadata.RuleNumber)(nil),          // 54: clustermetadata.RuleNumber
+	(*clustermetadata.PoolerPosition)(nil),      // 55: clustermetadata.PoolerPosition
+	(clustermetadata.RoutingRole)(0),            // 56: clustermetadata.RoutingRole
 }
 var file_multipoolermanagerdata_proto_depIdxs = []int32{
-	46, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
+	48, // 0: multipoolermanagerdata.StandbyReplicationStatus.lag:type_name -> google.protobuf.Duration
 	8,  // 1: multipoolermanagerdata.StandbyReplicationStatus.primary_conn_info:type_name -> multipoolermanagerdata.PrimaryConnInfo
-	47, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
-	46, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
-	46, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
-	47, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
-	46, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
+	49, // 2: multipoolermanagerdata.StandbyReplicationStatus.last_msg_receive_time:type_name -> google.protobuf.Timestamp
+	48, // 3: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_status_interval:type_name -> google.protobuf.Duration
+	48, // 4: multipoolermanagerdata.StandbyReplicationStatus.wal_receiver_timeout:type_name -> google.protobuf.Duration
+	49, // 5: multipoolermanagerdata.StandbyReplicationStatus.last_receive_lsn_advance_time:type_name -> google.protobuf.Timestamp
+	48, // 6: multipoolermanagerdata.WaitForLSNRequest.timeout:type_name -> google.protobuf.Duration
 	3,  // 7: multipoolermanagerdata.StopReplicationRequest.mode:type_name -> multipoolermanagerdata.ReplicationPauseMode
 	9,  // 8: multipoolermanagerdata.StopReplicationResponse.status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	6,  // 9: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_commit:type_name -> multipoolermanagerdata.SynchronousCommitLevel
 	4,  // 10: multipoolermanagerdata.SynchronousReplicationConfiguration.synchronous_method:type_name -> multipoolermanagerdata.SynchronousMethod
-	48, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
-	48, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
+	50, // 11: multipoolermanagerdata.SynchronousReplicationConfiguration.standby_ids:type_name -> clustermetadata.ID
+	50, // 12: multipoolermanagerdata.PrimaryStatus.connected_followers:type_name -> clustermetadata.ID
 	16, // 13: multipoolermanagerdata.PrimaryStatus.sync_replication_config:type_name -> multipoolermanagerdata.SynchronousReplicationConfiguration
-	49, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
+	51, // 14: multipoolermanagerdata.Status.pooler_type:type_name -> clustermetadata.PoolerType
 	17, // 15: multipoolermanagerdata.Status.primary_status:type_name -> multipoolermanagerdata.PrimaryStatus
 	9,  // 16: multipoolermanagerdata.Status.replication_status:type_name -> multipoolermanagerdata.StandbyReplicationStatus
 	0,  // 17: multipoolermanagerdata.Status.postgres_status:type_name -> multipoolermanagerdata.PostgresStatus
 	1,  // 18: multipoolermanagerdata.Status.postgres_action:type_name -> multipoolermanagerdata.PostgresAction
-	46, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
+	48, // 19: multipoolermanagerdata.Status.postgres_action_duration:type_name -> google.protobuf.Duration
 	18, // 20: multipoolermanagerdata.StatusResponse.status:type_name -> multipoolermanagerdata.Status
-	50, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
-	51, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
+	52, // 21: multipoolermanagerdata.StatusResponse.availability_status:type_name -> clustermetadata.AvailabilityStatus
+	53, // 22: multipoolermanagerdata.StatusResponse.consensus_status:type_name -> clustermetadata.ConsensusStatus
 	22, // 23: multipoolermanagerdata.ManagerHealthStreamClientMessage.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartRequest
 	23, // 24: multipoolermanagerdata.ManagerHealthStreamClientMessage.poll:type_name -> multipoolermanagerdata.ManagerHealthStreamPollRequest
-	46, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
-	46, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
-	46, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
+	48, // 25: multipoolermanagerdata.ManagerHealthStreamStartRequest.snapshot_interval:type_name -> google.protobuf.Duration
+	48, // 26: multipoolermanagerdata.ManagerHealthStreamStartRequest.staleness_timeout:type_name -> google.protobuf.Duration
+	48, // 27: multipoolermanagerdata.ManagerHealthStreamStartResponse.snapshot_interval:type_name -> google.protobuf.Duration
+	48, // 28: multipoolermanagerdata.ManagerHealthStreamStartResponse.staleness_timeout:type_name -> google.protobuf.Duration
 	24, // 29: multipoolermanagerdata.ManagerHealthStreamResponse.start:type_name -> multipoolermanagerdata.ManagerHealthStreamStartResponse
 	26, // 30: multipoolermanagerdata.ManagerHealthStreamResponse.snapshot:type_name -> multipoolermanagerdata.ManagerHealthSnapshot
 	20, // 31: multipoolermanagerdata.ManagerHealthSnapshot.status:type_name -> multipoolermanagerdata.StatusResponse
-	46, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
+	48, // 32: multipoolermanagerdata.ManagerHealthSnapshot.timeout:type_name -> google.protobuf.Duration
 	2,  // 33: multipoolermanagerdata.ManagerHealthSnapshot.trigger:type_name -> multipoolermanagerdata.SnapshotTrigger
-	47, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
+	49, // 34: multipoolermanagerdata.ManagerHealthSnapshot.captured_at:type_name -> google.protobuf.Timestamp
 	5,  // 35: multipoolermanagerdata.UpdateConsensusRuleRequest.operation:type_name -> multipoolermanagerdata.RuleOperation
-	48, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
-	52, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
-	48, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
-	53, // 39: multipoolermanagerdata.UpdateConsensusRuleResponse.current_position:type_name -> clustermetadata.PoolerPosition
-	44, // 40: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
+	50, // 36: multipoolermanagerdata.UpdateConsensusRuleRequest.standby_ids:type_name -> clustermetadata.ID
+	54, // 37: multipoolermanagerdata.UpdateConsensusRuleRequest.expected_outgoing_rule:type_name -> clustermetadata.RuleNumber
+	50, // 38: multipoolermanagerdata.UpdateConsensusRuleRequest.coordinator_id:type_name -> clustermetadata.ID
+	55, // 39: multipoolermanagerdata.UpdateConsensusRuleResponse.current_position:type_name -> clustermetadata.PoolerPosition
+	46, // 40: multipoolermanagerdata.BackupRequest.overrides:type_name -> multipoolermanagerdata.BackupRequest.OverridesEntry
 	39, // 41: multipoolermanagerdata.GetBackupsResponse.backups:type_name -> multipoolermanagerdata.BackupMetadata
 	39, // 42: multipoolermanagerdata.GetBackupByJobIdResponse.backup:type_name -> multipoolermanagerdata.BackupMetadata
-	45, // 43: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
-	46, // 44: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
+	47, // 43: multipoolermanagerdata.ExpireBackupsRequest.overrides:type_name -> multipoolermanagerdata.ExpireBackupsRequest.OverridesEntry
+	48, // 44: multipoolermanagerdata.VerifyBackupsResponse.duration:type_name -> google.protobuf.Duration
 	7,  // 45: multipoolermanagerdata.BackupMetadata.status:type_name -> multipoolermanagerdata.BackupMetadata.Status
-	54, // 46: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
-	47, // 47: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
-	47, // 48: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
-	47, // 49: multipoolermanagerdata.ReloadConfigResponse.config_load_time:type_name -> google.protobuf.Timestamp
+	56, // 46: multipoolermanagerdata.BackupMetadata.routing_role:type_name -> clustermetadata.RoutingRole
+	49, // 47: multipoolermanagerdata.BackupMetadata.start_timestamp:type_name -> google.protobuf.Timestamp
+	49, // 48: multipoolermanagerdata.BackupMetadata.stop_timestamp:type_name -> google.protobuf.Timestamp
+	49, // 49: multipoolermanagerdata.ReloadConfigResponse.config_load_time:type_name -> google.protobuf.Timestamp
 	50, // [50:50] is the sub-list for method output_type
 	50, // [50:50] is the sub-list for method input_type
 	50, // [50:50] is the sub-list for extension type_name
@@ -3171,7 +3261,7 @@ func file_multipoolermanagerdata_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_multipoolermanagerdata_proto_rawDesc), len(file_multipoolermanagerdata_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   38,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/services/multiadmin/server_connect.go
+++ b/go/services/multiadmin/server_connect.go
@@ -198,3 +198,11 @@ func (a *connectAdapter) ApplyCertifiedRuleChange(ctx context.Context, req *conn
 	}
 	return connect.NewResponse(resp), nil
 }
+
+func (a *connectAdapter) SwitchPrimary(ctx context.Context, req *connect.Request[multiadminpb.SwitchPrimaryRequest]) (*connect.Response[multiadminpb.SwitchPrimaryResponse], error) {
+	resp, err := a.MultiadminServer.SwitchPrimary(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/go/services/multiadmin/switch_primary.go
+++ b/go/services/multiadmin/switch_primary.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"context"
+	"time"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const defaultCatchupTimeout = 30 * time.Second
+
+// SwitchPrimary performs a graceful switchover: it quiesces writes on the
+// current leader (which publishes REQUESTING_DEMOTION), then polls topology
+// until multiorch's LeaderResignedAnalyzer elects a new primary.
+func (s *MultiAdminServer) SwitchPrimary(ctx context.Context, req *multiadminpb.SwitchPrimaryRequest) (*multiadminpb.SwitchPrimaryResponse, error) {
+	if req.GetShardKey() == nil {
+		return nil, status.Error(codes.InvalidArgument, "shard_key is required")
+	}
+	shardKey := req.GetShardKey()
+
+	// 1. Discover all poolers for this shard.
+	allPoolers, err := s.findShardPoolers(ctx, shardKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Identify the current leader (PRIMARY).
+	var leader *clustermetadatapb.MultiPooler
+	for _, p := range allPoolers {
+		if p.Type == clustermetadatapb.PoolerType_PRIMARY {
+			leader = p
+			break
+		}
+	}
+	if leader == nil {
+		return nil, status.Error(codes.FailedPrecondition, "no PRIMARY pooler found for shard")
+	}
+
+	hasStandby := false
+	for _, p := range allPoolers {
+		if p.Type != clustermetadatapb.PoolerType_PRIMARY {
+			hasStandby = true
+			break
+		}
+	}
+	if !hasStandby {
+		return nil, status.Error(codes.FailedPrecondition, "no standby poolers available for promotion")
+	}
+
+	// 3. Pre-check: wait for the coordinator backoff window to clear before
+	// quiescing writes. The 4-second guard in checkRecentTermAcceptance rejects
+	// a new Recruit if a previous one completed too recently (e.g. bootstrap).
+	// Waiting here — before writes are frozen — avoids the pause that would
+	// otherwise sit while the old primary's postgres is still running and
+	// generating WAL.
+	const coordinatorBackoffWindow = 4 * time.Second
+	if statusResp, err := s.rpcClient.Status(ctx, leader, &multipoolermanagerdatapb.StatusRequest{}); err == nil {
+		if rev := statusResp.GetConsensusStatus().GetTermRevocation(); rev != nil {
+			if initAt := rev.GetCoordinatorInitiatedAt(); initAt != nil {
+				age := time.Since(initAt.AsTime())
+				if age < coordinatorBackoffWindow {
+					waitDur := coordinatorBackoffWindow - age + 500*time.Millisecond
+					s.logger.InfoContext(ctx, "SwitchPrimary: coordinator backoff active, waiting before quiescing",
+						"wait", waitDur)
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-time.After(waitDur):
+					}
+				}
+			}
+		}
+	}
+
+	// 4. Quiesce writes and restart postgres as standby. ResignLeadership
+	// transitions to NOT_SERVING (rejecting new queries with MTF01 so the
+	// gateway buffers and retries), drains existing write connections, stops
+	// postgres cleanly (sending the shutdown-checkpoint WAL to connected
+	// standbys), and publishes REQUESTING_DEMOTION for multiorch to act on.
+	s.logger.InfoContext(ctx, "SwitchPrimary: resigning current leader",
+		"leader", topoclient.ClusterIDString(leader.Id),
+		"reason", req.GetReason())
+
+	resignResp, err := s.rpcClient.ResignLeadership(ctx, leader, &multipoolermanagerdatapb.ResignLeadershipRequest{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "ResignLeadership failed: %v", err)
+	}
+	flushLSN := resignResp.GetFlushLsn()
+	s.logger.InfoContext(ctx, "SwitchPrimary: writes quiesced; waiting for multiorch to elect new leader",
+		"flush_lsn", flushLSN,
+		"leader", topoclient.ClusterIDString(leader.Id))
+
+	// 5. Poll topology until a new PRIMARY appears (or timeout).
+	catchupTimeout := defaultCatchupTimeout
+	if d := req.GetCatchupTimeout().AsDuration(); d > 0 {
+		catchupTimeout = d
+	}
+	deadline := time.Now().Add(catchupTimeout)
+
+	var newLeader *clustermetadatapb.MultiPooler
+	for time.Now().Before(deadline) {
+		poolers, err := s.findShardPoolers(ctx, shardKey)
+		if err == nil {
+			for _, p := range poolers {
+				if p.Type == clustermetadatapb.PoolerType_PRIMARY && !proto.Equal(p.Id, leader.Id) {
+					newLeader = p
+					break
+				}
+			}
+		}
+		if newLeader != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	if newLeader == nil {
+		return nil, status.Errorf(codes.DeadlineExceeded,
+			"resigned (REQUESTING_DEMOTION persists) but no new leader elected within %s; "+
+				"multiorch will complete the election",
+			catchupTimeout)
+	}
+
+	s.logger.InfoContext(ctx, "SwitchPrimary complete",
+		"old_leader", topoclient.ClusterIDString(leader.Id),
+		"new_leader", topoclient.ClusterIDString(newLeader.Id))
+
+	return &multiadminpb.SwitchPrimaryResponse{
+		NewLeaderId: proto.Clone(newLeader.Id).(*clustermetadatapb.ID),
+		OldLeaderId: proto.Clone(leader.Id).(*clustermetadatapb.ID),
+	}, nil
+}
+
+// findShardPoolers returns all poolers registered for the given shard across
+// all cells.
+func (s *MultiAdminServer) findShardPoolers(ctx context.Context, shardKey *clustermetadatapb.ShardKey) ([]*clustermetadatapb.MultiPooler, error) {
+	cellNames, err := s.ts.GetCellNames(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list cells: %v", err)
+	}
+
+	var poolers []*clustermetadatapb.MultiPooler
+	for _, cell := range cellNames {
+		opts := &topoclient.GetMultiPoolersByCellOptions{
+			DatabaseShard: &topoclient.DatabaseShard{
+				Database:   shardKey.GetDatabase(),
+				TableGroup: shardKey.GetTableGroup(),
+			},
+		}
+		infos, err := s.ts.GetMultiPoolersByCell(ctx, cell, opts)
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to list poolers in cell", "cell", cell, "error", err)
+			continue
+		}
+		for _, info := range infos {
+			if info.MultiPooler != nil {
+				poolers = append(poolers, info.MultiPooler)
+			}
+		}
+	}
+
+	if len(poolers) == 0 {
+		return nil, status.Errorf(codes.NotFound, "no poolers found for shard %s/%s/%s",
+			shardKey.GetDatabase(), shardKey.GetTableGroup(), shardKey.GetShard())
+	}
+	return poolers, nil
+}

--- a/go/services/multiadmin/switch_primary.go
+++ b/go/services/multiadmin/switch_primary.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"context"
+	"time"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *MultiadminServer) findShardPrimary(ctx context.Context, shardKey *clustermetadatapb.ShardKey) (*clustermetadatapb.Multipooler, bool, error) {
+	allPoolers, err := s.findShardPoolers(ctx, shardKey)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var leader *clustermetadatapb.Multipooler
+	var hasStandby bool
+
+	for _, p := range allPoolers {
+		if p.GetRoutingState().GetRole() == clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY {
+			leader = p
+		} else {
+			hasStandby = true
+		}
+	}
+
+	if leader != nil {
+		return leader, hasStandby, nil
+	}
+
+	return nil, false, status.Errorf(codes.NotFound, "no PRIMARY pooler found for shard %s/%s/%s",
+		shardKey.GetDatabase(), shardKey.GetTableGroup(), shardKey.GetShard())
+}
+
+// SwitchPrimary performs a graceful switchover: it quiesces writes on the
+// current leader, which publishes REQUESTING_DEMOTION so multiorch's
+// LeaderResignedAnalyzer can elect a new primary through the normal consensus
+// flow. The RPC returns as soon as the old primary has been quiesced and
+// restarted as a standby — it does not wait for the new leader to appear.
+func (s *MultiadminServer) SwitchPrimary(ctx context.Context, req *multiadminpb.SwitchPrimaryRequest) (*multiadminpb.SwitchPrimaryResponse, error) {
+	if req.GetShardKey() == nil {
+		return nil, status.Error(codes.InvalidArgument, "shard_key is required")
+	}
+	shardKey := req.GetShardKey()
+
+	// 1. Find the primary pooler for this shard.
+	leader, hasStandby, err := s.findShardPrimary(ctx, shardKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hasStandby {
+		return nil, status.Error(codes.FailedPrecondition, "no standby poolers available for promotion")
+	}
+
+	// 3. Pre-check: wait for the coordinator backoff window to clear before
+	// quiescing writes. The 4-second guard in checkRecentTermAcceptance rejects
+	// a new Recruit if a previous one completed too recently (e.g. bootstrap).
+	// Waiting here — before writes are frozen — avoids the pause that would
+	// otherwise sit while the old primary's postgres is still running and
+	// generating WAL.
+	const coordinatorBackoffWindow = 4 * time.Second
+	if statusResp, err := s.rpcClient.Status(ctx, leader, &multipoolermanagerdatapb.StatusRequest{}); err == nil {
+		if rev := statusResp.GetConsensusStatus().GetTermRevocation(); rev != nil {
+			if initAt := rev.GetCoordinatorInitiatedAt(); initAt != nil {
+				age := time.Since(initAt.AsTime())
+				if age < coordinatorBackoffWindow {
+					waitDur := coordinatorBackoffWindow - age + 500*time.Millisecond
+					s.logger.InfoContext(ctx, "switch_primary: coordinator backoff active, waiting before quiescing",
+						"wait", waitDur)
+					select {
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					case <-time.After(waitDur):
+					}
+				}
+			}
+		}
+	}
+
+	// 4. Quiesce writes and restart postgres as standby. ResignLeadership
+	// transitions to DRAINING (rejecting new queries with MTF01 so the
+	// gateway buffers and retries), drains existing write connections, stops
+	// postgres cleanly (sending the shutdown-checkpoint WAL to connected
+	// standbys), and publishes REQUESTING_DEMOTION for multiorch to act on.
+	s.logger.InfoContext(ctx, "switch_primary: resigning current leader",
+		"leader", topoclient.ClusterIDString(leader.Id),
+		"reason", req.GetReason())
+
+	resignResp, err := s.rpcClient.ResignLeadership(ctx, leader, &multipoolermanagerdatapb.ResignLeadershipRequest{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "ResignLeadership failed: %v", err)
+	}
+
+	s.logger.InfoContext(ctx, "switch_primary: complete; multiorch will elect a new leader",
+		"old_leader", topoclient.ClusterIDString(leader.Id),
+		"flush_lsn", resignResp.GetFlushLsn())
+
+	response := &multiadminpb.SwitchPrimaryResponse{
+		OldLeaderId: proto.Clone(leader.Id).(*clustermetadatapb.ID),
+	}
+
+	return response, nil
+}
+
+// findShardPoolers returns all poolers registered for the given shard across
+// all cells.
+func (s *MultiadminServer) findShardPoolers(ctx context.Context, shardKey *clustermetadatapb.ShardKey) ([]*clustermetadatapb.Multipooler, error) {
+	cellNames, err := s.ts.GetCellNames(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list cells: %v", err)
+	}
+
+	var poolers []*clustermetadatapb.Multipooler
+	for _, cell := range cellNames {
+		opts := &topoclient.GetMultipoolersByCellOptions{
+			DatabaseShard: &topoclient.DatabaseShard{
+				Database:   shardKey.GetDatabase(),
+				TableGroup: shardKey.GetTableGroup(),
+				Shard:      shardKey.GetShard(),
+			},
+		}
+		infos, err := s.ts.GetMultipoolersByCell(ctx, cell, opts)
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to list poolers in cell", "cell", cell, "error", err)
+			continue
+		}
+		for _, info := range infos {
+			if info.Multipooler != nil {
+				poolers = append(poolers, info.Multipooler)
+			}
+		}
+	}
+
+	if len(poolers) == 0 {
+		return nil, status.Errorf(codes.NotFound, "no poolers found for shard %s/%s/%s",
+			shardKey.GetDatabase(), shardKey.GetTableGroup(), shardKey.GetShard())
+	}
+	return poolers, nil
+}

--- a/go/services/multiadmin/switch_primary_test.go
+++ b/go/services/multiadmin/switch_primary_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"github.com/multigres/multigres/go/common/topoclient"
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+)
+
+func makeRoutedPooler(cell, name string, role clustermetadatapb.RoutingRole) *clustermetadatapb.Multipooler {
+	p := makePooler(cell, name)
+	p.RoutingState = &clustermetadatapb.RoutingState{Role: role}
+	return p
+}
+
+func TestSwitchPrimary_NoShardKey(t *testing.T) {
+	s := newTestServer(t, "cell1")
+	_, err := s.SwitchPrimary(t.Context(), &multiadminpb.SwitchPrimaryRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestSwitchPrimary_NoPrimaryFound(t *testing.T) {
+	ctx := t.Context()
+	s := newTestServer(t, "cell1")
+
+	// Register a replica only — no primary.
+	replica := makeRoutedPooler("cell1", "mp-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	require.NoError(t, s.ts.CreateMultipooler(ctx, replica))
+
+	_, err := s.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "default", Shard: "0-inf"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestSwitchPrimary_NoStandby(t *testing.T) {
+	ctx := t.Context()
+	s := newTestServer(t, "cell1")
+
+	// Register a primary only — no standby to promote to.
+	primary := makeRoutedPooler("cell1", "mp-primary", clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY)
+	require.NoError(t, s.ts.CreateMultipooler(ctx, primary))
+
+	_, err := s.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "default", Shard: "0-inf"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestSwitchPrimary_Success(t *testing.T) {
+	ctx := t.Context()
+	s := newTestServer(t, "cell1")
+
+	primary := makeRoutedPooler("cell1", "mp-primary", clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY)
+	replica := makeRoutedPooler("cell1", "mp-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	require.NoError(t, s.ts.CreateMultipooler(ctx, primary))
+	require.NoError(t, s.ts.CreateMultipooler(ctx, replica))
+
+	fc := rpcclient.NewFakeClient()
+	primaryKey := topoclient.ComponentIDString(primary.Id)
+	fc.SetResignLeadershipResponse(primaryKey, &multipoolermanagerdatapb.ResignLeadershipResponse{
+		FlushLsn: "0/2000000",
+	})
+	s.SetRPCClient(fc)
+
+	resp, err := s.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "default", Shard: "0-inf"},
+		Reason:   "unit test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "mp-primary", resp.GetOldLeaderId().GetName())
+}
+
+// TestSwitchPrimary_BackoffWait verifies that SwitchPrimary waits for the
+// coordinator backoff window to expire before calling ResignLeadership when
+// the primary reports a very recent TermRevocation.
+func TestSwitchPrimary_BackoffWait(t *testing.T) {
+	ctx := t.Context()
+	s := newTestServer(t, "cell1")
+
+	primary := makeRoutedPooler("cell1", "mp-primary", clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY)
+	replica := makeRoutedPooler("cell1", "mp-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	require.NoError(t, s.ts.CreateMultipooler(ctx, primary))
+	require.NoError(t, s.ts.CreateMultipooler(ctx, replica))
+
+	fc := rpcclient.NewFakeClient()
+	primaryKey := topoclient.ComponentIDString(primary.Id)
+	// Report a TermRevocation initiated 3.6 seconds ago so the backoff path
+	// triggers but the remaining wait is small (~400 ms + 500 ms jitter).
+	fc.SetStatusResponse(primaryKey, &multipoolermanagerdatapb.StatusResponse{
+		ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+			TermRevocation: &clustermetadatapb.TermRevocation{
+				CoordinatorInitiatedAt: timestamppb.New(time.Now().Add(-3600 * time.Millisecond)),
+			},
+		},
+	})
+	fc.SetResignLeadershipResponse(primaryKey, &multipoolermanagerdatapb.ResignLeadershipResponse{
+		FlushLsn: "0/3000000",
+	})
+	s.SetRPCClient(fc)
+
+	resp, err := s.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "default", Shard: "0-inf"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "mp-primary", resp.GetOldLeaderId().GetName())
+}
+
+func TestSwitchPrimary_ResignLeadershipError(t *testing.T) {
+	ctx := t.Context()
+	s := newTestServer(t, "cell1")
+
+	primary := makeRoutedPooler("cell1", "mp-primary", clustermetadatapb.RoutingRole_ROUTING_ROLE_PRIMARY)
+	replica := makeRoutedPooler("cell1", "mp-replica", clustermetadatapb.RoutingRole_ROUTING_ROLE_REPLICA)
+	require.NoError(t, s.ts.CreateMultipooler(ctx, primary))
+	require.NoError(t, s.ts.CreateMultipooler(ctx, replica))
+
+	fc := rpcclient.NewFakeClient()
+	primaryKey := topoclient.ComponentIDString(primary.Id)
+	fc.Errors[primaryKey] = status.Error(codes.Unavailable, "pooler unreachable")
+	s.SetRPCClient(fc)
+
+	_, err := s.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{Database: "db1", TableGroup: "default", Shard: "0-inf"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}

--- a/go/services/multiorch/consensus/coordinator.go
+++ b/go/services/multiorch/consensus/coordinator.go
@@ -17,6 +17,7 @@ package consensus
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"sync"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -120,8 +121,20 @@ func (c *Coordinator) runFailover(ctx context.Context, cohort []*multiorchdatapb
 		return mterrors.Errorf(mtrpcpb.Code_FAILED_PRECONDITION, "%v", err)
 	}
 
-	poolerByID, _ := buildCohortMaps(cohort)
+	poolerByID, healthByID := buildCohortMaps(cohort)
+	less := poolerHealthStateLess(healthByID)
 	buildProposal := func(r commonconsensus.RecruitmentResult) (*consensusdatapb.CoordinatorProposal, error) {
+		// Prefer non-resigning nodes when multiple candidates share the highest
+		// LSN. A node signalling REQUESTING_DEMOTION has explicitly asked to be
+		// replaced. Electing it again immediately defeats the purpose of the
+		// switchover.
+		//
+		// A resigning node still wins if it holds a strictly higher LSN than
+		// every other node, but consensus status serves as a tiebreaker when
+		// multiple nodes are at the same WAL position.
+		sort.SliceStable(r.EligibleLeaders, func(i, j int) bool {
+			return less(r.EligibleLeaders[i], r.EligibleLeaders[j])
+		})
 		return buildFailoverProposal(r, poolerByID)
 	}
 	tryBuildProposal := func(rev *clustermetadatapb.TermRevocation, statuses []*clustermetadatapb.ConsensusStatus) (*consensusdatapb.CoordinatorProposal, error) {

--- a/go/services/multiorch/consensus/leader_appointment_test.go
+++ b/go/services/multiorch/consensus/leader_appointment_test.go
@@ -349,3 +349,87 @@ func TestAppointInitialLeader(t *testing.T) {
 		require.Equal(t, int64(1), commonconsensus.PossiblyUndecidedRule(stp.GetReplicationPrimary().GetPosition()).GetRuleNumber().GetCoordinatorTerm())
 	}
 }
+
+// TestAppointLeader_TiebreaksByResignation verifies that poolerHealthStateLess
+// deprioritises nodes signalling REQUESTING_DEMOTION when LSNs are tied.
+//
+// Under synchronous replication all standbys ACK every write, so they routinely
+// reach the same WAL position as the primary at shutdown. When SwitchPrimary
+// quiesces the primary and multiorch triggers a new election, the resigned
+// primary and each standby may be tied at the same flush LSN. Without the
+// tiebreaker the resigned primary could be re-elected immediately, defeating
+// the purpose of the switchover.
+func TestAppointLeader_TiebreaksByResignation(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	coordID := &clustermetadatapb.ID{
+		Component: clustermetadatapb.ID_MULTIORCH,
+		Cell:      "test-cell",
+		Name:      "test-coordinator",
+	}
+
+	fakeClient := rpcclient.NewFakeClient()
+	ts, _ := memorytopo.NewServerAndFactory(ctx, "zone1")
+	defer ts.Close()
+
+	c := NewCoordinator(coordID, ts, fakeClient, logger)
+
+	cohortIDs := []*clustermetadatapb.ID{
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "resigned"},
+		{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: "standby"},
+	}
+	outgoingRule := &clustermetadatapb.ShardRule{
+		RuleNumber:       &clustermetadatapb.RuleNumber{CoordinatorTerm: 5},
+		LeaderId:         cohortIDs[0],
+		CohortMembers:    cohortIDs,
+		DurabilityPolicy: topoclient.AtLeastN(2),
+	}
+
+	// Both nodes share the same flush LSN — the common outcome after a clean
+	// switchover where the primary quiesced before the standby caught up.
+	const flushLSN = "0/2000000"
+
+	resigned := createMockNode(fakeClient, "resigned", 5, flushLSN, true, outgoingRule)
+	standby := createMockNode(fakeClient, "standby", 5, flushLSN, true, outgoingRule)
+
+	// Mark the resigned node as REQUESTING_DEMOTION in its AvailabilityStatus.
+	resigned.AvailabilityStatus = &clustermetadatapb.AvailabilityStatus{
+		LeadershipStatus: &clustermetadatapb.LeadershipStatus{
+			LeaderTerm: 5,
+			Signal:     clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION,
+		},
+	}
+
+	for i, mp := range []*multiorchdatapb.PoolerHealthState{resigned, standby} {
+		id := cohortIDs[i]
+		mp.ConsensusStatus.Id = id
+		mp.ConsensusStatus.CurrentPosition = &clustermetadatapb.PoolerPosition{
+			Lsn:      flushLSN,
+			Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+		}
+		fakeClient.RecruitResponses[topoclient.ComponentIDString(id)] = &consensusdatapb.RecruitResponse{
+			ConsensusStatus: &clustermetadatapb.ConsensusStatus{
+				Id: id,
+				CurrentPosition: &clustermetadatapb.PoolerPosition{
+					Lsn:      flushLSN,
+					Position: &clustermetadatapb.RulePosition{Decision: outgoingRule},
+				},
+			},
+		}
+		require.NoError(t, ts.CreateMultipooler(ctx, mp.Multipooler))
+	}
+
+	cohort := []*multiorchdatapb.PoolerHealthState{resigned, standby}
+	shardKey := &clustermetadatapb.ShardKey{Database: "postgres", TableGroup: "default", Shard: "0-inf"}
+
+	require.NoError(t, c.AppointLeader(ctx, shardKey, cohort, "test_resignation_tiebreak"))
+
+	// The standby (non-resigning) should have been promoted, not the resigned primary.
+	standbyKey := topoclient.ComponentIDString(cohortIDs[1])
+	_, promoted := fakeClient.PromoteRequests[standbyKey]
+	require.True(t, promoted, "standby should be elected, not the resigning primary")
+
+	resignedKey := topoclient.ComponentIDString(cohortIDs[0])
+	_, promotedResigned := fakeClient.PromoteRequests[resignedKey]
+	require.False(t, promotedResigned, "resigned primary should NOT be re-elected when a standby is available")
+}

--- a/go/services/multiorch/consensus/rule_change.go
+++ b/go/services/multiorch/consensus/rule_change.go
@@ -415,6 +415,40 @@ func buildFailoverProposal(
 	}, nil
 }
 
+// leadershipSignalPriority maps each leadership signal to its sort priority.
+// Lower values sort first — nodes with higher priority values are deprioritised
+// as leader candidates when LSNs are tied. Add new signals here to extend the
+// ordering without touching poolerHealthStateLess.
+var leadershipSignalPriority = map[clustermetadatapb.LeadershipSignal]int{
+	clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_UNKNOWN:             0,
+	clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_ACTIVE:              0,
+	clustermetadatapb.LeadershipSignal_LEADERSHIP_SIGNAL_REQUESTING_DEMOTION: 1,
+}
+
+// poolerHealthStateLess returns a less function for sort.SliceStable that
+// orders ConsensusStatus entries by leadershipSignalPriority. It is used in
+// Coordinator.runFailover to prefer nodes with lower priority values among
+// candidates that share the highest LSN.
+//
+// WAL position is always the primary criterion: a node with a higher-priority
+// signal still wins if it holds a strictly higher LSN than every other node.
+// This tiebreaker only affects the ordering of tied eligible leaders.
+//
+// Recruited nodes participate in the outgoing-cohort quorum check regardless of
+// their leadership signal — this tiebreaker only affects which tied node is
+// proposed as leader, not the quorum denominator.
+func poolerHealthStateLess(healthByID map[string]*multiorchdatapb.PoolerHealthState) func(a, b *clustermetadatapb.ConsensusStatus) bool {
+	leadershipSignal := func(cs *clustermetadatapb.ConsensusStatus) clustermetadatapb.LeadershipSignal {
+		h := healthByID[topoclient.ClusterIDString(cs.GetId())]
+		return h.GetAvailabilityStatus().GetLeadershipStatus().GetSignal()
+	}
+	return func(a, b *clustermetadatapb.ConsensusStatus) bool {
+		sigA := leadershipSignal(a)
+		sigB := leadershipSignal(b)
+		return leadershipSignalPriority[sigA] < leadershipSignalPriority[sigB]
+	}
+}
+
 // buildBootstrapProposal constructs a CoordinatorProposal for initial leader
 // appointment on a fresh shard. Unlike buildFailoverProposal, the cohort and
 // durability policy come from the caller — there is no recorded rule to

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -155,6 +155,15 @@ func (s *managerService) VerifyBackups(ctx context.Context, req *multipoolermana
 	}, nil
 }
 
+// ResignLeadership gracefully resigns the pooler from leadership for use in a planned failover.
+func (s *managerService) ResignLeadership(ctx context.Context, req *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	resp, err := s.manager.ResignLeadership(ctx, req)
+	if err != nil {
+		return nil, mterrors.ToGRPC(err)
+	}
+	return resp, nil
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor
 func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)

--- a/go/services/multipooler/grpcmanagerservice/service.go
+++ b/go/services/multipooler/grpcmanagerservice/service.go
@@ -146,6 +146,15 @@ func (s *managerService) VerifyBackups(ctx context.Context, req *multipoolermana
 	}, nil
 }
 
+// ResignLeadership gracefully resigns the pooler from leadership for use in a planned failover.
+func (s *managerService) ResignLeadership(ctx context.Context, req *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	resp, err := s.manager.ResignLeadership(ctx, req)
+	if err != nil {
+		return nil, mterrors.ToGRPC(err)
+	}
+	return resp, nil
+}
+
 // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts by the monitor
 func (s *managerService) SetPostgresRestartsEnabled(ctx context.Context, req *multipoolermanagerdatapb.SetPostgresRestartsEnabledRequest) (*multipoolermanagerdatapb.SetPostgresRestartsEnabledResponse, error) {
 	return s.manager.SetPostgresRestartsEnabled(ctx, req)

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -286,6 +286,90 @@ func (pm *MultiPoolerManager) clearResignedLeaderAtTerm(ctx context.Context) err
 	return nil
 }
 
+// ResignLeadership gracefully resigns this pooler from leadership for use in a
+// planned failover. It quiesces writes, terminates remaining connections,
+// restarts PostgreSQL as a standby, then publishes REQUESTING_DEMOTION so
+// multiorch's LeaderResignedAnalyzer drives the election.
+//
+// By restarting postgres here, before Recruit runs on any node, we prevent the
+// "proposed leader not eligible" error: the Recruit fan-out in
+// ApplyCertifiedRuleChange calls emergencyDemoteLocked on the old primary, which
+// runs a shutdown checkpoint and advances the LSN beyond what the target standby
+// has. When this node is already in standby mode at Recruit time, Recruit runs
+// pauseReplication instead (no new checkpoint), so all nodes end up at the same
+// post-shutdown LSN and the most-advanced standby is eligible.
+//
+// Multiorch's LeaderIsDeadAnalyzer is suppressed for the brief restart window
+// because postgres was ready very recently (within LeaderPostgresResponseThreshold).
+func (pm *MultiPoolerManager) ResignLeadership(ctx context.Context, req *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "consensus/resign_leadership")
+	defer span.End()
+
+	var err error
+	ctx, err = pm.actionLock.Acquire(ctx, "ResignLeadership")
+	if err != nil {
+		return nil, err
+	}
+	defer pm.actionLock.Release(ctx)
+
+	// Guard: only a PRIMARY may resign.
+	if err := pm.checkPrimaryGuardrails(ctx); err != nil {
+		return nil, err
+	}
+
+	state, err := pm.checkDemotionState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 1: transition to NOT_SERVING so new queries are rejected with MTF01.
+	if err := pm.setNotServing(ctx, state); err != nil {
+		return nil, mterrors.Wrap(err, "failed to transition to NOT_SERVING")
+	}
+
+	// Step 2: drain in-flight write connections.
+	if err := pm.drainWriteActivity(ctx, recruitDrainTimeout); err != nil {
+		return nil, mterrors.Wrap(err, "failed to drain write activity")
+	}
+
+	// Step 3: terminate any remaining write connections.
+	if _, err := pm.terminateWriteConnections(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "ResignLeadership: failed to terminate write connections (non-fatal)", "error", err)
+	}
+
+	// Step 4: restart PostgreSQL as standby. This triggers a graceful shutdown
+	// (SIGTERM → smart shutdown → checkpoint → WAL sent to standbys → exit),
+	// so connected standbys receive the shutdown checkpoint WAL before postgres
+	// exits.
+	if err := pm.restartPostgresAsStandby(ctx, state); err != nil {
+		return nil, mterrors.Wrap(err, "failed to restart postgres as standby during resign")
+	}
+
+	// Step 5: mark rewind as not needed — this is a planned failover so there is
+	// no WAL divergence between the old primary and the new timeline.
+	pm.rewindPending.Store(false)
+	pm.healthStreamer.UpdateLeaderObservation(nil)
+
+	// Step 6: publish REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer
+	// drives the election. Best-effort: if this fails the caller can still poll
+	// for a new leader, and multiorch's LeaderIsDeadAnalyzer will eventually act.
+	if primaryTerm, err := pm.primaryTermLocked(ctx); err == nil && primaryTerm != 0 {
+		if err := pm.setResignedLeaderAtTerm(ctx, primaryTerm); err != nil {
+			pm.logger.WarnContext(ctx, "ResignLeadership: failed to publish REQUESTING_DEMOTION (non-fatal)", "error", err)
+		}
+	}
+
+	// Step 7: capture the post-shutdown WAL replay position. Callers can use
+	// this to poll for a new leader at or beyond this LSN.
+	flushLSN, err := pm.getStandbyReplayLSN(ctx)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to capture post-shutdown replay LSN")
+	}
+
+	pm.logger.InfoContext(ctx, "ResignLeadership complete", "flush_lsn", flushLSN)
+	return &multipoolermanagerdatapb.ResignLeadershipResponse{FlushLsn: flushLSN}, nil
+}
+
 // Recruit handles a coordinator's request to stop replication participation and
 // record a TermRevocation, returning the node's stable position afterward.
 //

--- a/go/services/multipooler/internal/manager/rpc_consensus.go
+++ b/go/services/multipooler/internal/manager/rpc_consensus.go
@@ -105,6 +105,107 @@ func (pm *MultipoolerManager) markPoolerActive(ctx context.Context) {
 	}
 }
 
+// ResignLeadership gracefully resigns this pooler from leadership for use in a
+// planned failover. It quiesces writes, terminates remaining connections,
+// restarts PostgreSQL as a standby, then publishes REQUESTING_DEMOTION so
+// multiorch's LeaderResignedAnalyzer drives the election.
+//
+// By restarting postgres here, before Recruit runs on any node, we prevent the
+// "proposed leader not eligible" error: the Recruit fan-out disconnects the
+// standby's WAL receiver before the shutdown checkpoint WAL arrives. When this
+// node is already in standby mode at Recruit time, Recruit runs
+// pauseReplication instead (no new checkpoint), so all nodes end up at the same
+// post-shutdown LSN and the most-advanced standby is eligible.
+//
+// Multiorch's LeaderIsDeadAnalyzer is suppressed for the brief restart window
+// because postgres was ready very recently (within LeaderPostgresResponseThreshold).
+func (pm *MultipoolerManager) ResignLeadership(ctx context.Context, req *multipoolermanagerdatapb.ResignLeadershipRequest) (*multipoolermanagerdatapb.ResignLeadershipResponse, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "consensus/resign_leadership")
+	defer span.End()
+
+	var err error
+	ctx, err = pm.actionLock.Acquire(ctx, "ResignLeadership")
+	if err != nil {
+		return nil, err
+	}
+	defer pm.actionLock.Release(ctx)
+
+	// Guard: only a PRIMARY may resign.
+	if err := pm.checkPrimaryGuardrails(ctx); err != nil {
+		return nil, err
+	}
+
+	state, err := pm.checkDemotionState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 1: transition to DRAINING so new queries are rejected while we drain.
+	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
+		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_SERVING {
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_DRAINING
+		}
+	}); err != nil {
+		return nil, mterrors.Wrap(err, "failed to transition to DRAINING")
+	}
+
+	// Step 2: drain in-flight write connections.
+	if err := pm.drainWriteActivity(ctx, recruitDrainTimeout); err != nil {
+		return nil, mterrors.Wrap(err, "failed to drain write activity")
+	}
+
+	// Step 3: terminate any remaining write connections.
+	if _, err := pm.terminateWriteConnections(ctx); err != nil {
+		pm.logger.WarnContext(ctx, "resign_leadership: failed to terminate write connections (non-fatal)", "error", err)
+	}
+
+	// Step 4: publish REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer
+	// drives the election. Best-effort: if this fails the caller can still poll
+	// for a new leader, and multiorch's LeaderIsDeadAnalyzer will eventually act.
+	if cs := pm.consensusMgr.CachedConsensusStatus(); commonconsensus.SelfConsensusRole(cs) == commonconsensus.ConsensusRoleLeader {
+		if err := pm.consensusMgr.SetResignedLeaderAtTerm(ctx, cs.GetCurrentPosition().GetPosition()); err != nil {
+			pm.logger.WarnContext(ctx, "resign_leadership: failed to publish REQUESTING_DEMOTION (non-fatal)", "error", err)
+		}
+	}
+
+	// Step 5: restart PostgreSQL as standby. This triggers a graceful shutdown
+	// (SIGTERM → smart shutdown → checkpoint → WAL sent to standbys → exit),
+	// so connected standbys receive the shutdown checkpoint WAL before postgres
+	// exits.
+	if err := pm.resetRestoreCommand(ctx); err != nil {
+		return nil, mterrors.Wrap(err, "failed to clear restore_command before resign restart")
+	}
+	if err := pm.restartPostgresAsStandby(ctx, state); err != nil {
+		return nil, mterrors.Wrap(err, "failed to restart postgres as standby during resign")
+	}
+
+	// Step 6: mark rewind as not needed — this is a planned failover so there is
+	// no WAL divergence between the old primary and the new timeline.
+	if _, err := pm.consensusMgr.SetSuspectedDivergence(ctx, false); err != nil {
+		pm.logger.WarnContext(ctx, "resign_leadership: failed to clear suspected divergence (non-fatal)", "error", err)
+	}
+
+	// Re-enable serving now that we're back as a healthy standby.
+	if err := pm.stateManager.Mutate(ctx, func(s *servingStateMutation) {
+		s.PostgresMode = pgmode.InRecovery
+		if s.ServingStatus == clustermetadatapb.PoolerServingStatus_DRAINING {
+			s.ServingStatus = clustermetadatapb.PoolerServingStatus_SERVING
+		}
+	}); err != nil {
+		return nil, mterrors.Wrap(err, "failed to re-enable serving after resign")
+	}
+
+	// Step 7: capture the post-shutdown WAL replay position. Callers can use
+	// this to poll for a new leader at or beyond this LSN.
+	flushLSN, err := pm.getStandbyReplayLSN(ctx)
+	if err != nil {
+		return nil, mterrors.Wrap(err, "failed to capture post-shutdown replay LSN")
+	}
+
+	pm.logger.InfoContext(ctx, "resign_leadership: complete", "flush_lsn", flushLSN)
+	return &multipoolermanagerdatapb.ResignLeadershipResponse{FlushLsn: flushLSN}, nil
+}
+
 // Recruit handles a coordinator's request to stop replication participation and
 // record a TermRevocation, returning the node's stable position afterward.
 //

--- a/go/test/endtoend/multiadmin/planned_failover_test.go
+++ b/go/test/endtoend/multiadmin/planned_failover_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPlannedFailoverAutoSelectStandby verifies that a planned failover
+// completes successfully when no target is specified: multiadmin picks the most
+// advanced standby, waits for it to catch up to the frozen LSN, and promotes it
+// without needing pg_rewind on the demoted primary.
+func TestPlannedFailoverAutoSelectStandby(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultiadmin(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.GetPrimary(t)
+	require.NotNil(t, initialPrimary)
+	t.Logf("Initial primary: %s", initialPrimary.Name)
+
+	// Write some rows through the gateway so we have data to verify after failover.
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	gatewayDB, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	defer gatewayDB.Close()
+
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
+		shardsetup.WithWorkerCount(2),
+		shardsetup.WithWriteInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(validatorCleanup)
+
+	validator.Start(t)
+	time.Sleep(200 * time.Millisecond)
+
+	// Perform planned failover — no target, let multiadmin choose.
+	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
+	defer adminConn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	t.Log("Calling PlannedFailover (auto-select standby)...")
+	resp, err := adminClient.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		Reason:         "integration test",
+		CatchupTimeout: durationpb.New(30 * time.Second),
+	})
+	require.NoError(t, err, "SwitchPrimary should succeed")
+	require.NotNil(t, resp.GetNewLeaderId())
+	require.NotNil(t, resp.GetOldLeaderId())
+
+	t.Logf("Failover complete: old=%s/%s, new=%s/%s",
+		resp.GetOldLeaderId().GetCell(), resp.GetOldLeaderId().GetName(),
+		resp.GetNewLeaderId().GetCell(), resp.GetNewLeaderId().GetName())
+
+	// The new leader must be different from the old one.
+	assert.NotEqual(t, resp.GetOldLeaderId().GetName(), resp.GetNewLeaderId().GetName(),
+		"new leader should be different from old leader")
+
+	// Wait for multiorch to fully converge (old primary demoted, replication established).
+	setup.RequireRecovery(t, "multiorch", 45*time.Second)
+
+	// The cluster should now have a new primary and the old primary rejoined as standby.
+	newPrimary := setup.RefreshPrimary(t)
+	require.NotNil(t, newPrimary)
+	assert.Equal(t, resp.GetNewLeaderId().GetName(), newPrimary.Name,
+		"cluster primary should match the failover response")
+
+	t.Logf("Cluster primary after failover: %s", newPrimary.Name)
+
+	// Verify the old primary is now a replica.
+	oldPrimaryInst := setup.GetMultipoolerInstance(initialPrimary.Name)
+	require.NotNil(t, oldPrimaryInst)
+	verifyIsStandby(t, oldPrimaryInst)
+
+	// Verify writes can still flow through the gateway after failover.
+	require.Eventually(t, func() bool {
+		return validator.WriteNow(t.Context()) == nil
+	}, 15*time.Second, 200*time.Millisecond,
+		"gateway should route writes to new primary after planned failover")
+
+	// Verify no data was lost: all successful pre-failover writes must appear
+	// on the new primary.
+	validator.Stop()
+	verifyWriteDurability(t, setup, validator)
+}
+
+// TestPlannedFailoverNoPgRewind verifies that the old primary rejoins as
+// standby without pg_rewind: because writes were quiesced before the standby
+// was promoted, the old primary's WAL is not diverged from the new timeline.
+func TestPlannedFailoverNoPgRewind(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiOrchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultiadmin(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiOrchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.GetPrimary(t)
+	require.NotNil(t, initialPrimary)
+
+	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
+	defer adminConn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	resp, err := adminClient.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		Reason:         "no-pg_rewind integration test",
+		CatchupTimeout: durationpb.New(30 * time.Second),
+	})
+	require.NoError(t, err, "SwitchPrimary should succeed")
+
+	setup.RequireRecovery(t, "multiorch", 45*time.Second)
+
+	// The old primary should rejoin as a streaming replica. If pg_rewind had
+	// been needed but failed, the old primary would stay stuck in NOT_SERVING
+	// or REQUESTING_DEMOTION state instead of becoming a healthy REPLICA.
+	oldPrimaryInst := setup.GetMultipoolerInstance(resp.GetOldLeaderId().GetName())
+	require.NotNil(t, oldPrimaryInst)
+
+	shardsetup.EventuallyPoolerCondition(t,
+		[]*shardsetup.MultipoolerInstance{oldPrimaryInst},
+		30*time.Second, 500*time.Millisecond,
+		func(r shardsetup.PoolerStatusResult) (bool, string) {
+			s := r.Status
+			if s.PoolerType != clustermetadatapb.PoolerType_REPLICA {
+				return false, fmt.Sprintf("old primary not REPLICA yet (is %v)", s.PoolerType)
+			}
+			if !s.PostgresReady {
+				return false, "postgres not running"
+			}
+			if s.ReplicationStatus == nil || s.ReplicationStatus.PrimaryConnInfo == nil {
+				return false, "replication not configured"
+			}
+			if s.ReplicationStatus.WalReceiverStatus != "streaming" {
+				return false, fmt.Sprintf("not streaming (wal_receiver=%s)", s.ReplicationStatus.WalReceiverStatus)
+			}
+			return true, ""
+		},
+		"old primary %s should rejoin as streaming replica without pg_rewind", resp.GetOldLeaderId().GetName(),
+	)
+
+	t.Logf("Old primary %s rejoined as streaming replica (no pg_rewind needed)",
+		resp.GetOldLeaderId().GetName())
+}
+
+// verifyIsStandby asserts that a multipooler is a healthy streaming replica.
+func verifyIsStandby(t *testing.T, inst *shardsetup.MultipoolerInstance) {
+	t.Helper()
+	client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer client.Close()
+
+	resp, err := client.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, resp.GetStatus().GetPoolerType(),
+		"demoted primary %s should be REPLICA", inst.Name)
+	assert.NotNil(t, resp.GetStatus().GetReplicationStatus(),
+		"demoted primary %s should have replication status", inst.Name)
+}
+
+// verifyWriteDurability checks that all writes recorded by the validator are
+// present on the (new) primary's postgres.
+func verifyWriteDurability(t *testing.T, setup *shardsetup.ShardSetup, validator *shardsetup.WriterValidator) {
+	t.Helper()
+	primaryInst := setup.GetPrimary(t)
+	require.NotNil(t, primaryInst)
+
+	poolerClient, err := shardsetup.NewMultiPoolerTestClient(
+		fmt.Sprintf("localhost:%d", primaryInst.Multipooler.GrpcPort),
+	)
+	require.NoError(t, err)
+	defer poolerClient.Close()
+
+	err = validator.Verify(t, []*shardsetup.MultiPoolerTestClient{poolerClient})
+	require.NoError(t, err, "all successful pre-failover writes should be present on the new primary")
+}

--- a/go/test/endtoend/multiadmin/planned_failover_test.go
+++ b/go/test/endtoend/multiadmin/planned_failover_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multiadmin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
+	multiadminpb "github.com/multigres/multigres/go/pb/multiadmin"
+	multipoolermanagerdatapb "github.com/multigres/multigres/go/pb/multipoolermanagerdata"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// TestPlannedFailoverAutoSelectStandby verifies that a planned failover
+// completes successfully when no target is specified: multiadmin quiesces the
+// current primary and publishes REQUESTING_DEMOTION; multiorch then picks the
+// most-advanced standby and promotes it without needing pg_rewind.
+func TestPlannedFailoverAutoSelectStandby(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultiadmin(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.GetPrimary(t)
+	require.NotNil(t, initialPrimary)
+	t.Logf("Initial primary: %s", initialPrimary.Name)
+
+	// Write some rows through the gateway so we have data to verify after failover.
+	gatewayDSN := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort, "sslmode=disable", "connect_timeout=5")
+	gatewayDB, err := sql.Open("postgres", gatewayDSN)
+	require.NoError(t, err)
+	defer gatewayDB.Close()
+
+	validator, validatorCleanup, err := shardsetup.NewWriterValidator(t, gatewayDB,
+		shardsetup.WithWorkerCount(2),
+		shardsetup.WithWriteInterval(20*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(validatorCleanup)
+
+	validator.Start(t)
+	time.Sleep(200 * time.Millisecond)
+
+	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
+	defer adminConn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	t.Log("Calling SwitchPrimary...")
+	resp, err := adminClient.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		Reason: "integration test",
+	})
+	require.NoError(t, err, "SwitchPrimary should succeed")
+	require.NotNil(t, resp.GetOldLeaderId())
+	assert.Equal(t, initialPrimary.Name, resp.GetOldLeaderId().GetName(),
+		"old leader should be the initial primary")
+
+	t.Logf("SwitchPrimary returned: old=%s/%s",
+		resp.GetOldLeaderId().GetCell(), resp.GetOldLeaderId().GetName())
+
+	// Wait for multiorch to elect a new leader.
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
+
+	newPrimary := setup.RefreshPrimary(t)
+	require.NotNil(t, newPrimary)
+	assert.NotEqual(t, initialPrimary.Name, newPrimary.Name,
+		"cluster primary should have changed after switchover")
+
+	t.Logf("Cluster primary after switchover: %s", newPrimary.Name)
+
+	// Verify the old primary is now a replica.
+	oldPrimaryInst := setup.GetMultipoolerInstance(initialPrimary.Name)
+	require.NotNil(t, oldPrimaryInst)
+	verifyIsStandby(t, oldPrimaryInst)
+
+	// Verify writes can still flow through the gateway after failover.
+	require.Eventually(t, func() bool {
+		return validator.WriteNow(t.Context()) == nil
+	}, 15*time.Second, 200*time.Millisecond,
+		"gateway should route writes to new primary after planned failover")
+
+	// Verify no data was lost.
+	validator.Stop()
+	verifyWriteDurability(t, setup, validator)
+}
+
+// TestPlannedFailoverNoPgRewind verifies that the old primary rejoins as
+// standby without pg_rewind: because writes were quiesced before the standby
+// was promoted, the old primary's WAL is not diverged from the new timeline.
+func TestPlannedFailoverNoPgRewind(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("skipping: PostgreSQL binaries not found")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerCount(2),
+		shardsetup.WithMultiorchCount(1),
+		shardsetup.WithMultigateway(),
+		shardsetup.WithMultiadmin(),
+		shardsetup.WithDatabase("postgres"),
+		shardsetup.WithCellName("test-cell"),
+	)
+	defer cleanup()
+
+	setup.StartMultiorchs(t.Context(), t)
+	setup.WaitForMultigatewayQueryServing(t)
+
+	initialPrimary := setup.GetPrimary(t)
+	require.NotNil(t, initialPrimary)
+
+	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
+	defer adminConn.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	resp, err := adminClient.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
+		ShardKey: &clustermetadatapb.ShardKey{
+			Database:   "postgres",
+			TableGroup: "default",
+			Shard:      "0-inf",
+		},
+		Reason: "no-pg_rewind integration test",
+	})
+	require.NoError(t, err, "SwitchPrimary should succeed")
+
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
+
+	// The old primary should rejoin as a streaming replica. If pg_rewind had
+	// been needed but failed, the old primary would stay stuck instead of
+	// becoming a healthy REPLICA.
+	oldPrimaryInst := setup.GetMultipoolerInstance(resp.GetOldLeaderId().GetName())
+	require.NotNil(t, oldPrimaryInst)
+
+	shardsetup.EventuallyPoolerCondition(t,
+		[]*shardsetup.MultipoolerInstance{oldPrimaryInst},
+		30*time.Second, 500*time.Millisecond,
+		func(r shardsetup.PoolerStatusResult) (bool, string) {
+			s := r.Status
+			if s.PoolerType != clustermetadatapb.PoolerType_REPLICA {
+				return false, fmt.Sprintf("old primary not REPLICA yet (is %v)", s.PoolerType)
+			}
+			if !s.PostgresReady {
+				return false, "postgres not running"
+			}
+			if s.ReplicationStatus == nil || s.ReplicationStatus.PrimaryConnInfo == nil {
+				return false, "replication not configured"
+			}
+			if s.ReplicationStatus.WalReceiverStatus != "streaming" {
+				return false, fmt.Sprintf("not streaming (wal_receiver=%s)", s.ReplicationStatus.WalReceiverStatus)
+			}
+			return true, ""
+		},
+		"old primary %s should rejoin as streaming replica without pg_rewind", resp.GetOldLeaderId().GetName(),
+	)
+
+	t.Logf("Old primary %s rejoined as streaming replica (no pg_rewind needed)",
+		resp.GetOldLeaderId().GetName())
+}
+
+// verifyIsStandby asserts that a multipooler is a healthy streaming replica.
+func verifyIsStandby(t *testing.T, inst *shardsetup.MultipoolerInstance) {
+	t.Helper()
+	client, err := shardsetup.NewMultipoolerClient(inst.Multipooler.GrpcPort)
+	require.NoError(t, err)
+	defer client.Close()
+
+	resp, err := client.Manager.Status(utils.WithTimeout(t, 5*time.Second), &multipoolermanagerdatapb.StatusRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, resp.GetStatus().GetPoolerType(),
+		"demoted primary %s should be REPLICA", inst.Name)
+	assert.NotNil(t, resp.GetStatus().GetReplicationStatus(),
+		"demoted primary %s should have replication status", inst.Name)
+}
+
+// verifyWriteDurability checks that all writes recorded by the validator are
+// present on the (new) primary's postgres.
+func verifyWriteDurability(t *testing.T, setup *shardsetup.ShardSetup, validator *shardsetup.WriterValidator) {
+	t.Helper()
+	primaryInst := setup.GetPrimary(t)
+	require.NotNil(t, primaryInst)
+
+	poolerClient, err := shardsetup.NewMultipoolerTestClient(
+		fmt.Sprintf("localhost:%d", primaryInst.Multipooler.GrpcPort),
+	)
+	require.NoError(t, err)
+	defer poolerClient.Close()
+
+	err = validator.Verify(t, []*shardsetup.MultipoolerTestClient{poolerClient})
+	require.NoError(t, err, "all successful pre-failover writes should be present on the new primary")
+}

--- a/go/test/endtoend/multiadmin/planned_failover_test.go
+++ b/go/test/endtoend/multiadmin/planned_failover_test.go
@@ -80,7 +80,7 @@ func TestPlannedFailoverAutoSelectStandby(t *testing.T) {
 	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
 	defer adminConn.Close()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), utils.ScaleTimeout(60*time.Second))
 	defer cancel()
 
 	t.Log("Calling SwitchPrimary...")
@@ -101,7 +101,7 @@ func TestPlannedFailoverAutoSelectStandby(t *testing.T) {
 		resp.GetOldLeaderId().GetCell(), resp.GetOldLeaderId().GetName())
 
 	// Wait for multiorch to elect a new leader.
-	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioPlannedFailover)
 
 	newPrimary := setup.RefreshPrimary(t)
 	require.NotNil(t, newPrimary)
@@ -156,7 +156,7 @@ func TestPlannedFailoverNoPgRewind(t *testing.T) {
 	adminClient, adminConn := newAdminClient(t, setup.MultiadminGrpcPort)
 	defer adminConn.Close()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), utils.ScaleTimeout(60*time.Second))
 	defer cancel()
 
 	resp, err := adminClient.SwitchPrimary(ctx, &multiadminpb.SwitchPrimaryRequest{
@@ -169,7 +169,7 @@ func TestPlannedFailoverNoPgRewind(t *testing.T) {
 	})
 	require.NoError(t, err, "SwitchPrimary should succeed")
 
-	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioEmergencyDemotion)
+	setup.RequireRecovery(t, "multiorch", shardsetup.RecoveryScenarioPlannedFailover)
 
 	// The old primary should rejoin as a streaming replica. If pg_rewind had
 	// been needed but failed, the old primary would stay stuck instead of

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -903,6 +903,10 @@ const (
 	// then hands control back to multiorch to elect a new primary and
 	// stabilize the shard.
 	RecoveryScenarioEmergencyDemotion RecoveryScenario = "emergency-demotion"
+	// RecoveryScenarioPlannedFailover is the wait after a SwitchPrimary / planned
+	// failover. The old primary restarts as standby before the election begins, so
+	// the end-to-end election window is longer than a pure emergency demotion.
+	RecoveryScenarioPlannedFailover RecoveryScenario = "planned-failover"
 )
 
 // recoveryScenarioTimeouts configures how long RequireRecovery waits per RecoveryScenario.
@@ -911,6 +915,7 @@ var recoveryScenarioTimeouts = map[RecoveryScenario]time.Duration{
 	RecoveryScenarioStalePrimaryDemote: 30 * time.Second,
 	RecoveryScenarioFixReplication:     30 * time.Second,
 	RecoveryScenarioEmergencyDemotion:  30 * time.Second,
+	RecoveryScenarioPlannedFailover:    60 * time.Second,
 }
 
 // RequireRecovery triggers immediate recovery and blocks until all problems are resolved or

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -163,6 +163,21 @@ service MultiAdminService {
       body: "*"
     };
   }
+
+  // SwitchPrimary performs a graceful switchover for a shard. It stops writes
+  // and freezes the WAL position on the current primary, waits for the chosen
+  // standby to catch up, then promotes it as the new leader via
+  // ApplyCertifiedRuleChange. The old leader is demoted to standby by the
+  // subsequent Recruit round.
+  //
+  // If target_leader_id is not set, multiadmin picks the standby with the
+  // highest current WAL position.
+  rpc SwitchPrimary(SwitchPrimaryRequest) returns (SwitchPrimaryResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"
+      body: "*"
+    };
+  }
 }
 
 // GetCellRequest specifies the cell to retrieve
@@ -571,4 +586,26 @@ message ApplyCertifiedRuleChangeResponse {
   // used or term_revocation was filled in by multiadmin, this exposes the
   // values that multiadmin chose.
   clustermetadata.ExternallyCertifiedRevocation cert_used = 2;
+}
+
+// SwitchPrimary operation messages
+
+message SwitchPrimaryRequest {
+  // Shard to perform the switchover on (required).
+  clustermetadata.ShardKey shard_key = 1;
+
+  // Free-text reason recorded in rule_history for audit.
+  string reason = 3;
+
+  // How long to poll for a new leader to be elected after the old primary
+  // resigns. Defaults to 30s if unset.
+  google.protobuf.Duration catchup_timeout = 4;
+}
+
+message SwitchPrimaryResponse {
+  // The pooler that was promoted to leader.
+  clustermetadata.ID new_leader_id = 1;
+
+  // The pooler that was demoted.
+  clustermetadata.ID old_leader_id = 2;
 }

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -155,6 +155,19 @@ service MultiadminService {
       body: "*"
     };
   }
+
+  // SwitchPrimary performs a graceful switchover for a shard. It quiesces
+  // writes on the current leader, restarts it as a standby, and publishes
+  // REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+  // leader through the normal consensus flow. The RPC returns as soon as the
+  // old primary has been quiesced — it does not wait for the new leader to
+  // appear.
+  rpc SwitchPrimary(SwitchPrimaryRequest) returns (SwitchPrimaryResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/shards/{shard_key.database}/{shard_key.table_group}/{shard_key.shard}/switch-primary"
+      body: "*"
+    };
+  }
 }
 
 // GetCellRequest specifies the cell to retrieve
@@ -564,4 +577,19 @@ message ApplyCertifiedRuleChangeResponse {
   // used or term_revocation was filled in by multiadmin, this exposes the
   // values that multiadmin chose.
   clustermetadata.ExternallyCertifiedRevocation cert_used = 2;
+}
+
+// SwitchPrimary operation messages
+
+message SwitchPrimaryRequest {
+  // Shard to perform the switchover on (required).
+  clustermetadata.ShardKey shard_key = 1;
+
+  // Free-text reason recorded in rule_history for audit.
+  string reason = 2;
+}
+
+message SwitchPrimaryResponse {
+  // The pooler that was demoted.
+  clustermetadata.ID old_leader_id = 1;
 }

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -591,6 +591,21 @@ message RewindToSourceResponse {
 }
 
 // =============================================================================
+// Leadership Resignation APIs
+// =============================================================================
+
+// ResignLeadershipRequest asks the primary pooler to gracefully resign from leadership.
+message ResignLeadershipRequest {}
+
+// ResignLeadershipResponse returns the WAL flush LSN at the moment writes were quiesced.
+message ResignLeadershipResponse {
+  // flush_lsn is the WAL flush position at the moment postgres stopped accepting
+  // writes. Callers should wait for standbys to reach this LSN before triggering
+  // a new election, ensuring no data loss.
+  string flush_lsn = 1;
+}
+
+// =============================================================================
 // PostgreSQL Monitoring Control APIs
 // =============================================================================
 

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -595,6 +595,22 @@ message BackupMetadata {
 }
 
 // =============================================================================
+// Leadership Resignation APIs
+// =============================================================================
+
+// ResignLeadershipRequest asks the primary pooler to gracefully resign from leadership.
+message ResignLeadershipRequest {
+}
+
+// ResignLeadershipResponse returns the WAL flush LSN at the moment writes were quiesced.
+message ResignLeadershipResponse {
+  // flush_lsn is the WAL flush position at the moment postgres stopped accepting
+  // writes. Callers should wait for standbys to reach this LSN before triggering
+  // a new election, ensuring no data loss.
+  string flush_lsn = 1;
+}
+
+// =============================================================================
 // PostgreSQL Monitoring Control APIs
 // =============================================================================
 

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -81,6 +81,18 @@ service MultiPoolerManager {
   // PostgreSQL Monitoring Control
   //
 
+  // ResignLeadership gracefully resigns this pooler from leadership.
+  // Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+  // drains write connections, publishes REQUESTING_DEMOTION, and returns the
+  // WAL flush LSN at the moment writes were quiesced. The caller can then wait
+  // for standbys to reach that LSN before triggering a new election.
+  //
+  // Only valid on a pooler that is currently the consensus leader (PRIMARY).
+  // Does NOT restart postgres as standby — that happens later via the normal
+  // Recruit path when multiorch picks up REQUESTING_DEMOTION.
+  rpc ResignLeadership(multipoolermanagerdata.ResignLeadershipRequest)
+      returns (multipoolermanagerdata.ResignLeadershipResponse);
+
   // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
   // When disabled, the monitor continues to run but will not auto-restart a stopped
   // PostgreSQL instance. Used by tests and demos to prevent premature restarts during

--- a/proto/multipoolermanagerservice.proto
+++ b/proto/multipoolermanagerservice.proto
@@ -77,6 +77,18 @@ service MultipoolerManager {
   // PostgreSQL Monitoring Control
   //
 
+  // ResignLeadership gracefully resigns this pooler from leadership.
+  // Transitions the pooler to NOT_SERVING (rejecting new queries with MTF01),
+  // drains write connections, publishes REQUESTING_DEMOTION, and returns the
+  // WAL flush LSN at the moment writes were quiesced. The caller can then wait
+  // for standbys to reach that LSN before triggering a new election.
+  //
+  // Only valid on a pooler that is currently the consensus leader (PRIMARY).
+  // Does NOT restart postgres as standby — that happens later via the normal
+  // Recruit path when multiorch picks up REQUESTING_DEMOTION.
+  rpc ResignLeadership(multipoolermanagerdata.ResignLeadershipRequest)
+      returns (multipoolermanagerdata.ResignLeadershipResponse);
+
   // SetPostgresRestartsEnabled enables or disables automatic PostgreSQL restarts.
   // When disabled, the monitor continues to run but will not auto-restart a stopped
   // PostgreSQL instance. Used by tests and demos to prevent premature restarts during

--- a/web/multiadmin/lib/api/generated/multiadminservice_connect.ts
+++ b/web/multiadmin/lib/api/generated/multiadminservice_connect.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ApplyCertifiedRuleChangeRequest, ApplyCertifiedRuleChangeResponse, BackupRequest, BackupResponse, ExpireBackupsRequest, ExpireBackupsResponse, GetBackupJobStatusRequest, GetBackupJobStatusResponse, GetBackupsRequest, GetBackupsResponse, GetCellNamesRequest, GetCellNamesResponse, GetCellRequest, GetCellResponse, GetDatabaseNamesRequest, GetDatabaseNamesResponse, GetDatabaseRequest, GetDatabaseResponse, GetGatewayConsolidatorRequest, GetGatewayConsolidatorResponse, GetGatewayQueriesRequest, GetGatewayQueriesResponse, GetGatewaysRequest, GetGatewaysResponse, GetOrchsRequest, GetOrchsResponse, GetPoolersRequest, GetPoolersResponse, GetPoolerStatusRequest, GetPoolerStatusResponse, SetPostgresRestartsEnabledRequest, SetPostgresRestartsEnabledResponse, VerifyBackupsRequest, VerifyBackupsResponse } from "./multiadminservice_pb";
+import { ApplyCertifiedRuleChangeRequest, ApplyCertifiedRuleChangeResponse, BackupRequest, BackupResponse, ExpireBackupsRequest, ExpireBackupsResponse, GetBackupJobStatusRequest, GetBackupJobStatusResponse, GetBackupsRequest, GetBackupsResponse, GetCellNamesRequest, GetCellNamesResponse, GetCellRequest, GetCellResponse, GetDatabaseNamesRequest, GetDatabaseNamesResponse, GetDatabaseRequest, GetDatabaseResponse, GetGatewayConsolidatorRequest, GetGatewayConsolidatorResponse, GetGatewayQueriesRequest, GetGatewayQueriesResponse, GetGatewaysRequest, GetGatewaysResponse, GetOrchsRequest, GetOrchsResponse, GetPoolersRequest, GetPoolersResponse, GetPoolerStatusRequest, GetPoolerStatusResponse, SetPostgresRestartsEnabledRequest, SetPostgresRestartsEnabledResponse, SwitchPrimaryRequest, SwitchPrimaryResponse, VerifyBackupsRequest, VerifyBackupsResponse } from "./multiadminservice_pb";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -226,6 +226,22 @@ export const MultiadminService = {
       name: "ApplyCertifiedRuleChange",
       I: ApplyCertifiedRuleChangeRequest,
       O: ApplyCertifiedRuleChangeResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * SwitchPrimary performs a graceful switchover for a shard. It quiesces
+     * writes on the current leader, restarts it as a standby, and publishes
+     * REQUESTING_DEMOTION so multiorch's LeaderResignedAnalyzer elects a new
+     * leader through the normal consensus flow. The RPC returns as soon as the
+     * old primary has been quiesced — it does not wait for the new leader to
+     * appear.
+     *
+     * @generated from rpc multiadmin.MultiadminService.SwitchPrimary
+     */
+    switchPrimary: {
+      name: "SwitchPrimary",
+      I: SwitchPrimaryRequest,
+      O: SwitchPrimaryResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
+++ b/web/multiadmin/lib/api/generated/multiadminservice_pb.ts
@@ -2027,3 +2027,89 @@ export class ApplyCertifiedRuleChangeResponse extends Message<ApplyCertifiedRule
   }
 }
 
+/**
+ * @generated from message multiadmin.SwitchPrimaryRequest
+ */
+export class SwitchPrimaryRequest extends Message<SwitchPrimaryRequest> {
+  /**
+   * Shard to perform the switchover on (required).
+   *
+   * @generated from field: clustermetadata.ShardKey shard_key = 1;
+   */
+  shardKey?: ShardKey;
+
+  /**
+   * Free-text reason recorded in rule_history for audit.
+   *
+   * @generated from field: string reason = 2;
+   */
+  reason = "";
+
+  constructor(data?: PartialMessage<SwitchPrimaryRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multiadmin.SwitchPrimaryRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "shard_key", kind: "message", T: ShardKey },
+    { no: 2, name: "reason", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SwitchPrimaryRequest {
+    return new SwitchPrimaryRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): SwitchPrimaryRequest {
+    return new SwitchPrimaryRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): SwitchPrimaryRequest {
+    return new SwitchPrimaryRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: SwitchPrimaryRequest | PlainMessage<SwitchPrimaryRequest> | undefined, b: SwitchPrimaryRequest | PlainMessage<SwitchPrimaryRequest> | undefined): boolean {
+    return proto3.util.equals(SwitchPrimaryRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message multiadmin.SwitchPrimaryResponse
+ */
+export class SwitchPrimaryResponse extends Message<SwitchPrimaryResponse> {
+  /**
+   * The pooler that was demoted.
+   *
+   * @generated from field: clustermetadata.ID old_leader_id = 1;
+   */
+  oldLeaderId?: ID;
+
+  constructor(data?: PartialMessage<SwitchPrimaryResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multiadmin.SwitchPrimaryResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "old_leader_id", kind: "message", T: ID },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SwitchPrimaryResponse {
+    return new SwitchPrimaryResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): SwitchPrimaryResponse {
+    return new SwitchPrimaryResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): SwitchPrimaryResponse {
+    return new SwitchPrimaryResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: SwitchPrimaryResponse | PlainMessage<SwitchPrimaryResponse> | undefined, b: SwitchPrimaryResponse | PlainMessage<SwitchPrimaryResponse> | undefined): boolean {
+    return proto3.util.equals(SwitchPrimaryResponse, a, b);
+  }
+}
+

--- a/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
+++ b/web/multiadmin/lib/api/generated/multipoolermanagerdata_pb.ts
@@ -2233,6 +2233,82 @@ proto3.util.setEnumType(BackupMetadata_Status, "multipoolermanagerdata.BackupMet
 ]);
 
 /**
+ * ResignLeadershipRequest asks the primary pooler to gracefully resign from leadership.
+ *
+ * @generated from message multipoolermanagerdata.ResignLeadershipRequest
+ */
+export class ResignLeadershipRequest extends Message<ResignLeadershipRequest> {
+  constructor(data?: PartialMessage<ResignLeadershipRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ResignLeadershipRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResignLeadershipRequest {
+    return new ResignLeadershipRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ResignLeadershipRequest {
+    return new ResignLeadershipRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ResignLeadershipRequest {
+    return new ResignLeadershipRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ResignLeadershipRequest | PlainMessage<ResignLeadershipRequest> | undefined, b: ResignLeadershipRequest | PlainMessage<ResignLeadershipRequest> | undefined): boolean {
+    return proto3.util.equals(ResignLeadershipRequest, a, b);
+  }
+}
+
+/**
+ * ResignLeadershipResponse returns the WAL flush LSN at the moment writes were quiesced.
+ *
+ * @generated from message multipoolermanagerdata.ResignLeadershipResponse
+ */
+export class ResignLeadershipResponse extends Message<ResignLeadershipResponse> {
+  /**
+   * flush_lsn is the WAL flush position at the moment postgres stopped accepting
+   * writes. Callers should wait for standbys to reach this LSN before triggering
+   * a new election, ensuring no data loss.
+   *
+   * @generated from field: string flush_lsn = 1;
+   */
+  flushLsn = "";
+
+  constructor(data?: PartialMessage<ResignLeadershipResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "multipoolermanagerdata.ResignLeadershipResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "flush_lsn", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResignLeadershipResponse {
+    return new ResignLeadershipResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ResignLeadershipResponse {
+    return new ResignLeadershipResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ResignLeadershipResponse {
+    return new ResignLeadershipResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ResignLeadershipResponse | PlainMessage<ResignLeadershipResponse> | undefined, b: ResignLeadershipResponse | PlainMessage<ResignLeadershipResponse> | undefined): boolean {
+    return proto3.util.equals(ResignLeadershipResponse, a, b);
+  }
+}
+
+/**
  * SetPostgresRestartsEnabledRequest enables or disables automatic PostgreSQL restarts
  * by the postgres monitor. When disabled, the monitor will still run and detect problems,
  * but will not automatically restart a stopped PostgreSQL instance.


### PR DESCRIPTION
Adds a new `multigres cluster switch-primary` command and the backing `SwitchPrimary` multiadmin RPC. Unlike emergency failover, this operation guarantees no data loss and no pg_rewind on the old primary.

Previously there was no way to do a planned failover without forcibly stopping the primary. This PR adds a proper, safe switchover path that is also useful for testing features that rely on failovers.

Key changes:
- New `ResignLeadership` multipooler RPC: quiesces writes (DRAINING state), drains connections, restarts postgres as standby, clears suspected divergence, and returns the post-shutdown flush LSN. Publishing `REQUESTING_DEMOTION` via `consensusMgr.SetResignedLeaderAtTerm()` lets multiorch's `LeaderResignedAnalyzer` drive the election.
- New `SwitchPrimary` multiadmin RPC: discovers the leader, waits for the coordinator backoff window to clear before quiescing writes, then calls `ResignLeadership` and returns immediately. Multiorch handles the election through the normal consensus flow.
- CLI: `multigres cluster switch-primary` with `--reason`, `--yes`, `--timeout` flags. Interactive confirmation (type shard name) unless `--yes`. Use `multigres cluster status` to watch for the new primary.
- Leader election tiebreaker: `poolerHealthStateLess` (keyed on `leadershipSignalPriority`) sorts `EligibleLeaders` so nodes signalling `REQUESTING_DEMOTION` are deprioritised when LSNs are tied. WAL position remains the primary criterion.
- Unit tests for `SwitchPrimary` (no-shard-key, no-primary, no-standby, success, backoff wait, resign error) and `poolerHealthStateLess` tiebreaker.
- Integration tests covering the planned failover path and no-pg_rewind guarantee.

## Message flow

```mermaid
sequenceDiagram
    participant CLI as multigres CLI
    participant MA as multiadmin
    participant MO as multiorch
    participant Etcd as etcd (topology)
    participant MP as multipooler (leader)

    CLI->>MA: SwitchPrimary(shard_key, reason)
    MA->>Etcd: GetMultipoolersByCell — discover poolers
    Etcd-->>MA: pooler list (PRIMARY + standbys)
    MA->>MP: Status() — check coordinator backoff
    MP-->>MA: StatusResponse
    Note over MA: wait if TermRevocation < 4 s old

    MA->>MP: ResignLeadership()
    activate MP
    Note over MP: Mutate → DRAINING (MTF01 to clients)
    Note over MP: drainWriteActivity()
    Note over MP: terminateWriteConnections()
    MP->>Etcd: SetResignedLeaderAtTerm → REQUESTING_DEMOTION
    Note over MP: restartPostgresAsStandby()
    Note over MP: SetSuspectedDivergence(false)
    Note over MP: Mutate → SERVING (InRecovery)
    MP-->>MA: ResignLeadershipResponse{flush_lsn}
    deactivate MP

    MA-->>CLI: SwitchPrimaryResponse{old_leader_id}

    MO->>Etcd: detect REQUESTING_DEMOTION
    MO->>Etcd: Recruit fan-out — elect new leader
```

Closes MUL-639
