### PR TITLE
refactor(connpool): taint logical replication conns on acquire

### DIFF
--- a/go/services/multipooler/internal/executor/executor.go
+++ b/go/services/multipooler/internal/executor/executor.go
@@ -395,19 +395,37 @@ func (e *Executor) reserveAndStreamExecute(
 		"begin_tx", beginTx,
 		"query", sql)
 
-	// If the query references a gateway-managed prepared statement (wrapped
-	// EXECUTE forms like CREATE TEMP TABLE ... AS EXECUTE), parse it during
-	// reserved-connection acquisition. Doing the Parse via the validate
-	// callback lets the reserved pool transparently swap a stale (silently
-	// closed) socket for a fresh one before we register the connection — the
-	// failure mode that flaked TestWrappedPreparedStatementExecution.
+	beginQuery := "BEGIN"
+	if reservationOptions.GetBeginQuery() != "" {
+		beginQuery = reservationOptions.GetBeginQuery()
+	}
+
+	// Do the first state-modifying writes on a newly borrowed socket inside the
+	// reserved-pool validate callback. If the regular pool hands us a stale socket
+	// that PostgreSQL closed while idle (for example after a backend restart), the
+	// validate path taints it and retries on a fresh socket before this reserved
+	// connection is registered.
 	//
-	// Parse is a session-level operation in PostgreSQL, so running it before
-	// BEGIN is safe; the prepared statement persists into the transaction.
+	// Parse is a session-level operation in PostgreSQL, so running it before BEGIN
+	// is safe; the prepared statement persists into the transaction. VPID stamping
+	// must happen before BEGIN so lock-detection can map this backend for the full
+	// transaction lifetime.
 	var reservedOpts []reserved.ReservedConnOption
