### PR TITLE
test(pgregress): review accepted patch baseline

### DIFF
--- a/.github/workflows/test-pgregress.yml
+++ b/.github/workflows/test-pgregress.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
+          # liblz4-dev is required for ./configure --with-lz4 (compression regression suite).
           # uuid-dev (libuuid / e2fs) is required for ./configure --with-uuid (uuid-ossp);
           # libssl-dev is required for ./configure --with-ssl=openssl (pgcrypto, PG16+;
           # enabled for the contrib suite, and for external runs whose extensions
@@ -71,7 +72,7 @@ jobs:
           # JSON-C, and SFCGAL when those libraries are present.
           sudo apt-get install -y \
             build-essential autoconf automake libtool bison flex \
-            libreadline-dev zlib1g-dev uuid-dev libssl-dev \
+            libreadline-dev zlib1g-dev liblz4-dev uuid-dev libssl-dev \
             libsodium-dev pkg-config libcurl4-openssl-dev \
             libgeos-dev libproj-dev libxml2-dev gettext xsltproc \
             libgdal-dev libjson-c-dev libprotobuf-c-dev \

--- a/docker/Dockerfile.pgregress
+++ b/docker/Dockerfile.pgregress
@@ -35,6 +35,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Build/test dependencies — same packages CI installs.
 #   build-essential bison flex libreadline-dev zlib1g-dev : build PostgreSQL 17.6 from source
+#   liblz4-dev : ./configure --with-lz4       (compression regression suite)
 #   uuid-dev   : ./configure --with-uuid       (uuid-ossp contrib)
 #   libssl-dev : ./configure --with-ssl=openssl (pgcrypto, PG16+; pgjwt depends on it)
 #   libsodium-dev pkg-config : pgsodium external extension (PkgConfigDeps)
@@ -50,7 +51,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   locales : glibc locales the regression collate suite needs (see locale-gen below)
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential autoconf automake libtool bison flex libreadline-dev zlib1g-dev \
-      uuid-dev libssl-dev libsodium-dev pkg-config libcurl4-openssl-dev \
+      liblz4-dev uuid-dev libssl-dev libsodium-dev pkg-config libcurl4-openssl-dev \
       libgeos-dev libproj-dev libxml2-dev gettext xsltproc \
       libgdal-dev libjson-c-dev libprotobuf-c-dev protobuf-c-compiler libsfcgal-dev \
       clang libclang-dev \

--- a/go/test/endtoend/pgregresstest/pgregress_test.go
+++ b/go/test/endtoend/pgregresstest/pgregress_test.go
@@ -103,6 +103,12 @@ func TestPostgreSQLRegression(t *testing.T) {
 		builder.Cleanup()
 	})
 
+	// The core compression regression test expects lz4 support in PostgreSQL;
+	// without --with-lz4, a stock run fails before exercising Multigres behavior.
+	if runRegress {
+		builder.ConfigureArgs = append(builder.ConfigureArgs, "--with-lz4")
+	}
+
 	// Two contrib modules need optional build features enabled at ./configure.
 	// Enable them only when the contrib suite runs so regression/isolation-only
 	// builds (and other pgbuilder callers) are unaffected and can't be broken

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/aggregates.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/aggregates.patch
@@ -1,0 +1,30 @@
+# Known divergence: error source/cursor locations differ after multigateway query rewriting.
+# The percentile_cont behavior difference in this test is intentionally left unpatched.
+--- a
++++ b
+@@ -1914,7 +1914,7 @@
+ select aggfns(distinct a,a,c order by a,b)
+ from (values (1,1,'foo')) v(a,b,c), generate_series(1,2) i;
+ ERROR: in an aggregate with DISTINCT, ORDER BY expressions must appear in argument list
+-LINE 1: select aggfns(distinct a,a,c order by a,b)
++LINE 2: from (values (1,1,'foo')) v(a,b,c), generate_series(1,2) i...
+ ^
+ -- string_agg tests
+ select string_agg(a,',') from (values('aaaa'),('bbbb'),('cccc')) g(a);
+@@ -1951,6 +1951,6 @@
+ select string_agg(distinct f1::text, ',' order by f1) from varchar_tbl; -- not ok
+ ERROR: in an aggregate with DISTINCT, ORDER BY expressions must appear in argument list
+-LINE 1: select string_agg(distinct f1::text, ',' order by f1) from v...
++LINE 1: ...tring_agg(distinct f1::text, ',' order by f1) from varchar_t...
+ ^
+ select string_agg(distinct f1, ',' order by f1::text) from varchar_tbl; -- not ok
+ ERROR: in an aggregate with DISTINCT, ORDER BY expressions must appear in argument list
+@@ -2449,7 +2449,7 @@
+ select rank('adam'::text collate "C") within group (order by x collate "POSIX")
+ from (values ('fred'),('jim')) v(x);
+ ERROR: collation mismatch between explicit collations "C" and "POSIX"
+-LINE 1: ...adam'::text collate "C") within group (order by x collate "P...
++LINE 1: ...:text collate "C") within group (order by x collate "POSIX")
+ ^
+ -- hypothetical-set type unification successes:
+ select rank('adam'::varchar) within group (order by x) from (values ('fred'),('jim')) v(x);

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/alter_table.patch
@@ -1,3 +1,8 @@
+# Known divergence (by design): this malformed statement is rejected by
+# multigateway's own SQL parser before it reaches PostgreSQL, so the error is
+# "parse error at position 27: syntax error" instead of PostgreSQL's "syntax
+# error at or near <tok>" with the "LINE n: ...\n  ^" source cursor.
+# Real COPY behavior differences in this test are intentionally left unpatched.
 --- a
 +++ b
 @@ -1445,9 +1445,7 @@
