### PR TITLE
feat(multipooler): surface start_lsn/stop_lsn/pg_version in backup metadata

### DIFF
--- a/go/pb/multiadmin/multiadminservice.pb.go
+++ b/go/pb/multiadmin/multiadminservice.pb.go
@@ -1675,7 +1675,13 @@ type BackupInfo struct {
 	// multipooler_service_id is the ID of the multipooler that reported the backup
 	MultipoolerServiceId string `protobuf:"bytes,9,opt,name=multipooler_service_id,json=multipoolerServiceId,proto3" json:"multipooler_service_id,omitempty"`
 	// pooler_type is the type of the multipooler (PRIMARY or REPLICA)
-	PoolerType    clustermetadata.PoolerType `protobuf:"varint,10,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
+	PoolerType clustermetadata.PoolerType `protobuf:"varint,10,opt,name=pooler_type,json=poolerType,proto3,enum=clustermetadata.PoolerType" json:"pooler_type,omitempty"`
+	// start_lsn is the WAL start LSN of the backup (pgbackrest backup[].lsn.start)
+	StartLsn string `protobuf:"bytes,11,opt,name=start_lsn,json=startLsn,proto3" json:"start_lsn,omitempty"`
+	// stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
+	StopLsn string `protobuf:"bytes,12,opt,name=stop_lsn,json=stopLsn,proto3" json:"stop_lsn,omitempty"`
+	// pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
+	PgVersion     string `protobuf:"bytes,13,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1778,6 +1784,27 @@ func (x *BackupInfo) GetPoolerType() clustermetadata.PoolerType {
 		return x.PoolerType
 	}
 	return clustermetadata.PoolerType(0)
+}
+
+func (x *BackupInfo) GetStartLsn() string {
+	if x != nil {
+		return x.StartLsn
+	}
+	return ""
+}
+
+func (x *BackupInfo) GetStopLsn() string {
+	if x != nil {
+		return x.StopLsn
+	}
+	return ""
+}
+
+func (x *BackupInfo) GetPgVersion() string {
+	if x != nil {
+		return x.PgVersion
+	}
+	return ""
 }
 
 // GetPoolerStatusRequest requests the status of a specific pooler
@@ -2517,7 +2544,7 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x15VerifyBackupsResponse\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x1d\n" +
 	"\n" +
-	"raw_output\x18\x02 \x01(\tR\trawOutput\"\x9f\x03\n" +
+	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xf6\x03\n" +
 	"\n" +
 	"BackupInfo\x12\x1b\n" +
 	"\tbackup_id\x18\x01 \x01(\tR\bbackupId\x12\x1a\n" +
@@ -2533,7 +2560,11 @@ const file_multiadminservice_proto_rawDesc = "" +
 	"\x16multipooler_service_id\x18\t \x01(\tR\x14multipoolerServiceId\x12<\n" +
 	"\vpooler_type\x18\n" +
 	" \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
-	"poolerType\"J\n" +
+	"poolerType\x12\x1b\n" +
+	"\tstart_lsn\x18\v \x01(\tR\bstartLsn\x12\x19\n" +
+	"\bstop_lsn\x18\f \x01(\tR\astopLsn\x12\x1d\n" +
+	"\n" +
+	"pg_version\x18\r \x01(\tR\tpgVersion\"J\n" +
 	"\x16GetPoolerStatusRequest\x120\n" +
 	"\tpooler_id\x18\x01 \x01(\v2\x13.clustermetadata.IDR\bpoolerId\"\x9e\x01\n" +
 	"\x17GetPoolerStatusResponse\x126\n" +

