### PR TITLE
feat(multigateway): route from pooler self_leadership in topology

### DIFF
--- a/go/common/consensus/compare.go
+++ b/go/common/consensus/compare.go
@@ -66,6 +66,24 @@ func FormatRuleNumber(rn *clustermetadatapb.RuleNumber) string {
 	return fmt.Sprintf("%d.%d", rn.GetCoordinatorTerm(), rn.GetLeaderSubterm())
 }
 
+// MostAuthoritativeObservation returns the LeaderObservation with the highest
+// rule number among those given (nil entries are skipped). Used to merge leader
+// observations from different sources — a topology record's self_leadership and
+// a health-stream report — choosing the one made under the newest rule. Returns
+// nil if all inputs are nil.
+func MostAuthoritativeObservation(obs ...*clustermetadatapb.LeaderObservation) *clustermetadatapb.LeaderObservation {
+	var best *clustermetadatapb.LeaderObservation
+	for _, o := range obs {
+		if o == nil {
+			continue
+		}
+		if best == nil || CompareRuleNumbers(o.GetLeaderRuleNumber(), best.GetLeaderRuleNumber()) > 0 {
+			best = o
+		}
+	}
+	return best
+}
+
 // MostAdvancedPosition returns the highest-ranked PoolerPosition among the
 // given statuses. Rule number takes precedence; LSN breaks ties within the
 // same rule. Returns nil if no status has a parseable LSN.

--- a/go/common/consensus/compare_test.go
+++ b/go/common/consensus/compare_test.go
@@ -240,3 +240,35 @@ func TestComparePosition(t *testing.T) {
 		})
 	}
 }
+
+func obs(name string, term, subterm int64) *clustermetadatapb.LeaderObservation {
+	return &clustermetadatapb.LeaderObservation{
+		LeaderId:         &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "zone1", Name: name},
+		LeaderRuleNumber: rn(term, subterm),
+	}
+}
+
+func TestMostAuthoritativeObservation(t *testing.T) {
+	a := obs("a", 5, 0)
+	b := obs("b", 6, 0)
+	c := obs("c", 6, 1)
+
+	t.Run("all nil returns nil", func(t *testing.T) {
+		assert.Nil(t, MostAuthoritativeObservation(nil, nil))
+		assert.Nil(t, MostAuthoritativeObservation())
+	})
+
+	t.Run("skips nil entries", func(t *testing.T) {
+		assert.Same(t, a, MostAuthoritativeObservation(nil, a, nil))
+	})
+
+	t.Run("highest rule number wins", func(t *testing.T) {
+		assert.Same(t, b, MostAuthoritativeObservation(a, b))
+		assert.Same(t, c, MostAuthoritativeObservation(a, b, c)) // subterm breaks the term tie
+	})
+
+	t.Run("first wins on an exact rule tie", func(t *testing.T) {
+		tie := obs("tie", 6, 1)
+		assert.Same(t, c, MostAuthoritativeObservation(c, tie))
+	})
+}

--- a/go/common/web/templates/gateway_index.html
+++ b/go/common/web/templates/gateway_index.html
@@ -58,7 +58,8 @@
           <tr>
             <th>Name</th>
             <th>Database</th>
-            <th>Type</th>
+            <th>Leadership</th>
+            <th>Lifecycle</th>
           </tr>
         </thead>
         <tbody>
@@ -66,7 +67,8 @@
           <tr>
             <th>{{.Name}}</th>
             <td>{{.Database}}</td>
-            <td>{{.Type}}</td>
+            <td>{{if .Leadership}}{{.Leadership}}{{else}}&mdash;{{end}}</td>
+            <td>{{.Lifecycle}}</td>
           </tr>
           {{end}}
         </tbody>

--- a/go/services/multigateway/discovery.go
+++ b/go/services/multigateway/discovery.go
@@ -171,7 +171,7 @@ func (pd *CellPoolerDiscovery) processInitialPoolers(initial []*topoclient.Watch
 				"addr", pooler.Addr(),
 				"database", pooler.GetShardKey().GetDatabase(),
 				"shard", pooler.GetShardKey().GetShard(),
-				"type", pooler.Type.String())
+				"is_leader", pooler.GetSelfLeadership() != nil)
 		}
 	}
 
@@ -257,7 +257,7 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 			"tableGroup", pooler.GetShardKey().GetTableGroup(),
 			"database", pooler.GetShardKey().GetDatabase(),
 			"shard", pooler.GetShardKey().GetShard(),
-			"type", pooler.Type.String())
+			"is_leader", pooler.GetSelfLeadership() != nil)
 	} else {
 		pd.logger.Info("Pooler updated",
 			"id", poolerID,
@@ -266,7 +266,7 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 			"tableGroup", pooler.GetShardKey().GetTableGroup(),
 			"database", pooler.GetShardKey().GetDatabase(),
 			"shard", pooler.GetShardKey().GetShard(),
-			"type", pooler.Type.String())
+			"is_leader", pooler.GetSelfLeadership() != nil)
 	}
 
 	if pd.onPoolerChanged != nil {

--- a/go/services/multigateway/discovery.go
+++ b/go/services/multigateway/discovery.go
@@ -274,10 +274,12 @@ func (pd *CellPoolerDiscovery) processPoolerChange(watchData *topoclient.WatchDa
 	}
 }
 
-// GetPoolersForAdmin returns a list of all discovered poolers in this cell.
-// This is intended for admin/status pages, not the hot query path.
-// Poolers are sorted by name for consistent display order.
-func (pd *CellPoolerDiscovery) GetPoolersForAdmin() []*clustermetadatapb.MultiPooler {
+// GetPoolersForAdmin returns a projected snapshot of all discovered poolers in
+// this cell, sorted by ID for consistent display order. Intended for
+// admin/status pages, not the hot query path. It includes every pooler known to
+// topology — even ones the load balancer is not connected to — so callers can
+// surface, e.g., a pooler in a shutdown lifecycle state.
+func (pd *CellPoolerDiscovery) GetPoolersForAdmin() []CellPoolerInfo {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 
@@ -288,12 +290,27 @@ func (pd *CellPoolerDiscovery) GetPoolersForAdmin() []*clustermetadatapb.MultiPo
 	}
 	sort.Strings(poolerIDs)
 
-	poolers := make([]*clustermetadatapb.MultiPooler, 0, len(pd.poolers))
+	infos := make([]CellPoolerInfo, 0, len(pd.poolers))
 	for _, id := range poolerIDs {
 		pooler := pd.poolers[id]
-		poolers = append(poolers, proto.Clone(pooler.MultiPooler).(*clustermetadatapb.MultiPooler))
+		infos = append(infos, CellPoolerInfo{
+			ID:        id,
+			Name:      pooler.Id.GetName(),
+			Database:  pooler.GetShardKey().GetDatabase(),
+			Lifecycle: lifecycleLabel(pooler.GetLifecycleStatus()),
+		})
 	}
-	return poolers
+	return infos
+}
+
+// lifecycleLabel renders a pooler's lifecycle status for display, e.g.
+// LIFECYCLE_SHUTDOWN -> "shutdown". A nil or unset status reads as "unknown".
+func lifecycleLabel(lc *clustermetadatapb.PoolerLifecycle) string {
+	status := lc.GetStatus()
+	if status == clustermetadatapb.PoolerLifecycleStatus_LIFECYCLE_UNKNOWN {
+		return "unknown"
+	}
+	return strings.ToLower(strings.TrimPrefix(status.String(), "LIFECYCLE_"))
 }
 
 // LastRefresh returns the timestamp of the last successful refresh.
@@ -732,11 +749,22 @@ func (gd *GlobalPoolerDiscovery) PoolerCount() int {
 	return count
 }
 
+// CellPoolerInfo is a projected, read-only snapshot of a discovered pooler for
+// the admin/status page — the topology facts only, not the raw proto. The load
+// balancer's live consensus view (leadership) is joined in by the caller, keyed
+// on ID.
+type CellPoolerInfo struct {
+	ID        string
+	Name      string
+	Database  string
+	Lifecycle string
+}
+
 // CellStatusInfo contains status information for a single cell's discovery.
 type CellStatusInfo struct {
 	Cell        string
 	LastRefresh time.Time
-	Poolers     []*clustermetadatapb.MultiPooler
+	Poolers     []CellPoolerInfo
 }
 
 // GetCellStatusesForAdmin returns status information for each cell.