@@ -11,40 +16,24 @@
  -- try dropping the xmin column, should fail
  alter table atacc1 drop xmin;
  ERROR: cannot drop system column "xmin"
-@@ -1631,14 +1629,13 @@
- insert into attest values (1,2,3);
- alter table attest drop a;
- copy attest to stdout;
--2 3
-+ERROR: COPY TO STDOUT not yet supported
- copy attest(a) to stdout;
--ERROR: column "a" of relation "attest" does not exist
-+ERROR: COPY TO STDOUT not yet supported
- copy attest("........pg.dropped.1........") to stdout;
--ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
-+ERROR: COPY TO STDOUT not yet supported
- copy attest from stdin;
--ERROR: extra data after last expected column
--CONTEXT: COPY attest, line 1: "10 11 12"
-+ERROR: failed to finalize COPY: COPY finalization failed: COPY operation failed: ERROR: extra data after last expected column
- select * from attest;
- b | c
- ---+---
-@@ -1654,9 +1651,15 @@
- (2 rows)
+@@ -3523,6 +3521,8 @@
+ DROP TABLE old_system_table;
+ -- set logged
+ CREATE UNLOGGED TABLE unlogged1(f1 SERIAL PRIMARY KEY, f2 TEXT); -- has sequence, toast
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ -- check relpersistence of an unlogged table
+ SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged1'
+ UNION ALL
+@@ -3540,7 +3540,11 @@
+ (5 rows)
 