--- a/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
+++ b/go/pb/multipoolermanagerdata/multipoolermanagerdata.pb.go
@@ -2533,7 +2533,7 @@ type BackupMetadata struct {
 	Shard      string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
 	Status     BackupMetadata_Status  `protobuf:"varint,3,opt,name=status,proto3,enum=multipoolermanagerdata.BackupMetadata_Status" json:"status,omitempty"`
 	BackupId   string                 `protobuf:"bytes,4,opt,name=backup_id,json=backupId,proto3" json:"backup_id,omitempty"`
-	FinalLsn   string                 `protobuf:"bytes,5,opt,name=final_lsn,json=finalLsn,proto3" json:"final_lsn,omitempty"` // Final checkpoint LSN (stop LSN) for this backup
+	StopLsn    string                 `protobuf:"bytes,5,opt,name=stop_lsn,json=stopLsn,proto3" json:"stop_lsn,omitempty"` // Stop (final checkpoint) LSN for this backup, from pgbackrest info backup[].lsn.stop
 	// Job ID annotation if present (for cross-process tracking)
 	JobId string `protobuf:"bytes,6,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
 	// Size of the backup in bytes (original database size before compression)
@@ -2548,8 +2548,13 @@ type BackupMetadata struct {
 	// backup[].timestamp.{start,stop}. Unset if unknown.
 	StartTimestamp *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=start_timestamp,json=startTimestamp,proto3" json:"start_timestamp,omitempty"`
 	StopTimestamp  *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=stop_timestamp,json=stopTimestamp,proto3" json:"stop_timestamp,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Start LSN for this backup, from pgbackrest info backup[].lsn.start. Empty if unknown.
+	StartLsn string `protobuf:"bytes,13,opt,name=start_lsn,json=startLsn,proto3" json:"start_lsn,omitempty"`
+	// Full PostgreSQL server_version (e.g. "16.2") captured at backup time via the
+	// pg_version pgbackrest annotation. Empty if it could not be captured.
+	PgVersion     string `protobuf:"bytes,14,opt,name=pg_version,json=pgVersion,proto3" json:"pg_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BackupMetadata) Reset() {
@@ -2610,9 +2615,9 @@ func (x *BackupMetadata) GetBackupId() string {
 	return ""
 }
 
-func (x *BackupMetadata) GetFinalLsn() string {
+func (x *BackupMetadata) GetStopLsn() string {
 	if x != nil {
-		return x.FinalLsn
+		return x.StopLsn
 	}
 	return ""
 }
@@ -2664,6 +2669,20 @@ func (x *BackupMetadata) GetStopTimestamp() *timestamppb.Timestamp {
 		return x.StopTimestamp
 	}
 	return nil
+}
+
+func (x *BackupMetadata) GetStartLsn() string {
+	if x != nil {
+		return x.StartLsn
+	}
+	return ""
+}
+
+func (x *BackupMetadata) GetPgVersion() string {
+	if x != nil {
+		return x.PgVersion
+	}
+	return ""
 }
 
 // RewindToSourceRequest requests pg_rewind to synchronize with a source server.
@@ -2996,14 +3015,14 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	"\x15VerifyBackupsResponse\x125\n" +
 	"\bduration\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\bduration\x12\x1d\n" +
 	"\n" +
-	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xc1\x04\n" +
+	"raw_output\x18\x02 \x01(\tR\trawOutput\"\xfb\x04\n" +
 	"\x0eBackupMetadata\x12\x1f\n" +
 	"\vtable_group\x18\x01 \x01(\tR\n" +
 	"tableGroup\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12E\n" +
 	"\x06status\x18\x03 \x01(\x0e2-.multipoolermanagerdata.BackupMetadata.StatusR\x06status\x12\x1b\n" +
-	"\tbackup_id\x18\x04 \x01(\tR\bbackupId\x12\x1b\n" +
-	"\tfinal_lsn\x18\x05 \x01(\tR\bfinalLsn\x12\x15\n" +
+	"\tbackup_id\x18\x04 \x01(\tR\bbackupId\x12\x19\n" +
+	"\bstop_lsn\x18\x05 \x01(\tR\astopLsn\x12\x15\n" +
 	"\x06job_id\x18\x06 \x01(\tR\x05jobId\x12*\n" +
 	"\x11backup_size_bytes\x18\a \x01(\x04R\x0fbackupSizeBytes\x12\x12\n" +
 	"\x04type\x18\b \x01(\tR\x04type\x12%\n" +
@@ -3012,7 +3031,10 @@ const file_multipoolermanagerdata_proto_rawDesc = "" +
 	" \x01(\x0e2\x1b.clustermetadata.PoolerTypeR\n" +
 	"poolerType\x12C\n" +
 	"\x0fstart_timestamp\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\x0estartTimestamp\x12A\n" +
-	"\x0estop_timestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\"3\n" +
+	"\x0estop_timestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\rstopTimestamp\x12\x1b\n" +
+	"\tstart_lsn\x18\r \x01(\tR\bstartLsn\x12\x1d\n" +
+	"\n" +
+	"pg_version\x18\x0e \x01(\tR\tpgVersion\"3\n" +
 	"\x06Status\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x0e\n" +
 	"\n" +

--- a/go/services/multiadmin/backup.go
+++ b/go/services/multiadmin/backup.go
@@ -371,6 +371,9 @@ func (s *MultiAdminServer) GetBackups(ctx context.Context, req *multiadminpb.Get
 			BackupSizeBytes:      b.BackupSizeBytes,
 			MultipoolerServiceId: b.MultipoolerId,
 			PoolerType:           b.PoolerType,
+			StartLsn:             b.StartLsn,
+			StopLsn:              b.StopLsn,
+			PgVersion:            b.PgVersion,
 		}
 	}
 

--- a/go/services/multiadmin/backup_test.go
+++ b/go/services/multiadmin/backup_test.go
@@ -274,6 +274,47 @@ func TestGetBackupJobStatus_FallbackToPooler(t *testing.T) {
 	})
 }
 
+func TestGetBackups_PropagatesLSNAndPgVersion(t *testing.T) {
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+	server := NewMultiAdminServer(ts, slog.Default(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	defer server.backupJobTracker.Stop()
+
+	replicaPooler := &clustermetadatapb.MultiPooler{
+		Id:       &clustermetadatapb.ID{Component: clustermetadatapb.ID_MULTIPOOLER, Cell: "cell1", Name: "replica-pooler"},
+		Hostname: "replica-pooler.cell1",
+		PortMap:  map[string]int32{"grpc": 8081},
+		ShardKey: &clustermetadatapb.ShardKey{Database: "testdb", TableGroup: "default"},
+		Type:     clustermetadatapb.PoolerType_REPLICA,
+	}
+	require.NoError(t, ts.CreateMultiPooler(ctx, replicaPooler))
+
+	fakeClient := rpcclient.NewFakeClient()
+	poolerKey := topoclient.ComponentID("multipooler-cell1-replica-pooler")
+	fakeClient.GetBackupsResponses[poolerKey] = &multipoolermanagerdata.GetBackupsResponse{
+		Backups: []*multipoolermanagerdata.BackupMetadata{{
+			BackupId:   "20250104-100000F",
+			TableGroup: "default",
+			Shard:      "0",
+			Type:       "full",
+			Status:     multipoolermanagerdata.BackupMetadata_COMPLETE,
+			StartLsn:   "0/21000028",
+			StopLsn:    "0/21000100",
+			PgVersion:  "16.2",
+		}},
+	}
+	server.SetRPCClient(fakeClient)
+
+	resp, err := server.GetBackups(ctx, &multiadminpb.GetBackupsRequest{
+		Database: "testdb", TableGroup: "default", Shard: "0",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Backups, 1)
+	require.Equal(t, "0/21000028", resp.Backups[0].StartLsn)
+	require.Equal(t, "0/21000100", resp.Backups[0].StopLsn)
+	require.Equal(t, "16.2", resp.Backups[0].PgVersion)
+}
+
 func TestBackup_ForcePrimary(t *testing.T) {
 	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "cell1")

--- a/go/services/multipooler/internal/manager/backup/backup.go
+++ b/go/services/multipooler/internal/manager/backup/backup.go
@@ -111,6 +111,18 @@ func (e *Engine) Backup(ctx context.Context, pgBackRestType PgBackRestType, jobI
 	args = append(args, "--annotation=pooler_type="+poolerType.String())
 	args = append(args, "--annotation=job_id="+effectiveJobID)
 
+	// Capture the full PostgreSQL server_version and persist it as an annotation
+	// so it can be surfaced in backup metadata (pgbackrest's info JSON only
+	// reports the major version). Best-effort: a failure here must never fail
+	// the backup.
+	if settingsFn := e.settingsProvider(); settingsFn != nil {
+		if pgSettings, verErr := settingsFn(ctx); verErr != nil {
+			e.logger.WarnContext(ctx, "failed to read server_version for backup annotation; backup will lack pg_version", "error", verErr)
+		} else if pgSettings.ServerVersion != "" {
+			args = append(args, "--annotation=pg_version="+pgSettings.ServerVersion)
+		}
+	}
+
 	args = append(args, "backup")
 
 	cmd := e.pgbackrestCmd(ctx, args...)

--- a/go/services/multipooler/internal/manager/backup/engine.go
+++ b/go/services/multipooler/internal/manager/backup/engine.go
@@ -83,6 +83,7 @@ type PGSettings struct {
 	ArchiveCommand string
 	ArchiveMode    string // "on" / "off" / "always"
 	RestoreCommand string
+	ServerVersion  string // full server_version (e.g. "16.2"), build suffix stripped
 }
 
 // PGSettingsFunc returns the backup-relevant PostgreSQL settings. It is injected

--- a/go/services/multipooler/internal/manager/backup/list.go
+++ b/go/services/multipooler/internal/manager/backup/list.go
@@ -160,11 +160,17 @@ func (e *Engine) parseBackups(ctx context.Context, infoData []pgBackRestInfo) []
 			continue
 		}
 
-		// Extract final LSN (stop LSN) from backup
-		finalLSN := ""
-		if pgBackup.LSN != nil && pgBackup.LSN.Stop != "" {
-			finalLSN = pgBackup.LSN.Stop
+		// Extract the LSN range (start/stop) from the backup, if reported.
+		startLSN, stopLSN := "", ""
+		if pgBackup.LSN != nil {
+			startLSN = pgBackup.LSN.Start
+			stopLSN = pgBackup.LSN.Stop
 		}
+
+		// PostgreSQL server_version captured at backup time, stored as a
+		// pgbackrest annotation. Empty if the backup predates the annotation
+		// or capture failed.
+		pgVersion := pgBackup.Annotation["pg_version"]
 
 		// Extract backup size if available
 		var backupSizeBytes uint64
@@ -187,7 +193,9 @@ func (e *Engine) parseBackups(ctx context.Context, infoData []pgBackRestInfo) []
 			Status:          status,
 			TableGroup:      tableGroup,
 			Shard:           shard,
-			FinalLsn:        finalLSN,
+			StartLsn:        startLSN,
+			StopLsn:         stopLSN,
+			PgVersion:       pgVersion,
 			JobId:           jobID,
 			BackupSizeBytes: backupSizeBytes,
 			Type:            pgBackup.Type,

--- a/go/services/multipooler/internal/manager/backup/list_test.go
+++ b/go/services/multipooler/internal/manager/backup/list_test.go
@@ -46,6 +46,25 @@ func TestListBackups(t *testing.T) {
 	assert.Equal(t, multipoolermanagerdata.BackupMetadata_COMPLETE, backups[0].Status)
 }
 
+func TestListBackups_LSNAndPgVersion(t *testing.T) {
+	json := `[{"backup":[
+		{"label":"20250104-100000F","type":"full",
+		 "lsn":{"start":"0/21000028","stop":"0/21000100"},
+		 "annotation":{"table_group":"tg1","shard":"0","job_id":"j1","pg_version":"16.2"}}
+	]}]`
+	stubPgbackrest(t, pgbackrestInfoStub(json))
+	poolerDir := t.TempDir()
+	e, _ := newTestEngine(t, poolerDir, "tg1", "0", "/tmp/backups")
+	e.SetConfigPath(setupMockPgBackRestConfig(t, poolerDir))
+
+	backups, err := e.ListBackups(t.Context())
+	require.NoError(t, err)
+	require.Len(t, backups, 1)
+	assert.Equal(t, "0/21000028", backups[0].StartLsn)
+	assert.Equal(t, "0/21000100", backups[0].StopLsn)
+	assert.Equal(t, "16.2", backups[0].PgVersion)
+}
+
 func TestListBackups_SkipsMismatchedTableGroup(t *testing.T) {
 	// A backup annotated with a different table_group must be filtered out
 	// (defense-in-depth), exercising the table_group-mismatch skip branch.

--- a/go/services/multipooler/internal/manager/pg_replication.go
+++ b/go/services/multipooler/internal/manager/pg_replication.go
@@ -112,8 +112,9 @@ func (pm *MultiPoolerManager) archiverStats(ctx context.Context) (backupengine.A
 	return stats, nil
 }
 
-// backupSettings reads the backup-relevant PostgreSQL settings for the
-// backup-health poller. These are cheap pg_settings reads (no forced I/O). It
+// backupSettings reads the backup-relevant PostgreSQL settings, used both by
+// the backup-health poller and to capture server_version for the backup-time
+// pg_version annotation. These are cheap pg_settings reads (no forced I/O). It
 // reuses the manager's query path and is injected into the backup engine via
 // SetPGSettingsProvider.
 func (pm *MultiPoolerManager) backupSettings(ctx context.Context) (backupengine.PGSettings, error) {
@@ -123,20 +124,22 @@ func (pm *MultiPoolerManager) backupSettings(ctx context.Context) (backupengine.
 	sql := `SELECT
 		COALESCE(current_setting('archive_command', true), '') AS archive_command,
 		COALESCE(current_setting('archive_mode', true), '')    AS archive_mode,
-		COALESCE(current_setting('restore_command', true), '') AS restore_command`
+		COALESCE(current_setting('restore_command', true), '') AS restore_command,
+		COALESCE(split_part(current_setting('server_version', true), ' ', 1), '') AS server_version`
 	result, err := pm.query(queryCtx, sql)
 	if err != nil {
 		return backupengine.PGSettings{}, mterrors.Wrap(err, "failed to query backup settings")
 	}
 
-	var archiveCommand, archiveMode, restoreCommand string
-	if err := executor.ScanSingleRow(result, &archiveCommand, &archiveMode, &restoreCommand); err != nil {
+	var archiveCommand, archiveMode, restoreCommand, serverVersion string
+	if err := executor.ScanSingleRow(result, &archiveCommand, &archiveMode, &restoreCommand, &serverVersion); err != nil {
 		return backupengine.PGSettings{}, mterrors.Wrap(err, "failed to scan backup settings result")
 	}
 	return backupengine.PGSettings{
 		ArchiveCommand: archiveCommand,
 		ArchiveMode:    archiveMode,
 		RestoreCommand: restoreCommand,
+		ServerVersion:  serverVersion,
 	}, nil
 }
 

--- a/go/services/multipooler/internal/manager/pg_replication_backup_test.go
+++ b/go/services/multipooler/internal/manager/pg_replication_backup_test.go
@@ -78,27 +78,29 @@ func TestBackupSettings(t *testing.T) {
 	t.Run("maps the three settings", func(t *testing.T) {
 		qs := mock.NewQueryService()
 		qs.AddQueryPattern("current_setting", mock.MakeQueryResult(
-			[]string{"archive_command", "archive_mode", "restore_command"},
-			[][]any{{"pgbackrest archive-push %p", "on", "pgbackrest archive-get %f %p"}}))
+			[]string{"archive_command", "archive_mode", "restore_command", "server_version"},
+			[][]any{{"pgbackrest archive-push %p", "on", "pgbackrest archive-get %f %p", "16.2"}}))
 
 		s, err := managerWithMockQuery(qs).backupSettings(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "pgbackrest archive-push %p", s.ArchiveCommand)
 		assert.Equal(t, "on", s.ArchiveMode)
 		assert.Equal(t, "pgbackrest archive-get %f %p", s.RestoreCommand)
+		assert.Equal(t, "16.2", s.ServerVersion)
 	})
 
 	t.Run("empty settings pass through", func(t *testing.T) {
 		qs := mock.NewQueryService()
 		qs.AddQueryPattern("current_setting", mock.MakeQueryResult(
-			[]string{"archive_command", "archive_mode", "restore_command"},
-			[][]any{{"", "off", ""}}))
+			[]string{"archive_command", "archive_mode", "restore_command", "server_version"},
+			[][]any{{"", "off", "", ""}}))
 
 		s, err := managerWithMockQuery(qs).backupSettings(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, s.ArchiveCommand)
 		assert.Equal(t, "off", s.ArchiveMode)
 		assert.Empty(t, s.RestoreCommand)
