### PR TITLE
test(pgregresstest): run pg_prewarm, pgstattuple, and pg_walinspect suites through multigateway

### DIFF
--- a/docs/query_serving/extensions.md
+++ b/docs/query_serving/extensions.md
@@ -22,8 +22,11 @@ complete `pg_available_extensions` inventory.
 | `fuzzystrmatch` | contrib  | -                                                                                              |
 | `hstore`        | contrib  | -                                                                                              |
 | `ltree`         | contrib  | -                                                                                              |
+| `pg_prewarm`    | contrib  | -                                                                                              |
 | `pg_trgm`       | contrib  | -                                                                                              |
+| `pg_walinspect` | contrib  | `NO_INSTALLCHECK`; explicit REGRESS list (cluster provides `wal_level=replica`).               |
 | `pgcrypto`      | contrib  | Requires PostgreSQL to be built with OpenSSL.                                                  |
+| `pgstattuple`   | contrib  | FDW-section patched (gateway blocks `CREATE FOREIGN DATA WRAPPER` / `CREATE SERVER`).          |
 | `unaccent`      | contrib  | -                                                                                              |
 | `uuid-ossp`     | contrib  | Requires PostgreSQL UUID support.                                                              |
 | `http`          | external | pgsql-http; local httpbin; upstream/autocommit suite; timeout-wording patch.                   |

--- a/go/test/endtoend/pgregresstest/extensions.go
+++ b/go/test/endtoend/pgregresstest/extensions.go
@@ -103,13 +103,16 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"pg_jsonschema", KindExternal, StatusCovered, "Rust/pgrx JSON Schema validator; ships no SQL suite (upstream tests are pgrx #[pg_test] functions in a private embedded server), so the harness carries a faithful SQL translation of that corpus in-repo (LocalTestDir) and runs it through multigateway"},
 	{"pg_net", KindExternal, StatusExternal, "background worker"},
 	{"pg_partman", KindExternal, StatusCovered, "pgTAP suite run via psql (not pg_regress); needs pgtap + max_locks_per_transaction>=128 (see testdata/pg17/external/pg_partman.conf). Runs the transaction-wrapped tests only (top-level + test_pg17plus/ + test_no_search_path/); autocommit/procedure subfolders can't run through a transaction pooler — see runExternalPgTAP. Also pgmq's build dependency (pgmq.create_partitioned → create_parent)."},
+	{"pg_prewarm", KindContrib, StatusCovered, ""},
 	{"pg_stat_statements", KindContrib, StatusUnsupported, "NO_INSTALLCHECK; records query text the gateway rewrites"},
 	{"pg_trgm", KindContrib, StatusCovered, ""},
+	{"pg_walinspect", KindContrib, StatusCovered, "WAL inspection; Makefile is NO_INSTALLCHECK (its REGRESS list lives only there) because it needs wal_level=replica — already satisfied by the multigres cluster's standby, so it runs in the stock contrib phase via an explicit REGRESS list (contribRegressTests) instead of make installcheck. The test asserts COUNT(*)>=1 booleans, not exact LSNs, so it is gateway-deterministic"},
 	{"pgaudit", KindExternal, StatusBuildOnly, "session/object audit logging; needs shared_preload_libraries (PreloadLibraries). The harness builds, preloads, and smoke-loads it, but does not run upstream's pg_regress suite because that suite asserts an exact audit-log stream (literal SET/RESET/SET ROLE/PREPARE/EXECUTE text and database DDL) that is not a valid multigateway pass/fail signal until session-state replay around SET ROLE and pgaudit.* GUCs is fixed"},
 	{"pgcrypto", KindContrib, StatusCovered, "needs --with-ssl=openssl"},
 	{"pgjwt", KindExternal, StatusCovered, "pure-SQL JWT extension; pgTAP suite (single BEGIN…ROLLBACK-wrapped test.sql) run via psql. Depends on pgcrypto (contrib) and pgtap; upstream never tags releases, so it is pinned to a commit"},
 	{"pgmq", KindExternal, StatusCovered, "tembo-io/pgmq; pure-SQL queue built as a PGXS module from pgmq-extension/; partitioned-queue tests depend on pg_partman"},
 	{"pgsodium", KindExternal, StatusCovered, "libsodium crypto wrapper (needs libsodium via pkg-config to build); pgTAP suite (single BEGIN…ROLLBACK-wrapped test.sql) run via psql in keyless mode — server-key/TCE tests self-skip via \\if :serverkeys since pgsodium is not in shared_preload_libraries"},