- copy attest(a) from stdin;
--ERROR: column "a" of relation "attest" does not exist
-+ERROR: failed to initiate COPY: failed to initiate COPY: Code: INTERNAL
-+failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "a" of relation "attest" does not exist
-+
-+failed to receive READY response
- copy attest("........pg.dropped.1........") from stdin;
--ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
-+ERROR: failed to initiate COPY: failed to initiate COPY: Code: INTERNAL
-+failed to initiate COPY: failed to create reserved connection for COPY: failed to initiate COPY FROM STDIN: ERROR: column "........pg.dropped.1........" of relation "attest" does not exist
-+
-+failed to receive READY response
- copy attest(b,c) from stdin;
- select * from attest;
- b | c
+ CREATE UNLOGGED TABLE unlogged2(f1 SERIAL PRIMARY KEY, f2 INTEGER REFERENCES unlogged1); -- foreign key
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ CREATE UNLOGGED TABLE unlogged3(f1 SERIAL PRIMARY KEY, f2 INTEGER REFERENCES unlogged3); -- self-referencing foreign key
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ ALTER TABLE unlogged3 SET LOGGED; -- skip self-referencing foreign key
+ ALTER TABLE unlogged2 SET LOGGED; -- fails because a foreign key to an unlogged table exists
+ ERROR: could not change table "unlogged2" to logged because it references unlogged table "unlogged1"

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/brin.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/brin.patch
@@ -1,0 +1,14 @@
+# Known divergence (by design): CREATE UNLOGGED TABLE emits an extra WARNING +
+# HINT because unlogged data is not replicated and is lost on failover. Planner
+# differences in this test are intentionally left unpatched.
+--- a
++++ b
+@@ -569,6 +569,8 @@
+ RESET enable_seqscan;
+ -- test an unlogged table, mostly to get coverage of brinbuildempty
+ CREATE UNLOGGED TABLE brintest_unlogged (n numrange);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ CREATE INDEX brinidx_unlogged ON brintest_unlogged USING brin (n);
+ INSERT INTO brintest_unlogged VALUES (numrange(0, 2^1000::numeric));
+ DROP TABLE brintest_unlogged;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_am.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/create_am.patch
@@ -1,0 +1,73 @@
+# Known divergences:
+#  1. Some malformed table-AM statements are rejected by multigateway's parser,
+#     producing different syntax wording/source cursors.
+#  2. Foreign-data wrapper/server/table operations are blocked through the
+#     connection pooler; cascaded transaction-aborted output is a direct result
+#     of that accepted policy.
+--- a
++++ b
+@@ -156,18 +156,12 @@
+ -- SELECT INTO doesn't support USING
+ SELECT INTO tableam_tblselectinto_heap2 USING heap2 FROM tableam_tbl_heap2;
+-ERROR: syntax error at or near "USING"
+-LINE 1: SELECT INTO tableam_tblselectinto_heap2 USING heap2 FROM tab...
+-^
++ERROR: parse error at position 45: syntax error
+ -- CREATE VIEW doesn't support USING
+ CREATE VIEW tableam_view_heap2 USING heap2 AS SELECT * FROM tableam_tbl_heap2;
+-ERROR: syntax error at or near "USING"
+-LINE 1: CREATE VIEW tableam_view_heap2 USING heap2 AS SELECT * FROM ...
+-^
++ERROR: parse error at position 36: syntax error
+ -- CREATE SEQUENCE doesn't support USING
+ CREATE SEQUENCE tableam_seq_heap2 USING heap2;
+-ERROR: syntax error at or near "USING"
+-LINE 1: CREATE SEQUENCE tableam_seq_heap2 USING heap2;
+-^
++ERROR: parse error at position 39: syntax error
+ -- CREATE MATERIALIZED VIEW does support USING
+ CREATE MATERIALIZED VIEW tableam_tblmv_heap2 USING heap2 AS SELECT * FROM tableam_tbl_heap2;
+ SELECT f1 FROM tableam_tblmv_heap2 ORDER BY f1;
+@@ -518,8 +512,11 @@
+ CREATE VIEW tableam_view_heapx AS SELECT * FROM tableam_tbl_heapx;
+ CREATE SEQUENCE tableam_seq_heapx;
+ CREATE FOREIGN DATA WRAPPER fdw_heap2 VALIDATOR postgresql_fdw_validator;
++ERROR: CREATE FOREIGN DATA WRAPPER is not supported through the connection pooler
+ CREATE SERVER fs_heap2 FOREIGN DATA WRAPPER fdw_heap2 ;
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ CREATE FOREIGN table tableam_fdw_heapx () SERVER fs_heap2;
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ -- Verify that new AM was used for tables, matviews, but not for sequences, views and fdws
+ SELECT
+ pc.relkind,
+@@ -533,28 +530,13 @@
+ LEFT JOIN pg_am AS pa ON (pa.oid = pc.relam)
+ WHERE pc.relname LIKE 'tableam_%_heapx'
+ ORDER BY 3, 1, 2;
+-relkind | amname | relname
+----------+--------+-----------------------------
+-f | | tableam_fdw_heapx
+-r | heap2 | tableam_parted_1_heapx
+-r | heap | tableam_parted_2_heapx
+-p | | tableam_parted_heapx
+-S | | tableam_seq_heapx
+-r | heap2 | tableam_tbl_heapx
+-r | heap2 | tableam_tblas_heapx
+-m | heap2 | tableam_tblmv_heapx
+-r | heap2 | tableam_tblselectinto_heapx
+-v | | tableam_view_heapx
+-(10 rows)
+-
++ERROR: current transaction is aborted, commands ignored until end of transaction block
+ -- don't want to keep those tables, nor the default
+ ROLLBACK;
+ -- Third, check that we can neither create a table using a nonexistent
+ -- AM, nor using an index AM
+ CREATE TABLE i_am_a_failure() USING "";
+-ERROR: zero-length delimited identifier at or near """"
+-LINE 1: CREATE TABLE i_am_a_failure() USING "";
+-^
++ERROR: zero-length delimited identifier
+ CREATE TABLE i_am_a_failure() USING i_do_not_exist_am;
+ ERROR: access method "i_do_not_exist_am" does not exist
+ CREATE TABLE i_am_a_failure() USING "I do not exist AM";

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/errors.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/errors.patch
@@ -49,17 +49,6 @@
  -- no such relation
  alter table nonesuch rename to newnonesuch;
  ERROR: relation "nonesuch" does not exist
-@@ -114,10 +106,8 @@
- -- TRANSACTION STUFF
- -- not in a xact
- abort;
--WARNING: there is no transaction in progress
- -- not in a xact
- end;
--WARNING: there is no transaction in progress
- --
- -- CREATE AGGREGATE
- -- sfunc/finalfunc type disagreement
 @@ -136,14 +126,10 @@
  -- DROP INDEX
  -- missing index name

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/gin.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/gin.patch
@@ -1,0 +1,14 @@
+# Known divergence (by design): CREATE UNLOGGED TABLE emits an extra WARNING +
+# HINT because unlogged data is not replicated and is lost on failover. Planner
+# differences in this test are intentionally left unpatched.
+--- a
++++ b
+@@ -290,6 +290,8 @@
+ drop table t_gin_test_tbl;
+ -- test an unlogged table, mostly to get coverage of ginbuildempty
+ create unlogged table t_gin_test_tbl(i int4[], j int4[]);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ create index on t_gin_test_tbl using gin (i, j);
+ insert into t_gin_test_tbl
+ values

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/sequence.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/sequence.patch
@@ -1,56 +1,8 @@
-# Two known divergences, both by design:
-#  1. Single-database model: multigres runs everything in the `postgres`
-#     database, so the sequence catalog listing shows `postgres` rather than the
-#     stock `regression` database name.
-#  2. CREATE UNLOGGED SEQUENCE emits an extra WARNING + HINT (unlogged sequence
-#     state is reset on failover; see docs/query_serving/unlogged_tables.md).
+# Known divergence (by design): CREATE UNLOGGED SEQUENCE emits an extra WARNING
+# + HINT because unlogged sequence state is not replicated and is reset on
+# failover. See docs/query_serving/unlogged_tables.md.
 --- a
 +++ b
-@@ -481,25 +481,25 @@
- ORDER BY sequence_name ASC;
- sequence_catalog | sequence_schema | sequence_name | data_type | numeric_precision | numeric_precision_radix | numeric_scale | start_value | minimum_value | maximum_value | increment | cycle_option
- ------------------+-----------------+--------------------+-----------+-------------------+-------------------------+---------------+-------------+----------------------+---------------------+-----------+--------------
--regression | public | sequence_test10 | smallint | 16 | 2 | 0 | 1 | -20000 | 32767 | 1 | NO
--regression | public | sequence_test11 | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
--regression | public | sequence_test12 | integer | 32 | 2 | 0 | -1 | -2147483648 | -1 | -1 | NO
--regression | public | sequence_test13 | integer | 32 | 2 | 0 | -32768 | -2147483648 | 2147483647 | 1 | NO
--regression | public | sequence_test14 | integer | 32 | 2 | 0 | 32767 | -2147483648 | 2147483647 | -1 | NO
--regression | public | sequence_test2 | bigint | 64 | 2 | 0 | 32 | 5 | 36 | 4 | YES
--regression | public | sequence_test3 | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
--regression | public | sequence_test4 | bigint | 64 | 2 | 0 | -1 | -9223372036854775808 | -1 | -1 | NO
--regression | public | sequence_test5 | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
--regression | public | sequence_test6 | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
--regression | public | sequence_test7 | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
--regression | public | sequence_test8 | smallint | 16 | 2 | 0 | 1 | 1 | 20000 | 1 | NO
--regression | public | sequence_test9 | smallint | 16 | 2 | 0 | -1 | -32768 | -1 | -1 | NO
--regression | public | serialtest1_f2_foo | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
--regression | public | serialtest2_f2_seq | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
--regression | public | serialtest2_f3_seq | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
--regression | public | serialtest2_f4_seq | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
--regression | public | serialtest2_f5_seq | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
--regression | public | serialtest2_f6_seq | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
-+postgres | public | sequence_test10 | smallint | 16 | 2 | 0 | 1 | -20000 | 32767 | 1 | NO
-+postgres | public | sequence_test11 | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
-+postgres | public | sequence_test12 | integer | 32 | 2 | 0 | -1 | -2147483648 | -1 | -1 | NO
-+postgres | public | sequence_test13 | integer | 32 | 2 | 0 | -32768 | -2147483648 | 2147483647 | 1 | NO
-+postgres | public | sequence_test14 | integer | 32 | 2 | 0 | 32767 | -2147483648 | 2147483647 | -1 | NO
-+postgres | public | sequence_test2 | bigint | 64 | 2 | 0 | 32 | 5 | 36 | 4 | YES
-+postgres | public | sequence_test3 | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
-+postgres | public | sequence_test4 | bigint | 64 | 2 | 0 | -1 | -9223372036854775808 | -1 | -1 | NO
-+postgres | public | sequence_test5 | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
-+postgres | public | sequence_test6 | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
-+postgres | public | sequence_test7 | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
-+postgres | public | sequence_test8 | smallint | 16 | 2 | 0 | 1 | 1 | 20000 | 1 | NO
-+postgres | public | sequence_test9 | smallint | 16 | 2 | 0 | -1 | -32768 | -1 | -1 | NO
-+postgres | public | serialtest1_f2_foo | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
-+postgres | public | serialtest2_f2_seq | integer | 32 | 2 | 0 | 1 | 1 | 2147483647 | 1 | NO
-+postgres | public | serialtest2_f3_seq | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
-+postgres | public | serialtest2_f4_seq | smallint | 16 | 2 | 0 | 1 | 1 | 32767 | 1 | NO
-+postgres | public | serialtest2_f5_seq | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
-+postgres | public | serialtest2_f6_seq | bigint | 64 | 2 | 0 | 1 | 1 | 9223372036854775807 | 1 | NO
- (19 rows)
- 
- SELECT schemaname, sequencename, start_value, min_value, max_value, increment_by, cycle, cache_size, last_value
 @@ -602,6 +602,8 @@
  -- unlogged sequences
  -- (more tests in src/test/recovery/)
@@ -60,12 +12,3 @@
  ALTER SEQUENCE sequence_test_unlogged SET LOGGED;
  \d sequence_test_unlogged
  Sequence "public.sequence_test_unlogged"
-@@ -814,7 +816,7 @@
- ORDER BY sequence_name ASC;
- sequence_catalog | sequence_schema | sequence_name | data_type | numeric_precision | numeric_precision_radix | numeric_scale | start_value | minimum_value | maximum_value | increment | cycle_option
- ------------------+-----------------+----------------+-----------+-------------------+-------------------------+---------------+-------------+---------------+---------------+-----------+--------------
--regression | public | sequence_test2 | bigint | 64 | 2 | 0 | 32 | 5 | 36 | 4 | YES
-+postgres | public | sequence_test2 | bigint | 64 | 2 | 0 | 32 | 5 | 36 | 4 | YES
- (1 row)
- 
- DROP USER regress_seq_user;

--- a/go/test/endtoend/pgregresstest/testdata/pg17/patches/spgist.patch
+++ b/go/test/endtoend/pgregresstest/testdata/pg17/patches/spgist.patch
@@ -1,0 +1,13 @@
+# Known divergence (by design): CREATE UNLOGGED TABLE emits an extra WARNING +
+# HINT because unlogged data is not replicated and is lost on failover. Planner
+# differences in this test are intentionally left unpatched.
+--- a
++++ b
+@@ -89,5 +89,7 @@
+ -- test an unlogged table, mostly to get coverage of spgistbuildempty
+ create unlogged table spgist_unlogged_tbl(id serial, b box);
++WARNING: unlogged table data is not replicated and is lost on failover
++HINT: On failover the table is dropped, or left empty if other objects depend on it; rebuild it from scratch. See docs/query_serving/unlogged_tables.md.
+ create index spgist_unlogged_idx on spgist_unlogged_tbl using spgist (b);
+ insert into spgist_unlogged_tbl(b)
+ select box(point(i,j))


### PR DESCRIPTION
## Summary

- Classify `compression`/lz4 as a Docker/CI PostgreSQL build issue, not an accepted Multigres deviation.
- Install `liblz4-dev` in the Docker/CI pg_regress environments and build PostgreSQL with `--with-lz4` for core regression runs.
- Trim the PG17 core regression patch baseline to reviewed intentional deviations only:
  - cosmetic diagnostic/source-location differences
  - unlogged relation warning/HINT policy
  - accepted blocked-policy cascades for pooler-unsafe operations
- Keep real behavior differences exposed as residual failures, including `horology` DateStyle/startup-GUC replay drift.

## Validation

- `git diff --check HEAD`
- Normalized dry-run application for changed/new core patches: `aggregates alter_table brin create_am errors gin sequence spgist`
- Docker verify mode:

```text
PGREGRESS_PATCH_MODE=verify RUN_VARS="RUN_PGREGRESS=1 RUN_PGISOLATION=1" docker/pgregress-generate.sh

Regression: 177/222 passed, 45 failed
```

- Docker isolation recheck:

```text
PGREGRESS_PATCH_MODE=verify RUN_VARS="RUN_PGISOLATION=1" docker/pgregress-generate.sh

Isolation: 97/117 passed, 20 failed
```

Note: isolation currently applies no patch baseline entries; failures remain visible for follow-up work.
