### PR TITLE
feat: match PostgreSQL statement_timeout error and add max_connections knob

### DIFF
--- a/.github/workflows/docker-compose-ci.yml
+++ b/.github/workflows/docker-compose-ci.yml
@@ -106,6 +106,60 @@ jobs:
           DROP EXTENSION vector;
           SQL
 
+      - name: Verify MULTIGRES_PG_MAX_CONNECTIONS knob
+        env:
+          # Re-bootstrap a fresh cluster with the knob set and check both of its
+          # effects: PostgreSQL's max_connections and the pooler's global
+          # capacity (max_connections minus the 10-connection reserve).
+          MULTIGRES_PG_MAX_CONNECTIONS: "100"
+          EXPECTED_POOL_CAPACITY: "90"
+        run: |
+          set -euo pipefail
+
+          # The knob is applied at data-dir init, so wipe the existing cluster
+          # (-v drops the volumes) and bring up a clean one with the env set.
+          docker compose down -v --remove-orphans
+          docker compose up -d
+
+          echo "Waiting for the reconfigured cluster to report healthy..."
+          for _ in $(seq 1 60); do
+            status="$(docker inspect --format '{{.State.Health.Status}}' "$(docker compose ps -q multigres)" 2>/dev/null || echo "starting")"
+            echo "  health: ${status}"
+            [ "${status}" = "healthy" ] && break
+            if [ "${status}" = "unhealthy" ]; then echo "Cluster unhealthy." >&2; exit 1; fi
+            sleep 5
+          done
+          [ "${status:-}" = "healthy" ] || { echo "Timed out waiting for health." >&2; exit 1; }
+
+          gateway_port="$(docker compose exec -T multigres sh -c 'echo "${MULTIGRES_GATEWAY_PG_PORT:-15432}"' | tr -d '\r')"
+
+          echo "== PostgreSQL max_connections should be ${MULTIGRES_PG_MAX_CONNECTIONS} =="
+          got_max="$(docker compose exec -T -e PGPASSWORD=postgres multigres \
+            psql -h 127.0.0.1 -p "${gateway_port}" -U postgres -d postgres -tAc 'SHOW max_connections;' | tr -d '[:space:]')"
+          echo "  SHOW max_connections => ${got_max}"
+          if [ "${got_max}" != "${MULTIGRES_PG_MAX_CONNECTIONS}" ]; then
+            echo "Expected max_connections=${MULTIGRES_PG_MAX_CONNECTIONS}, got ${got_max}" >&2
+            exit 1
+          fi
+
+          echo "== Each multipooler should run with CONNPOOL_GLOBAL_CAPACITY=${EXPECTED_POOL_CAPACITY} =="
+          # Read the env of every multipooler process in the container (one per
+          # cell); each must have been sized to max_connections minus the reserve.
+          caps="$(docker compose exec -T multigres sh -c \
+            'for p in $(pgrep -x multipooler); do tr "\0" "\n" < "/proc/$p/environ" | sed -n "s/^CONNPOOL_GLOBAL_CAPACITY=//p"; done' | tr -d '\r')"
+          echo "  pooler capacities: [${caps//$'\n'/ }]"
+          if [ -z "${caps}" ]; then
+            echo "No multipooler exposed CONNPOOL_GLOBAL_CAPACITY" >&2
+            exit 1
+          fi
+          while IFS= read -r c; do
+            if [ "${c}" != "${EXPECTED_POOL_CAPACITY}" ]; then
+              echo "Expected pooler capacity ${EXPECTED_POOL_CAPACITY}, got ${c}" >&2
+              exit 1
+            fi
+          done <<< "${caps}"
+          echo "Knob verified: postgres=${got_max}, pooler=${EXPECTED_POOL_CAPACITY}."
+
       - name: Dump cluster logs on failure
         if: failure()
         run: docker compose logs --no-color

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,10 @@ services:
       # container as a drop-in PostgreSQL on the default port (e.g. as Supabase
       # Storage's tenant_db). Keep ports/healthcheck below in sync.
       MULTIGRES_GATEWAY_PG_PORT: "15432"