-	if preparedStmt := options.GetPreparedStatement(); preparedStmt != nil {
+	preparedStmt := options.GetPreparedStatement()
+	if preparedStmt != nil || beginTx {
 		validate := func(ctx context.Context, conn *regular.Conn) error {
-			return e.ensurePreparedWithName(ctx, conn, preparedStmt)
+			if preparedStmt != nil {
+				if err := e.ensurePreparedWithName(ctx, conn, preparedStmt); err != nil {
+					return err
+				}
+			}
+			if beginTx {
+				e.stampVpidOnRegular(ctx, conn, options)
+				if _, err := conn.Query(ctx, beginQuery); err != nil {
+					return fmt.Errorf("failed to begin transaction: %w", err)
+				}
+			}
+			return nil
 		}
 		reservedOpts = append(reservedOpts, reserved.WithValidate(validate))
 	}
@@ -419,15 +437,23 @@ func (e *Executor) reserveAndStreamExecute(
 		return nil, fmt.Errorf("failed to create reserved connection: %w", err)
 	}
 
-	// Stamp multigres_vpid on the freshly reserved backend so subsequent
-	// lock-detection probes can map vpid → real pid. Done before BEGIN so
-	// the value is in place for the entire transaction lifecycle.
-	e.stampVpidOnReserved(ctx, reservedConn, options)
+	if beginTx {
+		// validate ran BEGIN via the raw *regular.Conn, which bypassed
+		// reserved.Conn.BeginWithQuery's bookkeeping. Mark the transaction reason
+		// explicitly and capture the rollback snapshot before any client statement
+		// runs in the transaction.
+		reservedConn.AddReservationReason(protoutil.ReasonTransaction)
+		reservedConn.SnapshotTxnState()
+	} else {
+		// Stamp multigres_vpid on the freshly reserved backend so subsequent
+		// lock-detection probes can map vpid → real pid. Transaction starts stamp
+		// inside validate before BEGIN so the tag is in place for the full txn.
+		e.stampVpidOnReserved(ctx, reservedConn, options)
+	}
 
-	// Apply all reservation reasons to the reserved connection.
-	// BeginWithQuery below adds ReasonTransaction internally, but non-transaction
-	// reasons (e.g., temp_table) must be added explicitly so that buildReservedState
-	// returns the correct bitmask and DiscardTempTables can find the shard.
+	// Apply all non-transaction reservation reasons to the reserved connection
+	// (e.g., temp_table) so buildReservedState returns the correct bitmask and
+	// DiscardTempTables can find the shard.
 	if nonBeginReasons := reasons &^ protoutil.ReasonTransaction; nonBeginReasons != 0 {
 		reservedConn.AddReservationReason(nonBeginReasons)
 	}
@@ -443,21 +469,6 @@ func (e *Executor) reserveAndStreamExecute(
 	// existing-reservation case.
 	for _, name := range reservationOptions.GetPinPortalNames() {
 		reservedConn.ReserveForPortal(name)
-	}
-
-	// If this is a transaction reservation, execute BEGIN first.
-	// The BEGIN result is not sent to the callback — it's an internal setup detail.
-	// The caller (multigateway) handles sending synthetic BEGIN results to the client.
-	// Use the original BEGIN query if provided to preserve isolation level and access mode.
-	if beginTx {
-		beginQuery := "BEGIN"
-		if reservationOptions.GetBeginQuery() != "" {
-			beginQuery = reservationOptions.GetBeginQuery()
-		}
-		if err := reservedConn.BeginWithQuery(ctx, beginQuery); err != nil {
-			reservedConn.Release(reserved.ReleaseError, nil)
-			return nil, err
-		}
 	}
 
 	// Execute the actual query and stream results to the callback as they arrive,

--- a/go/services/multipooler/internal/pools/connpool/pool_test.go
+++ b/go/services/multipooler/internal/pools/connpool/pool_test.go
@@ -383,6 +383,38 @@ func TestPoolTaint(t *testing.T) {
 	assert.GreaterOrEqual(t, pool.Active(), initialActive)
 }
 
+func TestPoolTaintOnRecycle(t *testing.T) {
+	pool := newTestPool(1)
+	defer pool.Close()
+
+	ctx := context.Background()
+	conn, err := pool.Get(ctx)
+	require.NoError(t, err)
+	original := conn.Conn
+
+	conn.TaintOnRecycle()
+
+	stats := pool.Stats()
+	assert.Equal(t, int64(1), stats.Active)
+	assert.Equal(t, int64(1), stats.Borrowed)
+	assert.Equal(t, int64(0), stats.Idle)
+	assert.False(t, original.IsClosed(), "taint-on-recycle must not close the active connection")
+
+	shortCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	blocked, err := pool.Get(shortCtx)
+	require.ErrorIs(t, err, ErrTimeout, "taint-on-recycle must not free capacity before Recycle")
+	assert.Nil(t, blocked)
+
+	conn.Recycle()
+	assert.True(t, original.IsClosed(), "tainted connection must close on recycle")
+
+	replacement, err := pool.Get(ctx)
+	require.NoError(t, err)
+	assert.NotSame(t, original, replacement.Conn)
+	replacement.Recycle()
+}
+
 func TestPoolSetCapacity_NonBlocking(t *testing.T) {
 	pool := newTestPool(10)
 	defer pool.Close()

--- a/go/services/multipooler/internal/pools/connpool/pooled.go
+++ b/go/services/multipooler/internal/pools/connpool/pooled.go
@@ -35,6 +35,11 @@ type Pooled[C Connection] struct {
 	// Used for the Recycle pattern.
 	pool *Pool[C]
 
+	// taintOnRecycle marks a borrowed connection as unusable without releasing
+	// its pool slot until Recycle. This is for connections that must remain
+	// capacity-accounted while active but must never return to the idle pool.
+	taintOnRecycle bool
+
 	// Conn is the underlying connection.
 	Conn C
 }
@@ -45,21 +50,38 @@ func (p *Pooled[C]) Close() {
 }
 
 // Recycle returns the connection to its pool.
-// If the connection is closed, a new connection will be created to replace it.
-// If the pool reference is nil, the connection is closed instead.
+// If the connection is closed or marked with TaintOnRecycle, a new connection
+// will be created to replace it. If the pool reference is nil, the connection
+// is closed instead.
 func (p *Pooled[C]) Recycle() {
 	switch {
 	case p.pool == nil:
 		p.Conn.Close()
 	case p.Conn.IsClosed():
-		p.pool.put(nil)
+		p.recycleDiscarded()
+	case p.taintOnRecycle:
+		p.Conn.Close()
+		p.recycleDiscarded()
 	default:
 		p.pool.put(p)
 	}
 }
 
-// Taint marks this connection as unusable and removes it from the pool.
-// The connection will be closed and a new one created when recycled.
+func (p *Pooled[C]) recycleDiscarded() {
+	pool := p.pool
+	p.pool = nil
+	pool.put(nil)
+}
+
+// TaintOnRecycle marks this borrowed connection as unusable while keeping its
+// pool slot borrowed until Recycle. Recycle will close this connection and
+// replace it instead of returning it to the idle pool.
+func (p *Pooled[C]) TaintOnRecycle() {
+	p.taintOnRecycle = true
+}
+
+// Taint marks this connection as unusable and immediately releases/replaces its
+// pool slot. Use TaintOnRecycle when the slot must remain borrowed until Recycle.
 func (p *Pooled[C]) Taint() {
 	if p.pool == nil {
 		return

--- a/go/services/multipooler/internal/pools/reserved/logical_replication.go
+++ b/go/services/multipooler/internal/pools/reserved/logical_replication.go
@@ -93,11 +93,11 @@ func (p *Pool) NewLogicalReplicationConn(ctx context.Context) (*Conn, error) {
 		return nil, fmt.Errorf("dial replication connection: %w", err)
 	}
 	pooled.Conn = regular.NewConn(clientConn, p.config.RegularPoolConfig.AdminPool)
-
-	// IMPORTANT: do NOT call pooled.Taint() here. Taint immediately frees
-	// the slot via p.pool.put(nil) — see connpool/pooled.go. The slot must
-	// stay held for the session's lifetime, so we leave pool intact and
-	// let reserved.Pool.release() Taint right before Recycle.
+	// Replication mode is a startup-time backend property, so this socket must
+	// never return to the regular idle pool. Mark it tainted now, but defer the
+	// slot release until Recycle so the active replication session remains
+	// capacity-accounted for its full lifetime.
+	pooled.TaintOnRecycle()
 
 	connID := p.lastID.Add(1)
 	c := newConn(pooled, connID, p)

--- a/go/services/multipooler/internal/pools/reserved/logical_replication_test.go
+++ b/go/services/multipooler/internal/pools/reserved/logical_replication_test.go
@@ -85,6 +85,35 @@ func TestNewLogicalReplicationConnTagsReasonAndStartupParam(t *testing.T) {
 		"replication=database must have been parsed by the server")
 }
 
+func TestNewLogicalReplicationConnMarksBackendTaintedAtAcquire(t *testing.T) {
+	server := fakepgserver.New(t)
+	defer server.Close()
+	server.SetCredentialProvider(fakeReplicationCredentialProvider{})
+
+	pool := NewPool(context.Background(), &PoolConfig{
+		InactivityTimeout: 5 * time.Second,
+		RegularPoolConfig: &regular.PoolConfig{
+			ClientConfig:   server.ClientConfig(),
+			ConnPoolConfig: &connpool.Config{Capacity: 1, MaxIdleCount: 1},
+		},
+	})
+	defer pool.Close()
+
+	conn, err := pool.NewLogicalReplicationConn(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, pgserver.ReplicationLogical, server.LastReplicationMode())
+
+	// ReleaseCommit does not prevent reuse by itself. The replacement normal
+	// startup below proves the replication-mode backend was marked tainted when
+	// it was acquired rather than relying on release-reason classification.
+	conn.Release(ReleaseCommit, nil)
+	assert.Equal(t, pgserver.ReplicationOff, server.LastReplicationMode())
+
+	plain, err := pool.NewConn(context.Background(), nil)
+	require.NoError(t, err)
+	plain.Release(ReleaseCommit, nil)
+}
+
 func TestNewLogicalReplicationConnIsExemptFromIdleKiller(t *testing.T) {
 	server := fakepgserver.New(t)
 	defer server.Close()

--- a/go/services/multipooler/internal/pools/reserved/reserved_conn.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_conn.go
@@ -141,12 +141,14 @@ func (c *Conn) BeginWithQuery(ctx context.Context, beginQuery string) error {
 // SnapshotTxnState captures the current session-state baseline as the
 // transaction snapshot. Transaction-start paths that run BEGIN outside
 // BeginWithQuery must call this so a later ROLLBACK can still revert the pool's
-// cached connstate in lock-step with PostgreSQL. In particular the COPY paths
-// run BEGIN on the raw *regular.Conn inside a connection-acquisition validate
-// callback (the *reserved.Conn wrapper doesn't exist yet), then add the
-// transaction reason manually; they call this immediately afterwards, before any
-// client statement runs in the transaction, so the captured baseline is the
-// pre-transaction state.
+// cached connstate in lock-step with PostgreSQL. In particular, acquisition
+// paths that need the first backend write to be retryable (COPY initiation and
+// transaction starts on fresh reserved connections) run BEGIN on the raw
+// *regular.Conn inside a connection-acquisition validate callback (the
+// *reserved.Conn wrapper doesn't exist yet), then add the transaction reason
+// manually; they call this immediately afterwards, before any client statement
+// runs in the transaction, so the captured baseline is the pre-transaction
+// state.
 func (c *Conn) SnapshotTxnState() {
 	c.txnSnapshot = c.pooled.Conn.State().SnapshotForTxn()
 }

--- a/go/services/multipooler/internal/pools/reserved/reserved_pool.go
+++ b/go/services/multipooler/internal/pools/reserved/reserved_pool.go
@@ -364,8 +364,8 @@ func (p *Pool) release(rc *Conn, reason ReleaseReason, gatewaySessionSettings ma
 		p.killCount.Add(1)
 	}
 
-	// Uncertain-state releases and replication sockets must never be reused.
-	if reason.preventsReuse() || (rc.reservedProps != nil && protoutil.HasLogicalReplicationReason(rc.reservedProps.Reasons)) {
+	// Uncertain-state releases must never be reused.
+	if reason.preventsReuse() {
 		rc.pooled.Taint()
 	} else if err := p.finalizeCleanRelease(rc, gatewaySessionSettings); err != nil {
 		p.logger.Warn("reserved clean-release finalization failed; tainting backend",


### PR DESCRIPTION
## Summary
- add `Pooled.TaintOnRecycle()` for borrowed conns that must stay capacity-accounted but never return to idle pool
- mark logical replication backends tainted immediately after replication-mode acquisition
- remove the logical-replication release-boundary special case

## Tests
- `go test -short ./go/services/multipooler/internal/pools/connpool ./go/services/multipooler/internal/pools/reserved`
- `go test -short ./go/services/multipooler/...`