--- a/go/services/multigateway/discovery_test.go
+++ b/go/services/multigateway/discovery_test.go
@@ -195,13 +195,7 @@ func TestPoolerDiscovery_MultiplePoolerUpdates(t *testing.T) {
 
 	// Verify the update is reflected
 	waitForCondition(t, func() bool {
-		poolers := pd.GetPoolersForAdmin()
-		for _, p := range poolers {
-			if p.Id.Name == "pooler1" && p.Hostname == "host1-updated" {
-				return true
-			}
-		}
-		return false
+		return rawDiscoveredPoolers(pd)["pooler1"].GetHostname() == "host1-updated"
 	}, "Expected pooler1 to be updated to host1-updated")
 
 	// Count should remain 2
@@ -235,6 +229,19 @@ func TestPoolerDiscovery_EmptyInitialState(t *testing.T) {
 	waitForPoolerCount(t, pd, 1)
 }
 
+// rawDiscoveredPoolers returns the internal pooler records keyed by name, for
+// assertions on fields the admin projection does not expose (hostname, type,
+// shard). The discovery test lives in-package, so it can read pd.poolers.
+func rawDiscoveredPoolers(pd *CellPoolerDiscovery) map[string]*clustermetadatapb.MultiPooler {
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	m := make(map[string]*clustermetadatapb.MultiPooler, len(pd.poolers))
+	for _, p := range pd.poolers {
+		m[p.Id.GetName()] = p.MultiPooler
+	}
+	return m
+}
+
 func TestPoolerDiscovery_VerifyPoolerDetails(t *testing.T) {
 	ctx := t.Context()
 	store, _ := memorytopo.NewServerAndFactory(ctx, "test-cell")
@@ -256,11 +263,7 @@ func TestPoolerDiscovery_VerifyPoolerDetails(t *testing.T) {
 	waitForPoolerCount(t, pd, 2)
 
 	// Verify all pooler details are correctly populated
-	poolers := pd.GetPoolersForAdmin()
-	poolerMap := make(map[string]*clustermetadatapb.MultiPooler)
-	for _, p := range poolers {
-		poolerMap[p.Id.Name] = p
-	}
+	poolerMap := rawDiscoveredPoolers(pd)
 
 	// Verify pooler1
 	require.Contains(t, poolerMap, "pooler1")
@@ -293,15 +296,15 @@ func TestPoolerDiscovery_GetPoolers_ThreadSafe(t *testing.T) {
 
 	waitForPoolerCount(t, pd, 1)
 
-	// Verify GetPoolers returns a copy (not the internal map)
+	// Each call returns an independent slice of value snapshots, not a view
+	// into the internal map.
 	poolers1 := pd.GetPoolersForAdmin()
 	poolers2 := pd.GetPoolersForAdmin()
+	require.Len(t, poolers1, 1)
+	require.Len(t, poolers2, 1)
 
-	// Modifying one shouldn't affect the other
-	assert.NotSame(t, poolers1[0], poolers2[0])
-
-	// But they should have the same data
-	assert.Equal(t, poolers1[0].Hostname, poolers2[0].Hostname)
+	assert.Equal(t, poolers1, poolers2)
+	assert.NotSame(t, &poolers1[0], &poolers2[0])
 }
 
 func TestPoolerDiscovery_InvalidDataHandling(t *testing.T) {
@@ -344,11 +347,7 @@ func TestPoolerDiscovery_InvalidDataHandling(t *testing.T) {
 	// Should discover only the valid poolers
 	waitForPoolerCount(t, pd, 2)
 
-	poolers := pd.GetPoolersForAdmin()
-	poolerMap := make(map[string]*clustermetadatapb.MultiPooler)
-	for _, p := range poolers {
-		poolerMap[p.Id.Name] = p
-	}
+	poolerMap := rawDiscoveredPoolers(pd)
 
 	// Verify only valid poolers were discovered
 	assert.Contains(t, poolerMap, "pooler1")
@@ -455,7 +454,7 @@ func TestPoolerDiscovery_ReconnectsAfterWatchClosed(t *testing.T) {
 
 	poolers := pd.GetPoolersForAdmin()
 	require.Len(t, poolers, 1)
-	assert.Equal(t, "pooler1", poolers[0].Id.Name)
+	assert.Equal(t, "pooler1", poolers[0].Name)
 
 	// Simulate watch channel closure (like etcd compaction)
 	// This closes all watch channels for the "poolers" path
@@ -479,7 +478,7 @@ func TestPoolerDiscovery_ReconnectsAfterWatchClosed(t *testing.T) {
 	// Verify both poolers are present
 	poolers = pd.GetPoolersForAdmin()
 	require.Len(t, poolers, 2)
-	names := []string{poolers[0].Id.Name, poolers[1].Id.Name}
+	names := []string{poolers[0].Name, poolers[1].Name}
 	assert.Contains(t, names, "pooler1")
 	assert.Contains(t, names, "pooler2")
 }
@@ -600,8 +599,8 @@ func TestGlobalPoolerDiscovery_GetCellStatusesForAdmin(t *testing.T) {
 	require.NotNil(t, zone2Status, "Should have zone2 status")
 	assert.Len(t, zone1Status.Poolers, 1)
 	assert.Len(t, zone2Status.Poolers, 1)
-	assert.Equal(t, "pooler1", zone1Status.Poolers[0].Id.Name)
-	assert.Equal(t, "pooler2", zone2Status.Poolers[0].Id.Name)
+	assert.Equal(t, "pooler1", zone1Status.Poolers[0].Name)
+	assert.Equal(t, "pooler2", zone2Status.Poolers[0].Name)
 }
 
 // TestPoolerDiscovery_PoolerDeletion tests that poolers are removed from
@@ -635,7 +634,7 @@ func TestPoolerDiscovery_PoolerDeletion(t *testing.T) {
 	// Verify only pooler2 remains
 	poolers := pd.GetPoolersForAdmin()
 	require.Len(t, poolers, 1)
-	assert.Equal(t, "pooler2", poolers[0].Id.Name)
+	assert.Equal(t, "pooler2", poolers[0].Name)
 }
 
 // TestPoolerDiscovery_TwoPrimariesCoexistDuringFailover is the regression test
@@ -673,7 +672,7 @@ func TestPoolerDiscovery_TwoPrimariesCoexistDuringFailover(t *testing.T) {
 	require.Len(t, poolers, 2)
 	names := make(map[string]bool, len(poolers))
 	for _, p := range poolers {
-		names[p.Id.Name] = true
+		names[p.Name] = true
 	}
 	assert.True(t, names["new-primary"], "new-primary must be present")
 	assert.True(t, names["stale-primary"], "stale-primary must NOT be evicted by discovery")
@@ -711,7 +710,7 @@ func TestPoolerDiscovery_ReplicaDoesNotEvictPrimary(t *testing.T) {
 	require.Len(t, poolers, 2)
 	names := make(map[string]bool)
 	for _, p := range poolers {
-		names[p.Id.Name] = true
+		names[p.Name] = true
 	}
 	assert.True(t, names["primary"], "Primary should still be present")
 	assert.True(t, names["replica"], "Replica should be present")

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -43,11 +43,14 @@ type shardKey struct {
 // It creates connections based on discovery events and destroys them when poolers
 // are removed from discovery.
 //
-// Leader identity is tracked per-shard via the leaders map, populated only from
-// LeaderObservation messages on health streams. The pooler.Type field from etcd
-// topology is a hint about intended role — never the source of truth for which
-// pooler leads a shard. A leaders entry survives connection lifecycle events:
-// removing a pooler does not erase consensus's choice of leader.
+// Leader identity is tracked per-shard via the leaders map, populated from two
+// sources that both carry a rule number: a pooler's self_leadership in its
+// topology record (read on discovery) and LeaderObservation messages on health
+// streams. The most-authoritative observation (highest rule number) wins,
+// regardless of source. The pooler.Type field from etcd topology is never
+// consulted for leader identity — only self_leadership is. A leaders entry
+// survives connection lifecycle events: removing a pooler does not erase
+// consensus's choice of leader.
 type LoadBalancer struct {
 	// localCell is the cell where this gateway is running
 	localCell string
@@ -64,10 +67,12 @@ type LoadBalancer struct {
 	// connections maps pooler ID to PoolerConnection
 	connections map[string]*PoolerConnection
 
-	// leaders maps shard key to the highest-term LeaderObservation seen for that
-	// shard. Populated only from health-stream observations; never from topology.
-	// The leader_id field of the observation may name a pooler we are not
-	// currently connected to — GetConnection handles that case at read time.
+	// leaders maps shard key to the most-authoritative LeaderObservation seen
+	// for that shard (highest rule number wins). Populated from a pooler's
+	// self_leadership topology record and from LeaderObservation messages on
+	// health streams. The leader_id field of the observation may name a pooler
+	// we are not currently connected to — GetConnection handles that case at
+	// read time.
 	leaders map[shardKey]*clustermetadatapb.LeaderObservation
 
 	// onPrimaryServing is called when a new primary is detected via health stream.
@@ -125,19 +130,14 @@ func (lb *LoadBalancer) SetReplicationLagThresholds(lowLag, highTolerance time.D
 // AddPooler creates a new PoolerConnection for the given pooler.
 // If a connection already exists for this pooler, it updates the pooler info.
 //
-// AddPooler does not establish leader identity from real consensus state —
-// that comes exclusively from LeaderObservation on health streams. The one
-// concession is a cold-start fallback: if no LeaderObservation has been
-// received for the shard yet and topology says this pooler is PRIMARY, we
-// seed `leaders[shard]` with a synthetic LeaderObservation at term 0. Any
-// real observation (term >= 1) beats this seed unconditionally, so a stale
-// Type=PRIMARY assertion from a demoted-then-restarted pooler cannot
-// override consensus. The seed only matters during the gateway's startup
-// window before health streams have produced any observations.
-//
-// TODO: once multipooler publishes its current LeaderObservation into its
-// etcd record (the proto would need a `last_observed_leader` field), drop
-// the synthetic seed and use that real observation instead.
+// If the pooler's topology record carries a self_leadership observation (the
+// leader publishes one naming itself under the rule it leads), AddPooler folds
+// it into `leaders[shard]`. This is a real consensus observation, not a Type
+// heuristic: a demoted pooler clears its self_leadership, so only the current
+// leader advertises one. It competes with health-stream observations on rule
+// number, so the most-authoritative view wins regardless of source. This lets
+// the gateway route to the leader as soon as it is discovered in etcd, before
+// any health stream has reported.
 func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	poolerID := poolerIDString(pooler.Id)
 
@@ -146,14 +146,14 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 	key := shardKey{tableGroup: pooler.GetShardKey().GetTableGroup(), shard: pooler.GetShardKey().GetShard()}
 
-	// Existing pooler — refresh topology metadata. The cold-start hint below
-	// can also fire here: at cluster bootstrap, poolers are first discovered
-	// as REPLICA, then their Type transitions to PRIMARY after multiorch
-	// promotes one. That transition is the first topology signal of who
-	// leads, before any health stream reports a LeaderObservation.
+	// Existing pooler — refresh topology metadata. The self_leadership merge
+	// below also fires here: a pooler first discovered as a non-leader is
+	// re-discovered with self_leadership set once multiorch promotes it. That
+	// republished record is often the first signal of who leads, before any
+	// health stream reports an observation.
 	if conn, exists := lb.connections[poolerID]; exists {
 		conn.UpdatePoolerInfo(pooler)
-		lb.maybeSeedColdStartLeaderLocked(key, pooler)
+		lb.mergeTopologyLeaderLocked(key, pooler)
 		lb.notifyIfLeaderServingLocked(key, conn)
 		return nil
 	}
@@ -164,7 +164,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	}
 
 	lb.connections[poolerID] = conn
-	lb.maybeSeedColdStartLeaderLocked(key, pooler)
+	lb.mergeTopologyLeaderLocked(key, pooler)
 
 	// If a prior LeaderObservation already named this pooler the leader, the
 	// first health update may be slow — trigger buffer drain now so traffic
@@ -179,31 +179,27 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 	return nil
 }
 
-// maybeSeedColdStartLeaderLocked sets `leaders[key]` to a term-0 synthetic
-// LeaderObservation when topology says this pooler is PRIMARY and no real
-// observation has been received yet for the shard. Any real observation
-// (term >= 1) overrides this seed via the standard term-reconciliation in
-// onPoolerHealthUpdate, so a stale Type=PRIMARY assertion from a
-// demoted-then-restarted pooler cannot override consensus. Caller must hold
-// lb.mu.
-//
-// TODO: once multipooler publishes its current LeaderObservation into its
-// etcd record (the proto would need a `last_observed_leader` field), drop
-// this synthetic seed and use the real observation instead.
-func (lb *LoadBalancer) maybeSeedColdStartLeaderLocked(key shardKey, pooler *clustermetadatapb.MultiPooler) {
-	if pooler.Type != clustermetadatapb.PoolerType_PRIMARY {
+// mergeTopologyLeaderLocked folds a pooler's self_leadership observation (from
+// its topology record) into `leaders[key]`, keeping whichever observation has
+// the higher rule number. A pooler that is not the leader carries no
+// self_leadership, so this is a no-op for it — it never clears an existing
+// entry, since a higher observation from any source is what supersedes a
+// leader. Caller must hold lb.mu.
+func (lb *LoadBalancer) mergeTopologyLeaderLocked(key shardKey, pooler *clustermetadatapb.MultiPooler) {
+	obs := pooler.GetSelfLeadership()
+	if obs == nil {
 		return
 	}
-	if lb.leaders[key] != nil {
+	merged := commonconsensus.MostAuthoritativeObservation(lb.leaders[key], obs)
+	if merged == lb.leaders[key] {
 		return
 	}
-	lb.leaders[key] = &clustermetadatapb.LeaderObservation{
-		LeaderId: pooler.Id,
-	}
-	lb.logger.Debug("cold-start leader hint from topology",
+	lb.leaders[key] = merged
+	lb.logger.Debug("leader observation from topology self_leadership",
 		"pooler_id", poolerIDString(pooler.Id),
 		"tablegroup", key.tableGroup,
-		"shard", key.shard)
+		"shard", key.shard,
+		"rule", commonconsensus.FormatRuleNumber(obs.GetLeaderRuleNumber()))
 }
 
 // RemovePooler closes and removes the PoolerConnection for the given pooler ID.
@@ -232,11 +228,11 @@ func (lb *LoadBalancer) RemovePooler(poolerID string) {
 // Returns an error immediately if no suitable connection is available.
 //
 // Selection logic:
-//   - For PRIMARY: consults `leaders` (highest-term LeaderObservation) to identify
-//     the leader, then looks up its connection. Two distinct error cases: no
-//     leader observed yet, vs. leader known but not connected.
+//   - For PRIMARY: consults `leaders` (most-authoritative LeaderObservation) to
+//     identify the leader, then looks up its connection. Two distinct error
+//     cases: no leader observed yet, vs. leader known but not connected.
 //   - For REPLICA: any connected pooler in the shard that is not the known
-//     leader. If no leader is known yet (cold start), falls back to topology
+//     leader. If no leader is known yet, falls back to topology
 //     pooler.Type == REPLICA to avoid serving reads from a pooler that may
 //     turn out to be the leader.
 func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, error) {
@@ -267,13 +263,9 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 	}
 
 	// REPLICA: collect every connection eligible to serve reads in the shard.
-	// A consensus-confirmed leader (rule > zero) is excluded by ID; the
-	// cold-start topology seed (zero rule) is treated as if no leader is known
-	// yet, so a pooler that has since transitioned to Type=REPLICA can still
-	// be selected. CompareRuleNumbers treats a nil/zero rule as the smallest
-	// value, so this also covers the no-leader-observed case.
+	// The leader is excluded by ID.
 	confirmedLeaderID := ""
-	if commonconsensus.CompareRuleNumbers(leaderObs.GetLeaderRuleNumber(), nil) > 0 {
+	if leaderObs != nil {
 		confirmedLeaderID = poolerIDString(leaderObs.LeaderId)
 	}
 	var candidates []*PoolerConnection

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -231,10 +231,10 @@ func (lb *LoadBalancer) RemovePooler(poolerID string) {
 //   - For PRIMARY: consults `leaders` (most-authoritative LeaderObservation) to
 //     identify the leader, then looks up its connection. Two distinct error
 //     cases: no leader observed yet, vs. leader known but not connected.
-//   - For REPLICA: any connected pooler in the shard that is not the known
-//     leader. If no leader is known yet, falls back to topology
-//     pooler.Type == REPLICA to avoid serving reads from a pooler that may
-//     turn out to be the leader.
+//   - For REPLICA: any connected pooler in the shard that does not believe
+//     itself the leader, judged per-connection from self_leadership and
+//     health-stream observations (see matchesReplicaTarget). This excludes both
+//     the current leader and a stale leader, never consulting pooler.Type.
 func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, error) {
 	if target == nil {
 		return nil, errors.New("target cannot be nil")

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -65,7 +65,7 @@ type LoadBalancer struct {
 	mu sync.Mutex
 
 	// connections maps pooler ID to PoolerConnection
-	connections map[string]*PoolerConnection
+	connections map[MultiPoolerID]*PoolerConnection
 
 	// leaders maps shard key to the most-authoritative LeaderObservation seen
 	// for that shard (highest rule number wins). Populated from a pooler's
@@ -101,7 +101,7 @@ func NewLoadBalancer(ctx context.Context, localCell string, logger *slog.Logger,
 		localCell:   localCell,
 		logger:      logger,
 		ctx:         ctx,
-		connections: make(map[string]*PoolerConnection),
+		connections: make(map[MultiPoolerID]*PoolerConnection),
 		leaders:     make(map[shardKey]*clustermetadatapb.LeaderObservation),
 		grpcDialOpt: grpcDialOpt,
 	}
@@ -204,7 +204,7 @@ func (lb *LoadBalancer) mergeTopologyLeaderLocked(key shardKey, pooler *clusterm
 
 // RemovePooler closes and removes the PoolerConnection for the given pooler ID.
 // If no connection exists for this pooler, it is a no-op.
-func (lb *LoadBalancer) RemovePooler(poolerID string) {
+func (lb *LoadBalancer) RemovePooler(poolerID MultiPoolerID) {
 	lb.mu.Lock()
 	conn, exists := lb.connections[poolerID]
 	if !exists {
@@ -297,7 +297,7 @@ func (lb *LoadBalancer) GetConnectionByID(poolerID *clustermetadatapb.ID) (*Pool
 		return nil, errors.New("pooler ID cannot be nil")
 	}
 
-	idStr := topoclient.MultiPoolerIDString(poolerID)
+	idStr := poolerIDString(poolerID)
 
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
@@ -550,10 +550,10 @@ func matchesReplicaTarget(conn *PoolerConnection, target *query.Target) bool {
 	return !conn.believesSelfLeader()
 }
 
-// poolerIDString returns the string ID for a pooler.
+// poolerIDString returns the serialized map-key ID for a pooler.
 // Uses the same format as PoolerConnection.ID() for consistency.
-func poolerIDString(id *clustermetadatapb.ID) string {
-	return topoclient.MultiPoolerIDString(id)
+func poolerIDString(id *clustermetadatapb.ID) MultiPoolerID {
+	return MultiPoolerID(topoclient.MultiPoolerIDString(id))
 }
 
 // ConnectionCount returns the number of active connections.
@@ -582,11 +582,11 @@ const (
 // with health-stream observations) and the pooler's own belief — never the
 // topology Type label. Poolers the gateway is not connected to are absent from
 // the map; the caller fills those in from discovery (e.g. as a lifecycle state).
-func (lb *LoadBalancer) LeadershipByID() map[string]string {
+func (lb *LoadBalancer) LeadershipByID() map[MultiPoolerID]string {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	roles := make(map[string]string, len(lb.connections))
+	roles := make(map[MultiPoolerID]string, len(lb.connections))
 	for _, conn := range lb.connections {
 		info := conn.PoolerInfo()
 		key := shardKey{
@@ -614,7 +614,7 @@ func (lb *LoadBalancer) LeadershipByID() map[string]string {
 func (lb *LoadBalancer) Close() error {
 	lb.mu.Lock()
 	connections := lb.connections
-	lb.connections = make(map[string]*PoolerConnection)
+	lb.connections = make(map[MultiPoolerID]*PoolerConnection)
 	lb.leaders = make(map[shardKey]*clustermetadatapb.LeaderObservation)
 	lb.mu.Unlock()
 

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -173,7 +173,7 @@ func (lb *LoadBalancer) AddPooler(pooler *clustermetadatapb.MultiPooler) error {
 
 	lb.logger.Debug("added pooler connection",
 		"pooler_id", poolerID,
-		"type", pooler.Type.String(),
+		"is_leader", pooler.GetSelfLeadership() != nil,
 		"cell", pooler.Id.GetCell())
 
 	return nil
@@ -263,14 +263,11 @@ func (lb *LoadBalancer) GetConnection(target *query.Target) (*PoolerConnection, 
 	}
 
 	// REPLICA: collect every connection eligible to serve reads in the shard.
-	// The leader is excluded by ID.
-	confirmedLeaderID := ""
-	if leaderObs != nil {
-		confirmedLeaderID = poolerIDString(leaderObs.LeaderId)
-	}
+	// A pooler that believes itself the leader — the current leader or a stale
+	// leader — is excluded; see matchesReplicaTarget.
 	var candidates []*PoolerConnection
-	for id, conn := range lb.connections {
-		if matchesReplicaTarget(id, conn, target, confirmedLeaderID) {
+	for _, conn := range lb.connections {
+		if matchesReplicaTarget(conn, target) {
 			candidates = append(candidates, conn)
 		}
 	}
@@ -531,18 +528,26 @@ func matchesShardTarget(conn *PoolerConnection, target *query.Target) bool {
 }
 
 // matchesReplicaTarget reports whether conn is eligible to serve REPLICA
-// traffic for target. With a consensus-confirmed leader, eligibility is
-// "in the shard and not the leader." With no confirmed leader yet (cold
-// start), fall back to topology Type==REPLICA so we don't accidentally
-// serve reads from a pooler that may turn out to be the leader.
-func matchesReplicaTarget(id string, conn *PoolerConnection, target *query.Target, confirmedLeaderID string) bool {
+// traffic for target: it is in the shard and does not believe itself the shard
+// leader. Leadership is judged per-connection from the better of the pooler's
+// etcd self_leadership and its health-stream observation (see
+// believesSelfLeader), never from the topology Type label.
+//
+// Excluding self-believed leaders covers both the current leader and a stale
+// leader — a pooler whose own view still names it the leader even though a
+// newer leader has been observed. Either would serve reads as a primary or from
+// a diverged timeline, so neither is a replica candidate.
+//
+// TODO(replica-quality): eligibility is otherwise binary. Longer term, treat a
+// replica as degraded when it is not actively replicating or has fallen behind,
+// and prefer non-degraded replicas when several are available. That belongs in
+// selectReplicaConnection (which already tiers by lag), with the per-pooler
+// signal carried on the health observation.
+func matchesReplicaTarget(conn *PoolerConnection, target *query.Target) bool {
 	if !matchesShardTarget(conn, target) {
 		return false
 	}
-	if confirmedLeaderID != "" {
-		return id != confirmedLeaderID
-	}
-	return conn.Type() == clustermetadatapb.PoolerType_REPLICA
+	return !conn.believesSelfLeader()
 }
 
 // poolerIDString returns the string ID for a pooler.

--- a/go/services/multigateway/poolergateway/load_balancer.go
+++ b/go/services/multigateway/poolergateway/load_balancer.go
@@ -563,6 +563,53 @@ func (lb *LoadBalancer) ConnectionCount() int {
 	return len(lb.connections)
 }
 
+// Consensus leadership roles reported by LeadershipByID for the status page.
+const (
+	// LeadershipLeader marks the shard's current consensus leader.
+	LeadershipLeader = "leader"
+	// LeadershipStaleLeader marks a pooler that still believes itself the leader
+	// (per its own self_leadership and health observation) even though consensus
+	// has moved on to a higher-rule leader. Such a pooler is excluded from
+	// replica reads; see matchesReplicaTarget.
+	LeadershipStaleLeader = "stale-leader"
+	// LeadershipFollower marks any other connected pooler.
+	LeadershipFollower = "follower"
+)
+
+// LeadershipByID returns the consensus leadership role of each connected pooler,
+// keyed by serialized pooler ID, for the admin/status page. The role reflects
+// the gateway's merged view — the per-shard leader map (self_leadership combined
+// with health-stream observations) and the pooler's own belief — never the
+// topology Type label. Poolers the gateway is not connected to are absent from
+// the map; the caller fills those in from discovery (e.g. as a lifecycle state).
+func (lb *LoadBalancer) LeadershipByID() map[string]string {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
+	roles := make(map[string]string, len(lb.connections))
+	for _, conn := range lb.connections {
+		info := conn.PoolerInfo()
+		key := shardKey{
+			tableGroup: info.GetShardKey().GetTableGroup(),
+			shard:      info.GetShardKey().GetShard(),
+		}
+
+		// The shard's consensus leader (merged across every pooler's
+		// self_leadership and health-stream reports) takes precedence, so a
+		// leader whose own record lags is still reported as the leader.
+		// Otherwise a pooler that still believes itself leader is stale.
+		role := LeadershipFollower
+		switch obs := lb.leaders[key]; {
+		case obs != nil && poolerIDString(obs.LeaderId) == conn.ID():
+			role = LeadershipLeader
+		case conn.believesSelfLeader():
+			role = LeadershipStaleLeader
+		}
+		roles[conn.ID()] = role
+	}
+	return roles
+}
+
 // Close closes all connections.
 func (lb *LoadBalancer) Close() error {
 	lb.mu.Lock()

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -55,6 +55,18 @@ func createTestMultiPooler(name, cell, tableGroup, shard string, poolerType clus
 	}
 }
 
+// withSelfLeadership sets the pooler's self_leadership observation naming itself
+// as leader at the given coordinator term. This mirrors a real leader's topology
+// record (Type=PRIMARY ⇒ self_leadership set), which is how the gateway learns a
+// shard's leader from etcd at discovery time.
+func withSelfLeadership(p *clustermetadatapb.MultiPooler, coordinatorTerm int64) *clustermetadatapb.MultiPooler {
+	p.SelfLeadership = &clustermetadatapb.LeaderObservation{
+		LeaderId:         p.Id,
+		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: coordinatorTerm},
+	}
+	return p
+}
+
 func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -350,17 +362,18 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		assert.Equal(t, poolerID(primary1), conn.ID(), "Should trust replica's observation with highest term")
 	})
 
-	t.Run("no observations uses discovery seed", func(t *testing.T) {
+	t.Run("no observations uses topology self_leadership", func(t *testing.T) {
 		logger := slog.Default()
 		lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-		primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+		primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
 		replica := createTestMultiPooler("replica1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 
 		require.NoError(t, lb.AddPooler(primary))
 		require.NoError(t, lb.AddPooler(replica))
 
-		// No health updates — but discovery seed (term 0) provides a primary
+		// No health updates — but the primary's self_leadership record names it
+		// the leader, so the gateway can route before any health stream connects.
 		target := &query.Target{
 			TableGroup: constants.DefaultTableGroup,
 			Shard:      "0",
@@ -369,7 +382,7 @@ func TestLoadBalancer_PrimaryCaching(t *testing.T) {
 		conn, err := lb.GetConnection(target)
 		require.NoError(t, err)
 		assert.Equal(t, poolerID(primary), conn.ID(),
-			"Should return discovery-seeded primary before health stream connects")
+			"Should return the self_leadership-named primary before health stream connects")
 	})
 
 	t.Run("leader identity preserved on pooler removal", func(t *testing.T) {
@@ -415,8 +428,8 @@ func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	// AddPooler with PRIMARY type seeds the cache — no health update needed
-	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	// AddPooler with a self_leadership record seeds the cache — no health update needed
+	primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
 	require.NoError(t, lb.AddPooler(primary))
 
 	target := &query.Target{
@@ -426,25 +439,26 @@ func TestLoadBalancer_PrimaryCachedFromDiscovery(t *testing.T) {
 	}
 	conn, err := lb.GetConnection(target)
 	require.NoError(t, err)
-	assert.Equal(t, poolerID(primary), conn.ID(), "Should find primary seeded from discovery")
+	assert.Equal(t, poolerID(primary), conn.ID(), "Should find primary seeded from self_leadership")
 }
 
-func TestLoadBalancer_HealthStreamOverridesSeed(t *testing.T) {
+func TestLoadBalancer_KnownLeaderSurvivesTopologyDemotion(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	// Add as PRIMARY — seeds cache with term 0
-	pooler := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	pooler := withSelfLeadership(createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 5)
 	require.NoError(t, lb.AddPooler(pooler))
 
-	// Health stream confirms primary with real term
+	// Health stream confirms the same leader at the same rule.
 	lb.mu.Lock()
 	conn := lb.connections[poolerID(pooler)]
 	lb.mu.Unlock()
 	simulateHealthUpdate(conn, clustermetadatapb.PoolerServingStatus_SERVING,
 		&clustermetadatapb.LeaderObservation{LeaderId: pooler.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 5}})
 
-	// Topo update: type changed to REPLICA — but health-confirmed entry (term > 0) is NOT invalidated
+	// The pooler is re-discovered demoted: Type=REPLICA and self_leadership
+	// cleared. mergeTopologyLeaderLocked must NOT erase the known leader — only
+	// a higher observation from a new leader supersedes it.
 	poolerAsReplica := createTestMultiPooler("pooler1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
 	require.NoError(t, lb.AddPooler(poolerAsReplica))
 
@@ -456,7 +470,7 @@ func TestLoadBalancer_HealthStreamOverridesSeed(t *testing.T) {
 	conn2, err := lb.GetConnection(target)
 	require.NoError(t, err)
 	assert.Equal(t, poolerID(pooler), conn2.ID(),
-		"Health-confirmed primary (term > 0) should survive topo type change")
+		"Known leader must persist until a higher observation supersedes it")
 }
 
 func TestLoadBalancer_UnknownTypePrimarySelection(t *testing.T) {
@@ -676,6 +690,37 @@ func TestLoadBalancer_StalePrimaryTypeDoesNotEvict(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, poolerID(newLeader), conn.ID(),
 		"Stale topology must not redirect PRIMARY traffic away from the consensus-elected leader")
+}
+
+// TestLoadBalancer_TopologySelfLeadershipMergesByRule verifies that
+// self_leadership observations read from topology are reconciled by rule
+// number: a higher rule supersedes the known leader, while a stale lower rule
+// is ignored.
+func TestLoadBalancer_TopologySelfLeadershipMergesByRule(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	oldLeader := withSelfLeadership(createTestMultiPooler("old-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
+	newLeader := withSelfLeadership(createTestMultiPooler("new-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 2)
+	require.NoError(t, lb.AddPooler(oldLeader))
+	require.NoError(t, lb.AddPooler(newLeader))
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_PRIMARY,
+	}
+
+	// new-leader's self_leadership (rule 2) supersedes old-leader's (rule 1).
+	conn, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(newLeader), conn.ID(), "higher-rule self_leadership should win")
+
+	// Re-discovering old-leader's stale rule-1 record must not move the leader back.
+	require.NoError(t, lb.AddPooler(withSelfLeadership(createTestMultiPooler("old-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)))
+	conn, err = lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(newLeader), conn.ID(), "stale lower-rule self_leadership must be ignored")
 }
 
 // TestLoadBalancer_ReplicaCandidatesExcludeLeader verifies that REPLICA

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -820,3 +820,49 @@ func TestLoadBalancer_StaleLeaderExcludedFromReplicas(t *testing.T) {
 			"reads must avoid both the leader and the stale leader")
 	}
 }
+
+// TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica
+// documents the inverse of the stale-leader case: a pooler the central leaders
+// map knows to be the leader — populated by a peer's health-stream observation
+// — is still eligible for replica reads when its own view does not yet name it
+// the leader (etcd self_leadership absent and its own health stream not yet
+// reported). matchesReplicaTarget consults only the per-connection
+// believesSelfLeader, never the central map, so the leader is not excluded here.
+//
+// This is benign: a read served by the actual current leader sees the most
+// up-to-date data, so it cannot violate read consistency. The window is also
+// narrow — it closes the moment the leader's own health stream reports or its
+// etcd record gains self_leadership. The dangerous direction (serving from a
+// stale leader on an older rule) is covered by the test above.
+func TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// leader's etcd record lags: discovered without self_leadership, and its own
+	// health stream has not reported, so believesSelfLeader(leader) is false.
+	leader := createTestMultiPooler("leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	require.NoError(t, lb.AddPooler(leader))
+
+	// A peer's health stream has already named `leader` the shard leader at rule
+	// 2, recorded in the central map. Set it directly rather than wiring a second
+	// connection, mirroring how onPoolerHealthUpdate would populate it.
+	key := shardKey{tableGroup: constants.DefaultTableGroup, shard: "0"}
+	lb.mu.Lock()
+	lb.leaders[key] = &clustermetadatapb.LeaderObservation{
+		LeaderId:         leader.Id,
+		LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2},
+	}
+	lb.mu.Unlock()
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_REPLICA,
+	}
+	// `leader` is the only connection and is eligible despite the central map
+	// naming it the leader, so it is returned rather than erroring as no-candidate.
+	conn, err := lb.GetConnection(target)
+	require.NoError(t, err)
+	assert.Equal(t, poolerID(leader), conn.ID(),
+		"a centrally-known leader unaware of its own leadership is eligible for replica reads")
+}

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -866,3 +866,35 @@ func TestLoadBalancer_CentrallyKnownLeaderUnknownToItselfEligibleAsReplica(t *te
 	assert.Equal(t, poolerID(leader), conn.ID(),
 		"a centrally-known leader unaware of its own leadership is eligible for replica reads")
 }
+
+// TestLoadBalancer_LeadershipByID verifies the three roles reported for the
+// admin/status page: the shard's consensus leader, a stale leader that still
+// believes itself the leader at an older rule, and a plain follower.
+func TestLoadBalancer_LeadershipByID(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	leader := withSelfLeadership(createTestMultiPooler("leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 2)
+	stale := createTestMultiPooler("stale", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	follower := createTestMultiPooler("follower", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	require.NoError(t, lb.AddPooler(leader))
+	require.NoError(t, lb.AddPooler(stale))
+	require.NoError(t, lb.AddPooler(follower))
+
+	lb.mu.Lock()
+	connStale := lb.connections[poolerID(stale)]
+	connFollower := lb.connections[poolerID(follower)]
+	lb.mu.Unlock()
+
+	// stale still believes it leads at the old rule 1; follower already tracks
+	// the new leader at rule 2.
+	simulateHealthUpdate(connStale, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: stale.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+	simulateHealthUpdate(connFollower, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: leader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+
+	roles := lb.LeadershipByID()
+	assert.Equal(t, LeadershipLeader, roles[poolerID(leader)])
+	assert.Equal(t, LeadershipStaleLeader, roles[poolerID(stale)])
+	assert.Equal(t, LeadershipFollower, roles[poolerID(follower)])
+}

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -99,7 +99,7 @@ func TestLoadBalancer_AddRemovePooler(t *testing.T) {
 	}
 	conn, err := lb.GetConnection(target)
 	require.NoError(t, err)
-	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, conn.Type(), "pooler type should be updated")
+	assert.Equal(t, clustermetadatapb.PoolerType_REPLICA, conn.PoolerInfo().Type, "pooler type should be updated")
 
 	// Remove the pooler
 	lb.RemovePooler(poolerID(pooler))
@@ -193,8 +193,8 @@ func TestLoadBalancer_GetConnection_NoMatch(t *testing.T) {
 	logger := slog.Default()
 	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	// Add a primary
-	primary := createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY)
+	// Add a primary (a real PRIMARY record carries self_leadership).
+	primary := withSelfLeadership(createTestMultiPooler("primary1", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 1)
 	require.NoError(t, lb.AddPooler(primary))
 
 	// Request a replica - should not find one
@@ -777,4 +777,46 @@ func TestLoadBalancerListener(t *testing.T) {
 	// OnPoolerRemoved should remove pooler
 	listener.OnPoolerRemoved(pooler)
 	assert.Equal(t, 0, lb.ConnectionCount())
+}
+
+// TestLoadBalancer_StaleLeaderExcludedFromReplicas verifies that a stale leader
+// — a pooler whose own health observation still names it the leader at a rule
+// older than the confirmed leader's — is not selected for replica reads, while
+// a replica that already tracks the new leader is.
+func TestLoadBalancer_StaleLeaderExcludedFromReplicas(t *testing.T) {
+	logger := slog.Default()
+	lb := NewLoadBalancer(context.Background(), "zone1", logger, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	newLeader := withSelfLeadership(createTestMultiPooler("new-leader", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_PRIMARY), 2)
+	stale := createTestMultiPooler("stale", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	replica := createTestMultiPooler("replica", "zone1", constants.DefaultTableGroup, "0", clustermetadatapb.PoolerType_REPLICA)
+	require.NoError(t, lb.AddPooler(newLeader))
+	require.NoError(t, lb.AddPooler(stale))
+	require.NoError(t, lb.AddPooler(replica))
+
+	lb.mu.Lock()
+	connStale := lb.connections[poolerID(stale)]
+	connReplica := lb.connections[poolerID(replica)]
+	lb.mu.Unlock()
+
+	// stale still believes it is the leader at the old rule 1; replica already
+	// tracks the new leader at rule 2.
+	simulateHealthUpdate(connStale, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: stale.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 1}})
+	simulateHealthUpdate(connReplica, clustermetadatapb.PoolerServingStatus_SERVING,
+		&clustermetadatapb.LeaderObservation{LeaderId: newLeader.Id, LeaderRuleNumber: &clustermetadatapb.RuleNumber{CoordinatorTerm: 2}})
+
+	target := &query.Target{
+		TableGroup: constants.DefaultTableGroup,
+		Shard:      "0",
+		PoolerType: clustermetadatapb.PoolerType_REPLICA,
+	}
+	// Only `replica` is eligible: new-leader is the leader (self_leadership) and
+	// stale believes itself the leader, so both are excluded.
+	for range 10 {
+		conn, err := lb.GetConnection(target)
+		require.NoError(t, err)
+		assert.Equal(t, poolerID(replica), conn.ID(),
+			"reads must avoid both the leader and the stale leader")
+	}
 }

--- a/go/services/multigateway/poolergateway/load_balancer_test.go
+++ b/go/services/multigateway/poolergateway/load_balancer_test.go
@@ -32,7 +32,7 @@ import (
 
 // poolerID returns the expected ID format for a pooler.
 // Uses the same format as LoadBalancer internally.
-func poolerID(pooler *clustermetadatapb.MultiPooler) string {
+func poolerID(pooler *clustermetadatapb.MultiPooler) MultiPoolerID {
 	return poolerIDString(pooler.Id)
 }
 

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -222,9 +222,19 @@ func NewPoolerConnection(
 	return pc, nil
 }
 
+// MultiPoolerID is a serialized pooler ID, used as the key for the gateway's
+// per-pooler maps. Giving it a name keeps a pooler ID from being silently
+// interchanged with a cell name, shard, or some other identifier at compile
+// time.
+//
+// TODO(typed-pooler-id): this is localized to the gateway for now. Promote it to
+// topoclient and have MultiPoolerIDString return it so every service shares the
+// type, instead of passing serialized IDs around as bare strings.
+type MultiPoolerID string
+
 // ID returns the unique identifier for this pooler connection.
-func (pc *PoolerConnection) ID() string {
-	return topoclient.MultiPoolerIDString(pc.poolerInfo.Load().Id)
+func (pc *PoolerConnection) ID() MultiPoolerID {
+	return MultiPoolerID(topoclient.MultiPoolerIDString(pc.poolerInfo.Load().Id))
 }
 
 // Cell returns the cell where this pooler is located.
@@ -243,7 +253,7 @@ func (pc *PoolerConnection) believesSelfLeader() bool {
 		healthObs = h.LeaderObservation
 	}
 	obs := commonconsensus.MostAuthoritativeObservation(pc.poolerInfo.Load().GetSelfLeadership(), healthObs)
-	return obs != nil && topoclient.MultiPoolerIDString(obs.GetLeaderId()) == pc.ID()
+	return obs != nil && poolerIDString(obs.GetLeaderId()) == pc.ID()
 }
 
 // UpdatePoolerInfo refreshes the pooler metadata (hostname, ports, shard) from

--- a/go/services/multigateway/poolergateway/pooler_connection.go
+++ b/go/services/multigateway/poolergateway/pooler_connection.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	commonconsensus "github.com/multigres/multigres/go/common/consensus"
 	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/queryservice"
 	"github.com/multigres/multigres/go/common/rpcclient"
@@ -167,7 +168,7 @@ func NewPoolerConnection(
 	logger.DebugContext(ctx, "creating pooler connection",
 		"pooler_id", poolerID,
 		"addr", addr,
-		"type", pooler.Type.String())
+		"is_leader", pooler.GetSelfLeadership() != nil)
 
 	// Create gRPC connection with telemetry attributes
 	conn, err := grpccommon.NewClient(addr,
@@ -186,10 +187,12 @@ func NewPoolerConnection(
 	queryService := newGRPCQueryService(conn, poolerID, logger)
 
 	// Initialize health state to NOT_SERVING until health stream provides data.
+	// PoolerType is left UNKNOWN until the health stream reports it — the gateway
+	// derives role from consensus observations, not the topology Type label.
 	initialTarget := &query.Target{
 		TableGroup: pooler.GetShardKey().GetTableGroup(),
 		Shard:      pooler.GetShardKey().GetShard(),
-		PoolerType: pooler.Type,
+		PoolerType: clustermetadatapb.PoolerType_UNKNOWN,
 	}
 
 	pc := &PoolerConnection{
@@ -229,22 +232,26 @@ func (pc *PoolerConnection) Cell() string {
 	return pc.poolerInfo.Load().Id.GetCell()
 }
 
-// Type returns the pooler type (PRIMARY or REPLICA).
-func (pc *PoolerConnection) Type() clustermetadatapb.PoolerType {
-	return pc.poolerInfo.Load().Type
+// believesSelfLeader reports whether this pooler considers itself the shard
+// leader, judged from the better of its topology self_leadership (read at
+// discovery) and its latest health-stream observation. A pooler in this state
+// is either the current leader or a stale leader that has not yet learned of a
+// newer one; either way it must not be selected for replica reads.
+func (pc *PoolerConnection) believesSelfLeader() bool {
+	var healthObs *clustermetadatapb.LeaderObservation
+	if h := pc.Health(); h != nil {
+		healthObs = h.LeaderObservation
+	}
+	obs := commonconsensus.MostAuthoritativeObservation(pc.poolerInfo.Load().GetSelfLeadership(), healthObs)
+	return obs != nil && topoclient.MultiPoolerIDString(obs.GetLeaderId()) == pc.ID()
 }
 
-// UpdatePoolerInfo updates the pooler metadata (e.g., when type changes from UNKNOWN to PRIMARY).
-// This is called when topology watch detects updates to the pooler.
+// UpdatePoolerInfo refreshes the pooler metadata (hostname, ports, shard) from
+// a topology update. Leader identity is tracked separately via consensus
+// observations (the load balancer's merged leader map), so a topology Type
+// change here is not acted upon.
 func (pc *PoolerConnection) UpdatePoolerInfo(pooler *clustermetadatapb.MultiPooler) {
-	oldType := pc.poolerInfo.Load().Type
 	pc.poolerInfo.Store(&topoclient.MultiPoolerInfo{MultiPooler: pooler})
-	if oldType != pooler.Type {
-		pc.logger.Info("pooler type updated",
-			"pooler_id", pc.ID(),
-			"old_type", oldType.String(),
-			"new_type", pooler.Type.String())
-	}
 }
 
 // PoolerInfo returns the underlying pooler metadata.

--- a/go/services/multigateway/poolergateway/pooler_connection_test.go
+++ b/go/services/multigateway/poolergateway/pooler_connection_test.go
@@ -139,7 +139,7 @@ func TestNewPoolerConnection(t *testing.T) {
 	// Verify basic properties
 	assert.Equal(t, "multipooler-zone1-pooler1", conn.ID())
 	assert.Equal(t, "zone1", conn.Cell())
-	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, conn.Type())
+	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, conn.PoolerInfo().Type)
 }
 
 // TestPoolerConnection_ID verifies ID generation for different pooler configurations.

--- a/go/services/multigateway/poolergateway/pooler_connection_test.go
+++ b/go/services/multigateway/poolergateway/pooler_connection_test.go
@@ -137,7 +137,7 @@ func TestNewPoolerConnection(t *testing.T) {
 	defer conn.Close()
 
 	// Verify basic properties
-	assert.Equal(t, "multipooler-zone1-pooler1", conn.ID())
+	assert.Equal(t, "multipooler-zone1-pooler1", string(conn.ID()))
 	assert.Equal(t, "zone1", conn.Cell())
 	assert.Equal(t, clustermetadatapb.PoolerType_PRIMARY, conn.PoolerInfo().Type)
 }
@@ -164,7 +164,7 @@ func TestPoolerConnection_ID(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			assert.Equal(t, tt.expected, conn.ID())
+			assert.Equal(t, tt.expected, string(conn.ID()))
 		})
 	}
 }

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -413,6 +413,13 @@ func (pg *PoolerGateway) Stats() map[string]any {
 	}
 }
 
+// LeadershipByID returns the consensus leadership role of each connected pooler,
+// keyed by serialized pooler ID, for the admin/status page.
+// See LoadBalancer.LeadershipByID.
+func (pg *PoolerGateway) LeadershipByID() map[string]string {
+	return pg.loadBalancer.LeadershipByID()
+}
+
 // CopySendData implements queryservice.QueryService.
 // It sends a chunk of data for an active COPY operation.
 func (pg *PoolerGateway) CopySendData(

--- a/go/services/multigateway/poolergateway/pooler_gateway.go
+++ b/go/services/multigateway/poolergateway/pooler_gateway.go
@@ -416,7 +416,7 @@ func (pg *PoolerGateway) Stats() map[string]any {
 // LeadershipByID returns the consensus leadership role of each connected pooler,
 // keyed by serialized pooler ID, for the admin/status page.
 // See LoadBalancer.LeadershipByID.
-func (pg *PoolerGateway) LeadershipByID() map[string]string {
+func (pg *PoolerGateway) LeadershipByID() map[MultiPoolerID]string {
 	return pg.loadBalancer.LeadershipByID()
 }
 

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -74,11 +74,7 @@ type Status struct {
 // handleIndex serves the index page
 func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 	ts := mg.ts.Status()
-	cellStatuses := mg.poolerDiscovery.GetCellStatusesForAdmin()
-	// Leadership is the load balancer's live consensus view; discovery supplies
-	// the full pooler list (including poolers we are not connected to). Join the
-	// two on serialized pooler ID.
-	leadership := mg.poolerGateway.LeadershipByID()
+	cells := mg.collectCellStatuses()
 
 	mg.serverStatus.mu.Lock()
 	defer mg.serverStatus.mu.Unlock()
@@ -86,7 +82,24 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 	mg.serverStatus.LocalCell = mg.cell.Get()
 	mg.serverStatus.ServiceID = mg.serviceID.Get()
 	mg.serverStatus.TopoStatus = ts
-	mg.serverStatus.Cells = make([]CellStatus, 0, len(cellStatuses))
+	mg.serverStatus.Cells = cells
+
+	err := web.Templates.ExecuteTemplate(w, "gateway_index.html", &mg.serverStatus)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
+		return
+	}
+}
+
+// collectCellStatuses joins the two sources behind the status page: discovery
+// supplies the full per-cell pooler list (including poolers the gateway is not
+// connected to), and the load balancer supplies each connected pooler's live
+// consensus leadership. They are merged on serialized pooler ID.
+func (mg *MultiGateway) collectCellStatuses() []CellStatus {
+	cellStatuses := mg.poolerDiscovery.GetCellStatusesForAdmin()
+	leadership := mg.poolerGateway.LeadershipByID()
+
+	cells := make([]CellStatus, 0, len(cellStatuses))
 	for _, cs := range cellStatuses {
 		cellStatus := CellStatus{
 			Cell:        cs.Cell,
@@ -101,12 +114,7 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 				Lifecycle:  pooler.Lifecycle,
 			})
 		}
-		mg.serverStatus.Cells = append(mg.serverStatus.Cells, cellStatus)
+		cells = append(cells, cellStatus)
 	}
-
-	err := web.Templates.ExecuteTemplate(w, "gateway_index.html", &mg.serverStatus)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to execute template: %v", err), http.StatusInternalServerError)
-		return
-	}
+	return cells
 }

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -30,7 +30,14 @@ import (
 type PoolerStatus struct {
 	Name     string `json:"name"`
 	Database string `json:"database"`
-	Type     string `json:"type"`
+	// Leadership is the gateway's merged consensus view of the pooler's role
+	// (leader/stale-leader/follower), empty when the gateway is not connected to
+	// it. Distinct from Lifecycle: a pooler's consensus role and its process
+	// lifecycle state are orthogonal.
+	Leadership string `json:"leadership"`
+	// Lifecycle is the pooler's process lifecycle state (e.g. active, shutdown),
+	// from its topology record.
+	Lifecycle string `json:"lifecycle"`
 }
 
 // CellStatus represents the status of pooler discovery for a single cell.
@@ -67,6 +74,10 @@ type Status struct {
 func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 	ts := mg.ts.Status()
 	cellStatuses := mg.poolerDiscovery.GetCellStatusesForAdmin()
+	// Leadership is the load balancer's live consensus view; discovery supplies
+	// the full pooler list (including poolers we are not connected to). Join the
+	// two on serialized pooler ID.
+	leadership := mg.poolerGateway.LeadershipByID()
 
 	mg.serverStatus.mu.Lock()
 	defer mg.serverStatus.mu.Unlock()
@@ -83,9 +94,10 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, pooler := range cs.Poolers {
 			cellStatus.Poolers = append(cellStatus.Poolers, PoolerStatus{
-				Name:     pooler.Id.GetName(),
-				Database: pooler.GetShardKey().GetDatabase(),
-				Type:     pooler.GetType().String(),
+				Name:       pooler.Name,
+				Database:   pooler.Database,
+				Leadership: leadership[pooler.ID],
+				Lifecycle:  pooler.Lifecycle,
 			})
 		}
 		mg.serverStatus.Cells = append(mg.serverStatus.Cells, cellStatus)

--- a/go/services/multigateway/status.go
+++ b/go/services/multigateway/status.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/multigres/multigres/go/common/web"
+	"github.com/multigres/multigres/go/services/multigateway/poolergateway"
 )
 
 // PoolerStatus represents the status of a multipooler instance.
@@ -96,7 +97,7 @@ func (mg *MultiGateway) handleIndex(w http.ResponseWriter, r *http.Request) {
 			cellStatus.Poolers = append(cellStatus.Poolers, PoolerStatus{
 				Name:       pooler.Name,
 				Database:   pooler.Database,
-				Leadership: leadership[pooler.ID],
+				Leadership: leadership[poolergateway.MultiPoolerID(pooler.ID)],
 				Lifecycle:  pooler.Lifecycle,
 			})
 		}

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -212,7 +212,7 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 // constructing a record with a Type (struct literal) is also unaffected — only
 // reading .Type off a discovered MultiPooler / MultiPoolerInfo is disallowed.
 //
-// Use MultiPoolerInfo.IsLeader (self_leadership set) instead.
+// Use GetSelfLeadership() != nil instead.
 func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
 	m.Import("github.com/multigres/multigres/go/common/topoclient")
@@ -223,5 +223,5 @@ func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 				m["x"].Type.Is("*topoclient.MultiPoolerInfo")) &&
 				m.File().PkgPath.Matches(`services/multigateway`) &&
 				!m.File().Name.Matches(`_test\.go$`)).
-		Report("do not consult MultiPooler.Type for leader identity; use self_leadership (MultiPoolerInfo.IsLeader)")
+		Report("do not consult MultiPooler.Type for leader identity; use self_leadership (GetSelfLeadership() != nil)")
 }

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -206,18 +206,19 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 }
 
 // disallowMultiPoolerTypeForRouting flags reads of a MultiPooler record's Type
-// field in the multigateway, which must derive leader identity from consensus
-// state (self_leadership), never from the topology role label. The PoolerType
-// routing label on a query.Target is a different field and is unaffected;
-// constructing a record with a Type (struct literal) is also unaffected — only
-// reading .Type off a discovered MultiPooler / MultiPoolerInfo is disallowed.
+// in the multigateway — both the .Type field and the generated GetType()
+// getter — which must derive leader identity from consensus state
+// (self_leadership), never from the topology role label. The PoolerType routing
+// label on a query.Target is a different field and is unaffected; constructing a
+// record with a Type (struct literal) is also unaffected — only reading the Type
+// off a discovered MultiPooler / MultiPoolerInfo is disallowed.
 //
 // Use GetSelfLeadership() != nil instead.
 func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
 	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
 	m.Import("github.com/multigres/multigres/go/common/topoclient")
 
-	m.Match(`$x.Type`).
+	m.Match(`$x.Type`, `$x.GetType()`).
 		Where(
 			(m["x"].Type.Is("*clustermetadata.MultiPooler") ||
 				m["x"].Type.Is("*topoclient.MultiPoolerInfo")) &&

--- a/go/tools/ruleguard/rules.go
+++ b/go/tools/ruleguard/rules.go
@@ -204,3 +204,24 @@ func disallowWallClockInConsensus(m dsl.Matcher) {
 			!m.File().Name.Matches(`_test\.go$`)).
 		Report("reading wall-clock time breaks determinism; pass the timestamp from the caller or use an injected clock")
 }
+
+// disallowMultiPoolerTypeForRouting flags reads of a MultiPooler record's Type
+// field in the multigateway, which must derive leader identity from consensus
+// state (self_leadership), never from the topology role label. The PoolerType
+// routing label on a query.Target is a different field and is unaffected;
+// constructing a record with a Type (struct literal) is also unaffected — only
+// reading .Type off a discovered MultiPooler / MultiPoolerInfo is disallowed.
+//
+// Use MultiPoolerInfo.IsLeader (self_leadership set) instead.
+func disallowMultiPoolerTypeForRouting(m dsl.Matcher) {
+	m.Import("github.com/multigres/multigres/go/pb/clustermetadata")
+	m.Import("github.com/multigres/multigres/go/common/topoclient")
+
+	m.Match(`$x.Type`).
+		Where(
+			(m["x"].Type.Is("*clustermetadata.MultiPooler") ||
+				m["x"].Type.Is("*topoclient.MultiPoolerInfo")) &&
+				m.File().PkgPath.Matches(`services/multigateway`) &&
+				!m.File().Name.Matches(`_test\.go$`)).
+		Report("do not consult MultiPooler.Type for leader identity; use self_leadership (MultiPoolerInfo.IsLeader)")
+}


### PR DESCRIPTION
With this change, pooler.Type is no longer consulted for leader vs follower identity anywhere in multigateway. It's still used in targeting for now, though

LeadershipObservation is used instead