+		assert.Empty(t, s.ServerVersion)
 	})
 
 	t.Run("query error is wrapped", func(t *testing.T) {

--- a/go/test/endtoend/multipooler/backup_test.go
+++ b/go/test/endtoend/multipooler/backup_test.go
@@ -141,8 +141,8 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 				t.Run("GetBackups_VerifyFullBackup", func(t *testing.T) {
 					t.Log("Listing backups to verify full backup...")
 					foundBackup := listAndFindBackup(t, backupClient, fullBackupID, 10)
-					t.Logf("Backup verified in list: ID=%s, Status=%s, FinalLSN=%s",
-						foundBackup.BackupId, foundBackup.Status, foundBackup.FinalLsn)
+					t.Logf("Backup verified in list: ID=%s, Status=%s, StopLSN=%s",
+						foundBackup.BackupId, foundBackup.Status, foundBackup.StopLsn)
 				})
 
 				t.Run("RestoreAndVerify", func(t *testing.T) {
@@ -173,8 +173,8 @@ func TestBackup_CreateListAndRestore(t *testing.T) {
 					// Find our backup in the standby's list
 					foundBackup := findBackupInList(t, listResp.Backups, fullBackupID)
 					assertBackupComplete(t, foundBackup, fullBackupID)
-					t.Logf("Backup verified in standby's list: ID=%s, Status=%s, FinalLSN=%s",
-						foundBackup.BackupId, foundBackup.Status, foundBackup.FinalLsn)
+					t.Logf("Backup verified in standby's list: ID=%s, Status=%s, StopLSN=%s",
+						foundBackup.BackupId, foundBackup.Status, foundBackup.StopLsn)
 
 					// Capture the standby's current term so we can verify it's preserved
 					// across the restore. Bootstrap recruits every member, so the
@@ -482,8 +482,8 @@ func TestBackup_FromStandby(t *testing.T) {
 				backupID := createAndVerifyBackup(t, backupClient, "full", false, 5*time.Minute, nil)
 				foundBackup := listAndFindBackup(t, backupClient, backupID, 10)
 
-				t.Logf("Standby backup verified in list: ID=%s, Status=%s, FinalLSN=%s",
-					foundBackup.BackupId, foundBackup.Status, foundBackup.FinalLsn)
+				t.Logf("Standby backup verified in list: ID=%s, Status=%s, StopLSN=%s",
+					foundBackup.BackupId, foundBackup.Status, foundBackup.StopLsn)
 			})
 
 			t.Run("CreateIncrementalBackupFromStandby", func(t *testing.T) {
@@ -567,7 +567,15 @@ func TestBackup_MultiAdminAPIs(t *testing.T) {
 					assert.Equal(t, "default", foundBackup.TableGroup)
 					assert.Equal(t, "0-inf", foundBackup.Shard)
 					assert.Equal(t, multiadminpb.BackupStatus_BACKUP_STATUS_COMPLETE, foundBackup.Status)
-					t.Logf("Backup verified in list: %s", foundBackup.BackupId)
+					// Verify the LSN range and server version make it all the way
+					// through multiadmin: pgbackrest info JSON (start/stop LSN) and the
+					// pg_version annotation captured at backup time are surfaced on the
+					// multiadmin BackupInfo.
+					assert.NotEmpty(t, foundBackup.StartLsn, "BackupInfo should carry start LSN")
+					assert.NotEmpty(t, foundBackup.StopLsn, "BackupInfo should carry stop LSN")
+					assert.NotEmpty(t, foundBackup.PgVersion, "BackupInfo should carry pg_version")
+					t.Logf("Backup verified in list: %s (start_lsn=%s stop_lsn=%s pg_version=%s)",
+						foundBackup.BackupId, foundBackup.StartLsn, foundBackup.StopLsn, foundBackup.PgVersion)
 				})
 			})
 

--- a/go/test/endtoend/multipooler/backup_test_helpers.go
+++ b/go/test/endtoend/multipooler/backup_test_helpers.go
@@ -121,7 +121,12 @@ func assertBackupComplete(t *testing.T, backup *multipoolermanagerdata.BackupMet
 	assert.Equal(t, expectedID, backup.BackupId, "Backup ID should match")
 	assert.Equal(t, multipoolermanagerdata.BackupMetadata_COMPLETE, backup.Status,
 		"Backup status should be COMPLETE")
-	assert.NotEmpty(t, backup.FinalLsn, "Backup should have final LSN")
+	assert.NotEmpty(t, backup.StopLsn, "Backup should have stop LSN")
+	assert.NotEmpty(t, backup.StartLsn, "Backup should have start LSN")
+	// pg_version capture is best-effort in production (a failed server_version
+	// read never fails the backup); this assertion assumes the read succeeds,
+	// which it always does in the controlled endtoend environment.
+	assert.NotEmpty(t, backup.PgVersion, "Backup should have pg_version")
 }
 
 // connectToPostgresViaSocket establishes a connection to PostgreSQL using Unix socket.

--- a/proto/multiadminservice.proto
+++ b/proto/multiadminservice.proto
@@ -426,6 +426,12 @@ message BackupInfo {
   string multipooler_service_id = 9;
   // pooler_type is the type of the multipooler (PRIMARY or REPLICA)
   clustermetadata.PoolerType pooler_type = 10;
+  // start_lsn is the WAL start LSN of the backup (pgbackrest backup[].lsn.start)
+  string start_lsn = 11;
+  // stop_lsn is the WAL stop LSN of the backup (pgbackrest backup[].lsn.stop)
+  string stop_lsn = 12;
+  // pg_version is the full PostgreSQL server_version the backup was taken from (e.g. "16.2")
+  string pg_version = 13;
 }
 
 // BackupStatus indicates the state of a backup artifact

--- a/proto/multipoolermanagerdata.proto
+++ b/proto/multipoolermanagerdata.proto
@@ -537,7 +537,7 @@ message BackupMetadata {
   string shard = 2;
   Status status = 3;
   string backup_id = 4;
-  string final_lsn = 5; // Final checkpoint LSN (stop LSN) for this backup
+  string stop_lsn = 5; // Stop (final checkpoint) LSN for this backup, from pgbackrest info backup[].lsn.stop
 
   // Job ID annotation if present (for cross-process tracking)
   string job_id = 6;
@@ -558,6 +558,13 @@ message BackupMetadata {
   // backup[].timestamp.{start,stop}. Unset if unknown.
   google.protobuf.Timestamp start_timestamp = 11;
   google.protobuf.Timestamp stop_timestamp = 12;
+
+  // Start LSN for this backup, from pgbackrest info backup[].lsn.start. Empty if unknown.
+  string start_lsn = 13;
+
+  // Full PostgreSQL server_version (e.g. "16.2") captured at backup time via the
+  // pg_version pgbackrest annotation. Empty if it could not be captured.
+  string pg_version = 14;
 
   // Status represents the state of a backup
   enum Status {


### PR DESCRIPTION
## Summary

- Surface `start_lsn`, `stop_lsn`, and `pg_version` on multiadmin's `BackupInfo` so the platform-backups integration can fully populate its record.
- `start_lsn`/`stop_lsn` come straight from pgBackRest's `info` JSON (`backup[].lsn.{start,stop}`); they just needed to be threaded through the pooler `BackupMetadata` → multiadmin `BackupInfo` chain.
- `pg_version` (the full `server_version`, e.g. `16.2`) is not in pgBackRest's JSON, so it is captured at backup time via a `current_setting('server_version')` read, persisted as a pgBackRest annotation, and read back during info parsing.
- The pooler-layer field `final_lsn` is renamed to `stop_lsn` for cross-layer naming consistency. Prerelease software — no back-compat concern.

## Description

The change spans the full read path:

- **Proto** (`proto/multipoolermanagerdata.proto`, `proto/multiadminservice.proto`): renamed `BackupMetadata.final_lsn` → `stop_lsn`, added `start_lsn`/`pg_version`; added `start_lsn`/`stop_lsn`/`pg_version` to `BackupInfo`. Regenerated with `make proto`.
- **Pooler list path** (`backup/list.go`): reads the LSN range from `backup[].lsn` and `pg_version` from the annotation map.
- **Settings** (`backup/engine.go`, `pg_replication.go`): `PGSettings` gains `ServerVersion`; `backupSettings` reads `split_part(current_setting('server_version', true), ' ', 1)` to strip any build suffix.
- **Backup time** (`backup/backup.go`): best-effort capture of `server_version` written as `--annotation=pg_version=...`. A failed read warns and continues — it never fails the backup.
- **multiadmin** (`backup.go`): `GetBackups` copies the three fields from `BackupMetadata` to `BackupInfo`.

## Test Plan

- Unit tests for the pooler list path, `backupSettings` scan, and multiadmin propagation (fake client).
- Endtoend `TestBackup_CreateListAndRestore` and `TestBackup_MultiAdminAPIs` assert non-empty `start_lsn`/`stop_lsn`/`pg_version` on real backups across the filesystem and S3 backends, exercising the full annotation write→read round-trip through multiadmin (observed e.g. `start_lsn=0/6000028 stop_lsn=0/6000368 pg_version=17.7`).