### PR TITLE
feat(pgprotocol): add START_REPLICATION SLOT copy-both streaming

### DIFF
--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -147,6 +147,10 @@ type Conn struct {
 	// ctx is the context for this connection.
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// replState tracks the copy-both replication lifecycle. Zero value
+	// (replStreamIdle) is correct for every non-replication connection.
+	replState replStreamState
 }
 
 // Connect establishes a new connection to a PostgreSQL server.

--- a/go/common/pgprotocol/client/copy_done_response_test.go
+++ b/go/common/pgprotocol/client/copy_done_response_test.go
@@ -87,6 +87,7 @@ func newTestReadOnlyConn(input []byte) *Conn {
 		conn:           &mockNetConn{buf: bytes.NewBuffer(nil)},
 		bufferedReader: bufio.NewReader(r),
 		bufferedWriter: bufio.NewWriter(bytes.NewBuffer(nil)),
+		serverParams:   make(map[string]string),
 	}
 }
 

--- a/go/common/pgprotocol/client/replication.go
+++ b/go/common/pgprotocol/client/replication.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// replStreamState tracks where a connection is in the copy-both replication
+// lifecycle. It guards the write path: a Standby Status Update may only be
+// sent while the stream is live.
+type replStreamState int
+
+const (
+	replStreamIdle      replStreamState = iota // not in copy-both
+	replStreamStreaming                        // CopyBothResponse received; bytes flow both ways
+	replStreamDead                             // server ErrorResponse or CopyDone observed; no more sends
+)
+
+// StartReplication issues a START_REPLICATION command and reads until the
+// server sends CopyBothResponse ('W'), at which point the connection is in
+// copy-both streaming mode. Interleaved NoticeResponse diagnostics are
+// collected and returned to the caller (never silently dropped — they carry
+// operational signal such as slot/WAL warnings); ParameterStatus updates are
+// recorded into the connection's server params. On ErrorResponse (e.g. no such
+// slot, max_wal_senders exhausted) the PG error is parsed, the trailing
+// ReadyForQuery is drained so the socket stays reusable, and the error is
+// returned alongside any notices seen before the failure.
+//
+// cmd is passed through verbatim — the caller is responsible for its contents.
+// Multigres does not parse or validate the replication command.
+//
+// Call with a deadline-bearing or cancelable ctx: the read of the server's
+// response is bounded by ctx (an absolute deadline applied across the whole
+// handshake, so a server that stalls mid-response is still bounded). An
+// unbounded ctx (context.Background with no deadline) will block indefinitely
+// against an unhealthy server that accepts the command but never replies.
+func (c *Conn) StartReplication(ctx context.Context, cmd string) ([]*mterrors.PgDiagnostic, error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	var notices []*mterrors.PgDiagnostic
+
+	if err := c.writeQueryMessage(cmd); err != nil {
+		return notices, fmt.Errorf("send START_REPLICATION: %w", err)
+	}
+
+	stop := c.makeReadsCancelable(ctx)
+	defer stop()
+
+	for {
+		msgType, body, err := c.readMessage()
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return notices, ctxErr
+			}
+			return notices, fmt.Errorf("read START_REPLICATION response: %w", err)
+		}
+
+		switch msgType {
+		case protocol.MsgCopyBothResponse:
+			// Body is format byte + column formats; opaque to this layer.
+			c.replState = replStreamStreaming
+			return notices, nil
+
+		case protocol.MsgErrorResponse:
+			// The PG error (pgErr) is the meaningful failure we return. We then
+			// drain the trailing ReadyForQuery best-effort so the socket is left
+			// clean and reusable; its return is intentionally ignored — a drain
+			// failure means the conn is broken, which the caller discovers on
+			// next use, and pgErr remains the more informative error to surface.
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			return notices, pgErr
+
+		case protocol.MsgNoticeResponse:
+			notices = append(notices, c.parseNotice(body))
+
+		case protocol.MsgParameterStatus:
+			// A parse failure here means a malformed ParameterStatus body —
+			// real postgres never sends one, so it signals wire corruption.
+			// Surface it rather than silently failing to record the param.
+			if err := c.handleParameterStatus(body); err != nil {
+				return notices, fmt.Errorf("malformed ParameterStatus during START_REPLICATION: %w", err)
+			}
+
+		default:
+			return notices, fmt.Errorf("unexpected message during START_REPLICATION: '%c' (0x%02x)", msgType, msgType)
+		}
+	}
+}
+
+// ReplicationMessage is a single message read from a copy-both stream.
+// Exactly one of Data or Notice is set on a nil-error return:
+//   - Data holds the raw CopyData payload — including the leading replication
+//     sub-type byte ('w'/'k'/etc.), which is NOT interpreted here; it is
+//     forwarded verbatim (byte-level passthrough).
+//   - Notice holds a NoticeResponse diagnostic the server interleaved with the
+//     stream. These are surfaced rather than dropped: postgres can emit
+//     warnings (slot/WAL retention, plugin messages) mid-stream and the caller
+//     decides what to do with them.
+type ReplicationMessage struct {
+	Data   []byte
+	Notice *mterrors.PgDiagnostic
+}
+
+// ReadReplicationMessage reads the next message from a copy-both stream.
+//
+// Returns a ReplicationMessage carrying either a CopyData payload or a
+// NoticeResponse diagnostic. ParameterStatus frames are recorded into the
+// connection's server params and reading continues (they remain observable via
+// ServerParams(), so nothing is silently dropped). Returns io.EOF when the
+// server sends CopyDone. Returns the parsed PG error (after draining to
+// ReadyForQuery) on ErrorResponse. Both CopyDone and ErrorResponse terminate
+// the stream in both directions: no CopyDone must be sent afterward, and the
+// stream is marked dead so WriteReplicationData will refuse further sends.
+//
+// ctx is honored: if it has a deadline or is cancelled, a blocked read unblocks
+// and returns a context error. This is the teardown primitive used to abort
+// long-lived streams (e.g. on leader change).
+func (c *Conn) ReadReplicationMessage(ctx context.Context) (ReplicationMessage, error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	stop := c.makeReadsCancelable(ctx)
+	defer stop()
+
+	for {
+		msgType, body, err := c.readMessage()
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ReplicationMessage{}, ctxErr
+			}
+			return ReplicationMessage{}, fmt.Errorf("read replication message: %w", err)
+		}
+
+		switch msgType {
+		case protocol.MsgCopyData:
+			return ReplicationMessage{Data: body}, nil
+
+		case protocol.MsgNoticeResponse:
+			return ReplicationMessage{Notice: c.parseNotice(body)}, nil
+
+		case protocol.MsgParameterStatus:
+			// Recorded into serverParams; not a stream-terminating event
+			// under normal operation. A parse failure means a malformed body
+			// (wire corruption), which we surface rather than swallow.
+			if err := c.handleParameterStatus(body); err != nil {
+				c.replState = replStreamDead
+				return ReplicationMessage{}, fmt.Errorf("malformed ParameterStatus in copy-both stream: %w", err)
+			}
+
+		case protocol.MsgCopyDone:
+			c.replState = replStreamDead
+			return ReplicationMessage{}, io.EOF
+
+		case protocol.MsgErrorResponse:
+			// Return the PG error; drain the trailing ReadyForQuery best-effort
+			// (its return is ignored — pgErr is the error worth surfacing).
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			c.replState = replStreamDead
+			return ReplicationMessage{}, pgErr
+
+		default:
+			c.replState = replStreamDead
+			return ReplicationMessage{}, fmt.Errorf("unexpected message in copy-both stream: '%c' (0x%02x)", msgType, msgType)
+		}
+	}
+}
+
+// WriteReplicationData sends a client→server CopyData payload (e.g. a Standby
+// Status Update, leading byte 'r') on a live copy-both stream. The payload is
+// opaque: multigres does not build or validate it — the consumer does. Refuses
+// to send once the stream is dead (server sent ErrorResponse or CopyDone),
+// since per the protocol no further frames (including CopyDone) may follow.
+//
+// Single-owner contract: like the rest of *Conn, the replication stream is
+// single-owner — ReadReplicationMessage holds bufMu across its (possibly
+// blocking) read, so a write from a second goroutine would block until that
+// read returns. Drive the stream from one goroutine: read with a deadline (see
+// ReadReplicationMessage's ctx) and send acks between reads, walreceiver-style.
+// Do NOT run a concurrent read goroutine and ack goroutine on the same Conn.
+func (c *Conn) WriteReplicationData(payload []byte) error {
+	c.bufMu.Lock()
+	notStreaming := c.replState != replStreamStreaming
+	c.bufMu.Unlock()
+	if notStreaming {
+		return errors.New("replication stream is not streaming; cannot send CopyData")
+	}
+	return c.WriteCopyData(payload)
+}
+
+// FinishReplication completes a client-initiated copy-both shutdown. The caller
+// must have sent CopyDone (via WriteCopyDone) first. The server may still send
+// in-flight CopyData before its own CopyDone (copy-both -> copy-out), so this
+// drains CopyData, then consumes the server CopyDone, then reads until
+// ReadyForQuery (tolerating more than one CommandComplete, as the physical
+// START_REPLICATION format the docs reference can emit two). NoticeResponse
+// diagnostics seen during the drain are collected and returned rather than
+// dropped. Returns the last command tag seen and any notices.
+//
+// Call with a deadline-bearing or cancelable ctx: the drain reads are bounded
+// by ctx (an absolute deadline across the whole drain). An unbounded ctx will
+// block indefinitely if an unhealthy server never completes the shutdown.
+func (c *Conn) FinishReplication(ctx context.Context) (string, []*mterrors.PgDiagnostic, error) {
+	c.bufMu.Lock()
+	defer c.bufMu.Unlock()
+
+	stop := c.makeReadsCancelable(ctx)
+	defer stop()
+
+	var (
+		tag     string
+		notices []*mterrors.PgDiagnostic
+	)
+	for {
+		msgType, body, err := c.readMessage()
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return tag, notices, ctxErr
+			}
+			return tag, notices, fmt.Errorf("drain replication shutdown: %w", err)
+		}
+		switch msgType {
+		case protocol.MsgCopyData, protocol.MsgCopyDone:
+			// In-flight data or the server's CopyDone — discard and continue.
+		case protocol.MsgCommandComplete:
+			t := string(body)
+			if len(t) > 0 && t[len(t)-1] == 0 {
+				t = t[:len(t)-1]
+			}
+			tag = t
+		case protocol.MsgNoticeResponse:
+			notices = append(notices, c.parseNotice(body))
+		case protocol.MsgErrorResponse:
+			// Return the PG error; drain the trailing ReadyForQuery best-effort
+			// (its return is ignored — pgErr is the error worth surfacing).
+			pgErr := c.parseError(body)
+			_ = c.waitForReadyForQuery(ctx)
+			c.replState = replStreamDead
+			return tag, notices, pgErr
+		case protocol.MsgReadyForQuery:
+			if len(body) > 0 {
+				c.txnStatus = protocol.TransactionStatus(body[0])
+			}
+			c.replState = replStreamDead
+			return tag, notices, nil
+		default:
+			return tag, notices, fmt.Errorf("unexpected message during replication shutdown: '%c'", msgType)
+		}
+	}
+}
+
+// makeReadsCancelable wires ctx cancellation/deadline to the socket read
+// deadline so a blocked readMessage returns promptly when ctx is cancelled or
+// its deadline passes. It returns a stop func that clears the deadline and
+// tears down the watcher. If ctx can never be cancelled (context.Background
+// with no deadline), it is a no-op.
+//
+// stop blocks until the watcher goroutine has fully exited before clearing the
+// deadline. This is load-bearing: if stop merely closed done and cleared the
+// deadline, a watcher that had already committed to the ctx.Done() branch could
+// re-arm a now() deadline after the clear, leaving the connection with a stale
+// past deadline that poisons the next read. Joining the goroutine first
+// guarantees the clear is the last SetReadDeadline call.
+func (c *Conn) makeReadsCancelable(ctx context.Context) (stop func()) {
+	if ctx.Done() == nil {
+		return func() {}
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		_ = c.SetReadDeadline(dl)
+	}
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		select {
+		case <-ctx.Done():
+			// Force the in-flight Read to return immediately.
+			_ = c.SetReadDeadline(time.Now())
+		case <-done:
+		}
+	}()
+	return func() {
+		close(done)
+		<-finished                         // wait for the watcher to exit (no late SetReadDeadline)
+		_ = c.SetReadDeadline(time.Time{}) // clear deadline
+	}
+}

