### PR TITLE
feat(pgprotocol): support direct SSL negotiation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,8 @@
 version: "2"
 run:
   timeout: 10m
+  # Keep the full-repo analysis under GitHub-hosted runner memory limits.
+  concurrency: 1
   build-tags:
     - ruleguard
 linters:

--- a/go/common/pgprotocol/client/conn.go
+++ b/go/common/pgprotocol/client/conn.go
@@ -81,6 +81,14 @@ type Config struct {
 	// and which verification rules apply.
 	SSLMode SSLMode
 
+	// SSLNegotiation selects how TLS is established on TCP connections
+	// (libpq sslnegotiation, PostgreSQL 17+). Empty string and "postgres"
+	// use the classic SSLRequest → 'S'/'N' negotiation; "direct" starts the
+	// TLS handshake immediately after the TCP dial with mandatory ALPN
+	// ("postgresql"). Direct requires a TLS-enforcing SSLMode (require /
+	// verify-ca / verify-full); startup fails otherwise, matching libpq.
+	SSLNegotiation SSLNegotiation
+
 	// TLSConfig is the TLS configuration for SSL connections.
 	// Only used for TCP connections. Pair with SSLMode; for prefer/require/
 	// verify-ca/verify-full this must be non-nil. Built via BuildTLSConfig.

--- a/go/common/pgprotocol/client/ssl.go
+++ b/go/common/pgprotocol/client/ssl.go
@@ -80,6 +80,64 @@ func ParseSSLMode(s string) (SSLMode, error) {
 	}
 }
 
