### PR TITLE
fix(pgregresstest): add WARNING/HINT for unlogged tables in pg17 expected output

### DIFF
--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_index.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_index.patch
@@ -11,3 +11,12 @@
  CREATE INDEX onek_unique2 ON onek USING btree(unique2 int4_ops);
  CREATE INDEX onek_hundred ON onek USING btree(hundred int4_ops);
  CREATE INDEX onek_stringu1 ON onek USING btree(stringu1 name_ops);
+@@ -1209,6 +1207,8 @@
+ -- HASH
+ --
+ CREATE UNLOGGED TABLE unlogged_hash_table (id int4);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ CREATE INDEX unlogged_hash_index ON unlogged_hash_table USING hash (id int4_ops);
+ DROP TABLE unlogged_hash_table;
+ -- CREATE INDEX hash_ovfl_index ON hash_ovfl_heap USING hash (x int4_ops);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_table.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_table.patch
@@ -1,6 +1,27 @@
 --- a
 +++ b
-@@ -82,9 +82,7 @@
+@@ -14,6 +14,8 @@
+ CREATE TABLE tas_case WITH ("Fillfactor" = 10) AS SELECT 1 a;
+ ERROR: unrecognized parameter "Fillfactor"
+ CREATE UNLOGGED TABLE unlogged1 (a int primary key); -- OK
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ CREATE TEMPORARY TABLE unlogged2 (a int primary key); -- OK
+ SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged\d' ORDER BY relname;
+ relname | relkind | relpersistence
+@@ -38,7 +40,11 @@
+ DROP TABLE unlogged2;
+ INSERT INTO unlogged1 VALUES (42);
+ CREATE UNLOGGED TABLE public.unlogged2 (a int primary key); -- also OK
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ CREATE UNLOGGED TABLE pg_temp.unlogged3 (a int primary key); -- not OK
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ ERROR: only temporary relations may be created in temporary schemas
+ LINE 1: CREATE UNLOGGED TABLE pg_temp.unlogged3 (a int primary key);
+ ^
+@@ -82,9 +88,7 @@
  
  -- check that tables with oids cannot be created anymore
  CREATE TABLE withoid() WITH OIDS;
@@ -11,7 +32,7 @@
  CREATE TABLE withoid() WITH (oids);
  ERROR: tables declared WITH OIDS are not supported
  CREATE TABLE withoid() WITH (oids = true);
-@@ -445,9 +443,7 @@
+@@ -445,9 +449,7 @@
  ^
  -- syntax does not allow empty list of values for list partitions
  CREATE TABLE fail_part PARTITION OF list_parted FOR VALUES IN ();

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/vector/hnsw_vector.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/vector/hnsw_vector.patch
@@ -1,0 +1,11 @@
+--- a
++++ b
+@@ -134,6 +134,8 @@
+ DROP TABLE t;
+ -- unlogged
+ CREATE UNLOGGED TABLE t (val vector(3));
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+ CREATE INDEX ON t USING hnsw (val vector_l2_ops);
+ SELECT * FROM t ORDER BY val <-> '[3,3,3]';

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/vector/ivfflat_vector.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/external/vector/ivfflat_vector.patch
@@ -1,0 +1,11 @@
+--- a
++++ b
+@@ -124,6 +124,8 @@
+ DROP TABLE t;
+ -- unlogged
+ CREATE UNLOGGED TABLE t (val vector(3));
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+ CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 1);
+ SELECT * FROM t ORDER BY val <-> '[3,3,3]';

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/gist.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/gist.patch
@@ -1,0 +1,11 @@
+--- a
++++ b
+@@ -397,6 +397,8 @@
+ drop table gist_tbl;
+ -- test an unlogged table, mostly to get coverage of gistbuildempty
+ create unlogged table gist_tbl (b box);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ create index gist_tbl_box_index on gist_tbl using gist (b);
+ insert into gist_tbl
+ select box(point(0.05*i, 0.05*i)) from generate_series(0,10) as i;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/identity.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/identity.patch
@@ -1,0 +1,20 @@
+--- a
++++ b
+@@ -367,6 +367,8 @@
+ ERROR: identity column type must be smallint, integer, or bigint
+ -- check that unlogged propagates to sequence
+ CREATE UNLOGGED TABLE itest17 (a int NOT NULL, b text);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ ALTER TABLE itest17 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;
+ ALTER TABLE itest17 ADD COLUMN c int GENERATED ALWAYS AS IDENTITY;
+ \d itest17
+@@ -910,6 +912,8 @@
+ CREATE TABLE identity_dump_logged (a INT GENERATED ALWAYS AS IDENTITY);
+ ALTER SEQUENCE identity_dump_logged_a_seq SET UNLOGGED;
+ CREATE UNLOGGED TABLE identity_dump_unlogged (a INT GENERATED ALWAYS AS IDENTITY);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ ALTER SEQUENCE identity_dump_unlogged_a_seq SET LOGGED;
+ SELECT relname, relpersistence FROM pg_class
+ WHERE relname ~ '^identity_dump_' ORDER BY 1;


### PR DESCRIPTION
## Summary
- Update `create_table.patch` and `create_index.patch` expected outputs to include the WARNING/HINT now emitted when creating unlogged tables (introduced in #1157)
- Add new `gist.patch` and `identity.patch` covering the same WARNING/HINT for the gist and identity regress tests
- Add `external/vector/hnsw_vector.patch` and `external/vector/ivfflat_vector.patch` covering the same WARNING/HINT for pgvector's unlogged-table test cases

## Test plan
- [x] Ran pg17 regress tests for test_setup, create_table, create_index, gist, and identity — all 5 pass with the patches applied
- [x] Ran pgvector external extension tests (14 tests) — all pass with the new patches applied