+      # PostgreSQL max_connections (default 60). Raising it also sizes the
+      # connection pooler to this value minus 10. Forwarded from the host env so
+      # CI / callers can override it without editing this file; empty = default.
+      MULTIGRES_PG_MAX_CONNECTIONS: "${MULTIGRES_PG_MAX_CONNECTIONS:-}"
     ports:
       - "15432:15432" # zone1 multigateway — PostgreSQL wire protocol
       - "15100:15100" # multigateway HTTP (status/metrics)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       # need to publish below to reach them from the host.
       MULTIGRES_NUM_CELLS: "2"
       # Port the zone1 multigateway serves PostgreSQL on. Set to 5432 to use the
-      # container as a drop-in PostgreSQL on the default port (e.g. as Supabase
-      # Storage's tenant_db). Keep ports/healthcheck below in sync.
+      # container as a drop-in PostgreSQL on the default port (e.g. for a setup
+      # that hardcodes 5432). Keep ports/healthcheck below in sync.
       MULTIGRES_GATEWAY_PG_PORT: "15432"
       # PostgreSQL max_connections (default 60). Raising it also sizes the
       # connection pooler to this value minus 10. Forwarded from the host env so

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,14 +47,14 @@ isn't supported by the local provisioner.)
 The zone1 multigateway serves the PostgreSQL wire protocol on `15432` by
 default. Set `MULTIGRES_GATEWAY_PG_PORT=5432` to make the container a drop-in
 PostgreSQL on the standard port — useful when slotting Multigres into a setup
-that hardcodes `5432`, such as Supabase Storage's `tenant_db`. Additional cells
+that hardcodes `5432`. Additional cells
 take consecutive ports (`base+1`, `base+2`). Keep the published `ports:` and the
 healthcheck in `docker-compose.yml` in sync with this value.
 
 ### Max connections (`MULTIGRES_PG_MAX_CONNECTIONS`)
 