+	{"pgstattuple", KindContrib, StatusCovered, "tuple-level statistics; stock contrib installcheck suite. The foreign-data-wrapper section of its test diverges — multigateway blocks CREATE FOREIGN DATA WRAPPER / CREATE SERVER by design (see unsafe_stmt.go), so those statements and the dependent foreign-table checks fail with multigres-specific errors — captured in a per-module patch"},
 	{"pgtap", KindExternal, StatusCovered, "runs its own pg_regress suite (every test wrapped in BEGIN…ROLLBACK by test/setup.sql); extension.sql needs contrib citext/isn/ltree installed (ContribDeps). Also the test dependency of pg_partman, pgjwt, and pgsodium"},
 	{"plpgsql", KindContrib, StatusUnsupported, "built-in PL; exercised by the core regression suite, not contrib"},
 	{"plpgsql_check", KindExternal, StatusCovered, "plpgsql linter/profiler; needs shared_preload_libraries (PreloadLibraries) so the passive-mode hooks and shared-memory profiler work on every pooled backend; the gateway-blocked LOAD statements its tests open with are patched"},
@@ -121,6 +124,22 @@ var ExtensionCatalog = []ExtensionInfo{
 	{"uuid-ossp", KindContrib, StatusCovered, "needs --with-uuid"},
 	{"vector", KindExternal, StatusCovered, "pgvector; built as a PGXS module from externalSpecs"},
 	{"wrappers", KindExternal, StatusExternal, "Rust"},
+}
+
+// contribRegressTests holds the explicit pg_regress test list for covered
+// contrib modules whose Makefile is NO_INSTALLCHECK — so `make installcheck`
+// is a no-op and the harness cannot derive the list from it (the REGRESS
+// variable lives only in the Makefile). For these the contrib suite invokes
+// pg_regress directly with this list (mirroring the module's REGRESS line),
+// instead of `make installcheck`. Keyed by contrib directory (== module name).
+//
+// pg_walinspect is NO_INSTALLCHECK because it requires wal_level=replica, which
+// the multigres cluster already provides via its standby — so unlike
+// pg_stat_statements (which also needs shared_preload_libraries and a dedicated
+// preloaded phase) it runs in the stock contrib phase with no extra server
+// config. Keep each list in sync with the pinned PostgreSQL's module Makefile.
+var contribRegressTests = map[string][]string{
+	"pg_walinspect": {"pg_walinspect", "oldextversions"},
 }
 
 // TestHarness selects how an external extension is verified. The zero value

--- a/go/test/endtoend/pgregresstest/pg_regress.go
+++ b/go/test/endtoend/pgregresstest/pg_regress.go
@@ -158,9 +158,36 @@ func (pb *PostgresBuilder) RunContribTests(t *testing.T, ctx context.Context, mo
 			t.Logf("contrib/%s: warning: public schema reset failed: %v", mod, err)
 		}
 