+// SSLNegotiation mirrors libpq's sslnegotiation connection parameter
+// (PostgreSQL 17+). It selects how the TLS layer is established on a TCP
+// connection; it does not change whether TLS is attempted (that remains
+// sslmode's job).
+//
+// Reference: https://www.postgresql.org/docs/17/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION
+type SSLNegotiation string
+
+const (
+	// SSLNegotiationPostgres performs the classic PostgreSQL handshake:
+	// send SSLRequest, wait for 'S'/'N', then run the TLS handshake.
+	// libpq default.
+	SSLNegotiationPostgres SSLNegotiation = "postgres"
+
+	// SSLNegotiationDirect starts the TLS handshake immediately after the
+	// TCP connection is established, skipping the SSLRequest round trip
+	// (PostgreSQL 17 direct SSL). ALPN "postgresql" is mandatory in this
+	// mode — the dial fails if the server does not negotiate it. Requires
+	// a TLS-enforcing sslmode (require / verify-ca / verify-full): there is
+	// no plaintext fallback once the first byte on the wire is a TLS
+	// ClientHello, so libpq rejects weaker modes and so do we.
+	SSLNegotiationDirect SSLNegotiation = "direct"
+)
+
+// ParseSSLNegotiation parses the string form of an sslnegotiation value.
+// Empty input returns SSLNegotiationPostgres (libpq default).
+func ParseSSLNegotiation(s string) (SSLNegotiation, error) {
+	switch SSLNegotiation(strings.ToLower(strings.TrimSpace(s))) {
+	case "":
+		return SSLNegotiationPostgres, nil
+	case SSLNegotiationPostgres:
+		return SSLNegotiationPostgres, nil
+	case SSLNegotiationDirect:
+		return SSLNegotiationDirect, nil
+	default:
+		return "", fmt.Errorf("invalid sslnegotiation %q (want postgres|direct)", s)
+	}
+}
+
+// ValidateSSLNegotiation enforces libpq's compatibility rule between
+// sslnegotiation and sslmode: direct negotiation cannot fall back to
+// plaintext, so it may only be combined with a mode that requires TLS.
+// Mirrors libpq's "weak sslmode ... may not be used with
+// sslnegotiation=direct" check in fe-connect.c.
+func ValidateSSLNegotiation(negotiation SSLNegotiation, mode SSLMode) error {
+	switch negotiation {
+	case "", SSLNegotiationPostgres:
+		return nil
+	case SSLNegotiationDirect:
+		if !mode.RequiresTLS() {
+			return fmt.Errorf("weak sslmode %q may not be used with sslnegotiation=direct (use \"require\", \"verify-ca\", or \"verify-full\")", mode)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid sslnegotiation %q (want postgres|direct)", negotiation)
+	}
+}
+
 // AttemptsTLS reports whether the mode wants the SSLRequest negotiation step.
 func (m SSLMode) AttemptsTLS() bool {
 	switch m {

--- a/go/common/pgprotocol/client/ssl_negotiation_test.go
+++ b/go/common/pgprotocol/client/ssl_negotiation_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the libpq sslnegotiation parameter mirror (PostgreSQL 17
+// direct SSL). The option-compatibility cases come straight from libpq's
+// fe-connect.c validation ("weak sslmode ... may not be used with
+// sslnegotiation=direct") and the ALPN requirement from
+// fe-secure-openssl.c ("direct SSL connection was established without
+// ALPN protocol negotiation extension").
+
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+func TestParseSSLNegotiation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected SSLNegotiation
+		wantErr  bool
+	}{
+		{"", SSLNegotiationPostgres, false},
+		{"postgres", SSLNegotiationPostgres, false},
+		{"POSTGRES", SSLNegotiationPostgres, false},
+		{" direct ", SSLNegotiationDirect, false},
+		{"direct", SSLNegotiationDirect, false},
+		{"Direct", SSLNegotiationDirect, false},
+		{"requiredirect", "", true}, // dropped from PG 17 before release
+		{"on", "", true},
+		{"tls", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSSLNegotiation(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid sslnegotiation")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestValidateSSLNegotiation mirrors libpq's option compatibility matrix:
+// direct may only pair with a TLS-enforcing sslmode.
+func TestValidateSSLNegotiation(t *testing.T) {
+	// postgres (and unset) pair with everything.
+	for _, mode := range []SSLMode{SSLModeDisable, SSLModePrefer, SSLModeRequire, SSLModeVerifyCA, SSLModeVerifyFull} {
+		require.NoError(t, ValidateSSLNegotiation("", mode))
+		require.NoError(t, ValidateSSLNegotiation(SSLNegotiationPostgres, mode))
+	}
+
+	// direct requires require/verify-ca/verify-full.
+	for _, mode := range []SSLMode{SSLModeRequire, SSLModeVerifyCA, SSLModeVerifyFull} {
+		require.NoError(t, ValidateSSLNegotiation(SSLNegotiationDirect, mode))
+	}
+	for _, mode := range []SSLMode{SSLModeDisable, SSLModePrefer, SSLMode("")} {
+		err := ValidateSSLNegotiation(SSLNegotiationDirect, mode)
+		require.Error(t, err, "mode %q must be rejected with direct", mode)
+		assert.Contains(t, err.Error(), "may not be used with sslnegotiation=direct")
+	}
+
+	// Unknown negotiation values are rejected.
+	require.Error(t, ValidateSSLNegotiation("bogus", SSLModeRequire))
+}
+
+// TestDirectTLS_WeakSSLModeFailsBeforeDial: startup must fail fast on the
+// libpq compatibility rule without writing anything to the server.
+func TestDirectTLS_WeakSSLModeFailsBeforeDial(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := &Conn{config: &Config{
+		SSLMode:        SSLModePrefer,
+		SSLNegotiation: SSLNegotiationDirect,
+	}}
+	c.resetConn(clientConn)
+
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		errCh <- c.startup(ctx)
+	}()
+
+	err := <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may not be used with sslnegotiation=direct")
+
+	// Nothing must have been written to the wire.
+	require.NoError(t, serverConn.SetReadDeadline(time.Now().Add(100*time.Millisecond)))
+	buf := make([]byte, 1)
+	n, _ := serverConn.Read(buf)
+	assert.Equal(t, 0, n, "weak-sslmode failure must not write to the connection")
+}
+
+// TestDirectTLS_NilTLSConfigRejected: direct mode with no TLS config is a
+// configuration error, reported before any handshake bytes go out.
+func TestDirectTLS_NilTLSConfigRejected(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := &Conn{config: &Config{
+		Host:           "127.0.0.1",
+		SSLMode:        SSLModeRequire,
+		SSLNegotiation: SSLNegotiationDirect,
+		TLSConfig:      nil,
+	}}
+	c.resetConn(clientConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := c.startup(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS config is nil")
+}
+
+// generateClientTestServerTLS builds an ephemeral self-signed server TLS
+// config for the raw TLS listeners below.
+func generateClientTestServerTLS(t *testing.T, nextProtos []string) *tls.Config {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		MinVersion:   tls.VersionTLS12,
+		NextProtos:   nextProtos,
+	}
+}
+
+// TestDirectTLS_ALPNRequired: a server that completes the handshake without
+// selecting the "postgresql" ALPN protocol must be rejected with libpq's
+// diagnostic. Such a server is either not PostgreSQL or predates direct
+// TLS — proceeding would defeat ALPN's cross-protocol hardening.
+func TestDirectTLS_ALPNRequired(t *testing.T) {
+	// Raw TLS listener with NO ALPN protocols: Go ignores the client's
+	// offer and negotiates none.
+	srvCfg := generateClientTestServerTLS(t, nil)
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", srvCfg)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		// Drive the handshake; the client should drop the connection
+		// right after when it notices the missing ALPN.
+		buf := make([]byte, 1)
+		_, _ = conn.Read(buf)
+		conn.Close()
+	}()
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	clientTLS, err := BuildTLSConfig(SSLModeRequire, "", "")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = Connect(ctx, ctx, &Config{
+		Host:           "127.0.0.1",
+		Port:           addr.Port,
+		User:           "u",
+		Password:       "p",
+		Database:       "d",
+		SSLMode:        SSLModeRequire,
+		SSLNegotiation: SSLNegotiationDirect,
+		TLSConfig:      clientTLS,
+		DialTimeout:    5 * time.Second,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"direct SSL connection was established without ALPN protocol negotiation extension")
+}
+
+// TestDirectTLS_OffersALPN verifies the wire behavior: the client's first
+// bytes are a TLS ClientHello (no SSLRequest), and the handshake offers
+// ALPN "postgresql".
+func TestDirectTLS_OffersALPN(t *testing.T) {
+	srvCfg := generateClientTestServerTLS(t, []string{protocol.ALPNProtocol})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	alpnCh := make(chan string, 1)
+	go func() {
+		raw, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			alpnCh <- "accept-error"
+			return
+		}
+		tlsConn := tls.Server(raw, srvCfg)
+		if hsErr := tlsConn.Handshake(); hsErr != nil {
+			alpnCh <- "handshake-error"
+			return
+		}
+		alpnCh <- tlsConn.ConnectionState().NegotiatedProtocol
+		// Hold the conn open until the client gives up on startup; the
+		// raw server never answers the startup message.
+		buf := make([]byte, 64)
+		_, _ = tlsConn.Read(buf)
+		tlsConn.Close()
+	}()
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	clientTLS, err := BuildTLSConfig(SSLModeRequire, "", "")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Connect will fail (the fake server never completes startup), but the
+	// handshake portion is what this test observes.
+	_, _ = Connect(ctx, ctx, &Config{
+		Host:           "127.0.0.1",
+		Port:           addr.Port,
+		User:           "u",
+		Password:       "p",
+		Database:       "d",
+		SSLMode:        SSLModeRequire,
+		SSLNegotiation: SSLNegotiationDirect,
+		TLSConfig:      clientTLS,
+		DialTimeout:    2 * time.Second,
+	})
+
+	assert.Equal(t, protocol.ALPNProtocol, <-alpnCh,
+		"client must offer (and server select) the postgresql ALPN protocol")
+}
+
+// TestDirectTLS_SharedTLSConfigNotMutated: adding the ALPN offer must not
+// mutate a TLSConfig shared across dials (pool managers reuse one config
+// for every connection).
+func TestDirectTLS_SharedTLSConfigNotMutated(t *testing.T) {
+	shared, err := BuildTLSConfig(SSLModeRequire, "", "")
+	require.NoError(t, err)
+	require.Empty(t, shared.NextProtos)
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	c := &Conn{config: &Config{
+		Host:           "127.0.0.1",
+		SSLMode:        SSLModeRequire,
+		SSLNegotiation: SSLNegotiationDirect,
+		TLSConfig:      shared,
+	}}
+	c.resetConn(clientConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	go func() {
+		// Sink whatever the client handshake writes so it doesn't block
+		// on the pipe; the context timeout ends the attempt.
+		buf := make([]byte, 4096)
+		for {
+			if _, readErr := serverConn.Read(buf); readErr != nil {
+				return
+			}
+		}
+	}()
+	_ = c.startup(ctx)
+
+	assert.Empty(t, shared.NextProtos, "shared TLS config must not be mutated by directTLS")
+}

--- a/go/common/pgprotocol/client/startup.go
+++ b/go/common/pgprotocol/client/startup.go
@@ -29,10 +29,22 @@ import (
 // This includes SSL negotiation (if configured), sending the startup message,
 // and handling authentication.
 func (c *Conn) startup(ctx context.Context) error {
+	// libpq parity: sslnegotiation=direct may only pair with a TLS-enforcing
+	// sslmode — there is no plaintext fallback once the first wire byte is a
+	// TLS ClientHello. Checked before any bytes are exchanged so a
+	// misconfiguration fails fast on every dial (Connect and Reconnect).
+	if err := ValidateSSLNegotiation(c.config.SSLNegotiation, c.config.SSLMode); err != nil {
+		return err
+	}
+
 	// Honor libpq-style sslmode. Unix-socket connections always run plaintext,
 	// matching libpq behavior.
 	if c.config.SocketFile == "" && c.config.SSLMode.AttemptsTLS() {
-		if err := c.negotiateSSL(ctx); err != nil {
+		if c.config.SSLNegotiation == SSLNegotiationDirect {
+			if err := c.directTLS(ctx); err != nil {
+				return fmt.Errorf("direct TLS failed: %w", err)
+			}
+		} else if err := c.negotiateSSL(ctx); err != nil {
 			return fmt.Errorf("SSL negotiation failed: %w", err)
 		}
 	}
@@ -104,6 +116,49 @@ func (c *Conn) negotiateSSL(ctx context.Context) error {
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return fmt.Errorf("TLS handshake failed: %w", err)
 	}
+	c.conn = tlsConn
+	c.bufferedReader = bufio.NewReaderSize(tlsConn, connBufferSize)
+	c.bufferedWriter = bufio.NewWriterSize(tlsConn, connBufferSize)
+	return nil
+}
+
+// directTLS implements libpq's sslnegotiation=direct (PostgreSQL 17): the
+// TLS handshake starts immediately on the fresh TCP connection — no
+// SSLRequest round trip — with the "postgresql" ALPN protocol offered and
+// required. The server disambiguates on the first byte (0x16, TLS handshake
+// record), so nothing may be written before the ClientHello.
+//
+// Caller guarantees ValidateSSLNegotiation passed (TLS-enforcing sslmode)
+// and c.config.SocketFile is empty.
+func (c *Conn) directTLS(ctx context.Context) error {
+	if c.config.TLSConfig == nil {
+		return errors.New("TLS config is nil but sslnegotiation=direct requested TLS")
+	}
+
+	// Offer ALPN "postgresql" (RFC 7301). libpq always offers it in direct
+	// mode, and PostgreSQL 17 rejects direct connections without it. Clone
+	// so a shared TLSConfig isn't mutated under the caller.
+	tlsCfg := c.config.TLSConfig
+	if !slices.Contains(tlsCfg.NextProtos, protocol.ALPNProtocol) {
+		tlsCfg = tlsCfg.Clone()
+		tlsCfg.NextProtos = append(tlsCfg.NextProtos, protocol.ALPNProtocol)
+	}
+
+	tlsConn := tls.Client(c.conn, tlsCfg)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return fmt.Errorf("TLS handshake failed: %w", err)
+	}
+
+	// libpq parity: "ALPN is mandatory with direct SSL connections". A
+	// server that completed the handshake without selecting "postgresql"
+	// is either not PostgreSQL or predates direct-TLS support; using the
+	// channel anyway would defeat the cross-protocol hardening ALPN exists
+	// for (fe-secure-openssl.c emits the same diagnostic).
+	if tlsConn.ConnectionState().NegotiatedProtocol != protocol.ALPNProtocol {
+		_ = tlsConn.Close()
+		return errors.New("direct SSL connection was established without ALPN protocol negotiation extension")
+	}
+
 	c.conn = tlsConn
 	c.bufferedReader = bufio.NewReaderSize(tlsConn, connBufferSize)
 	c.bufferedWriter = bufio.NewWriterSize(tlsConn, connBufferSize)

--- a/go/common/pgprotocol/server/conn.go
+++ b/go/common/pgprotocol/server/conn.go
@@ -157,6 +157,15 @@ type Conn struct {
 	// SCRAM-SHA-256-PLUS. Nil for plaintext connections.
 	tlsServerCert *x509.Certificate
 
+	// directTLSFailed is set when a direct-TLS attempt (first byte 0x16,
+	// PG 17 sslnegotiation=direct) was detected but could not be completed
+	// — either TLS is not configured or the handshake itself failed. The
+	// client is speaking raw TLS on the wire in both cases, so serve()'s
+	// best-effort plaintext ErrorResponse would surface as garbage;
+	// canSendPlaintextStartupError consults this flag to suppress it,
+	// matching PostgreSQL's silent rejection of failed direct SSL startups.
+	directTLSFailed bool
+
 	// gssDone indicates that a GSSENCRequest has already been handled
 	// for this connection. Prevents double negotiation.
 	gssDone bool
@@ -550,9 +559,15 @@ func (c *Conn) endWriterBuffering() error {
 // client. If the client sent SSLRequest and the server already answered
 // 'S' but the TLS handshake hasn't completed, the underlying conn is
 // still plaintext while the client is waiting for encrypted bytes — so
-// any plaintext write would surface as garbage. Every other startup
-// state (raw plaintext or fully upgraded TLS) can carry the reply.
+// any plaintext write would surface as garbage. Likewise a failed
+// direct-TLS attempt (directTLSFailed): the client opened with a TLS
+// ClientHello, so only TLS alerts — already sent by crypto/tls where
+// applicable — make sense on the wire. Every other startup state (raw
+// plaintext or fully upgraded TLS) can carry the reply.
 func (c *Conn) canSendPlaintextStartupError() bool {
+	if c.directTLSFailed {
+		return false
+	}
 	return !(c.sslDone && c.tlsConfig != nil && !c.tlsHandshakeComplete)
 }
 

--- a/go/common/pgprotocol/server/direct_tls.go
+++ b/go/common/pgprotocol/server/direct_tls.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Direct TLS (PostgreSQL 17 "sslnegotiation=direct") server-side support.
+//
+// PostgreSQL 17 added a TLS-first connection mode: instead of the classic
+// SSLRequest → 'S' → handshake dance, the client opens the TCP connection
+// and immediately sends a TLS ClientHello. The server disambiguates by
+// looking at the first byte — 0x16 is the TLS "handshake" record type and
+// can never start a legitimate startup packet (it would imply a length of
+// hundreds of megabytes, far past MaxStartupPacketLength).
+//
+// This mirrors ProcessSSLStartup in PostgreSQL's
+// src/backend/tcop/backend_startup.c, with the same hard requirements:
+//
+//   - Direct TLS is accepted whenever TLS is configured; there is no
+//     opt-in knob (PG 17 likewise has no GUC for it).
+//   - ALPN ("postgresql", RFC 7301) is MANDATORY for direct connections.
+//     A client that completes the handshake without negotiating it is
+//     rejected as a protocol violation. This is PG's cross-protocol-attack
+//     hardening: without ALPN, a generic TLS client (e.g. an HTTPS client
+//     coaxed into connecting here) could be replayed against the database.
+//     Negotiated (SSLRequest) connections keep ALPN optional, matching PG's
+//     compatibility posture for pre-17 clients.
+//   - When TLS is not configured, the connection is closed without writing
+//     anything: the peer is speaking TLS, so a plaintext ErrorResponse
+//     would be unintelligible garbage. PostgreSQL also rejects silently.
+//
+// This is the server half of the Envoy SSLRequest-offload model (MINT-37):
+// an edge proxy can answer the client's SSLRequest itself and forward the
+// raw TLS byte stream, which the gateway then sees as a direct TLS
+// connection.
+
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"slices"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+)
+
+// directTLSFirstByte is the first byte of every TLS record carrying a
+// handshake message (ContentType handshake = 22 = 0x16). PostgreSQL 17 uses
+// the same single-byte disambiguation between a TLS ClientHello and a
+// startup packet length word.
+const directTLSFirstByte = 0x16
+
+// maybeHandleDirectTLS peeks the first byte of a fresh connection and, when
+// it announces a TLS handshake, upgrades the connection via handleDirectTLS.
+// For anything else it returns nil without consuming bytes so the classic
+// startup-packet flow proceeds untouched.
+//
+// Runs exactly once per connection, before the first startup packet read —
+// the same point PostgreSQL calls ProcessSSLStartup. The peek blocks until
+// the client sends its first byte, covered by the same authentication
+// deadline that bounds the rest of the startup phase.
+func (c *Conn) maybeHandleDirectTLS() error {
+	firstByte, err := c.bufferedReader.Peek(1)
+	if err != nil {
+		// io.EOF here means the client connected and left without sending
+		// anything (port scanners, health checks). serve() recognizes the
+		// wrapped EOF and treats it as a clean disconnect, matching PG's
+		// "don't clutter the log" behavior.
+		return fmt.Errorf("failed to read first startup byte: %w", err)
+	}
+	if firstByte[0] != directTLSFirstByte {
+		return nil
+	}
+	return c.handleDirectTLS()
+}
+
+// handleDirectTLS performs the server-side direct TLS upgrade: handshake
+// first (replaying any ClientHello bytes the peek pulled into the buffered
+// reader), mandatory ALPN check second. On success c.conn is the *tls.Conn
+// and the caller reads the startup packet (or cancel request) over the
+// encrypted channel.
+func (c *Conn) handleDirectTLS() error {
+	c.logger.Debug("client initiated direct TLS handshake")
+
+	if c.tlsConfig == nil {
+		// PG parity: reject without writing anything. The client is
+		// mid-ClientHello; any plaintext bytes we emit would corrupt its
+		// TLS state machine rather than convey an error.
+		c.directTLSFailed = true
+		c.metrics().RecordDirectTLSRejected(c.ctx, DirectTLSRejectedReasonTLSDisabled)
+		c.logger.Warn("rejecting direct TLS connection: TLS is not configured",
+			"remote_addr", c.RemoteAddr())
+		return errors.New("direct TLS connection rejected: TLS is not configured")
+	}
+
+	// The single-byte peek may have pulled an arbitrary prefix of the
+	// ClientHello into the buffered reader (bufio reads as much as is
+	// available). Hand those bytes back to the TLS engine by replaying
+	// them ahead of the raw connection.
+	transport, err := c.replayBufferedBytes()
+	if err != nil {
+		c.directTLSFailed = true
+		return fmt.Errorf("direct TLS: %w", err)
+	}
+
+	tlsConn, err := c.completeTLSHandshake(transport, c.directTLSConfig(), TLSNegotiationDirect)
+	if err != nil {
+		// crypto/tls already sent the appropriate TLS alert; nothing
+		// intelligible can be written in plaintext after a TLS failure.
+		c.directTLSFailed = true
+		return fmt.Errorf("direct TLS: %w", err)
+	}
+
+	// ALPN is mandatory for direct TLS connections (PG 17 parity; see the
+	// package comment). A client that offered a non-"postgresql" ALPN list
+	// already failed the handshake above with a no_application_protocol
+	// alert; this branch catches clients that offered no ALPN at all.
+	//
+	// Divergence from PostgreSQL, deliberately: PG logs a COMMERROR and
+	// closes without telling the client anything. We have a fully
+	// established TLS channel at this point, so we return the FATAL
+	// PgDiagnostic (same wording, SQLSTATE 08P01 protocol_violation) and
+	// let serve()'s startup-error path deliver it through the tunnel —
+	// strictly more debuggable for the operator of a misconfigured client,
+	// and wire-safe because the bytes are encrypted.
+	if tlsConn.ConnectionState().NegotiatedProtocol != protocol.ALPNProtocol {
+		c.metrics().RecordDirectTLSRejected(c.ctx, DirectTLSRejectedReasonNoALPN)
+		c.logger.Warn("rejecting direct TLS connection: no ALPN protocol negotiated",
+			"remote_addr", c.RemoteAddr())
+		return mterrors.NewPgError("FATAL", mterrors.PgSSProtocolViolation,
+			"received direct SSL connection request without ALPN protocol negotiation extension", "")
+	}
+
+	return nil
+}
+
+// directTLSConfig returns the TLS config to use for a direct handshake,
+// guaranteeing the "postgresql" ALPN protocol is offered. ALPN is mandatory
+// for direct connections, so a listener config without NextProtos must not
+// cause a well-behaved libpq (which always offers ALPN in direct mode) to be
+// rejected just because Go ignored its offer. Configs that already advertise
+// the protocol — like multigateway's — are used as-is.
+func (c *Conn) directTLSConfig() *tls.Config {
+	if slices.Contains(c.tlsConfig.NextProtos, protocol.ALPNProtocol) {
+		return c.tlsConfig
+	}
+	cfg := c.tlsConfig.Clone()
+	cfg.NextProtos = append(cfg.NextProtos, protocol.ALPNProtocol)
+	return cfg
+}
+
+// replayBufferedBytes drains whatever the startup reader has buffered and
+// returns a net.Conn that replays those bytes before reading from the
+// underlying connection. crypto/tls must see the complete record stream from
+// its first byte, and the disambiguation peek may have buffered part (or
+// all) of the ClientHello.
+func (c *Conn) replayBufferedBytes() (net.Conn, error) {
+	buffered := c.bufferedReader.Buffered()
+	prefix := make([]byte, buffered)
+	if _, err := io.ReadFull(c.bufferedReader, prefix); err != nil {
+		return nil, fmt.Errorf("failed to drain buffered startup bytes: %w", err)
+	}
+	return &prefixConn{
+		Conn:   c.conn,
+		reader: io.MultiReader(bytes.NewReader(prefix), c.conn),
+	}, nil
+}
+
+// prefixConn is a net.Conn whose reads are served from a replay reader (the
+// buffered prefix followed by the underlying connection). Writes, deadlines,
+// addresses, and Close delegate to the embedded connection, so deadline
+// handling in serve() keeps working after the *tls.Conn wraps this.
+type prefixConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (p *prefixConn) Read(b []byte) (int, error) { return p.reader.Read(b) }

--- a/go/common/pgprotocol/server/direct_tls.go
+++ b/go/common/pgprotocol/server/direct_tls.go
@@ -136,13 +136,15 @@ func (c *Conn) handleDirectTLS() error {
 	// let serve()'s startup-error path deliver it through the tunnel —
 	// strictly more debuggable for the operator of a misconfigured client,
 	// and wire-safe because the bytes are encrypted.
-	if tlsConn.ConnectionState().NegotiatedProtocol != protocol.ALPNProtocol {
+	connState := tlsConn.ConnectionState()
+	if connState.NegotiatedProtocol != protocol.ALPNProtocol {
 		c.metrics().RecordDirectTLSRejected(c.ctx, DirectTLSRejectedReasonNoALPN)
 		c.logger.Warn("rejecting direct TLS connection: no ALPN protocol negotiated",
 			"remote_addr", c.RemoteAddr())
 		return mterrors.NewPgError("FATAL", mterrors.PgSSProtocolViolation,
 			"received direct SSL connection request without ALPN protocol negotiation extension", "")
 	}
+	c.metrics().RecordTLSConnection(c.ctx, TLSNegotiationDirect, connState.Version, connState.CipherSuite)
 
 	return nil
 }

--- a/go/common/pgprotocol/server/direct_tls_test.go
+++ b/go/common/pgprotocol/server/direct_tls_test.go
@@ -1,0 +1,523 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Direct-TLS (PostgreSQL 17 sslnegotiation=direct) server-side tests.
+//
+// The scenarios mirror the direct-SSL rows of PostgreSQL's connection
+// negotiation matrix in src/test/libpq/t/005_negotiate_encryption.pl and
+// the ALPN checks in src/test/ssl/t/001_ssltests.pl, translated to the
+// multigres unit-test harness:
+//
+//	server has SSL, client direct + ALPN          -> connect over TLS
+//	server has SSL, client direct without ALPN    -> reject (protocol violation)
+//	server has SSL, client direct with wrong ALPN -> handshake failure
+//	server lacks SSL, client direct               -> silently closed
+//	SSLRequest inside the direct tunnel           -> 'N' (decline, continue)
+//	cancel request over direct TLS                -> processed, conn closed
+
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/multigres/multigres/go/common/mterrors"
+	"github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// startDirectTLSServer accepts one connection on a fresh TCP listener,
+// builds a test Conn around it with the supplied TLS config, and runs
+// handleStartup, delivering the result on the returned channel. configure
+// (optional) tweaks the Conn before startup runs.
+func startDirectTLSServer(t *testing.T, tlsConfig *tls.Config, configure func(*Conn)) (net.Listener, <-chan error) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			errCh <- acceptErr
+			return
+		}
+		c := newTestConn(t, netConn, tlsConfig)
+		if configure != nil {
+			configure(c)
+		}
+		errCh <- c.handleStartup()
+	}()
+
+	return ln, errCh
+}
+
+// dialDirect opens a TCP connection and immediately performs a client-side
+// TLS handshake (no SSLRequest first) — the libpq sslnegotiation=direct
+// wire behavior. Returns the established *tls.Conn.
+func dialDirect(t *testing.T, addr string, clientCfg *tls.Config) *tls.Conn {
+	t.Helper()
+	raw, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { raw.Close() })
+	tlsConn := tls.Client(raw, clientCfg)
+	require.NoError(t, tlsConn.Handshake(), "direct TLS handshake should succeed")
+	return tlsConn
+}
+
+// TestDirectTLS_AcceptedWithALPN is the happy path: TLS-first connection
+// offering ALPN "postgresql" is admitted, and startup + SCRAM complete over
+// the encrypted channel. Mirrors 005_negotiate_encryption.pl's
+// sslnegotiation=direct / server ssl=on row.
+func TestDirectTLS_AcceptedWithALPN(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+	require.Equal(t, protocol.ALPNProtocol, tlsConn.ConnectionState().NegotiatedProtocol,
+		"server must negotiate the postgresql ALPN protocol")
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user":     "direct_user",
+		"database": "direct_db",
+	})
+	scramClientHelper(t, tlsConn, "direct_user", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_ServerConfigWithALPNPreset verifies the directTLSConfig
+// fast path: when the listener's TLS config already advertises
+// "postgresql" (multigateway's production shape), it is used as-is and the
+// connection is admitted.
+func TestDirectTLS_ServerConfigWithALPNPreset(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	tlsConfig.NextProtos = []string{protocol.ALPNProtocol}
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+	require.Equal(t, protocol.ALPNProtocol, tlsConn.ConnectionState().NegotiatedProtocol)
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user": "alpn_preset_user",
+	})
+	scramClientHelper(t, tlsConn, "alpn_preset_user", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_RejectedWithoutALPN: a client that completes the direct TLS
+// handshake without offering ALPN must be rejected with PostgreSQL's exact
+// diagnostic (SQLSTATE 08P01). Mirrors the server-side requirement added in
+// PG 17 (backend_startup.c: "received direct SSL connection request without
+// ALPN protocol negotiation extension").
+func TestDirectTLS_RejectedWithoutALPN(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	// No NextProtos: handshake succeeds (Go ignores absent ALPN) but the
+	// server's post-handshake gate must fire.
+	dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+
+	err := <-errCh
+	require.Error(t, err)
+	var diag *mterrors.PgDiagnostic
+	require.ErrorAs(t, err, &diag)
+	assert.Equal(t, "FATAL", diag.Severity)
+	assert.Equal(t, mterrors.PgSSProtocolViolation, diag.Code)
+	assert.Contains(t, diag.Message, "without ALPN protocol negotiation extension")
+}
+
+// TestDirectTLS_RejectedWithoutALPN_WireLevel drives the full serve() path
+// and asserts the FATAL ErrorResponse is delivered to the client through
+// the TLS tunnel, then the connection is closed.
+func TestDirectTLS_RejectedWithoutALPN_WireLevel(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	listener, err := NewListener(ListenerConfig{
+		Address:            "127.0.0.1:0",
+		Handler:            &mockHandler{},
+		CredentialProvider: newMockCredentialProvider("postgres"),
+		TLSConfig:          tlsConfig,
+		Logger:             testLogger(t),
+	})
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := listener.listener.Accept()
+		if acceptErr != nil {
+			serverErrCh <- acceptErr
+			return
+		}
+		c := newConn(netConn, listener, 1)
+		c.handler = listener.handler
+		c.credentialProvider = listener.credentialProvider
+		c.tlsConfig = listener.tlsConfig
+		serveErr := c.serve()
+		_ = c.Close()
+		serverErrCh <- serveErr
+	}()
+
+	tlsConn := dialDirect(t, listener.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		// No ALPN offered.
+	})
+	require.NoError(t, tlsConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	msgType, body := readMessage(t, tlsConn)
+	assert.Equal(t, byte(protocol.MsgErrorResponse), msgType)
+	assert.True(t, containsErrField(body, 'S', "FATAL"), "severity should be FATAL")
+	assert.True(t, containsErrField(body, 'C', "08P01"), "SQLSTATE should be 08P01 (protocol_violation)")
+
+	// Server closes after the FATAL — next read returns EOF/reset.
+	one := make([]byte, 1)
+	_, readErr := tlsConn.Read(one)
+	require.Error(t, readErr, "server must close connection after FATAL")
+
+	require.Error(t, <-serverErrCh)
+}
+
+// TestDirectTLS_RejectedWrongALPN: a client offering only non-PostgreSQL
+// ALPN protocols fails the handshake itself with a no_application_protocol
+// alert — the cross-protocol-attack hardening ALPN provides.
+func TestDirectTLS_RejectedWrongALPN(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer raw.Close()
+
+	tlsConn := tls.Client(raw, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+	})
+	require.Error(t, tlsConn.Handshake(), "handshake must fail when no ALPN protocol overlaps")
+
+	err = <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS handshake failed")
+}
+
+// TestDirectTLS_NoTLSConfig_ClosedSilently: when the server has no TLS
+// config, a TLS-first client is rejected by closing the connection without
+// writing anything — a plaintext ErrorResponse would be garbage inside the
+// client's TLS state machine. Mirrors PG's silent reject in
+// ProcessSSLStartup when !LoadedSSL.
+func TestDirectTLS_NoTLSConfig_ClosedSilently(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			serverErrCh <- acceptErr
+			return
+		}
+		c := newTestConn(t, netConn, nil) // no TLS config
+		serveErr := c.handleStartup()
+		// Mirror serve()'s error path decision: it must conclude that no
+		// plaintext reply can be sent.
+		assert.False(t, c.canSendPlaintextStartupError(),
+			"plaintext startup error must be suppressed after a direct TLS rejection")
+		_ = netConn.Close()
+		serverErrCh <- serveErr
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// First byte 0x16 marks a TLS ClientHello.
+	_, err = clientConn.Write([]byte{0x16, 0x03, 0x01, 0x00, 0x10, 0x01, 0x02, 0x03})
+	require.NoError(t, err)
+
+	serveErr := <-serverErrCh
+	require.Error(t, serveErr)
+	assert.Contains(t, serveErr.Error(), "TLS is not configured")
+
+	// The client must receive zero bytes before the close.
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	buf := make([]byte, 16)
+	n, readErr := clientConn.Read(buf)
+	assert.Equal(t, 0, n, "server must not write anything to a rejected direct TLS client")
+	assert.ErrorIs(t, readErr, io.EOF)
+}
+
+// TestDirectTLS_SSLRequestInTunnel_DeclinedWithN: PostgreSQL responds 'N'
+// to an SSLRequest that arrives inside an established direct TLS tunnel
+// (the ssl_in_use check in ProcessStartupPacket); the client then proceeds
+// with a regular StartupMessage on the same encrypted channel.
+func TestDirectTLS_SSLRequestInTunnel_DeclinedWithN(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+
+	// SSLRequest inside the tunnel.
+	writeSSLRequest(t, tlsConn)
+	require.Equal(t, byte('N'), readSingleByte(t, tlsConn),
+		"SSLRequest inside a direct TLS tunnel must be declined with 'N'")
+
+	// Continue with the normal startup on the same TLS channel.
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user": "tunnel_user",
+	})
+	scramClientHelper(t, tlsConn, "tunnel_user", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_GSSENCRequestInTunnel_Declined: GSSENCRequest inside the
+// tunnel is declined with 'N' (we never support GSS encryption), and
+// startup continues.
+func TestDirectTLS_GSSENCRequestInTunnel_Declined(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+
+	writeGSSENCRequest(t, tlsConn)
+	require.Equal(t, byte('N'), readSingleByte(t, tlsConn))
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user": "gss_tunnel_user",
+	})
+	scramClientHelper(t, tlsConn, "gss_tunnel_user", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_RequireTLS_Admitted: a direct TLS client satisfies the
+// --pg-require-ssl posture (tlsHandshakeComplete is set before the
+// StartupMessage is read), so the plaintext-rejection gate must not fire.
+func TestDirectTLS_RequireTLS_Admitted(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, func(c *Conn) {
+		c.requireTLS = true
+	})
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user": "require_direct_user",
+	})
+	scramClientHelper(t, tlsConn, "require_direct_user", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_SCRAMPlusChannelBinding: the server certificate captured
+// during the direct handshake must feed SCRAM-SHA-256-PLUS channel binding,
+// exactly as on the negotiated path.
+func TestDirectTLS_SCRAMPlusChannelBinding(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+
+	writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+		"user": "scram_plus_direct",
+	})
+	scramPlusClientHelper(t, tlsConn, "scram_plus_direct", "postgres")
+
+	require.NoError(t, <-errCh)
+}
+
+// TestDirectTLS_CancelRequest: a CancelRequest may follow the direct TLS
+// handshake instead of a StartupMessage (libpq sends cancels through the
+// same encryption negotiation it used for the original connection). The
+// request is processed and the connection closed without a reply.
+func TestDirectTLS_CancelRequest(t *testing.T) {
+	tlsConfig, caPool := generateTestTLSConfig(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	listener := testListener(t)
+	connCh := make(chan *Conn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		netConn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			errCh <- acceptErr
+			return
+		}
+		c := newConn(netConn, listener, 1)
+		c.handler = listener.handler
+		c.credentialProvider = listener.credentialProvider
+		c.tlsConfig = tlsConfig
+		connCh <- c
+		errCh <- c.handleStartup()
+	}()
+
+	tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+		RootCAs:    caPool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{protocol.ALPNProtocol},
+	})
+
+	// CancelRequest over the tunnel.
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(16))
+	_ = binary.Write(&buf, binary.BigEndian, uint32(protocol.CancelRequestCode))
+	_ = binary.Write(&buf, binary.BigEndian, uint32(12345)) // PID
+	_ = binary.Write(&buf, binary.BigEndian, uint32(67890)) // secret
+	_, err = tlsConn.Write(buf.Bytes())
+	require.NoError(t, err)
+
+	c := <-connCh
+	require.NoError(t, <-errCh)
+	assert.True(t, c.closed.Load(), "connection must be closed after a cancel request")
+}
+
+// TestDirectTLS_TLS11Rejected: MinVersion enforcement applies to the direct
+// path the same as the negotiated one. Mirrors 001_ssltests.pl's TLS
+// version-range coverage.
+func TestDirectTLS_TLS11Rejected(t *testing.T) {
+	tlsConfig, _ := generateTestTLSConfig(t)
+	ln, errCh := startDirectTLSServer(t, tlsConfig, nil)
+
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer raw.Close()
+
+	//nolint:gosec // G402: intentionally using TLS 1.1 to test version enforcement
+	tlsConn := tls.Client(raw, &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS10,
+		MaxVersion:         tls.VersionTLS11,
+		NextProtos:         []string{protocol.ALPNProtocol},
+	})
+	require.Error(t, tlsConn.Handshake(), "TLS 1.1 must be rejected")
+
+	// Unblock the server's handshake read in case the client aborted
+	// without sending a ClientHello.
+	raw.Close()
+
+	err = <-errCh
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS handshake failed")
+}
+
+// TestDirectTLS_DisconnectBeforeFirstByte: a client that connects and
+// disconnects without sending anything surfaces as a wrapped io.EOF, which
+// serve() suppresses as a clean disconnect (matching PG's "don't clutter
+// the log" rule in ProcessSSLStartup).
+func TestDirectTLS_DisconnectBeforeFirstByte(t *testing.T) {
+	ln, errCh := startDirectTLSServer(t, nil, nil)
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	clientConn.Close()
+
+	err = <-errCh
+	require.Error(t, err)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestDirectTLS_PGProtocolClientLoopback wires the in-repo pgprotocol
+// client's sslnegotiation=direct mode against this package's listener — a
+// full loopback of multigres' own client and server direct-TLS
+// implementations including SCRAM auth over the tunnel.
+func TestDirectTLS_PGProtocolClientLoopback(t *testing.T) {
+	tlsConfig, _ := generateTestTLSConfig(t)
+
+	listener, err := NewListener(ListenerConfig{
+		Address:            "127.0.0.1:0",
+		Handler:            &mockHandler{},
+		CredentialProvider: newMockCredentialProvider("postgres"),
+		TLSConfig:          tlsConfig,
+		Logger:             testLogger(t),
+	})
+	require.NoError(t, err)
+	defer listener.Close()
+	go func() { _ = listener.Serve() }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	clientTLS, err := client.BuildTLSConfig(client.SSLModeRequire, "", "")
+	require.NoError(t, err)
+
+	ctx := utils.WithTimeout(t, 10*time.Second)
+	conn, err := client.Connect(ctx, ctx, &client.Config{
+		Host:           "127.0.0.1",
+		Port:           tcpAddr.Port,
+		User:           "loopback_user",
+		Password:       "postgres",
+		Database:       "loopback_db",
+		SSLMode:        client.SSLModeRequire,
+		SSLNegotiation: client.SSLNegotiationDirect,
+		TLSConfig:      clientTLS,
+		DialTimeout:    5 * time.Second,
+	})
+	require.NoError(t, err, "direct TLS loopback connect must succeed")
+	defer conn.Close()
+}

--- a/go/common/pgprotocol/server/direct_tls_test.go
+++ b/go/common/pgprotocol/server/direct_tls_test.go
@@ -30,6 +30,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"io"
@@ -72,6 +73,37 @@ func startDirectTLSServer(t *testing.T, tlsConfig *tls.Config, configure func(*C
 	}()
 
 	return ln, errCh
+}
+
+type recordingAuthMetrics struct {
+	tlsHandshakes  map[string]int
+	tlsConnections []string
+	directRejected map[string]int
+}
+
+func newRecordingAuthMetrics() *recordingAuthMetrics {
+	return &recordingAuthMetrics{
+		tlsHandshakes:  make(map[string]int),
+		directRejected: make(map[string]int),
+	}
+}
+
+func (r *recordingAuthMetrics) RecordSCRAMDuration(context.Context, string, time.Duration) {}
+func (r *recordingAuthMetrics) RecordAuthAttempt(context.Context, string)                  {}
+func (r *recordingAuthMetrics) RecordCredentialLookup(context.Context, time.Duration)      {}
+func (r *recordingAuthMetrics) RecordPlaintextRejected(context.Context, string)            {}
+func (r *recordingAuthMetrics) RecordSSLRequestDeclined(context.Context)                   {}
+
+func (r *recordingAuthMetrics) RecordTLSHandshake(_ context.Context, negotiation, outcome string, _ time.Duration) {
+	r.tlsHandshakes[negotiation+"/"+outcome]++
+}
+
+func (r *recordingAuthMetrics) RecordTLSConnection(_ context.Context, negotiation string, _, _ uint16) {
+	r.tlsConnections = append(r.tlsConnections, negotiation)
+}
+
+func (r *recordingAuthMetrics) RecordDirectTLSRejected(_ context.Context, reason string) {
+	r.directRejected[reason]++
 }
 
 // dialDirect opens a TCP connection and immediately performs a client-side
@@ -162,6 +194,54 @@ func TestDirectTLS_RejectedWithoutALPN(t *testing.T) {
 	assert.Equal(t, "FATAL", diag.Severity)
 	assert.Equal(t, mterrors.PgSSProtocolViolation, diag.Code)
 	assert.Contains(t, diag.Message, "without ALPN protocol negotiation extension")
+}
+
+func TestDirectTLS_MetricsCountOnlyAdmittedConnections(t *testing.T) {
+	t.Run("missing ALPN is rejected but not counted as a TLS connection", func(t *testing.T) {
+		tlsConfig, caPool := generateTestTLSConfig(t)
+		metrics := newRecordingAuthMetrics()
+		ln, errCh := startDirectTLSServer(t, tlsConfig, func(c *Conn) {
+			c.authMetrics = metrics
+		})
+
+		dialDirect(t, ln.Addr().String(), &tls.Config{
+			RootCAs:    caPool,
+			ServerName: "localhost",
+			MinVersion: tls.VersionTLS12,
+		})
+
+		err := <-errCh
+		require.Error(t, err)
+		assert.Equal(t, 1, metrics.tlsHandshakes[TLSNegotiationDirect+"/"+TLSOutcomeSuccess],
+			"TLS handshake still completed successfully")
+		assert.Empty(t, metrics.tlsConnections,
+			"ALPN-rejected direct TLS must not be counted as an admitted TLS connection")
+		assert.Equal(t, 1, metrics.directRejected[DirectTLSRejectedReasonNoALPN])
+	})
+
+	t.Run("accepted direct TLS is counted after ALPN validation", func(t *testing.T) {
+		tlsConfig, caPool := generateTestTLSConfig(t)
+		metrics := newRecordingAuthMetrics()
+		ln, errCh := startDirectTLSServer(t, tlsConfig, func(c *Conn) {
+			c.authMetrics = metrics
+		})
+
+		tlsConn := dialDirect(t, ln.Addr().String(), &tls.Config{
+			RootCAs:    caPool,
+			ServerName: "localhost",
+			MinVersion: tls.VersionTLS12,
+			NextProtos: []string{protocol.ALPNProtocol},
+		})
+		writeStartupPacketToPipe(t, tlsConn, protocol.ProtocolVersionNumber, map[string]string{
+			"user": "metrics_direct_user",
+		})
+		scramClientHelper(t, tlsConn, "metrics_direct_user", "postgres")
+
+		require.NoError(t, <-errCh)
+		assert.Equal(t, 1, metrics.tlsHandshakes[TLSNegotiationDirect+"/"+TLSOutcomeSuccess])
+		assert.Equal(t, []string{TLSNegotiationDirect}, metrics.tlsConnections)
+		assert.Empty(t, metrics.directRejected)
+	})
 }
 
 // TestDirectTLS_RejectedWithoutALPN_WireLevel drives the full serve() path

--- a/go/common/pgprotocol/server/metrics.go
+++ b/go/common/pgprotocol/server/metrics.go
@@ -96,11 +96,13 @@ type AuthMetricsRecorder interface {
 	// handshake wall-clock duration, and one of the TLSOutcome* values.
 	RecordTLSHandshake(ctx context.Context, negotiation, outcome string, d time.Duration)
 
-	// RecordTLSConnection is called once per connection that completed
+	// RecordTLSConnection is called once per admitted connection that completed
 	// TLS negotiation, tagged with the negotiation style (one of the
 	// TLSNegotiation* values) plus the negotiated tls_version and
 	// cipher_suite (raw uint16 values from crypto/tls; the recorder
-	// stringifies via tls.VersionName / tls.CipherSuiteName).
+	// stringifies via tls.VersionName / tls.CipherSuiteName). Direct-TLS
+	// handshakes rejected after TLS (for example, missing ALPN) are tracked via
+	// RecordDirectTLSRejected but are not counted here.
 	RecordTLSConnection(ctx context.Context, negotiation string, version, cipher uint16)
 
 	// RecordDirectTLSRejected is called when a direct-TLS (TLS-first)

--- a/go/common/pgprotocol/server/metrics.go
+++ b/go/common/pgprotocol/server/metrics.go
@@ -43,6 +43,24 @@ const (
 	TLSOutcomeClientAborted    = "client_aborted"
 )
 
+// TLS negotiation-style label values: how the TLS session was established.
+// "negotiated" is the classic SSLRequest → 'S' upgrade; "direct" is the
+// PostgreSQL 17 TLS-first handshake (libpq sslnegotiation=direct), where
+// the client opens with a TLS ClientHello instead of an SSLRequest.
+const (
+	TLSNegotiationNegotiated = "negotiated"
+	TLSNegotiationDirect     = "direct"
+)
+
+// Direct-TLS rejection reason labels. Bounded set, mirroring the two
+// rejection sites in handleDirectTLS: the server has no TLS config at all,
+// or the client completed the handshake without negotiating the mandatory
+// "postgresql" ALPN protocol (PG 17 rejects that as a protocol violation).
+const (
+	DirectTLSRejectedReasonTLSDisabled = "tls_not_configured"
+	DirectTLSRejectedReasonNoALPN      = "alpn_missing"
+)
+
 // Plaintext-rejection reason labels.
 const (
 	PlaintextRejectedReasonNoSSLRequest        = "no_sslrequest"
@@ -73,15 +91,24 @@ type AuthMetricsRecorder interface {
 	// future cache work has a baseline.
 	RecordCredentialLookup(ctx context.Context, d time.Duration)
 
-	// RecordTLSHandshake is called once per TLS negotiation with the
-	// handshake wall-clock duration and one of the TLSOutcome* values.
-	RecordTLSHandshake(ctx context.Context, outcome string, d time.Duration)
+	// RecordTLSHandshake is called once per TLS handshake attempt with
+	// the negotiation style (one of the TLSNegotiation* values), the
+	// handshake wall-clock duration, and one of the TLSOutcome* values.
+	RecordTLSHandshake(ctx context.Context, negotiation, outcome string, d time.Duration)
 
 	// RecordTLSConnection is called once per connection that completed
-	// TLS negotiation, tagged with the negotiated tls_version and
+	// TLS negotiation, tagged with the negotiation style (one of the
+	// TLSNegotiation* values) plus the negotiated tls_version and
 	// cipher_suite (raw uint16 values from crypto/tls; the recorder
 	// stringifies via tls.VersionName / tls.CipherSuiteName).
-	RecordTLSConnection(ctx context.Context, version, cipher uint16)
+	RecordTLSConnection(ctx context.Context, negotiation string, version, cipher uint16)
+
+	// RecordDirectTLSRejected is called when a direct-TLS (TLS-first)
+	// connection attempt is rejected before a session is admitted,
+	// tagged with one of the DirectTLSRejectedReason* values. Useful
+	// during the Envoy SSLRequest-offload rollout to spot fleets whose
+	// gateway lacks TLS config or whose clients omit ALPN.
+	RecordDirectTLSRejected(ctx context.Context, reason string)
 
 	// RecordPlaintextRejected is called when a plaintext StartupMessage
 	// arrives on a RequireTLS listener, tagged with one of the
@@ -99,13 +126,14 @@ type AuthMetricsRecorder interface {
 // unconditionally. Eliminates per-call nil checks at every emission site.
 type noopAuthMetrics struct{}
 
-func (noopAuthMetrics) RecordSCRAMDuration(context.Context, string, time.Duration) {}
-func (noopAuthMetrics) RecordAuthAttempt(context.Context, string)                  {}
-func (noopAuthMetrics) RecordCredentialLookup(context.Context, time.Duration)      {}
-func (noopAuthMetrics) RecordTLSHandshake(context.Context, string, time.Duration)  {}
-func (noopAuthMetrics) RecordTLSConnection(context.Context, uint16, uint16)        {}
-func (noopAuthMetrics) RecordPlaintextRejected(context.Context, string)            {}
-func (noopAuthMetrics) RecordSSLRequestDeclined(context.Context)                   {}
+func (noopAuthMetrics) RecordSCRAMDuration(context.Context, string, time.Duration)        {}
+func (noopAuthMetrics) RecordAuthAttempt(context.Context, string)                         {}
+func (noopAuthMetrics) RecordCredentialLookup(context.Context, time.Duration)             {}
+func (noopAuthMetrics) RecordTLSHandshake(context.Context, string, string, time.Duration) {}
+func (noopAuthMetrics) RecordTLSConnection(context.Context, string, uint16, uint16)       {}
+func (noopAuthMetrics) RecordDirectTLSRejected(context.Context, string)                   {}
+func (noopAuthMetrics) RecordPlaintextRejected(context.Context, string)                   {}
+func (noopAuthMetrics) RecordSSLRequestDeclined(context.Context)                          {}
 
 // metrics returns the connection's auth metrics sink, substituting a noop
 // when none was injected. Tests that construct *Conn directly (rather than

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -88,7 +88,18 @@ func parseReplicationMode(value string) (ReplicationMode, error) {
 // handleStartup handles the initial connection startup phase.
 // This includes SSL/GSSAPI encryption negotiation and processing the startup message.
 // Returns an error if the startup fails.
+//
+// Direct-TLS detection runs first, before any startup packet is read — the
+// same ordering as PostgreSQL 17, where ProcessSSLStartup peeks the first
+// byte ahead of ProcessStartupPacket (src/backend/tcop/backend_startup.c).
+// A client that opens with a TLS ClientHello (libpq sslnegotiation=direct,
+// or an Envoy edge that answered the SSLRequest itself and forwards the raw
+// TLS stream) is upgraded in maybeHandleDirectTLS; everyone else falls
+// through to the classic startup-packet dispatch untouched.
 func (c *Conn) handleStartup() error {
+	if err := c.maybeHandleDirectTLS(); err != nil {
+		return err
+	}
 	return c.readAndDispatchStartup()
 }
 
@@ -161,10 +172,20 @@ func (c *Conn) readAndDispatchStartup() error {
 func (c *Conn) handleSSLRequest() error {
 	c.sslDone = true
 
-	if c.tlsConfig == nil {
-		// No TLS configured, decline SSL.
-		c.logger.Debug("client requested SSL, declining (no TLS config)")
-		c.metrics().RecordSSLRequestDeclined(c.ctx)
+	if c.tlsConfig == nil || c.tlsHandshakeComplete {
+		if c.tlsHandshakeComplete {
+			// SSLRequest arriving inside an already-established TLS tunnel
+			// (the client connected with direct TLS and then sent an
+			// SSLRequest anyway). PostgreSQL declines with 'N' here rather
+			// than erroring — the `port->ssl_in_use` check in
+			// ProcessStartupPacket — so the client falls through to a
+			// regular StartupMessage on the existing encrypted channel.
+			c.logger.Debug("client requested SSL inside TLS tunnel, declining")
+		} else {
+			// No TLS configured, decline SSL.
+			c.logger.Debug("client requested SSL, declining (no TLS config)")
+			c.metrics().RecordSSLRequestDeclined(c.ctx)
+		}
 		if err := c.writeRawByte('N'); err != nil {
 			return fmt.Errorf("failed to send SSL response: %w", err)
 		}
@@ -191,31 +212,51 @@ func (c *Conn) handleSSLRequest() error {
 		return fmt.Errorf("received unencrypted data after SSL request: possible man-in-the-middle attack (buffered %d bytes)", c.bufferedReader.Buffered())
 	}
 
+	if _, err := c.completeTLSHandshake(c.conn, c.tlsConfig, TLSNegotiationNegotiated); err != nil {
+		return err
+	}
+
+	// Read the actual startup message over the encrypted connection.
+	return c.readAndDispatchStartup()
+}
+
+// completeTLSHandshake runs the server-side TLS handshake on transport using
+// the supplied base config, records the handshake metrics tagged with the
+// negotiation style (negotiated vs direct), and on success installs the TLS
+// connection as this connection's transport: c.conn is swapped to the
+// *tls.Conn, the buffered reader is reset onto it, and tlsHandshakeComplete
+// is set. It also captures the server leaf certificate so SCRAM-SHA-256-PLUS
+// channel binding can be advertised.
+//
+// transport is the conn the TLS engine should read/write — c.conn for the
+// negotiated path, or a replay wrapper for the direct path where part of the
+// ClientHello already sits in the buffered reader.
+func (c *Conn) completeTLSHandshake(transport net.Conn, baseCfg *tls.Config, negotiation string) (*tls.Conn, error) {
 	// Wrap the TLS config so dynamic-cert deployments (GetCertificate /
 	// GetConfigForClient, typical for SNI multi-tenant edges) capture the
 	// actually-selected leaf cert into c.tlsServerCert during the handshake.
 	// Static Certificates[0] deployments are handled by the post-handshake
 	// fallback below and skip the wrapper.
-	handshakeCfg := wrapTLSConfigForCertCapture(c.tlsConfig, c.captureTLSServerCert)
+	handshakeCfg := wrapTLSConfigForCertCapture(baseCfg, c.captureTLSServerCert)
 
 	// Perform TLS handshake. Time it for mg.gateway.tls.handshake.duration
 	// and classify the outcome so the fleet-validation alert can tell a
 	// crypto failure from a client tear-down. net.ErrClosed / io.EOF map
 	// to client_aborted; everything else is treated as a handshake_failure.
-	tlsConn := tls.Server(c.conn, handshakeCfg)
+	tlsConn := tls.Server(transport, handshakeCfg)
 	handshakeStart := time.Now()
 	if err := tlsConn.Handshake(); err != nil {
 		outcome := TLSOutcomeHandshakeFailure
 		if isClientAbortError(err) {
 			outcome = TLSOutcomeClientAborted
 		}
-		c.metrics().RecordTLSHandshake(c.ctx, outcome, time.Since(handshakeStart))
-		return fmt.Errorf("TLS handshake failed: %w", err)
+		c.metrics().RecordTLSHandshake(c.ctx, negotiation, outcome, time.Since(handshakeStart))
+		return nil, fmt.Errorf("TLS handshake failed: %w", err)
 	}
 	handshakeDuration := time.Since(handshakeStart)
-	c.metrics().RecordTLSHandshake(c.ctx, TLSOutcomeSuccess, handshakeDuration)
+	c.metrics().RecordTLSHandshake(c.ctx, negotiation, TLSOutcomeSuccess, handshakeDuration)
 	connState := tlsConn.ConnectionState()
-	c.metrics().RecordTLSConnection(c.ctx, connState.Version, connState.CipherSuite)
+	c.metrics().RecordTLSConnection(c.ctx, negotiation, connState.Version, connState.CipherSuite)
 
 	// Replace the underlying connection and reset the buffered reader
 	// to read from the TLS connection. The buffered writer is nil during
@@ -230,8 +271,8 @@ func (c *Conn) handleSSLRequest() error {
 	// the dynamic wrapper above is a no-op and the cert was not captured.
 	// Recover it from Certificates[0] here. A parse failure is non-fatal —
 	// auth simply falls back to SCRAM-SHA-256 without channel binding.
-	if c.tlsServerCert == nil && len(c.tlsConfig.Certificates) > 0 {
-		cert := &c.tlsConfig.Certificates[0]
+	if c.tlsServerCert == nil && len(baseCfg.Certificates) > 0 {
+		cert := &baseCfg.Certificates[0]
 		switch {
 		case cert.Leaf != nil:
 			c.tlsServerCert = cert.Leaf
@@ -245,11 +286,11 @@ func (c *Conn) handleSSLRequest() error {
 	}
 
 	c.logger.Info("TLS connection established",
-		"version", tlsConn.ConnectionState().Version,
-		"cipher_suite", tls.CipherSuiteName(tlsConn.ConnectionState().CipherSuite))
+		"negotiation", negotiation,
+		"version", connState.Version,
+		"cipher_suite", tls.CipherSuiteName(connState.CipherSuite))
 
-	// Read the actual startup message over the encrypted connection.
-	return c.readAndDispatchStartup()
+	return tlsConn, nil
 }
 
 // handleGSSENCRequest handles a GSSAPI encryption request.

--- a/go/common/pgprotocol/server/startup.go
+++ b/go/common/pgprotocol/server/startup.go
@@ -212,17 +212,20 @@ func (c *Conn) handleSSLRequest() error {
 		return fmt.Errorf("received unencrypted data after SSL request: possible man-in-the-middle attack (buffered %d bytes)", c.bufferedReader.Buffered())
 	}
 
-	if _, err := c.completeTLSHandshake(c.conn, c.tlsConfig, TLSNegotiationNegotiated); err != nil {
+	tlsConn, err := c.completeTLSHandshake(c.conn, c.tlsConfig, TLSNegotiationNegotiated)
+	if err != nil {
 		return err
 	}
+	connState := tlsConn.ConnectionState()
+	c.metrics().RecordTLSConnection(c.ctx, TLSNegotiationNegotiated, connState.Version, connState.CipherSuite)
 
 	// Read the actual startup message over the encrypted connection.
 	return c.readAndDispatchStartup()
 }
 
 // completeTLSHandshake runs the server-side TLS handshake on transport using
-// the supplied base config, records the handshake metrics tagged with the
-// negotiation style (negotiated vs direct), and on success installs the TLS
+// the supplied base config, records the handshake-attempt metrics tagged with
+// the negotiation style (negotiated vs direct), and on success installs the TLS
 // connection as this connection's transport: c.conn is swapped to the
 // *tls.Conn, the buffered reader is reset onto it, and tlsHandshakeComplete
 // is set. It also captures the server leaf certificate so SCRAM-SHA-256-PLUS
@@ -256,7 +259,6 @@ func (c *Conn) completeTLSHandshake(transport net.Conn, baseCfg *tls.Config, neg
 	handshakeDuration := time.Since(handshakeStart)
 	c.metrics().RecordTLSHandshake(c.ctx, negotiation, TLSOutcomeSuccess, handshakeDuration)
 	connState := tlsConn.ConnectionState()
-	c.metrics().RecordTLSConnection(c.ctx, negotiation, connState.Version, connState.CipherSuite)
 
 	// Replace the underlying connection and reset the buffered reader
 	// to read from the TLS connection. The buffered writer is nil during

--- a/go/observability/metriccatalog/catalog_generated.go
+++ b/go/observability/metriccatalog/catalog_generated.go
@@ -54,7 +54,7 @@ type Metric struct {
 }
 
 // Metrics is the catalog of every metric Multigres defines, sorted by OTel name.
-// There are 79 metrics.
+// There are 80 metrics.
 var Metrics = []Metric{
 	{
 		OTelName:       "db.client.connection.count",
@@ -72,7 +72,7 @@ var Metrics = []Metric{
 		Unit:           "{attempt}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:90",
+		Source:         "go/services/multigateway/metrics.go:91",
 		PrometheusName: "mg_gateway_auth_attempts_total",
 		Series:         []string{"mg_gateway_auth_attempts_total"},
 	},
@@ -82,7 +82,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:100",
+		Source:         "go/services/multigateway/metrics.go:101",
 		PrometheusName: "mg_gateway_auth_credential_lookup_duration_seconds",
 		Series:         []string{"mg_gateway_auth_credential_lookup_duration_seconds_bucket", "mg_gateway_auth_credential_lookup_duration_seconds_count", "mg_gateway_auth_credential_lookup_duration_seconds_sum"},
 	},
@@ -92,7 +92,7 @@ var Metrics = []Metric{
 		Unit:           "{lookup}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:111",
+		Source:         "go/services/multigateway/metrics.go:112",
 		PrometheusName: "mg_gateway_auth_credential_lookup_rate_total",
 		Series:         []string{"mg_gateway_auth_credential_lookup_rate_total"},
 	},
@@ -102,7 +102,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:79",
+		Source:         "go/services/multigateway/metrics.go:80",
 		PrometheusName: "mg_gateway_auth_scram_duration_seconds",
 		Series:         []string{"mg_gateway_auth_scram_duration_seconds_bucket", "mg_gateway_auth_scram_duration_seconds_count", "mg_gateway_auth_scram_duration_seconds_sum"},
 	},
@@ -112,7 +112,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:70",
+		Source:         "go/services/multigateway/metrics.go:71",
 		PrometheusName: "mg_gateway_client_connections",
 		Series:         []string{"mg_gateway_client_connections"},
 	},
@@ -202,9 +202,19 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:132",
+		Source:         "go/services/multigateway/metrics.go:133",
 		PrometheusName: "mg_gateway_tls_connections_total",
 		Series:         []string{"mg_gateway_tls_connections_total"},
+	},
+	{
+		OTelName:       "mg.gateway.tls.direct_rejected",
+		Constructor:    "Int64Counter",
+		Unit:           "{connection}",
+		Package:        "github.com/multigres/multigres/go/services/multigateway",
+		Binaries:       []string{"multigateway"},
+		Source:         "go/services/multigateway/metrics.go:163",
+		PrometheusName: "mg_gateway_tls_direct_rejected_total",
+		Series:         []string{"mg_gateway_tls_direct_rejected_total"},
 	},
 	{
 		OTelName:       "mg.gateway.tls.handshake.duration",
@@ -212,7 +222,7 @@ var Metrics = []Metric{
 		Unit:           "s",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:121",
+		Source:         "go/services/multigateway/metrics.go:122",
 		PrometheusName: "mg_gateway_tls_handshake_duration_seconds",
 		Series:         []string{"mg_gateway_tls_handshake_duration_seconds_bucket", "mg_gateway_tls_handshake_duration_seconds_count", "mg_gateway_tls_handshake_duration_seconds_sum"},
 	},
@@ -222,7 +232,7 @@ var Metrics = []Metric{
 		Unit:           "{connection}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:142",
+		Source:         "go/services/multigateway/metrics.go:143",
 		PrometheusName: "mg_gateway_tls_plaintext_rejected_total",
 		Series:         []string{"mg_gateway_tls_plaintext_rejected_total"},
 	},
@@ -232,7 +242,7 @@ var Metrics = []Metric{
 		Unit:           "{request}",
 		Package:        "github.com/multigres/multigres/go/services/multigateway",
 		Binaries:       []string{"multigateway"},
-		Source:         "go/services/multigateway/metrics.go:152",
+		Source:         "go/services/multigateway/metrics.go:153",
 		PrometheusName: "mg_gateway_tls_sslrequest_declined_total",
 		Series:         []string{"mg_gateway_tls_sslrequest_declined_total"},
 	},
@@ -857,7 +867,7 @@ var Metrics = []Metric{
 //     action: keep
 //
 // Histogram families collapse to a "<base>_(bucket|count|sum)" group.
-const PrometheusKeepListRegex = `db_client_connection_count|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|pgbackrest_backup_attempts_total|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
+const PrometheusKeepListRegex = `db_client_connection_count|mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|pgbackrest_backup_attempts_total|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|pgbackrest_server_restart_count|pgbackrest_server_up|pgbackrest_server_uptime|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`
 
 // PrometheusKeepListByBinary maps each binary to a keep-list regex covering only
 // the series that binary exposes, for scoping a keep rule per Prometheus scrape
@@ -866,7 +876,7 @@ const PrometheusKeepListRegex = `db_client_connection_count|mg_gateway_auth_atte
 // links them.
 var PrometheusKeepListByBinary = map[string]string{
 	"multiadmin":   `rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
-	"multigateway": `mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
+	"multigateway": `mg_gateway_auth_attempts_total|mg_gateway_auth_credential_lookup_duration_seconds_(bucket|count|sum)|mg_gateway_auth_credential_lookup_rate_total|mg_gateway_auth_scram_duration_seconds_(bucket|count|sum)|mg_gateway_client_connections|mg_gateway_notification_streams|mg_gateway_notifications_dropped_total|mg_gateway_query_duration_seconds_(bucket|count|sum)|mg_gateway_query_errors_total|mg_gateway_query_info|mg_gateway_query_log_emits_total|mg_gateway_query_rows_returned_(bucket|count|sum)|mg_gateway_query_table_queries_total|mg_gateway_tls_connections_total|mg_gateway_tls_direct_rejected_total|mg_gateway_tls_handshake_duration_seconds_(bucket|count|sum)|mg_gateway_tls_plaintext_rejected_total|mg_gateway_tls_sslrequest_declined_total|mg_gateway_transaction_count_total|mg_gateway_transaction_duration_seconds_(bucket|count|sum)|mg_plancache_hits_total|mg_plancache_misses_total|mg_scatter_execute_duration_seconds_(bucket|count|sum)|mg_scatter_execute_errors_total|multigateway_buffer_failover_duration_seconds_(bucket|count|sum)|multigateway_buffer_failovers_total|multigateway_buffer_queue_depth|multigateway_buffer_requests_buffered_total|multigateway_buffer_requests_drained_total|multigateway_buffer_requests_evicted_total|multigateway_buffer_requests_skipped_total|multigateway_buffer_wait_duration_seconds_(bucket|count|sum)|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multigres":    `topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multiorch":    `multiorch_recovery_action_duration_milliseconds_(bucket|count|sum)|multiorch_recovery_detected_problems|multiorch_recovery_errors_total|multiorch_recovery_pooler_store_size|multiorch_recovery_stream_connected|multiorch_recovery_stream_snapshots_received|rpcclient_connection_cache_size|rpcclient_connection_creates_total|rpcclient_connection_dial_duration_seconds_(bucket|count|sum)|rpcclient_connection_dial_timeouts_total|rpcclient_connection_reuses_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,
 	"multipooler":  `db_client_connection_count|mg_pooler_auth_credential_query_duration_seconds_(bucket|count|sum)|mg_pooler_auth_credential_query_errors_total|mg_pooler_client_wait_time_seconds_total|mg_pooler_client_waiting_connections|mg_pooler_config_max_server_connections|mg_pooler_databases|mg_pooler_drain_duration_seconds_(bucket|count|sum)|mg_pooler_drain_force_closed_total|mg_pooler_drain_outcome_total|mg_pooler_pool_capacity|mg_pooler_pool_current_connections|mg_pooler_pools|mg_pooler_queries_pooled_total|mg_pooler_reserved_active_connections|mg_pooler_server_connections|mg_pooler_up|mg_pooler_users|mg_pubsub_channels|mg_pubsub_notifications_dropped_total|mg_pubsub_reconnect_gap_duration_seconds_(bucket|count|sum)|mg_pubsub_reconnects_total|mg_pubsub_subscribers|pgbackrest_backup_attempts_total|pgbackrest_backup_duration_seconds_(bucket|count|sum)|pgbackrest_backup_failures_total|pgbackrest_backup_lock_wait_seconds_(bucket|count|sum)|pgbackrest_backup_successes_total|pgbackrest_backup_verify_duration_seconds_(bucket|count|sum)|pgbackrest_restore_attempts_total|pgbackrest_restore_duration_seconds_(bucket|count|sum)|pgbackrest_restore_failures_total|pgbackrest_restore_successes_total|topoclient_lock_duration_seconds_(bucket|count|sum)`,

--- a/go/services/multigateway/metrics.go
+++ b/go/services/multigateway/metrics.go
@@ -55,6 +55,7 @@ type GatewayMetrics struct {
 	tlsConnections        metric.Int64Counter
 	tlsPlaintextRejected  metric.Int64Counter
 	tlsSSLRequestDeclined metric.Int64Counter
+	tlsDirectRejected     metric.Int64Counter
 }
 
 // NewGatewayMetrics initializes OTel metrics for the multigateway service.
@@ -159,6 +160,16 @@ func NewGatewayMetrics() (*GatewayMetrics, error) {
 		m.tlsSSLRequestDeclined = noop.Int64Counter{}
 	}
 
+	m.tlsDirectRejected, err = meter.Int64Counter(
+		"mg.gateway.tls.direct_rejected",
+		metric.WithDescription("Direct-TLS (sslnegotiation=direct) connection attempts rejected, tagged by reason"),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("mg.gateway.tls.direct_rejected counter: %w", err))
+		m.tlsDirectRejected = noop.Int64Counter{}
+	}
+
 	if len(errs) > 0 {
 		return m, errors.Join(errs...)
 	}
@@ -218,27 +229,43 @@ func (m *GatewayMetrics) RecordCredentialLookup(ctx context.Context, d time.Dura
 	m.authCredentialLookupRate.Add(ctx, 1)
 }
 
-// RecordTLSHandshake records the TLS handshake duration tagged by outcome.
-func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, outcome string, d time.Duration) {
+// RecordTLSHandshake records the TLS handshake duration tagged by the
+// negotiation style (negotiated vs direct) and outcome.
+func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, negotiation, outcome string, d time.Duration) {
 	if m == nil {
 		return
 	}
 	m.tlsHandshakeDuration.Record(ctx, d.Seconds(),
-		metric.WithAttributes(attribute.String("outcome", outcome)))
+		metric.WithAttributes(
+			attribute.String("negotiation", negotiation),
+			attribute.String("outcome", outcome)))
 }
 
 // RecordTLSConnection increments the completed-TLS-connections counter tagged
-// with the negotiated tls_version and cipher_suite. Names come from
-// crypto/tls so they match Go's published constants (e.g. "TLS 1.3",
-// "TLS_AES_128_GCM_SHA256").
-func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, version, cipher uint16) {
+// with the negotiation style (negotiated vs direct) plus the negotiated
+// tls_version and cipher_suite. Names come from crypto/tls so they match
+// Go's published constants (e.g. "TLS 1.3", "TLS_AES_128_GCM_SHA256").
+func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, negotiation string, version, cipher uint16) {
 	if m == nil {
 		return
 	}
 	m.tlsConnections.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("negotiation", negotiation),
 		attribute.String("tls_version", tls.VersionName(version)),
 		attribute.String("cipher_suite", tls.CipherSuiteName(cipher)),
 	))
+}
+
+// RecordDirectTLSRejected increments the direct-TLS-rejection counter tagged
+// by reason (server has no TLS config / client omitted mandatory ALPN).
+// Sized for the Envoy SSLRequest-offload rollout: a sustained non-zero rate
+// means direct-TLS traffic is arriving at a gateway that cannot admit it.
+func (m *GatewayMetrics) RecordDirectTLSRejected(ctx context.Context, reason string) {
+	if m == nil {
+		return
+	}
+	m.tlsDirectRejected.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("reason", reason)))
 }
 
 // RecordPlaintextRejected increments the plaintext-rejection counter tagged

--- a/go/services/multigateway/metrics.go
+++ b/go/services/multigateway/metrics.go
@@ -241,10 +241,10 @@ func (m *GatewayMetrics) RecordTLSHandshake(ctx context.Context, negotiation, ou
 			attribute.String("outcome", outcome)))
 }
 
-// RecordTLSConnection increments the completed-TLS-connections counter tagged
-// with the negotiation style (negotiated vs direct) plus the negotiated
-// tls_version and cipher_suite. Names come from crypto/tls so they match
-// Go's published constants (e.g. "TLS 1.3", "TLS_AES_128_GCM_SHA256").
+// RecordTLSConnection increments the admitted completed-TLS-connections
+// counter tagged with the negotiation style (negotiated vs direct) plus the
+// negotiated tls_version and cipher_suite. Names come from crypto/tls so they
+// match Go's published constants (e.g. "TLS 1.3", "TLS_AES_128_GCM_SHA256").
 func (m *GatewayMetrics) RecordTLSConnection(ctx context.Context, negotiation string, version, cipher uint16) {
 	if m == nil {
 		return

--- a/go/services/multigateway/metrics_test.go
+++ b/go/services/multigateway/metrics_test.go
@@ -139,7 +139,7 @@ func TestGatewayMetrics_RecordTLSConnection_TagsVersionAndCipher(t *testing.T) {
 	m, reader := setupGatewayMetrics(t)
 	ctx := context.Background()
 
-	m.RecordTLSConnection(ctx, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
+	m.RecordTLSConnection(ctx, server.TLSNegotiationNegotiated, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
 
 	agg := findMetric(t, reader, "mg.gateway.tls.connections")
 	require.NotNil(t, agg)
@@ -147,10 +147,47 @@ func TestGatewayMetrics_RecordTLSConnection_TagsVersionAndCipher(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, sum.DataPoints, 1)
 	dp := sum.DataPoints[0]
+	require.Equal(t, server.TLSNegotiationNegotiated, attrLookup(t, dp.Attributes, "negotiation"))
 	require.Equal(t, "TLS 1.3", attrLookup(t, dp.Attributes, "tls_version"))
 	require.Equal(t, tls.CipherSuiteName(tls.TLS_AES_128_GCM_SHA256),
 		attrLookup(t, dp.Attributes, "cipher_suite"))
 	require.Equal(t, int64(1), dp.Value)
+}
+
+func TestGatewayMetrics_RecordTLSConnection_DirectNegotiationLabel(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordTLSConnection(ctx, server.TLSNegotiationDirect, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
+
+	agg := findMetric(t, reader, "mg.gateway.tls.connections")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, server.TLSNegotiationDirect,
+		attrLookup(t, sum.DataPoints[0].Attributes, "negotiation"))
+}
+
+func TestGatewayMetrics_RecordDirectTLSRejected_TagsReason(t *testing.T) {
+	m, reader := setupGatewayMetrics(t)
+	ctx := context.Background()
+
+	m.RecordDirectTLSRejected(ctx, server.DirectTLSRejectedReasonTLSDisabled)
+	m.RecordDirectTLSRejected(ctx, server.DirectTLSRejectedReasonNoALPN)
+	m.RecordDirectTLSRejected(ctx, server.DirectTLSRejectedReasonNoALPN)
+
+	agg := findMetric(t, reader, "mg.gateway.tls.direct_rejected")
+	require.NotNil(t, agg)
+	sum, ok := agg.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	values := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		values[attrLookup(t, dp.Attributes, "reason")] = dp.Value
+	}
+	require.Equal(t, int64(1), values[server.DirectTLSRejectedReasonTLSDisabled])
+	require.Equal(t, int64(2), values[server.DirectTLSRejectedReasonNoALPN])
 }
 
 func TestGatewayMetrics_RecordPlaintextRejected_TagsReason(t *testing.T) {
@@ -201,9 +238,10 @@ func TestGatewayMetrics_NilReceiverIsNoop(t *testing.T) {
 		m.RecordSCRAMDuration(ctx, server.AuthOutcomeSuccess, time.Second)
 		m.RecordAuthAttempt(ctx, server.AuthOutcomeSuccess)
 		m.RecordCredentialLookup(ctx, time.Second)
-		m.RecordTLSHandshake(ctx, server.TLSOutcomeSuccess, time.Second)
-		m.RecordTLSConnection(ctx, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
+		m.RecordTLSHandshake(ctx, server.TLSNegotiationNegotiated, server.TLSOutcomeSuccess, time.Second)
+		m.RecordTLSConnection(ctx, server.TLSNegotiationNegotiated, tls.VersionTLS13, tls.TLS_AES_128_GCM_SHA256)
 		m.RecordPlaintextRejected(ctx, server.PlaintextRejectedReasonNoSSLRequest)
 		m.RecordSSLRequestDeclined(ctx)
+		m.RecordDirectTLSRejected(ctx, server.DirectTLSRejectedReasonNoALPN)
 	})
 }

--- a/go/services/multipooler/internal/connpoolmanager/config.go
+++ b/go/services/multipooler/internal/connpoolmanager/config.go
@@ -53,6 +53,12 @@ type ConnectionConfig struct {
 	// Only honored on TCP connections (SocketFile == "").
 	SSLMode client.SSLMode
 
+	// SSLNegotiation controls how TLS is established (libpq sslnegotiation,
+	// PostgreSQL 17+): "postgres" (SSLRequest negotiation, default) or
+	// "direct" (TLS-first with mandatory ALPN). Only honored on TCP
+	// connections; direct requires a TLS-enforcing SSLMode.
+	SSLNegotiation client.SSLNegotiation
+
 	// TLSConfig is the *tls.Config built from SSLMode + sslrootcert. Nil for
 	// disable/allow; non-nil otherwise. Only honored on TCP connections.
 	TLSConfig *tls.Config
@@ -96,8 +102,9 @@ type Config struct {
 	// --- PostgreSQL TLS (multipooler → postgres leg) ---
 	// libpq-style server verification. Mode + optional CA bundle. Client cert
 	// auth (sslcert/sslkey) and CRLs are deferred — see MUL-383.
-	pgSSLMode     viperutil.Value[string]
-	pgSSLRootCert viperutil.Value[string]
+	pgSSLMode        viperutil.Value[string]
+	pgSSLRootCert    viperutil.Value[string]
+	pgSSLNegotiation viperutil.Value[string]
 
 	// --- Pool sizing configuration ---
 
@@ -225,6 +232,10 @@ func NewConfig(reg *viperutil.Registry) *Config {
 			Default:  "",
 			FlagName: "pg-client-sslrootcert",
 		}),
+		pgSSLNegotiation: viperutil.Configure(reg, "connpool.pg.sslnegotiation", viperutil.Options[string]{
+			Default:  string(client.SSLNegotiationPostgres),
+			FlagName: "pg-client-sslnegotiation",
+		}),
 
 		// Admin pool (shared across all users)
 		adminCapacity: viperutil.Configure(reg, "connpool.admin.capacity", viperutil.Options[int64]{
@@ -314,6 +325,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	// PostgreSQL TLS (multipooler → postgres). Mirrors libpq sslmode/sslrootcert.
 	fs.String("pg-client-sslmode", c.pgSSLMode.Default(), "TLS mode for connections to PostgreSQL: disable|prefer|require|verify-ca|verify-full (libpq parity; sslmode=allow is not supported)")
 	fs.String("pg-client-sslrootcert", c.pgSSLRootCert.Default(), "PEM CA bundle used to verify the PostgreSQL server certificate (required for verify-ca and verify-full)")
+	fs.String("pg-client-sslnegotiation", c.pgSSLNegotiation.Default(), "TLS negotiation style for connections to PostgreSQL: postgres (SSLRequest handshake) or direct (TLS-first, PostgreSQL 17+, requires sslmode require|verify-ca|verify-full)")
 
 	// Admin pool flags (shared across all users)
 	fs.Int64("connpool-admin-capacity", c.adminCapacity.Default(), "Maximum number of admin connections for control operations")
@@ -348,6 +360,7 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 		c.pgPasswordFile,
 		c.pgSSLMode,
 		c.pgSSLRootCert,
+		c.pgSSLNegotiation,
 		c.adminCapacity,
 		c.userRegularIdleTimeout,
 		c.userRegularMaxLifetime,
@@ -490,6 +503,13 @@ func (c *Config) PgSSLRootCert() string {
 	return c.pgSSLRootCert.Get()
 }
 
+// PgSSLNegotiation parses and returns the configured libpq-style
+// sslnegotiation value. An invalid value returns the parser error so the
+// caller can fail startup rather than silently using the default.
+func (c *Config) PgSSLNegotiation() (client.SSLNegotiation, error) {
+	return client.ParseSSLNegotiation(c.pgSSLNegotiation.Get())
+}
+
 // ValidatePGSSL checks the libpq-style sslmode + sslrootcert flags at startup
 // so a typo or missing CA bundle aborts the multipooler before the connection
 // pool manager opens — preventing a silent downgrade to plaintext.
@@ -508,6 +528,13 @@ func (c *Config) ValidatePGSSL(host string) error {
 	}
 	if _, err := client.BuildTLSConfig(mode, c.pgSSLRootCert.Get(), host); err != nil {
 		return fmt.Errorf("--pg-client-sslmode=%s: %w", mode, err)
+	}
+	negotiation, err := client.ParseSSLNegotiation(c.pgSSLNegotiation.Get())
+	if err != nil {
+		return fmt.Errorf("--pg-client-sslnegotiation: %w", err)
+	}
+	if err := client.ValidateSSLNegotiation(negotiation, mode); err != nil {
+		return fmt.Errorf("--pg-client-sslnegotiation=%s: %w", negotiation, err)
 	}
 	return nil
 }

--- a/go/services/multipooler/internal/connpoolmanager/manager.go
+++ b/go/services/multipooler/internal/connpoolmanager/manager.go
@@ -265,15 +265,16 @@ func (m *Manager) Open(ctx context.Context, connConfig *ConnectionConfig) {
 // client startup code skips SSLRequest when SocketFile is set.
 func (m *Manager) buildClientConfig(user, password string) *client.Config {
 	return &client.Config{
-		SocketFile:  m.connConfig.SocketFile,
-		Host:        m.connConfig.Host,
-		Port:        m.connConfig.Port,
-		Database:    m.connConfig.Database,
-		User:        user,
-		Password:    password,
-		SSLMode:     m.connConfig.SSLMode,
-		TLSConfig:   m.connConfig.TLSConfig,
-		DialTimeout: m.config.DialTimeout(),
+		SocketFile:     m.connConfig.SocketFile,
+		Host:           m.connConfig.Host,
+		Port:           m.connConfig.Port,
+		Database:       m.connConfig.Database,
+		User:           user,
+		Password:       password,
+		SSLMode:        m.connConfig.SSLMode,
+		SSLNegotiation: m.connConfig.SSLNegotiation,
+		TLSConfig:      m.connConfig.TLSConfig,
+		DialTimeout:    m.config.DialTimeout(),
 	}
 }
 

--- a/go/services/multipooler/internal/manager/manager.go
+++ b/go/services/multipooler/internal/manager/manager.go
@@ -660,6 +660,16 @@ func (pm *MultiPoolerManager) openConnectionsLocked() {
 				connConfig.SSLMode = sslMode
 				connConfig.TLSConfig = tlsCfg
 			}
+			// libpq-style sslnegotiation (postgres | direct). Validated during
+			// startup (ValidatePGSSL); a post-startup parse failure here keeps
+			// the default (postgres) and the per-dial ValidateSSLNegotiation
+			// check in client.startup surfaces any residual inconsistency.
+			sslNegotiation, err := pm.config.ConnPoolConfig.PgSSLNegotiation()
+			if err != nil {
+				pm.logger.ErrorContext(pm.ctx, "invalid --pg-client-sslnegotiation at pool open; using default \"postgres\"", "error", err)
+				sslNegotiation = client.SSLNegotiationPostgres
+			}
+			connConfig.SSLNegotiation = sslNegotiation
 		}
 		pm.connPoolMgr.Open(pm.ctx, connConfig)
 		pm.logger.Info("Connection pool manager opened")

--- a/go/test/endtoend/multipooler/pg_client_tls_test.go
+++ b/go/test/endtoend/multipooler/pg_client_tls_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
+	pgclient "github.com/multigres/multigres/go/common/pgprotocol/client"
 	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
 )
 
@@ -89,4 +90,110 @@ func TestPGClientTLS_VerifyFull(t *testing.T) {
 	`).Scan(&sslBackends), "query pg_stat_ssl")
 
 	require.Greater(t, sslBackends, 0, "expected at least one TLS-encrypted multipooler backend in pg_stat_ssl")
+}
+
+// TestPGClientTLS_DirectNegotiation validates the pgprotocol client's
+// sslnegotiation=direct (PostgreSQL 17 TLS-first handshake, mandatory ALPN)
+// against a REAL PostgreSQL 17 server — the same oracle PG's own
+// 005_negotiate_encryption.pl uses for its direct-SSL rows. The connection
+// is asserted encrypted via pg_stat_ssl from inside the session itself.
+func TestPGClientTLS_DirectNegotiation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerPGTLS(),
+	)
+	defer cleanup()
+
+	require.NotNil(t, setup.MultipoolerPGTLSCertPaths, "expected PG TLS assets to be provisioned")
+
+	primary := setup.GetPrimary(t)
+	require.NotNil(t, primary, "expected a primary multipooler")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	tlsCfg, err := pgclient.BuildTLSConfig(pgclient.SSLModeVerifyFull,
+		setup.MultipoolerPGTLSCertPaths.CACertFile, "localhost")
+	require.NoError(t, err)
+
+	conn, err := pgclient.Connect(ctx, ctx, &pgclient.Config{
+		Host:           "localhost",
+		Port:           primary.Pgctld.PgPort,
+		User:           "postgres",
+		Password:       shardsetup.TestPostgresPassword,
+		Database:       "postgres",
+		SSLMode:        pgclient.SSLModeVerifyFull,
+		SSLNegotiation: pgclient.SSLNegotiationDirect,
+		TLSConfig:      tlsCfg,
+		DialTimeout:    10 * time.Second,
+	})
+	require.NoError(t, err, "direct TLS connect to real PostgreSQL must succeed")
+	defer conn.Close()
+
+	// The backend must report this very session as SSL-encrypted.
+	results, err := conn.Query(ctx,
+		"SELECT ssl::text FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+	require.NoError(t, err, "query over direct TLS must succeed")
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Rows, 1)
+	require.Equal(t, "true", string(results[0].Rows[0].Values[0]),
+		"pg_stat_ssl must report the direct-TLS session as encrypted")
+}
+
+// TestPGClientTLS_DirectNegotiation_Multipooler boots a shard whose
+// multipoolers dial postgres with --pg-client-sslnegotiation=direct and
+// asserts (a) queries flow end-to-end and (b) the pool connections are
+// encrypted per pg_stat_ssl — the multipooler → postgres leg of query
+// serving running entirely on PG 17 direct TLS.
+func TestPGClientTLS_DirectNegotiation_Multipooler(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping end-to-end tests in short mode")
+	}
+
+	setup, cleanup := shardsetup.NewIsolated(t,
+		shardsetup.WithMultipoolerPGTLSDirect(),
+	)
+	defer cleanup()
+
+	require.NotNil(t, setup.MultipoolerPGTLSCertPaths, "expected PG TLS assets to be provisioned")
+
+	primary := setup.GetPrimary(t)
+	require.NotNil(t, primary, "expected a primary multipooler")
+
+	mpClient, err := shardsetup.NewMultipoolerClient(primary.Multipooler.GrpcPort)
+	require.NoError(t, err, "create multipooler client")
+	defer mpClient.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	_, err = mpClient.Pooler.ExecuteQuery(ctx, "SELECT 1", 1)
+	require.NoError(t, err, "SELECT 1 through multipooler over direct TLS")
+
+	// Confirm via a direct admin connection that the multipooler backends
+	// are SSL-encrypted.
+	dsn := fmt.Sprintf(
+		"host=localhost port=%d user=postgres password=%s dbname=postgres sslmode=verify-full sslrootcert=%s",
+		primary.Pgctld.PgPort,
+		shardsetup.TestPostgresPassword,
+		setup.MultipoolerPGTLSCertPaths.CACertFile,
+	)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err, "open admin TLS connection")
+	defer db.Close()
+	require.NoError(t, db.PingContext(ctx), "ping postgres over TLS")
+
+	var sslBackends int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM pg_stat_ssl
+		WHERE ssl = true
+		  AND pid <> pg_backend_pid()
+	`).Scan(&sslBackends), "query pg_stat_ssl")
+
+	require.Greater(t, sslBackends, 0,
+		"expected at least one direct-TLS-encrypted multipooler backend in pg_stat_ssl")
 }

--- a/go/test/endtoend/queryserving/ssl_direct_test.go
+++ b/go/test/endtoend/queryserving/ssl_direct_test.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Supabase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Direct TLS (PostgreSQL 17 sslnegotiation=direct) end-to-end tests against
+// multigateway.
+//
+// The accept/reject matrix is logically imported from PostgreSQL's own
+// negotiation test suite, src/test/libpq/t/005_negotiate_encryption.pl
+// (sslnegotiation=direct rows):
+//
+//	server ssl=on,  sslmode=require sslnegotiation=direct -> connect (TLS)
+//	server ssl=off, sslmode=require sslnegotiation=direct -> fail
+//	weak sslmode + sslnegotiation=direct                  -> client-side error
+//
+// plus the ALPN requirement from PG 17's backend_startup.c. The positive
+// paths are driven through real psql/libpq (the same client PG's TAP tests
+// use), so the gateway's direct-TLS implementation is validated against the
+// canonical client implementation rather than a re-implementation.
+
+package queryserving
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pgclient "github.com/multigres/multigres/go/common/pgprotocol/client"
+	"github.com/multigres/multigres/go/common/pgprotocol/protocol"
+	"github.com/multigres/multigres/go/test/endtoend/shardsetup"
+	"github.com/multigres/multigres/go/test/utils"
+)
+
+// skipIfNoDirectTLSPsql skips the test unless a psql with libpq >= 17 is on
+// PATH (sslnegotiation was added in PostgreSQL 17).
+func skipIfNoDirectTLSPsql(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("psql", "--version").CombinedOutput()
+	if err != nil {
+		t.Skipf("psql not available: %v", err)
+	}
+	// "psql (PostgreSQL) 17.7 (Homebrew)" -> 17
+	m := regexp.MustCompile(`(\d+)(?:\.\d+)?`).FindStringSubmatch(string(out))
+	if m == nil {
+		t.Skipf("cannot parse psql version from %q", string(out))
+	}
+	major, err := strconv.Atoi(m[1])
+	require.NoError(t, err)
+	if major < 17 {
+		t.Skipf("psql major version %d < 17; sslnegotiation=direct unsupported", major)
+	}
+}
+
+// runPsql executes one psql command against the given conninfo and returns
+// combined output and the run error.
+func runPsql(t *testing.T, conninfo, query string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("psql", conninfo, "-X", "-At", "-c", query)
+	out, err := cmd.CombinedOutput()
+	t.Logf("psql %q -c %q => err=%v output=%s", conninfo, query, err, string(out))
+	return string(out), err
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_Psql connects real libpq with
+// sslnegotiation=direct to a TLS-enabled multigateway and runs a query.
+// This is the Envoy-handles-SSLRequest model's client-visible behavior:
+// the first bytes on the wire are a TLS ClientHello, no SSLRequest.
+func TestMultiGateway_SSL_DirectNegotiation_Psql(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=require", "sslnegotiation=direct", "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT 41 + 1")
+	require.NoError(t, err, "psql with sslnegotiation=direct should succeed: %s", out)
+	assert.Equal(t, "42", strings.TrimSpace(out))
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_VerifyCA pairs direct negotiation
+// with certificate verification (sslmode=verify-ca), matching the stricter
+// rows of PG's negotiation matrix.
+func TestMultiGateway_SSL_DirectNegotiation_VerifyCA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+	require.NotNil(t, setup.MultigatewayTLSCertPaths, "TLS cert paths should be set")
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=verify-ca", "sslnegotiation=direct",
+		"sslrootcert="+setup.MultigatewayTLSCertPaths.CACertFile, "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT current_user")
+	require.NoError(t, err, "psql direct + verify-ca should succeed: %s", out)
+	assert.Equal(t, shardsetup.DefaultTestUser, strings.TrimSpace(out))
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_RequireSSLGateway verifies direct
+// TLS satisfies the --pg-require-ssl=true posture (the client negotiated
+// TLS before its StartupMessage, just not via SSLRequest).
+func TestMultiGateway_SSL_DirectNegotiation_RequireSSLGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getRequireSSLSharedSetup(t)
+	setup.SetupTest(t)
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=require", "sslnegotiation=direct", "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT 1")
+	require.NoError(t, err, "direct TLS must satisfy --pg-require-ssl=true: %s", out)
+	assert.Equal(t, "1", strings.TrimSpace(out))
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_NoTLSGateway_Fails: a gateway
+// without TLS configured must reject the TLS-first connection (silently
+// closed, libpq reports a connection failure). Mirrors the server-ssl=off /
+// sslnegotiation=direct row of 005_negotiate_encryption.pl.
+func TestMultiGateway_SSL_DirectNegotiation_NoTLSGateway_Fails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getSharedSetup(t) // no TLS on the gateway
+	setup.SetupTest(t)
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=require", "sslnegotiation=direct", "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT 1")
+	require.Error(t, err, "direct TLS against a non-TLS gateway must fail, got: %s", out)
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_WeakSSLMode_ClientError: libpq
+// itself rejects weak sslmode values combined with sslnegotiation=direct
+// before connecting. Documents the client-side contract our pgprotocol
+// client mirrors.
+func TestMultiGateway_SSL_DirectNegotiation_WeakSSLMode_ClientError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=prefer", "sslnegotiation=direct", "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT 1")
+	require.Error(t, err, "libpq must reject sslmode=prefer with sslnegotiation=direct, got: %s", out)
+	assert.Contains(t, out, "sslnegotiation")
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_GoClient drives a query through
+// the full path (pgprotocol client -> multigateway -> multipooler ->
+// postgres) over a direct TLS session, proving query serving works on the
+// TLS-first channel, not just connection admission.
+func TestMultiGateway_SSL_DirectNegotiation_GoClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	clientTLS, err := pgclient.BuildTLSConfig(pgclient.SSLModeRequire, "", "")
+	require.NoError(t, err)
+
+	ctx := utils.WithTimeout(t, 30*time.Second)
+	conn, err := pgclient.Connect(ctx, ctx, &pgclient.Config{
+		Host:           "localhost",
+		Port:           setup.MultigatewayPgPort,
+		User:           shardsetup.DefaultTestUser,
+		Password:       shardsetup.TestPostgresPassword,
+		Database:       "postgres",
+		SSLMode:        pgclient.SSLModeRequire,
+		SSLNegotiation: pgclient.SSLNegotiationDirect,
+		TLSConfig:      clientTLS,
+		DialTimeout:    10 * time.Second,
+	})
+	require.NoError(t, err, "direct TLS connect to multigateway must succeed")
+	defer conn.Close()
+
+	results, err := conn.Query(ctx, "SELECT 6 * 7")
+	require.NoError(t, err, "query over direct TLS must succeed")
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Rows, 1)
+	assert.Equal(t, "42", string(results[0].Rows[0].Values[0]))
+}
+
+// TestMultiGateway_SSL_DirectNegotiation_NoALPN_Rejected: a TLS-first
+// client that completes the handshake without offering ALPN must receive
+// PostgreSQL's exact FATAL diagnostic (SQLSTATE 08P01) through the tunnel
+// and then lose the connection. Mirrors PG 17's mandatory-ALPN rule for
+// direct connections.
+func TestMultiGateway_SSL_DirectNegotiation_NoALPN_Rejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	raw, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", setup.MultigatewayPgPort), 5*time.Second)
+	require.NoError(t, err)
+	defer raw.Close()
+
+	tlsConn := tls.Client(raw, &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // test asserts rejection, not cert validity
+		MinVersion:         tls.VersionTLS12,
+		// No ALPN offered.
+	})
+	require.NoError(t, tlsConn.Handshake(), "TLS handshake itself should succeed without ALPN")
+	require.NoError(t, tlsConn.SetReadDeadline(time.Now().Add(10*time.Second)))
+
+	// Expect an ErrorResponse ('E') frame carrying FATAL / 08P01.
+	header := make([]byte, 5)
+	_, err = io.ReadFull(tlsConn, header)
+	require.NoError(t, err)
+	require.Equal(t, byte(protocol.MsgErrorResponse), header[0])
+	bodyLen := int(binary.BigEndian.Uint32(header[1:5])) - 4
+	body := make([]byte, bodyLen)
+	_, err = io.ReadFull(tlsConn, body)
+	require.NoError(t, err)
+
+	bodyStr := string(body)
+	assert.Contains(t, bodyStr, "FATAL")
+	assert.Contains(t, bodyStr, "08P01")
+	assert.Contains(t, bodyStr, "ALPN protocol negotiation extension")
+
+	// Server closes after the FATAL.
+	one := make([]byte, 1)
+	_, readErr := tlsConn.Read(one)
+	require.Error(t, readErr, "server must close the connection after the ALPN rejection")
+}
+
+// TestMultiGateway_SSL_NegotiatedStillWorks_Regression guards the classic
+// SSLRequest path against regressions from the direct-TLS first-byte peek:
+// libpq's default sslnegotiation=postgres must behave exactly as before.
+func TestMultiGateway_SSL_NegotiatedStillWorks_Regression(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SSL test in short mode")
+	}
+	if utils.ShouldSkipRealPostgres() {
+		t.Skip("PostgreSQL binaries not found, skipping SSL tests")
+	}
+	skipIfNoDirectTLSPsql(t)
+
+	setup := getTLSSharedSetup(t)
+	setup.SetupTest(t)
+
+	conninfo := shardsetup.GetTestUserDSN("localhost", setup.MultigatewayPgPort,
+		"sslmode=require", "sslnegotiation=postgres", "connect_timeout=5")
+	out, err := runPsql(t, conninfo, "SELECT 1")
+	require.NoError(t, err, "sslnegotiation=postgres must keep working: %s", out)
+	assert.Equal(t, "1", strings.TrimSpace(out))
+}

--- a/go/test/endtoend/shardsetup/process.go
+++ b/go/test/endtoend/shardsetup/process.go
@@ -118,6 +118,12 @@ type ProcessInstance struct {
 	PgClientSSLMode     string
 	PgClientSSLRootCert string
 
+	// PgClientSSLNegotiation selects the libpq-style sslnegotiation value for
+	// the multipooler → postgres dial: "postgres" (SSLRequest negotiation,
+	// default) or "direct" (PostgreSQL 17 TLS-first handshake). Only
+	// meaningful with a TLS-enforcing PgClientSSLMode.
+	PgClientSSLNegotiation string
+
 	// BackupLocation stores backup configuration from topology (used by pgctld)
 	BackupLocation *clustermetadatapb.BackupLocation
 
@@ -179,6 +185,9 @@ func (p *ProcessInstance) multipoolerArgs() []string {
 	}
 	if p.PgClientSSLRootCert != "" {
 		args = append(args, "--pg-client-sslrootcert", p.PgClientSSLRootCert)
+	}
+	if p.PgClientSSLNegotiation != "" {
+		args = append(args, "--pg-client-sslnegotiation", p.PgClientSSLNegotiation)
 	}
 	if p.PgBackRestCertPaths != nil {
 		args = append(args,

--- a/go/test/endtoend/shardsetup/setup.go
+++ b/go/test/endtoend/shardsetup/setup.go
@@ -65,6 +65,7 @@ type SetupConfig struct {
 	EnableMultiadmin                   bool // Enable multiadmin (opt-in, default: false)
 	EnableMultigatewayTLS              bool // Enable TLS for multigateway PostgreSQL listener
 	EnableMultipoolerPGTLS             bool // Provision postgres with TLS and point multipooler at it via verify-full
+	MultipoolerPGTLSDirect             bool // With EnableMultipoolerPGTLS: dial postgres with sslnegotiation=direct (PG 17 TLS-first)
 	Database                           string
 	TableGroup                         string
 	Shard                              string
@@ -220,6 +221,18 @@ func WithMultigatewayRequireSSL() SetupOption {
 func WithMultipoolerPGTLS() SetupOption {
 	return func(c *SetupConfig) {
 		c.EnableMultipoolerPGTLS = true
+	}
+}
+
+// WithMultipoolerPGTLSDirect is WithMultipoolerPGTLS plus
+// --pg-client-sslnegotiation=direct: the multipooler skips the SSLRequest
+// round trip and opens every postgres connection with a TLS-first handshake
+// (PostgreSQL 17 direct SSL, mandatory ALPN). Exercises the
+// pgprotocol/client direct-TLS dial against a real PostgreSQL server.
+func WithMultipoolerPGTLSDirect() SetupOption {
+	return func(c *SetupConfig) {
+		c.EnableMultipoolerPGTLS = true
+		c.MultipoolerPGTLSDirect = true
 	}
 }
 
@@ -607,6 +620,9 @@ func New(t *testing.T, opts ...SetupOption) *ShardSetup {
 			inst.Multipooler.SocketFile = ""
 			inst.Multipooler.PgClientSSLMode = "verify-full"
 			inst.Multipooler.PgClientSSLRootCert = paths.CACertFile
+			if config.MultipoolerPGTLSDirect {
+				inst.Multipooler.PgClientSSLNegotiation = "direct"
+			}
 		}
 
 		// Configure Prometheus metrics export on multipooler if enabled.


### PR DESCRIPTION
## Summary
- Add PostgreSQL 17 `sslnegotiation=direct` support to pgprotocol client and server, including TLS-first startup detection and mandatory `postgresql` ALPN negotiation.
- Wire `--pg-client-sslnegotiation` through multipooler → PostgreSQL connections so poolers can use direct TLS to Postgres.
- Add gateway TLS metrics for negotiated vs direct TLS and direct-TLS rejection reasons, and refresh the generated metric catalog.
- Add unit and end-to-end coverage for direct TLS, ALPN rejection, RequireTLS, SCRAM-PLUS, cancel requests, real `psql`, and multipooler backend TLS.

## Problem
PostgreSQL TLS normally starts after an SSLRequest round trip. For Envoy SSLRequest offload / TLS-first forwarding and PostgreSQL 17 clients using `sslnegotiation=direct`, multigateway must accept a TLS ClientHello as the first byte instead of treating it as an invalid startup packet. Direct TLS also requires ALPN so the server can verify the TLS connection is intended for PostgreSQL and avoid cross-protocol confusion.

## Solution
The server now peeks the first startup byte and, when it sees a TLS handshake record, replays any buffered ClientHello bytes into a server TLS handshake, requires ALPN `postgresql`, and then continues normal startup over the encrypted connection. The client side parses and validates `sslnegotiation`, starts TLS immediately for direct mode, offers and requires ALPN, and multipooler passes the setting into Postgres client configs. This PR also adds direct-TLS metrics and caps golangci-lint concurrency to keep full-repo lint within GitHub runner memory limits.

## Validation
- `make metrics`
- `go run ./go/tools/metricsgen/main -verify`
- `make build`
- `go test -short ./go/common/pgprotocol/client ./go/common/pgprotocol/server -run 'Test(ParseSSLNegotiation|ValidateSSLNegotiation|DirectTLS)' -count=1`
- `MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock go test ./go/test/endtoend/queryserving -run 'TestMultiGateway_SSL_(DirectNegotiation|NegotiatedStillWorks)' -count=1 -timeout=30m -v`
- `MULTIGRES_PORT_POOL_ADDR=/tmp/multigres-port-pool.sock go test ./go/test/endtoend/multipooler -run 'TestPGClientTLS_DirectNegotiation' -count=1 -timeout=30m -v`
- `golangci-lint run` under a 7 GB Docker memory limit
- commit hook lint passed