-The bundled PostgreSQL defaults to `max_connections = 60` (the Supabase Pico
-preset). Set `MULTIGRES_PG_MAX_CONNECTIONS` to raise it:
+The bundled PostgreSQL defaults to `max_connections = 60`. Set
+`MULTIGRES_PG_MAX_CONNECTIONS` to raise it:
 
 ```bash
 MULTIGRES_PG_MAX_CONNECTIONS=100 docker compose up --build

--- a/docker/README.md
+++ b/docker/README.md
@@ -51,6 +51,42 @@ that hardcodes `5432`, such as Supabase Storage's `tenant_db`. Additional cells
 take consecutive ports (`base+1`, `base+2`). Keep the published `ports:` and the
 healthcheck in `docker-compose.yml` in sync with this value.
 
+### Max connections (`MULTIGRES_PG_MAX_CONNECTIONS`)
+
+The bundled PostgreSQL defaults to `max_connections = 60` (the Supabase Pico
+preset). Set `MULTIGRES_PG_MAX_CONNECTIONS` to raise it:
+
+```bash
+MULTIGRES_PG_MAX_CONNECTIONS=100 docker compose up --build
+```
+
+This does two things so PostgreSQL and the pooler stay consistent:
+
+- sets PostgreSQL's `max_connections` to the value, and
+- sizes the connection pooler's global capacity to that value **minus 10**
+  (here, 90). The 10-connection reserve leaves room for superuser logins,
+  replication, so the pooler never tries to
+  open more backends than PostgreSQL allows.
+
+`SHOW max_connections` through the gateway then reports the value you set, since
+the gateway passes it through to PostgreSQL. Applied only at first init (a fresh
+data dir). The value must be greater than 10.
+
+### Extra PostgreSQL config (`MULTIGRES_PG_EXTRA_CONF`)
+
+For anything `MULTIGRES_PG_MAX_CONNECTIONS` doesn't cover, set
+`MULTIGRES_PG_EXTRA_CONF` to raw `postgresql.conf` text. It is appended verbatim
+onto every cell's config at init, last-write-wins:
+
+```bash
+MULTIGRES_PG_EXTRA_CONF=$'shared_buffers = 256MB\nwork_mem = 8MB' docker compose up --build
+```
+
+The value may span multiple lines (one setting per line). Like the knob above,
+it is applied only at first init. Advanced callers can instead point
+`POSTGRES_INITDB_EXTRA_CONF` at a mounted snippet directly — if both are set,
+the values from these knobs are appended last and win.
+
 ## Usage
 
 From the repository root:

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,8 +69,13 @@ This does two things so PostgreSQL and the pooler stay consistent:
   open more backends than PostgreSQL allows.
 
 `SHOW max_connections` through the gateway then reports the value you set, since
-the gateway passes it through to PostgreSQL. Applied only at first init (a fresh
-data dir). The value must be greater than 10.
+the gateway passes it through to PostgreSQL. The value must be greater than 10.
+
+PostgreSQL's `max_connections` is applied only at first init (a fresh data dir),
+so on a **persistent volume** changing `MULTIGRES_PG_MAX_CONNECTIONS` later has
+no effect on PostgreSQL (the pooler would re-read it but PostgreSQL would keep
+the original value, leaving them mismatched). To change it on a persisted
+cluster, re-initialize from a clean state (`docker compose down -v`).
 
 ### Extra PostgreSQL config (`MULTIGRES_PG_EXTRA_CONF`)
 

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -37,6 +37,31 @@ NUM_CELLS="${MULTIGRES_NUM_CELLS:-2}"
 # `tenant_db`). Additional cells use consecutive ports (base+1, base+2).
 GATEWAY_PG_PORT="${MULTIGRES_GATEWAY_PG_PORT:-15432}"
 
+# PostgreSQL max_connections. The bundled default is 60 (Supabase Pico preset).
+# Setting this raises PostgreSQL's ceiling AND sizes the connection pooler to
+# match: the pooler's global capacity is set to this value minus POOL_RESERVE,
+# leaving headroom for superuser logins, replication, and the pooler's own admin
+# pool. So the pooler never tries to open more backends than PostgreSQL allows.
+#
+#   MULTIGRES_PG_MAX_CONNECTIONS=100   # postgres=100, pooler global capacity=90
+#
+# Applied only at first init (a fresh data dir).
+PG_MAX_CONNECTIONS="${MULTIGRES_PG_MAX_CONNECTIONS:-}"
+
+# Connections held back from the pooler when MULTIGRES_PG_MAX_CONNECTIONS is set.
+POOL_RESERVE=10
+
+# Extra PostgreSQL configuration, as raw postgresql.conf text (one setting per
+# line) for anything MULTIGRES_PG_MAX_CONNECTIONS doesn't cover. Appended
+# verbatim onto every cell's generated postgresql.conf at data-dir init,
+# last-write-wins, so it overrides the bundled defaults:
+#
+#   MULTIGRES_PG_EXTRA_CONF=$'shared_buffers = 256MB\nwork_mem = 8MB'
+#
+# Applied only at first init (a fresh data dir); changing it after a cluster has
+# already initialized has no effect, matching POSTGRES_INITDB_EXTRA_CONF.
+PG_EXTRA_CONF="${MULTIGRES_PG_EXTRA_CONF:-}"
+
 # trim_cells rewrites a generated multigres.yaml in place, keeping only the
 # first ${NUM_CELLS} cells. It deletes the extra cell blocks from both the
 # provisioner-config `cells:` map and the `topology.cells:` list. Keeping
@@ -95,6 +120,16 @@ if ! [[ "${GATEWAY_PG_PORT}" =~ ^[1-9][0-9]*$ ]]; then
   echo "MULTIGRES_GATEWAY_PG_PORT must be a positive integer, got '${GATEWAY_PG_PORT}'" >&2
   exit 1
 fi
+if [ -n "${PG_MAX_CONNECTIONS}" ]; then
+  if ! [[ "${PG_MAX_CONNECTIONS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "MULTIGRES_PG_MAX_CONNECTIONS must be a positive integer, got '${PG_MAX_CONNECTIONS}'" >&2
+    exit 1
+  fi
+  if [ "${PG_MAX_CONNECTIONS}" -le "${POOL_RESERVE}" ]; then
+    echo "MULTIGRES_PG_MAX_CONNECTIONS must be greater than ${POOL_RESERVE} (the pooler reserve), got '${PG_MAX_CONNECTIONS}'" >&2
+    exit 1
+  fi
+fi
 
 mkdir -p "${CONFIG_PATH}"
 
@@ -106,6 +141,35 @@ if [ ! -f "${CONFIG_PATH}/multigres.yaml" ]; then
   multigres cluster init --config-path "${CONFIG_PATH}"
   trim_cells "${CONFIG_PATH}/multigres.yaml" "${NUM_CELLS}"
   set_gateway_ports "${CONFIG_PATH}/multigres.yaml" "${GATEWAY_PG_PORT}" "${NUM_CELLS}"
+fi
+
+# Assemble extra PostgreSQL config from the max_connections knob and any raw
+# MULTIGRES_PG_EXTRA_CONF, then hand it to every cell's pgctld via
+# POSTGRES_INITDB_EXTRA_CONF (a whitespace-separated list of postgresql.conf
+# snippet paths pgctld appends at init). The local provisioner spawns pgctld and
+# multipooler with the container's environment, so exporting here reaches every
+# cell. Our snippet is appended last so it wins under postgres' last-write-wins,
+# even if the caller already pointed POSTGRES_INITDB_EXTRA_CONF at their own file.
+if [ -n "${PG_MAX_CONNECTIONS}" ] || [ -n "${PG_EXTRA_CONF}" ]; then
+  extra_conf_file="${CONFIG_PATH}/pg-extra.conf"
+  : >"${extra_conf_file}" # truncate so reruns don't accumulate duplicate lines
+
+  if [ -n "${PG_MAX_CONNECTIONS}" ]; then
+    echo "max_connections = ${PG_MAX_CONNECTIONS}" >>"${extra_conf_file}"
+    # multipooler reads CONNPOOL_GLOBAL_CAPACITY; keep it below max_connections.
+    export CONNPOOL_GLOBAL_CAPACITY=$((PG_MAX_CONNECTIONS - POOL_RESERVE))
+    echo "==> max_connections=${PG_MAX_CONNECTIONS}; pooler global capacity=${CONNPOOL_GLOBAL_CAPACITY} (reserved ${POOL_RESERVE})"
+  fi
+  if [ -n "${PG_EXTRA_CONF}" ]; then
+    printf '%s\n' "${PG_EXTRA_CONF}" >>"${extra_conf_file}"
+  fi
+
+  if [ -n "${POSTGRES_INITDB_EXTRA_CONF:-}" ]; then
+    export POSTGRES_INITDB_EXTRA_CONF="${POSTGRES_INITDB_EXTRA_CONF} ${extra_conf_file}"
+  else
+    export POSTGRES_INITDB_EXTRA_CONF="${extra_conf_file}"
+  fi
+  echo "==> Applying extra PostgreSQL config via ${extra_conf_file}"
 fi
 
 echo "==> Starting Multigres cluster..."

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -45,7 +45,9 @@ GATEWAY_PG_PORT="${MULTIGRES_GATEWAY_PG_PORT:-15432}"
 #
 #   MULTIGRES_PG_MAX_CONNECTIONS=100   # postgres=100, pooler global capacity=90
 #
-# Applied only at first init (a fresh data dir).
+# PostgreSQL's max_connections is applied only at first init (a fresh data dir).
+# On a persistent volume, changing this later re-sizes the pooler but not
+# PostgreSQL, leaving them mismatched; re-init from clean to change it.
 PG_MAX_CONNECTIONS="${MULTIGRES_PG_MAX_CONNECTIONS:-}"
 
 # Connections held back from the pooler when MULTIGRES_PG_MAX_CONNECTIONS is set.

--- a/docker/cluster-entrypoint.sh
+++ b/docker/cluster-entrypoint.sh
@@ -33,11 +33,11 @@ NUM_CELLS="${MULTIGRES_NUM_CELLS:-2}"
 
 # Port the zone1 multigateway listens on for the PostgreSQL wire protocol.
 # Defaults to multigres' standard 15432. Set to 5432 to make the container a
-# drop-in PostgreSQL on the default port (e.g. as Supabase Storage's
-# `tenant_db`). Additional cells use consecutive ports (base+1, base+2).
+# drop-in PostgreSQL on the default port (e.g. for a setup that hardcodes
+# `5432`). Additional cells use consecutive ports (base+1, base+2).
 GATEWAY_PG_PORT="${MULTIGRES_GATEWAY_PG_PORT:-15432}"
 
-# PostgreSQL max_connections. The bundled default is 60 (Supabase Pico preset).
+# PostgreSQL max_connections. The bundled default is 60.
 # Setting this raises PostgreSQL's ceiling AND sizes the connection pooler to
 # match: the pooler's global capacity is set to this value minus POOL_RESERVE,
 # leaving headroom for superuser logins, replication, and the pooler's own admin

--- a/go/common/constants/gateway.go
+++ b/go/common/constants/gateway.go
@@ -18,4 +18,10 @@ const (
 	// MaxBufferingRetries is the maximum number of times a query will be
 	// retried after failover buffering completes.
 	MaxBufferingRetries = 3
+
+	// MaxStatementTimeoutMS is PostgreSQL's upper bound for statement_timeout:
+	// the max of the underlying integer GUC, measured in its base unit
+	// (milliseconds). Values outside 0 .. MaxStatementTimeoutMS are rejected,
+	// matching PostgreSQL.
+	MaxStatementTimeoutMS = 2147483647
 )

--- a/go/services/multigateway/handler/statement_timeout.go
+++ b/go/services/multigateway/handler/statement_timeout.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -69,13 +70,16 @@ func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 		return 0, invalidParamError(paramName, value,
 			`Valid units for this parameter are "us", "ms", "s", "m", "h".`)
 	}
-	// PostgreSQL range-checks in the base unit (milliseconds), and reports the
-	// value converted to it. d < 0 also catches negative sub-millisecond values
-	// that truncate to 0 ms.
-	if ms := d.Milliseconds(); d < 0 || ms > constants.MaxStatementTimeoutMS {
+	// PostgreSQL stores statement_timeout as whole milliseconds, so round to the
+	// base unit (rather than truncate) before range-checking and reporting. This
+	// keeps the reported value honest for sub-millisecond inputs: e.g. "-600us"
+	// reports "-1 ms ..." instead of a misleading "0 ms ...", and "-400us" rounds
+	// to 0 (no timeout), matching PostgreSQL.
+	ms := int64(math.Round(float64(d) / float64(time.Millisecond)))
+	if ms < 0 || ms > constants.MaxStatementTimeoutMS {
 		return 0, outOfRangeParamError(paramName, ms)
 	}
-	return d, nil
+	return time.Duration(ms) * time.Millisecond, nil
 }
 
 // invalidParamError returns a PgDiagnostic for an invalid parameter value (SQLSTATE 22023).

--- a/go/services/multigateway/handler/statement_timeout.go
+++ b/go/services/multigateway/handler/statement_timeout.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/multigres/multigres/go/common/constants"
 	"github.com/multigres/multigres/go/common/mterrors"
 	"github.com/multigres/multigres/go/common/parser/ast"
 )
@@ -56,8 +57,8 @@ func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 
 	// Try parsing as plain integer (milliseconds) first — this is the common PG case.
 	if ms, err := strconv.ParseInt(value, 10, 64); err == nil {
-		if ms < 0 {
-			return 0, outOfRangeParamError(paramName, value)
+		if ms < 0 || ms > constants.MaxStatementTimeoutMS {
+			return 0, outOfRangeParamError(paramName, ms)
 		}
 		return time.Duration(ms) * time.Millisecond, nil
 	}
@@ -68,8 +69,11 @@ func ParsePostgresInterval(paramName, value string) (time.Duration, error) {
 		return 0, invalidParamError(paramName, value,
 			`Valid units for this parameter are "us", "ms", "s", "m", "h".`)
 	}
-	if d < 0 {
-		return 0, outOfRangeParamError(paramName, value)
+	// PostgreSQL range-checks in the base unit (milliseconds), and reports the
+	// value converted to it. d < 0 also catches negative sub-millisecond values
+	// that truncate to 0 ms.
+	if ms := d.Milliseconds(); d < 0 || ms > constants.MaxStatementTimeoutMS {
+		return 0, outOfRangeParamError(paramName, ms)
 	}
 	return d, nil
 }
@@ -82,10 +86,16 @@ func invalidParamError(paramName, value, hint string) *mterrors.PgDiagnostic {
 	return diag
 }
 
-// outOfRangeParamError returns a PgDiagnostic for an out-of-range parameter value (SQLSTATE 22023).
-func outOfRangeParamError(paramName, value string) *mterrors.PgDiagnostic {
+// outOfRangeParamError returns a PgDiagnostic for an out-of-range statement_timeout
+// value (SQLSTATE 22023). ms is the value in the base unit (milliseconds). The
+// message matches PostgreSQL's guc.c exactly: the "ms" unit is appended to the
+// value and to both range bounds, e.g.
+//
+//	-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)
+func outOfRangeParamError(paramName string, ms int64) *mterrors.PgDiagnostic {
 	return mterrors.NewPgError("ERROR", mterrors.PgSSInvalidParameterValue,
-		fmt.Sprintf("%s is outside the valid range for parameter %q (0 .. 2147483647)", value, paramName), "")
+		fmt.Sprintf("%d ms is outside the valid range for parameter %q (0 ms .. %d ms)",
+			ms, paramName, constants.MaxStatementTimeoutMS), "")
 }
 
 // formatDurationPg formats a time.Duration using PostgreSQL's GUC_UNIT_MS display

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -71,10 +71,11 @@ func TestResolveStatementTimeout(t *testing.T) {
 
 func TestParsePostgresInterval(t *testing.T) {
 	tests := []struct {
-		name    string
-		value   string
-		want    time.Duration
-		wantErr bool
+		name        string
+		value       string
+		want        time.Duration
+		wantErr     bool
+		errContains string // when set, the error message must contain this substring
 	}{
 		{
 			name:  "integer milliseconds",
@@ -102,14 +103,27 @@ func TestParsePostgresInterval(t *testing.T) {
 			want:  0,
 		},
 		{
-			name:    "negative integer",
-			value:   "-1",
-			wantErr: true,
+			name:  "max boundary",
+			value: "2147483647",
+			want:  2147483647 * time.Millisecond,
 		},
 		{
-			name:    "negative Go duration",
-			value:   "-5s",
-			wantErr: true,
+			name:        "negative integer",
+			value:       "-1",
+			wantErr:     true,
+			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+		},
+		{
+			name:        "negative Go duration",
+			value:       "-5s",
+			wantErr:     true,
+			errContains: `-5000 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+		},
+		{
+			name:        "over max integer",
+			value:       "2147483648",
+			wantErr:     true,
+			errContains: `2147483648 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
 		},
 		{
 			name:    "invalid string",
@@ -133,6 +147,9 @@ func TestParsePostgresInterval(t *testing.T) {
 			got, err := ParsePostgresInterval("statement_timeout", tt.value)
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.want, got)

--- a/go/services/multigateway/handler/statement_timeout_test.go
+++ b/go/services/multigateway/handler/statement_timeout_test.go
@@ -120,6 +120,19 @@ func TestParsePostgresInterval(t *testing.T) {
 			errContains: `-5000 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
 		},
 		{
+			// Rounds to -1 ms, not a misleading 0 ms (truncation would report 0).
+			name:        "negative sub-millisecond duration",
+			value:       "-600us",
+			wantErr:     true,
+			errContains: `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`,
+		},
+		{
+			// Sub-millisecond magnitude rounds to 0 ms (no timeout), matching PG.
+			name:  "sub-millisecond rounds to zero",
+			value: "200us",
+			want:  0,
+		},
+		{
 			name:        "over max integer",
 			value:       "2147483648",
 			wantErr:     true,

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -266,6 +266,7 @@ func NewConfig(reg *viperutil.Registry) *Config {
 		globalCapacity: viperutil.Configure(reg, "connpool.global-capacity", viperutil.Options[int64]{
 			Default:  globalCapacity,
 			FlagName: "connpool-global-capacity",
+			EnvVars:  []string{"CONNPOOL_GLOBAL_CAPACITY"},
 		}),
 		reservedRatio: viperutil.Configure(reg, "connpool.reserved-ratio", viperutil.Options[float64]{
 			Default:  reservedRatio,
@@ -330,7 +331,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Int64("connpool-settings-cache-size", c.settingsCacheSize.Default(), "Maximum number of unique settings combinations to cache (0 = use default)")
 
 	// Fair share allocation flags
-	fs.Int64("connpool-global-capacity", c.globalCapacity.Default(), "Total PostgreSQL connections to manage (divided between regular and reserved pools)")
+	fs.Int64("connpool-global-capacity", c.globalCapacity.Default(), "Total PostgreSQL connections to manage (divided between regular and reserved pools) (env: CONNPOOL_GLOBAL_CAPACITY)")
 	fs.Float64("connpool-reserved-ratio", c.reservedRatio.Default(), "Fraction of global capacity allocated to reserved pools (0.0-1.0)")
 
 	// Rebalancer flags

--- a/go/services/multipooler/internal/connpoolmanager/config_test.go
+++ b/go/services/multipooler/internal/connpoolmanager/config_test.go
@@ -133,6 +133,23 @@ func TestConfig_Getters_ReturnDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, config.DialTimeout())
 }
 
+func TestConfig_GlobalCapacityFromEnv(t *testing.T) {
+	viper.Reset()
+	defer func() { viper.Reset() }()
+
+	// The cluster docker image sets CONNPOOL_GLOBAL_CAPACITY (max_connections
+	// minus a reserve) so the pooler sizes itself to the backing PostgreSQL.
+	t.Setenv("CONNPOOL_GLOBAL_CAPACITY", "90")
+
+	reg := viperutil.NewRegistry()
+	config := NewConfig(reg)
+
+	cmd := &cobra.Command{}
+	config.RegisterFlags(cmd.Flags())
+
+	assert.Equal(t, int64(90), config.GlobalCapacity())
+}
+
 func TestConfig_NewManager(t *testing.T) {
 	viper.Reset()
 	defer func() { viper.Reset() }()

--- a/go/services/pgctld/postgresconfig_gen.go
+++ b/go/services/pgctld/postgresconfig_gen.go
@@ -73,8 +73,7 @@ func GeneratePostgresServerConfig(poolerDir string, pgUser string, extraConfFile
 		return nil, fmt.Errorf("failed to create Unix socket directory: %w", err)
 	}
 
-	// Set Multigres default values - starting with Pico instance defaults from Supabase
-	// Reference: https://github.com/supabase/supabase-admin-api/blob/3765a153ef6361cb19a1cbd485cdbf93e0a1820a/optimizations/postgres.go#L38
+	// Set Multigres default values tuned for a small instance.
 	// These can be changed in the future based on instance size/requirements
 	cnf.MaxConnections = 60
 	cnf.SharedBuffers = "64MB"

--- a/go/test/endtoend/pgregresstest/statement_timeout_parity_test.go
+++ b/go/test/endtoend/pgregresstest/statement_timeout_parity_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgregresstest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// setOutcome is the result of running a SET statement: the SQLSTATE and message
+// when it errors, or zero values when it succeeds.
+type setOutcome struct {
+	errored  bool
+	sqlState string
+	message  string
+}
+
+// runSet opens a fresh connection to port and runs stmt, returning its outcome.
+func runSet(ctx context.Context, t *testing.T, port int, stmt string) setOutcome {
+	t.Helper()
+	connStr := shardsetup.GetTestUserDSN("localhost", port, "sslmode=disable", "connect_timeout=5")
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	_, err = conn.Exec(ctx, stmt, pgx.QueryExecModeSimpleProtocol)
+	if err == nil {
+		return setOutcome{}
+	}
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected *pgconn.PgError, got %T: %v", err, err)
+	return setOutcome{errored: true, sqlState: pgErr.Code, message: pgErr.Message}
+}
+
+// TestStatementTimeoutErrorParity verifies that `SET statement_timeout` behaves
+// identically through the multigateway and against the backing PostgreSQL — the
+// same success/failure, SQLSTATE, and (for errors) byte-for-byte message.
+//
+// statement_timeout is gateway-managed: the multigateway parses and validates it
+// itself rather than forwarding the SET to PostgreSQL, so its error text is
+// hand-written (handler/statement_timeout.go). This test guards that the
+// hand-written text stays exactly aligned with PostgreSQL's, comparing against a
+// live PostgreSQL instead of a hardcoded string.
+func TestStatementTimeoutErrorParity(t *testing.T) {
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found")
+	}
+	setup := getSharedSetup(t)
+	setup.SetupTest(t)
+	ctx := utils.WithTimeout(t, 2*time.Minute)
+	directPgPort := setup.GetPrimary(t).Pgctld.PgPort
+	gatewayPgPort := setup.MultigatewayPgPort
+
+	// Values exercised on both engines. Mixes valid settings with out-of-range
+	// ones (plain ms and unit-suffixed). Avoids the exact half-millisecond
+	// rounding boundary and over-INT_MAX values, where PostgreSQL's integer GUC
+	// overflow/rounding behavior is genuinely undefined-ish and not worth pinning.
+	values := []string{
+		"0",     // valid: disables the timeout
+		"5000",  // valid: 5s as plain milliseconds
+		"30s",   // valid: unit-suffixed
+		"250ms", // valid: unit-suffixed
+		"-1",    // out of range: negative milliseconds
+		"-100",  // out of range: negative milliseconds
+		"-5s",   // out of range: negative, unit-suffixed (-> -5000 ms)
+	}
+
+	for _, v := range values {
+		t.Run(v, func(t *testing.T) {
+			stmt := fmt.Sprintf("SET statement_timeout TO '%s'", v)
+			direct := runSet(ctx, t, directPgPort, stmt)
+			gateway := runSet(ctx, t, gatewayPgPort, stmt)
+
+			t.Logf("direct:  errored=%v sqlstate=%s msg=%q", direct.errored, direct.sqlState, direct.message)
+			t.Logf("gateway: errored=%v sqlstate=%s msg=%q", gateway.errored, gateway.sqlState, gateway.message)
+
+			require.Equal(t, direct.errored, gateway.errored,
+				"multigateway must error iff PostgreSQL errors")
+			require.Equal(t, direct.sqlState, gateway.sqlState,
+				"multigateway SQLSTATE must match PostgreSQL")
+			require.Equal(t, direct.message, gateway.message,
+				"multigateway error message must match PostgreSQL byte-for-byte")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The gateway-managed `statement_timeout` out-of-range error now matches PostgreSQL exactly. It includes the `ms` unit on the value and on both range bounds (e.g. `-1 ms is outside the valid range for parameter "statement_timeout" (0 ms .. 2147483647 ms)`), and it now also rejects values above the upper bound instead of silently overflowing the duration.
- New `MULTIGRES_PG_MAX_CONNECTIONS` env var on the cluster image raises PostgreSQL's `max_connections` and sizes the connection pooler's global capacity to that value minus a 10-connection reserve, so PostgreSQL and the pooler stay consistent. This is backed by a new `CONNPOOL_GLOBAL_CAPACITY` env binding on the multipooler, plus docs and a docker-compose CI check.