-		t.Logf("Running contrib/%s installcheck against multigateway...", mod)
-		cmd := executil.Command(ctx, "make", "-C", moduleDir, "installcheck",
-			"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
+		var cmd *executil.Cmd
+		if tests, ok := contribRegressTests[mod]; ok {
+			// NO_INSTALLCHECK module: `make installcheck` is a no-op and the
+			// REGRESS list lives only in the Makefile, so drive pg_regress
+			// directly with the explicit list (mirroring the module's REGRESS
+			// line). Read sql/ + expected/ from the source tree (--inputdir /
+			// --expecteddir) and write results/ into the build tree (--outputdir),
+			// matching what verifyContribModule reads. --use-existing --dbname=postgres
+			// because multigateway rejects DROP/CREATE DATABASE; the module's
+			// --temp-config is unnecessary since we run against the existing
+			// cluster (pg_walinspect's wal_level=replica is already provided by
+			// the multigres standby).
+			srcDir := filepath.Join(pb.SourceDir, "contrib", mod)
+			pgRegress := filepath.Join(pb.BuildDir, "src", "test", "regress", "pg_regress")
+			t.Logf("Running contrib/%s pg_regress (%d tests, NO_INSTALLCHECK) against multigateway...", mod, len(tests))
+			args := []string{
+				"--inputdir=" + srcDir,
+				"--outputdir=" + moduleDir,
+				"--expecteddir=" + srcDir,
+				"--bindir=" + pb.BinDir(),
+				"--use-existing",
+				"--dbname=postgres",
+			}
+			args = append(args, tests...)
+			cmd = executil.Command(ctx, pgRegress, args...).WithProcessGroup().SetDir(moduleDir)
+		} else {
+			t.Logf("Running contrib/%s installcheck against multigateway...", mod)
+			cmd = executil.Command(ctx, "make", "-C", moduleDir, "installcheck",
+				"EXTRA_REGRESS_OPTS=--use-existing --dbname=postgres").WithProcessGroup()
+		}
 
 		res, err := pb.runTestSuite(t, ctx, cmd, testSuiteConfig{
 			suiteName: "Contrib/" + mod,

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pgstattuple/pgstattuple.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/contrib/pgstattuple/pgstattuple.patch
@@ -1,0 +1,61 @@
+# Known divergence: multigateway blocks CREATE FOREIGN DATA WRAPPER and CREATE
+# SERVER by design (foreign-data wrappers open outbound connections, which the
+# connection pooler does not permit; see
+# go/services/multigateway/planner/unsafe_stmt.go). pgstattuple's test creates a
+# dummy FDW, server, and foreign table only to assert its functions reject
+# foreign tables; with the FDW/server creation rejected, those statements and the
+# dependent foreign-table checks instead fail with multigres-specific "does not
+# exist" errors. Not a multigres bug. The rest of the suite (tuple/index/page
+# statistics on tables, btree/GIN/hash indexes, sequences, toast tables, and
+# partitions) matches upstream.
+--- a
++++ b
+@@ -193,24 +193,30 @@
+ select pgstathashindex('test_view');
+ ERROR: relation "test_view" is not a hash index
+ create foreign data wrapper dummy;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ create server dummy_server foreign data wrapper dummy;
++ERROR: CREATE SERVER is not supported: creating foreign server connections is not permitted through the connection pooler
+ create foreign table test_foreign_table () server dummy_server;
++ERROR: server "dummy_server" does not exist
+ -- these should all fail
+ select pgstattuple('test_foreign_table');
+-ERROR: cannot get tuple-level statistics for relation "test_foreign_table"
+-DETAIL: This operation is not supported for foreign tables.
++ERROR: relation "test_foreign_table" does not exist
+ select pgstattuple_approx('test_foreign_table');
+-ERROR: relation "test_foreign_table" is of wrong relation kind
+-DETAIL: This operation is not supported for foreign tables.
++ERROR: relation "test_foreign_table" does not exist
++LINE 1: select pgstattuple_approx('test_foreign_table');
++^
+ select pg_relpages('test_foreign_table');
+-ERROR: cannot get page count of relation "test_foreign_table"
+-DETAIL: This operation is not supported for foreign tables.
++ERROR: relation "test_foreign_table" does not exist
+ select pgstatindex('test_foreign_table');
+-ERROR: relation "test_foreign_table" is not a btree index
++ERROR: relation "test_foreign_table" does not exist
+ select pgstatginindex('test_foreign_table');
+-ERROR: relation "test_foreign_table" is not a GIN index
++ERROR: relation "test_foreign_table" does not exist
++LINE 1: select pgstatginindex('test_foreign_table');
++^
+ select pgstathashindex('test_foreign_table');
+-ERROR: relation "test_foreign_table" is not a hash index
++ERROR: relation "test_foreign_table" does not exist
++LINE 1: select pgstathashindex('test_foreign_table');
++^
+ -- a partition of a partitioned table should work though
+ create table test_partition partition of test_partitioned for values from (1) to (100);
+ select pgstattuple('test_partition');
+@@ -301,5 +307,8 @@
+ drop table test_partitioned;
+ drop view test_view;
+ drop foreign table test_foreign_table;
++ERROR: foreign table "test_foreign_table" does not exist
+ drop server dummy_server;
++ERROR: server "dummy_server" does not exist
+ drop foreign data wrapper dummy;
++ERROR: foreign-data wrapper "dummy" does not exist


### PR DESCRIPTION
Summary
----

Generalize the contrib test runner so modules whose Makefile is NO_INSTALLCHECK where make installcheck is a no-op and the REGRESS list lives only in the Makefile can run through the harness, by driving pg_regress directly with an explicit REGRESS list instead of only supporting the make installcheck path.

Enroll three more contrib extensions in the pg_regress compatibility harness: `pg_prewarm`, `pgstattuple`, and `pg_walinspect`.

Net result: +113/−3 across catalog, harness, docs, and one patch; coverage grows by three extensions / four tests, added through a single `contribRegressTests` map entry rather than a dedicated code path per extension, and the existing per-module patch pipeline applies to the new modules unchanged.

Description
----
Generalize the contrib runner. `RunContribTests` only knew how to drive make -C contrib/<mod> installcheck. A module whose Makefile sets `NO_INSTALLCHECK` makes that target a no-op and keeps its REGRESS list only in the Makefile, so the harness produced zero tests for it. The runner now consults a `contribRegressTests` map: for a listed module it invokes the built `pg_regress` directly with the explicit REGRESS list (mirroring the Makefile's REGRESS line), reading sql/+expected/ from the source tree and writing results/ into the build tree so the existing `verifyContribModule` patch pipeline applies unchanged. No new test phase, type, or per-extension code path. One map entry enrolls a `NO_INSTALLCHECK` module.

Enroll the extensions. `pg_prewarm` (1 test) is a plain installcheck module. A catalog flip to covered, runs on the stock contrib path, output matches upstream with no patch. `pgstattuple` (1 test) is covered the same way; its only divergence is the test's foreign-data-wrapper section — multigateway blocks `CREATE FOREIGN DATA WRAPPER` / `CREATE SERVER` by design (see `unsafe_stmt.go`), so those statements and the dependent foreign-table checks fail with multigres-specific errors, captured in a per-module patch. While the core tuple/index/page statistics on tables, indexes, sequences, toast tables, and partitions match upstream. `pg_walinspect` (2 tests) is `NO_INSTALLCHECK` because it needs `wal_level=replica`, which the multigres cluster already provides via its standby. So it needs no preload and no dedicated phase, riding the new explicit-REGRESS path on the stock cluster. Its tests assert COUNT(*)>=1 booleans rather than exact LSNs, so they pass unchanged (no patch), including the replication-slot, CHECKPOINT, and role/privilege steps the gateway does not block.

Validated locally (RUN_PGCONTRIB, macOS): pg_prewarm 1/1, pgstattuple 1/1 (foreign-data-wrapper section patched), pg_walinspect 2/2 (no patch) — 4/4 in a single contrib run.