--- a/go/common/pgprotocol/client/replication_test.go
+++ b/go/common/pgprotocol/client/replication_test.go
@@ -1,0 +1,432 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// newTestConnFromNetConn builds a *Conn whose reader/writer/SetReadDeadline
+// target a real net.Conn. Used for tests that need a read to genuinely block
+// (the in-memory mockNetConn's SetReadDeadline is a no-op and cannot unblock).
+func newTestConnFromNetConn(nc net.Conn) *Conn {
+	return &Conn{
+		conn:           nc,
+		bufferedReader: bufio.NewReader(nc),
+		bufferedWriter: bufio.NewWriter(nc),
+		serverParams:   make(map[string]string),
+	}
+}
+
+// buildCopyBothResponse builds a 'W' message: Int8 format + Int16 N + Int16[N].
+func buildCopyBothResponse(format byte, colFormats []int16) []byte {
+	var body bytes.Buffer
+	body.WriteByte(format)
+	n := make([]byte, 2)
+	binary.BigEndian.PutUint16(n, uint16(len(colFormats)))
+	body.Write(n)
+	for _, f := range colFormats {
+		fb := make([]byte, 2)
+		binary.BigEndian.PutUint16(fb, uint16(f))
+		body.Write(fb)
+	}
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgCopyBothResponse, body.Bytes())
+	return out.Bytes()
+}
+
+// buildNoticeBody builds the diagnostic-field body for a NoticeResponse (same
+// field layout as ErrorResponse): severity NOTICE + SQLSTATE + message. Wrap
+// it with writeRawMessage(.., MsgNoticeResponse, ..).
+func buildNoticeBody(sqlstate, message string) []byte {
+	var body bytes.Buffer
+	body.WriteByte('S') // severity
+	body.WriteString("NOTICE")
+	body.WriteByte(0)
+	body.WriteByte('C') // SQLSTATE
+	body.WriteString(sqlstate)
+	body.WriteByte(0)
+	body.WriteByte('M') // human-readable message
+	body.WriteString(message)
+	body.WriteByte(0)
+	body.WriteByte(0) // end of fields
+	return body.Bytes()
+}
+
+// buildParameterStatus builds an 'S' message with a key/value pair.
+func buildParameterStatus(key, val string) []byte {
+	var body bytes.Buffer
+	body.WriteString(key)
+	body.WriteByte(0)
+	body.WriteString(val)
+	body.WriteByte(0)
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgParameterStatus, body.Bytes())
+	return out.Bytes()
+}
+
+func TestReplicationStartReplication_EntersCopyBoth(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildParameterStatus("in_hot_standby", "off")) // interleaved, must be consumed
+	input.Write(buildCopyBothResponse(0, nil))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	notices, err := c.StartReplication(t.Context(),
+		"START_REPLICATION SLOT s LOGICAL 0/0 (proto_version '2', publication_names 'p')")
+	require.NoError(t, err)
+	assert.Empty(t, notices)
+	assert.Equal(t, replStreamStreaming, c.replState)
+	// ParameterStatus must be recorded, not dropped.
+	assert.Equal(t, "off", c.serverParams["in_hot_standby"])
+}
+
+func TestReplicationStartReplication_SurfacesNotices(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgNoticeResponse, buildNoticeBody("00000", "logical decoding will begin using saved snapshot"))
+	input.Write(buildCopyBothResponse(0, nil))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	notices, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.NoError(t, err)
+	require.Len(t, notices, 1, "handshake notice must be surfaced, not dropped")
+	assert.Contains(t, notices[0].Message, "saved snapshot")
+	assert.Equal(t, replStreamStreaming, c.replState)
+}
+
+func TestReplicationStartReplication_ErrorResponseDrains(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildErrorResponse("42704", `replication slot "s" does not exist`))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	_, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Equal(t, replStreamIdle, c.replState, "failed start must leave conn idle/reusable")
+}
+
+// buildReplCopyData wraps a payload in a 'd' CopyData envelope.
+func buildReplCopyData(payload []byte) []byte {
+	var out bytes.Buffer
+	writeRawMessage(&out, protocol.MsgCopyData, payload)
+	return out.Bytes()
+}
+
+func TestReplicationRead_ReturnsPayloadVerbatim(t *testing.T) {
+	// 'w' XLogData payload: leading 'w' byte must survive untouched.
+	payload := append([]byte{'w'}, []byte("rawwalbytes")...)
+	c := newTestReadOnlyConn(buildReplCopyData(payload))
+	c.replState = replStreamStreaming
+
+	got, err := c.ReadReplicationMessage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, payload, got.Data, "payload returned verbatim, including sub-type byte")
+	assert.Nil(t, got.Notice)
+}
+
+func TestReplicationRead_SurfacesMidStreamNotice(t *testing.T) {
+	// A NoticeResponse interleaved in the stream must be surfaced, not dropped,
+	// and must NOT terminate the stream.
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgNoticeResponse, buildNoticeBody("01000", "wal segment recycled soon"))
+	input.Write(buildReplCopyData(append([]byte{'w'}, []byte("more wal")...)))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	msg, err := c.ReadReplicationMessage(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, msg.Notice, "mid-stream notice must be surfaced")
+	assert.Contains(t, msg.Notice.Message, "recycled")
+	assert.Nil(t, msg.Data)
+	assert.Equal(t, replStreamStreaming, c.replState, "a notice must not kill the stream")
+
+	// The stream is still live: the next read returns the CopyData payload.
+	next, err := c.ReadReplicationMessage(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, append([]byte{'w'}, []byte("more wal")...), next.Data)
+}
+
+func TestReplicationRead_ParameterStatusRecordedAndContinues(t *testing.T) {
+	// ParameterStatus mid-stream is recorded (observable, not dropped) and the
+	// read continues to the next data frame rather than terminating.
+	var input bytes.Buffer
+	input.Write(buildParameterStatus("application_name", "walreceiver"))
+	input.Write(buildReplCopyData(append([]byte{'k'}, make([]byte, 17)...)))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	msg, err := c.ReadReplicationMessage(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, msg.Data)
+	assert.Equal(t, byte('k'), msg.Data[0])
+	assert.Equal(t, "walreceiver", c.serverParams["application_name"], "ParameterStatus must be recorded")
+	assert.Equal(t, replStreamStreaming, c.replState)
+}
+
+func TestReplicationRead_MalformedParameterStatusErrors(t *testing.T) {
+	// A ParameterStatus body with no null terminator can't be parsed; rather
+	// than swallow it, the stream surfaces the corruption and goes dead.
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgParameterStatus, []byte("no_null_terminator"))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	_, err := c.ReadReplicationMessage(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed ParameterStatus")
+	assert.Equal(t, replStreamDead, c.replState)
+}
+
+func TestReplicationRead_ServerCopyDoneIsEOF(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgCopyDone, nil)
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	_, err := c.ReadReplicationMessage(t.Context())
+	assert.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, replStreamDead, c.replState)
+}
+
+func TestReplicationRead_ErrorResponseMarksDeadAndDrains(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildErrorResponse("XX000", "decoding terminated"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	_, err := c.ReadReplicationMessage(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding terminated")
+	assert.Equal(t, replStreamDead, c.replState, "error terminates the stream both directions")
+}
+
+func TestReplicationRead_ContextCancelUnblocks(t *testing.T) {
+	serverSide, clientSide := net.Pipe()
+	t.Cleanup(func() { _ = serverSide.Close(); _ = clientSide.Close() })
+
+	c := newTestConnFromNetConn(clientSide)
+	c.replState = replStreamStreaming
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := c.ReadReplicationMessage(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), 2*time.Second, "must unblock promptly on cancel, not hang")
+}
+
+func TestReplicationWrite_AfterDeadStreamErrors(t *testing.T) {
+	c := newTestReadOnlyConn(nil)
+	c.replState = replStreamDead
+
+	err := c.WriteReplicationData(append([]byte{'r'}, make([]byte, 33)...))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not streaming")
+}
+
+func TestReplicationWrite_IdleStreamErrors(t *testing.T) {
+	c := newTestReadOnlyConn(nil)
+	// Zero value: replStreamIdle — never entered copy-both.
+	err := c.WriteReplicationData(append([]byte{'r'}, make([]byte, 33)...))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not streaming")
+}
+
+func TestReplicationWrite_StreamingSucceeds(t *testing.T) {
+	// newTestReadOnlyConn's writer discards; we only assert no error here.
+	c := newTestReadOnlyConn(nil)
+	c.replState = replStreamStreaming
+	err := c.WriteReplicationData(append([]byte{'r'}, make([]byte, 33)...))
+	require.NoError(t, err)
+}
+
+func TestReplicationFinish_DrainsInFlightThenCompletes(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildReplCopyData(append([]byte{'w'}, []byte("late wal")...))) // in-flight server data
+	writeRawMessage(&input, protocol.MsgCopyDone, nil)                         // server CopyDone
+	input.Write(buildCommandComplete("START_REPLICATION"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	tag, notices, err := c.FinishReplication(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "START_REPLICATION", tag)
+	assert.Empty(t, notices)
+	assert.Equal(t, replStreamDead, c.replState)
+}
+
+func TestReplicationFinish_SurfacesNotices(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgCopyDone, nil)
+	writeRawMessage(&input, protocol.MsgNoticeResponse, buildNoticeBody("00000", "logical decoding stopped"))
+	input.Write(buildCommandComplete("START_REPLICATION"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+
+	_, notices, err := c.FinishReplication(t.Context())
+	require.NoError(t, err)
+	require.Len(t, notices, 1, "shutdown notice must be surfaced, not dropped")
+	assert.Contains(t, notices[0].Message, "decoding stopped")
+}
+
+func TestReplicationFinish_TwoCommandCompletes(t *testing.T) {
+	// Physical-format START_REPLICATION can emit two CommandCompletes; loop to 'Z'.
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgCopyDone, nil)
+	input.Write(buildCommandComplete("START_REPLICATION"))
+	input.Write(buildCommandComplete("START_REPLICATION"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+	_, _, err := c.FinishReplication(t.Context())
+	require.NoError(t, err)
+}
+
+func TestReplicationStartReplication_MaxSlotsExhausted(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildErrorResponse("53400", "all replication slots are in use"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+	c := newTestReadOnlyConn(input.Bytes())
+	_, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replication slots")
+}
+
+func TestReplicationRead_GarbageMessageTypeErrorsCleanly(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, 'X', []byte("nonsense")) // unexpected type
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+	_, err := c.ReadReplicationMessage(t.Context())
+	require.Error(t, err)
+	assert.Equal(t, replStreamDead, c.replState)
+}
+
+func TestReplicationStartReplication_WALRemoved(t *testing.T) {
+	// Deterministic stand-in for the e2e "recycled LSN" case: surface the error.
+	var input bytes.Buffer
+	input.Write(buildErrorResponse("58P01", `requested WAL segment has already been removed`))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+	c := newTestReadOnlyConn(input.Bytes())
+	_, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already been removed")
+}
+
+// --- coverage: StartReplication error/edge paths ---
+
+func TestReplicationStartReplication_ReadErrorWrapped(t *testing.T) {
+	// Empty input: the first read hits EOF. With a non-cancelable ctx the error
+	// is wrapped (not a ctx error).
+	c := newTestReadOnlyConn(nil)
+	_, err := c.StartReplication(context.Background(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read START_REPLICATION response")
+}
+
+func TestReplicationStartReplication_MalformedParameterStatus(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, protocol.MsgParameterStatus, []byte("no_null_terminator"))
+	c := newTestReadOnlyConn(input.Bytes())
+	_, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed ParameterStatus during START_REPLICATION")
+}
+
+func TestReplicationStartReplication_UnexpectedMessage(t *testing.T) {
+	// A CopyData frame before CopyBothResponse is unexpected during the handshake.
+	c := newTestReadOnlyConn(buildReplCopyData([]byte("x")))
+	_, err := c.StartReplication(t.Context(), "START_REPLICATION SLOT s LOGICAL 0/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message during START_REPLICATION")
+}
+
+// --- coverage: ReadReplicationMessage read error + deadline arming ---
+
+func TestReplicationRead_ReadErrorWrapped(t *testing.T) {
+	c := newTestReadOnlyConn(nil) // EOF on first read
+	c.replState = replStreamStreaming
+	_, err := c.ReadReplicationMessage(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read replication message")
+}
+
+func TestReplicationRead_DeadlineContextArmsAndReads(t *testing.T) {
+	// A ctx with a deadline exercises makeReadsCancelable's SetReadDeadline path
+	// (and stop's deadline clear) while still returning the frame.
+	c := newTestReadOnlyConn(buildReplCopyData(append([]byte{'k'}, make([]byte, 17)...)))
+	c.replState = replStreamStreaming
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	msg, err := c.ReadReplicationMessage(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, msg.Data)
+	assert.Equal(t, byte('k'), msg.Data[0])
+}
+
+// --- coverage: FinishReplication error/edge paths ---
+
+func TestReplicationFinish_ReadErrorWrapped(t *testing.T) {
+	c := newTestReadOnlyConn(nil) // EOF mid-drain
+	c.replState = replStreamStreaming
+	_, _, err := c.FinishReplication(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "drain replication shutdown")
+}
+
+func TestReplicationFinish_ErrorResponseDuringDrain(t *testing.T) {
+	var input bytes.Buffer
+	input.Write(buildErrorResponse("XX000", "shutdown failed"))
+	input.Write(buildReadyForQuery(protocol.TxnStatusIdle))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+	_, _, err := c.FinishReplication(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shutdown failed")
+	assert.Equal(t, replStreamDead, c.replState)
+}
+
+func TestReplicationFinish_UnexpectedMessage(t *testing.T) {
+	var input bytes.Buffer
+	writeRawMessage(&input, 'X', []byte("junk"))
+	c := newTestReadOnlyConn(input.Bytes())
+	c.replState = replStreamStreaming
+	_, _, err := c.FinishReplication(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message during replication shutdown")
+}

--- a/go/common/pgprotocol/client/replication_test.go
+++ b/go/common/pgprotocol/client/replication_test.go
@@ -392,6 +392,25 @@ func TestReplicationRead_ReadErrorWrapped(t *testing.T) {
 	assert.Equal(t, replStreamDead, c.replState, "transport read error must mark the stream dead")
 }
 
+// TestReplicationRead_ReadErrorRefusesSubsequentWrite is the behavior-level
+// regression for the dead-transition that was originally missed: after a
+// transport read failure, a send must be refused. Before the fix the stream
+// stayed in replStreamStreaming, so this WriteReplicationData wrongly succeeded
+// — checking the observable contract (not just the internal replState) is what
+// catches that class of bug.
+func TestReplicationRead_ReadErrorRefusesSubsequentWrite(t *testing.T) {
+	c := newTestReadOnlyConn(nil) // EOF on first read
+	c.replState = replStreamStreaming
+
+	_, err := c.ReadReplicationMessage(context.Background())
+	require.Error(t, err, "read on a closed stream must error")
+
+	// The stream is broken; the next send must be refused.
+	err = c.WriteReplicationData(append([]byte{'r'}, make([]byte, 33)...))
+	require.Error(t, err, "WriteReplicationData must refuse after a failed read")
+	assert.Contains(t, err.Error(), "not streaming")
+}
+
 func TestReplicationRead_DeadlineContextArmsAndReads(t *testing.T) {
 	// A ctx with a deadline exercises makeReadsCancelable's SetReadDeadline path
 	// (and stop's deadline clear) while still returning the frame.

--- a/go/test/endtoend/multipooler/logical_replication_stream_test.go
+++ b/go/test/endtoend/multipooler/logical_replication_stream_test.go
@@ -1,0 +1,725 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multipooler
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/constants"
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// xlogDataHeaderLen is the fixed header before the WAL bytes in a 'w' frame:
+// 'w' + walStart(8) + walEnd(8) + sendTime(8).
+const xlogDataHeaderLen = 25
+
+// streamUntilFrame reads from a copy-both stream until it sees one XLogData
+// ('w') or keepalive ('k') frame, returning the highest walEnd LSN observed.
+// Notices are logged and skipped. Fatal if nothing arrives before timeout.
+func streamUntilFrame(t *testing.T, conn *client.Conn, timeout time.Duration) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		// Per-read context bound to the outer deadline (not a fixed sub-timeout)
+		// so a single read can use the full remaining budget, and cancelled
+		// promptly each iteration rather than accumulating on the cleanup stack.
+		rctx, cancel := context.WithDeadline(t.Context(), deadline)
+		msg, err := conn.ReadReplicationMessage(rctx)
+		cancel()
+		require.NoError(t, err)
+		if msg.Notice != nil {
+			t.Logf("notice during stream: %s", msg.Notice.Message)
+			continue
+		}
+		require.NotEmpty(t, msg.Data)
+		switch msg.Data[0] {
+		case 'w':
+			_, walEnd := parseXLogData(t, msg.Data)
+			return walEnd
+		case 'k':
+			walEnd, _ := parseKeepalive(t, msg.Data)
+			return walEnd
+		}
+	}
+	t.Fatal("no XLogData/keepalive frame received before timeout")
+	return 0
+}
+
+// requireSlotInactive asserts the slot exists and (eventually) has active=false.
+func requireSlotInactive(t *testing.T, setup *MultipoolerTestSetup, slot string) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	require.Eventually(t, func() bool {
+		ctx := utils.WithTimeout(t, 5*time.Second)
+		rows, err := conn.Query(ctx, fmt.Sprintf(
+			"SELECT active FROM pg_replication_slots WHERE slot_name = '%s'", slot))
+		if err != nil || len(rows) == 0 || len(rows[0].Rows) == 0 {
+			return false
+		}
+		return string(rows[0].Rows[0].Values[0]) == "f"
+	}, 15*time.Second, 250*time.Millisecond, "slot %s must persist and become inactive", slot)
+}
+
+// requireSlotPresent asserts the slot currently exists.
+func requireSlotPresent(t *testing.T, setup *MultipoolerTestSetup, slot string) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	ctx := utils.WithTimeout(t, 5*time.Second)
+	rows, err := conn.Query(ctx, fmt.Sprintf(
+		"SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s'", slot))
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	require.NotEmpty(t, rows[0].Rows, "slot %s must exist", slot)
+}
+
+// requireSlotGone asserts the slot is (eventually) absent from the catalog.
+func requireSlotGone(t *testing.T, setup *MultipoolerTestSetup, slot string) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	require.Eventually(t, func() bool {
+		ctx := utils.WithTimeout(t, 5*time.Second)
+		rows, err := conn.Query(ctx, fmt.Sprintf(
+			"SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s'", slot))
+		return err == nil && (len(rows) == 0 || len(rows[0].Rows) == 0)
+	}, 15*time.Second, 250*time.Millisecond, "slot %s must disappear", slot)
+}
+
+// fixtureCounter makes table/publication/slot names unique within a run.
+var fixtureCounter atomic.Int64
+
+// normalConnConfig is the client.Config for a plain (non-replication) SQL
+// connection to the shared fixture's primary.
+func normalConnConfig(setup *MultipoolerTestSetup) *client.Config {
+	return &client.Config{
+		Host:        "localhost",
+		Port:        setup.PrimaryPgctld.PgPort,
+		User:        constants.DefaultPostgresUser,
+		Password:    testPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+	}
+}
+
+// dialNormalConn opens a plain SQL connection for use in a test body, used for
+// catalog queries, DDL, and INSERTs that generate WAL. Replication-mode
+// connections (dialReplicationConn) can't run ordinary SQL, so the stream
+// tests pair the two. Bound to t.Context(); do NOT call from a t.Cleanup
+// handler (t.Context() is already canceled there) — use cleanupConn instead.
+func dialNormalConn(t *testing.T, setup *MultipoolerTestSetup) *client.Conn {
+	t.Helper()
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	conn, err := client.Connect(ctx, ctx, normalConnConfig(setup))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// cleanupConn dials a normal SQL connection from a t.Cleanup handler. It uses a
+// background-derived context with its own timeout because t.Context() is
+// canceled before cleanups run. Returns the conn plus a done func; nil conn if
+// the dial failed (logged, non-fatal — cleanup is best-effort).
+func cleanupConn(t *testing.T, setup *MultipoolerTestSetup, timeout time.Duration) (*client.Conn, context.Context, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	conn, err := client.Connect(ctx, ctx, normalConnConfig(setup))
+	if err != nil {
+		t.Logf("cleanup dial failed: %v", err)
+		cancel()
+		return nil, nil, func() {}
+	}
+	return conn, ctx, func() { _ = conn.Close(); cancel() }
+}
+
+// setupReplicationFixture creates a fresh table + publication on the primary
+// over a normal connection and returns their names. Each call uses a unique
+// suffix so sub-tests don't collide.
+func setupReplicationFixture(t *testing.T, setup *MultipoolerTestSetup) (tableName, pubName string) {
+	t.Helper()
+	n := fixtureCounter.Add(1)
+	tableName = fmt.Sprintf("repl_e2e_%d", n)
+	pubName = fmt.Sprintf("pub_e2e_%d", n)
+
+	conn := dialNormalConn(t, setup)
+	ctx := utils.WithTimeout(t, 15*time.Second)
+
+	_, err := conn.Query(ctx, fmt.Sprintf("CREATE TABLE %s (id int primary key, v text)", tableName))
+	require.NoError(t, err, "create fixture table")
+	_, err = conn.Query(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pubName, tableName))
+	require.NoError(t, err, "create fixture publication")
+
+	t.Cleanup(func() {
+		conn, ctx, done := cleanupConn(t, setup, 10*time.Second)
+		if conn == nil {
+			return
+		}
+		defer done()
+		_, _ = conn.Query(ctx, "DROP PUBLICATION IF EXISTS "+pubName)
+		_, _ = conn.Query(ctx, "DROP TABLE IF EXISTS "+tableName)
+	})
+
+	return tableName, pubName
+}
+
+// parseXLogData extracts walStart, walEnd from a 'w' payload (header is
+// 'w' + walStart(8) + walEnd(8) + sendTime(8) + WAL bytes).
+func parseXLogData(t *testing.T, p []byte) (walStart, walEnd uint64) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(p), 25)
+	require.Equal(t, byte('w'), p[0])
+	return binary.BigEndian.Uint64(p[1:9]), binary.BigEndian.Uint64(p[9:17])
+}
+
+// parseKeepalive extracts walEnd + replyRequested from a 'k' payload
+// ('k' + walEnd(8) + sendTime(8) + replyRequested(1)).
+func parseKeepalive(t *testing.T, p []byte) (walEnd uint64, replyRequested bool) {
+	t.Helper()
+	require.Len(t, p, 18)
+	require.Equal(t, byte('k'), p[0])
+	return binary.BigEndian.Uint64(p[1:9]), p[17] != 0
+}
+
+// buildStandbyStatus builds an 'r' payload acking the given LSN as
+// received/flushed/applied (the value PG compares against confirmed_flush_lsn).
+func buildStandbyStatus(lsn uint64) []byte {
+	b := make([]byte, 34)
+	b[0] = 'r'
+	binary.BigEndian.PutUint64(b[1:9], lsn)   // received
+	binary.BigEndian.PutUint64(b[9:17], lsn)  // flushed
+	binary.BigEndian.PutUint64(b[17:25], lsn) // applied
+	// clientTime microseconds since 2000-01-01; 0 is acceptable to the server.
+	b[33] = 0 // replyRequested
+	return b
+}
+
+// insertRow writes one row into the fixture table over a normal connection,
+// generating WAL that the publication will stream.
+func insertRow(t *testing.T, setup *MultipoolerTestSetup, table string, id int, v string) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	_, err := conn.Query(ctx, fmt.Sprintf("INSERT INTO %s (id, v) VALUES (%d, '%s')", table, id, v))
+	require.NoError(t, err, "insert fixture row")
+}
+
+// lsnToText formats a uint64 LSN as PG's canonical X/Y hex form.
+func lsnToText(lsn uint64) string {
+	return fmt.Sprintf("%X/%X", uint32(lsn>>32), uint32(lsn))
+}
+
+// requireConfirmedFlushAdvances polls pg_replication_slots until the slot's
+// confirmed_flush_lsn has advanced to at least ackLSN (the value we acked via
+// a Standby Status Update). Comparison is done server-side via pg_lsn ordering.
+func requireConfirmedFlushAdvances(t *testing.T, setup *MultipoolerTestSetup, slot string, ackLSN uint64) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	q := fmt.Sprintf(
+		"SELECT confirmed_flush_lsn >= '%s'::pg_lsn FROM pg_replication_slots WHERE slot_name = '%s'",
+		lsnToText(ackLSN), slot)
+	require.Eventually(t, func() bool {
+		ctx := utils.WithTimeout(t, 5*time.Second)
+		rows, err := conn.Query(ctx, q)
+		if err != nil || len(rows) == 0 || len(rows[0].Rows) == 0 {
+			return false
+		}
+		return string(rows[0].Rows[0].Values[0]) == "t"
+	}, 15*time.Second, 250*time.Millisecond, "confirmed_flush_lsn must advance to >= acked LSN")
+}
+
+// dropReplicationSlot best-effort drops a slot during cleanup. Register it
+// BEFORE dialing the replication conn so it runs (LIFO) after that conn closes
+// and the slot becomes inactive. A temporary slot is already gone by then, so
+// this becomes a no-op.
+func dropReplicationSlot(t *testing.T, setup *MultipoolerTestSetup, slot string) {
+	conn, _, done := cleanupConn(t, setup, 30*time.Second)
+	if conn == nil {
+		return
+	}
+	defer done()
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		rows, err := conn.Query(ctx, fmt.Sprintf(
+			"SELECT 1 FROM pg_replication_slots WHERE slot_name = '%s'", slot))
+		if err == nil && (len(rows) == 0 || len(rows[0].Rows) == 0) {
+			return true // already gone
+		}
+		_, derr := conn.Query(ctx, fmt.Sprintf("SELECT pg_drop_replication_slot('%s')", slot))
+		return derr == nil
+	}, 15*time.Second, 250*time.Millisecond, "slot %s must be droppable (no leak)", slot)
+}
+
+func TestLogicalReplicationStreamHappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+
+	for _, temporary := range []bool{true, false} {
+		name := "permanent"
+		if temporary {
+			name = "temporary"
+		}
+		t.Run(name, func(t *testing.T) {
+			table, pub := setupReplicationFixture(t, setup)
+			slot := fmt.Sprintf("slot_%s_%d", name, fixtureCounter.Add(1))
+			ctx := utils.WithTimeout(t, 30*time.Second)
+
+			// Register slot cleanup before dialing so it runs after the
+			// replication conn closes (temporary slots auto-drop; this is a
+			// no-op for them).
+			t.Cleanup(func() { dropReplicationSlot(t, setup, slot) })
+
+			conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+
+			// CREATE_REPLICATION_SLOT via the normal query path (reuses Query()).
+			tempKw := ""
+			if temporary {
+				tempKw = "TEMPORARY "
+			}
+			_, err := conn.Query(ctx, fmt.Sprintf(
+				"CREATE_REPLICATION_SLOT %s %sLOGICAL pgoutput NOEXPORT_SNAPSHOT", slot, tempKw))
+			require.NoError(t, err)
+
+			// START_REPLICATION — matches Realtime's exact command, including
+			// binary 'true' (opaque to multigres; must flow through verbatim).
+			_, err = conn.StartReplication(ctx, fmt.Sprintf(
+				"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s', binary 'true')",
+				slot, pub))
+			require.NoError(t, err)
+
+			// Generate WAL on the published table via a separate normal conn.
+			insertRow(t, setup, table, 1, "hello")
+
+			// Read frames until we see >=1 'w' and >=1 'k'; ack the highest LSN.
+			var sawW, sawK bool
+			var ackLSN uint64
+			deadline := time.Now().Add(20 * time.Second)
+			for (!sawW || !sawK) && time.Now().Before(deadline) {
+				rctx, cancel := context.WithDeadline(t.Context(), deadline)
+				msg, err := conn.ReadReplicationMessage(rctx)
+				cancel()
+				require.NoError(t, err)
+				if msg.Notice != nil {
+					t.Logf("notice during stream: %s", msg.Notice.Message)
+					continue
+				}
+				payload := msg.Data
+				require.NotEmpty(t, payload)
+				switch payload[0] {
+				case 'w':
+					_, walEnd := parseXLogData(t, payload)
+					sawW = true
+					if walEnd > ackLSN {
+						ackLSN = walEnd
+					}
+				case 'k':
+					walEnd, _ := parseKeepalive(t, payload)
+					sawK = true
+					if walEnd > ackLSN {
+						ackLSN = walEnd
+					}
+				}
+			}
+			require.True(t, sawW, "must receive at least one XLogData frame")
+			require.True(t, sawK, "must receive at least one keepalive frame")
+
+			require.NoError(t, conn.WriteReplicationData(buildStandbyStatus(ackLSN)))
+
+			// confirmed_flush_lsn should advance. Poll via a normal conn.
+			requireConfirmedFlushAdvances(t, setup, slot, ackLSN)
+		})
+	}
+}
+
+// TestLogicalReplicationStreamSlotPersistence verifies that a permanent slot
+// survives a client disconnect (and can be resumed by a fresh connection),
+// while a temporary slot is dropped when its owning connection closes.
+func TestLogicalReplicationStreamSlotPersistence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+
+	startCmd := func(slot string) string {
+		return fmt.Sprintf(
+			"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')",
+			slot, pub)
+	}
+
+	// --- permanent slot survives disconnect and resumes ---
+	permSlot := fmt.Sprintf("slot_persist_%d", fixtureCounter.Add(1))
+	t.Cleanup(func() { dropReplicationSlot(t, setup, permSlot) })
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", permSlot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, startCmd(permSlot))
+	require.NoError(t, err)
+	insertRow(t, setup, table, 1, "persist")
+	streamUntilFrame(t, conn, 20*time.Second)
+	require.NoError(t, conn.Close())
+
+	// Slot still present, now inactive.
+	requireSlotInactive(t, setup, permSlot)
+
+	// A fresh connection resumes the same slot.
+	conn2 := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx2 := utils.WithTimeout(t, 30*time.Second)
+	_, err = conn2.StartReplication(ctx2, startCmd(permSlot))
+	require.NoError(t, err, "permanent slot must resume after reconnect")
+	insertRow(t, setup, table, 2, "resume")
+	streamUntilFrame(t, conn2, 20*time.Second)
+	require.NoError(t, conn2.Close())
+
+	// --- temporary slot disappears on disconnect ---
+	tmpSlot := fmt.Sprintf("slot_tmp_%d", fixtureCounter.Add(1))
+	conn3 := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx3 := utils.WithTimeout(t, 30*time.Second)
+	_, err = conn3.Query(ctx3, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", tmpSlot))
+	require.NoError(t, err)
+	requireSlotPresent(t, setup, tmpSlot)
+	require.NoError(t, conn3.Close())
+	requireSlotGone(t, setup, tmpSlot)
+}
+
+// TestLogicalReplicationStreamLargePayload streams a row whose text value
+// exceeds 1 MiB and asserts the WAL bytes round-trip across 'w' frames without
+// frame-boundary corruption (the reader must reassemble a multi-MiB message).
+func TestLogicalReplicationStreamLargePayload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_large_%d", fixtureCounter.Add(1))
+	t.Cleanup(func() { dropReplicationSlot(t, setup, slot) })
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 60*time.Second)
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')",
+		slot, pub))
+	require.NoError(t, err)
+
+	const payloadSize = 2 * 1024 * 1024 // 2 MiB, comfortably over 1 MiB
+	insertRow(t, setup, table, 1, strings.Repeat("x", payloadSize))
+
+	// Accumulate WAL bytes from 'w' frames until we've covered the payload.
+	var walBytes int
+	deadline := time.Now().Add(40 * time.Second)
+	for walBytes < payloadSize && time.Now().Before(deadline) {
+		rctx, cancel := context.WithDeadline(t.Context(), deadline)
+		msg, err := conn.ReadReplicationMessage(rctx)
+		cancel()
+		require.NoError(t, err)
+		if msg.Notice != nil {
+			continue
+		}
+		require.NotEmpty(t, msg.Data)
+		if msg.Data[0] == 'w' {
+			require.GreaterOrEqual(t, len(msg.Data), xlogDataHeaderLen, "truncated XLogData frame")
+			walBytes += len(msg.Data) - xlogDataHeaderLen
+		}
+	}
+	require.GreaterOrEqual(t, walBytes, payloadSize,
+		"must receive at least the inserted payload size across 'w' frames without corruption")
+	require.NoError(t, conn.Close())
+}
+
+// slotActivePID polls until the slot has a non-null active_pid (the walsender
+// backend serving it) and returns it.
+func slotActivePID(t *testing.T, setup *MultipoolerTestSetup, slot string) int64 {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	var pid int64
+	require.Eventually(t, func() bool {
+		ctx := utils.WithTimeout(t, 5*time.Second)
+		rows, err := conn.Query(ctx, fmt.Sprintf(
+			"SELECT active_pid FROM pg_replication_slots WHERE slot_name = '%s'", slot))
+		if err != nil || len(rows) == 0 || len(rows[0].Rows) == 0 {
+			return false
+		}
+		v := string(rows[0].Rows[0].Values[0])
+		if v == "" {
+			return false // active_pid is NULL — walsender not attached yet
+		}
+		p, perr := strconv.ParseInt(v, 10, 64)
+		if perr != nil {
+			return false
+		}
+		pid = p
+		return true
+	}, 15*time.Second, 250*time.Millisecond, "a walsender must attach to slot %s", slot)
+	return pid
+}
+
+// requireBackendGone polls pg_stat_activity until the given backend pid is gone.
+func requireBackendGone(t *testing.T, setup *MultipoolerTestSetup, pid int64) {
+	t.Helper()
+	conn := dialNormalConn(t, setup)
+	require.Eventually(t, func() bool {
+		ctx := utils.WithTimeout(t, 5*time.Second)
+		rows, err := conn.Query(ctx, fmt.Sprintf(
+			"SELECT 1 FROM pg_stat_activity WHERE pid = %d", pid))
+		return err == nil && (len(rows) == 0 || len(rows[0].Rows) == 0)
+	}, 15*time.Second, 250*time.Millisecond, "walsender backend pid %d must terminate", pid)
+}
+
+// TestLogicalReplicationStreamNonexistentSlot verifies a START_REPLICATION
+// against a missing slot returns an error and leaves the connection usable.
+func TestLogicalReplicationStreamNonexistentSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	slot := fmt.Sprintf("does_not_exist_%d", fixtureCounter.Add(1))
+	_, err := conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names 'nopub')", slot))
+	require.Error(t, err, "START_REPLICATION on a missing slot must fail")
+
+	// The trailing ReadyForQuery was drained, so the conn is still usable.
+	rows, err := conn.Query(ctx, "IDENTIFY_SYSTEM")
+	require.NoError(t, err, "connection must remain usable after a failed START_REPLICATION")
+	require.Len(t, rows, 1)
+}
+
+// TestLogicalReplicationStreamDuplicateSlot verifies creating a slot twice
+// surfaces SQLSTATE 42710 (duplicate_object) from PostgreSQL.
+func TestLogicalReplicationStreamDuplicateSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	slot := fmt.Sprintf("slot_dup_%d", fixtureCounter.Add(1))
+	t.Cleanup(func() { dropReplicationSlot(t, setup, slot) })
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+
+	create := fmt.Sprintf("CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot)
+	_, err := conn.Query(ctx, create)
+	require.NoError(t, err)
+	_, err = conn.Query(ctx, create)
+	require.Error(t, err, "creating a duplicate slot must fail")
+	require.Equal(t, "42710", mterrors.ExtractSQLSTATE(err), "duplicate slot must be duplicate_object (42710)")
+}
+
+// TestLogicalReplicationStreamCleanTermination verifies the graceful two-phase
+// copy-both shutdown (CopyDone + FinishReplication): the slot is released and,
+// once the connection closes, the walsender backend terminates.
+func TestLogicalReplicationStreamCleanTermination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_clean_%d", fixtureCounter.Add(1))
+	t.Cleanup(func() { dropReplicationSlot(t, setup, slot) })
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')", slot, pub))
+	require.NoError(t, err)
+	insertRow(t, setup, table, 1, "clean")
+	streamUntilFrame(t, conn, 20*time.Second)
+
+	pid := slotActivePID(t, setup, slot)
+
+	// Graceful copy-both shutdown.
+	require.NoError(t, conn.WriteCopyDone())
+	_, _, err = conn.FinishReplication(ctx)
+	require.NoError(t, err, "FinishReplication must drain to ReadyForQuery cleanly")
+
+	// The slot is released (still present — it's non-temporary).
+	requireSlotInactive(t, setup, slot)
+
+	// Closing the connection terminates the walsender backend.
+	require.NoError(t, conn.Close())
+	requireBackendGone(t, setup, pid)
+}
+
+// TestLogicalReplicationStreamAbruptTermination verifies that force-closing the
+// socket mid-stream terminates the walsender backend and drops a temporary slot.
+func TestLogicalReplicationStreamAbruptTermination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_abrupt_%d", fixtureCounter.Add(1))
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')", slot, pub))
+	require.NoError(t, err)
+	insertRow(t, setup, table, 1, "abrupt")
+	streamUntilFrame(t, conn, 20*time.Second)
+
+	pid := slotActivePID(t, setup, slot)
+
+	// Abrupt teardown: no copy-both shutdown, just kill the socket.
+	require.NoError(t, conn.ForceClose())
+
+	requireBackendGone(t, setup, pid)
+	requireSlotGone(t, setup, slot) // temporary slot vanishes with its backend
+}
+
+// TestLogicalReplicationStreamServerTerminate verifies that when the walsender
+// backend is terminated server-side mid-stream, a blocked read surfaces a clear
+// error promptly rather than hanging. (Design Tier-2 case.)
+func TestLogicalReplicationStreamServerTerminate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_srvterm_%d", fixtureCounter.Add(1))
+
+	conn := dialReplicationConn(t, setup.PrimaryPgctld.PgPort)
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	// Temporary slot: it vanishes with the terminated backend, no cleanup needed.
+	_, err := conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s')", slot, pub))
+	require.NoError(t, err)
+	insertRow(t, setup, table, 1, "srvterm")
+	streamUntilFrame(t, conn, 20*time.Second)
+
+	pid := slotActivePID(t, setup, slot)
+
+	// Terminate the walsender backend from a normal connection.
+	killer := dialNormalConn(t, setup)
+	kctx := utils.WithTimeout(t, 10*time.Second)
+	_, err = killer.Query(kctx, fmt.Sprintf("SELECT pg_terminate_backend(%d)", pid))
+	require.NoError(t, err)
+
+	// A subsequent read must surface an error promptly. Skip any in-flight
+	// frames that were buffered before the termination propagated; the per-read
+	// context is bound to the outer deadline so a regression that ignored the
+	// backend death fails loudly instead of hanging.
+	deadline := time.Now().Add(20 * time.Second)
+	var readErr error
+	for time.Now().Before(deadline) {
+		rctx, cancel := context.WithDeadline(t.Context(), deadline)
+		_, e := conn.ReadReplicationMessage(rctx)
+		cancel()
+		if e != nil {
+			readErr = e
+			break
+		}
+	}
+	require.Error(t, readErr, "server-side backend termination must surface as a read error, not a hang")
+}
+
+// TestLogicalReplicationStreamKeepaliveReplyAck mirrors how Realtime acks: when
+// the server sends a keepalive with reply-requested set, the consumer responds
+// with a Standby Status Update acking walEnd+1 (realtime adapters/postgres/
+// protocol.ex). PG's walsender sends a reply-requested keepalive after
+// wal_sender_timeout/2 of silence, so the connection lowers wal_sender_timeout
+// to make one arrive quickly; the ack is then sent well within the timeout.
+func TestLogicalReplicationStreamKeepaliveReplyAck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+	setup := getSharedTestSetup(t)
+	table, pub := setupReplicationFixture(t, setup)
+	slot := fmt.Sprintf("slot_kaack_%d", fixtureCounter.Add(1))
+
+	// Replication connection with a low wal_sender_timeout (8s): the server
+	// then sends a reply-requested keepalive ~every 4s, and terminates only
+	// after 8s of no reply — ample margin to ack the one we receive.
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	conn, err := client.Connect(ctx, ctx, &client.Config{
+		Host:        "localhost",
+		Port:        setup.PrimaryPgctld.PgPort,
+		User:        constants.DefaultPostgresUser,
+		Password:    testPostgresPassword,
+		Database:    "postgres",
+		DialTimeout: 5 * time.Second,
+		Parameters: map[string]string{
+			"replication": "database",
+			"options":     "-c wal_sender_timeout=8000",
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = conn.Query(ctx, fmt.Sprintf(
+		"CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT", slot))
+	require.NoError(t, err)
+	_, err = conn.StartReplication(ctx, fmt.Sprintf(
+		"START_REPLICATION SLOT %s LOGICAL 0/0 (proto_version '2', publication_names '%s', binary 'true')",
+		slot, pub))
+	require.NoError(t, err)
+
+	insertRow(t, setup, table, 1, "kaack")
+	dataLSN := streamUntilFrame(t, conn, 20*time.Second)
+
+	// Read until the server sends a keepalive that requests a reply, then ack
+	// walEnd+1 — exactly what Realtime does in response.
+	var ackedReplyRequested bool
+	deadline := time.Now().Add(20 * time.Second)
+	for !ackedReplyRequested && time.Now().Before(deadline) {
+		rctx, cancel := context.WithDeadline(t.Context(), deadline)
+		msg, err := conn.ReadReplicationMessage(rctx)
+		cancel()
+		require.NoError(t, err)
+		if msg.Notice != nil {
+			continue
+		}
+		require.NotEmpty(t, msg.Data)
+		if msg.Data[0] == 'k' {
+			walEnd, replyRequested := parseKeepalive(t, msg.Data)
+			if replyRequested {
+				require.NoError(t, conn.WriteReplicationData(buildStandbyStatus(walEnd+1)))
+				ackedReplyRequested = true
+			}
+		}
+	}
+	require.True(t, ackedReplyRequested,
+		"server must send a reply-requested keepalive on the wal_sender_timeout schedule")
+
+	requireConfirmedFlushAdvances(t, setup, slot, dataLSN)
+}


### PR DESCRIPTION
## Summary

- Add a copy-both replication-streaming layer to the PostgreSQL wire-protocol client so multipooler's pinned `replication=database` connection can drive `START_REPLICATION SLOT`, receive `'w'`/`'k'` CopyData frames, and send `'r'` frames. Payloads are forwarded verbatim (byte-level passthrough) and never parsed in production. Slot creation reuses the existing `Query()` (`CREATE_REPLICATION_SLOT` is an ordinary simple-query command and needs no new code).
- Protocol messages are never silently dropped: `NoticeResponse` is surfaced to the caller, `ParameterStatus` is recorded into server params, and a malformed `ParameterStatus` is propagated rather than swallowed.
- Exercised end-to-end against real Postgres using Realtime's exact commands (`CREATE_REPLICATION_SLOT … TEMPORARY LOGICAL pgoutput NOEXPORT_SNAPSHOT` and `START_REPLICATION … (proto_version '2', publication_names '…', binary 'true')`) and its keepalive-reply-driven ack pattern.

## Description

New `go/common/pgprotocol/client/replication.go` adds on `*Conn`:

- `StartReplication` — send the command, loop to `CopyBothResponse`, enter streaming; on `ErrorResponse` parse the PG error and drain `ReadyForQuery` so the socket stays reusable.
- `ReadReplicationMessage` — returns `ReplicationMessage{Data, Notice}`: the CopyData payload verbatim (including the sub-type byte), `io.EOF` on server `CopyDone`, the parsed PG error on `ErrorResponse`, and surfaced mid-stream notices. ctx-cancelable via a read deadline (`makeReadsCancelable`) — the teardown primitive for future leader-change termination.
- `WriteReplicationData` — guarded send, refused once the stream is dead.
- `FinishReplication` — drain the two-phase copy-both close.

The stream is single-owner (consistent with the rest of `*Conn`): drive reads and acks from one goroutine, walreceiver-style. `StartReplication`/`ReadReplicationMessage`/`FinishReplication` honor `ctx`, so callers must pass a deadline-bearing or cancelable context — an unbounded context can block indefinitely against an unhealthy server.

## Test plan

- [ ] Unit (`go test ./go/common/pgprotocol/client/... -race`): handshake, opaque payload round-trip, notice/ParameterStatus surfacing, dead-stream guard, two-phase close, ctx cancellation, and error edge cases. `replication.go` statement coverage ~97%.
- [ ] E2E against real Postgres (`go/test/endtoend/multipooler`):
  - happy path (temporary + permanent slots), `confirmed_flush_lsn` advances
  - keepalive-reply-driven ack (mirrors Realtime: ack `walEnd+1` on a reply-requested keepalive)
  - slot persistence + resume, >1 MiB payload
  - nonexistent slot, duplicate slot (`42710`)
  - clean / abrupt / server-side (`pg_terminate_backend`) termination